### PR TITLE
infra: dev container + cross-arch toolchains

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,101 @@
+# kuna dev container — reproducible build + cross-arch fixture environment.
+#
+# This image is ENV-ONLY: it does NOT COPY the kuna repo. The workspace is mounted
+# at runtime (/workspaces/kuna), so the same image serves every branch/worktree.
+#
+# Base is ubuntu:22.04 deliberately: it matches the host toolchain era so the
+# vendored cross-arch ELF test fixtures stay byte-reproducible.
+FROM ubuntu:22.04
+
+# Non-interactive apt + sane locale for the build tools.
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+# ---------------------------------------------------------------------------
+# Single apt layer: core build chain, every cross toolchain WITH its linker
+# (each gcc-<triple> pulls binutils-<triple> = the assembler + ld), binary
+# inspection tools, and the language/dev tooling. apt lists cleaned at the end.
+#
+# NOTE: each `gcc-<triple>` package depends on `binutils-<triple>`, so the
+# cross *linkers* (e.g. arm-linux-gnueabihf-ld) come in for free — that is the
+# key unblock: this image can LINK cross-arch ELFs, not just assemble objects.
+# Non-ELF toolchains (mingw-w64 / osxcross) are intentionally out of scope; an
+# agent can `sudo apt-get install` them later if scope expands (docs note this).
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        # core build
+        build-essential \
+        make \
+        cmake \
+        pkg-config \
+        gcc \
+        g++ \
+        clang \
+        lld \
+        # cross toolchains (each pulls its binutils => assembler + linker)
+        gcc-arm-linux-gnueabihf \
+        g++-arm-linux-gnueabihf \
+        gcc-aarch64-linux-gnu \
+        g++-aarch64-linux-gnu \
+        gcc-riscv64-linux-gnu \
+        gcc-mips-linux-gnu \
+        gcc-mipsel-linux-gnu \
+        gcc-mips64el-linux-gnuabi64 \
+        gcc-powerpc64le-linux-gnu \
+        gcc-sparc64-linux-gnu \
+        # binary inspection
+        binutils-multiarch \
+        file \
+        # languages / tooling
+        golang-go \
+        python3 \
+        python3-pip \
+        git \
+        curl \
+        wget \
+        ca-certificates \
+        gnupg \
+        unzip \
+        xz-utils \
+        gdb \
+        sudo \
+        less \
+        vim \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# Non-root user `dev` (uid 1000) with passwordless sudo.
+# ---------------------------------------------------------------------------
+RUN useradd --create-home --shell /bin/bash --uid 1000 dev \
+    && echo 'dev ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/dev \
+    && chmod 0440 /etc/sudoers.d/dev
+
+# ---------------------------------------------------------------------------
+# Rust toolchain, installed AS the dev user and pinned to the host's 1.90.0
+# (matches decompiler/Cargo.toml `rust-version = "1.90"`). CARGO_HOME /
+# RUSTUP_HOME live under the dev home so the toolchain is owned by `dev`.
+# ---------------------------------------------------------------------------
+ENV RUSTUP_HOME=/home/dev/.rustup \
+    CARGO_HOME=/home/dev/.cargo \
+    PATH=/home/dev/.cargo/bin:$PATH
+
+USER dev
+WORKDIR /home/dev
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --no-modify-path --default-toolchain 1.90.0 --profile minimal \
+    && rustup toolchain install 1.90.0 \
+    && rustup default 1.90.0 \
+    && rustup component add rustfmt clippy
+
+# ---------------------------------------------------------------------------
+# Image sanity: fail the build if the pinned rustc or the ARM cross-compiler
+# (the headline unblock) are not present/working.
+# ---------------------------------------------------------------------------
+RUN rustc --version | grep -q '1\.90\.0' \
+    && cargo --version \
+    && arm-linux-gnueabihf-gcc --version
+
+WORKDIR /workspaces/kuna
+CMD ["/bin/bash", "-l"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  // kuna dev container. The image (Dockerfile) is env-only — the repo is mounted
+  // at runtime into /workspaces/kuna, so one image serves every branch/worktree.
+  //
+  // privileged + passwordless sudo are INTENTIONAL per project policy: the user
+  // requires the ability to always run privileged and to `apt-get install`
+  // anything (e.g. add mingw-w64/osxcross later) without rebuilding the image.
+  "name": "kuna-dev",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+  "privileged": true,
+  "runArgs": ["--privileged"],
+  "remoteUser": "dev",
+  "workspaceFolder": "/workspaces/kuna",
+  "postCreateCommand": "rustc --version && cargo --version"
+}

--- a/docs/analysis-port-frontier.md
+++ b/docs/analysis-port-frontier.md
@@ -1,0 +1,46 @@
+# Analysis-port frontier — Docker-enabled (post-Increment-17)
+
+## Context
+
+The ELF-feasible analyzer frontier is **complete** (Increments 1–17 in
+`docs/analysis-port-log.md`; the completeness sweep is Increment 15). Every feasible-at-tier,
+decompiler-relevant ELF analyzer has been ported onto kuna's current analysis tier
+(`kuna-analysis`). This document tracks the **remaining** work under the chosen
+**"Feasible + Docker-unblock"** scope:
+
+- **Port** everything still portable onto kuna's current analysis tier.
+- Use the **devcontainer** (this PR) to build cross-arch ELF fixtures that unblock the passes
+  that were stuck only because the build host lacked cross linkers (the documented ARM decode
+  e2e being the headline).
+- Close the **cosmetic `_INIT_<i>` / `_FINI_<i>`** array-element naming.
+- **Document (do not build)** the items that need a brand-new engine subsystem — a
+  post-disassembly Listing / ReferenceManager tier that does not yet exist — or non-ELF
+  loaders (PE / Mach-O / COFF) and the large recognizer subsystems (Go pclntab, FID).
+
+One PR per item.
+
+## Work-list
+
+Ordered easy → hard.
+
+| # | Item | Type | Depends-on | Status | Notes |
+|---|------|------|-----------|--------|-------|
+| 1 | devcontainer + cross-arch toolchains | infra | — | **done (THIS PR)** | The reproducible env + ARM/aarch64/riscv/mips/ppc/sparc linkers. See `docs/devcontainer.md`. Unblocks #2–#5. |
+| 2 | ARM decode e2e | port/test | #1 | todo | Linked Thumb fixture via the container ARM linker; the deferred Increment-8/17 e2e (paint TMode + decode a Thumb function end-to-end). |
+| 3 | AArch64 PLT/markers linked-exe e2e | test | #1 | todo | `elf_plt` already supports AArch64; add a LINKED fixture + e2e proving import names resolve. |
+| 4 | RISC-V64 PLT linked-exe e2e | test | #1 | todo | `elf_plt` supports RISC-V; add a LINKED fixture + e2e. |
+| 5 | MIPS16 ISA_MODE context paint | port | #1 | todo | The MIPS analog of ARM `$t` (`MIPS_ElfExtension.applyIsaMode`, a context bit); needs a MIPS16 fixture (container mips gcc). |
+| 6 | `_INIT_<i>` / `_FINI_<i>` array-element naming | port | — | todo | Reshape `AnalysisOutput.entries` to carry optional names + commit seam; host-testable; documented follow-up from Increment 15. |
+| 7 | Build-plan doc: infeasible-at-tier + non-ELF + huge subsystems | doc | — | todo | Concrete build plans (NOT implementations) for: AIF / discovered-no-return / operand-reference markup (all need a post-disassembly Listing / ReferenceManager tier that does not exist), non-ELF loaders (PE / Mach-O / COFF), Go pclntab name recovery, FID fingerprinting. |
+
+## Problems / notes log
+
+- **2026-06-23 — Host lacked cross linkers.** The original build host had **no ARM linker**
+  (and no aarch64 / riscv linkers either): `which arm-linux-gnueabihf-gcc` was empty,
+  `make`/`ld.lld` could assemble objects but not produce a *linked* cross-arch ELF. This is
+  exactly what blocked the documented ARM decode e2e (Increment 8/17): the `s1_loader`
+  `arm_markers` pass and its `.o` unit test were done, but the full decode e2e needs a
+  **linked** ARM fixture. **Now provided by the container** (#1): `ubuntu:22.04` with
+  `gcc-arm-linux-gnueabihf` + every other cross toolchain *and* its `binutils` (so the cross
+  `ld`s are present). Proof captured in the PR: the container links a `PT_LOAD`, `Type: EXEC`,
+  `Machine: ARM` Thumb executable (odd entry `0x100d1` = Thumb bit). This unblocks #2–#5.

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -1,0 +1,143 @@
+# Dev container — reproducible build + cross-arch fixture environment
+
+`.devcontainer/` provides a fully reproducible environment for (a) building and testing
+kuna and (b) building cross-architecture ELF test fixtures (x86-64, ARM32/Thumb, AArch64,
+RISC-V64, MIPS/MIPSel/MIPS64el, PPC64le, SPARC64) **including their linkers**, plus Go and
+a pinned Rust toolchain.
+
+The single most important thing this container fixes: the original build host had **no ARM
+linker**, which blocked the documented "ARM decode end-to-end test" (see
+`docs/analysis-port-log.md`, Increment 17). The container ships every cross toolchain *with*
+its `binutils` (assembler + `ld`), so a **linked** ARM Thumb ELF — not just a bare `.o` — can
+now be produced in-env.
+
+## Files
+
+| File | Role |
+|---|---|
+| `.devcontainer/Dockerfile` | The image. **Env-only** — it does NOT copy the repo; the workspace is mounted at runtime so one image serves every branch/worktree. |
+| `.devcontainer/devcontainer.json` | VS Code / `devcontainer` CLI config. References the Dockerfile, runs as user `dev`, mounts the repo at `/workspaces/kuna`. |
+
+## Design notes
+
+- **Base `ubuntu:22.04`** — matches the host toolchain era so the vendored cross-arch ELF
+  fixtures stay byte-reproducible.
+- **Env-only image** — the Dockerfile never `COPY`s the repo. Mount the worktree at
+  `/workspaces/kuna` at runtime. The build context is just `.devcontainer/` (tiny).
+- **Non-root `dev` user (uid 1000)** with **passwordless sudo** (`/etc/sudoers.d/dev`).
+- **Privileged by default** — `devcontainer.json` sets `privileged: true` and
+  `runArgs: ["--privileged"]`. This (and passwordless sudo) is **intentional per project
+  policy**: an agent must always be able to run privileged and `apt-get install` anything
+  without rebuilding the image.
+- **Rust pinned to 1.90.0** (the host version; matches `decompiler/Cargo.toml`
+  `rust-version = "1.90"`), installed via rustup **as the `dev` user** with `CARGO_HOME` /
+  `RUSTUP_HOME` under `/home/dev`. The image build fails if `rustc` is not 1.90.0 or if
+  `arm-linux-gnueabihf-gcc` is missing (a baked-in sanity gate).
+
+## Build the image
+
+From the repo root:
+
+```bash
+docker build -t kuna-dev -f .devcontainer/Dockerfile .devcontainer
+```
+
+(Build context is `.devcontainer` on purpose — the image is env-only, so it needs none of the
+repo.) Or open the folder in VS Code with the Dev Containers extension / use the `devcontainer`
+CLI, which reads `.devcontainer/devcontainer.json` directly.
+
+## Run the gates inside the container
+
+Mount the repo worktree and run the make targets. From the repo root:
+
+```bash
+# build all binaries (decomp_dbg, decomp_test_dbg, slacomp, kuna)
+docker run --rm -v "$(pwd)":/workspaces/kuna -w /workspaces/kuna kuna-dev \
+    bash -lc 'make binaries'
+
+# the three required gates
+docker run --rm -v "$(pwd)":/workspaces/kuna -w /workspaces/kuna kuna-dev \
+    bash -lc 'make test'         # 675/675 datatest parity  -> PARITY OK
+docker run --rm -v "$(pwd)":/workspaces/kuna -w /workspaces/kuna kuna-dev \
+    bash -lc 'make test-stages'  # stage-model corpus       -> PARITY OK
+docker run --rm -v "$(pwd)":/workspaces/kuna -w /workspaces/kuna kuna-dev \
+    bash -lc 'make rust-test'    # full cargo workspace suite
+```
+
+`decompiler/target/` is gitignored, so building inside the mounted worktree leaves the host
+tree clean of artifacts (the `target/` produced is the host's own and is never committed).
+
+For an interactive session:
+
+```bash
+docker run --rm -it -v "$(pwd)":/workspaces/kuna -w /workspaces/kuna kuna-dev bash -l
+```
+
+## Build a cross-arch fixture (the ARM-linker unblock)
+
+The headline capability — produce a **linked** ARM Thumb executable (the previously-blocked
+fixture), then confirm it has a `LOAD`/exec segment:
+
+```bash
+printf 'int f(int x){return x+1;} void _start(){f(41);}' > /tmp/thumb.c
+arm-linux-gnueabihf-gcc -mthumb -static -nostdlib -e _start /tmp/thumb.c -o /tmp/arm_thumb_linked
+readelf -h /tmp/arm_thumb_linked   # Type EXEC, Machine ARM
+readelf -l /tmp/arm_thumb_linked   # a LOAD segment (R E)
+```
+
+Verified output: `Type: EXEC`, `Machine: ARM`, entry `0x100d1` (odd = Thumb bit set), and a
+`LOAD` segment with `R E` flags. Before this container, `which arm-linux-gnueabihf-gcc` on the
+host was empty.
+
+The same pattern builds fixtures for the other arches by swapping the triple, e.g.:
+
+```bash
+aarch64-linux-gnu-gcc       -static -nostdlib -e _start /tmp/x.c -o /tmp/aarch64_linked
+riscv64-linux-gnu-gcc       -static -nostdlib -e _start /tmp/x.c -o /tmp/riscv64_linked
+mipsel-linux-gnu-gcc        -static -nostdlib -e _start /tmp/x.c -o /tmp/mipsel_linked
+powerpc64le-linux-gnu-gcc   -static -nostdlib -e _start /tmp/x.c -o /tmp/ppc64le_linked
+sparc64-linux-gnu-gcc       -static -nostdlib -e _start /tmp/x.c -o /tmp/sparc64_linked
+```
+
+## Toolchain inventory
+
+| Category | Packages / commands |
+|---|---|
+| Core build | `build-essential`, `make`, `cmake`, `pkg-config`, `gcc`, `g++`, `clang` 14, `lld` (`ld.lld`) |
+| Rust | rustup, toolchain **1.90.0** (default), `rustfmt`, `clippy` — `cargo`/`rustc` on the `dev` PATH |
+| ARM32/Thumb | `gcc-arm-linux-gnueabihf`, `g++-arm-linux-gnueabihf` → `arm-linux-gnueabihf-{gcc,g++,ld,as}` |
+| AArch64 | `gcc-aarch64-linux-gnu`, `g++-aarch64-linux-gnu` → `aarch64-linux-gnu-{gcc,g++,ld}` |
+| RISC-V64 | `gcc-riscv64-linux-gnu` → `riscv64-linux-gnu-{gcc,ld}` |
+| MIPS | `gcc-mips-linux-gnu`, `gcc-mipsel-linux-gnu`, `gcc-mips64el-linux-gnuabi64` → `mips[-/el/64el]-…-{gcc,ld}` |
+| PPC64le | `gcc-powerpc64le-linux-gnu` → `powerpc64le-linux-gnu-{gcc,ld}` |
+| SPARC64 | `gcc-sparc64-linux-gnu` → `sparc64-linux-gnu-{gcc,ld}` |
+| Binary inspection | `binutils-multiarch` (multiarch `readelf`/`objdump`), `file` |
+| Languages / tools | `golang-go` (Go 1.18), `python3` + `python3-pip`, `git`, `curl`, `wget`, `ca-certificates`, `gnupg`, `unzip`, `xz-utils`, `gdb`, `sudo`, `less`, `vim` |
+
+Every `gcc-<triple>` package depends on `binutils-<triple>`, so the cross **linkers** come in
+for free — that is what unblocks producing *linked* cross-arch ELFs, not just objects.
+
+### Verified cross-compiler versions (ubuntu:22.04)
+
+- ARM / AArch64 / RISC-V64 / PPC64le / SPARC64 GCC: **11.4.0**
+- MIPS / MIPSel / MIPS64el GCC: **10.3.0** (the 22.04 archive ships these MIPS cross GCCs at
+  the 10.x series; this is the stock package, no substitution).
+
+## Out of scope (add later if scope expands)
+
+Non-ELF toolchains are **not** installed, because non-ELF formats are out of the current
+analysis-port scope:
+
+- **mingw-w64** (PE / Windows) — `sudo apt-get install -y gcc-mingw-w64 g++-mingw-w64`
+- **osxcross** (Mach-O / macOS) — not packaged in apt; build from source.
+
+Because the container has passwordless sudo and is privileged, an agent can install these (or
+anything else) at runtime when PE/Mach-O loader work begins, without changing the image.
+
+## Package-name notes / substitutions
+
+No substitutions were required — every requested `gcc-<triple>` package exists in the
+`ubuntu:22.04` archive under the exact name. The only thing worth recording is the MIPS cross
+GCCs being 10.3.0 vs 11.4.0 for the others (stock packaging, above). If a future arch's
+package name differs, find it with `apt-cache search gcc-<arch>` and note the substitution
+here.


### PR DESCRIPTION
First PR of the analysis-port fan-out: a fully reproducible dev container for (a) building & testing kuna and (b) building cross-architecture ELF test fixtures **including their linkers**, plus Go and a pinned Rust toolchain. Env-only image (the repo is mounted at runtime, not COPYed); base `ubuntu:22.04` to keep the vendored cross-arch fixtures reproducible.

## The unblock (before → after)

The build host has **no ARM linker**, which blocked the documented ARM decode end-to-end test (see `docs/analysis-port-log.md`, Increment 17). The container fixes this.

- **Host, before:** `which arm-linux-gnueabihf-gcc` → *empty* (no ARM gcc/ld; aarch64/riscv linkers also absent).
- **Container, after:** links a `PT_LOAD`, `Type EXEC`, `Machine ARM` Thumb executable.

```
$ printf 'int f(int x){return x+1;} void _start(){f(41);}' > /tmp/thumb.c
$ arm-linux-gnueabihf-gcc -mthumb -static -nostdlib -e _start /tmp/thumb.c -o /tmp/arm_thumb_linked
$ readelf -h /tmp/arm_thumb_linked
  Type:                              EXEC (Executable file)
  Machine:                           ARM
  Entry point address:               0x100d1          # odd => Thumb bit set
$ readelf -l /tmp/arm_thumb_linked
Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  LOAD           0x000000 0x00010000 0x00010000 0x000de 0x000de R E 0x10000
  NOTE           0x000094 0x00010094 0x00010094 0x00024 0x00024 R   0x4
  GNU_STACK      0x000000 0x00000000 0x00000000 0x00000 0x00000 RW  0x10
```

A LINKED ARM Thumb ELF with an executable LOAD segment — the previously-blocked e2e fixture is now buildable in-env.

## Toolchain inventory

| Category | Packages → commands |
|---|---|
| Core build | `build-essential make cmake pkg-config gcc g++ clang lld` (`ld.lld`) |
| Rust | rustup, toolchain **1.90.0** (default; matches `decompiler/Cargo.toml`), `rustfmt`+`clippy`, on the `dev` PATH |
| ARM32/Thumb | `gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf` → `arm-linux-gnueabihf-{gcc,g++,ld}` (GCC 11.4.0) |
| AArch64 | `gcc-aarch64-linux-gnu g++-aarch64-linux-gnu` → `aarch64-linux-gnu-{gcc,g++,ld}` (11.4.0) |
| RISC-V64 | `gcc-riscv64-linux-gnu` → `riscv64-linux-gnu-{gcc,ld}` (11.4.0) |
| MIPS | `gcc-mips-linux-gnu gcc-mipsel-linux-gnu gcc-mips64el-linux-gnuabi64` → `mips[/el/64el]-…-{gcc,ld}` (10.3.0) |
| PPC64le | `gcc-powerpc64le-linux-gnu` → `powerpc64le-linux-gnu-{gcc,ld}` (11.4.0) |
| SPARC64 | `gcc-sparc64-linux-gnu` → `sparc64-linux-gnu-{gcc,ld}` (11.4.0) |
| Binary inspection | `binutils-multiarch file` |
| Languages/tools | `golang-go` (Go 1.18) `python3 python3-pip git curl wget ca-certificates gnupg unzip xz-utils gdb sudo less vim` |

Every `gcc-<triple>` pulls `binutils-<triple>`, so all 8 cross **linkers** are present (verified `/usr/bin/<triple>-ld` for each). Non-ELF toolchains (mingw-w64 / osxcross) are intentionally out of scope; the container is privileged with passwordless sudo so an agent can `apt-get install` them later. **No package-name substitutions were needed** — every requested `gcc-<triple>` exists under its exact name on 22.04 (only note: the MIPS cross GCCs ship at 10.3.0 vs 11.4.0 for the others; stock packaging).

## Container policy

`devcontainer.json` sets `privileged: true` + `runArgs: ["--privileged"]`, `remoteUser: dev`, `workspaceFolder: /workspaces/kuna`; the `dev` user (uid 1000) has passwordless sudo. Privileged + sudo are intentional per project policy (always able to run privileged / install anything without rebuilding the image), noted inline in both files.

## Verification run + results

| # | Command | Result |
|---|---------|--------|
| 1 | `docker build -t kuna-dev -f .devcontainer/Dockerfile .devcontainer` | **PASS** — image built; baked sanity gate confirmed `rustc 1.90.0`, `cargo 1.90.0`, `arm-linux-gnueabihf-gcc 11.4.0`. |
| 2 | `docker run --rm -v "$(pwd)":/workspaces/kuna -w /workspaces/kuna kuna-dev bash -lc 'make binaries'` | **PASS** — full workspace (kuna-console, kuna-harness, kuna-slacomp, kuna-cli + deps) built in 28.9s, exit 0; `kuna --help` runs. (Ran the full `make binaries`, not just `kuna-cli`.) |
| 3 | ARM link proof (above) | **PASS** — `Type EXEC`, `Machine ARM`, LOAD segment (R E), Thumb-bit entry `0x100d1`. |

`make test` / `make rust-test` were **not** run here (this is infra+docs only; no engine code changed) — they remain the gates later analysis-port PRs will run inside this container.

## Docs

- `docs/devcontainer.md` — build/use, the three gates, cross-arch fixture how-to, full inventory, out-of-scope notes.
- `docs/analysis-port-frontier.md` — the live work-list / progress tracker for the fan-out (this is item #1; #2–#5 are unblocked by these cross linkers).

Scope: only `.devcontainer/` + `docs/`; no code touched; no build artifacts committed (`decompiler/target/` is gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvRnfTgYKoZvS2TEvdYpWb