### PR TITLE
Listing/xref tier (scope-B) PR0: recursive-descent disassembly core + design doc

### DIFF
--- a/decompiler/Cargo.lock
+++ b/decompiler/Cargo.lock
@@ -98,6 +98,7 @@ dependencies = [
  "kuna-decomp",
  "kuna-num",
  "kuna-sleigh",
+ "object",
 ]
 
 [[package]]

--- a/decompiler/crates/kuna-analysis/src/lib.rs
+++ b/decompiler/crates/kuna-analysis/src/lib.rs
@@ -56,3 +56,4 @@ pub mod s1_entry;
 pub mod s1_dwarf;
 pub mod s1_formatstring;
 pub mod s1_callfixup;
+pub mod listing;

--- a/decompiler/crates/kuna-analysis/src/listing/classify.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/classify.rs
@@ -1,0 +1,297 @@
+//! Flow classification of a decoded instruction's p-code (design doc §4.3).
+//!
+//! [`classify`] is a faithful transliteration of the decompiler's single source
+//! of truth, `s2_lift/flow.rs::xref_control_flow` (`flow.rs:1039-1185`). It maps
+//! the flat p-code op list the SLEIGH decoder emits for one machine instruction
+//! into a [`FlowType`], the list of static control targets, and the fall-through
+//! VMA. It performs no decode and needs no engine — it is pure over the ops, so
+//! it is unit-tested directly (see the tests at the bottom).
+//!
+//! Three load-bearing rules carried over from `flow.rs` (the design's gotchas):
+//!
+//!  1. **constant-space `in0` is p-code-relative, not a VMA.** A BRANCH/CBRANCH
+//!     whose `in0` is in the constant space is an *intra-instruction* relative
+//!     branch (a multi-op instruction branching within itself); for
+//!     single-instruction flow it resolves to fall-through and is never a real
+//!     target. Only a non-constant `in0` carries an absolute target VMA
+//!     (`flow.rs:1067-1109`). Always test `is_constant()` first.
+//!  2. **fall-through is decided by the LAST op, not the first.** An
+//!     instruction's *targets* come from every op, but its *fall-through* is the
+//!     last-op test only: it falls through UNLESS the last op is
+//!     BRANCH / BRANCHIND / RETURN (`flow.rs:1170-1183`). An instruction that
+//!     emits NO ops falls through.
+//!  3. **delay slots are already folded into `len`** by `one_instruction`, so
+//!     `fall_vma = vma + len` is correct — never re-decode the delay slot.
+
+use kuna_num::opcodes::OpCode;
+
+use super::model::{FlowKind, FlowType, RawOp};
+
+/// The result of classifying one instruction's p-code.
+pub struct Classified {
+    /// The instruction's flow type (predicate set + kind).
+    pub flow: FlowType,
+    /// Static control targets (absolute VMAs): branch/call destinations.
+    pub flows: Vec<u64>,
+    /// The fall-through VMA, or `None` for a terminal instruction.
+    pub fall_through: Option<u64>,
+}
+
+/// Classify the p-code `ops` emitted for the instruction at `vma` of byte length
+/// `len`. Faithful to `xref_control_flow` (`flow.rs:1039-1185`).
+///
+/// `flows` collects only *statically derivable* absolute targets: constant-space
+/// (p-code-relative) branch operands and indirect (BRANCHIND/CALLIND) ops never
+/// contribute a target. The fall-through is the last-op test (gotcha 2).
+pub fn classify(ops: &[RawOp], vma: u64, len: u32) -> Classified {
+    let fall_vma = vma.wrapping_add(len as u64);
+    let mut flows: Vec<u64> = Vec::new();
+    let mut flow = FlowType::default();
+
+    // Per-op target collection + kind/predicate accumulation. The op order is
+    // observable in flow.rs; we walk every op so a multi-op instruction's
+    // targets are all collected (the last-op test below decides fall-through).
+    for op in ops {
+        match op.opcode {
+            OpCode::CPUI_CBRANCH => {
+                // Conditional branch: target unless the in0 is p-code-relative
+                // (constant space), which resolves to fall-through (gotcha 1).
+                if let Some(target) = absolute_branch_target(op) {
+                    flows.push(target);
+                }
+                flow.kind = FlowKind::ConditionalBranch;
+                flow.is_jump = true;
+                flow.is_conditional = true;
+            }
+            OpCode::CPUI_BRANCH => {
+                if let Some(target) = absolute_branch_target(op) {
+                    flows.push(target);
+                }
+                flow.kind = FlowKind::UnconditionalBranch;
+                flow.is_jump = true;
+            }
+            OpCode::CPUI_BRANCHIND => {
+                // Indirect/computed jump: no static target (deferred jump-table
+                // resolution, design §8). Recorded as computed/indirect.
+                flow.kind = FlowKind::ComputedJump;
+                flow.is_jump = true;
+                flow.is_computed = true;
+                flow.is_indirect = true;
+            }
+            OpCode::CPUI_CALL => {
+                // CALL target == in0 (flow.rs CALL case; the in0 address is the
+                // callee entry). It is a code address, never constant-relative.
+                if let Some(target) = absolute_branch_target(op) {
+                    flows.push(target);
+                }
+                flow.kind = FlowKind::Call;
+                flow.is_call = true;
+            }
+            OpCode::CPUI_CALLIND => {
+                // Indirect call: no static target, but it still falls through.
+                flow.kind = FlowKind::ComputedCall;
+                flow.is_call = true;
+                flow.is_computed = true;
+                flow.is_indirect = true;
+            }
+            OpCode::CPUI_CALLOTHER => {
+                flow.kind = FlowKind::CallOther;
+            }
+            OpCode::CPUI_RETURN => {
+                flow.kind = FlowKind::Return;
+                flow.is_terminal = true;
+            }
+            _ => {}
+        }
+    }
+
+    // Fall-through is the LAST-op test (gotcha 2): falls through unless the last
+    // op is BRANCH / BRANCHIND / RETURN. No ops at all ⇒ falls through.
+    let has_fallthrough = match ops.last() {
+        None => true,
+        Some(last) => !matches!(
+            last.opcode,
+            OpCode::CPUI_BRANCH | OpCode::CPUI_BRANCHIND | OpCode::CPUI_RETURN
+        ),
+    };
+    flow.has_fallthrough = has_fallthrough;
+    let fall_through = has_fallthrough.then_some(fall_vma);
+
+    Classified { flow, flows, fall_through }
+}
+
+/// The absolute target VMA carried by a branch/call op's `in0`, or `None` if the
+/// `in0` is constant-space (p-code-relative, intra-instruction — gotcha 1) or
+/// absent.
+fn absolute_branch_target(op: &RawOp) -> Option<u64> {
+    let in0 = op.in0.as_ref()?;
+    let addr = in0.get_addr();
+    if addr.is_constant() {
+        // p-code-relative: resolves to fall-through, never a real target.
+        None
+    } else {
+        Some(addr.get_offset())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::rc::Rc;
+
+    use kuna_base::space::{spacetype, AddrSpace};
+    use kuna_num::opcodes::OpCode;
+    use kuna_num::pcoderaw::VarnodeData;
+
+    use super::*;
+    use crate::listing::model::FlowKind;
+
+    /// A throwaway processor (RAM) space and the constant space, so we can build
+    /// `VarnodeData` whose `in0` is either an absolute code address (RAM) or a
+    /// p-code-relative constant.
+    fn spaces() -> (Rc<AddrSpace>, Rc<AddrSpace>) {
+        let ram = Rc::new(AddrSpace::new_for_decode(spacetype::IPTR_PROCESSOR));
+        let cst = Rc::new(AddrSpace::new_for_decode(spacetype::IPTR_CONSTANT));
+        (ram, cst)
+    }
+
+    /// A varnode at `offset` in the given space, 8 bytes wide.
+    fn vn(space: &Rc<AddrSpace>, offset: u64) -> VarnodeData {
+        VarnodeData { space: Some(Rc::clone(space)), offset, size: 8 }
+    }
+
+    fn op(opcode: OpCode, in0: Option<VarnodeData>) -> RawOp {
+        RawOp { opcode, in0 }
+    }
+
+    /// CBRANCH to an absolute target: two successors (target + fall-through),
+    /// ConditionalBranch, is_conditional set, falls through.
+    #[test]
+    fn cbranch_target_and_fallthrough() {
+        let (ram, _cst) = spaces();
+        let ops = vec![op(OpCode::CPUI_CBRANCH, Some(vn(&ram, 0x2000)))];
+        let c = classify(&ops, 0x1000, 4);
+        assert_eq!(c.flow.kind, FlowKind::ConditionalBranch);
+        assert!(c.flow.is_conditional);
+        assert!(c.flow.is_jump);
+        assert!(c.flow.has_fallthrough);
+        assert_eq!(c.flows, vec![0x2000]);
+        assert_eq!(c.fall_through, Some(0x1004));
+    }
+
+    /// Unconditional BRANCH: the target, NO fall-through.
+    #[test]
+    fn unconditional_branch_no_fallthrough() {
+        let (ram, _cst) = spaces();
+        let ops = vec![op(OpCode::CPUI_BRANCH, Some(vn(&ram, 0x3000)))];
+        let c = classify(&ops, 0x1000, 4);
+        assert_eq!(c.flow.kind, FlowKind::UnconditionalBranch);
+        assert!(!c.flow.has_fallthrough);
+        assert_eq!(c.flows, vec![0x3000]);
+        assert_eq!(c.fall_through, None);
+    }
+
+    /// CALL: the callee target, is_call, falls through (a call returns).
+    #[test]
+    fn call_target_falls_through() {
+        let (ram, _cst) = spaces();
+        let ops = vec![op(OpCode::CPUI_CALL, Some(vn(&ram, 0x4000)))];
+        let c = classify(&ops, 0x1000, 5);
+        assert_eq!(c.flow.kind, FlowKind::Call);
+        assert!(c.flow.is_call);
+        assert!(c.flow.has_fallthrough);
+        assert_eq!(c.flows, vec![0x4000]);
+        assert_eq!(c.fall_through, Some(0x1005));
+    }
+
+    /// RETURN: terminal — no fall-through, no target.
+    #[test]
+    fn return_is_terminal() {
+        let ops = vec![op(OpCode::CPUI_RETURN, None)];
+        let c = classify(&ops, 0x1000, 1);
+        assert_eq!(c.flow.kind, FlowKind::Return);
+        assert!(c.flow.is_terminal);
+        assert!(!c.flow.has_fallthrough);
+        assert!(c.flows.is_empty());
+        assert_eq!(c.fall_through, None);
+    }
+
+    /// BRANCHIND: computed/indirect, NO static target, no fall-through.
+    #[test]
+    fn branchind_is_computed_no_target() {
+        let (ram, _cst) = spaces();
+        // in0 of a BRANCHIND is a register/temp, not a code address; classify
+        // must NOT treat it as a target regardless.
+        let ops = vec![op(OpCode::CPUI_BRANCHIND, Some(vn(&ram, 0x9999)))];
+        let c = classify(&ops, 0x1000, 2);
+        assert_eq!(c.flow.kind, FlowKind::ComputedJump);
+        assert!(c.flow.is_computed);
+        assert!(c.flow.is_indirect);
+        assert!(c.flow.is_jump);
+        assert!(c.flows.is_empty(), "BRANCHIND yields no static target");
+        assert_eq!(c.fall_through, None);
+    }
+
+    /// CALLIND: computed/indirect call, NO static target, but FALLS THROUGH.
+    #[test]
+    fn callind_is_computed_falls_through() {
+        let (ram, _cst) = spaces();
+        let ops = vec![op(OpCode::CPUI_CALLIND, Some(vn(&ram, 0x9999)))];
+        let c = classify(&ops, 0x1000, 2);
+        assert_eq!(c.flow.kind, FlowKind::ComputedCall);
+        assert!(c.flow.is_call);
+        assert!(c.flow.is_computed);
+        assert!(c.flow.is_indirect);
+        assert!(c.flows.is_empty(), "CALLIND yields no static target");
+        assert_eq!(c.fall_through, Some(0x1002));
+    }
+
+    /// Gotcha 1: a constant-space BRANCH `in0` is p-code-relative (intra-insn),
+    /// NOT a real target. The instruction still classifies as a branch (so the
+    /// last-op test drops the fall-through), but it contributes no `flows` entry.
+    #[test]
+    fn constant_space_branch_in0_is_not_a_target() {
+        let (_ram, cst) = spaces();
+        // A relative BRANCH inside a multi-op instruction (offset 1 in the
+        // constant space ⇒ "the next p-code op", not VMA 0x1).
+        let ops = vec![op(OpCode::CPUI_BRANCH, Some(vn(&cst, 1)))];
+        let c = classify(&ops, 0x1000, 4);
+        assert_eq!(c.flow.kind, FlowKind::UnconditionalBranch);
+        assert!(
+            c.flows.is_empty(),
+            "a constant-space (p-code-relative) BRANCH in0 must not be a VMA target"
+        );
+        // Last op is BRANCH ⇒ still no fall-through.
+        assert_eq!(c.fall_through, None);
+    }
+
+    /// An ordinary multi-op instruction (no flow break): falls through, no
+    /// targets, Fallthrough kind.
+    #[test]
+    fn plain_instruction_falls_through() {
+        let (ram, _cst) = spaces();
+        let ops = vec![
+            op(OpCode::CPUI_COPY, Some(vn(&ram, 0x10))),
+            op(OpCode::CPUI_INT_ADD, Some(vn(&ram, 0x10))),
+        ];
+        let c = classify(&ops, 0x1000, 3);
+        assert_eq!(c.flow.kind, FlowKind::Fallthrough);
+        assert!(c.flow.has_fallthrough);
+        assert!(c.flows.is_empty());
+        assert_eq!(c.fall_through, Some(0x1003));
+    }
+
+    /// Gotcha 2: a CBRANCH followed by trailing non-flow ops still falls through
+    /// (the LAST op is not a flow break), AND keeps its absolute target.
+    #[test]
+    fn cbranch_then_trailing_op_keeps_fallthrough() {
+        let (ram, _cst) = spaces();
+        let ops = vec![
+            op(OpCode::CPUI_CBRANCH, Some(vn(&ram, 0x2000))),
+            op(OpCode::CPUI_COPY, Some(vn(&ram, 0x10))),
+        ];
+        let c = classify(&ops, 0x1000, 4);
+        assert_eq!(c.flow.kind, FlowKind::ConditionalBranch);
+        assert_eq!(c.flows, vec![0x2000]);
+        assert_eq!(c.fall_through, Some(0x1004));
+    }
+}

--- a/decompiler/crates/kuna-analysis/src/listing/decode.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/decode.rs
@@ -1,0 +1,92 @@
+//! Decode one machine instruction by driving the ported SLEIGH engine (design §4).
+//!
+//! The decompiler returns **length + a flat list of p-code ops** via a
+//! [`PcodeEmit`] sink (there is no `getFlow()` outside the decompiler), and the
+//! mnemonic via a parallel [`AssemblyEmit`] sink. [`decode_one`] builds an
+//! [`Address`] in the code space, drives [`Translate::one_instruction`] with a
+//! capturing `PcodeEmit`, and [`Translate::print_assembly`] with a capturing
+//! `AssemblyEmit`, returning `(len, ops, mnemonic)`.
+//!
+//! The decode reads bytes through the loader the engine already has attached
+//! (the same loader `bootstrap_from_elf` installed), so no extra setup is needed
+//! beyond a live [`Translate`].
+
+use std::rc::Rc;
+
+use kuna_base::address::Address;
+use kuna_base::space::AddrSpace;
+use kuna_base::error::KunaResult;
+use kuna_num::opcodes::OpCode;
+use kuna_num::pcoderaw::VarnodeData;
+use kuna_sleigh::translate::{AssemblyEmit, PcodeEmit, Translate};
+
+use super::model::RawOp;
+
+/// A capturing [`PcodeEmit`] that records the emitted ops (opcode + first input)
+/// for one instruction. Only `in0` is kept — enough for the classifier and a
+/// future `skipNOPS` consumer (design §2.1).
+#[derive(Default)]
+struct OpCapture {
+    ops: Vec<RawOp>,
+}
+
+impl PcodeEmit for OpCapture {
+    fn dump(
+        &mut self,
+        _addr: &Address,
+        opc: OpCode,
+        _outvar: Option<&VarnodeData>,
+        vars: &[VarnodeData],
+    ) {
+        self.ops.push(RawOp { opcode: opc, in0: vars.first().cloned() });
+    }
+}
+
+/// A capturing [`AssemblyEmit`] that records the mnemonic for one instruction.
+#[derive(Default)]
+struct AsmCapture {
+    mnemonic: String,
+}
+
+impl AssemblyEmit for AsmCapture {
+    fn dump(&mut self, _addr: &Address, mnem: &str, _body: &str) {
+        self.mnemonic = mnem.to_string();
+    }
+}
+
+/// One decoded instruction's raw output.
+pub struct Decoded {
+    /// The fall-through byte length (the `one_instruction` return; folds in
+    /// delay slots — design §4.3 gotcha 3).
+    pub len: u32,
+    /// The flat p-code op list the decoder emitted.
+    pub ops: Vec<RawOp>,
+    /// The decoded mnemonic.
+    pub mnemonic: String,
+}
+
+/// Decode the instruction at `vma` (in `code_space`) by driving `translate`.
+///
+/// Returns `Err` for an undecodable address (`KunaError::Unimpl` / `BadData`
+/// from the engine); the caller's policy is to stop-this-path on an error
+/// (design §3.4). The mnemonic capture is best-effort: if `print_assembly`
+/// errs after `one_instruction` succeeded, the instruction is still returned
+/// (with whatever mnemonic was captured, possibly empty) — the p-code (and thus
+/// the flow classification) is the load-bearing output.
+pub fn decode_one(
+    translate: &dyn Translate,
+    vma: u64,
+    code_space: &Rc<AddrSpace>,
+) -> KunaResult<Decoded> {
+    let addr = Address::new(Rc::clone(code_space), vma);
+
+    let mut cap = OpCapture::default();
+    let len = translate.one_instruction(&mut cap, &addr)?;
+
+    let mut asm = AsmCapture::default();
+    // The mnemonic is non-essential to flow; if the disassembly emit errs we
+    // keep the (possibly empty) captured string rather than failing the decode.
+    let _ = translate.print_assembly(&mut asm, &addr);
+
+    Ok(Decoded { len: len.max(0) as u32, ops: cap.ops, mnemonic: asm.mnemonic })
+}

--- a/decompiler/crates/kuna-analysis/src/listing/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/mod.rs
@@ -1,0 +1,198 @@
+//! The Listing/xref tier — a post-disassembly recursive-descent disassembler +
+//! instruction/xref/function model that reuses the ported SLEIGH decoder.
+//!
+//! This is **scope-B**: an optional, default-OFF subsystem (the canonical spec
+//! is `docs/listing-tier-design.md`). It performs program-wide recursive-descent
+//! disassembly over loadimage bytes — reusing [`Translate::one_instruction`] and
+//! a *lifted copy* of the S2 flow classifier ([`classify`]) — to build three
+//! sub-models behind one [`Listing`] facade:
+//!
+//!  - the **instruction model** ([`model::Insn`]),
+//!  - the **cross-reference model** ([`model::Reference`], Call/Code edges), and
+//!  - the **discovered-function model** ([`model::DiscoveredFunction`]).
+//!
+//! # PR0 scope (this module)
+//!
+//! The keystone core: [`model`], [`decode`], [`classify`], [`walk`], and the
+//! [`Listing`] facade. [`Listing::build`] is assembled but **not invoked from
+//! the engine** (PR2) and has **no `--option` flag** (PR1) and **no
+//! `AnalysisCtx` change** (PR1). `context.rs` (ARM/MIPS decode-context paint) is
+//! PR5; x86-64 (the PR0 target) needs no context. The CodeUnit partition
+//! *queries* are PR3, but the [`model::CodeUnit`] type and the
+//! `covered`/`exec_ranges` fields are defined here now.
+
+pub mod classify;
+pub mod decode;
+pub mod model;
+pub mod walk;
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use kuna_base::address::RangeList;
+use kuna_decomp::architecture::Architecture;
+use kuna_sleigh::translate::Translate;
+
+use crate::loadimage_object::ObjectLoadImage;
+
+pub use model::{
+    CodeUnit, DiscoveredFunction, FlowKind, FlowType, Insn, RawOp, RefKind, Reference,
+};
+
+/// The Listing facade: three sub-models sharing one decode pass (design §2.5).
+pub struct Listing {
+    /// Instruction model, keyed by VMA.
+    insns: BTreeMap<u64, Insn>,
+    /// Incoming xref edges (callers / branch sources), keyed by target VMA.
+    refs_to: BTreeMap<u64, Vec<Reference>>,
+    /// Outgoing xref edges, keyed by source VMA.
+    refs_from: BTreeMap<u64, Vec<Reference>>,
+    /// Discovered/seeded functions, keyed by entry VMA (ordered).
+    funcs: BTreeMap<u64, DiscoveredFunction>,
+    /// Instruction-byte coverage (`[vma, vma+len-1]` per decoded insn).
+    #[allow(dead_code)] // gap = exec_ranges - covered: queried in PR3/PR7.
+    covered: RangeList,
+    /// The coverage universe for the partition / gap walk.
+    #[allow(dead_code)] // partition / gap queries are PR3/PR7.
+    exec_ranges: Vec<(u64, u64)>,
+}
+
+impl Listing {
+    /// Build the Listing by recursive-descent over the loadimage, seeded from
+    /// `seeds` (design §3). `file` supplies the executable-range universe;
+    /// `image` and `arch` are part of the keystone contract (the partition uses
+    /// the exec ranges; the decode reads through the engine loader). `translate`
+    /// drives the SLEIGH decoder.
+    ///
+    /// `seed_names` is an optional `(addr, name)` overlay for the seed functions
+    /// (e.g. from `existing_function_addrs` / entry-name overlays). `from_symbol`
+    /// is recorded for every seed listed in `funcsym_seeds`.
+    pub fn build(
+        file: &object::File,
+        _image: &ObjectLoadImage,
+        arch: &Architecture,
+        translate: &dyn Translate,
+        seeds: &[u64],
+    ) -> Listing {
+        Self::build_with_meta(file, _image, arch, translate, seeds, &[], &[])
+    }
+
+    /// Like [`Listing::build`], but with seed metadata: `funcsym_seeds` is the
+    /// subset of `seeds` that came from a real funcsym (sets `from_symbol`), and
+    /// `seed_names` is an `(addr, name)` overlay for naming seed functions.
+    pub fn build_with_meta(
+        file: &object::File,
+        _image: &ObjectLoadImage,
+        arch: &Architecture,
+        translate: &dyn Translate,
+        seeds: &[u64],
+        funcsym_seeds: &[u64],
+        seed_names: &[(u64, String)],
+    ) -> Listing {
+        // The executable-range universe (design §2.4 / §3.4 out-of-bounds gate).
+        let exec_ranges: Vec<(u64, u64)> = crate::s1_entry::executable_sections(file)
+            .into_iter()
+            .map(|(lo, hi, _data)| (lo, hi))
+            .collect();
+
+        // The code space the Addresses are built in.
+        let code_space = match arch.manage().get_default_code_space() {
+            Some(s) => Rc::clone(s),
+            None => {
+                // No code space ⇒ nothing decodable; return an empty Listing.
+                return Listing {
+                    insns: BTreeMap::new(),
+                    refs_to: BTreeMap::new(),
+                    refs_from: BTreeMap::new(),
+                    funcs: BTreeMap::new(),
+                    covered: RangeList::new(),
+                    exec_ranges,
+                };
+            }
+        };
+
+        // Build the seed metadata map.
+        let name_of: BTreeMap<u64, String> =
+            seed_names.iter().map(|(a, n)| (*a, n.clone())).collect();
+        let mut seed_funcs: BTreeMap<u64, DiscoveredFunction> = BTreeMap::new();
+        for &entry in seeds {
+            seed_funcs.insert(
+                entry,
+                DiscoveredFunction {
+                    entry,
+                    name: name_of.get(&entry).cloned(),
+                    from_symbol: funcsym_seeds.contains(&entry),
+                    has_no_return: false,
+                    call_fixup: None,
+                },
+            );
+        }
+
+        let st = walk::walk(translate, &code_space, &exec_ranges, seeds, &seed_funcs);
+
+        Listing {
+            insns: st.insns,
+            refs_to: st.refs_to,
+            refs_from: st.refs_from,
+            funcs: st.funcs,
+            covered: st.covered,
+            exec_ranges,
+        }
+    }
+
+    // ---- instruction model ----
+
+    /// The instruction starting exactly at `vma`, if one was decoded.
+    pub fn instruction_at(&self, vma: u64) -> Option<&Insn> {
+        self.insns.get(&vma)
+    }
+
+    /// True iff a decoded instruction starts exactly at `vma`.
+    pub fn is_instruction_start(&self, vma: u64) -> bool {
+        self.insns.contains_key(&vma)
+    }
+
+    /// The number of decoded instructions.
+    pub fn num_instructions(&self) -> usize {
+        self.insns.len()
+    }
+
+    /// Iterate the decoded instructions in address order.
+    pub fn instructions(&self) -> impl Iterator<Item = (&u64, &Insn)> {
+        self.insns.iter()
+    }
+
+    // ---- xref model (read-only) ----
+
+    /// Incoming references to `to` (callers / branch sources).
+    pub fn refs_to(&self, to: u64) -> &[Reference] {
+        self.refs_to.get(&to).map(Vec::as_slice).unwrap_or(&[])
+    }
+
+    /// Outgoing references from `from`.
+    pub fn refs_from(&self, from: u64) -> &[Reference] {
+        self.refs_from.get(&from).map(Vec::as_slice).unwrap_or(&[])
+    }
+
+    // ---- function model (ordered) ----
+
+    /// The function entry at exactly `vma`, if any.
+    pub fn function_at(&self, vma: u64) -> Option<&DiscoveredFunction> {
+        self.funcs.get(&vma)
+    }
+
+    /// The next function strictly after `vma`, by address (ordered query).
+    pub fn next_function_after(&self, vma: u64) -> Option<&DiscoveredFunction> {
+        self.funcs.range(vma + 1..).next().map(|(_, f)| f)
+    }
+
+    /// The number of discovered/seeded functions.
+    pub fn function_count(&self) -> usize {
+        self.funcs.len()
+    }
+
+    /// Iterate the functions in address order.
+    pub fn functions(&self) -> impl Iterator<Item = (&u64, &DiscoveredFunction)> {
+        self.funcs.iter()
+    }
+}

--- a/decompiler/crates/kuna-analysis/src/listing/model.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/model.rs
@@ -1,0 +1,158 @@
+//! Core data model for the Listing/xref tier (design doc `docs/listing-tier-design.md` §2).
+//!
+//! Three sub-models behind one [`super::Listing`] facade: the instruction model
+//! ([`Insn`]/[`FlowType`]/[`FlowKind`]/[`RawOp`]), the cross-reference model
+//! ([`Reference`]/[`RefKind`]), and the discovered-function model
+//! ([`DiscoveredFunction`]). [`CodeUnit`] is the program-partition projection.
+//!
+//! These are owned, flat structs produced by the recursive-descent walk
+//! ([`super::walk`]); they never borrow the engine. The `FlowType` predicate set
+//! is the faithful projection of Ghidra's `FlowType` (`typeop.rs`/`op.rs` flags),
+//! derived once from the emitted p-code by [`super::classify::classify`], the
+//! lifted copy of `s2_lift/flow.rs::xref_control_flow`.
+
+use kuna_num::opcodes::OpCode;
+use kuna_num::pcoderaw::VarnodeData;
+
+/// One decoded machine instruction. Owned; produced by the walker.
+///
+/// `len` is the fall-through byte length the SLEIGH decoder returned from
+/// `one_instruction` — it already folds in delay slots (SPARC/MIPS), so
+/// `addr + len` is the correct fall-through VMA (design §4.3 gotcha 3).
+#[derive(Debug, Clone)]
+pub struct Insn {
+    /// `getMinAddress` — the instruction's VMA.
+    pub addr: u64,
+    /// Bytes consumed incl. delay slots (the `one_instruction` return value).
+    pub len: u32,
+    /// `None` iff `!flow.has_fallthrough` (a terminal instruction).
+    pub fall_through: Option<u64>,
+    /// Flow class projected from the emitted p-code (NOT a separate API result).
+    pub flow: FlowType,
+    /// Static control targets (`getFlows`): branch/call destination VMAs.
+    pub flows: Vec<u64>,
+    /// The decoded mnemonic (from a capturing `AssemblyEmit`).
+    pub mnemonic: String,
+    /// Lazy: only `skipNOPS` / `isUsedForCalculation` need the raw ops, so the
+    /// common case keeps this `None` (design §2.1 / §8).
+    pub pcode: Option<Vec<RawOp>>,
+}
+
+/// Faithful projection of Ghidra's `FlowType` predicate set.
+///
+/// The predicates are derived once from the [`FlowKind`] (which itself is the
+/// OpCode → flow-class projection), so this is the same bit-logic Ghidra uses
+/// (`op.rs` `pcodeop_flags`), not a re-classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct FlowType {
+    /// The flow class of the instruction.
+    pub kind: FlowKind,
+    /// CALL / CALLIND.
+    pub is_call: bool,
+    /// BRANCH / CBRANCH / BRANCHIND (any branch).
+    pub is_jump: bool,
+    /// RETURN (no fall-through, no static target).
+    pub is_terminal: bool,
+    /// Indirect/computed target (BRANCHIND / CALLIND).
+    pub is_computed: bool,
+    /// Indirect target (BRANCHIND / CALLIND).
+    pub is_indirect: bool,
+    /// CBRANCH (conditional — also falls through).
+    pub is_conditional: bool,
+    /// `true` unless the LAST op is BRANCH / BRANCHIND / RETURN (design §4.3).
+    pub has_fallthrough: bool,
+}
+
+/// OpCode → flow-class projection (mirrors `typeop.rs` / `op.rs` flow flags).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FlowKind {
+    /// Emits ops; last op is not a flow break. Falls through.
+    #[default]
+    Fallthrough,
+    /// Last op `CPUI_BRANCH` with a non-constant `in0`. No fall-through.
+    UnconditionalBranch,
+    /// `CPUI_CBRANCH` — also falls through.
+    ConditionalBranch,
+    /// `CPUI_BRANCHIND` — indirect, target unresolved. No fall-through.
+    ComputedJump,
+    /// `CPUI_CALL` — falls through.
+    Call,
+    /// `CPUI_CALLIND` — indirect, falls through.
+    ComputedCall,
+    /// `CPUI_CALLOTHER` — syscall/userop, falls through.
+    CallOther,
+    /// `CPUI_RETURN` — terminal.
+    Return,
+    /// Decode produced no flow effect at all (rare; treated as fall-through).
+    Unimplemented,
+}
+
+/// Minimal captured p-code op (materialized only when [`Insn::pcode`] is set).
+///
+/// Carries just enough for a future `skipNOPS` / `isUsedForCalculation`
+/// consumer: the opcode and the first input varnode.
+#[derive(Debug, Clone)]
+pub struct RawOp {
+    /// The op's opcode.
+    pub opcode: OpCode,
+    /// The first input varnode, if any (`in0`).
+    pub in0: Option<VarnodeData>,
+}
+
+/// The kind of a cross-reference edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefKind {
+    /// A CALL/CALLIND edge (callsite → callee entry).
+    Call,
+    /// A branch/jump/fall-through edge (intra-function control flow).
+    Code,
+    /// A data reference (reserved; not populated by the keystone — design §2.2).
+    Data,
+    /// A read of a data location (reserved).
+    Read,
+    /// A write to a data location (reserved).
+    Write,
+}
+
+/// A cross-reference edge `from -> to`.
+///
+/// The keystone populates only [`RefKind::Call`] and [`RefKind::Code`] (control
+/// flow); the data kinds and `op_index` are present for faithfulness (so the
+/// type never changes if operand markup is ever revisited) — design §2.2.
+#[derive(Debug, Clone)]
+pub struct Reference {
+    /// Source VMA (the referencing instruction).
+    pub from: u64,
+    /// Target VMA (the referenced location).
+    pub to: u64,
+    /// The edge kind.
+    pub kind: RefKind,
+    /// Operand index (reserved for operand markup; mostly `None`).
+    pub op_index: Option<u8>,
+}
+
+/// A function entry discovered (or seeded) by the walk.
+#[derive(Debug, Clone)]
+pub struct DiscoveredFunction {
+    /// The function entry VMA.
+    pub entry: u64,
+    /// Name from a funcsym / entry-name overlay; `None` ⇒ `sub_<addr>`.
+    pub name: Option<String>,
+    /// `true` iff seeded by a real funcsym (vs discovered via a CALL target).
+    pub from_symbol: bool,
+    /// Seeded from the no-return Known-list (refined by a future consumer).
+    pub has_no_return: bool,
+    /// From `s1_callfixup` facts (skip-modeled-callees); `None` for the keystone.
+    pub call_fixup: Option<String>,
+}
+
+/// The code/data partition class of a VMA (design §2.4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodeUnit {
+    /// The start of a decoded instruction (carries the instruction's VMA).
+    Instruction(u64),
+    /// A typed data record (carries `(addr, len)`).
+    Data(u64, u32),
+    /// Neither code nor typed data inside an executable range.
+    Undefined,
+}

--- a/decompiler/crates/kuna-analysis/src/listing/walk.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/walk.rs
@@ -1,0 +1,167 @@
+//! The recursive-descent disassembly driver (design §3).
+//!
+//! Two-level worklist, mirroring `FlowInfo`'s `VisitStat`/`addrlist` *design*
+//! (`flow.rs`) but lightweight (no `Funcdata`, no banks, no blocks): an outer
+//! **function worklist** (CALL targets become new function entries) and an inner
+//! per-function **instruction worklist** (branch/fall-through successors).
+//!
+//! The walk is the program-wide extension `FlowInfo` lacks: `FlowInfo` stops at
+//! RETURN, treats CALL as fall-through, and never recurses into callees; here a
+//! CALL/CALLIND *direct* target seeds a new function entry. Indirect targets
+//! (BRANCHIND/CALLIND) are recorded with the computed/indirect predicates but
+//! contribute NO static successor (deferred jump-table resolution, design §8).
+//!
+//! Termination: `visited_funcs` bounds the function worklist and `insns`
+//! membership bounds the instruction worklist; both are monotonic over a finite
+//! address universe.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::rc::Rc;
+
+use kuna_base::address::RangeList;
+use kuna_base::space::AddrSpace;
+use kuna_sleigh::translate::Translate;
+
+use super::classify::classify;
+use super::decode::decode_one;
+use super::model::{DiscoveredFunction, Insn, Reference, RefKind};
+
+/// The accumulating maps the walk fills. Lifted into [`super::Listing`] by
+/// [`super::Listing::build`].
+pub(super) struct WalkState {
+    /// Instruction model, keyed by VMA.
+    pub insns: BTreeMap<u64, Insn>,
+    /// Incoming xref edges (callers / branch sources), keyed by target VMA.
+    pub refs_to: BTreeMap<u64, Vec<Reference>>,
+    /// Outgoing xref edges, keyed by source VMA.
+    pub refs_from: BTreeMap<u64, Vec<Reference>>,
+    /// Discovered/seeded functions, keyed by entry VMA (ordered).
+    pub funcs: BTreeMap<u64, DiscoveredFunction>,
+    /// Instruction-byte coverage (`[vma, vma+len-1]` per decoded insn).
+    pub covered: RangeList,
+}
+
+impl WalkState {
+    fn new() -> Self {
+        WalkState {
+            insns: BTreeMap::new(),
+            refs_to: BTreeMap::new(),
+            refs_from: BTreeMap::new(),
+            funcs: BTreeMap::new(),
+            covered: RangeList::new(),
+        }
+    }
+
+    /// File a reference into both directions (`refs_to[to]` and `refs_from[from]`).
+    fn file_ref(&mut self, from: u64, to: u64, kind: RefKind) {
+        let r = Reference { from, to, kind, op_index: None };
+        self.refs_to.entry(to).or_default().push(r.clone());
+        self.refs_from.entry(from).or_default().push(r);
+    }
+}
+
+/// True if `vma` lands inside any executable range `[lo, hi)`.
+fn in_exec(exec_ranges: &[(u64, u64)], vma: u64) -> bool {
+    exec_ranges.iter().any(|&(lo, hi)| vma >= lo && vma < hi)
+}
+
+/// Run the two-level recursive-descent walk.
+///
+/// `seeds` is the function-entry root set the caller supplies (already
+/// exec-filtered/deduped — design §3.1). `seed_funcs` carries the
+/// [`DiscoveredFunction`] metadata for each seed (name / from_symbol); seeds
+/// without an entry there get a generic discovered record. `exec_ranges` bounds
+/// every decode (out-of-bounds = stop-this-path). `code_space` is the space the
+/// `Address`es are built in.
+pub(super) fn walk(
+    translate: &dyn Translate,
+    code_space: &Rc<AddrSpace>,
+    exec_ranges: &[(u64, u64)],
+    seeds: &[u64],
+    seed_funcs: &BTreeMap<u64, DiscoveredFunction>,
+) -> WalkState {
+    let mut st = WalkState::new();
+
+    // Function-entry worklist, seeded from the root set.
+    let mut func_worklist: Vec<u64> = seeds.to_vec();
+    let mut visited_funcs: BTreeSet<u64> = BTreeSet::new();
+
+    // Pre-populate the function model with the seed metadata so a seeded entry
+    // keeps its name/from_symbol even if a later CALL also targets it.
+    for &entry in seeds {
+        let df = seed_funcs.get(&entry).cloned().unwrap_or_else(|| discovered(entry));
+        st.funcs.entry(entry).or_insert(df);
+    }
+
+    while let Some(entry) = func_worklist.pop() {
+        if !visited_funcs.insert(entry) {
+            continue; // already walked this function
+        }
+
+        // Per-function instruction worklist.
+        let mut insn_worklist: Vec<u64> = vec![entry];
+        while let Some(vma) = insn_worklist.pop() {
+            if st.insns.contains_key(&vma) {
+                continue; // the VisitStat dedup (overlap detection free)
+            }
+            if !in_exec(exec_ranges, vma) {
+                continue; // out-of-bounds gate (flow.rs:891 analog)
+            }
+
+            let decoded = match decode_one(translate, vma, code_space) {
+                Ok(d) => d,
+                Err(_) => continue, // decode error: stop this path (mark gap)
+            };
+            if decoded.len == 0 {
+                continue; // zero-length decode would not advance; stop this path
+            }
+
+            let c = classify(&decoded.ops, vma, decoded.len);
+
+            st.insns.insert(
+                vma,
+                Insn {
+                    addr: vma,
+                    len: decoded.len,
+                    fall_through: c.fall_through,
+                    flow: c.flow,
+                    flows: c.flows.clone(),
+                    mnemonic: decoded.mnemonic,
+                    pcode: None,
+                },
+            );
+            st.covered.insert_range(Rc::clone(code_space), vma, vma + decoded.len as u64 - 1);
+
+            // Successor edges.
+            for &t in &c.flows {
+                if c.flow.is_call {
+                    // CALL/CALLIND direct target → a NEW function entry.
+                    st.funcs.entry(t).or_insert_with(|| discovered(t));
+                    func_worklist.push(t);
+                    st.file_ref(vma, t, RefKind::Call);
+                } else {
+                    // Branch target → same-function successor.
+                    insn_worklist.push(t);
+                    st.file_ref(vma, t, RefKind::Code);
+                }
+            }
+            if let Some(fall) = c.fall_through {
+                insn_worklist.push(fall);
+                st.file_ref(vma, fall, RefKind::Code);
+            }
+        }
+    }
+
+    st
+}
+
+/// A generic discovered (not symbol-seeded) function record at `entry`.
+fn discovered(entry: u64) -> DiscoveredFunction {
+    DiscoveredFunction {
+        entry,
+        name: None,
+        from_symbol: false,
+        has_no_return: false,
+        call_fixup: None,
+    }
+}

--- a/decompiler/crates/kuna-analysis/src/s1_entry/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/s1_entry/mod.rs
@@ -221,7 +221,7 @@ pub fn collect_entry_names(file: &object::File, kept: &[u64]) -> Vec<(u64, Strin
 /// `(address, address+size, data)` for every executable section. SHF_EXECINSTR
 /// or the high-level `SectionKind::Text` (`.text`/`.init`/`.fini`/`.plt`). Used
 /// both as the prologue-sweep target and the "is this VMA plausible code?" oracle.
-fn executable_sections(file: &object::File) -> Vec<(u64, u64, Vec<u8>)> {
+pub(crate) fn executable_sections(file: &object::File) -> Vec<(u64, u64, Vec<u8>)> {
     // ELF section header flag: SHF_EXECINSTR (the section holds machine code).
     const SHF_EXECINSTR: u64 = 0x4;
 
@@ -246,7 +246,7 @@ fn executable_sections(file: &object::File) -> Vec<(u64, u64, Vec<u8>)> {
 }
 
 /// True if `vma` lands inside any executable section's `[address, address+size)`.
-fn in_executable_section(execs: &[(u64, u64, Vec<u8>)], vma: u64) -> bool {
+pub(crate) fn in_executable_section(execs: &[(u64, u64, Vec<u8>)], vma: u64) -> bool {
     execs.iter().any(|&(lo, hi, _)| vma >= lo && vma < hi)
 }
 
@@ -254,7 +254,7 @@ fn in_executable_section(execs: &[(u64, u64, Vec<u8>)], vma: u64) -> bool {
 /// FUNC symbols (UND imports have `st_value == 0`) plus PLT import stubs. The
 /// commit seam's `find_function` already no-ops a covered address, but skipping
 /// these here keeps the emitted set to genuinely *new* starts.
-fn existing_function_addrs(file: &object::File) -> Vec<u64> {
+pub(crate) fn existing_function_addrs(file: &object::File) -> Vec<u64> {
     let mut out: Vec<u64> = Vec::new();
     for sym in file.symbols().chain(file.dynamic_symbols()) {
         if sym.kind() != SymbolKind::Text {

--- a/decompiler/crates/kuna-console/Cargo.toml
+++ b/decompiler/crates/kuna-console/Cargo.toml
@@ -14,6 +14,11 @@ kuna-num.workspace = true
 kuna-sleigh.workspace = true
 kuna-analysis.workspace = true
 
+[dev-dependencies]
+# The Listing/xref tier integration test (`tests/verify_listing_core.rs`) parses
+# the fixture ELF into an `object::File` to drive `Listing::build`.
+object.workspace = true
+
 [lints]
 workspace = true
 

--- a/decompiler/crates/kuna-console/tests/verify_listing_core.rs
+++ b/decompiler/crates/kuna-console/tests/verify_listing_core.rs
@@ -1,0 +1,207 @@
+//! End-to-end gate for the Listing/xref tier keystone (scope-B PR0).
+//!
+//! Drives `Listing::build` over a real, bootstrapped x86-64 ELF — the
+//! recursive-descent disassembler reusing the ported SLEIGH decoder
+//! (`Translate::one_instruction` + `print_assembly`) and the lifted flow
+//! classifier — and asserts the design doc's §7 PR0 acceptance criteria against
+//! the vendored `fauxware` fixture (a non-PIE x86-64 with a `main` that calls a
+//! helper, contains a CBRANCH, and a RETURN).
+//!
+//! Obtaining a real `Translate` is the whole point: `Listing::build` decodes
+//! through the SLEIGH engine, which needs the `.sla` loaded and the loadimage
+//! attached. The realistic place is here (a `kuna-console` integration test):
+//! `bootstrap_from_elf` gives a fully-built `ConsoleProgram`, and
+//! `prog.arch().translate()` is the `&dyn Translate` the keystone drives, with
+//! `prog.arch().manage()` supplying the default code space.
+//!
+//! ## `.sla` precondition
+//!
+//! Like the sibling `verify_*` gates, bootstrapping needs the built x86 `.sla`
+//! under `specs/` (gitignored; `make specs`). When it is absent the bootstrap
+//! fails; the test prints that and returns early (a specs-less CI is a visible
+//! skip, never a false green).
+
+use std::path::PathBuf;
+
+use kuna_analysis::listing::{FlowKind, Listing, RefKind};
+use kuna_console::engine::bootstrap_from_elf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+/// The vendored non-PIE x86-64 fauxware fixture (shared with several gates). Its
+/// `main` (0x40071d) calls `authenticate` (0x400664), has a CBRANCH `je` at
+/// 0x4007bb, and a `ret` at 0x4007d4 — the exact load-bearing sites below.
+fn fauxware() -> PathBuf {
+    repo_root().join("decompiler/crates/kuna-analysis/tests/fixtures/fauxware")
+}
+
+// Load-bearing VMAs, read from `objdump -d` of the fixture at test-write time
+// (a non-PIE ET_EXEC, so the addresses are stable file offsets+base 0x400000):
+const MAIN: u64 = 0x40071d; // <main>: push %rbp
+const AUTHENTICATE: u64 = 0x400664; // <authenticate>
+const CALL_AUTH: u64 = 0x4007ae; // call 400664 <authenticate>
+const CBRANCH_JE: u64 = 0x4007bb; // je 4007c9   (target 0x4007c9, fall 0x4007bd)
+const CBRANCH_TARGET: u64 = 0x4007c9;
+const CBRANCH_FALL: u64 = 0x4007bd;
+const RET: u64 = 0x4007d4; // ret
+
+#[test]
+fn listing_build_recovers_instructions_flow_and_functions() {
+    let root = repo_root();
+    let specs = root.join("specs");
+    let spec_roots = vec![specs.to_str().unwrap().to_string()];
+
+    let bin = fauxware();
+    let bin = match bin.to_str() {
+        Some(s) => s.to_string(),
+        None => return,
+    };
+
+    let prog = match bootstrap_from_elf(&bin, "", &spec_roots) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "verify_listing_core: skipping (bootstrap failed, build the x86 `.sla` with \
+                 `make specs`): {}",
+                e.explain()
+            );
+            return;
+        }
+    };
+
+    // Parse the fixture bytes into an `object::File` for the exec-range universe,
+    // and build the seed set the way PR2 will: existing funcsyms ∪ discovered
+    // entries. fauxware is not stripped, so its funcsyms (incl. `main`) seed the
+    // walk; we add `main` explicitly to be robust to the funcsym filter.
+    let bytes = std::fs::read(&bin).expect("read fixture bytes");
+    let file = object::File::parse(&*bytes).expect("parse fixture ELF");
+
+    let mut seeds = kuna_analysis::s1_entry::collect_entries(&file);
+    seeds.push(MAIN);
+    seeds.sort_unstable();
+    seeds.dedup();
+
+    let arch = prog.arch();
+    let translate = arch.translate();
+
+    // The keystone's `image` parameter: the PR0 decode path reads through the
+    // engine loader the bootstrap already attached (it drives `translate`), so a
+    // throwaway `ObjectLoadImage` over the same bytes satisfies the contract.
+    let image = kuna_analysis::loadimage_object::ObjectLoadImage::from_bytes(&bin, &bytes)
+        .expect("open throwaway loadimage");
+
+    // The keystone: recursive-descent disassembly over the loadimage, seeded
+    // from `seeds`, reusing the SLEIGH decoder + the lifted flow classifier.
+    let listing = Listing::build(&file, &image, arch, translate, &seeds);
+
+    // --- (a) instruction_at(entry) has a plausible len + non-empty mnemonic. --
+    let entry = listing
+        .instruction_at(MAIN)
+        .unwrap_or_else(|| panic!("no instruction decoded at main ({MAIN:#x})"));
+    assert!(
+        entry.len >= 1 && entry.len <= 15,
+        "main's first instruction has an implausible length {}",
+        entry.len
+    );
+    assert!(
+        !entry.mnemonic.is_empty(),
+        "main's first instruction has an empty mnemonic"
+    );
+
+    // --- (b) a known CBRANCH yields two successors and ConditionalBranch. ------
+    let cb = listing
+        .instruction_at(CBRANCH_JE)
+        .unwrap_or_else(|| panic!("CBRANCH site {CBRANCH_JE:#x} not decoded"));
+    assert_eq!(
+        cb.flow.kind,
+        FlowKind::ConditionalBranch,
+        "the `je` at {CBRANCH_JE:#x} must classify as a ConditionalBranch, got {:?}",
+        cb.flow.kind
+    );
+    assert!(cb.flow.is_conditional, "the `je` must be is_conditional");
+    // Two successors: the branch target (in `flows`) + the fall-through.
+    assert!(
+        cb.flows.contains(&CBRANCH_TARGET),
+        "the `je` must target {CBRANCH_TARGET:#x}, flows = {:#x?}",
+        cb.flows
+    );
+    assert_eq!(
+        cb.fall_through,
+        Some(CBRANCH_FALL),
+        "the `je` must fall through to {CBRANCH_FALL:#x}"
+    );
+
+    // --- (c) a RETURN site is terminal (fall_through == None). -----------------
+    let ret = listing
+        .instruction_at(RET)
+        .unwrap_or_else(|| panic!("RETURN site {RET:#x} not decoded"));
+    assert_eq!(
+        ret.flow.kind,
+        FlowKind::Return,
+        "the `ret` at {RET:#x} must classify as Return, got {:?}",
+        ret.flow.kind
+    );
+    assert!(ret.flow.is_terminal, "the `ret` must be is_terminal");
+    assert_eq!(ret.fall_through, None, "the `ret` must have no fall-through");
+
+    // --- (d) a CALL site records a RefKind::Call edge + seeds a function. ------
+    let call = listing
+        .instruction_at(CALL_AUTH)
+        .unwrap_or_else(|| panic!("CALL site {CALL_AUTH:#x} not decoded"));
+    assert!(call.flow.is_call, "the `call authenticate` must be is_call");
+    assert!(
+        call.flow.has_fallthrough,
+        "a CALL falls through (returns to the next instruction)"
+    );
+    // The Call edge is filed from the call site to the callee entry.
+    let call_edges: Vec<_> = listing
+        .refs_from(CALL_AUTH)
+        .iter()
+        .filter(|r| r.kind == RefKind::Call)
+        .collect();
+    assert!(
+        call_edges.iter().any(|r| r.to == AUTHENTICATE),
+        "a RefKind::Call edge {CALL_AUTH:#x} -> {AUTHENTICATE:#x} must be filed, edges = {:#x?}",
+        call_edges.iter().map(|r| r.to).collect::<Vec<_>>()
+    );
+    // The callee is incoming-referenced and seeded as a function entry.
+    assert!(
+        listing.refs_to(AUTHENTICATE).iter().any(|r| r.kind == RefKind::Call),
+        "authenticate ({AUTHENTICATE:#x}) must have an incoming Call ref"
+    );
+    assert!(
+        listing.function_at(AUTHENTICATE).is_some(),
+        "the CALL target authenticate ({AUTHENTICATE:#x}) must be seeded as a function entry"
+    );
+
+    // --- (e) function_count() >= number of seeds. -----------------------------
+    assert!(
+        listing.function_count() >= seeds.len(),
+        "function_count ({}) must be >= the seed count ({})",
+        listing.function_count(),
+        seeds.len()
+    );
+
+    // Diagnostic sample (printed so the PR body / report can quote it): how much
+    // the keystone recovered, plus a few classified instructions.
+    let call_edges_total: usize =
+        listing.instructions().map(|(_, i)| i.flows.iter().filter(|_| i.flow.is_call).count()).sum();
+    eprintln!(
+        "verify_listing_core: decoded {} instructions, discovered {} functions, {} call edges \
+         (seeds = {})",
+        listing.num_instructions(),
+        listing.function_count(),
+        call_edges_total,
+        seeds.len()
+    );
+    for vma in [MAIN, CALL_AUTH, CBRANCH_JE, RET] {
+        if let Some(i) = listing.instruction_at(vma) {
+            eprintln!(
+                "  {:#x}: {:<8} kind={:?} flows={:#x?} fall={:#x?}",
+                vma, i.mnemonic, i.flow.kind, i.flows, i.fall_through
+            );
+        }
+    }
+}

--- a/docs/analysis-port-log.md
+++ b/docs/analysis-port-log.md
@@ -2083,3 +2083,88 @@ datatest oracle is structurally untouched (no XML path constructs an
 - **Tests:** `kuna-console` +1 (`verify_mips_plt`); `kuna-analysis` +2
   (`mips_stub_imports_resolve_to_named_functions`,
   `mips_got_const_ranges_cover_external_slots`). New fixture `plt_mips32` (+ source).
+
+### Increment 28 — Listing/xref tier PR0: recursive-descent core + instruction/flow/xref/function model ✅
+
+**Goal.** Land the **keystone** of "scope-B": a post-disassembly,
+program-wide **recursive-descent disassembler** + an instruction / cross-reference
+/ discovered-function model, built by *reusing* the ported SLEIGH decoder and a
+*lifted copy* of the S2 flow classifier. This is the first PR of a multi-PR tier
+whose canonical spec is the new **`docs/listing-tier-design.md`** (transcribed
+from the design fan-out). The keystone unlocks Ghidra analyzers kuna cannot port
+today (foremost the "Discovered" `FindNoReturnFunctionsAnalyzer`), which need a
+disassembled `Listing`/`ReferenceManager`/`FunctionManager` the analysis tier has
+never had.
+
+**Scope (PR0 ONLY).** The core lands as a self-contained module
+`kuna-analysis/src/listing/` and is **not wired into the engine**: no
+`--option listing` flag (PR1), no `AnalysisCtx::listing` field / driver build
+(PR1-PR2), no `context.rs` ARM/MIPS decode-paint (PR5). The CodeUnit partition
+*queries* are PR3, but the `CodeUnit` type and the `covered`/`exec_ranges` fields
+are defined now. So this PR touches **no engine path the XML datatests use** — the
+module is dormant until a later PR invokes it.
+
+**The subsystem.**
+- `model.rs` — the §2 data model: `Insn` (addr/len/fall_through/flow/flows/
+  mnemonic/lazy-pcode), `FlowType` (the faithful `FlowType` predicate set:
+  is_call/is_jump/is_terminal/is_computed/is_indirect/is_conditional/
+  has_fallthrough) + `FlowKind`, `RawOp`, `Reference`/`RefKind` (Call/Code
+  populated; Data/Read/Write reserved), `DiscoveredFunction` (ordered
+  `BTreeMap` model), `CodeUnit` (Instruction/Data/Undefined partition class).
+- `decode.rs::decode_one` — drives `Translate::one_instruction` (`translate.rs:472`)
+  with a capturing `PcodeEmit` (`translate.rs:166`) for `(len, ops)` and
+  `print_assembly` (`translate.rs:481`) with a capturing `AssemblyEmit` for the
+  mnemonic; builds the `Address` in the default code space.
+- `classify.rs::classify` — a faithful transliteration of
+  `s2_lift/flow.rs::xref_control_flow` (`flow.rs:1039-1185`), honoring the three
+  gotchas: (1) a constant-space `in0` is p-code-relative (tested via
+  `is_constant()` first — never a VMA target); (2) fall-through is decided by the
+  **last** op (BRANCH/BRANCHIND/RETURN ⇒ no fall-through); (3) delay slots are
+  already folded into `len` (no re-decode). BRANCHIND/CALLIND are recorded as
+  computed/indirect with NO static target (deferred jump-table resolution).
+- `walk.rs` — the two-level recursive-descent: an outer function worklist
+  (CALL/CALLIND direct targets become new function entries + `RefKind::Call`
+  edges) and an inner per-function instruction worklist (branch/fall-through →
+  same-function successors + `RefKind::Code` edges), with `BTreeMap`-membership
+  dedup, an exec-range bounds gate, and decode-error = stop-this-path.
+- `mod.rs` — the `Listing` facade + `Listing::build(file, image, arch, translate,
+  seeds)` and the read-only query API (instruction/xref/ordered-function).
+
+The `s1_entry` seed helpers `executable_sections`/`existing_function_addrs`/
+`in_executable_section` were promoted to `pub(crate)` so PR2 can build the seed set.
+
+**Tests (both layers REAL, not skipped).**
+- **Classifier unit tests** (`classify.rs`, 9 cases): hand-built `RawOp` lists
+  (no Translate) pin `classify` against the `flow.rs` rules — CBRANCH (two
+  successors, ConditionalBranch, is_conditional), unconditional BRANCH (target,
+  no fall-through), CALL (target, is_call, falls through), RETURN (terminal),
+  BRANCHIND (computed/indirect, no static target), CALLIND (computed, falls
+  through), a **constant-space BRANCH in0** (intra-insn, NOT a target), and the
+  last-op fall-through rule.
+- **Real-decode integration test** (`kuna-console/tests/verify_listing_core.rs`,
+  modeled on the `verify_*.rs` bootstrap pattern): `bootstrap_from_elf` over the
+  vendored x86-64 `fauxware` fixture gives a built `Translate`
+  (`prog.arch().translate()`) + code space (`prog.arch().manage()`); seeds =
+  `collect_entries ∪ {main}`; `Listing::build` is driven end-to-end and the §7
+  PR0 criteria asserted: `instruction_at(main)` has a plausible len + non-empty
+  mnemonic; the `je`@0x4007bb yields two successors and `ConditionalBranch`; the
+  `ret`@0x4007d4 is terminal (`fall_through == None`); the `call`@0x4007ae records
+  a `RefKind::Call` edge to `authenticate`@0x400664 and seeds it as a function;
+  `function_count() >= seeds`. **The test RAN (not skipped)** — `x86-64.sla` is
+  built; it recovered **108 instructions, 11 functions, 16 call edges** from 2
+  seeds, with `0x40071d: PUSH` (Fallthrough), `0x4007ae: CALL → 0x400664`,
+  `0x4007bb: JZ` (ConditionalBranch, target 0x4007c9, fall 0x4007bd),
+  `0x4007d4: RET` (Return).
+
+**Result (the proof).** `make test` **675/675 PARITY OK**; `make test-stages`
+**158/158 PARITY OK**; `make rust-test` green (incl. the 9 classifier unit tests
++ the new `verify_listing_core` console test). Structurally additive on a dormant
+module (no engine invocation, no flag, no `AnalysisCtx` change), so the XML
+datatest oracle is untouched — the keystone is not yet on any decompilation path.
+
+- **New:** `docs/listing-tier-design.md` (the tier spec); `kuna-analysis/src/listing/`
+  (`mod.rs`/`model.rs`/`decode.rs`/`classify.rs`/`walk.rs`) + `pub mod listing;`
+  in `lib.rs`; `kuna-console/tests/verify_listing_core.rs` (+ `object` dev-dep).
+- **Changed:** `s1_entry/mod.rs` — three seed helpers promoted to `pub(crate)`.
+- **Behind the (forthcoming) `--option listing` flag** (PR1) and **not yet wired
+  into the engine** (PR2).

--- a/docs/listing-tier-design.md
+++ b/docs/listing-tier-design.md
@@ -1,0 +1,454 @@
+# kuna Listing/Xref Tier — Implementation Plan
+
+> **Transcriber's note (folded-in corrections):** the settable count test asserts **34**
+> (not 31 as a stale header comment said), and the no-return commit path uses
+> `NoReturnFact { addr, name }` resolved via `find_function_across_scopes` /
+> `query_global_function` then `set_function_no_return` — it is proven and exists.
+
+**Status:** spec for the implementation fan-out. Every file:line below is verified against the working tree at the start of this task.
+
+**Goal.** Add an optional, default-OFF post-disassembly Listing/xref subsystem to the `kuna-analysis` crate. It performs program-wide recursive-descent disassembly over loadimage bytes — reusing the ported SLEIGH decoder (`Sleigh::one_instruction`) and a *lifted copy* of the S2 flow classifier (`s2_lift/flow.rs`) — to build three sub-models (instruction / cross-reference / discovered-function). It is the keystone that unlocks three Ghidra analyzers kuna cannot port today. It runs **only on the real-ELF bootstrap path**, never the XML datatest path, so the 675/675 + 158/158 parity oracles are structurally untouched. It ships as a sequence of small PRs, each with a fixture testcase and all three gates green.
+
+The plan **adopts DRAFT B's three-sub-model faithfulness** (the consumers were written against `Listing`/`ReferenceManager`/`FunctionManager` as separate contracts, and collapsing them breaks consumer transliteration) but **adopts DRAFT A's tighter PR sequencing and its "build-at-load, gated, in-memory-not-a-fact" stance**. Where the two drafts disagreed on build timing, this plan resolves it explicitly in §5.3.
+
+---
+
+## 1. Module layout & invocation
+
+### 1.1 New module tree
+
+All new code lives in the `kuna-analysis` crate:
+
+```
+decompiler/crates/kuna-analysis/src/listing/
+  mod.rs        # Listing facade + Listing::build(file, image, arch, translate, seeds); re-exports
+  model.rs      # Insn, FlowType/FlowKind, Reference/RefKind, DiscoveredFunction, CodeUnit
+  decode.rs     # decode_one(): drive Sleigh::one_instruction at a VMA + capture ops/mnemonic
+  classify.rs   # classify(): the lifted xref_control_flow switch (the single source of truth)
+  walk.rs       # recursive-descent driver: VisitStat map + intra/inter-function worklists
+  context.rs    # decode-context resolution (ARM TMode / MIPS ISA_MODE) before decode
+```
+
+The three sub-models (instruction / xref / function) live as fields of one `Listing` facade in `mod.rs` over types in `model.rs` — they share a single decode pass. We keep them queryable as three distinct API surfaces (§6) so each consumer's upstream code transliterates method-for-method.
+
+### 1.2 Touched existing files (additive)
+
+| File | Change | Verified anchor |
+|---|---|---|
+| `kuna-analysis/src/lib.rs` | `pub mod listing;` | module list ~`lib.rs:46-58` |
+| `kuna-analysis/src/pass.rs` | add `pub listing: Option<&'a Listing>` to `AnalysisCtx` | `pass.rs:292` |
+| `kuna-analysis/src/passes.rs` | build the Listing once (flag-gated) before the pass loop in both drivers; thread `translate` param | `passes.rs:175`, `passes.rs:197` (the two `let ctx = AnalysisCtx {...}` sites) |
+| `kuna-analysis/src/s1_entry/mod.rs` | promote `executable_sections` (`:224`), `existing_function_addrs` (`:257`), `in_executable_section` (`:249`) to `pub(crate)` (`collect_entries` `:132` is already `pub`) | confirmed private today |
+| `kuna-decomp/src/infra/architecture.rs` | the `analysis_listing` flag (field/default/reset/`set_kuna_option` arm) | field block `:360-381`, defaults `:574-575`, reset `:667-668`, `set_kuna_option` analysis arms `:759-771` |
+| `kuna-decomp/src/p0_knowledge/options.rs` | `"listing"` in `KUNA_OPTION_NAMES` | allowlist (`KUNA_OPTION_NAMES`) |
+| `kuna-console/src/engine.rs` | thread `translate` into the driver call; add `"listing" => arch.analysis_listing` to `analysis_pass_enabled` | driver call `engine.rs:634-635`, `analysis_pass_enabled` `engine.rs:271-285` |
+| `kuna-decomp/stages.toml` | a `[[settable]]` analysis-enablement row | analysis-gates block `:1805+` (addrtable row at `:1807`) |
+| `kuna-decomp/src/p0_knowledge/kuna_stages/tests.rs` | bump `settable_count_is_34` → `35` | `tests.rs:31,37,38` |
+| `docs/assertions.md` | regenerate via `kuna catalog --markdown` | — |
+
+### 1.3 Invocation (built once, shared with consumer passes)
+
+`Listing::build` is invoked **inside `run_default_analyses_per_pass`** (`passes.rs:188`), the real-ELF-only driver, whose sole caller is `bootstrap_from_elf` (`engine.rs:547`) via the driver call at `engine.rs:634-635`. The decoder is in hand there: `sleigh.base().unwrap()` is already passed as the third arg (`engine.rs:635`). We add a fourth arg `translate: &dyn Translate` (the same `sleigh.base().unwrap().translate()` the bootstrap already holds), and in the driver:
+
+```rust
+let seeds = { /* existing_function_addrs(&file) ∪ collect_entries(&file), exec-filtered, sorted/deduped */ };
+let listing = arch.analysis_listing
+    .then(|| crate::listing::Listing::build(&file, image, arch, translate, &seeds));
+let ctx = AnalysisCtx { file: &file, image, arch, listing: listing.as_ref() };
+```
+
+The `Listing` is owned by the driver, outlives the pass loop (same lifetime shape as `file`), and is borrowed read-only by every consumer pass via `ctx.listing`. It decodes eagerly into owned `model.rs` structs and drops the `translate` borrow when `build` returns — it holds no long-term engine borrow. This honors the `AnalysisPass::run(&self, ctx: &AnalysisCtx)` "pure-over-ctx, additive, never-failing" contract (`pass.rs:309`): the Listing is just a richer read-only ctx borrow.
+
+`run_default_analyses` (the non-per-pass driver, `passes.rs:163`) gets the same fourth param for signature symmetry but, since only `run_default_analyses_per_pass` is wired into the live engine (`engine.rs:635`), the build call only needs to be live in the per-pass driver. Add the param to both; build the Listing only where a caller passes a real translate.
+
+---
+
+## 2. Core data model (`model.rs`)
+
+Three sub-models behind one facade. Each field is justified by a buildable consumer (Consumer A) or a near-term one (the CodeUnit partition feeds both A's "fell into data" signal and a future AIF gap walk).
+
+### 2.1 Instruction model
+
+```rust
+/// One decoded machine instruction. Owned; produced by the walker.
+pub struct Insn {
+    pub addr: u64,                  // getMinAddress
+    pub len: u32,                   // bytes consumed incl. delay slots (one_instruction return)
+    pub fall_through: Option<u64>,  // None iff !flow.has_fallthrough (terminal)
+    pub flow: FlowType,             // classified from emitted pcode — NOT a separate API result
+    pub flows: Vec<u64>,           // static control targets (getFlows): branch/call dest VMAs
+    pub mnemonic: String,           // x86 INT3, ARM nop/mov/ld*, ELF add/push dispatch
+    pub pcode: Option<Vec<RawOp>>, // lazy: only skipNOPS / isUsedForCalculation need it
+}
+
+/// Faithful projection of Ghidra's FlowType predicate set.
+pub struct FlowType {
+    pub kind: FlowKind,
+    pub is_call: bool,
+    pub is_jump: bool,
+    pub is_terminal: bool,
+    pub is_computed: bool,     // indirect/computed target (BRANCHIND/CALLIND)
+    pub is_indirect: bool,
+    pub is_conditional: bool,
+    pub has_fallthrough: bool,
+}
+
+/// OpCode → flow-class projection (mirrors typeop.rs:370-405 / op.rs:73 flags).
+pub enum FlowKind {
+    Fallthrough,           // emits ops; last op not a flow break
+    UnconditionalBranch,   // last op CPUI_BRANCH (4), in0 non-constant
+    ConditionalBranch,     // CPUI_CBRANCH (5) — also falls through
+    ComputedJump,          // CPUI_BRANCHIND (6) — indirect, target unresolved
+    Call,                  // CPUI_CALL (7) — falls through
+    ComputedCall,          // CPUI_CALLIND (8) — indirect, falls through
+    CallOther,             // CPUI_CALLOTHER (9) — syscall/userop, falls through
+    Return,                // CPUI_RETURN (10) — terminal
+    Unimplemented,         // decode Err(Unimpl): has length, no flow effect
+}
+
+/// Minimal captured op (only when pcode is materialized).
+pub struct RawOp { pub opcode: OpCode, pub in0: Option<VarnodeData> /* enough for skipNOPS */ }
+```
+
+*Why `FlowType` carries the predicate set, not just `FlowKind`:* Consumer A queries `hasFallthrough() && !isFallthrough()` (a distinct test from `isTerminal()`), `isCall`, `isComputed`, `isIndirect` individually. The predicates are derived once from the OpCode + the `pcodeop_flags` table (the same flags `set_opcode` ORs onto each op, `substrate/op.rs:73,458-477`), so this is the same bit-logic Ghidra uses, not a re-classification. *Why `pcode` is `Option`/lazy:* `one_instruction` produces ops during decode; only `skipNOPS`/`isUsedForCalculation` (a niche of Consumer A, and Consumers B/C which are deferred) read them. Keep `None` in the common case.
+
+### 2.2 Cross-reference model
+
+```rust
+pub enum RefKind { Call, Code /* branch/jump */, Data, Read, Write }
+
+pub struct Reference {
+    pub from: u64,
+    pub to: u64,
+    pub kind: RefKind,
+    pub op_index: Option<u8>,   // present-but-mostly-None; reserved for operand markup
+}
+```
+
+The keystone **populates only `Call` and `Code` edges** (control-flow), generated during the walk from each `Insn.flows`. `Data/Read/Write` and `op_index` are in the type for faithfulness so the type never changes if operand markup is ever revisited (only population density would) — but **no reference-writing API is exposed** (Consumer B is declined; §8). The model is a bidirectional multimap (`refs_to` + `refs_from`), because Consumer A reads `to`-wards (callers of X) and a future operand consumer reads `from`-wards.
+
+### 2.3 Discovered-function model
+
+```rust
+pub struct DiscoveredFunction {
+    pub entry: u64,
+    pub name: Option<String>,         // from funcsym / entry_names overlay; None ⇒ sub_<addr>
+    pub from_symbol: bool,            // seeded by a real funcsym (existing_function_addrs) vs discovered via CALL
+    pub has_no_return: bool,          // seeded from s1_loader::noreturn Known-list (cheap; refined by Consumer A)
+    pub call_fixup: Option<String>,   // from s1_callfixup facts (skip-modeled-callees)
+}
+```
+
+Backed by `BTreeMap<u64, DiscoveredFunction>` so `function_containing` / `next_function_after` are ordered interval lookups (`range(..=vma).next_back()` / `range(vma+1..).next()`) — the faithful analog of Ghidra's ordered FunctionManager and Consumer A's strongest signal.
+
+### 2.4 CodeUnit partition
+
+```rust
+pub enum CodeUnit { Instruction(u64 /*insn addr*/), Data(u64, u32), Undefined }
+```
+
+Computed once at end of build: every VMA inside an executable range (`s1_entry::executable_sections`) that is not the start-or-interior of a decoded `Insn` and not a symbol-typed data record is `Undefined`. At this tier "Data" comes from the symbol/section model + `.rodata` strings (`s1_strings`); the conservative partition is `Instruction` (decoded) / `Data` (non-exec or symbol-typed) / `Undefined` (everything else in exec ranges). This is faithful enough for the two relevant consumers: A's "fell into data" reduces to `!is_instruction_start(fall_vma)`; AIF's gap walk uses `first_undefined_after`.
+
+### 2.5 The facade
+
+```rust
+pub struct Listing {
+    insns: BTreeMap<u64, Insn>,                 // instruction model
+    refs_to: BTreeMap<u64, Vec<Reference>>,     // xref: incoming (callers)
+    refs_from: BTreeMap<u64, Vec<Reference>>,   // xref: outgoing
+    funcs: BTreeMap<u64, DiscoveredFunction>,   // ordered function model
+    covered: RangeList,                         // kuna_base::address::RangeList — instruction coverage
+    exec_ranges: Vec<(u64, u64)>,               // coverage universe for the partition / gaps
+}
+```
+
+`RangeList` is the same type `get_readonly`/`engine.rs:600` already use (insert/subtract/iterate), so gap = `exec_ranges` minus `covered` is free when PR8 needs it.
+
+---
+
+## 3. The recursive-descent algorithm
+
+### 3.1 Seeding
+
+Root set = `existing_function_addrs(file) ∪ collect_entries(file)`, both already exec-section-filtered (`collect_entries` filters; `existing_function_addrs` are real funcsyms), then sorted/deduped. `existing_function_addrs` (`s1_entry/mod.rs:257`) = `.symtab`/`.dynsym` FUNC + PLT stubs; `collect_entries` (`s1_entry/mod.rs:132`) = e_entry ∪ DT_INIT/FINI arrays ∪ `.eh_frame` FDE pcBegin ∪ `_start`→`main` idiom ∪ x86-64 prologue patterns, funcsym-dedup'd. Each seed becomes a `DiscoveredFunction { from_symbol = (came from existing_function_addrs), name = funcsym/entry-overlay name }` and goes on the **function worklist**.
+
+### 3.2 Decode one instruction (the decoder reuse — see §4)
+
+`decode.rs::decode_one(translate, vma, code_space) -> Result<(len, Vec<RawOp>, mnemonic), DecodeErr>`. Builds the `Address` in the code space, paints context (§4.2), drives `Translate::one_instruction` with a capturing `PcodeEmit`, and `print_assembly` with a capturing `AssemblyEmit` for the mnemonic.
+
+### 3.3 Successor computation (lifted classifier — see §4.3 and `classify.rs`)
+
+`classify(ops, vma, len) -> (FlowType, flows: Vec<u64>, fall_through: Option<u64>)`. A transliteration of `s2_lift/flow.rs::xref_control_flow` (`flow.rs:1039-1185`). Exact rules in §4.3.
+
+### 3.4 The worklist (two-level, the program-wide extension)
+
+Mirrors `FlowInfo`'s `VisitStat`/`addrlist` *design* (`flow.rs:155,425`) but lightweight (no `Funcdata`, no banks, no blocks):
+
+```
+func_worklist  = seeds                          # function-entry worklist
+visited_funcs  = {}
+while let Some(entry) = func_worklist.pop():
+    if entry in visited_funcs: continue
+    visited_funcs.insert(entry)
+    insn_worklist = [entry]                      # intra-function fall-through/branch walk
+    while let Some(vma) = insn_worklist.pop():
+        if vma in insns: continue               # the VisitStat dedup (overlap detection free)
+        if vma not in any exec_range: continue   # out-of-bounds gate (flow.rs:891 analog)
+        match decode_one(translate, vma):
+            Err(Unimpl|BadData) => continue      # decode-error policy: stop this path, mark gap
+            Ok((len, ops, mnem)):
+              (flow, targets, fall) = classify(ops, vma, len)
+              insns.insert(vma, Insn { addr:vma, len, flow, flows:targets.clone(), fall_through:fall, mnemonic:mnem, pcode:None })
+              covered.insert(vma, vma + len - 1)
+              for t in targets:
+                  if flow.is_call:                          # CALL/CALLIND target → NEW function entry
+                      funcs.entry(t).or_insert(discovered); func_worklist.push(t)
+                      file_ref(vma, t, RefKind::Call)
+                  else:                                      # branch target → same-function successor
+                      insn_worklist.push(t)
+                      file_ref(vma, t, RefKind::Code)
+              if let Some(f) = fall:
+                  insn_worklist.push(f)
+                  file_ref(vma, f, RefKind::Code)            # fall-through edge
+# after the loop:
+partition_code_units()   # exec_ranges minus covered → Undefined
+```
+
+`file_ref(from,to,kind)` pushes into both `refs_to[to]` and `refs_from[from]`.
+
+**Key choices, each grounded:**
+- **Cross-function driver** is the one thing `FlowInfo` lacks (it stops at RETURN, treats CALL as fall-through, never recurses into callees): CALL/CALLIND targets become **new function entries** on `func_worklist`. This is the program-wide walk.
+- **Indirect/unresolved targets:** `ComputedJump` (BRANCHIND) and `ComputedCall` (CALLIND) push **no static successor** (and CALLIND seeds no new entry — target unknown). They are *recorded* (so a consumer sees "there is computed flow here" via `is_computed`/`is_indirect`) but unresolved. This is the documented "partial flow, assume no out-branches" path the engine itself takes (`flow.rs:1523-1525` `findJumpTable==0`). **Jump-table resolution is deferred** (§8): it is intrinsically post-dataflow (needs the action pipeline + `EmulateFunction` over the SSA tree, `s2_lift/jumptable.rs`); no cheap pre-decompile form exists.
+- **Termination:** `visited_funcs` bounds the function worklist; `insns` membership bounds the instruction worklist; both are monotonic over a finite address universe ⇒ terminates.
+- **Coverage:** `covered: RangeList` accrues `[vma, vma+len-1]` per decoded insn; gap = `exec_ranges − covered` (PR8).
+
+---
+
+## 4. The decoder reuse
+
+### 4.1 Driving SLEIGH for one instruction outside the decompiler
+
+The engine returns **length + a flat list of p-code ops** via a `PcodeEmit` sink; there is no `getFlow()`. Drive it with a capturing sink:
+
+```rust
+struct OpCapture { ops: Vec<RawOp> }
+impl PcodeEmit for OpCapture {
+    fn dump(&mut self, _addr:&Address, opc:OpCode, _out:Option<&VarnodeData>, vars:&[VarnodeData]) {
+        self.ops.push(RawOp { opcode: opc, in0: vars.first().cloned() });
+    }
+}
+// decode:
+let addr = Address::new(Rc::clone(code_space), vma);
+let mut cap = OpCapture::default();
+let len = translate.one_instruction(&mut cap, &addr)?;   // returns fall-through byte length incl. delay slots
+```
+
+`PcodeEmit::dump` signature is verified at `translate.rs:166`: `fn dump(&mut self, addr:&Address, opc:OpCode, outvar:Option<&VarnodeData>, vars:&[VarnodeData])`. The mnemonic comes from a parallel `AssemblyEmit` capture via `translate.print_assembly(&mut asm_cap, &addr)` (`AssemblyEmit::dump(addr, mnem, body)` at `translate.rs:217`). The code space comes from the engine's space manager (`get_default_code_space` / `manage().get_space_by_name("ram")`).
+
+`Translate` is the public trait (`translate.rs:386`); `one_instruction` (`:472`), `instruction_length` (`:459`), `print_assembly` (`:481`). These are `&self` (interior mutability) — no engine setup beyond what `bootstrap_from_elf` already did (`.sla` loaded, `ObjectLoadImage` attached as the loader).
+
+### 4.2 Context-mode gotchas (`context.rs`)
+
+Context (ARM `TMode`, MIPS `ISA_MODE`/MIPS16) **must be painted before decoding at an address**, or you get an A32-vs-Thumb misdecode. kuna already produces these paints: `s1_loader/arm_markers.rs` (ARM TMode) and `s1_loader/mips_markers.rs` (MIPS ISA_MODE) emit `ContextPaint`/`tracked_regs` facts (`pass.rs:257`). `context.rs` resolves, per seed/per address, the right context value and paints it via the context DB (`set_variable(name, addr, value)`, reached through the engine's context DB the way `verify_arm_thumb_decode.rs` does) before the first decode at that address. x86-64 needs nothing — **PR3-PR5 target x86-64 only**; the context-paint correctness (PR6) is isolated to ARM/MIPS and gated off by default.
+
+The decode also self-applies context *commits* the constructor itself sets (e.g. an ARM mode switch on `bx`) inside `one_instruction` (`apply_commits`) — those are handled by the engine, not us.
+
+### 4.3 The exact classifier (`classify.rs`)
+
+A transliteration of `xref_control_flow` (`flow.rs:1039-1185`). Two load-bearing rules below.
+
+```
+fall_vma = vma + len
+last_op  = ops.last()
+flows = []
+for (opcode, in0) in ops:
+  CPUI_CBRANCH(5):  if in0.is_constant() => intra-insn relative (resolves to fall-through; ignore)
+                    else => flows.push(in0.get_addr().get_offset()); kind = ConditionalBranch; is_conditional=true
+  CPUI_BRANCH(4):   if in0.is_constant() => relative (ignore)
+                    else => flows.push(in0 offset); kind = UnconditionalBranch
+  CPUI_BRANCHIND(6):kind = ComputedJump; is_jump=true; is_computed=true; is_indirect=true   # no static target
+  CPUI_CALL(7):     flows.push(in0 offset); kind = Call; is_call=true                        # target == in0 (flow.rs:1765)
+  CPUI_CALLIND(8):  kind = ComputedCall; is_call=true; is_computed=true; is_indirect=true     # no static target
+  CPUI_CALLOTHER(9):kind = CallOther
+  CPUI_RETURN(10):  kind = Return; is_terminal=true
+  else:             no flow effect
+
+# fall-through (flow.rs:1170-1183): falls through UNLESS the LAST op ∈ {BRANCH, BRANCHIND, RETURN}
+has_fallthrough = !matches!(last_op.opcode, CPUI_BRANCH|CPUI_BRANCHIND|CPUI_RETURN)
+fall_through    = has_fallthrough.then_some(fall_vma)
+# an instruction that emits NO ops falls through (has_fallthrough = true)
+```
+
+**Gotcha 1 — constant-space in0 is p-code-relative, not a VMA.** Always test `in0.is_constant()` first. A constant-offset BRANCH/CBRANCH is intra-instruction (a multi-pcode-op instruction branching within itself); for single-instruction flow it resolves to fall-through, never a real target. Only a non-constant in0 carries an absolute target VMA (`flow.rs:768-790`). `VarnodeData::get_addr()` is at `pcoderaw.rs:143`; `Address::is_constant()`/`get_offset()` confirmed.
+
+**Gotcha 2 — fall-through is decided by the LAST op, not the first.** A multi-op instruction's *targets* come from every op, but its *fall-through* is the last-op test only. CBRANCH/CALL/CALLIND/CALLOTHER all fall through; BRANCH/BRANCHIND/RETURN do not.
+
+**Gotcha 3 — delay slots** (SPARC/MIPS) are already folded into `len` by `one_instruction` (`sleigh.rs:2064-2083`), so `fall_vma = vma + len` is correct — do **not** decode the delay slot again.
+
+A golden test (PR2) pins `classify` against `flow.rs` for the same bytes, so the two stay in sync by construction.
+
+---
+
+## 5. The `--option listing` flag (default OFF) + parity safety
+
+### 5.1 Wiring (follows the `addrtable`/`formatstring` template exactly)
+
+- **`architecture.rs`**:
+  - field, in the `analysis_*` block after `analysis_formatstring` (`:381`): `pub analysis_listing: bool,`
+  - constructor default after `:575`: `analysis_listing: false,`
+  - `reset_defaults_internal` after `:668`: `self.analysis_listing = false; // Listing/xref tier default-off`
+  - `set_kuna_option` arm in the analysis block after `:771`: `"listing" => on_off!(analysis_listing, "Listing/xref disassembly tier"),`
+- **`options.rs`**: add `"listing",` to `KUNA_OPTION_NAMES`.
+- **`engine.rs::analysis_pass_enabled`** (`:271-285`): add `"listing" => arch.analysis_listing,`. The default arm is `_ => true` (fail-OPEN, `:284`), so this MUST be added explicitly, and so must any consumer's id (PR7).
+- **`stages.toml`**: a `[[settable]]` row in the analysis-gates block (after the `formatstring` row at `:1823`), copying the `addrtable` shape (`:1807`): `option="listing"`, `values="on|off"`, `default="off"`, `stage`/`substage`/`strength`/`rewind`, `summary`, `use_when`, `example`, `source_decompiler`, `change_kind="analysis-enablement"`, **no `live_field`** (analysis gates flip a plain bool). Fix the stale header count comment `stages.toml:8` (currently "settable=31", actually 34 → make it 35).
+- **count test**: bump `settable_count_is_34` → `35` at `tests.rs:31,37,38` (and the header comment at `tests.rs:4`).
+- **docs**: `make binaries` then `kuna catalog --markdown > docs/assertions.md`. The `build.rs` codegen regenerates `SETTABLE_TABLE`/`OptionValues` from `stages.toml` at compile time automatically.
+- **drift gate**: `kuna catalog --check` cross-checks the catalog against `KUNA_OPTION_NAMES` in-process; run it before committing.
+
+### 5.2 Parity-safety argument (three independent layers)
+
+1. **Structural (the real one).** `Listing::build` is invoked only from `run_default_analyses_per_pass` (`passes.rs:188`), whose only caller is `bootstrap_from_elf` (`engine.rs:547`, driver call `:634-635`), reached only via the `\x7fELF` magic dispatch in `bootstrap_from_file` (`engine.rs:1021`). The XML datatest path (`bootstrap_program`/`bootstrap_from_root`) never calls the analysis driver and never builds `pending_analysis`. **No datatest can build or observe a Listing.** The 675/675 oracle runs on a code path the Listing tier does not touch.
+2. **Default-OFF.** Even on the real-ELF path, `analysis_listing` defaults `false`, so `arch.analysis_listing.then(|| Listing::build(...))` is `None` — no decode work, `ctx.listing = None`. The real-ELF bootstrap is byte-identical to today by default. The 158/158 stage-model oracle is untouched.
+3. **In-memory intermediate, not a fact.** The Listing is a borrow in `AnalysisCtx`, never an `AnalysisOutput` field, never committed into the engine IR. Only a *consumer's* derived `AnalysisOutput` (e.g. `NoReturnFact`) reaches the decompiler, through commit arms that already exist and are individually gated + additive (`engine.rs:781-803`). The `AnalysisOutput::merge`-is-concatenation invariant (`pass.rs:277`) is untouched.
+
+Because of layer 1, `make test` and `make test-stages` are guaranteed untouched by every PR; PRs only need to keep `make rust-test` green (new unit tests on the new module) and `kuna catalog --check` clean.
+
+### 5.3 Build-timing resolution (where the drafts disagreed)
+
+DRAFT A noted a tension: the per-pass *commit* gate (`analysis_pass_enabled`) runs late (at `read symbols`, after `--option` flags are applied), but the Listing *build* happens at load (inside the driver). **Resolution: build-at-load gated on the flag is correct.** The CLI emits `--option listing on` *before* load for build-time gates (the same as `addrtable`), so `arch.analysis_listing` is already set when `bootstrap_from_elf` runs. Default-off ⇒ default-not-built ⇒ the zero-cost path. We do **not** build unconditionally-then-gate-consumers (DRAFT B's fallback), because default-not-built is strictly cheaper and is the parity-safe path. If a future need arises to flip the flag *after* load, revisit then; it is not needed now.
+
+---
+
+## 6. Consumer API & build order
+
+The union of the three consumers' needs is exactly the §2 model. Read-only API on `Listing`:
+
+```rust
+impl Listing {
+    // instruction model
+    pub fn instruction_at(&self, vma: u64) -> Option<&Insn>;
+    pub fn instruction_containing(&self, vma: u64) -> Option<&Insn>;
+    pub fn is_instruction_start(&self, vma: u64) -> bool;
+    pub fn num_instructions(&self) -> usize;                  // AIF gate
+    // codeunit partition
+    pub fn code_unit_at(&self, vma: u64) -> CodeUnit;
+    pub fn is_data(&self, vma: u64) -> bool;                  // A's "fell into data"
+    pub fn is_undefined(&self, vma: u64) -> bool;
+    pub fn first_undefined_after(&self, vma: u64) -> Option<u64>;  // AIF gaps (PR8)
+    // xref model (read-only is enough for the buildable consumers)
+    pub fn refs_to(&self, to: u64) -> &[Reference];          // callers
+    pub fn refs_from(&self, from: u64) -> &[Reference];
+    pub fn ref_source_iter(&self) -> impl Iterator<Item=u64>; // call-site worklist
+    pub fn has_refs_to(&self, to: u64) -> bool;
+    pub fn ref_count_to(&self, to: u64) -> usize;
+    // function model (ordered)
+    pub fn function_at(&self, vma: u64) -> Option<&DiscoveredFunction>;
+    pub fn function_containing(&self, vma: u64) -> Option<&DiscoveredFunction>;
+    pub fn next_function_after(&self, vma: u64) -> Option<&DiscoveredFunction>;
+    pub fn function_count(&self) -> usize;
+}
+```
+
+**Build Consumer A FIRST — `FindNoReturnFunctionsAnalyzer` (discovered-no-return).** Cheapest, highest-confidence. It maps onto the API with no escape hatches:
+- callers of a callee → `refs_to(callee).filter(|r| r.kind == Call)`
+- call-site worklist → `ref_source_iter()`
+- "fall-through landed in data" (highest-value signal) → `!is_instruction_start(fall_vma)`
+- "function defined immediately after this call" → `next_function_after(call_addr)`
+- per-call predicates → `insn.flow.{is_call, has_fallthrough, is_terminal, is_indirect}`, `insn.flows`
+- skip already-modeled callees → `function_at(target).has_no_return / .call_fixup`
+- `skipNOPS` real-NOP test → `insn.pcode` (lazy-materialized)
+
+**Its output and commit path already exist and are proven**: it emits `NoReturnFact { addr, name }` (`pass.rs:108`), whose commit arm resolves via `find_function_across_scopes`/`query_global_function` then `set_function_no_return` (`engine.rs:781-803`). Flow-repair is *inherited* — kuna's engine already does post-no-return dead-code elimination, so Consumer A needs no `ClearFlowAndRepairCmd`/`CreateFunctionCmd`/bookmarks. Net-new logic = the evidence-tally fixpoint (callee no-return if ≥3 callers show no-valid-fall-through; 2-pass to fixpoint) — a few dozen read-only lines.
+
+**Consumers B and C are declined** (§8) — the keystone makes them buildable but does not pull them in.
+
+---
+
+## 7. Ordered PR breakdown
+
+Each PR: small, one fixture testcase, all three gates green, `kuna catalog --check` clean. No PR depends on an unbuilt consumer. Fixtures are tiny checked-in ELFs under `decompiler/crates/kuna-analysis/tests/fixtures/` (reuse existing fauxware/test ELFs the `s1_entry` tests already use at `s1_entry/mod.rs:1414+` where possible).
+
+### PR0 — Recursive-descent core + instruction model + classifier (the keystone heart)
+**Scope.** `listing/{model.rs, decode.rs, classify.rs, walk.rs}` with: the `Insn`/`FlowType`/`FlowKind`/`Reference`/`DiscoveredFunction`/`CodeUnit` types; `decode_one` over `Translate::one_instruction` + `print_assembly`; the `classify` switch (lifted from `flow.rs:1039-1185`); the two-level worklist walk seeded from a caller-supplied seed list. `Listing::build(file, image, arch, translate, seeds)` wired but **not yet invoked from the engine** (unit-tested in isolation with a test `Translate`/fixture). No flag yet, no `AnalysisCtx` change. `s1_entry` seed helpers promoted to `pub(crate)`.
+**Files.** New `listing/` module + `lib.rs` `pub mod listing;`; `s1_entry/mod.rs` visibility bumps.
+**Testcase.** Unit test in `listing/` over a vendored tiny x86-64 ELF: decode from `main`'s entry, assert (a) `instruction_at(entry)` has the right `len` + `mnemonic`; (b) a known CBRANCH yields two successors (target + fall_through) and `flow.kind == ConditionalBranch`; (c) a RETURN is terminal (`fall_through == None`); (d) a CALL records `RefKind::Call` and seeds a new function entry; (e) **the classifier agrees with `flow.rs` on the same bytes** (decode the same insn through a minimal FlowInfo-style harness or a recorded golden). 
+**Risk.** Medium — this is the load-bearing logic. Mitigated by copying the proven switch verbatim and the explicit `flow.rs`-agreement test, plus the constant-space and last-op rules tested directly.
+**Deps.** None.
+
+### PR1 — The `--option listing` flag, default-OFF, wired end-to-end (no build yet)
+**Scope.** All of §5.1: `analysis_listing` field/default/reset/`set_kuna_option`; `KUNA_OPTION_NAMES`; `analysis_pass_enabled`; `stages.toml` row + header count fix; count-test bump; `docs/assertions.md` regen. Add `pub listing: Option<&'a Listing>` to `AnalysisCtx` (always `None` — build deferred to PR2).
+**Files.** `architecture.rs`, `options.rs`, `engine.rs`, `stages.toml`, `tests.rs`, `pass.rs`, `docs/assertions.md`.
+**Testcase.** `kuna catalog --check` passes; a `tests/stages/` case flipping `--option listing on` asserting it parses/round-trips and changes nothing (default-off parity); `settable_count_is_35` green.
+**Risk.** Low — pure plumbing, default-off.
+**Deps.** PR0 (the `Listing` type must exist for the `AnalysisCtx` field).
+
+### PR2 — Invoke the keystone from the engine (flag-gated build)
+**Scope.** Thread `translate` into `run_default_analyses_per_pass` (and the symmetric `run_default_analyses` signature); build the seed union in the driver; `let listing = arch.analysis_listing.then(|| Listing::build(...))`; populate `ctx.listing`. Engine call site updated (`engine.rs:634-635`).
+**Files.** `passes.rs`, `engine.rs`.
+**Testcase.** A `tests/stages/` (or rust-test) case: with `--option listing on`, decompile a fixture ELF and assert it still produces identical decompiler output (the Listing is built but no consumer reads it yet ⇒ no behavior change); with flag off, byte-identical to today. A rust-test asserts `Listing::build` over a fixture populates `function_count()` and `instruction_at(entry)`.
+**Risk.** Low — the build is proven by PR0's unit tests; this is the wiring + the default-off/flag-on no-op proof.
+**Deps.** PR0, PR1.
+
+### PR3 — CodeUnit partition + FunctionModel ordered queries
+**Scope.** `partition_code_units()` at end of build (exec ranges minus covered → Undefined); `code_unit_at`/`is_data`/`is_undefined`/`first_undefined_after`/`num_instructions`; ordered `function_at`/`function_containing`/`next_function_after`/`function_count`.
+**Files.** `listing/model.rs`, `listing/mod.rs`.
+**Testcase.** Over the fixture ELF: assert the partition (a known instruction VMA → `Instruction`, a known gap VMA → `Undefined`); assert `next_function_after(main)` returns the next-by-address function; `function_containing(mid_of_main)` returns `main`.
+**Risk.** Low — pure derived queries over the already-built maps.
+**Deps.** PR0.
+
+### PR4 — Reference model read API hardening
+**Scope.** Bidirectional `refs_to`/`refs_from`/`ref_source_iter`/`has_refs_to`/`ref_count_to` finalized and tested (the walk already files edges in PR0; this PR pins the public API + ordering/dedup semantics).
+**Files.** `listing/mod.rs`, `listing/model.rs`.
+**Testcase.** Fixture with `main` calling a helper: assert `refs_to(helper)` contains the call site with `RefKind::Call`; `ref_source_iter()` includes `main`'s call address; `ref_count_to(helper)` matches call count.
+**Risk.** Low.
+**Deps.** PR0.
+
+### PR5 — Context-paint correctness (ARM Thumb / MIPS ISA_MODE)
+**Scope.** `context.rs`: resolve `ContextPaint`/`tracked_regs` (TMode/ISA_MODE) per seed/address and paint into the context DB before decode. x86-64 unaffected.
+**Files.** `listing/context.rs`, `listing/walk.rs` (call the painter before `decode_one`).
+**Testcase.** An ARM fixture with a Thumb function (TMode=1): assert the seed decodes to the expected Thumb mnemonic, not the A32 misdecode. Reuse the `verify_arm_thumb_decode.rs` pattern.
+**Risk.** Medium — isolated to ARM/MIPS, gated off by default; cannot perturb the parity gates (real-ELF-path-only + default-off).
+**Deps.** PR2 (needs the engine-wired build to have the arch context available).
+
+### PR6 — Consumer A: `FindNoReturnFunctionsAnalyzer` (the payoff)
+**Scope.** New gated pass `id = "noreturn_disc"`, default-OFF, its own flag (full §5.1 wiring for `noreturn_disc`, including `analysis_pass_enabled` arm), `run` short-circuits to empty when `ctx.listing.is_none()`. Read-only over the Listing: the evidence-tally fixpoint (callee no-return if ≥3 callers show no-valid-fall-through; 2-pass). Emits `NoReturnFact { addr, name }`.
+**Files.** New `s1_noreturn_disc/mod.rs`; register in `lib.rs` + `passes_for` (`passes.rs:38`); `architecture.rs`/`options.rs`/`engine.rs`/`stages.toml`/`tests.rs` for the `noreturn_disc` flag (settable_count → 36); `docs/assertions.md`.
+**Testcase.** `tests/stages/` case: a fixture with a static no-return wrapper (e.g. an `abort()`-style helper) called ≥3× whose call sites have no valid fall-through. With `--option listing on --option noreturn_disc on`, assert the wrapper is marked no-return (and, via the inherited engine repair, the caller's post-call dead code is eliminated). With either flag off, assert byte-identical-to-today (parity).
+**Risk.** Low given PR0-PR5 — a few-dozen-line read-only fixpoint with an existing, proven output fact + commit seam (`engine.rs:781-803`). This validates the whole keystone end-to-end.
+**Deps.** PR0-PR4 (PR5 only if the no-return fixture is ARM/MIPS; an x86-64 fixture needs only PR0-PR4).
+
+### PR7 (optional, only if AIF/FID is ever taken) — gap-query groundwork
+**Scope.** `covered`/`exec_ranges` already present from PR0/PR3; this only adds the gap-iteration helper (`exec_ranges − covered`) and tests. **No consumer.** Do not land unless AIF is scheduled.
+**Testcase.** Assert a known uncovered exec sub-range is reported as a gap.
+**Risk.** Low.
+**Deps.** PR3.
+
+---
+
+## 8. What to DEFER (and why)
+
+- **Jump-table / indirect-branch target resolution.** Intrinsically post-dataflow (action pipeline + `EmulateFunction` over the SSA tree, `s2_lift/jumptable.rs`). No cheap pre-decompile form. Treat BRANCHIND/CALLIND as unresolved terminals with `is_computed`/`is_indirect` set — the sound, engine-consistent behavior (`flow.rs:1523-1525`). A future consumer can branch on the predicates without the keystone lying about resolution.
+- **Per-op pcode storage by default.** `Insn.pcode` stays `None` unless a consumer materializes it (only `skipNOPS`/`isUsedForCalculation` need it).
+- **Consumer B (operand/reference markup family).** Its primary output is *references written into a ReferenceManager*, and kuna's decompiler consumes **no `RefFact`** (no commit arm; the engine reads bytes + symbol/type tables). It is ELF-default-OFF upstream (`ScalarOperandAnalyzer.canAnalyze = !ElfLoader.isElf`), `ElfScalarOperandAnalyzer` only *deletes* bad `.got`/`.plt` refs kuna never wrongly creates, and its one decompiler-relevant idea (scalar → `.rodata` string ⇒ `char*`) is already delivered by `s1_strings` + `s1_protos` + S5 and is printer-shadowed by MapGlobals. The keystone exposes **no reference-writing API** — faithfully, because there is nowhere for those writes to land. Decline as producing passes.
+- **Consumer C (AggressiveInstructionFinder).** Needs the keystone **plus two net-new capabilities it deliberately omits**: (1) a SLEIGH instruction-**mask** accessor in `kuna-sleigh` (buildable from the existing `PatternBlock::get_mask`/`DisjointPattern::get_mask` at `slghpattern.rs:385/848`, but only with its consumer); (2) the full `PseudoDisassembler.checkValidSubroutine`/`followSubFlows` decode-with-validation (a superset of plain decode — a new `walk.rs` mode). Its *unique* contribution (guessing code in gaps with no symbol/FDE/xref) is exactly the high-false-positive case Ghidra ships `setDefaultEnablement(false)`; for a decompiler *given* entries, the sound output is already covered by `s1_entry` + `.eh_frame` FDE scanning. Decline AIF itself; the mask accessor it needs is the same one FID would need, so build it independently only if FID is taken.
+- **A committed engine `Listing` fact.** Keep the Listing in-memory. Inventing a `RefFact` nobody consumes would break the additive-merge invariant for no payoff.
+
+---
+
+## 9. Risks & mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| **Parity-gate perturbation** (a Listing change leaks into 675/158) | High if it happened | **Structurally impossible** by layer 1 (§5.2): the build is real-ELF-path-only, never reached from the XML datatest path. Layer 2 (default-OFF) + layer 3 (in-memory, not a fact) are belt-and-suspenders. Every PR re-runs all three gates; layers 1-2 guarantee `make test`/`make test-stages` untouched, so PRs only need `make rust-test` + `kuna catalog --check` green. |
+| **Classifier divergence from `flow.rs`** (the two flow models drift) | Medium | `classify` is a *lifted copy* of the single source of truth (`flow.rs:1039-1185`), not a reinvention. PR0's golden test pins `classify` against `flow.rs` on the same bytes; if upstream flow logic changes, the test catches the drift. |
+| **Decode-correctness traps** | Medium | Three explicitly handled: (a) **constant-space in0 is p-code-relative** — tested first (§4.3 gotcha 1); (b) **fall-through is the *last* op** (gotcha 2); (c) **delay slots already in `len`** — don't double-decode (gotcha 3). Plus: variable-length ISAs always advance by the returned `len`; alignment errors and `Err(Unimpl/BadData)` are caught and stop that path (not assumed-success). |
+| **Context misdecode** (ARM A32-vs-Thumb, MIPS16) | Medium | PR5 paints `ContextPaint`/`tracked_regs` before decode, isolated to ARM/MIPS and default-OFF. PR0-PR4 fixtures are x86-64 (no mode context), so the core lands without this risk. |
+| **Whole-program disassembly cost** | Medium | The walk is O(covered bytes) with `BTreeMap`-membership dedup (each VMA decoded at most once via the `insns`/`visited_funcs` sets). It runs **only behind `--option listing on`** (default-OFF ⇒ zero cost), and only on the real-ELF path (never the 675-datatest hot loop). If a large binary is slow, the cost is opt-in and the walk is bounded; no decompilation IR is built (no `Funcdata`/banks/blocks), so it is far cheaper than a real decompile. |
+| **False positives (AIF's distinctive danger)** | High *for AIF* | AIF is **declined** (§8): its unique gap-guessing is the exact case Ghidra ships default-OFF for false-positive reasons. The keystone seeds only from *sound* roots (`existing_function_addrs ∪ collect_entries` — real funcsyms + the five entry oracles), and discovered functions come only from *concrete* CALL targets (`in0` of a CPUI_CALL), never speculative gap decoding. Consumer A's no-return fixpoint requires ≥3 corroborating callers, matching Ghidra's `evidenceThresholdFunctions`. |
+| **Indirect-target unsoundness** (pretending to resolve jump tables) | Low | Deferred (§8): BRANCHIND/CALLIND are unresolved terminals with `is_computed`/`is_indirect` set — the keystone never claims a target it didn't statically derive. |
+
+---
+
+**First value delivered:** PR6 (`FindNoReturnFunctionsAnalyzer`) — the cheapest consumer, validating the keystone end-to-end through an output fact (`NoReturnFact`) and commit seam (`engine.rs:781-803`) that already exist and are proven, with flow-repair inherited from the engine.
+
+**Key file references (absolute):** new `/home/mahaloz/github/kuna/decompiler/crates/kuna-analysis/src/listing/` ; edits to `/home/mahaloz/github/kuna/decompiler/crates/kuna-analysis/src/{pass.rs:292, passes.rs:188/197, s1_entry/mod.rs:132/224/249/257}` , `/home/mahaloz/github/kuna/decompiler/crates/kuna-decomp/src/infra/architecture.rs:{381,575,668,771}` , `/home/mahaloz/github/kuna/decompiler/crates/kuna-decomp/src/p0_knowledge/options.rs (KUNA_OPTION_NAMES)` , `/home/mahaloz/github/kuna/decompiler/crates/kuna-console/src/engine.rs:{271,634,781}` , `/home/mahaloz/github/kuna/decompiler/crates/kuna-decomp/stages.toml:{8,1807,1823}` , `/home/mahaloz/github/kuna/decompiler/crates/kuna-decomp/src/p0_knowledge/kuna_stages/tests.rs:{4,31,37,38}` ; reused unchanged: `Sleigh::one_instruction`/`instruction_length` (`/home/mahaloz/github/kuna/decompiler/crates/kuna-sleigh/src/translate.rs:{459,472,481}`, `PcodeEmit::dump` `:166`), the classifier source-of-truth `/home/mahaloz/github/kuna/decompiler/crates/kuna-decomp/src/s2_lift/flow.rs:{1039-1188}` , `ObjectLoadImage::load_fill` `/home/mahaloz/github/kuna/decompiler/crates/kuna-analysis/src/loadimage_object.rs:354` .


### PR DESCRIPTION
## What

Lands **PR0 of the Listing/xref tier** ("scope-B") — the keystone of a post-disassembly subsystem in `kuna-analysis`: a program-wide **recursive-descent disassembler** plus an instruction / cross-reference / discovered-function model, built by *reusing* the ported SLEIGH decoder and a *lifted copy* of the S2 flow classifier. This is the foundation the rest of the tier's PRs (the `--option listing` flag, the engine build wiring, the CodeUnit partition, the `FindNoReturnFunctionsAnalyzer` consumer) build on.

### The design doc

`docs/listing-tier-design.md` is the **canonical spec** for the whole tier (§1 module layout, §2 data model, §3 the recursive-descent algorithm, §4 decoder reuse + the flow classifier, §5 the flag + parity-safety argument, §6 consumer API, §7 the ordered PR breakdown, §8 deferrals). It is transcribed faithfully from the design fan-out.

### The subsystem (`kuna-analysis/src/listing/`)

- **`model.rs`** — `Insn` (addr/len/fall_through/flow/flows/mnemonic/lazy-pcode), `FlowType` (the faithful `FlowType` predicate set) + `FlowKind`, `RawOp`, `Reference`/`RefKind` (Call/Code populated; Data/Read/Write reserved), `DiscoveredFunction` (ordered `BTreeMap` model), `CodeUnit`.
- **`decode.rs::decode_one`** — drives `Translate::one_instruction` with a capturing `PcodeEmit` for `(len, ops)` and `print_assembly` with a capturing `AssemblyEmit` for the mnemonic; builds the `Address` in the default code space.
- **`classify.rs::classify`** — a faithful transliteration of `s2_lift/flow.rs::xref_control_flow` (`flow.rs:1039-1185`), honoring the three gotchas: constant-space `in0` is p-code-relative (not a VMA), fall-through is the **last**-op test, delay slots are already folded into `len`. BRANCHIND/CALLIND ⇒ computed/indirect with no static target (deferred jump-table resolution).
- **`walk.rs`** — the two-level recursive-descent (function worklist + per-function instruction worklist), `BTreeMap`-membership dedup, exec-range bounds gate, decode-error = stop-this-path, CALL targets → new function entries + `RefKind::Call` edges, branch/fall-through → same-function successors + `RefKind::Code` edges.
- **`mod.rs`** — the `Listing` facade + `Listing::build(file, image, arch, translate, seeds)` and the read-only query API.

The `s1_entry` seed helpers (`executable_sections`/`existing_function_addrs`/`in_executable_section`) are promoted to `pub(crate)` so PR2 can build the seed set.

## Scope discipline (PR0 ONLY)

The module is **dormant**: no `--option listing` flag (PR1), no `AnalysisCtx::listing` / driver build (PR1-PR2), no `context.rs` ARM/MIPS decode-paint (PR5). It touches **no engine path the XML datatests use** — so the 675/675 + 158/158 oracles are structurally untouched.

## Demonstration — what `Listing::build` recovers on the fixture

The real-decode integration test (`kuna-console/tests/verify_listing_core.rs`) bootstraps the vendored x86-64 `fauxware` ELF, obtains a real `Translate` (`prog.arch().translate()`) + code space (`prog.arch().manage()`), seeds with `collect_entries ∪ {main}`, and drives `Listing::build` end-to-end:

```
decoded 108 instructions, discovered 11 functions, 16 call edges (seeds = 2)
  0x40071d: PUSH     kind=Fallthrough          flows=[]          fall=0x40071e
  0x4007ae: CALL     kind=Call                 flows=[0x400664]  fall=0x4007b3   (-> authenticate)
  0x4007bb: JZ       kind=ConditionalBranch    flows=[0x4007c9]  fall=0x4007bd   (two successors)
  0x4007d4: RET      kind=Return               flows=[]          fall=None       (terminal)
```

From 2 entry seeds the walk discovered the rest of the call graph (11 functions, 16 call edges) by following CALL targets. The `je`@0x4007bb yields two successors + `ConditionalBranch`; the `ret` is terminal; the `call`@0x4007ae files a `RefKind::Call` edge to `authenticate`@0x400664 and seeds it as a function.

## Tests (both layers REAL, not skipped)

- **9 classifier unit tests** (`classify.rs`) pin `classify` against the `flow.rs` rules: CBRANCH (two successors), unconditional BRANCH (no fall-through), CALL (target + falls through), RETURN (terminal), BRANCHIND (computed, no target), CALLIND (computed, falls through), a **constant-space BRANCH in0** (intra-insn, NOT a target), and the last-op fall-through rule.
- **`verify_listing_core.rs`** — the end-to-end drive above. **Ran (not skipped)** — `x86-64.sla` is built.

## Gates

- `make test` — **675/675 PARITY OK**
- `make test-stages` — **158/158 PARITY OK**
- `make rust-test` — **green** (incl. the 9 classifier tests + `verify_listing_core`)

## Deviations from the plan

- The integration test lives in `kuna-console/tests/` (a `kuna-console` integration test, exactly as the task suggested) — that is the realistic place to obtain a built `Translate`. It is reached via `prog.arch().translate()` (a `&Sleigh: Translate`) + `prog.arch().manage().get_default_code_space()`, mirroring the `verify_*.rs` bootstrap pattern. The keystone's `image` parameter is part of the contract but not read by the PR0 decode path (the decode drives `translate`, which reads through the engine loader the bootstrap already attached), so the test threads a throwaway `ObjectLoadImage` over the same bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvRnfTgYKoZvS2TEvdYpWb