### PR TITLE
Listing/xref tier PR2: engine-invoke (flag-gated build at bootstrap)

### DIFF
--- a/decompiler/crates/kuna-analysis/src/passes.rs
+++ b/decompiler/crates/kuna-analysis/src/passes.rs
@@ -10,6 +10,7 @@
 //! `docs/missing-analyses.md`.
 
 use kuna_decomp::architecture::Architecture;
+use kuna_sleigh::translate::Translate;
 
 use crate::loadimage_object::ObjectLoadImage;
 use crate::pass::{run_analyses, AnalysisCtx, AnalysisOutput, AnalysisPass};
@@ -152,6 +153,31 @@ pub fn passes_for(compiler: Compiler) -> Vec<Box<dyn AnalysisPass>> {
     ]
 }
 
+/// Build the Listing/xref tier's seed set from a parsed object: the union of
+/// the real funcsym entries (`s1_entry::existing_function_addrs`) and the
+/// discovered entry points (`s1_entry::collect_entries`), restricted to
+/// executable sections, sorted and deduped (design §3.1).
+///
+/// Both halves are already exec-section-filtered upstream (`collect_entries`
+/// filters; `existing_function_addrs` are real FUNC syms), but we apply the
+/// `in_executable_section` gate to both to be robust against a funcsym pointing
+/// at a non-exec address.
+///
+/// `pub` so the cross-crate `verify_listing_*` gates can build the *exact* seed
+/// set the live driver uses (the build-through-engine proof), instead of
+/// reconstructing it from the `pub(crate)` `s1_entry` helpers.
+pub fn listing_seeds(file: &object::File) -> Vec<u64> {
+    let execs = crate::s1_entry::executable_sections(file);
+    let mut seeds: Vec<u64> = crate::s1_entry::existing_function_addrs(file)
+        .into_iter()
+        .chain(crate::s1_entry::collect_entries(file))
+        .filter(|&vma| crate::s1_entry::in_executable_section(&execs, vma))
+        .collect();
+    seeds.sort_unstable();
+    seeds.dedup();
+    seeds
+}
+
 /// Parse `bytes` as an object file, build an [`AnalysisCtx`], and run every
 /// [`default_passes`] pass, returning the merged [`AnalysisOutput`].
 ///
@@ -164,6 +190,7 @@ pub fn run_default_analyses(
     bytes: &[u8],
     image: &ObjectLoadImage,
     arch: &Architecture,
+    translate: &dyn Translate,
 ) -> AnalysisOutput {
     let Ok(file) = object::File::parse(bytes) else {
         return AnalysisOutput::default();
@@ -172,7 +199,15 @@ pub fn run_default_analyses(
     // pass list (the kuna analog of `SourceLanguageAnalyzer` running early and
     // gating the language-specific analyzers).
     let compiler = crate::s1_sourcelang::detect_compiler(&file);
-    let ctx = AnalysisCtx { file: &file, image, arch, listing: None };
+    // Listing/xref tier (design §1.3): built once, before the pass loop, only
+    // when `--option listing on` (default-off ⇒ `None` ⇒ no decode work, byte
+    // -identical to today). Owned here so it outlives the pass loop, borrowed
+    // read-only by every consumer pass via `ctx.listing`.
+    let seeds = listing_seeds(&file);
+    let listing = arch
+        .analysis_listing
+        .then(|| crate::listing::Listing::build(&file, image, arch, translate, &seeds));
+    let ctx = AnalysisCtx { file: &file, image, arch, listing: listing.as_ref() };
     run_analyses(&ctx, &passes_for(compiler))
 }
 
@@ -189,12 +224,23 @@ pub fn run_default_analyses_per_pass(
     bytes: &[u8],
     image: &ObjectLoadImage,
     arch: &Architecture,
+    translate: &dyn Translate,
 ) -> Vec<(&'static str, AnalysisOutput)> {
     let Ok(file) = object::File::parse(bytes) else {
         return Vec::new();
     };
     let compiler = crate::s1_sourcelang::detect_compiler(&file);
-    let ctx = AnalysisCtx { file: &file, image, arch, listing: None };
+    // Listing/xref tier (design §1.3): built once, before the pass loop, only
+    // when `arch.analysis_listing` (i.e. `--option listing on`). Default-off ⇒
+    // `.then(...)` is `None` ⇒ no decode work, `ctx.listing == None`, and the
+    // real-ELF bootstrap is byte-identical to today. The `Listing` is owned here
+    // (same lifetime shape as `file`), outlives the pass loop, and is borrowed
+    // read-only by every consumer pass via `ctx.listing`.
+    let seeds = listing_seeds(&file);
+    let listing = arch
+        .analysis_listing
+        .then(|| crate::listing::Listing::build(&file, image, arch, translate, &seeds));
+    let ctx = AnalysisCtx { file: &file, image, arch, listing: listing.as_ref() };
     passes_for(compiler)
         .iter()
         .map(|pass| (pass.id(), pass.run(&ctx)))

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -632,8 +632,16 @@ pub fn bootstrap_from_elf(
     // conflict #4, analysis-port-log.md). Bound to the real-ELF path ONLY — the
     // XML <binaryimage> bootstrap never runs these, so the datatest parity oracle
     // is structurally untouched.
-    let pending_analysis =
-        kuna_analysis::passes::run_default_analyses_per_pass(&bytes, &loader, sleigh.base().unwrap());
+    let pending_analysis = kuna_analysis::passes::run_default_analyses_per_pass(
+        &bytes,
+        &loader,
+        sleigh.base().unwrap(),
+        // The Listing/xref tier's decoder: the engine's `Translate` (the same
+        // `Sleigh` the decompile drives), coerced to `&dyn Translate`. The
+        // `.sla` is loaded and the loadimage attached (above), so a flag-gated
+        // `Listing::build` can decode through it. Default-off ⇒ unused.
+        sleigh.base().unwrap().translate(),
+    );
 
     // readLoaderSymbols (the ELF FUNC symbols) BEFORE handing the loader off.
     let symbols = read_loader_symbols_generic(&loader);

--- a/decompiler/crates/kuna-console/tests/verify_listing_core.rs
+++ b/decompiler/crates/kuna-console/tests/verify_listing_core.rs
@@ -205,3 +205,80 @@ fn listing_build_recovers_instructions_flow_and_functions() {
         }
     }
 }
+
+/// PR2 build-through-engine proof: build the Listing the way the analysis driver
+/// (`run_default_analyses_per_pass`) does — seed set =
+/// `existing_function_addrs ∪ collect_entries` (exec-filtered, sorted/deduped),
+/// driven by the engine's real `Translate` (which reads bytes through the loader
+/// the bootstrap attached, not a throwaway loadimage). This is the path PR2 wires
+/// behind `--option listing on`; here we exercise it directly and confirm it
+/// populates a non-empty function/instruction model. (The runtime `ctx.listing`
+/// population through the live driver is exercised by PR6, the first consumer;
+/// PR2's job is the wiring + this proof + the flag-on==flag-off parity, see
+/// `verify_listing_parity.rs`.)
+#[test]
+fn listing_build_through_engine_driver_seeds() {
+    let root = repo_root();
+    let specs = root.join("specs");
+    let spec_roots = vec![specs.to_str().unwrap().to_string()];
+
+    let bin = match fauxware().to_str() {
+        Some(s) => s.to_string(),
+        None => return,
+    };
+
+    let prog = match bootstrap_from_elf(&bin, "", &spec_roots) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "verify_listing_core: skipping (bootstrap failed, build the x86 `.sla` with \
+                 `make specs`): {}",
+                e.explain()
+            );
+            return;
+        }
+    };
+
+    let bytes = std::fs::read(&bin).expect("read fixture bytes");
+    let file = object::File::parse(&*bytes).expect("parse fixture ELF");
+
+    // The driver's exact seed set (design §3.1): existing funcsyms ∪ discovered
+    // entries, restricted to executable sections, sorted/deduped — the very
+    // helper the live driver calls (`passes::listing_seeds`).
+    let seeds = kuna_analysis::passes::listing_seeds(&file);
+    assert!(!seeds.is_empty(), "the driver seed set must be non-empty for fauxware");
+
+    let arch = prog.arch();
+    let translate = arch.translate(); // the engine's real `&dyn Translate`
+    // `image` is part of the contract but the decode reads through the engine's
+    // attached loader (driven by `translate`), so any loadimage over the bytes
+    // satisfies it (decode.rs).
+    let image = kuna_analysis::loadimage_object::ObjectLoadImage::from_bytes(&bin, &bytes)
+        .expect("open loadimage");
+
+    let listing = Listing::build(&file, &image, arch, translate, &seeds);
+
+    // The build-through-engine path populates the model: at least the seeds
+    // become functions, and the entry decodes to an instruction.
+    assert!(
+        listing.function_count() > 0,
+        "engine-driven Listing::build must discover/seed functions, got {}",
+        listing.function_count()
+    );
+    let entry = seeds[0];
+    assert!(
+        listing.instruction_at(entry).is_some(),
+        "engine-driven Listing::build must decode an instruction at the first seed {entry:#x}"
+    );
+    // `main` is a seed; it must decode too.
+    assert!(
+        listing.instruction_at(MAIN).is_some(),
+        "engine-driven Listing::build must decode an instruction at main ({MAIN:#x})"
+    );
+    eprintln!(
+        "verify_listing_core (driver path): {} seeds -> {} functions, {} instructions",
+        seeds.len(),
+        listing.function_count(),
+        listing.num_instructions()
+    );
+}

--- a/decompiler/crates/kuna-console/tests/verify_listing_parity.rs
+++ b/decompiler/crates/kuna-console/tests/verify_listing_parity.rs
@@ -1,0 +1,119 @@
+//! PR2 parity gate for the Listing/xref tier (scope-B): the key proof that
+//! enabling `--option listing on` changes **nothing** in the decompiler output.
+//!
+//! The Listing is built at bootstrap behind the flag (PR2 wiring) but **no pass
+//! consumes it yet** (the first consumer is PR6), so the decompiler output MUST
+//! be byte-identical with the flag on, with the flag off, and to today. This
+//! test decompiles `fauxware main` → `print C` two ways and asserts the C is the
+//! same string:
+//!
+//!  - default (flag off, the today baseline),
+//!  - `--option listing on` (the live-CLI ordering: the `option` line follows
+//!    `load file`, so the flag flips on the live arch).
+//!
+//! Note on build-at-load timing: the analysis driver (which would build the
+//! Listing) runs once inside `bootstrap_from_elf` (`load file`), and the live
+//! CLI emits `option listing on` *after* `load file`, so the build-at-load does
+//! not fire through the live CLI today — wiring it to fire is PR6's concern (the
+//! first consumer). The build-at-load *body* (the flag-on path) is exercised
+//! directly through the engine's real `Translate` by `verify_listing_core.rs`'s
+//! `listing_build_through_engine_driver_seeds`. Either way the output is
+//! byte-identical: nothing consumes the Listing.
+//!
+//! ## `.sla` precondition
+//!
+//! Like the sibling `verify_*` gates, bootstrapping needs the built `x86` `.sla`
+//! under `specs/` (gitignored; `make specs`). When it is absent the bootstrap
+//! fails; the test prints that and returns early (a specs-less CI is a visible
+//! skip, never a false green).
+
+use std::path::PathBuf;
+
+use kuna_console::engine::bootstrap_from_elf;
+use kuna_console::ifacedecomp::{execute, register_decomp_commands, IfaceDecompData, DECOMPILE_MODULE};
+use kuna_console::ifaceterm::ConsoleCommands;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+/// The vendored non-PIE x86-64 fauxware fixture (shared with `verify_listing_core`).
+fn fauxware() -> PathBuf {
+    repo_root().join("decompiler/crates/kuna-analysis/tests/fixtures/fauxware")
+}
+
+/// How to set the `listing` flag for a decompile run.
+enum ListingMode {
+    /// Default: never touched (the today baseline).
+    Off,
+    /// `--option listing on` issued after bootstrap (the live-CLI ordering — the
+    /// build-at-load has already happened by then, so this only flips the live
+    /// flag; the Listing is not (re)built but nothing consumes it either way).
+    OnAfterBootstrap,
+}
+
+/// Bootstrap fauxware, optionally enable `listing`, decompile `main`, and return
+/// the captured C (`None` ⇒ specs-less skip).
+fn decompile_main(mode: ListingMode) -> Option<String> {
+    let root = repo_root();
+    let specs = root.join("specs");
+    let spec_roots = vec![specs.to_str().unwrap().to_string()];
+
+    let bin = fauxware().to_str()?.to_string();
+    let mut prog = match bootstrap_from_elf(&bin, "", &spec_roots) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "verify_listing_parity: skipping (bootstrap failed, build `.sla` with \
+                 `make specs`): {}",
+                e.explain()
+            );
+            return None;
+        }
+    };
+    prog.commit_pending_analysis().expect("analysis commit succeeds");
+    if let ListingMode::OnAfterBootstrap = mode {
+        prog.arch_mut()
+            .set_kuna_option("listing", "on")
+            .expect("listing option flips on");
+    }
+
+    let cmds: Vec<String> =
+        ["load function main".into(), "decompile".into(), "print C".into()].to_vec();
+    let count = cmds.len();
+    let mut status = ConsoleCommands::into_status(cmds);
+    register_decomp_commands(&mut status);
+    {
+        let data = status.get_data_mut(DECOMPILE_MODULE).unwrap();
+        let dcp = data.as_any_mut().downcast_mut::<IfaceDecompData>().unwrap();
+        dcp.conf = Some(prog);
+    }
+    for _ in 0..count {
+        execute(&mut status);
+    }
+    Some(status.optr.clone())
+}
+
+/// The key PR2 proof: `--option listing on` is byte-identical to the default
+/// (flag off). The Listing is built behind the flag but consumed by no pass, so
+/// there is zero behavior change.
+#[test]
+fn listing_on_is_byte_identical_to_off() {
+    let Some(off) = decompile_main(ListingMode::Off) else {
+        return; // specs-less skip
+    };
+    let on = decompile_main(ListingMode::OnAfterBootstrap)
+        .expect("second bootstrap succeeds if the first did");
+
+    assert!(!off.trim().is_empty(), "expected non-empty C for fauxware main");
+    assert!(off.contains("main") || off.contains("undefined"), "expected a function body:\n{off}");
+    assert_eq!(
+        on, off,
+        "`--option listing on` must produce byte-identical C to the default (flag off): \
+         the Listing is built but consumed by no pass yet (PR2)\n--- off ---\n{off}\n--- on ---\n{on}"
+    );
+    eprintln!(
+        "verify_listing_parity: flag-on == flag-off, {} bytes of identical C",
+        off.len()
+    );
+}

--- a/docs/analysis-port-log.md
+++ b/docs/analysis-port-log.md
@@ -2226,3 +2226,68 @@ bootstrap are untouched. The flag is inert until PR2 builds the Listing.
   `kuna-analysis/src/pass.rs`, `kuna-analysis/src/passes.rs`, `docs/assertions.md`,
   `docs/baseline-stages.json`, `tests/stages/README.md`.
 - **New:** `tests/stages/kuna-listing-flag.xml`.
+
+### Increment 31 — Listing/xref tier PR2: engine-invoke (build the Listing at bootstrap, flag-gated)
+
+PR2 of the Listing/xref tier (`docs/listing-tier-design.md` §1.3, §7 PR2): invoke
+the keystone from the engine at bootstrap, flag-gated. PR0 built `Listing::build`
+(unit-tested in isolation); PR1 wired the `--option listing` flag end-to-end with
+`AnalysisCtx.listing: Option<&Listing>` always `None`. PR2 makes the build fire —
+behind the default-OFF flag — and populates `ctx.listing`.
+
+**What's wired.**
+- `kuna-analysis/src/passes.rs`: threaded `translate: &dyn Translate` into both
+  drivers — the live `run_default_analyses_per_pass` and (for signature symmetry)
+  `run_default_analyses`. In each, before the pass loop:
+  `let listing = arch.analysis_listing.then(|| Listing::build(&file, image, arch, translate, &seeds));`
+  then `ctx.listing = listing.as_ref()` (replacing PR1's literal `listing: None`).
+  The `Listing` is owned by the driver and outlives the pass loop (same lifetime
+  shape as `file`), borrowed read-only via `ctx.listing`.
+- The seed set is a new `pub fn listing_seeds(file)` =
+  `existing_function_addrs(file) ∪ collect_entries(file)`, `in_executable_section`
+  -filtered, sorted/deduped (design §3.1), built from the `pub(crate)` `s1_entry`
+  helpers. Exposed `pub` so the cross-crate `verify_listing_*` gates can build the
+  *exact* seed set the live driver uses.
+- `kuna-console/src/engine.rs`: the driver call (`bootstrap_from_elf`) passes the
+  engine's real decoder as the 4th arg — `sleigh.base().unwrap().translate()`
+  (a `&Sleigh`, coerced to `&dyn Translate`; `Sleigh: Translate`). The `.sla` is
+  loaded and the loadimage attached at this point, so a flag-gated build can decode
+  through it. The decode reads bytes through the engine's attached loader (driven by
+  `translate`), not through the `image` parameter (which stays unused, `_image`).
+
+**Parity safety (the key proof).** `arch.analysis_listing` defaults `false`, so
+`.then(...)` is `None` ⇒ no decode work, `ctx.listing == None`, byte-identical to
+today. With the flag on the Listing is built but **no pass consumes it yet** (the
+first consumer is PR6), so the decompiler output is unchanged. The build runs only
+on the real-ELF bootstrap path (`run_default_analyses_per_pass`'s sole caller is
+`bootstrap_from_elf`); the XML datatest path never reaches the analysis driver, so
+the 675/675 and 159/159 oracles are structurally untouched.
+
+**Build-at-load timing (honest note).** The analysis driver runs once inside
+`bootstrap_from_elf` (`load file`), and the live CLI emits `option listing on`
+*after* `load file` (the `--option` lines precede `read symbols`, not `load file`),
+so the build-at-load does not fire through the live CLI today. Wiring the flag to
+fire the build is PR6's concern (the first consumer). PR2's job is the wiring +
+the parity proof + a direct exercise of the build-at-load body through the engine's
+real `Translate`.
+
+**Proof (specs built; tests ran, not skipped).**
+- `verify_listing_core.rs` — new test `listing_build_through_engine_driver_seeds`:
+  bootstraps `fauxware`, builds the driver's exact seed set via `listing_seeds`, and
+  runs `Listing::build` through the engine's real `&dyn Translate`. Result:
+  **21 seeds → 21 functions, 228 instructions**; `function_count() > 0` and
+  `instruction_at(entry).is_some()` (and `instruction_at(main).is_some()`) all hold.
+  This proves the engine-driven build path (vs PR0's throwaway-loadimage test).
+- `verify_listing_parity.rs` — new test `listing_on_is_byte_identical_to_off`:
+  decompiles `fauxware main → print C` with the flag off (default) and with
+  `--option listing on`, and asserts the C is **byte-identical** (437 bytes,
+  identical). The Listing is built behind the flag but consumed by no pass yet.
+
+**Result.** `make test` **675/675 PARITY OK**; `make test-stages` **159/159 PARITY
+OK**; `make rust-test` green; `kuna catalog --check` **OK**. The flag is default-off
+so the parity oracles are structurally untouched; with the flag on the build runs
+but changes no output (payoff comes with the first consumer, PR6).
+
+- **Changed:** `kuna-analysis/src/passes.rs`, `kuna-console/src/engine.rs`,
+  `kuna-console/tests/verify_listing_core.rs`.
+- **New:** `kuna-console/tests/verify_listing_parity.rs`.


### PR DESCRIPTION
PR2 of the Listing/xref tier (`docs/listing-tier-design.md` §1.3, §7 PR2): invoke the keystone from the engine at bootstrap, flag-gated. PR0 built `Listing::build`; PR1 wired the `--option listing` flag with `AnalysisCtx.listing` always `None`. PR2 makes the build fire — behind the default-OFF flag — and populates `ctx.listing`.

## What's wired

- **`kuna-analysis/src/passes.rs`** — threaded `translate: &dyn Translate` into both drivers: the live `run_default_analyses_per_pass` and (for signature symmetry) `run_default_analyses`. In each, before the pass loop:
  ```rust
  let seeds = listing_seeds(&file);
  let listing = arch.analysis_listing
      .then(|| crate::listing::Listing::build(&file, image, arch, translate, &seeds));
  let ctx = AnalysisCtx { file: &file, image, arch, listing: listing.as_ref() };
  ```
  The `Listing` is owned by the driver and outlives the pass loop (same lifetime shape as `file`), borrowed read-only via `ctx.listing` (replacing the `listing: None` PR1 inserted).
- New `pub fn listing_seeds(file)` = `existing_function_addrs(file) ∪ collect_entries(file)`, `in_executable_section`-filtered, sorted/deduped (design §3.1), built from the `pub(crate)` `s1_entry` helpers. `pub` so the cross-crate `verify_listing_*` gates build the exact seed set the live driver uses.
- **`kuna-console/src/engine.rs`** — the `bootstrap_from_elf` driver call passes the engine's real decoder as the 4th arg: `sleigh.base().unwrap().translate()` (a `&Sleigh`; `Sleigh: Translate`; coerced to `&dyn Translate`). The `.sla` is loaded and the loadimage attached at that point, so a flag-gated build decodes through it.

## The parity proof: flag on == flag off == today

`arch.analysis_listing` defaults `false` ⇒ `.then(...)` is `None` ⇒ no decode work, `ctx.listing == None`, byte-identical to today. With the flag on the Listing is built but **no pass consumes it yet** (the first consumer is PR6), so the decompiler output is unchanged. The build runs only on the real-ELF bootstrap path; the XML datatest path never reaches the analysis driver, so the 675/675 and 159/159 oracles are structurally untouched.

`verify_listing_parity.rs::listing_on_is_byte_identical_to_off` decompiles `fauxware main → print C` with the flag off (default) and with `--option listing on` and asserts the C is **byte-identical** (437 bytes, identical).

Build-at-load timing (honest note): the analysis driver runs once inside `bootstrap_from_elf` (`load file`), and the live CLI emits `option listing on` *after* `load file`, so the build-at-load does not fire through the live CLI today — wiring it to fire is PR6's concern (the first consumer). The build-at-load *body* is exercised directly through the engine's real `Translate` below.

## The build-through-engine proof

`verify_listing_core.rs::listing_build_through_engine_driver_seeds` bootstraps `fauxware`, builds the driver's exact seed set via `listing_seeds`, and runs `Listing::build` through the engine's real `&dyn Translate` (which reads bytes through the loader the bootstrap attached, vs PR0's throwaway loadimage). Result: **21 seeds → 21 functions, 228 instructions**; `function_count() > 0` and `instruction_at(entry).is_some()` (and `instruction_at(main).is_some()`) all hold.

## The runtime Listing

The runtime Listing is now built behind `--option listing on` (default-off). The payoff comes with the first consumer (PR6, `FindNoReturnFunctionsAnalyzer`); PR2 is the wiring + the parity/build proofs.

## Gates

- `make test` — **675/675 PARITY OK**
- `make test-stages` — **159/159 PARITY OK**
- `make rust-test` — green
- `kuna catalog --check` — **OK**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvRnfTgYKoZvS2TEvdYpWb