### PR TITLE
Listing/xref tier PR5: ARM/MIPS context-paint in the walker

### DIFF
--- a/decompiler/crates/kuna-analysis/src/listing/context.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/context.rs
@@ -1,0 +1,115 @@
+//! Decode-context resolution for the recursive-descent walker (design §4.2).
+//!
+//! Some ISAs steer instruction decode with a SLEIGH *processor-context* variable:
+//! ARM `TMode` (0 = A32, 1 = Thumb) and MIPS `ISA_MODE` (0 = MIPS32, 1 = the
+//! alternate MIPS16e/microMIPS ISA). That context **must be painted into the
+//! engine's `ContextDatabase` before the bytes at an address are decoded**, or the
+//! same byte stream misdecodes — a Thumb function read as A32, a MIPS16 function
+//! read as MIPS32: garbage.
+//!
+//! The decompiler's normal pipeline gets this from the analysis-tier commit seam
+//! (`kuna-console::engine::commit_analysis_output` step 6 paints
+//! [`crate::pass::ContextPaint`] facts over the engine's `ContextDatabase` before
+//! `load function`). The Listing's recursive-descent walker decodes **outside**
+//! that path — it drives [`crate::listing::decode::decode_one`] directly — so it
+//! must perform the same paint itself, with the same facts, before it walks.
+//!
+//! # How the per-address decode mode is obtained
+//!
+//! [`ContextPainter`] does **not** re-derive the decode mode: it *calls into the
+//! existing marker logic* — [`crate::s1_loader::arm_markers::scan_arm_markers`]
+//! (ARM `$t`/`$a` mapping symbols + STT_FUNC LSB → `TMode`) and
+//! [`crate::s1_loader::mips_markers::scan_mips_isa_markers`] (STT_FUNC LSB /
+//! `STO_MIPS_MIPS16` `st_other` → `ISA_MODE`) — and reuses their
+//! [`crate::pass::ContextPaint`] facts verbatim. The same computation the
+//! decompiler's analysis tier trusts is the one the walker paints.
+//!
+//! # Mechanism (mirrors the commit seam exactly)
+//!
+//! [`ContextPainter::paint_all`] applies every collected paint to the engine's
+//! `ContextDatabase` via [`Architecture::with_context_db_mut`] →
+//! `db.set_variable(var, addr, value)` — the *same* call
+//! `commit_analysis_output` makes. `set_variable` sets the value from `addr` up to
+//! the next change point, so painting only the markers (where the mode *changes*)
+//! correctly fills every region in between. The walk then decodes against an
+//! already-painted context DB, so each [`decode_one`](crate::listing::decode::decode_one)
+//! reads the right mode.
+//!
+//! # Gate safety (x86-64 and every non-ARM/MIPS language is untouched)
+//!
+//! The marker scans gate on the object architecture (ARM-only / MIPS-only), so on
+//! x86-64 (and anything else with no decode-mode context) [`ContextPainter::new`]
+//! collects **zero** paints and [`paint_all`] is a no-op — x86-64 decode is
+//! byte-identical to no painter at all. Belt-and-suspenders: `set_variable`
+//! returns `Err` for a context variable the active language does not register
+//! (e.g. `TMode` on a MIPS object), and that error is swallowed — the exact
+//! `ContextDatabase`-not-registered no-op the commit seam relies on.
+
+use std::rc::Rc;
+
+use kuna_base::address::Address;
+use kuna_base::space::AddrSpace;
+use kuna_decomp::architecture::Architecture;
+
+use crate::pass::ContextPaint;
+use crate::s1_loader::arm_markers::scan_arm_markers;
+use crate::s1_loader::mips_markers::scan_mips_isa_markers;
+
+/// Resolves and applies the per-address decode-mode context (ARM `TMode`, MIPS
+/// `ISA_MODE`) the recursive-descent walker needs before it decodes (design §4.2).
+///
+/// Built once per [`Listing::build`](crate::listing::Listing::build) from the
+/// object file by **reusing the marker logic** (not re-deriving it); holds the
+/// collected [`ContextPaint`] facts so [`paint_all`](ContextPainter::paint_all)
+/// can apply them to the engine's `ContextDatabase` before the walk.
+pub(super) struct ContextPainter {
+    /// The decode-mode paints to apply, collected from the marker scans. Empty on
+    /// any language with no decode-mode context (e.g. x86-64) ⇒ a no-op painter.
+    paints: Vec<ContextPaint>,
+}
+
+impl ContextPainter {
+    /// Collect the decode-mode paints for `file` by calling into the existing ARM
+    /// and MIPS marker logic (design §4.2). The marker scans self-gate on the
+    /// object architecture, so for x86-64 (or any language without a decode-mode
+    /// context variable) this yields an empty, no-op painter.
+    pub(super) fn new(file: &object::File) -> Self {
+        let mut paints = Vec::new();
+        // ARM `$t`/`$a` mapping symbols + STT_FUNC-LSB → `TMode` (Thumb). The scan
+        // is ARM-gated; on a non-ARM object it returns an empty output.
+        paints.extend(scan_arm_markers(file).context_paints);
+        // MIPS STT_FUNC-LSB / `STO_MIPS_MIPS16` `st_other` → `ISA_MODE` (MIPS16e /
+        // microMIPS). The scan is MIPS-gated; empty on a non-MIPS object.
+        paints.extend(scan_mips_isa_markers(file).context_paints);
+        ContextPainter { paints }
+    }
+
+    /// `true` iff there is nothing to paint (x86-64 / any language with no
+    /// decode-mode context) — the walk needs no context step at all.
+    pub(super) fn is_empty(&self) -> bool {
+        self.paints.is_empty()
+    }
+
+    /// Paint every collected decode-mode context value into the engine's
+    /// `ContextDatabase`, BEFORE the walk decodes anything (the timing ARM Thumb /
+    /// MIPS16 mode requires). Mirrors `commit_analysis_output` step 6: a `None`
+    /// end is the point set (`set_variable`, paint-to-next-change-point); a `Some`
+    /// end paints the explicit `[addr, end)` region (`set_variable_region`).
+    ///
+    /// Gate-safe: an unregistered context variable (a faithful no-op for a
+    /// language that does not define it) is swallowed via the dropped `Result`.
+    pub(super) fn paint_all(&self, arch: &Architecture, code_space: &Rc<AddrSpace>) {
+        for paint in &self.paints {
+            let begin = Address::new(Rc::clone(code_space), paint.addr);
+            // Drop the Result: an unregistered context variable is a faithful
+            // no-op (the commit seam relies on the same swallow).
+            let _ = arch.with_context_db_mut(|db| match paint.end {
+                Some(end) => {
+                    let endad = Address::new(Rc::clone(code_space), end);
+                    db.set_variable_region(paint.var.as_bytes(), &begin, &endad, paint.value)
+                }
+                None => db.set_variable(paint.var.as_bytes(), &begin, paint.value),
+            });
+        }
+    }
+}

--- a/decompiler/crates/kuna-analysis/src/listing/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/mod.rs
@@ -22,6 +22,7 @@
 //! `covered`/`exec_ranges` fields are defined here now.
 
 pub mod classify;
+pub mod context;
 pub mod decode;
 pub mod model;
 pub mod walk;
@@ -129,7 +130,14 @@ impl Listing {
             );
         }
 
-        let st = walk::walk(translate, &code_space, &exec_ranges, seeds, &seed_funcs);
+        // Resolve the decode-mode context (ARM TMode / MIPS ISA_MODE) by reusing
+        // the marker logic (design §4.2 / PR5). On x86-64 (and any language with no
+        // decode-mode context) this painter is empty and the walk decodes exactly
+        // as before; on ARM/MIPS it paints Thumb/MIPS16 mode so alt-ISA functions
+        // decode correctly instead of as A32/MIPS32 garbage.
+        let painter = context::ContextPainter::new(file);
+
+        let st = walk::walk(translate, arch, &code_space, &exec_ranges, seeds, &seed_funcs, &painter);
 
         let mut refs_to = st.refs_to;
         let mut refs_from = st.refs_from;

--- a/decompiler/crates/kuna-analysis/src/listing/walk.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/walk.rs
@@ -20,9 +20,11 @@ use std::rc::Rc;
 
 use kuna_base::address::RangeList;
 use kuna_base::space::AddrSpace;
+use kuna_decomp::architecture::Architecture;
 use kuna_sleigh::translate::Translate;
 
 use super::classify::classify;
+use super::context::ContextPainter;
 use super::decode::decode_one;
 use super::model::{DiscoveredFunction, Insn, Reference, RefKind};
 
@@ -72,14 +74,30 @@ fn in_exec(exec_ranges: &[(u64, u64)], vma: u64) -> bool {
 /// [`DiscoveredFunction`] metadata for each seed (name / from_symbol); seeds
 /// without an entry there get a generic discovered record. `exec_ranges` bounds
 /// every decode (out-of-bounds = stop-this-path). `code_space` is the space the
-/// `Address`es are built in.
+/// `Address`es are built in. `arch` exposes the engine's `ContextDatabase`, into
+/// which `painter` paints the per-address decode mode (ARM `TMode` / MIPS
+/// `ISA_MODE`) **before** any [`decode_one`] runs (design §4.2 / PR5) — without
+/// it a Thumb/MIPS16 function misdecodes as A32/MIPS32. On x86-64 (no decode-mode
+/// context) the painter is empty and this is a no-op.
 pub(super) fn walk(
     translate: &dyn Translate,
+    arch: &Architecture,
     code_space: &Rc<AddrSpace>,
     exec_ranges: &[(u64, u64)],
     seeds: &[u64],
     seed_funcs: &BTreeMap<u64, DiscoveredFunction>,
+    painter: &ContextPainter,
 ) -> WalkState {
+    // Paint the decode-mode context (ARM TMode / MIPS ISA_MODE) into the engine's
+    // ContextDatabase BEFORE we decode a single instruction — the timing the
+    // alternate ISAs require (the same ordering `commit_analysis_output` uses).
+    // `set_variable` fills each mode from its marker up to the next change point,
+    // so painting once here covers every address the walk visits. A no-op when
+    // `painter` is empty (x86-64 / any language with no decode-mode context).
+    if !painter.is_empty() {
+        painter.paint_all(arch, code_space);
+    }
+
     let mut st = WalkState::new();
 
     // Function-entry worklist, seeded from the root set.

--- a/decompiler/crates/kuna-analysis/src/s1_loader/arm_markers.rs
+++ b/decompiler/crates/kuna-analysis/src/s1_loader/arm_markers.rs
@@ -101,7 +101,7 @@ fn is_arm_marker(name: &str) -> bool {
 ///    documented no-op (no `createUndefinedData` at this tier).
 /// 2. **STT_FUNC with `st_value & 1`** (the Thumb odd-address convention): emit
 ///    `TMode=1` at the normalized even address `value & !1`.
-fn scan_arm_markers(file: &object::File) -> AnalysisOutput {
+pub(crate) fn scan_arm_markers(file: &object::File) -> AnalysisOutput {
     let mut out = AnalysisOutput::default();
     // canAnalyze gate: ARM only. Mirrors ArmSymbolAnalyzer.canAnalyze:172-177
     // (processor==ARM && getRegister("TMode")!=null). On any other language the

--- a/decompiler/crates/kuna-analysis/src/s1_loader/mips_markers.rs
+++ b/decompiler/crates/kuna-analysis/src/s1_loader/mips_markers.rs
@@ -211,7 +211,7 @@ pub struct MipsIsaModePass;
 /// Faithful to `applyIsaMode`'s gate + the `setValue(ISA_MODE, addr, addr, 1)`:
 /// gated on a MIPS ELF object, one paint per STT_FUNC carrying the alternate-ISA
 /// marker. Undefined imports (`.dynsym` UND, address 0) are skipped (no body).
-fn scan_mips_isa_markers(file: &object::File) -> AnalysisOutput {
+pub(crate) fn scan_mips_isa_markers(file: &object::File) -> AnalysisOutput {
     let mut out = AnalysisOutput::default();
     // canHandle gate: MIPS only (the analog of MIPS_ElfExtension.canHandle:331,
     // e_machine == EM_MIPS). MIPS32 and MIPS64 both report Architecture::Mips /

--- a/decompiler/crates/kuna-console/tests/verify_listing_context.rs
+++ b/decompiler/crates/kuna-console/tests/verify_listing_context.rs
@@ -1,0 +1,298 @@
+//! End-to-end gate for the Listing/xref tier decode-mode context paint (scope-B
+//! PR5): the recursive-descent walker paints the right decode mode (ARM `TMode` /
+//! MIPS `ISA_MODE`) into the engine's `ContextDatabase` BEFORE it decodes, so an
+//! alternate-ISA (Thumb / MIPS16) function decodes correctly instead of being
+//! misread as A32 / MIPS32 garbage.
+//!
+//! ## What this proves (and how it is a real proof)
+//!
+//! `Listing::build`'s walker drives `Translate::one_instruction` directly —
+//! *outside* the decompiler's normal `commit_analysis_output` paint path — so it
+//! must paint the decode mode itself (`listing/context.rs`, reusing the
+//! `arm_markers` / `mips_markers` marker logic). Without that paint, the same byte
+//! stream misdecodes:
+//!
+//!  - **ARM Thumb.** `compute`'s entry (`0x100b8`) is the 2-byte Thumb op
+//!    `push {r7}` (`80 b4`). Decoded in Thumb mode it has length **2**; an A32
+//!    misdecode reads a fixed **4**-byte word (`b0 83 80 b4` LE) — a different,
+//!    garbage instruction. The width alone is decisive (A32 is *always* 4 bytes),
+//!    and we also confirm a Thumb mnemonic and the multiply/shift body.
+//!  - **MIPS16.** `m16_square`'s entry (`0x400130`) is the 2-byte MIPS16 op
+//!    `mult a0,a0` (`ec 98`). Decoded as MIPS16 it has length **2**; a MIPS32
+//!    misdecode reads a fixed **4**-byte word. Same width-based proof.
+//!
+//! Each case also runs a **control**: the SAME seed decoded through a fresh
+//! bootstrap's raw `Translate` (no Listing, no paint) gets the un-painted default
+//! decode — and we assert the Listing's painted decode DIFFERS from it (so the
+//! paint, not some incidental default, is what flips the ISA). x86-64 needs no
+//! decode-mode context, so the `verify_listing_core` gate (which never paints)
+//! still passes unchanged — this gate adds the ARM/MIPS half.
+//!
+//! ## `.sla` precondition
+//!
+//! Bootstrapping needs the built ARM (and MIPS) `.sla` under `specs/` (gitignored;
+//! `make specs`). When it is absent the bootstrap fails; the test prints that and
+//! returns early (a specs-less CI is a visible skip, never a false green).
+
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use kuna_analysis::listing::Listing;
+use kuna_base::address::Address;
+use kuna_console::engine::{bootstrap_from_elf, ConsoleProgram};
+use kuna_sleigh::translate::{AssemblyEmit, PcodeEmit};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+fn spec_roots() -> Vec<String> {
+    vec![repo_root().join("specs").to_str().unwrap().to_string()]
+}
+
+/// The vendored LINKED ARM Thumb fixture (`compute` is `x*3 + 7`, a Thumb FUNC at
+/// the odd `entry|1` address; `$t` marks the Thumb run start). Shared with
+/// `verify_arm_thumb_decode`.
+fn arm_thumb_linked() -> PathBuf {
+    repo_root().join("decompiler/crates/kuna-analysis/tests/fixtures/arm_thumb_linked_le32")
+}
+
+/// The vendored freestanding MIPS16 fixture (`m16_square` is `n*n + 3`, marked
+/// MIPS16 via `st_other & 0xf0 == STO_MIPS_MIPS16`). Shared with
+/// `verify_mips16_isa`.
+fn mips16() -> PathBuf {
+    repo_root().join("decompiler/crates/kuna-analysis/tests/fixtures/mips16_le32")
+}
+
+// ARM Thumb load-bearing VMAs (`readelf --syms` / `.text` dump at fixture-build
+// time): `$t` + `compute`'s even decode entry @ 0x100b8 (Thumb), `_start`'s even
+// entry @ 0x100d6. `compute` starts with the 2-byte Thumb `push {r7}` (`80 b4`).
+const COMPUTE_EVEN_ENTRY: u64 = 0x100b8;
+
+// MIPS16 load-bearing VMAs: `m16_square`'s entry @ 0x400130 (MIPS16, 8-byte body
+// `ec98 ea12 e820 4a03`), starting with the 2-byte MIPS16 `mult a0,a0` (`ec 98`).
+const M16_SQUARE_ENTRY: u64 = 0x400130;
+
+/// Bootstrap a fixture for a real `Translate`, or return `None` (a visible skip)
+/// if the `.sla` is absent.
+fn boot(bin: &str, who: &str) -> Option<ConsoleProgram> {
+    match bootstrap_from_elf(bin, "", &spec_roots()) {
+        Ok(p) => Some(p),
+        Err(e) => {
+            eprintln!("{who}: skipping (bootstrap failed, build the `.sla` with `make specs`): {}", e.explain());
+            None
+        }
+    }
+}
+
+/// Decode one instruction at `vma` through the engine's raw `Translate` (no
+/// Listing, no context paint) — the un-painted DEFAULT-mode decode used as the
+/// "before"/control. Returns `Some((len, mnemonic))`, or `None` if the default
+/// ISA cannot decode the bytes at all (itself proof the bytes are not valid in
+/// the default mode — e.g. MIPS16 bytes read as MIPS32).
+fn raw_decode(prog: &ConsoleProgram, vma: u64) -> Option<(u32, String)> {
+    let arch = prog.arch();
+    let translate = arch.translate();
+    let code_space = Rc::clone(arch.manage().get_default_code_space().expect("code space"));
+    let addr = Address::new(code_space, vma);
+
+    struct Sink;
+    impl PcodeEmit for Sink {
+        fn dump(
+            &mut self,
+            _a: &Address,
+            _o: kuna_num::opcodes::OpCode,
+            _ov: Option<&kuna_num::pcoderaw::VarnodeData>,
+            _v: &[kuna_num::pcoderaw::VarnodeData],
+        ) {
+        }
+    }
+    #[derive(Default)]
+    struct Asm {
+        m: String,
+    }
+    impl AssemblyEmit for Asm {
+        fn dump(&mut self, _a: &Address, mnem: &str, _b: &str) {
+            self.m = mnem.to_string();
+        }
+    }
+
+    let mut sink = Sink;
+    // The default-ISA decode may legitimately FAIL on alt-ISA bytes (e.g. MIPS16
+    // bytes are not a valid MIPS32 word) — that is a `None`, the strongest control.
+    let len = translate.one_instruction(&mut sink, &addr).ok()?;
+    let mut asm = Asm::default();
+    let _ = translate.print_assembly(&mut asm, &addr);
+    Some((len.max(0) as u32, asm.m))
+}
+
+/// Build a Listing seeded at `seed` over `bin` (already bootstrapped as `prog`).
+fn build_listing(prog: &ConsoleProgram, bin: &str, seed: u64) -> Listing {
+    let bytes = std::fs::read(bin).expect("read fixture bytes");
+    let file = object::File::parse(&*bytes).expect("parse fixture ELF");
+    let arch = prog.arch();
+    let translate = arch.translate();
+    let image = kuna_analysis::loadimage_object::ObjectLoadImage::from_bytes(bin, &bytes)
+        .expect("open loadimage");
+    Listing::build(&file, &image, arch, translate, &[seed])
+}
+
+/// ARM Thumb: the walker paints `TMode=1` at `compute`'s even entry (reusing the
+/// `arm_markers` logic), so the Listing decodes it as Thumb. Proof: the seed
+/// instruction has Thumb width (2 bytes, not A32's fixed 4), a Thumb mnemonic, and
+/// the painted decode DIFFERS from the un-painted A32 control.
+#[test]
+fn arm_thumb_seed_decodes_in_thumb_mode_in_listing() {
+    let bin = match arm_thumb_linked().to_str() {
+        Some(s) => s.to_string(),
+        None => return,
+    };
+    let Some(prog) = boot(&bin, "verify_listing_context(arm)") else { return };
+
+    // Control: the un-painted (default A32) decode of `compute`'s entry. Built on a
+    // FRESH bootstrap so no Listing paint has touched its ContextDatabase. The
+    // Thumb `push {r7}` bytes form a valid (but different) 4-byte A32 word.
+    let prog_ctrl = boot(&bin, "verify_listing_context(arm-control)").expect("re-bootstrap");
+    let (a32_len, a32_mnem) = raw_decode(&prog_ctrl, COMPUTE_EVEN_ENTRY)
+        .expect("the A32 control decodes the bytes as a 4-byte word");
+    // A32 is always a 4-byte word.
+    assert_eq!(a32_len, 4, "the un-painted control must decode `compute` as a fixed 4-byte A32 word");
+
+    // The Listing builds with the context paint: `compute` decodes as Thumb.
+    let listing = build_listing(&prog, &bin, COMPUTE_EVEN_ENTRY);
+
+    let seed = listing
+        .instruction_at(COMPUTE_EVEN_ENTRY)
+        .unwrap_or_else(|| panic!("the Listing decoded no instruction at compute ({COMPUTE_EVEN_ENTRY:#x})"));
+
+    eprintln!(
+        "verify_listing_context(arm): seed {:#x} thumb=`{}`(len {}) vs control a32=`{}`(len {})",
+        COMPUTE_EVEN_ENTRY, seed.mnemonic, seed.len, a32_mnem, a32_len
+    );
+
+    // (1) Width proof: a Thumb op at the entry is 2 bytes; A32 is fixed 4.
+    assert_eq!(
+        seed.len, 2,
+        "the painted Thumb decode of `compute`'s `push {{r7}}` must be 2 bytes (Thumb), not {} \
+         (an A32 misdecode reads a fixed 4-byte word)",
+        seed.len
+    );
+
+    // (2) The painted decode DIFFERS from the un-painted A32 control — the paint
+    //     (not some incidental default) is what flips the ISA.
+    assert!(
+        seed.len != a32_len || seed.mnemonic != a32_mnem,
+        "the painted Thumb decode must differ from the un-painted A32 control \
+         (thumb len={}/mnem=`{}` vs a32 len={}/mnem=`{}`)",
+        seed.len, seed.mnemonic, a32_len, a32_mnem
+    );
+
+    // (3) Sane Thumb mnemonic: `compute` opens with `push {r7}`.
+    let m = seed.mnemonic.to_lowercase();
+    assert!(
+        m.contains("push"),
+        "the Thumb-decoded entry of `compute` must be a `push` (got `{}`)",
+        seed.mnemonic
+    );
+
+    // (4) The whole small function decodes cleanly as Thumb: every instruction in
+    //     `compute`'s body is 2 or 4 bytes (the Thumb widths), and the body carries
+    //     the `*3` shift/add — recover at least one shift mnemonic (`lsl`).
+    let body: Vec<_> = listing
+        .instructions()
+        .filter(|(&a, _)| (COMPUTE_EVEN_ENTRY..COMPUTE_EVEN_ENTRY + 30).contains(&a))
+        .collect();
+    assert!(body.len() >= 3, "expected several Thumb instructions in `compute`, got {}", body.len());
+    for (&a, insn) in &body {
+        assert!(
+            insn.len == 2 || insn.len == 4,
+            "every Thumb instruction is 2 or 4 bytes; insn at {a:#x} has len {}",
+            insn.len
+        );
+    }
+    let has_shift = body.iter().any(|(_, i)| {
+        let m = i.mnemonic.to_lowercase();
+        m.contains("lsl") || m.contains("lsr") || m.contains("asr")
+    });
+    assert!(
+        has_shift,
+        "the Thumb decode of `x*3+7` must include a shift (the `*3 = (x<<1)+x`); body = {:#x?}",
+        body.iter().map(|(a, i)| (**a, i.mnemonic.clone())).collect::<Vec<_>>()
+    );
+}
+
+/// MIPS16: the walker paints `ISA_MODE=1` at `m16_square`'s entry (reusing the
+/// `mips_markers` ISA-mode logic), so the Listing decodes it as MIPS16. Proof: the
+/// seed instruction has MIPS16 width (2 bytes, not MIPS32's fixed 4) and the
+/// painted decode DIFFERS from the un-painted MIPS32 control.
+#[test]
+fn mips16_seed_decodes_in_mips16_mode_in_listing() {
+    let bin = match mips16().to_str() {
+        Some(s) => s.to_string(),
+        None => return,
+    };
+    let Some(prog) = boot(&bin, "verify_listing_context(mips16)") else { return };
+
+    // Control: the un-painted (default MIPS32) decode of `m16_square`'s entry. The
+    // MIPS16 bytes are not a valid MIPS32 word, so this may legitimately fail to
+    // resolve a constructor (`None`) — the strongest control: the bytes simply are
+    // not MIPS32. If it does resolve, it reads a fixed 4-byte word.
+    let prog_ctrl = boot(&bin, "verify_listing_context(mips16-control)").expect("re-bootstrap");
+    let m32 = raw_decode(&prog_ctrl, M16_SQUARE_ENTRY);
+
+    // The Listing builds with the context paint: `m16_square` decodes as MIPS16.
+    let listing = build_listing(&prog, &bin, M16_SQUARE_ENTRY);
+
+    let seed = listing
+        .instruction_at(M16_SQUARE_ENTRY)
+        .unwrap_or_else(|| panic!("the Listing decoded no instruction at m16_square ({M16_SQUARE_ENTRY:#x})"));
+
+    eprintln!(
+        "verify_listing_context(mips16): seed {:#x} mips16=`{}`(len {}) vs control mips32={:?}",
+        M16_SQUARE_ENTRY, seed.mnemonic, seed.len, m32
+    );
+
+    // (1) Width proof: a MIPS16 op at the entry is 2 bytes; MIPS32 is fixed 4.
+    assert_eq!(
+        seed.len, 2,
+        "the painted MIPS16 decode of `m16_square`'s `mult a0,a0` must be 2 bytes (MIPS16), not {} \
+         (a MIPS32 misdecode reads a fixed 4-byte word, or fails to decode at all)",
+        seed.len
+    );
+
+    // (2) The painted MIPS16 decode DIFFERS from the un-painted MIPS32 control: the
+    //     control either fails to decode the bytes (the bytes are not MIPS32) or
+    //     yields a different (4-byte) word. Either way the paint flipped the ISA.
+    match m32 {
+        None => { /* MIPS32 can't decode these bytes at all — decisive. */ }
+        Some((m32_len, m32_mnem)) => assert!(
+            seed.len != m32_len || seed.mnemonic != m32_mnem,
+            "the painted MIPS16 decode must differ from the un-painted MIPS32 control \
+             (mips16 len={}/mnem=`{}` vs mips32 len={}/mnem=`{}`)",
+            seed.len, seed.mnemonic, m32_len, m32_mnem
+        ),
+    }
+
+    // (3) The 8-byte MIPS16 body decodes as several MIPS16 ops (the hallmark of the
+    //     alternate ISA; MIPS32 would read it as two 4-byte words or fail). The
+    //     entry `mult` and the `mflo` are 2-byte MIPS16 ops; the `jr ra` is 4 bytes
+    //     because MIPS16 folds its delay slot (`addiu v0,3`) into the length
+    //     (design §4.3 gotcha 3) — both are MIPS16 widths, never a stray odd or
+    //     >4-byte length.
+    let body: Vec<_> = listing
+        .instructions()
+        .filter(|(&a, _)| (M16_SQUARE_ENTRY..M16_SQUARE_ENTRY + 8).contains(&a))
+        .collect();
+    assert!(
+        body.iter().all(|(_, i)| i.len == 2 || i.len == 4),
+        "MIPS16 ops are 2 bytes (4 with a folded delay slot); `m16_square`'s body = {:#x?}",
+        body.iter().map(|(a, i)| (**a, i.len, i.mnemonic.clone())).collect::<Vec<_>>()
+    );
+    // The seed op is decisively a 2-byte MIPS16 `mult` (asserted above); the body
+    // begins with a self-multiply (the `n*n`), a MIPS16-only shape.
+    assert!(
+        body.iter().any(|(_, i)| i.mnemonic.to_lowercase().contains("mult")),
+        "the MIPS16 decode of `n*n+3` must include a `mult`; body = {:#x?}",
+        body.iter().map(|(a, i)| (**a, i.mnemonic.clone())).collect::<Vec<_>>()
+    );
+}

--- a/docs/analysis-port-log.md
+++ b/docs/analysis-port-log.md
@@ -2358,3 +2358,63 @@ but changes no output (payoff comes with the first consumer, PR6).
 - **Changed:** `kuna-analysis/src/passes.rs`, `kuna-console/src/engine.rs`,
   `kuna-console/tests/verify_listing_core.rs`.
 - **New:** `kuna-console/tests/verify_listing_parity.rs`.
+
+### Increment 32 — Listing/xref tier PR5: ARM/MIPS context-paint in the walker
+
+The Listing's recursive-descent walker decodes through `Translate::one_instruction`
+**outside** the decompiler's normal `commit_analysis_output` paint path, so an
+alternate-ISA function (ARM Thumb / MIPS16) was misdecoded: a Thumb `compute` read
+as A32, a MIPS16 `m16_square` read as MIPS32 — garbage. PR5 paints the correct
+decode-mode context (`TMode` / `ISA_MODE`) into the engine's `ContextDatabase`
+**before** the walk decodes, so alt-ISA functions decode correctly. Internal to
+`Listing::build` (default-OFF behind `--option listing`), so it is parity-safe and
+only active when the Listing is built. x86-64 (no decode-mode context) is untouched.
+
+**How the per-address decode mode is obtained (reused, not re-derived).**
+`listing/context.rs::ContextPainter::new(file)` **calls into the existing marker
+logic** — `s1_loader::arm_markers::scan_arm_markers` (ARM `$t`/`$a` mapping symbols
++ STT_FUNC-LSB → `TMode`) and `s1_loader::mips_markers::scan_mips_isa_markers`
+(STT_FUNC-LSB / `STO_MIPS_MIPS16` `st_other` → `ISA_MODE`) — and reuses their
+`ContextPaint` facts verbatim. Both scans were promoted `fn` → `pub(crate)`; they
+self-gate on the object architecture (ARM-only / MIPS-only), so on x86-64 the
+painter collects **zero** paints and is a no-op.
+
+**Mechanism (mirrors the commit seam exactly).** `ContextPainter::paint_all` applies
+every collected paint via `Architecture::with_context_db_mut` →
+`db.set_variable(var, addr, value)` / `set_variable_region(...)` — the *same* calls
+`engine.rs::commit_analysis_output` step 6 makes. `set_variable` fills each mode
+from its marker up to the next change point, so painting only the markers covers
+every address the walk visits. The walk paints once at its start (before any
+`decode_one`), then decodes against the already-painted context DB. Gate-safe: an
+unregistered context variable (a faithful no-op for a language that does not define
+it) is swallowed via the dropped `Result`, the same swallow the commit seam relies on.
+
+**Wiring.** `walk::walk` takes `arch: &Architecture` + `painter: &ContextPainter`
+and paints before the worklist loop; `Listing::build_with_meta` constructs the
+painter from the `object::File` and threads both into the walk.
+
+**Proof (specs built with `make specs`; the gate RAN, not skipped).**
+`kuna-console/tests/verify_listing_context.rs` bootstraps each fixture for a real
+`Translate`, builds the Listing seeded at the alt-ISA function's entry, and asserts
+the seed decodes in the alternate ISA — with a **control**: the same seed decoded
+through a fresh bootstrap's raw `Translate` (no Listing, no paint = the default
+mode), asserting the painted decode DIFFERS.
+- **ARM Thumb** (`arm_thumb_linked_le32`, `compute` @ 0x100b8): the Listing decodes
+  `push` (len **2**, Thumb); the un-painted A32 control reads `addlt` (len **4**) —
+  a different, garbage instruction. The body carries the `*3` shift (`lsl`).
+- **MIPS16** (`mips16_le32`, `m16_square` @ 0x400130): the Listing decodes `mult`
+  (len **2**, MIPS16) → `mflo` (2) → `jr`+delay-slot (4, the §4.3-gotcha-3 fold) =
+  the 8-byte body; the un-painted MIPS32 control **fails to decode the bytes at all**
+  ("Unable to resolve constructor") — the strongest control: they simply are not
+  MIPS32.
+
+**Result.** `make test` **675/675 PARITY OK**; `make test-stages` **159/159 PARITY
+OK**; `make rust-test` green (incl. the 2 new `verify_listing_context` cases). The
+paint is internal to the default-OFF Listing build, so the parity oracles are
+structurally untouched (no new `--option`, catalog unchanged).
+
+- **Changed:** `kuna-analysis/src/listing/mod.rs`, `kuna-analysis/src/listing/walk.rs`,
+  `kuna-analysis/src/s1_loader/arm_markers.rs` (`scan_arm_markers` → `pub(crate)`),
+  `kuna-analysis/src/s1_loader/mips_markers.rs` (`scan_mips_isa_markers` → `pub(crate)`).
+- **New:** `kuna-analysis/src/listing/context.rs`,
+  `kuna-console/tests/verify_listing_context.rs`.


### PR DESCRIPTION
## Summary

The Listing's recursive-descent walker decodes through `Translate::one_instruction` **outside** the decompiler's normal `commit_analysis_output` paint path, so an alternate-ISA function (ARM Thumb / MIPS16) was misdecoded. PR5 paints the correct decode-mode context (`TMode` / `ISA_MODE`) into the engine's `ContextDatabase` **before** the walk decodes, so alt-ISA functions decode correctly. Internal to `Listing::build` (default-OFF behind `--option listing`) ⇒ parity-safe; x86-64 (no decode-mode context) is untouched.

## Before / after

For the vendored `arm_thumb_linked_le32` fixture, the Thumb `compute` function (entry `0x100b8`):

| | seed `0x100b8` decode |
|---|---|
| **Before** (no paint, A32 default) | `addlt` (len **4**) — garbage; the same byte stream read as a 4-byte A32 word |
| **After** (PR5 paints `TMode=1`) | `push` (len **2**, Thumb) — correct; body carries the `*3` shift (`lsl`) |

For `mips16_le32`, the MIPS16 `m16_square` function (entry `0x400130`):

| | seed `0x400130` decode |
|---|---|
| **Before** (no paint, MIPS32 default) | fails to decode — "Unable to resolve constructor" (the bytes are not a valid MIPS32 word) |
| **After** (PR5 paints `ISA_MODE=1`) | `mult` (len **2**, MIPS16) → `mflo`(2) → `jr`+delay-slot(4) = the 8-byte body |

## How the per-address decode mode is obtained (reused, not re-derived)

`listing/context.rs::ContextPainter::new(file)` **calls into the existing marker logic** — `s1_loader::arm_markers::scan_arm_markers` and `s1_loader::mips_markers::scan_mips_isa_markers` — and reuses their `ContextPaint` facts verbatim (both promoted `fn` → `pub(crate)`). `paint_all` applies them via `Architecture::with_context_db_mut` → `set_variable`/`set_variable_region` — the same calls `engine.rs::commit_analysis_output` step 6 makes — once at the start of the walk, before any `decode_one`. Gate-safe: an unregistered context variable is a swallowed no-op.

## Test (RAN, not skipped — ARM `.sla` built via `make specs`)

`kuna-console/tests/verify_listing_context.rs` — two cases, each with a **control** (the same seed decoded through a fresh bootstrap's raw `Translate` = the un-painted default mode), asserting the painted decode DIFFERS. Captured output:

```
verify_listing_context(arm):    seed 0x100b8 thumb=`push`(len 2) vs control a32=`addlt`(len 4)
verify_listing_context(mips16): seed 0x400130 mips16=`mult`(len 2) vs control mips32=None
```

## Gates

- `make test` — **675/675 PARITY OK**
- `make test-stages` — **159/159 PARITY OK**
- `make rust-test` — **green** (incl. the 2 new `verify_listing_context` cases)

Internal to a default-OFF build ⇒ no new `--option`, catalog unchanged, parity oracles structurally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvRnfTgYKoZvS2TEvdYpWb