### PR TITLE
[PROPOSAL] angr-tr-o2-parse-str-7b9159: relocatable ELF object (ET_REL .o) loading

### DIFF
--- a/docs/features/tr-o2-parse-str-7b9159/analysis.md
+++ b/docs/features/tr-o2-parse-str-7b9159/analysis.md
@@ -1,0 +1,85 @@
+# analysis — tr-o2-parse-str-7b9159
+
+- **Opportunity (angr testcase):** `test_decompiling_tr_O2_parse_str::parse_str`
+- **Binary:** `/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/tr_O2.o`  (arch `x86_64`)
+- **Selector:** `parse_str` @ section-offset `0xa20`, size 2082 bytes
+
+## What angr does better
+
+angr (via CLE) produces a full, correct decompilation of `parse_str` with **resolved
+external calls** — `xmalloc`, `strncmp`, `dcgettext`, `error`, `make_printable_str`,
+`quote`, `xstrtoumax`, `free`, … — and correct control flow. See
+[`angr-vs-kuna.txt`](./angr-vs-kuna.txt).
+
+kuna produces **no output at all**. `decomp_dbg`:
+
+```
+[decomp]> load file .../tr_O2.o
+.../tr_O2.o successfully loaded: x86:LE:64:default:gcc
+[decomp]> read symbols
+[decomp]> load function parse_str
+Execution error: Unable to load 512 bytes at r0x00000a20
+[decomp]> decompile
+Execution error: No function selected
+```
+
+This is not a *structuring* gap — kuna cannot **load the bytes** of the function.
+
+## The exact construct / root cause
+
+`tr_O2.o` is an **ELF `ET_REL` relocatable object** (`.o`):
+
+```
+$ readelf -h tr_O2.o   →  Type: REL (Relocatable file);  Number of program headers: 0
+$ readelf -l tr_O2.o   →  There are no program headers in this file.
+$ readelf -S tr_O2.o   →  .text  PROGBITS  addr 0x0  size 0x1821   (every section has sh_addr = 0)
+$ readelf -sW tr_O2.o  →  parse_str  value 0xa20  size 2082  FUNC LOCAL  (section .text)
+```
+
+kuna's `ObjectLoadImage` (the `LoadImageBfd` analog) builds its byte map **only from
+`PT_LOAD` program-header segments**:
+
+- `decompiler/crates/kuna-analysis/src/loadimage_object.rs:204` —
+  `for seg in file.segments() { … segments.push(Segment { vma, data }) }`.
+- A relocatable `.o` has **no program headers**, so `file.segments()` is empty →
+  `segments` is empty → `find_section` (`loadimage_object.rs:334`) always returns
+  `None` → `load_fill` (`loadimage_object.rs:375`) breaks on the first byte
+  ("Initial address not mapped") → `Unable to load N bytes`.
+- Sections are snapshotted (`loadimage_object.rs:224`) only for the info/flags walk; the
+  loaded byte image never consults them. There is **no relocation application** anywhere.
+
+So kuna can load **no** function from **any** `ET_REL` object, not just `parse_str`.
+
+## Owning stage / tier
+
+This is entirely in the **analysis/loader tier** (`kuna-analysis`, stage S1 loader —
+`docs/stage-mapping.md` → the loadimage/markup layer), specifically
+`loadimage_object.rs` (the upstream `LoadImageBfd` analog). **No S1–S9 decompiler stage
+owns this**; there is no Action/Rule in `kuna-decomp` that could fix it via a gated
+early-return.
+
+## Hypothesis for the kuna change
+
+When `file.segments()` yields nothing, build the byte map from **allocatable
+PROGBITS/NOBITS sections**, laying each section out at a distinct non-overlapping base
+(all `sh_addr == 0` in `ET_REL`, so a layout must be chosen), record per-section bases so
+symbol vmas map consistently, then **apply ELF relocations** (`.rela.text`:
+`R_X86_64_PC32`/`PLT32`/`64`/`32S`, with synthesized PLT/GOT stubs for undefined externs)
+by patching the loaded bytes. Only then will `parse_str`'s call targets resolve the way
+angr's do.
+
+## Scope verdict — **LARGE** (proposal fork, Hard Rule 7)
+
+This is **loader infrastructure**, not one option-gated `kuna-decomp` Action/Rule:
+
+- It needs a **new code path + subsystem** in the loader (section layout + a relocation
+  engine + consistent symbol-address mapping) — a new pass *type*, >1 new module — which
+  trips Hard Rule 7's "new infrastructure" / ">1 new module" triggers.
+- It lives in `kuna-analysis`, not `kuna-decomp`; the feature template
+  (`kuna_*.rs` Action + Architecture flag + `universalaction.rs` registration) does not
+  apply.
+- It carries real design choices (layout policy, PLT-stub synthesis, per-arch relocation
+  tables) that warrant human go/no-go.
+
+A decider subagent independently confirmed `scope: large` (recorded verbatim in
+`record.json`). Per the protocol, this stops at design with a `[PROPOSAL]` draft PR.

--- a/docs/features/tr-o2-parse-str-7b9159/angr-vs-kuna.txt
+++ b/docs/features/tr-o2-parse-str-7b9159/angr-vs-kuna.txt
@@ -1,0 +1,453 @@
+==============================================================================
+test_decompiling_tr_O2_parse_str :: parse_str   (angr 9.2.213 @ 0x400a20)
+==============================================================================
+
+--- angr ---
+typedef struct struct_0 {
+    char padding_0[8];
+    void* field_8;
+} struct_0;
+
+extern unsigned long long char_class_name[4];
+
+long long parse_str(char *ptr6, struct_0 *ptr)
+{
+    unsigned long len;  // rax
+    unsigned long v21;  // rbp
+    unsigned int v30;  // r15d
+    char *ptr4;  // rbx
+    unsigned long long ptr5;  // r13
+    unsigned int v33;  // edx
+    unsigned long long v34;  // r13
+    unsigned int v35;  // eax
+    unsigned long v36;  // rsi
+    unsigned int v37;  // r8d
+    unsigned int v38;  // esi
+    unsigned int v39;  // eax
+    void* v22;  // r12
+    unsigned long v40;  // rdx
+    unsigned long v42;  // rax
+    unsigned long long i;  // r13
+    unsigned long long v44;  // r14
+    char v45;  // bl
+    unsigned long long v46;  // rdx
+    unsigned long long v47;  // rax
+    unsigned long long v48;  // r15
+    unsigned long long v49;  // rax
+    char v23;  // al
+    unsigned long v50;  // rax
+    void* ptr;  // rax
+    char v52;  // dl
+    void* ptr8;  // rdx
+    unsigned long long v54;  // r15
+    unsigned long long v55;  // rax
+    unsigned long long v56;  // r15
+    unsigned long long v57;  // r15
+    unsigned int v24;  // ecx
+    char v59;  // bl
+    void* ptr;  // rax
+    void* ptr9;  // rdx
+    long long v62;  // r13
+    long long v63;  // r13
+    char *v64;  // r14
+    unsigned long long v65;  // rdx
+    void* ptr;  // rax
+    void* ptr10;  // rdx
+    unsigned long long v68;  // r15
+    unsigned int v25;  // r14d
+    unsigned long v69;  // r13
+    char *v70;  // rdx
+    void* v71;  // rax
+    void* v72;  // rax
+    char *v74;  // rsi
+    char *v75;  // rsi
+    char *j;  // r13
+    char *v26;  // r10
+    unsigned long long v27;  // rdx
+    unsigned long v28;  // rsi
+    unsigned int v29;  // r9d
+    unsigned long v0;  // [bp-0xd8]
+    unsigned long v1;  // [bp-0xd0]
+    unsigned long v2;  // [bp-0xc8]
+    char *v3;  // [bp-0xc0]
+    unsigned int v4;  // [bp-0xb0], Other Possible Types: unsigned long long
+    char *v5;  // [bp-0xa8], Other Possible Types: unsigned int, unsigned long long
+    char *v6;  // [bp-0xa0]
+    unsigned long v7;  // [bp-0x98]
+    char *ptr7;  // [bp-0x90]
+    unsigned long long v9;  // [bp-0x88]
+    unsigned long long v10;  // [bp-0x80]
+    char v11;  // [bp-0x72]
+    char v12;  // [bp-0x71]
+    unsigned long long v13;  // [bp-0x70]
+    unsigned long long v14;  // [bp-0x68]
+    char v15;  // [bp-0x60]
+    unsigned long ptr;  // [bp-0x58]
+    void* ptr;  // [bp-0x50]
+    unsigned long long v18;  // [bp-0x48]
+
+    len = strlen(ptr6);
+    ptr = xmalloc(len);
+    v21 = ptr;
+    ptr = xcalloc(len, 1);
+    v22 = ptr;
+    v23 = *(ptr6);
+    if (v23)
+    {
+        v24 = 0;
+        v25 = 0;
+        v26 = ptr6;
+        while (true)
+        {
+            v27 = v25;
+            v28 = v24 + 1;
+            v25 += 1;
+            v29 = v26[v28];
+            v30 = v28;
+            ptr4 = v21 + v27;
+            if (v23 != 92)
+            {
+                *(ptr4) = v23;
+                v23 = v29;
+                v24 = v28;
+                if (!v23)
+                    break;
+            }
+            else
+            {
+                ptr5 = v22 + v27;
+                *((char *)ptr5) = 1;
+                if ((char)v29)
+                {
+                    v33 = v29 - 48;
+                    v34 = v29 & 255;
+                    switch ((char)v33)
+                    {
+                    case 0: case 1: case 2: case 3: case 4: case 5: case 6: case 7:
+                        v36 = v24 + 2;
+                        v34 = v33;
+                        v37 = v26[v36];
+                        v35 = v36;
+                        v38 = v37 - 48;
+                        if (v38 <= 7)
+                        {
+                            v34 = v38 + (unsigned int)v34 * 8;
+                            v39 = v26[3 + v24];
+                            v40 = v39 - 48;
+                            v4 = v39;
+                            v35 = v30 + 2;
+                            if ((unsigned int)v40 <= 7)
+                            {
+                                if ((unsigned int)v40 + (char)v34 * 8 <= 255)
+                                {
+                                    v34 = v40 + v34 * 8;
+                                    v35 = v24 + 4;
+                                    break;
+                                }
+                                else
+                                {
+                                    v6 = v26;
+                                    v11 = v29;
+                                    v5 = v37;
+                                    v3 = dcgettext(NULL, "warning: the ambiguous octal escape \\%c%c%c is being\n\tinterpreted as the 2-byte sequence \\0%c%c, %c", 5);
+                                    v2 = v4;
+                                    v1 = v5;
+                                    v0 = v11;
+                                    error(0, 0, v3);
+                                    v35 = v30 + 2;
+                                    v26 = v6;
+                                    break;
+                                }
+                            }
+                        }
+                        break;
+                    case 44:
+                        v34 = 92;
+                        v35 = v24 + 2;
+                        break;
+                    case 49:
+                        v34 = 7;
+                        goto LABEL_400aef;
+                    case 50:
+                        v34 = 8;
+                        v35 = v24 + 2;
+                        break;
+                    case 54:
+                        v34 = 12;
+                        v35 = v24 + 2;
+                        break;
+                    case 62:
+                        v34 = 10;
+                        v35 = v24 + 2;
+                        break;
+                    case 66:
+                        v34 = 13;
+                        v35 = v24 + 2;
+                        break;
+                    case 68:
+                        v34 = 9;
+                        v35 = v24 + 2;
+                        break;
+                    case 70:
+                        v34 = 11;
+                        v35 = v24 + 2;
+                        break;
+                    default:
+LABEL_400aef:
+                        v35 = v24 + 2;
+                        break;
+                    }
+                }
+                else
+                {
+                    v5 = v26;
+                    v4 = v24;
+                    error(0, 0, dcgettext(NULL, "warning: an unescaped backslash at end of string is not portable", 5));
+                    *((char *)ptr5) = 0;
+                    v26 = v5;
+                    v34 = 92;
+                    v35 = v4 + 1;
+                }
+                v42 = v35;
+                *(ptr4) = v34;
+                v24 = v42;
+                v23 = v26[v42];
+                if (!v23)
+                    break;
+            }
+        }
+        v5 = v25;
+        v18 = v5;
+        if (v25 > 2)
+        {
+            i = 2;
+            v44 = 0;
+            do
+            {
+                v45 = *((char *)(v21 + v44 + 1));
+                v4 = v44 + 1;
+                v11 = *((char *)(v21 + v44));
+                if (*((char *)(v21 + v44)) != 91 || (*((char *)&v6) = *((char *)((char *)v22 + v44)), *((char *)((char *)v22 + v44))))
+                {
+LABEL_400b30:
+                    if (v45 != 45 || (*((char *)&v6) = *((char *)((char *)v22 + v4)), *((char *)((char *)v22 + v4))))
+                    {
+                        append_normal_char(ptr);
+                        v44 = v4;
+                        goto LABEL_400b4c;
+                    }
+                    else
+                    {
+                        v59 = *((char *)(v21 + i));
+                        if (v59 < v11)
+                        {
+                            v71 = make_printable_char(v11);
+                            v72 = make_printable_char(v59);
+                            error(0, 0, dcgettext(NULL, "range-endpoints of '%s-%s' are in reverse collating sequence order", 5));
+                            free(v71);
+                            free(v72);
+                            free(v21);
+                            free(v22);
+                            return *((char *)&v6);
+                        }
+                        ptr = xmalloc(32);
+                        *((void* *)&ptr[8]) = NULL;
+                        ptr9 = ptr->field_8;
+                        *((unsigned int *)ptr) = 1;
+                        *((char *)&ptr[16]) = v11;
+                        *((char *)&ptr[17]) = v59;
+                        if (!ptr9)
+                            __assert_fail(); /* do not return */
+                        *((void* *)&ptr9[8]) = ptr;
+                        v44 += 3;
+                        ptr->field_8 = ptr;
+                        goto LABEL_400b4c;
+                    }
+                }
+                else
+                {
+                    if ((v45 == 58 || v45 == 61) && !*((char *)v22 + v4) && (v46 = v5 - 1, v46 > i))
+                    {
+                        v47 = i;
+                        while (true)
+                        {
+                            v48 = v47;
+                            v49 = v47 + 1;
+                            if (*((char *)(v21 + v47)) == v45 && *((char *)(v21 + v48 + 1)) == 93 && !*(-1 + (char *)v22 + v49) && !*(1 + (char *)v22 + v48))
+                                break;
+                            v47 = v49;
+                            if (v46 <= v47)
+                                goto LABEL_400ba0;
+                        }
+                        v50 = v48 - v44;
+                        ptr7 = v21 + i;
+                        v7 = v50 - 2;
+                        if (v50 == 2)
+                        {
+                            v75 = "missing character class name '[::]'";
+                            if (v45 != 58)
+                                v75 = "missing equivalence class character '[==]'";
+                            error(0, 0, dcgettext(NULL, v75, 5));
+                            free(v21);
+                            free(v22);
+                            return *((char *)&v6);
+                        }
+                        if (v45 != 58)
+                        {
+                            if (v7 != 1)
+                            {
+                                if ((char)star_digits_closebracket(&ptr, i))
+                                    goto LABEL_400ba0;
+                                v69 = make_printable_str(ptr7, v7);
+                                v70 = dcgettext(NULL, "%s: equivalence class operand must be a single character", 5);
+                                goto LABEL_400dc5;
+                            }
+                            else
+                            {
+                                ptr = xmalloc(32);
+                                *((void* *)&ptr[8]) = NULL;
+                                v52 = *(ptr7);
+                                *((unsigned int *)ptr) = 3;
+                                *((char *)&ptr[16]) = v52;
+                                ptr8 = ptr->field_8;
+                                if (!ptr8)
+                                    __assert_fail(); /* do not return */
+LABEL_401087:
+                                *((void* *)&ptr8[8]) = ptr;
+                                v44 = v48 + 2;
+                                ptr->field_8 = ptr;
+                            }
+LABEL_400b4c:
+                            i = v44 + 2;
+                            if (i < v5)
+                                continue;
+                        }
+                        else
+                        {
+                            v10 = v44;
+                            v9 = i;
+                            v12 = v45;
+                            v13 = v48;
+                            v54 = 0;
+                            do
+                            {
+                                if (!strncmp(ptr7, char_class_name[v54], v7) && v7 == strlen(char_class_name[v54]))
+                                {
+                                    v48 = v13;
+                                    ptr = xmalloc(32);
+                                    *((void* *)&ptr[8]) = NULL;
+                                    ptr8 = ptr->field_8;
+                                    *((unsigned int *)ptr) = 2;
+                                    *((unsigned int *)&ptr[16]) = v54;
+                                    if (!ptr8)
+                                        __assert_fail(); /* do not return */
+                                    goto LABEL_401087;
+                                }
+                            } while ((v54 += 1, v54 != 12));
+                            i = v9;
+                            v44 = v10;
+                            v45 = v12;
+                            if (!(char)star_digits_closebracket(&ptr, i))
+                            {
+                                v69 = make_printable_str(ptr7, v7);
+                                quote(v69);
+                                v74 = "invalid character class %s";
+LABEL_401031:
+                                v70 = dcgettext(NULL, v74, 5);
+LABEL_400dc5:
+                                error(0, 0, v70);
+                                free(v69);
+                                free(v21);
+                                free(v22);
+                                return *((char *)&v6);
+                            }
+                        }
+                    }
+LABEL_400ba0:
+                    if (*((char *)(v21 + i)) != 42 || *((char *)v22 + i) || (v55 = v44 + 3, v56 = v55, v5 <= v55) || !((v57 = v56, !*((char *)((char *)v22 + v57)))))
+                        goto LABEL_400b30;
+                    if (*((char *)(v21 + v57)) != 93)
+                    {
+                        if (v5 <= v57 + 1)
+                            goto LABEL_400b30;
+                        continue;
+                    }
+                }
+                v62 = v57 - v4;
+                v63 = v62 - 2;
+                if (v62 != 2)
+                {
+                    v64 = v21 + v55;
+                    if (!(int)xstrtoumax(v64, &v15, (*(v64) != 48) * 2 + 8, &v14, 0) && !((v65 = v14, v65 == 18446744073709551615 || v15 != v64 + v63)))
+                        goto LABEL_400c49;
+                    v69 = make_printable_str(v64, v63);
+                    quote(v69);
+                    v74 = "invalid repeat count %s in [c*n] construct";
+                    goto LABEL_401031;
+                }
+                v14 = 0;
+                v65 = 0;
+LABEL_400c49:
+                v4 = v65;
+                ptr = xmalloc(32);
+                *((void* *)&ptr[8]) = NULL;
+                *((unsigned long long *)&ptr[24]) = v4;
+                ptr10 = ptr->field_8;
+                *((unsigned int *)ptr) = 4;
+                *((char *)&ptr[16]) = v45;
+                if (!ptr10)
+                    append_repeated_char.part.0(); /* do not return */
+                v44 = v57 + 1;
+                *((void* *)&ptr10[8]) = ptr;
+                i = v44 + 2;
+                ptr->field_8 = ptr;
+            } while (i < v5);
+            v68 = v44;
+        }
+        else
+        {
+            v68 = 0;
+        }
+        j = v21 + v68;
+        if (v5 > v68)
+        {
+            do
+            {
+                append_normal_char(ptr, *(j));
+                j += 1;
+            } while (v21 + v5 != j);
+        }
+    }
+    *((char *)&v6) = 1;
+    free(v21);
+    free(v22);
+    return *((char *)&v6);
+}
+
+
+--- kuna (addr mode) ---
+  (no output: addr-mode: no C output for '0x400a20' in /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/tr_O2.o; decompiler said:
+[decomp]> load file /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/tr_O2.o
+/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/tr_O2.o successfully loaded: x86:LE:64:default:gcc
+[decomp]> read symbols
+[decomp]> load addr 0x400a20
+Execution error: Unable to load 512 bytes at r0x00400a20
+[decomp]> decompile
+Execution error: No function selected
+[decomp]> openfile write /tmp/kuna_c_9w7zf4j_.c
+[decomp]> print C
+Execution error: No function selected
+[decomp]> closefile
+[decomp]> quit (name-mode: no C output for 'parse_str' in /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/tr_O2.o; decompiler said:
+[decomp]> load file /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/tr_O2.o
+/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/tr_O2.o successfully loaded: x86:LE:64:default:gcc
+[decomp]> read symbols
+[decomp]> load function parse_str
+Execution error: Unable to load 512 bytes at r0x00000a20
+[decomp]> decompile
+Execution error: No function selected
+[decomp]> openfile write /tmp/kuna_c_r4emm1jt.c
+[decomp]> print C
+Execution error: No function selected
+[decomp]> closefile
+[decomp]> quit))

--- a/docs/features/tr-o2-parse-str-7b9159/proposal.md
+++ b/docs/features/tr-o2-parse-str-7b9159/proposal.md
@@ -1,0 +1,88 @@
+# [PROPOSAL] Relocatable ELF object (`ET_REL` `.o`) loading
+
+**Opportunity:** `test_decompiling_tr_O2_parse_str::parse_str`
+**Binary:** `binaries/tests/x86_64/decompiler/tr_O2.o` (ELF `ET_REL`, x86_64)
+**Proposed option:** `relocatable_object_loader` (default off until validated)
+**Scope:** LARGE — loader infrastructure (Hard Rule 7). Stops at design for human go/no-go.
+
+## The problem
+
+kuna cannot decompile any function from an ELF **relocatable object** (`.o`,
+`e_type == ET_REL`). For `tr_O2.o::parse_str`, `decomp_dbg` fails at load time:
+
+```
+[decomp]> load function parse_str
+Execution error: Unable to load 512 bytes at r0x00000a20
+```
+
+angr (via CLE) loads the same object and produces a complete, correct decompilation with
+all external calls resolved (`xmalloc`, `strncmp`, `dcgettext`, …). Full side-by-side and
+root-cause in [`analysis.md`](./analysis.md).
+
+### Root cause (verified)
+
+`kuna-analysis/src/loadimage_object.rs` builds its loadable byte map **exclusively from
+`PT_LOAD` program-header segments** (`for seg in file.segments()`, line 204). An `ET_REL`
+object has **no program headers** (`readelf -l` → "There are no program headers"), so the
+segment list is empty, `find_section` always returns `None`, and every byte load fails.
+Sections are snapshotted for flags only (line 224) and are never consulted for bytes.
+There is no relocation application anywhere in the tree.
+
+## angr reference
+
+CLE's `cle.backends.elf` (the static ELF backend) plus `cle.backends.elf.relocation`:
+for `ET_REL` it maps each allocatable section into the load space at a distinct base and
+then applies the section's relocations (`R_X86_64_PC32`, `PLT32`, `64`, `32S`, …),
+synthesizing extern/PLT stubs for undefined symbols. angr's decompiler then sees a fully
+linked-in-memory image, which is why its `parse_str` call targets resolve.
+
+## Proposed implementation plan (multi-step)
+
+All in `kuna-analysis` (loader tier); gated behind `--option relocatable_object_loader`,
+default OFF, so existing `ET_EXEC`/`ET_DYN` output stays byte-identical.
+
+1. **Detect `ET_REL` / empty-segment case.** In `ObjectLoadImage::new`, when
+   `file.segments()` is empty (or `file.kind() == Relocatable`), enter a new section-based
+   layout path instead of the segment path.
+2. **Section layout (new module `reloc_layout.rs`).** Assign each allocatable
+   `PROGBITS`/`NOBITS` section a distinct, non-overlapping base address (chosen base, e.g.
+   `0x400000 + cumulative`, page-aligned). Record a `section_index → base` map so symbol
+   vmas (`st_shndx` + `st_value`) translate consistently. Build the `segments`/`sections`
+   byte map and the `funcsyms` list from this layout (`parse_str` lands at
+   `text_base + 0xa20`).
+3. **Relocation engine (new module `reloc_apply.rs`).** Parse `.rela.<sec>` and apply the
+   x86_64 relocation types present (`PC32`/`PLT32`/`64`/`32S`/`32`), patching the loaded
+   bytes. For undefined externs (`xmalloc`, `strncmp`, `dcgettext`, `error`, …) synthesize
+   a small PLT/extern-stub region and point the relocations at named stub addresses so the
+   decompiler renders the call names. Per-arch reloc tables behind a seam (x86_64 first).
+4. **Symbol/markup consistency.** Ensure the strings/DWARF/entry walks in
+   `kuna-analysis/src/s1_*` use the same per-section bases (they already key off the
+   loadimage symbol/section info, so feeding the layout through is the main work).
+5. **Validation.** A `tests/stages/ghangr-tr-o2-parse-str-7b9159.xml` two-pass test:
+   off ⇒ current "Unable to load" / empty; on ⇒ `parse_str` renders with resolved calls.
+   Plus a regression check that an existing `ET_EXEC` ELF datatest is byte-identical with
+   the flag on (the flag must be inert for non-`ET_REL` inputs).
+
+## Speed / risk assessment
+
+- **Speed:** load-time work only (section layout + a single relocation pass), bounded by
+  reloc count; negligible vs decompilation. The target is currently *unmeasurable* (kuna
+  emits nothing), so there is no regression risk to existing binaries — the flag is inert
+  unless the input is `ET_REL`.
+- **Risk (moderate–high):**
+  - Must not perturb the existing `PT_LOAD` path — default output byte-identical for all
+    current binaries (gate strictly on `ET_REL` + flag).
+  - Relocation tables are per-architecture; start x86_64-only with a clear seam, others
+    return "unsupported" rather than mis-patching.
+  - Layout/PLT-stub address choices propagate to every downstream symbol/xref; a
+    consistency bug **silently corrupts** call resolution rather than failing loudly →
+    needs the byte-for-byte regression gate above and careful review.
+  - This is the first kuna feature that lays down *synthetic* extern stubs; the address
+    policy should be reviewed so it doesn't collide with real section bases.
+
+## Why this needs go/no-go
+
+It is a new loader subsystem (>1 new module, a new pass type, design choices around
+layout/stub policy and per-arch reloc tables) — outside the one-Action/Rule feature model
+and squarely a Hard Rule 7 "large" feature. Requesting human approval before an
+implementation worker is spent on the branch.

--- a/docs/features/tr-o2-parse-str-7b9159/record.json
+++ b/docs/features/tr-o2-parse-str-7b9159/record.json
@@ -1,0 +1,27 @@
+{
+  "opportunity": "test_decompiling_tr_O2_parse_str::parse_str",
+  "test_name": "test_decompiling_tr_O2_parse_str",
+  "binary": "/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/tr_O2.o",
+  "selector": "parse_str",
+  "func_addr": "0xa20",
+  "scope": "large",
+  "proposal": true,
+  "option": "relocatable_object_loader",
+  "change_kind": "structure-recovery",
+  "source_decompiler": "angr",
+  "inspiration": "test_decompiling_tr_O2_parse_str; cle.backends.elf relocatable-object loading + ELF relocation engine (R_X86_64_PC32/PLT32); parse_str",
+  "root_cause": "kuna-analysis/src/loadimage_object.rs builds its byte map only from PT_LOAD program-header segments (file.segments()); an ELF ET_REL object has no program headers, so the segment list is empty, find_section always returns None, and every byte load fails ('Unable to load 512 bytes at r0x00000a20'). No relocation application exists.",
+  "decisions": [
+    {
+      "question": "Is closing the tr_O2.o::parse_str gap small (one option-gated kuna-decomp Action/Rule) or large (loader infrastructure requiring a proposal + human go/no-go)?",
+      "decider_verdict": {
+        "scope": "large",
+        "owning_stage": "kuna-analysis (loader/analysis tier — loadimage_object.rs, the LoadImageBfd analog); no S1-S9 decompiler stage owns this",
+        "approach": "Add an ET_REL code path in ObjectLoadImage: when file.segments() is empty, synthesize the byte map from allocatable PROGBITS/NOBITS sections, assigning each a distinct non-overlapping base address (since all sh_addr=0); record per-section bases so symbol vmas map consistently; then apply ELF relocations (.rela.text R_X86_64_PC32/PLT32/64/32S, with PLT/GOT stubs synthesized for undefined externs like xmalloc/strncmp/dcgettext) by patching the loaded bytes; build funcsym/section info off the same layout. This is a new relocation+layout subsystem, not an Action/Rule.",
+        "why": "The gap is entirely in byte loading and relocation in the analysis tier - there is no decompiler pass that could fix it via a gated early-return, so the kuna-decomp one-file Action/Rule model does not apply. It needs a new layout/relocation engine (a new pass type and >1 new module: section layout + reloc application + symbol mapping), squarely tripping Hard Rule 7. It also carries genuine correctness/design choices (layout policy, PLT-stub synthesis, per-arch reloc tables) that warrant human go/no-go.",
+        "proposed_option_name": "relocatable_object_loader",
+        "risk": "Moderate-to-high: must not perturb the existing ET_EXEC/ET_DYN (PT_LOAD) path (default output byte-identical for current binaries); reloc tables are per-architecture (start x86_64-only, others a seam); layout/PLT-stub address choices affect every downstream symbol/xref, so getting symbol-vma consistency wrong silently corrupts call resolution rather than failing loudly. Gate behind --option and default off until validated against the angr tr_O2 testcase."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# [PROPOSAL] Relocatable ELF object (`ET_REL` `.o`) loading

**Opportunity:** `test_decompiling_tr_O2_parse_str::parse_str`
**Binary:** `binaries/tests/x86_64/decompiler/tr_O2.o` (ELF `ET_REL`, x86_64)
**Proposed option:** `relocatable_object_loader` (default off until validated)
**Scope:** LARGE — loader infrastructure (Hard Rule 7). Stops at design for human go/no-go.

## The problem

kuna cannot decompile any function from an ELF **relocatable object** (`.o`,
`e_type == ET_REL`). For `tr_O2.o::parse_str`, `decomp_dbg` fails at load time:

```
[decomp]> load function parse_str
Execution error: Unable to load 512 bytes at r0x00000a20
```

angr (via CLE) loads the same object and produces a complete, correct decompilation with
all external calls resolved (`xmalloc`, `strncmp`, `dcgettext`, …). Full side-by-side and
root-cause in [`analysis.md`](./analysis.md).

### Root cause (verified)

`kuna-analysis/src/loadimage_object.rs` builds its loadable byte map **exclusively from
`PT_LOAD` program-header segments** (`for seg in file.segments()`, line 204). An `ET_REL`
object has **no program headers** (`readelf -l` → "There are no program headers"), so the
segment list is empty, `find_section` always returns `None`, and every byte load fails.
Sections are snapshotted for flags only (line 224) and are never consulted for bytes.
There is no relocation application anywhere in the tree.

## angr reference

CLE's `cle.backends.elf` (the static ELF backend) plus `cle.backends.elf.relocation`:
for `ET_REL` it maps each allocatable section into the load space at a distinct base and
then applies the section's relocations (`R_X86_64_PC32`, `PLT32`, `64`, `32S`, …),
synthesizing extern/PLT stubs for undefined symbols. angr's decompiler then sees a fully
linked-in-memory image, which is why its `parse_str` call targets resolve.

## Proposed implementation plan (multi-step)

All in `kuna-analysis` (loader tier); gated behind `--option relocatable_object_loader`,
default OFF, so existing `ET_EXEC`/`ET_DYN` output stays byte-identical.

1. **Detect `ET_REL` / empty-segment case.** In `ObjectLoadImage::new`, when
   `file.segments()` is empty (or `file.kind() == Relocatable`), enter a new section-based
   layout path instead of the segment path.
2. **Section layout (new module `reloc_layout.rs`).** Assign each allocatable
   `PROGBITS`/`NOBITS` section a distinct, non-overlapping base address (chosen base, e.g.
   `0x400000 + cumulative`, page-aligned). Record a `section_index → base` map so symbol
   vmas (`st_shndx` + `st_value`) translate consistently. Build the `segments`/`sections`
   byte map and the `funcsyms` list from this layout (`parse_str` lands at
   `text_base + 0xa20`).
3. **Relocation engine (new module `reloc_apply.rs`).** Parse `.rela.<sec>` and apply the
   x86_64 relocation types present (`PC32`/`PLT32`/`64`/`32S`/`32`), patching the loaded
   bytes. For undefined externs (`xmalloc`, `strncmp`, `dcgettext`, `error`, …) synthesize
   a small PLT/extern-stub region and point the relocations at named stub addresses so the
   decompiler renders the call names. Per-arch reloc tables behind a seam (x86_64 first).
4. **Symbol/markup consistency.** Ensure the strings/DWARF/entry walks in
   `kuna-analysis/src/s1_*` use the same per-section bases (they already key off the
   loadimage symbol/section info, so feeding the layout through is the main work).
5. **Validation.** A `tests/stages/ghangr-tr-o2-parse-str-7b9159.xml` two-pass test:
   off ⇒ current "Unable to load" / empty; on ⇒ `parse_str` renders with resolved calls.
   Plus a regression check that an existing `ET_EXEC` ELF datatest is byte-identical with
   the flag on (the flag must be inert for non-`ET_REL` inputs).

## Speed / risk assessment

- **Speed:** load-time work only (section layout + a single relocation pass), bounded by
  reloc count; negligible vs decompilation. The target is currently *unmeasurable* (kuna
  emits nothing), so there is no regression risk to existing binaries — the flag is inert
  unless the input is `ET_REL`.
- **Risk (moderate–high):**
  - Must not perturb the existing `PT_LOAD` path — default output byte-identical for all
    current binaries (gate strictly on `ET_REL` + flag).
  - Relocation tables are per-architecture; start x86_64-only with a clear seam, others
    return "unsupported" rather than mis-patching.
  - Layout/PLT-stub address choices propagate to every downstream symbol/xref; a
    consistency bug **silently corrupts** call resolution rather than failing loudly →
    needs the byte-for-byte regression gate above and careful review.
  - This is the first kuna feature that lays down *synthetic* extern stubs; the address
    policy should be reviewed so it doesn't collide with real section bases.

## Why this needs go/no-go

It is a new loader subsystem (>1 new module, a new pass type, design choices around
layout/stub policy and per-arch reloc tables) — outside the one-Action/Rule feature model
and squarely a Hard Rule 7 "large" feature. Requesting human approval before an
implementation worker is spent on the branch.
