### PR TITLE
[PROPOSAL] angr-printenv-main-ec8020: return unstructurable loop subgraphs instead of goto-refining (loopsubgraphreturn)

### DIFF
--- a/docs/features/printenv-main-ec8020/analysis.md
+++ b/docs/features/printenv-main-ec8020/analysis.md
@@ -1,0 +1,77 @@
+# printenv-main-ec8020 — analysis
+
+## Opportunity
+- angr testcase: `test_decompiling_printenv_main` (`angr/tests/analyses/decompiler/test_decompiler.py:2347`)
+- Binary: `/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/printenv.o`
+- Function: `main` (x86_64), angr addr `0x4007a0`.
+- angr assertion: **`"goto " not in d.codegen.text`** — the function must structure with **zero gotos**.
+
+## What angr does better (the construct)
+The angr test docstring states the mechanism precisely:
+
+> when a subgraph inside a loop cannot be structured, instead of entering last-resort
+> refinement, we should return the subgraph and let structuring resume with the knowledge
+> of the loop. otherwise, in this function, we will see a goto while in reality we do not
+> need any gotos.
+
+The fix is in angr's **Phoenix structurer** (`angr/analyses/decompiler/structuring/phoenix.py:221-226`):
+
+```python
+if not progressed:
+    if self._region.cyclic_ancestor and not self._region.cyclic:
+        # we prefer directly returning this subgraph in case it can be further
+        # restructured within a loop region
+        l.debug("No progress is made on this acyclic graph with a cyclic ancestor. Give up.")
+        break
+    l.debug("No progress is made. Enter last resort refinement.")
+    removed_edge = self._last_resort_refinement(...)   # <- this is what injects gotos
+```
+
+i.e. an **acyclic** subgraph that has a **cyclic ancestor** but made no structuring
+progress is *returned to its enclosing loop region* rather than forced through
+`_last_resort_refinement()` (which deletes a CFG edge and materializes it as a `goto`).
+The outer loop region then restructures it with full loop context, producing
+`continue`/structured exits instead of gotos.
+
+## Owning stage
+- **S7 structuring** (`docs/stage-mapping.md`: Stage 16 → S7/S8). kuna's structurer is
+  Ghidra's `blockaction` — `ActionBlockStructure` / `CollapseStructure` / `TraceDAG`
+  (`blockaction.cc:2170`), implemented in `decompiler/crates/kuna-decomp/src/substrate/block.rs`
+  + the S7 region code. Goto selection (S8) lives in the same collapse engine.
+
+## kuna's current output (the bug)
+`printenv.o` is **ET_REL** (`readelf -h` → `Type: REL`). kuna's loader maps PT_LOAD
+segments only, so it cannot load the object at all (`Unable to load 512 bytes at
+r0x004007a0`) — the [ET_REL loader gap], tracked separately as proposal PR #37. To
+characterise the *decompiler* gap I linked the `.o` into a standalone non-PIE ELF
+(stub every UND symbol, `-no-pie -nostdlib -static`) and ran
+`kuna decompile ./synth main`. Result: **7 gotos** (see `angr-vs-kuna.txt`):
+
+```
+if (v4 != v2) goto label_4011ef;
+goto label_4011ef;
+else if (v4 == '\0') goto label_4011ef;
+goto label_4012d0;
+if (*(char **)&v10[0x10] == (char *)0x0) goto label_4012e9;
+goto label_401393;
+if ((v6 != ...) && (v5 = strncmp(...), v5 != 0)) goto label_401430;
+```
+
+The `goto label_4011ef` cluster is exactly the angr-described case: jumps to the tail of
+an inner `for` loop body (a `continue`-equivalent), inside an outer `do/while`. kuna's
+`blockaction` collapse cannot structure that inner subgraph and falls back to unstructured
+goto edges.
+
+## Hypothesis / why this is NOT a single-pass option
+1. **Loader-blocked.** Full-pipeline reproduction is impossible until the ET_REL loader
+   gap (proposal #37) lands; the gap is reproducible only via the link-to-ELF bypass.
+2. **Algorithm mismatch.** angr's fix is a change to its *Phoenix iterative region
+   collapse* recursion (cyclic-ancestor awareness). kuna uses Ghidra's
+   `blockaction`/`TraceDAG` — a structurally different algorithm with no `cyclic_ancestor`
+   / `_last_resort_refinement` concept. Reducing these gotos requires modifying kuna's
+   **core S7 structuring engine** (`CollapseStructure`/`TraceDAG` goto-edge selection),
+   not an option-gated `Action`/`Rule` with a gated early-return.
+
+Per Hard rule 7 this is a **LARGE** feature (touches S7 structuring/region code beyond a
+single gated early-return; cannot be modelled as one Action/Rule like `kuna_loweredswitch.rs`).
+The formal scope/proposal-vs-negative decision is recorded in `record.json` `decisions`.

--- a/docs/features/printenv-main-ec8020/angr-vs-kuna.txt
+++ b/docs/features/printenv-main-ec8020/angr-vs-kuna.txt
@@ -1,0 +1,189 @@
+================ angr (test_decompiling_printenv_main :: main) ================
+# angr asserts: "goto " NOT in output. angr output (from compare):
+# (angr produced a goto-free but heavily-incomplete main; assertion is goto-absence)
+
+================ kuna (via link-to-ELF loader bypass; .o is ET_REL) ============
+# NOTE: printenv.o is ET_REL — kuna's PT_LOAD-only loader cannot load it directly
+# (Unable to load 512 bytes at r0x004007a0). Linked to standalone ELF to bypass.
+
+uint1 main(uint4 a0,void *a1)
+
+{
+  char *v1;
+  void *v10; // rbx
+  unsigned long v11; // stack - 0xf0
+  int4 v12; // r9d
+  unsigned long v13;
+  int8 v14; // r15
+  int8 v15; // fs_offset
+  bool v16; // al
+  char *v17; // stack - 0xe8
+  char *v18; // stack - 0xe0
+  char *v19; // stack - 0xd8
+  char v2;
+  char *v20; // stack - 0xd0
+  char *v21; // stack - 0xc8
+  char *v22; // stack - 0xc0
+  char *v23; // stack - 0xb8
+  char *v24; // stack - 0xb0
+  char *v25; // stack - 0xa8
+  char *v26; // stack - 0xa0
+  char *v27; // stack - 0x98
+  unsigned long v28; // stack - 0x90
+  unsigned long v29; // stack - 0x88
+  void *v3;
+  int8 v30; // stack - 0x78
+  void *v31; // stack - 0x70
+  uint8 v32; // stack - 0x68
+  char *v33; // stack - 0x60
+  unsigned long v34; // stack - 0x58
+  code *v35; // stack - 0x50
+  int8 *v36; // stack - 0x40
+  char v4;
+  int4 v5; // eax
+  char *v6;
+  unsigned long v7; // rax
+  char *v8;
+  int8 *v9;
+  
+  v13 = 0;
+  v35 = (code *)0x401030;
+  set_program_name(*a1);
+  v35 = (code *)0x401041;
+  setlocale(6,0x40207e);
+  v35 = (code *)0x401050;
+  bindtextdomain(0x402083,"/usr/local/share/locale");
+  v35 = (code *)0x40105f;
+  textdomain(0x402083);
+  v35 = (code *)0x401064;
+  initialize_exit_failure.constprop.0();
+  v35 = (code *)0x401070;
+  atexit(close_stdout);
+  do {
+    v35 = (code *)0x401083;
+    v5 = getopt_long(a0,a1,"+iu:0",longopts);
+    if (v5 == -1) {
+      v14 = (int8)dat_404000;
+      if (dat_404000 < (int4)a0) {
+        v5 = 0;
+        do {
+          v35 = (code *)0x40117c;
+          v6 = strchr((char *)a1[v14],0x3d);
+          if (v6 == (char *)0x0) {
+            v12 = 0;
+            for (v9 = dat_404008; v6 = (char *)*v9, v6 != (char *)0x0; v9 = &v9[1]) {
+              v4 = *v6;
+              v8 = (char *)a1[v14];
+              if (v4 != '\0') {
+                while (v2 = *v8, v2 != '\0') {
+                  v1 = &v6[1];
+                  v8 = &v8[1];
+                  if (v4 != v2) goto label_4011ef;
+                  v4 = v6[1];
+                  if (v4 == '=') {
+                    if (*v8 == '\0') {
+                      v35 = (code *)0x4011e4;
+                      v36 = v9;
+                      __printf_chk(1,0x4020eb,&v6[2],-((char)v13 == '\0') & 10);
+                      v12 = 1;
+                      v9 = v36;
+                      goto label_4011ef;
+                    }
+                  }
+                  else if (v4 == '\0') goto label_4011ef;
+                  v6 = v1;
+                }
+              }
+label_4011ef:
+            }
+            v5 = v5 + v12;
+          }
+          v14 = v14 + 1;
+        } while ((int4)v14 < (int4)a0);
+        v16 = a0 - dat_404000 == v5;
+      }
+      else {
+        for (v9 = dat_404008; *v9 != 0; v9 = &v9[1]) {
+          v35 = (code *)0x401124;
+          __printf_chk(1,0x4020eb,*v9,-((char)v13 == '\0') & 10);
+        }
+        v16 = 1;
+      }
+      return v16 ^ 1;
+    }
+    if (v5 == -0x82) {
+      v35 = (code *)0x401215;
+      usage(0);
+      v35 = longopts;
+      v33 = "+iu:0";
+      v30 = *(int8 *)(v15 + 0x28);
+      v22 = "sha256sum";
+      v24 = "sha384sum";
+      v26 = "sha512sum";
+      v28 = 0;
+      v29 = 0;
+      v11 = 0x402009;
+      v17 = "test invocation";
+      v18 = "coreutils";
+      v19 = "Multi-call invocation";
+      v20 = "sha224sum";
+      v21 = "sha2 utilities";
+      v23 = "sha2 utilities";
+      v25 = "sha2 utilities";
+      v27 = "sha2 utilities";
+      v3 = &v11;
+      v31 = a1;
+      v32 = (uint8)a0;
+      v34 = v13;
+      goto label_4012d0;
+    }
+    v13 = 1;
+    if (v5 != 0x30) {
+      if (v5 != -0x83) {
+        v35 = (code *)0x4010af;
+        usage(2);
+      }
+      v34 = 0;
+      v33 = (char *)0x4010e7;
+      version_etc(dat_404018,"printenv","GNU coreutils",dat_4023ef,"David MacKenzie","Richard Mlynarik");
+                    /* WARNING: Subroutine does not return */
+      v33 = "Lc=\v/";
+      exit(0);
+    }
+  } while( true );
+  while (v5 = strcmp("printenv",*(char **)&v10[0x10]), v3 = (void *)&v10[0x10], v5 != 0) {
+label_4012d0:
+    v10 = (void *)v3;
+    if (*(char **)&v10[0x10] == (char *)0x0) goto label_4012e9;
+  }
+label_4012e9:
+  if (*(int8 *)&v10[0x18] == 0) {
+    v13 = dcgettext(0,"\n%s online help: <%s>\n",5);
+    __printf_chk(1,v13,"GNU coreutils","https://www.gnu.org/software/coreutils/");
+    v6 = (char *)setlocale(5,0);
+    if ((v6 == (char *)0x0) || (v5 = strncmp(v6,"en_",3), v5 == 0)) {
+      v13 = dcgettext(0,"Full documentation <%s%s>\n",5);
+      __printf_chk(1,v13,"https://www.gnu.org/software/coreutils/","printenv");
+      goto label_401393;
+    }
+label_401430:
+    v13 = dat_404018;
+    v7 = dcgettext(0,"Report any translation bugs to <https://translationproject.org/team/>\n",5);
+    fputs_unlocked(v7,v13);
+  }
+  else {
+    v13 = dcgettext(0,"\n%s online help: <%s>\n",5);
+    __printf_chk(1,v13,"GNU coreutils","https://www.gnu.org/software/coreutils/");
+    v6 = (char *)setlocale(5,0);
+    if ((v6 != (char *)0x0) && (v5 = strncmp(v6,"en_",3), v5 != 0)) goto label_401430;
+  }
+  v13 = dcgettext(0,"Full documentation <%s%s>\n",5);
+  __printf_chk(1,v13,"https://www.gnu.org/software/coreutils/","printenv");
+label_401393:
+  dcgettext(0,"or available locally via: info \'(coreutils) %s%s\'\n",5);
+  if (v30 != *(int8 *)(v15 + 0x28)) {
+                    /* WARNING: Subroutine does not return */
+    __stack_chk_fail();
+  }
+  return 0;
+}

--- a/docs/features/printenv-main-ec8020/proposal.md
+++ b/docs/features/printenv-main-ec8020/proposal.md
@@ -1,0 +1,97 @@
+# [PROPOSAL] loopsubgraphreturn — return unstructurable loop subgraphs instead of goto-refining them
+
+**Status:** draft proposal, awaiting human go/no-go. Do **not** implement until approved.
+**Opportunity:** angr `test_decompiling_printenv_main` :: `main` (`printenv.o`, x86_64).
+**Proposed option:** `loopsubgraphreturn` (S7 structuring, default-off opt-in).
+**Scope (decider):** LARGE — touches S7 structuring/region code beyond a single gated early-return.
+
+## The problem
+angr's test asserts `main` structures with **zero gotos**. kuna emits **7 gotos**
+(reproduced via the link-to-ELF bypass — `printenv.o` is ET_REL, see *Dependency* below).
+The salient cluster:
+
+```c
+while (v2 = *v8, v2 != '\0') {
+  ...
+  if (v4 != v2) goto label_4011ef;     // continue-equivalent to inner for-loop tail
+  ...
+  goto label_4011ef;
+  else if (v4 == '\0') goto label_4011ef;
+  ...
+}
+label_4011ef:
+```
+
+These are `continue`-equivalent jumps to the tail of an inner `for` loop nested in an
+outer `do/while`. kuna's structurer cannot collapse the inner subgraph and falls back to
+unstructured goto edges.
+
+## The angr reference fix
+angr Phoenix structurer, `angr/analyses/decompiler/structuring/phoenix.py:221-226`:
+
+```python
+if not progressed:
+    if self._region.cyclic_ancestor and not self._region.cyclic:
+        # we prefer directly returning this subgraph in case it can be further
+        # restructured within a loop region
+        break                                     # <- return the subgraph
+    # otherwise:
+    removed_edge = self._last_resort_refinement(...)   # <- deletes a CFG edge => goto
+```
+
+Mechanism: an **acyclic** subgraph with a **cyclic ancestor** that made no structuring
+progress is *returned to its enclosing loop region* rather than forced through
+`_last_resort_refinement()` (which deletes an edge and materializes it as a `goto`). The
+outer loop region then restructures it with full loop context (producing
+`continue`/structured exits).
+
+## Why this is LARGE (not one Action/Rule)
+kuna's structurer is **Ghidra's `blockaction`** — `ActionBlockStructure` /
+`CollapseStructure` / `TraceDAG` (`blockaction.cc:2170`, Rust in
+`decompiler/crates/kuna-decomp/src/substrate/block.rs` + S7 region code). It is a
+*structurally different* algorithm from angr's Phoenix/SAILR:
+- no `cyclic_ancestor` / `_last_resort_refinement` concept;
+- goto-edge selection happens inside the TraceDAG collapse engine, not a discrete pass.
+
+Replicating "return the loop subgraph instead of goto-refining it" therefore requires
+modifying kuna's **core S7 collapse engine** (TraceDAG/CollapseStructure goto-edge
+selection): detect a sub-DAG with a cyclic ancestor that cannot be collapsed, defer its
+goto materialization, and let the enclosing loop collapse run first. This cannot be a
+gated early-return on a single new `Action`. It is multi-anchor S7 surgery → Hard rule 7
+LARGE.
+
+## Proposed implementation plan (for the approving human)
+1. **Loader prerequisite.** Land proposal #37 (`elf-reloc-objects`) first, so the full
+   pipeline can load `printenv.o` and reproduce end-to-end. Until then this proposal is
+   validatable only via the link-to-ELF bypass.
+2. **Identify the deferral point** in kuna's TraceDAG/CollapseStructure where an
+   uncollapsible acyclic sub-DAG currently gets a forced goto edge (the analog of angr's
+   `not progressed → _last_resort_refinement`).
+3. **Add a cyclic-ancestor check**: if the stuck sub-DAG sits inside a not-yet-collapsed
+   loop region, defer (return) it rather than emitting the goto, and re-run the loop
+   collapse so loop context is available.
+4. **Gate behind `loopsubgraphreturn`** (new architecture flag, default-off), with an
+   early-return to byte-identical default output. New element id `4020+` (next free after
+   4019).
+5. **Tests:** a `tests/stages/ghangr-loopsubgraphreturn.xml` two-pass datatest (bytechunk
+   of the inner-loop subgraph) asserting the goto cluster off-default and its
+   absence/`continue` on-default; ablation over the 675-assertion corpus; speed measurement.
+
+## Speed / risk assessment
+- **Risk: high.** Changes to the core collapse engine can perturb structuring for *many*
+  functions; the ablation risk over 675 assertions is the main reason for opt-in default-off
+  and for a human go/no-go before spending an implementation worker.
+- **Speed:** an extra deferral + re-collapse pass per stuck loop subgraph is bounded by the
+  region count; expected within the +5% budget but must be measured. Stays opt-in regardless
+  until measured.
+
+## Dependency
+- **Blocked-on #37** for full-pipeline reproduction (`printenv.o` is ET_REL; kuna's
+  PT_LOAD-only loader returns `Unable to load 512 bytes at r0x004007a0`). The decompiler
+  gap itself is real and reproduced via link-to-ELF (`docs/features/printenv-main-ec8020/angr-vs-kuna.txt`).
+
+## Distinctness
+- Distinct from **#37** (`elf-reloc-objects`, the loader gap — a prerequisite, not this fix).
+- Distinct from **#39** (`condfold` — SAILR condition-folding / crossing-edge goto
+  reduction). This is a *different* SAILR/Phoenix mechanism: loop-subgraph return vs
+  last-resort edge deletion.

--- a/docs/features/printenv-main-ec8020/record.json
+++ b/docs/features/printenv-main-ec8020/record.json
@@ -1,0 +1,34 @@
+{
+  "opportunity": "test_decompiling_printenv_main::main",
+  "test_name": "test_decompiling_printenv_main",
+  "binary": "/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/printenv.o",
+  "selector": "main",
+  "func_addr": "0x4007a0",
+  "angr_version": "9.2.213",
+  "scope": "large",
+  "proposal": true,
+  "option": "loopsubgraphreturn",
+  "change_kind": "structure-recovery",
+  "source_decompiler": "angr",
+  "inspiration": "test_decompiling_printenv_main; angr Phoenix structurer _analyze loop-subgraph return (phoenix.py:221-226, cyclic_ancestor vs _last_resort_refinement); main",
+  "owning_stage": "S7 structuring / blockaction (TraceDAG collapse, blockaction.cc:2170)",
+  "blocked_on": "Noelo-Lab/kuna#37 (ET_REL elf-reloc-objects loader gap; printenv.o is ET_REL, kuna PT_LOAD-only loader cannot load it)",
+  "kuna_goto_count": 7,
+  "angr_goto_count": 0,
+  "reproduction": "loader-blocked (ET_REL); decompiler gap reproduced via link-to-ELF bypass (stub UND symbols, gcc -no-pie -nostdlib -static), kuna decompile ./synth main -> 7 gotos incl. goto label_4011ef cluster",
+  "decisions": [
+    {
+      "question": "Is closing this gap a small single-pass option-gated feature, or LARGE? proposal vs negative?",
+      "decider": "general-purpose (opus)",
+      "verdict": {
+        "scope": "large",
+        "outcome": "proposal",
+        "rationale": "The fix is a deep S7 structuring change: it must invent angr's Phoenix loop-subgraph-return behavior inside Ghidra's TraceDAG collapse engine, which has no cyclic_ancestor/_last_resort_refinement analog, so it cannot be a single gated early-return Action/Rule (fails hard rule 7 LARGE). It is nonetheless a real, bounded, citable mechanism (angr phoenix.py:221-226) that demonstrably materializes the exact 7-goto / goto label_4011ef continue-cluster in kuna today via link-bypass, so it merits a human go/no-go rather than a silent drop. It is also gated on the ET_REL loader (#37) for true end-to-end reproduction, which is itself a proposal-stage dependency, not a reason to discard the distinct structuring finding.",
+        "owning_stage": "S7 structuring/blockaction (TraceDAG collapse, blockaction.cc:2170)",
+        "proposed_option_name": "loopsubgraphreturn",
+        "is_distinct_from_existing_proposals": true,
+        "distinctness_note": "Distinct from #37 (ET_REL elf-reloc-objects loader gap — a prerequisite for full-pipeline repro, not the structuring fix) and from #39 (condfold, a SAILR condition-folding / crossing-edge goto-reduction mechanism). This is a different SAILR/Phoenix mechanism: returning an unmade-progress acyclic subgraph with a cyclic ancestor to its enclosing loop region instead of last-resort edge-deletion, yielding continue/structured exits. Should be its own tracked draft [PROPOSAL] PR, explicitly blocked-on/gated-behind #37 for end-to-end reproduction, not folded into #39."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# [PROPOSAL] loopsubgraphreturn — return unstructurable loop subgraphs instead of goto-refining them

**Status:** draft proposal, awaiting human go/no-go. Do **not** implement until approved.
**Opportunity:** angr `test_decompiling_printenv_main` :: `main` (`printenv.o`, x86_64).
**Proposed option:** `loopsubgraphreturn` (S7 structuring, default-off opt-in).
**Scope (decider):** LARGE — touches S7 structuring/region code beyond a single gated early-return.

## The problem
angr's test asserts `main` structures with **zero gotos**. kuna emits **7 gotos**
(reproduced via the link-to-ELF bypass — `printenv.o` is ET_REL, see *Dependency* below).
The salient cluster:

```c
while (v2 = *v8, v2 != '\0') {
  ...
  if (v4 != v2) goto label_4011ef;     // continue-equivalent to inner for-loop tail
  ...
  goto label_4011ef;
  else if (v4 == '\0') goto label_4011ef;
  ...
}
label_4011ef:
```

These are `continue`-equivalent jumps to the tail of an inner `for` loop nested in an
outer `do/while`. kuna's structurer cannot collapse the inner subgraph and falls back to
unstructured goto edges.

## The angr reference fix
angr Phoenix structurer, `angr/analyses/decompiler/structuring/phoenix.py:221-226`:

```python
if not progressed:
    if self._region.cyclic_ancestor and not self._region.cyclic:
        # we prefer directly returning this subgraph in case it can be further
        # restructured within a loop region
        break                                     # <- return the subgraph
    # otherwise:
    removed_edge = self._last_resort_refinement(...)   # <- deletes a CFG edge => goto
```

Mechanism: an **acyclic** subgraph with a **cyclic ancestor** that made no structuring
progress is *returned to its enclosing loop region* rather than forced through
`_last_resort_refinement()` (which deletes an edge and materializes it as a `goto`). The
outer loop region then restructures it with full loop context (producing
`continue`/structured exits).

## Why this is LARGE (not one Action/Rule)
kuna's structurer is **Ghidra's `blockaction`** — `ActionBlockStructure` /
`CollapseStructure` / `TraceDAG` (`blockaction.cc:2170`, Rust in
`decompiler/crates/kuna-decomp/src/substrate/block.rs` + S7 region code). It is a
*structurally different* algorithm from angr's Phoenix/SAILR:
- no `cyclic_ancestor` / `_last_resort_refinement` concept;
- goto-edge selection happens inside the TraceDAG collapse engine, not a discrete pass.

Replicating "return the loop subgraph instead of goto-refining it" therefore requires
modifying kuna's **core S7 collapse engine** (TraceDAG/CollapseStructure goto-edge
selection): detect a sub-DAG with a cyclic ancestor that cannot be collapsed, defer its
goto materialization, and let the enclosing loop collapse run first. This cannot be a
gated early-return on a single new `Action`. It is multi-anchor S7 surgery → Hard rule 7
LARGE.

## Proposed implementation plan (for the approving human)
1. **Loader prerequisite.** Land proposal #37 (`elf-reloc-objects`) first, so the full
   pipeline can load `printenv.o` and reproduce end-to-end. Until then this proposal is
   validatable only via the link-to-ELF bypass.
2. **Identify the deferral point** in kuna's TraceDAG/CollapseStructure where an
   uncollapsible acyclic sub-DAG currently gets a forced goto edge (the analog of angr's
   `not progressed → _last_resort_refinement`).
3. **Add a cyclic-ancestor check**: if the stuck sub-DAG sits inside a not-yet-collapsed
   loop region, defer (return) it rather than emitting the goto, and re-run the loop
   collapse so loop context is available.
4. **Gate behind `loopsubgraphreturn`** (new architecture flag, default-off), with an
   early-return to byte-identical default output. New element id `4020+` (next free after
   4019).
5. **Tests:** a `tests/stages/ghangr-loopsubgraphreturn.xml` two-pass datatest (bytechunk
   of the inner-loop subgraph) asserting the goto cluster off-default and its
   absence/`continue` on-default; ablation over the 675-assertion corpus; speed measurement.

## Speed / risk assessment
- **Risk: high.** Changes to the core collapse engine can perturb structuring for *many*
  functions; the ablation risk over 675 assertions is the main reason for opt-in default-off
  and for a human go/no-go before spending an implementation worker.
- **Speed:** an extra deferral + re-collapse pass per stuck loop subgraph is bounded by the
  region count; expected within the +5% budget but must be measured. Stays opt-in regardless
  until measured.

## Dependency
- **Blocked-on #37** for full-pipeline reproduction (`printenv.o` is ET_REL; kuna's
  PT_LOAD-only loader returns `Unable to load 512 bytes at r0x004007a0`). The decompiler
  gap itself is real and reproduced via link-to-ELF (`docs/features/printenv-main-ec8020/angr-vs-kuna.txt`).

## Distinctness
- Distinct from **#37** (`elf-reloc-objects`, the loader gap — a prerequisite, not this fix).
- Distinct from **#39** (`condfold` — SAILR condition-folding / crossing-edge goto
  reduction). This is a *different* SAILR/Phoenix mechanism: loop-subgraph return vs
  last-resort edge deletion.
