### PR TITLE
[PROPOSAL] angr-od-else-simplification-5194c9: earlyreturn — early-return guard hoisting (else simplification)

### DIFF
--- a/docs/features/od-else-simplification-5194c9/analysis.md
+++ b/docs/features/od-else-simplification-5194c9/analysis.md
@@ -1,0 +1,71 @@
+# Analysis — angr `test_od_else_simplification` (`skip` in `od_gccO2.o`)
+
+## The gap
+
+angr's decompiler emits the early-exit guard of `skip` as the **first** statement and
+de-indents the body:
+
+```c
+if (!cur)
+    return 1;
+v3 = 0;
+v4 = 1;
+while (in_stream) { ... }       // body de-indented, no else wrapping
+```
+
+kuna instead wraps the **entire** function body inside `if (a0 != 0) { ... }` and lets the
+`!a0` path fall implicitly through to a shared epilogue:
+
+```c
+if (a0 != 0) {
+    ...whole body...
+}
+v14 = 1;
+label_403d25:
+if (canary != ...) __stack_chk_fail();
+return v14;                      // the !a0 path lands here -> return 1
+```
+
+The angr test (`cstyle_ifs=False`) asserts the first `if` is `if (!a0) { return 1; }` with
+**no else** — i.e. an early-return guard, not a body-wrapping condition.
+
+## Why angr is better here
+
+The early-return guard is the idiomatic shape for a function whose first action is an
+argument-validity check. kuna's body-wrapping `if (a0 != 0) { ... }` pushes the entire
+function one indent level deeper and obscures the guard.
+
+## angr's mechanism (read from angr source)
+
+Closing this gap is **two cooperating angr passes**, both operating on angr's mutable
+region tree (`ConditionNode` / `SequenceNode` / `LoopNode`):
+
+1. **Return duplication** — `optimization_passes/return_duplicator_*.py`. The shared
+   canary+`return 1` epilogue is duplicated into the `!a0` guard path so that path becomes a
+   standalone, *terminating* `return 1`.
+2. **If/else flattening** — `region_simplifiers/ifelse.py` `IfElseFlattener`. Once the if's
+   true-branch always terminates (returns) and the false-branch does not, it removes the
+   `else` node and re-parents the body as a sibling **after** the `if`, de-indenting it.
+
+## Owning stage in kuna
+
+kuna has **no angr-style mutable region tree at emit time**. The if/else shape is decided by
+Ghidra's **block-graph collapse Structurer** — `CollapseStructure` / the block-if-else rules
+in `decompiler/crates/kuna-decomp/src/s8_structure/blockaction.rs` (~3600 lines), Ghidra's
+S7/S8 region recovery. Reproducing angr's output requires re-creating both halves of angr's
+mechanism (return duplication into the guard path + else removal + body de-indent) inside
+that Structurer, plus a likely emit-side change.
+
+## Verdict
+
+**LARGE** (Hard Rule 7): a new structuring pass *type* that touches S7/S8 structuring code
+well beyond a single gated early-return. Not modelable as one Action/Rule like
+`kuna_loweredswitch.rs` (an S2 detection pass). A decider subagent independently confirmed
+`scope: large` (see `record.json` → `decisions`). This is the same S7/S8 SAILR
+region-structuring class consistently parked LARGE in the five prior ET_REL opportunities
+(`condfold`, `elf-reloc-objects`, …).
+
+Note: `od_gccO2.o` is an ET_REL object that kuna's PT_LOAD-only loader cannot map (the
+loader gap, proposal PR #37). The kuna side above was obtained by link-bypass into a
+standalone ELF (`/tmp/kuna_od/synth`) so the *structuring* gap could be isolated from the
+loader gap. The residual structuring gap is the subject of this proposal.

--- a/docs/features/od-else-simplification-5194c9/angr-vs-kuna.txt
+++ b/docs/features/od-else-simplification-5194c9/angr-vs-kuna.txt
@@ -1,0 +1,236 @@
+=== angr (cstyle_ifs=False) — skip @ od_gccO2.o ===
+if (!cur) return 1; as FIRST stmt, body de-indented (no else)
+
+--- angr ---
+typedef struct FILE {
+} FILE;
+
+typedef struct stat {
+    unsigned int st_mode;
+    char padding_4[4];
+    unsigned int st_ino;
+    char padding_c[4];
+    char st_dev;
+    char padding_11[7];
+    unsigned int st_nlink;
+    unsigned int st_uid;
+    unsigned int st_gid;
+    char padding_24[4];
+    int st_size;
+    char padding_2c[4];
+    int st_atime;
+    char padding_34[4];
+    int st_mtime;
+    char padding_3c[4];
+    int st_ctime;
+} stat;
+
+extern unsigned long in_stream;
+extern unsigned long input_filename;
+
+unsigned int skip(long long cur)
+{
+    unsigned int v3;  // r13d
+    unsigned int v4;  // r12d
+    long long v13;  // rdi
+    long long v14;  // rsi
+    long long v15;  // rdx
+    long long v16;  // rcx
+    long long v17;  // r8
+    long long v18;  // r9
+    char v5;  // al
+    long long v6;  // rdx
+    long long v7;  // rcx
+    long long v8;  // rbx
+    long long v9;  // rbx
+    long long count;  // rax
+    int *err;  // rax
+    unsigned int v12;  // eax
+    stat v0;  // [bp-0x20c8]
+    char v1;  // [bp-0x2038]
+
+    if (!cur)
+        return 1;
+    v3 = 0;
+    v4 = 1;
+    while (in_stream)
+    {
+        if (!fstat(fileno(in_stream), &v0))
+        {
+            v5 = usable_st_size.isra.0(v0.st_nlink);
+            if (v5)
+            {
+                v6 = 0x200;
+                v7 = *((unsigned long long *)((void*)&v0 + 48));
+                if (*((unsigned long long *)((void*)&v0 + 56)) - 1 <= 2305843009213693951)
+                    v6 = *((unsigned long long *)((void*)&v0 + 56));
+                if (v7 > v6)
+                {
+                    if (v7 < cur)
+                    {
+                        cur -= v7;
+                    }
+                    else if ((int)rpl_fseeko(in_stream, cur, 1))
+                    {
+                        v4 = 0;
+                        cur = 0;
+                        v3 = *(__errno_location());
+                    }
+                    else
+                    {
+                        cur = 0;
+                    }
+LABEL_4020d0:
+                    if (!cur)
+                        break;
+                    else
+                        goto LABEL_4020d9;
+                }
+            }
+            if (v5 || (int)rpl_fseeko(in_stream, cur, 1))
+            {
+                v8 = 0x2000;
+                while (cur)
+                {
+                    if (v8 > cur)
+                        v9 = cur;
+                    else
+                        v9 = v8;
+                    v8 = v9;
+                    count = __fread_unlocked_chk(&v1, 0x2000, 1, v8, in_stream);
+                    cur -= count;
+                    if (v8 == count)
+                        continue;
+                    if (ferror_unlocked(in_stream))
+                    {
+                        v4 = 0;
+                        cur = 0;
+                        v3 = *(__errno_location());
+                        break;
+                    }
+                    else if (feof_unlocked(in_stream))
+                    {
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                cur = 0;
+                goto LABEL_4020d0;
+            }
+        }
+        else
+
+=== kuna (synth-ELF link-bypass of ET_REL loader) — skip ===
+uint1 skip(uint8 a0)
+
+{
+  bool v1; // al
+  int8 v10; // rdx
+  uint8 v11; // rbx
+  char v12 [24];
+  char v13 [8200];
+  uint1 v14; // r12b
+  int4 v15;
+  int8 v16; // fs_offset
+  int8 v17; // fs_offset
+  unsigned int v18; // stack - 0x20b0
+  unsigned int v18; // stack - 0x20b0
+  uint8 v19; // stack - 0x2098
+  uint8 v19; // stack - 0x2098
+  bool v2; // al
+  int8 v20; // stack - 0x2090
+  int8 v20; // stack - 0x2090
+  int8 v21; // stack - 0x30
+  char v3; // al
+  unsigned int v4; // eax
+  int4 v5; // eax
+  int4 *v6; // rax
+  uint8 v7; // rax
+  void *v8; // rax
+  unsigned long v9; // rax
+  
+  v21 = *(int8 *)(v16 + 0x28);
+  if (a0 != 0) {
+    v15 = 0;
+    v14 = 1;
+    while (dat_4090c8 != 0) {
+      v4 = fileno(dat_4090c8);
+      v5 = fstat(v4,v12);
+      if (v5 == 0) {
+        v3 = usable_st_size.isra.0(v18);
+        if (v3 == '\0') {
+label_403bb0:
+          if ((v3 == '\0') && (v5 = rpl_fseeko(Unique1000026c,a0,1), v5 == 0)) {
+            a0 = 0;
+          }
+          else {
+            v11 = 0x2000;
+            do {
+              do {
+                if (a0 == 0) goto label_403c40;
+                if (a0 < v11) {
+                }
+                v7 = __fread_unlocked_chk(v13,0x2000,1,v11,dat_4090c8);
+                a0 = a0 - v7;
+              } while (v11 == v7);
+              v5 = ferror_unlocked(dat_4090c8);
+              if (v5 != 0) {
+                v6 = (int4 *)__errno_location();
+                v14 = 0;
+                a0 = 0;
+                v15 = *v6;
+                goto label_403c40;
+              }
+              v5 = feof_unlocked(Unique10000264);
+            } while (v5 == 0);
+          }
+        }
+        else {
+          v10 = 0x200;
+          if ((uint8)(v20 - 1U) <= 0x1fffffffffffffff) {
+          }
+          if ((int8)v19 <= v10) goto label_403bb0;
+          if (v19 < a0) {
+            a0 = a0 - v19;
+          }
+          else {
+            v5 = rpl_fseeko(Unique1000026c,a0,1);
+            if (v5 == 0) {
+              a0 = 0;
+            }
+            else {
+              v6 = (int4 *)__errno_location();
+              v14 = 0;
+              a0 = 0;
+              v15 = *v6;
+            }
+          }
+        }
+label_403c40:
+        if (a0 == 0) goto label_403d20;
+      }
+      else {
+        v9 = quotearg_n_style_colon(0,3,dat_4090d8);
+        v8 = (void *)__errno_location();
+        v14 = 0;
+        error(0,*v8,0x406273,v9);
+      }
+      v1 = check_and_close(v15);
+      v2 = open_next_file();
+      v14 = v14 & v1 & v2;
+    }
+label_403d20:
+    if (a0 == 0) goto label_403d25;
+    v9 = dcgettext(0,"cannot skip past end of combined input",5);
+    error(1,0,v9);
+  }
+  v14 = 1;
+label_403d25:
+  if (v21 != *(int8 *)(v17 + 0x28)) {
+                    /* WARNING: Subroutine does not return */
+    __stack_chk_fail();
+  }
+  return v14;
+}

--- a/docs/features/od-else-simplification-5194c9/proposal.md
+++ b/docs/features/od-else-simplification-5194c9/proposal.md
@@ -1,0 +1,86 @@
+# [PROPOSAL] `earlyreturn` — angr-style early-return guard hoisting ("else simplification")
+
+**Opportunity:** angr `test_od_else_simplification` · function `skip` · `od_gccO2.o` (x86_64)
+**Proposed option:** `earlyreturn` (default-off, opt-in) · **Scope: LARGE** (human go/no-go)
+
+## The problem
+
+For a function whose first action is an argument-validity check, angr emits an idiomatic
+early-return guard and de-indents the body; kuna wraps the entire body in an inverted
+condition. See `analysis.md` and the captured side-by-side in `angr-vs-kuna.txt`.
+
+```c
+// angr (desired)                         // kuna (today)
+if (!cur)                                 if (a0 != 0) {
+    return 1;                                 ...whole body...
+v3 = 0;                                    }
+... body de-indented ...                   v14 = 1;
+                                           label: if (canary) __stack_chk_fail();
+                                           return v14;     // !a0 path lands here
+```
+
+The angr test (`cstyle_ifs=False`) asserts the **first** `if` is `if (!a0) { return 1; }`
+with no else.
+
+## angr reference passes
+
+1. `optimization_passes/return_duplicator_{base,high,low}.py` — duplicate the shared
+   epilogue (`__stack_chk_fail` guard + `return 1`) into the `!a0` path so it becomes a
+   standalone *terminating* return.
+2. `region_simplifiers/ifelse.py` `IfElseFlattener` — when the if's true-branch always
+   terminates and the false-branch does not, drop the `else` and re-parent the body as a
+   sibling after the `if`.
+
+Both run on angr's mutable region tree.
+
+## Why this is LARGE (not one option-gated Action/Rule)
+
+- kuna has **no angr-style mutable region tree** at emit time. The if/else shape is fixed by
+  Ghidra's block-graph collapse Structurer in
+  `decompiler/crates/kuna-decomp/src/s8_structure/blockaction.rs` (~3600 lines, S7/S8 region
+  recovery).
+- Reproducing angr's output requires **two cooperating transformations** woven into that
+  Structurer: (a) return/epilogue duplication into the guard path, and (b) else removal +
+  body de-indent — i.e. a **new structuring pass type**, not a single `Action`/`Rule` like
+  `kuna_loweredswitch.rs`.
+- It touches S7/S8 structuring/region code well beyond a single gated early-return → Hard
+  Rule 7 LARGE. A decider subagent independently confirmed `scope: large`.
+
+## Proposed multi-step implementation plan (for the approved implementation worker)
+
+1. **Pattern detection (S8).** In/after `CollapseStructure`, identify a top-level
+   `BlockIf { cond, body }` whose *false* (fall-through) path reaches the function's shared
+   return epilogue with no side effects other than constant return-value setup.
+2. **Epilogue duplication.** Synthesize a duplicated terminating return (carrying the
+   constant from the false path, e.g. `return 1`) into a new guard block `if (!cond) return
+   K;` — the analogue of angr's return-duplicator.
+3. **Restructure.** Replace the body-wrapping `BlockIf` with the guard followed by the
+   de-indented body as siblings (analogue of `IfElseFlattener`). Preserve canary handling so
+   `make test` / `make test-stages` parity is unaffected when the flag is off.
+4. **Gate.** New `earlyreturn` bool on the architecture struct (default off in reset),
+   registered action early-returns when off so default output is byte-identical;
+   `settableTable` row + `options.rs` registration; LLM-discoverable.
+5. **Verify.** Two-pass `tests/stages/ghangr-od-else-simplification-5194c9.xml` (off = body-wrapped
+   bug, on = early-return guard). Ablation over the 675 datatests; default decision gated by
+   the speed budget.
+
+## Speed / risk assessment
+
+- **Risk:** structuring rewrites are the highest-blast-radius part of the pipeline; an
+  over-broad pattern could change many functions. Mitigate by a tight pattern (top-level
+  single-guard + constant-return shared epilogue only) and keeping it **default-off opt-in**
+  initially, with a full 675-assertion ablation before any DIV flip.
+- **Speed:** one extra structuring walk per function; expected within the +5% budget but
+  must be measured on the target (`skip`) before any default-on decision.
+- **Loader caveat:** the opportunity binary is ET_REL (loader gap, PR #37); the
+  implementation worker should validate via the link-bypass ELF or a bytechunk stage test.
+
+## Relation to existing proposals
+
+Distinct from `condfold` (#39: short-circuit `&&`/`||` folding + crossing-edge goto
+reduction) and `elf-reloc-objects` (#37: the ET_REL loader). Same broad SAILR S7/S8
+region-structuring family, but a separate, specific transformation (early-return guard
+hoisting / else flattening). Not covered by any existing option (`returnpair`,
+`sparcstructret`, `stackguard` are unrelated).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/od-else-simplification-5194c9/record.json
+++ b/docs/features/od-else-simplification-5194c9/record.json
@@ -1,0 +1,27 @@
+{
+  "opportunity": "test_od_else_simplification::skip",
+  "test_name": "test_od_else_simplification",
+  "binary": "/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/od_gccO2.o",
+  "selector": "skip",
+  "func_addr": "0x401fc0",
+  "angr_version": "angr-dev (local checkout)",
+  "option": "earlyreturn",
+  "change_kind": "structure-recovery",
+  "source_decompiler": "angr",
+  "inspiration": "test_od_else_simplification; IfElseFlattener (region_simplifiers/ifelse.py) + return_duplicator_*.py; skip",
+  "scope": "large",
+  "proposal": true,
+  "decisions": [
+    {
+      "question": "Is early-return guard hoisting ('else simplification') a small (one gated Action/Rule) or large feature in kuna?",
+      "decider_verdict": {
+        "scope": "large",
+        "owning_stage": "S8 structuring (block-graph Structurer, blockaction.rs) — angr maps this to its S7 region recovery",
+        "rationale": "The if/else shape kuna emits is decided by Ghidra's block-graph collapse Structurer (CollapseStructure/rule_block_if_else in s8_structure/blockaction.rs, ~3635 lines), which has no angr-style mutable region tree to re-parent at emit time. Reproducing angr's output requires both halves of angr's mechanism — return duplication (synthesizing a duplicated canary+return epilogue into the !a0 guard path so the true-branch terminates) and IfElseFlattener (removing the else and de-indenting the body) — which is new structuring logic woven into the collapse Structurer plus a likely emit-side change, well beyond a single gated early-return. This is the same S7/S8 region-structuring class consistently parked LARGE in the five prior ET_REL opportunities (condfold etc.), and unlike the small template kuna_loweredswitch.rs which is an S2 detection pass.",
+        "if_large_proposal_option_name": "earlyreturn",
+        "if_small_plan": ""
+      }
+    }
+  ],
+  "loader_note": "od_gccO2.o is ET_REL; kuna's PT_LOAD-only loader cannot map it (loader gap, proposal PR #37). kuna side isolated via link-bypass into a standalone ELF to expose the structuring gap."
+}


### PR DESCRIPTION
# [PROPOSAL] `earlyreturn` — angr-style early-return guard hoisting ("else simplification")

**Opportunity:** angr `test_od_else_simplification` · function `skip` · `od_gccO2.o` (x86_64)
**Proposed option:** `earlyreturn` (default-off, opt-in) · **Scope: LARGE** (human go/no-go)

## The problem

For a function whose first action is an argument-validity check, angr emits an idiomatic
early-return guard and de-indents the body; kuna wraps the entire body in an inverted
condition. See `analysis.md` and the captured side-by-side in `angr-vs-kuna.txt`.

```c
// angr (desired)                         // kuna (today)
if (!cur)                                 if (a0 != 0) {
    return 1;                                 ...whole body...
v3 = 0;                                    }
... body de-indented ...                   v14 = 1;
                                           label: if (canary) __stack_chk_fail();
                                           return v14;     // !a0 path lands here
```

The angr test (`cstyle_ifs=False`) asserts the **first** `if` is `if (!a0) { return 1; }`
with no else.

## angr reference passes

1. `optimization_passes/return_duplicator_{base,high,low}.py` — duplicate the shared
   epilogue (`__stack_chk_fail` guard + `return 1`) into the `!a0` path so it becomes a
   standalone *terminating* return.
2. `region_simplifiers/ifelse.py` `IfElseFlattener` — when the if's true-branch always
   terminates and the false-branch does not, drop the `else` and re-parent the body as a
   sibling after the `if`.

Both run on angr's mutable region tree.

## Why this is LARGE (not one option-gated Action/Rule)

- kuna has **no angr-style mutable region tree** at emit time. The if/else shape is fixed by
  Ghidra's block-graph collapse Structurer in
  `decompiler/crates/kuna-decomp/src/s8_structure/blockaction.rs` (~3600 lines, S7/S8 region
  recovery).
- Reproducing angr's output requires **two cooperating transformations** woven into that
  Structurer: (a) return/epilogue duplication into the guard path, and (b) else removal +
  body de-indent — i.e. a **new structuring pass type**, not a single `Action`/`Rule` like
  `kuna_loweredswitch.rs`.
- It touches S7/S8 structuring/region code well beyond a single gated early-return → Hard
  Rule 7 LARGE. A decider subagent independently confirmed `scope: large`.

## Proposed multi-step implementation plan (for the approved implementation worker)

1. **Pattern detection (S8).** In/after `CollapseStructure`, identify a top-level
   `BlockIf { cond, body }` whose *false* (fall-through) path reaches the function's shared
   return epilogue with no side effects other than constant return-value setup.
2. **Epilogue duplication.** Synthesize a duplicated terminating return (carrying the
   constant from the false path, e.g. `return 1`) into a new guard block `if (!cond) return
   K;` — the analogue of angr's return-duplicator.
3. **Restructure.** Replace the body-wrapping `BlockIf` with the guard followed by the
   de-indented body as siblings (analogue of `IfElseFlattener`). Preserve canary handling so
   `make test` / `make test-stages` parity is unaffected when the flag is off.
4. **Gate.** New `earlyreturn` bool on the architecture struct (default off in reset),
   registered action early-returns when off so default output is byte-identical;
   `settableTable` row + `options.rs` registration; LLM-discoverable.
5. **Verify.** Two-pass `tests/stages/ghangr-od-else-simplification-5194c9.xml` (off = body-wrapped
   bug, on = early-return guard). Ablation over the 675 datatests; default decision gated by
   the speed budget.

## Speed / risk assessment

- **Risk:** structuring rewrites are the highest-blast-radius part of the pipeline; an
  over-broad pattern could change many functions. Mitigate by a tight pattern (top-level
  single-guard + constant-return shared epilogue only) and keeping it **default-off opt-in**
  initially, with a full 675-assertion ablation before any DIV flip.
- **Speed:** one extra structuring walk per function; expected within the +5% budget but
  must be measured on the target (`skip`) before any default-on decision.
- **Loader caveat:** the opportunity binary is ET_REL (loader gap, PR #37); the
  implementation worker should validate via the link-bypass ELF or a bytechunk stage test.

## Relation to existing proposals

Distinct from `condfold` (#39: short-circuit `&&`/`||` folding + crossing-edge goto
reduction) and `elf-reloc-objects` (#37: the ET_REL loader). Same broad SAILR S7/S8
region-structuring family, but a separate, specific transformation (early-return guard
hoisting / else flattening). Not covered by any existing option (`returnpair`,
`sparcstructret`, `stackguard` are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
