### PR TITLE
[PROPOSAL] angr-phoenix-natural-loop-region-1c12bf: recover head-in-body natural loops (S7 structuring)

### DIFF
--- a/docs/features/phoenix-natural-loop-region-1c12bf/analysis.md
+++ b/docs/features/phoenix-natural-loop-region-1c12bf/analysis.md
@@ -1,0 +1,88 @@
+# phoenix-natural-loop-region-1c12bf — analysis
+
+## Opportunity
+
+- angr testcase: `test_decompiling_phoenix_natural_loop_region_head_in_body :: 0x442300`
+- Binary: `binaries/tests/x86_64/windows/059ef54d0a97345369d236aafb051917c50680020a1bc532236072f4d341d9e3`
+  (PE32+ console x86-64, a large statically-linked **Go** Windows executable).
+- angr version: 9.2.213.
+- arch override: `x86_64`.
+
+## What angr does better
+
+angr's `RegionIdentifier` (Phoenix structuring,
+`angr/analyses/decompiler/region_identifier.py`) recovers the function as a single,
+clean natural loop:
+
+```c
+while (true)
+{
+    ...
+    if (...) { ...; continue; }
+    ...
+    goto LABEL_442558;   // exactly ONE forced edge
+    ...
+}
+```
+
+The test name — *natural loop region, head in body* — pins the specific angr fix:
+when Phoenix identifies a natural loop, the loop **head** node can also be reachable
+from inside the loop **body** (the back-edge target is referenced mid-region). angr's
+region identifier handles that case so the loop collapses into one `while (true)` with
+`continue`s, leaving only one genuine `goto`.
+
+## What kuna produces (the gap)
+
+kuna decompiles the same function (it loads only with `--experimental-formats`; the
+default loader rejects the PE) into a body shredded by gotos:
+
+- **31** `goto label_*` / `label_*:` tokens total (see `kuna-full.txt`).
+- The natural-loop head at `0x4425a0` is emitted as `label_4425a0:` with
+  `goto label_4425a0;` back-edges, instead of being recovered as a loop header.
+- One `while (...)` *is* formed, but most of the loop body is scattered across
+  `label_4423d8`, `label_442597`, `label_442661`, `label_4426a8`, `label_4426ad`,
+  `label_4426e6`, `label_442705`, `label_442711`, `label_442340`, `label_442696`,
+  `label_4426a0`, … as unstructured gotos.
+
+Side-by-side: `angr-vs-kuna.txt`. Full kuna rendering: `kuna-full.txt`.
+
+## Owning stage
+
+S7/S8 region-and-loop **structuring**. In kuna the printed C is produced by the
+upstream Ghidra **collapse-based** block structurer
+(`decompiler/crates/kuna-decomp/src/s8_structure/blockaction.rs` —
+`CollapseStructure` / `LoopBody` / `TraceDAG`), *not* by a region identifier.
+
+kuna *does* contain a faithful port of angr's `RegionIdentifier`
+(`s7_regions/kuna_regionid.rs` + `kuna_regiongraph.rs`), but it is **analysis-only /
+observability** (driven by the `region tree/blocks/walk` console commands over
+synthetic input). It is not wired into the emit path — it appears only as a module
+declaration in `lib.rs`/`mod.rs` and produces no C.
+
+## Why this is NOT a single option-gated Action (scope = large)
+
+The `kuna_loweredswitch.rs` template works because it manufactures an **S2 artifact**
+(a `BRANCHIND` + `JumpTable`) *upstream* of the structurer and lets the existing
+structurer + printer do the rest. There is **no analogous single artifact** to inject
+for a generic natural-loop-head structuring improvement: the fix lives *inside* the
+structurer's loop detection.
+
+Closing the gap requires EITHER:
+
+1. **(a)** Extending Ghidra's collapse structurer's loop/region detection
+   (`blockaction.rs` `CollapseStructure`/`LoopBody`/`TraceDAG`) to recognise the
+   head-in-body natural loop — a change to S7/S8 structuring **core**, well beyond a
+   single gated early-return; or
+2. **(b)** Wiring the analysis-only `kuna_regionid` RegionIdentifier port into the
+   emit path — a **new pass type** plus new emit infrastructure.
+
+Both paths violate Hard rule 7 (new pass type / infrastructure, S7 structuring touch
+beyond a gated early-return, >3 anchor files / >1 module). The decider subagent
+returned `scope: "large"` (verbatim in `record.json`).
+
+## Conclusion
+
+This is a legitimate, reproducible gap (angr clean loop vs kuna 31-token goto soup),
+but it cannot be reduced to one Action/Rule. Per the proposal fork it is escalated as
+a `[PROPOSAL]` draft PR for human go/no-go on which path (a or b) to fund. No engine
+code is changed in this PR.

--- a/docs/features/phoenix-natural-loop-region-1c12bf/angr-vs-kuna.txt
+++ b/docs/features/phoenix-natural-loop-region-1c12bf/angr-vs-kuna.txt
@@ -1,0 +1,222 @@
+==============================================================================
+test_decompiling_phoenix_natural_loop_region_head_in_body :: 0x442300   (angr 9.2.213 @ 0x442300)
+==============================================================================
+
+--- angr ---
+typedef struct struct_0 {
+    unsigned long long field_0;
+    unsigned int field_8;
+    unsigned short field_c;
+} struct_0;
+
+typedef struct struct_1 {
+    char padding_0[16];
+    struct struct_2 *field_10;
+    unsigned long long field_18;
+} struct_1;
+
+typedef struct struct_2 {
+    unsigned int field_0;
+} struct_2;
+
+extern unsigned long long g_4db2e0;
+extern unsigned long long g_4dc600;
+extern long long g_4dc608;
+extern int g_5638c0;
+
+struct_0 * sub_442300(unsigned long long a0, unsigned long a1, unsigned long long ptr, long long a3)
+{
+    unsigned long v21;  // r14
+    struct_0 *v22;  // rax
+    struct_0 *v28;  // rdx
+    long long v29;  // rcx
+    struct_0 *v30;  // rax
+    long long v31;  // rdx
+    long long v32;  // rax
+    long long v33;  // rdx
+    long long v34;  // rcx
+    long long v35;  // rax
+    long long v36;  // rbx
+    struct_0 *v37;  // rcx
+    unsigned long v38;  // rax
+    long long index;  // rax
+    unsigned long long v23;  // rsi
+    long long v24;  // rdi
+    unsigned long long v25;  // rcx
+    long long v26;  // rsi
+    long long v27;  // rdx
+    struct_0 *v0;  // [bp-0x90]
+    long long v1;  // [bp-0x88]
+    char v2;  // [bp-0x80]
+    long long v3;  // [bp-0x78]
+    long long v4;  // [bp-0x70]
+    long long v5;  // [bp-0x68]
+    long long v6;  // [bp-0x60]
+    long long v7;  // [bp-0x58]
+    long long v9;  // [bp-0x48]
+    long long v10;  // [bp-0x40]
+    long long v11;  // [bp-0x40]
+    struct_0 *v12;  // [bp-0x38]
+    struct_0 *v14;  // [bp-0x28]
+    struct_0 *v15;  // [bp-0x20]
+    unsigned long long v16;  // [bp-0x18]
+    int <0x442300[is_1]|Stack bp-0x10, 1 B>;  // [bp-0x10]
+    struct_0 *v17;  // [bp-0x10]
+    struct_0 *v18;  // [bp+0x8]
+    long long v19;  // [bp+0x10]
+    unsigned long long v20;  // [bp+0x18]
+
+    if (&<0x442300[is_1]|Stack bp-0x10, 1 B> <= *((long long *)(v21 + 16)))
+    {
+        v18 = v30;
+        v19 = v10;
+        v20 = a0;
+        sub_459da0(); /* do not return */
+    }
+    v18 = v22;
+    v20 = a0;
+    while (true)
+    {
+        v25 = a0;
+        v10 = v11;
+        v30 = v17;
+        if (!v10)
+        {
+            if (g_5638c0 <= 1)
+                return v30;
+            index = sub_430840();
+        }
+        if (v25)
+        {
+            v26 = v10 - 1;
+            while (true)
+            {
+                if (v26 >= 0)
+                {
+                    v24 = *((char *)v30 + v26);
+                    if ((char)v24 != 44)
+                    {
+                        v26 -= 1;
+                    }
+                    else if (v26 >= 0)
+                    {
+                        if (v26 <= v10)
+                        {
+                            v27 = v26 + 1;
+                            if (v10 < v27)
+                                sub_45c0e0(v10);
+                            v24 = -(v10 - v26 - 1) >> 63;
+                            v28 = (v27 & v24) + (char *)v30;
+                            break;
+                        }
+                        else
+                        {
+                            sub_45c060(v26, v10);
+                        }
+                    }
+                }
+                else
+                {
+                    v26 = 0;
+                    v28 = v30;
+                    v30 = NULL;
+                    break;
+                }
+            }
+            v29 = v10;
+        }
+        else
+        {
+            v5 = v10;
+            v14 = v30;
+            v0 = v30;
+            v1 = v10;
+            v2 = 44;
+            sub_402960();
+            v29 = v3;
+            if (v29 < 0)
+            {
+                v28 = v14;
+                v26 = 0;
+                v30 = NULL;
+                v29 = v5;
+            }
+            else
+            {
+                v31 = v5;
+                if (v31 < v29)
+                    sub_45c060();
+                v32 = v29 + 1;
+                if (v31 < v32)
+                    sub_45c0e0(v31);
+                v33 = v31 - v29 - 1;
+                v26 = v33;
+                v28 = v14;
+                v30 = (v32 & -(v33) >> 63) + (char *)v28;
+            }
+        }
+        v7 = v29;
+        v15 = v28;
+        v10 = v26;
+        v0 = v28;
+        v1 = v29;
+        v2 = 61;
+        sub_402960(v29, v28);
+        v34 = v3;
+        if (v34 < 0)
+        {
+            v23 = v20;
+            continue;
+        }
+        if (v7 < v34)
+            sub_45c060();
+        v35 = v34 + 1;
+        if (v7 < v35)
+            sub_45c0e0(v7);
+        v6 = v34;
+        v9 = v35;
+        v24 = v6;
+        v36 = v7 - v24 - 1;
+        v37 = v15;
+        if (*((char *)sub_40ed20(v15)))
+        {
+            v23 = v20;
+            continue;
+        }
+        v4 = v36;
+        v12 = (v9 & -(v36) >> 63) + (char *)v37;
+        v23 = v20;
+        if (v23)
+        {
+            *((char *)sub_40f0e0()) = 1;
+            v37 = v15;
+            v36 = v4;
+            v23 = v20;
+            v24 = v6;
+            goto LABEL_442558;
+        }
+        else if (!v23 && v24 == 14 && !((ptr = 7594880358910092653, v37->field_0 != 7594880358910092653 || v37->field_8 != 1634887020 || v37->field_c != 25972)))
+        {
+            v38 = sub_448d40();
+            if ((char)v36)
+                g_4db2e0 = v38;
+            v23 = v20;
+            v17 = v30;
+            v11 = v10;
+            a0 = v23;
+        }
+        else
+        {
+LABEL_442558:
+            ptr = g_4dc600;
+            v16 = g_4dc600;
+            a3 = g_4dc608;
+            v9 = g_4dc608;
+            index = 0;
+        }
+    }
+}
+
+
+--- kuna (addr mode) ---
+  (no output: addr-mode: could not build an architecture for /home/mahaloz/github/angr-dev/binaries/tests/x86_64/windows/059ef54d0a97345369d236aafb051917c50680020a1bc532236072f4d341d9e3 (unsupported/!recognized binary))

--- a/docs/features/phoenix-natural-loop-region-1c12bf/kuna-full.txt
+++ b/docs/features/phoenix-natural-loop-region-1c12bf/kuna-full.txt
@@ -1,0 +1,243 @@
+void sub_442300(uint8 a0,unsigned long long a1,int8 a2,int8 a3)
+
+{
+  uint8 v1;
+  uint8 v13;
+  void *v14;
+  void *v15;
+  void *v16;
+  void *v17;
+  uint8 v19;
+  char v2; // al
+  int8 v20;
+  int8 v21; // gs_offset
+  bool v22; // zf
+  char *v4; // rax
+  void *v5; // rax
+  unsigned long long v6;
+  
+label_4425a0:
+  if (a3 <= v7) goto label_44232c;
+  v11 = *(int8 *)(a2 + v7 * 8);
+  v13 = *(uint8 *)(v11 + 8);
+  if (v13 == v19) {
+    *(int8 *)&v14[-0x50] = v7;
+    *(int8 *)&v14[-0x30] = v11;
+    *(void *)&v14[-0x98] = 0x4425ce;
+    v2 = runtime.memequal(v13);
+    if (v2 == '\0') {
+      v7 = *(int8 *)&v14[-0x50];
+      v19 = *(uint8 *)&v14[-0x60];
+      a2 = *(int8 *)&v14[-0x18];
+      a3 = *(int8 *)&v14[-0x48];
+      a0 = *(uint8 *)&v14[0x18];
+    }
+    else {
+      v6 = *(void *)&v14[-0x70];
+      *(void *)&v14[-0x98] = 0x44260e;
+      v7 = runtime.atoi64();
+      v22 = v7 == (int4)v7;
+      v9 = 0;
+      if (v22) {
+        v9 = (int4)v7;
+      }
+      if ((v22 & (uint1)v6) == 0) {
+        a0 = *(uint8 *)&v14[0x18];
+      }
+      else {
+        a0 = *(uint8 *)&v14[0x18];
+        if (a0 == 0) {
+          v7 = *(int8 *)&v14[-0x30];
+          if (*(int4 **)(v7 + 0x10) != (int4 *)0x0) {
+            **(int4 **)(v7 + 0x10) = v9;
+            goto label_442661;
+          }
+        }
+        else {
+          v7 = *(int8 *)&v14[-0x30];
+        }
+        if (*(int4 **)(v7 + 0x18) != (int4 *)0x0) {
+          LOCK();
+          **(int4 **)(v7 + 0x18) = v9;
+          UNLOCK();
+        }
+      }
+label_442661:
+      v7 = *(int8 *)&v14[-0x50];
+      v19 = *(uint8 *)&v14[-0x60];
+      a2 = *(int8 *)&v14[-0x18];
+      a3 = *(int8 *)&v14[-0x48];
+    }
+  }
+label_442597:
+  v7 = v7 + 1;
+  goto label_4425a0;
+label_4426ad:
+  v19 = (uint8)*(uint1 *)(v3 + v18);
+  v13 = v18;
+  if (*(uint1 *)(v3 + v18) != 0x2c) goto label_4426a8;
+  if ((int8)v18 < 0) {
+label_4426e6:
+    v18 = 0;
+    v7 = 0;
+  }
+  else {
+    if (v12 < v18) goto label_442705;
+    if (v12 < v10) {
+      *(void *)&v14[-0x98] = 0x442705;
+      runtime.panicSliceB(v12);
+label_442705:
+      *(void *)&v14[-0x98] = 0x442710;
+      a0 = v18;
+      v3 = runtime.panicSliceAlen(v18,v12);
+      goto label_442711;
+    }
+    v12 = (v12 - v18) - 1;
+    v19 = (int8)-v12 >> 0x3f;
+    v11 = (v10 & v19) + v3;
+    v7 = v3;
+    v3 = v11;
+  }
+  v13 = v12;
+label_4423d8:
+  *(uint8 *)&v14[-0x58] = v12;
+  *(int8 *)&v14[-0x20] = v3;
+  *(uint8 *)&v14[-0x40] = v18;
+  *(int8 *)&v14[-0x10] = v7;
+  *(int8 *)&v14[-0x90] = v3;
+  *(uint8 *)&v14[-0x88] = v12;
+  v14[-0x80] = 0x3d;
+  *(void *)&v14[-0x98] = 0x442405;
+  internal/bytealg.IndexByteString.abi0();
+  v20 = **(int8 **)(v21 + dat_5635a8);
+  v1 = *(uint8 *)&v14[-0x78];
+  if (0 <= (int8)v1) {
+    v10 = *(uint8 *)&v14[-0x58];
+    if (v1 <= v10) {
+      if (v1 + 1 <= v10) {
+        *(uint8 *)&v14[-0x60] = v1;
+        *(uint8 *)&v14[-0x48] = v1 + 1;
+        *(void *)&v14[-0x98] = 0x44247c;
+        v4 = (char *)runtime.mapaccess1_faststr(*(void *)&v14[-0x20]);
+        v19 = *(uint8 *)&v14[-0x60];
+        v11 = (*(int8 *)&v14[-0x58] - v19) + -1;
+        v8 = *(int8 **)&v14[-0x20];
+        v7 = (*(uint8 *)&v14[-0x48] & -v11 >> 0x3f) + (int8)v8;
+        if (*v4 != '\0') {
+          a0 = *(uint8 *)&v14[0x18];
+          goto label_44232c;
+        }
+        *(int8 *)&v14[-0x70] = v11;
+        *(int8 *)&v14[-0x38] = v7;
+        v22 = *(int8 *)&v14[0x18] == 0;
+        a0 = 0;
+        if (!v22) {
+          *(void *)&v14[-0x98] = 0x4424df;
+          v5 = (void *)runtime.mapassign_faststr();
+          *v5 = 1;
+          v22 = *(int8 *)&v14[0x18] == 0;
+          v8 = *(int8 **)&v14[-0x20];
+          v7 = *(int8 *)&v14[-0x38];
+          v11 = *(int8 *)&v14[-0x70];
+          a0 = *(uint8 *)&v14[0x18];
+          v19 = *(uint8 *)&v14[-0x60];
+        }
+        if ((((!v22) || (v19 != 0xe)) || (a2 = 0x69666f72706d656d, *v8 != 0x69666f72706d656d)) || (((int4)v8[1] != 0x6172656c || (*(int2 *)((int8)v8 + 0xc) != 0x6574)))) {
+          *(int8 *)&v14[-0x18] = dat_4dc600;
+          *(int8 *)&v14[-0x48] = dat_4dc608;
+          v7 = 0;
+          a2 = dat_4dc600;
+          a3 = dat_4dc608;
+          goto label_4425a0;
+        }
+        *(void *)&v14[-0x98] = 0x44253e;
+        v6 = runtime.atoi64(v8,v7);
+        if ((char)v11 != '\0') {
+          Unique100002b6 = v6;
+        }
+        a0 = *(uint8 *)&v14[0x18];
+        goto label_44232c;
+      }
+      *(void *)&v14[-0x98] = 0x442691;
+      runtime.panicSliceB(v10);
+    }
+    *(void *)&v14[-0x98] = 0x442696;
+    runtime.panicSliceAlen();
+label_442696:
+    *(void *)&v14[-0x98] = 0x44269e;
+    runtime.panicSliceB(v10);
+label_4426a0:
+    *(void *)&v14[-0x98] = 0x4426a5;
+    v3 = runtime.panicSliceAlen();
+    v12 = v13;
+    v13 = v18;
+    goto label_4426a8;
+  }
+  a0 = *(uint8 *)&v14[0x18];
+label_44232c:
+  v3 = *(int8 *)&v14[-0x10];
+  v13 = *(uint8 *)&v14[-0x40];
+  v18 = a0;
+  goto label_442340;
+  v14 = PTRSUB(RSP,0);
+  while (v15 = v14, v17 = v16, &v14[-0x10] <= *(void **)(v20 + 0x10)) {
+label_442711:
+    *(int8 *)&v15[8] = v3;
+    *(uint8 *)&v15[0x10] = v12;
+    *(uint8 *)&v15[0x18] = a0;
+    *(void *)&v15[-8] = 0x442725;
+    runtime.morestack_noctxt.abi0();
+    v3 = *(int8 *)&v15[8];
+    v12 = *(uint8 *)&v15[0x10];
+    a0 = *(uint8 *)&v15[0x18];
+    v14 = v15;
+    v16 = v17;
+  }
+  v17 = &v14[-8];
+  *(void **)&v14[-8] = v16;
+  v15 = &v14[-0x90];
+  *(int8 *)&v14[8] = v3;
+  *(uint8 *)&v14[0x18] = a0;
+  v13 = v12;
+label_442340:
+  if (v13 == 0) {
+    if (2 <= dat_5638c0) {
+      *(void *)&v14[-0x98] = 0x442597;
+      v7 = runtime.throw();
+      a0 = v18;
+      goto label_442597;
+    }
+    return;
+  }
+  v12 = v13;
+  if (a0 == 0) {
+    *(uint8 *)&v14[-0x68] = v13;
+    *(int8 *)&v14[-0x28] = v3;
+    *(int8 *)&v14[-0x90] = v3;
+    *(uint8 *)&v14[-0x88] = v13;
+    v14[-0x80] = 0x2c;
+    *(void *)&v14[-0x98] = 0x442374;
+    internal/bytealg.IndexByteString.abi0();
+    v20 = **(int8 **)(v21 + dat_5635a8);
+    v12 = *(uint8 *)&v14[-0x78];
+    if (0 <= (int8)v12) {
+      v10 = *(uint8 *)&v14[-0x68];
+      if (v10 < v12) goto label_4426a0;
+      if (v10 < v12 + 1) goto label_442696;
+      v18 = (v10 - v12) - 1;
+      v3 = *(int8 *)&v14[-0x28];
+      v7 = (v12 + 1 & (int8)-v18 >> 0x3f) + v3;
+      goto label_4423d8;
+    }
+    v3 = *(int8 *)&v14[-0x28];
+    v18 = 0;
+    v7 = 0;
+    v12 = *(uint8 *)&v14[-0x68];
+    goto label_4423d8;
+  }
+label_4426a8:
+  v10 = v13;
+  v18 = v10 - 1;
+  if (0 <= (int8)v18) goto label_4426ad;
+  goto label_4426e6;
+}

--- a/docs/features/phoenix-natural-loop-region-1c12bf/proposal.md
+++ b/docs/features/phoenix-natural-loop-region-1c12bf/proposal.md
@@ -1,0 +1,83 @@
+# [PROPOSAL] phoenix-natural-loop-region: recover head-in-body natural loops (angr Phoenix)
+
+**Status:** proposal / draft — no engine code changed. Human go/no-go requested on
+which implementation path to fund.
+
+## The problem
+
+angr's decompiler structures `sub_442300`
+(`test_decompiling_phoenix_natural_loop_region_head_in_body`, 0x442300, a Go Windows
+PE) as a single clean `while (true) { … continue; … }` with exactly one `goto`.
+kuna renders the *same* function with **31** `goto`/`label_` tokens: the natural-loop
+head at `0x4425a0` becomes `label_4425a0:` with `goto label_4425a0;` back-edges, and
+the loop body is scattered across ~10 more labels. See
+`docs/features/phoenix-natural-loop-region-1c12bf/analysis.md`,
+`angr-vs-kuna.txt`, `kuna-full.txt`.
+
+(kuna currently loads this binary only under `--experimental-formats`; the default
+loader rejects the PE. A stage testcase would therefore need a synthesised bytechunk
+of just the loop CFG, not the whole Go function.)
+
+## angr reference
+
+- Pass/class: `RegionIdentifier` (Phoenix structuring),
+  `angr/analyses/decompiler/region_identifier.py` — natural-loop region construction
+  where the loop **head** node is also reachable inside the loop **body**.
+- angr 9.2.213.
+
+## Why it is large (not a single Action/Rule)
+
+kuna's printed C comes from the upstream Ghidra **collapse-based** structurer
+(`s8_structure/blockaction.rs`: `CollapseStructure` / `LoopBody` / `TraceDAG`), not
+from a region identifier. Unlike `kuna_loweredswitch.rs` — which manufactures an S2
+`BRANCHIND`+`JumpTable` artifact upstream and lets the existing structurer+printer
+emit the `switch` — there is **no single artifact** to inject here; the loop-recovery
+logic lives *inside* the structurer. The decider subagent returned `scope: "large"`.
+
+## Two candidate implementation paths (pick one to fund)
+
+### Path A — extend the collapse structurer's loop detection (in-place)
+Teach `blockaction.rs` `LoopBody`/`CollapseStructure` to recognise the head-in-body
+natural loop and prefer a loop-header collapse over emitting a back-edge goto,
+gated by a new `option naturalloophead on|off` (default off).
+
+- **Pros:** stays in the engine kuna already uses to print C; no emit-path rewrite;
+  the option can be ablated against the 675-datatest corpus like every other feature.
+- **Cons:** touches S7/S8 structuring **core** (loop body/loop-edge selection). High
+  regression risk across the datatest corpus; requires careful guards so it only fires
+  on the head-in-body shape. Multi-step: (1) detect the shape on the collapsed graph,
+  (2) reorder/relabel the loop-edge so the header collapses, (3) verify goto/label
+  count drops with no datatest churn.
+
+### Path B — wire the ported `RegionIdentifier` into emit
+Promote `s7_regions/kuna_regionid.rs` (today analysis-only) into a real structuring
+pass that produces the region tree the printer consumes, gated by the new option.
+
+- **Pros:** reuses the already-ported, already-faithful angr algorithm — the
+  head-in-body case is *already handled* in that port; closest to "do what angr does."
+- **Cons:** a **new pass type** + new emit infrastructure (region-tree → C printer
+  adapter, `getStart()/lastOp()` block-graph adapter that is currently SEAM'd off).
+  The largest of the two; effectively a second structurer.
+
+## Speed / risk assessment
+
+- **Speed:** the target function is large; region identification is `~O(n²)` (the port
+  carries `2n²+64` guard caps). Either path must measure decompile wall-time off vs on
+  (Hard rule 6) and stay within the +5% budget, else ship default-OFF opt-in.
+- **Risk:** Path A risks datatest-corpus churn (it edits the structurer everyone uses);
+  Path B risks correctness drift between two structurers but isolates blast radius
+  behind the option (default-off, only the gated path uses the region tree).
+- **Recommendation:** Path A as a *narrow, heavily-guarded* gated structurer tweak is
+  the smaller bet if the head-in-body shape can be detected cheaply; Path B is the
+  faithful-to-angr bet if a second structurer is acceptable. Human decision requested.
+
+## Proposed option
+
+`option naturalloophead on|off` (default off), `change_kind = structure-recovery`,
+`source_decompiler = angr`,
+`inspiration = "test_decompiling_phoenix_natural_loop_region_head_in_body; RegionIdentifier (Phoenix); 0x442300"`.
+
+## What this PR contains
+
+Analysis + reproduction artifacts + this proposal only. No `kuna_*.rs`, no option
+registration, no stage test, no baseline change.

--- a/docs/features/phoenix-natural-loop-region-1c12bf/record.json
+++ b/docs/features/phoenix-natural-loop-region-1c12bf/record.json
@@ -1,0 +1,30 @@
+{
+  "opportunity": "test_decompiling_phoenix_natural_loop_region_head_in_body::0x442300",
+  "test_name": "test_decompiling_phoenix_natural_loop_region_head_in_body",
+  "binary": "/home/mahaloz/github/angr-dev/binaries/tests/x86_64/windows/059ef54d0a97345369d236aafb051917c50680020a1bc532236072f4d341d9e3",
+  "selector": "0x442300",
+  "func_addr": "0x442300",
+  "arch": "x86_64",
+  "angr_version": "9.2.213",
+  "option": "naturalloophead",
+  "change_kind": "structure-recovery",
+  "source_decompiler": "angr",
+  "inspiration": "test_decompiling_phoenix_natural_loop_region_head_in_body; RegionIdentifier (Phoenix); 0x442300",
+  "scope": "large",
+  "proposal": true,
+  "parity": "OK (no engine change)",
+  "gap_summary": "angr structures sub_442300 as a single clean while(true) with continue and ONE goto; kuna emits 31 goto/label tokens, rendering the natural-loop head at 0x4425a0 as label_4425a0 with goto back-edges instead of recovering it as a loop header.",
+  "owning_stage": "S7/S8 region-and-loop structuring (s8_structure/blockaction.rs CollapseStructure/LoopBody/TraceDAG; the C printer is collapse-based, not region-identifier based)",
+  "decisions": [
+    {
+      "question": "Can this gap be closed as a single option-gated Action/Rule (small), or does it require S7 structuring infrastructure (large)?",
+      "decider_verdict": {
+        "scope": "large",
+        "reasoning": "The gap lives entirely in S7/S8 loop-and-region structuring: kuna's printed C comes from Ghidra's collapse-based structurer (blockaction.rs CollapseStructure/LoopBody/TraceDAG), and fixing the head-in-body natural loop means either modifying that collapse loop-detection (touching S7 structuring core well beyond a single gated early-return) or wiring the analysis-only s7_regions/kuna_regionid.rs RegionIdentifier port into the emit path (a new pass type plus new emit infrastructure). Both violate the hard rule (>3 anchor files / new pass-type / S7 structuring touch). Unlike loweredswitch, there is no upstream single artifact (e.g. a manufactured jumptable) to inject that lets the existing structurer+printer produce the clean loop, so it cannot be reduced to one option-gated Action/Rule.",
+        "if_small_hook": "",
+        "proposed_option_name": "naturalloophead",
+        "recommended_path": "Stop and open a [PROPOSAL] draft PR scoping whether to (a) extend the collapse structurer's loop detection or (b) wire the existing RegionIdentifier port into emit, for human go/no-go."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# [PROPOSAL] phoenix-natural-loop-region: recover head-in-body natural loops (angr Phoenix)

**Status:** proposal / draft — no engine code changed. Human go/no-go requested on
which implementation path to fund.

## The problem

angr's decompiler structures `sub_442300`
(`test_decompiling_phoenix_natural_loop_region_head_in_body`, 0x442300, a Go Windows
PE) as a single clean `while (true) { … continue; … }` with exactly one `goto`.
kuna renders the *same* function with **31** `goto`/`label_` tokens: the natural-loop
head at `0x4425a0` becomes `label_4425a0:` with `goto label_4425a0;` back-edges, and
the loop body is scattered across ~10 more labels. See
`docs/features/phoenix-natural-loop-region-1c12bf/analysis.md`,
`angr-vs-kuna.txt`, `kuna-full.txt`.

(kuna currently loads this binary only under `--experimental-formats`; the default
loader rejects the PE. A stage testcase would therefore need a synthesised bytechunk
of just the loop CFG, not the whole Go function.)

## angr reference

- Pass/class: `RegionIdentifier` (Phoenix structuring),
  `angr/analyses/decompiler/region_identifier.py` — natural-loop region construction
  where the loop **head** node is also reachable inside the loop **body**.
- angr 9.2.213.

## Why it is large (not a single Action/Rule)

kuna's printed C comes from the upstream Ghidra **collapse-based** structurer
(`s8_structure/blockaction.rs`: `CollapseStructure` / `LoopBody` / `TraceDAG`), not
from a region identifier. Unlike `kuna_loweredswitch.rs` — which manufactures an S2
`BRANCHIND`+`JumpTable` artifact upstream and lets the existing structurer+printer
emit the `switch` — there is **no single artifact** to inject here; the loop-recovery
logic lives *inside* the structurer. The decider subagent returned `scope: "large"`.

## Two candidate implementation paths (pick one to fund)

### Path A — extend the collapse structurer's loop detection (in-place)
Teach `blockaction.rs` `LoopBody`/`CollapseStructure` to recognise the head-in-body
natural loop and prefer a loop-header collapse over emitting a back-edge goto,
gated by a new `option naturalloophead on|off` (default off).

- **Pros:** stays in the engine kuna already uses to print C; no emit-path rewrite;
  the option can be ablated against the 675-datatest corpus like every other feature.
- **Cons:** touches S7/S8 structuring **core** (loop body/loop-edge selection). High
  regression risk across the datatest corpus; requires careful guards so it only fires
  on the head-in-body shape. Multi-step: (1) detect the shape on the collapsed graph,
  (2) reorder/relabel the loop-edge so the header collapses, (3) verify goto/label
  count drops with no datatest churn.

### Path B — wire the ported `RegionIdentifier` into emit
Promote `s7_regions/kuna_regionid.rs` (today analysis-only) into a real structuring
pass that produces the region tree the printer consumes, gated by the new option.

- **Pros:** reuses the already-ported, already-faithful angr algorithm — the
  head-in-body case is *already handled* in that port; closest to "do what angr does."
- **Cons:** a **new pass type** + new emit infrastructure (region-tree → C printer
  adapter, `getStart()/lastOp()` block-graph adapter that is currently SEAM'd off).
  The largest of the two; effectively a second structurer.

## Speed / risk assessment

- **Speed:** the target function is large; region identification is `~O(n²)` (the port
  carries `2n²+64` guard caps). Either path must measure decompile wall-time off vs on
  (Hard rule 6) and stay within the +5% budget, else ship default-OFF opt-in.
- **Risk:** Path A risks datatest-corpus churn (it edits the structurer everyone uses);
  Path B risks correctness drift between two structurers but isolates blast radius
  behind the option (default-off, only the gated path uses the region tree).
- **Recommendation:** Path A as a *narrow, heavily-guarded* gated structurer tweak is
  the smaller bet if the head-in-body shape can be detected cheaply; Path B is the
  faithful-to-angr bet if a second structurer is acceptable. Human decision requested.

## Proposed option

`option naturalloophead on|off` (default off), `change_kind = structure-recovery`,
`source_decompiler = angr`,
`inspiration = "test_decompiling_phoenix_natural_loop_region_head_in_body; RegionIdentifier (Phoenix); 0x442300"`.

## What this PR contains

Analysis + reproduction artifacts + this proposal only. No `kuna_*.rs`, no option
registration, no stage test, no baseline change.
