### PR TITLE
[PROPOSAL] angr-fmt0-main-85c389: structure irreducible (multi-entry) loops

### DIFF
--- a/docs/features/fmt0-main-85c389/analysis.md
+++ b/docs/features/fmt0-main-85c389/analysis.md
@@ -1,0 +1,99 @@
+# fmt0-main-85c389 — analysis
+
+- **Opportunity:** `test_decompiling_fmt0_main :: main`
+- **Binary:** `/home/mahaloz/github/angr-dev/binaries/tests/x86_64/fmt_0` (GNU coreutils `fmt`)
+- **Function:** `main` @ `0x4019b0` (arch `x86_64`)
+- **Reference:** angr 9.2.213
+
+## What angr does better
+
+angr recovers a clean, **valid** C structuring of `main`'s option-parsing loop:
+
+```c
+v1 = 0;
+while (true) {
+    v6 = getopt_long(v3, cur, "0123456789cstuw:p:g:", &long_options.name, NULL);
+    if (v6 == -1)
+        break;
+    if (v6 > 119)            goto LABEL_401d6a;
+    if (v6 > 98) { switch (v6) { case 99: ...; case 103: ...; default: LABEL_401d6a: ... } }
+    else if (v6 == -131) { version_etc(...); exit(0); }
+    else if (v6 == -130) { usage(0); }
+}
+```
+
+3 gotos, 2 loops, 187 loc, fully valid C.
+
+## What kuna produces (the bug)
+
+kuna emits **syntactically invalid C** — verified to be the genuine raw `decomp_dbg`
+`print C` output (not a pipeline/CLI text artifact; confirmed by driving `decomp_dbg`
+directly and by inspecting `scripts/decompile.py`, which only strips newlines):
+
+```c
+  if ((2 <= a0) && (v7 = (char *)a1[1], v13 = a1, v2 = "", v8 = dat_216128, *v7 == '-')) goto label_1ba7;
+                    /* WARNING: Subroutine does not return */
+  while (dat_216128 = v8, v14[0] = (char *)0x0           // <- incomplete: no ") {" no body
+  while (v5 = getopt_long(a0,a1,"...",long_options,0)    // <- incomplete
+  if v5 == -1 {                                          // <- missing parens
+    ...
+    elsev8 = (char *)dcgettext(...), ... if v14[0] != ...// <- mangled else-branch
+  if 0x77 < v5 goto label_1d6a;99 <= v5) {               // <- totally broken
+```
+
+kuna: 8 gotos, 4 loops, **invalid C** (the `compare` tool also flags a recovery-failure
+marker). See `angr-vs-kuna.txt` for the full side-by-side.
+
+## Root cause — irreducible loop
+
+`main` contains an **irreducible (multi-entry) loop**. GNU `fmt`'s `-WIDTH` first-argument
+special case (`fmt` accepts a leading `-NN` as a width) compiles to a `goto` that jumps
+**into** the `getopt_long` option-parsing loop body:
+
+```
+if ((2 <= a0) && ... *v7 == '-') goto label_1ba7;   // label_1ba7 is INSIDE the loop
+```
+
+kuna's region tree confirms the multi-entry cyclic structure (block `0x1ba7` is a
+**sibling entry** into the loop region):
+
+```
+region head=0x1a6e nodes=2 cyclic
+  region head=0x1a6e nodes=3 cyclic
+    block 0x1a6e
+    region head=0x1a90 nodes=23 cyclic      <- the getopt loop body
+      ...
+  block 0x1ba7                              <- second entry into the loop
+```
+
+kuna's structurer is Ghidra's **collapse-based** `BlockGraph` engine
+(`s8`/`blockaction.rs`; `BlockWhileDo` etc.), whose only response to irreducibility is
+`markUnstructured` → gotos. On this loop the collapse engine additionally produces a
+while-block whose **condition block carries multiple side-effecting statements** that the
+S9 printer (`printc.rs::emitBlockWhileDo`) cannot render as a single expression — so it
+emits incomplete `while (...` lines: invalid C.
+
+## Owning stage
+
+- **S7** region structuring / **S8** block structuring (`blockaction.rs`) — the structurer
+  fails on the irreducible loop.
+- **S9** emit (`printc.rs`) — the printer emits invalid C for the side-effecting
+  while-condition.
+
+angr handles this with its `RegionIdentifier` + SAILR/Phoenix **condition-based**
+structuring and goto/loop refinement. kuna *has* an angr-`RegionIdentifier` port
+(`kuna_regionid`/`kuna_regiongraph`, S7), but it is a **parallel, read-only** surface
+(queried via the console `region tree`); it does **not** drive `print C`.
+
+## Hypothesis / why this is NOT a small option-gated Action
+
+`loweredswitch` is the canonical small template because it **manufactures a missing S2
+artifact** (a `JumpTable`) that the existing collapse structurer already knows how to render.
+Here there is **no artifact to manufacture**: the collapse structurer itself is wrong on
+irreducible loops. Making kuna emit angr-like output requires either augmenting the collapse
+structurer with condition-based irreducible-loop handling, or promoting the read-only
+`kuna_regiongraph` into an emit-capable structured-tree producer plus a new S9 printer path.
+Both are new pass infrastructure spanning S7/S8/S9 and well over the >3-anchor-file /
+>1-new-module limit. **A scope-decider (recorded in `record.json`) confirmed `scope:
+large`.** Per Hard rule 7 this goes through a `[PROPOSAL]` draft PR for human go/no-go —
+see `proposal.md`.

--- a/docs/features/fmt0-main-85c389/angr-vs-kuna.txt
+++ b/docs/features/fmt0-main-85c389/angr-vs-kuna.txt
@@ -1,0 +1,359 @@
+==============================================================================
+test_decompiling_fmt0_main :: main   (angr 9.2.213 @ 0x4019b0)
+==============================================================================
+
+--- angr ---
+typedef struct option {
+    char * name;
+    int has_arg;
+    char padding_c[4];
+    int * flag;
+    int val;
+} option;
+
+extern long long Version;
+extern char crown;
+extern char g_407aa1;
+extern unsigned int goal_width;
+extern option long_options;
+extern unsigned int max_width;
+extern long long optarg;
+extern unsigned int optind;
+extern unsigned long long prefix;
+extern unsigned int prefix_full_length;
+extern unsigned int prefix_lead_space;
+extern unsigned int prefix_length;
+extern char split;
+extern long long stdin;
+extern long long stdout;
+extern char tagged;
+extern char uniform;
+
+int main(int a0, void* a1)
+{
+    int v3;  // ebp
+    void* cur;  // rbx
+    int *err;  // rax
+    int *err;  // rax
+    char v5[2];  // rax
+    int v6;  // ecx
+    unsigned int v7;  // eax
+    char v8;  // r13b
+    unsigned int v9;  // r12d
+    char v10[2];  // r15
+    unsigned long fp;  // rax
+    char *v12;  // rax
+    long long v0;  // [bp-0x48], Other Possible Types: unsigned long, unsigned long long
+    long long v1;  // [bp-0x40]
+
+    v3 = a0;
+    cur = a1;
+    set_program_name(*((long long *)a1));
+    setlocale(6, &g_407aa1);
+    bindtextdomain("coreutils", "/usr/local/share/locale");
+    textdomain("coreutils");
+    atexit(close_stdout);
+    uniform = 0;
+    split = 0;
+    tagged = 0;
+    crown = 0;
+    max_width = 75;
+    prefix = &g_407aa1;
+    prefix_full_length = 0;
+    prefix_lead_space = 0;
+    prefix_length = 0;
+    v0 = 0;
+    if (v3 > 1)
+    {
+        v5 = (long long)cur[8];
+        if (v5[0] == 45 && v5[1] - 48 <= 9)
+        {
+            cur += 8;
+            v3 -= 1;
+            v0 = &v5[1];
+            *((long long *)cur) = (long long)cur[8];
+        }
+    }
+    v1 = 0;
+    while (true)
+    {
+        v6 = getopt_long(v3, cur, "0123456789cstuw:p:g:", &long_options.name, NULL);
+        if (v6 == -1)
+            break;
+        if (v6 > 119)
+            goto LABEL_401d6a;
+        if (v6 > 98)
+        {
+            switch (v6)
+            {
+            case 99:
+                crown = 1;
+                break;
+            case 103:
+                v1 = optarg;
+                break;
+            case 112:
+                set_prefix(optarg);
+                break;
+            case 115:
+                split = 1;
+                break;
+            case 116:
+                tagged = 1;
+                break;
+            case 117:
+                uniform = 1;
+                break;
+            case 119:
+                v0 = optarg;
+                break;
+            default:
+LABEL_401d6a:
+                if (v6 - 48 <= 9)
+                {
+                    *((int *)&v0) = v6;
+                    error(0, 0, dcgettext(NULL, "invalid option -- %c; -WIDTH is recognized only when it is the first\noption; use -w N instead", 5));
+                }
+                usage(1); /* do not return */
+            }
+        }
+        else if (v6 == -131)
+        {
+            version_etc(stdout, "fmt", "GNU coreutils", Version, "Ross Paterson", 0);
+            exit(0); /* do not return */
+        }
+        else if (v6 == -130)
+        {
+            usage(0); /* do not return */
+        }
+    }
+    if (v0)
+    {
+        max_width = xdectoumax(v0, 0, 2500, &g_407aa1, dcgettext(NULL, "invalid width", 5), 0);
+        if (!v1)
+            goto LABEL_401d4d;
+        goal_width = xdectoumax(v1, 0, max_width, &g_407aa1, dcgettext(NULL, "invalid width", 5), 0);
+    }
+    else if (!v1)
+    {
+LABEL_401d4d:
+        goal_width = max_width * 187 / 200;
+    }
+    else
+    {
+        goal_width = xdectoumax(v1, 0, 75, &g_407aa1, dcgettext(NULL, "invalid width", 5), 0);
+        max_width = goal_width + 10;
+    }
+    v7 = optind;
+    if (optind != v3)
+    {
+        v8 = 0;
+        v9 = 1;
+        if (optind < v3)
+        {
+            do
+            {
+                v10 = *((long long *)((char *)cur + 8 * v7));
+                if (v10[0] == 45 && !v10[1])
+                {
+                    v8 = 1;
+                    v9 &= fmt(stdin, v10);
+                }
+                else
+                {
+                    fp = fopen(v10, "r");
+                    if (fp)
+                    {
+                        v9 &= fmt(fp, v10);
+                    }
+                    else
+                    {
+                        v0 = quotearg_style(4);
+                        v12 = dcgettext(NULL, "cannot open %s for reading", 5);
+                        err = __errno_location();
+                        v9 = 0;
+                        error(0, *(err), v12);
+                    }
+                }
+            } while ((v7 = optind + 1, optind = v7, v7 < v3));
+            if (v8)
+                goto LABEL_401cd7;
+        }
+    }
+    else
+    {
+        v9 = fmt(stdin, "-");
+LABEL_401cd7:
+        if (rpl_fclose(stdin))
+        {
+            dcgettext(NULL, "closing standard input", 5);
+            err = __errno_location();
+            error(1, *(err), "%s");
+        }
+    }
+    return (char)v9 ^ 1;
+}
+
+
+--- kuna (name mode) ---
+uint1 main(int4 a0,void *a1)
+
+{
+  _IO_FILE *f; // rax
+  bool v1;
+  unsigned long v10; // rax
+  void *v11; // rax
+  unsigned long v12; // rdx
+  void *v13;
+  char *v14 [2]; // stack - 0x40
+  char *v15; // stack - 0x48
+  char *v2;
+  bool v3; // al
+  bool v4; // al
+  int4 v5;
+  char *v6; // rax
+  char *v7;
+  char *v8;
+  uint8 v9; // rax
+  
+  set_program_name((char *)*a1);
+  setlocale(6,0x7aa1);
+  bindtextdomain(0x7492,"/usr/local/share/locale");
+  textdomain(0x7492);
+  atexit(close_stdout);
+  uniform = 0;
+  split = 0;
+  tagged = 0;
+  crown = 0;
+  dat_216120 = 0x4b;
+  dat_216128 = "";
+  dat_21611c = 0;
+  dat_216118 = 0;
+  dat_216114 = 0;
+  v15 = (char *)0x0;
+  v8 = "";
+  if ((2 <= a0) && (v7 = (char *)a1[1], v13 = a1, v2 = "", v8 = dat_216128, *v7 == '-')) goto label_1ba7;
+                    /* WARNING: Subroutine does not return */
+  while (dat_216128 = v8, v14[0] = (char *)0x0
+  while (v5 = getopt_long(a0,a1,"0123456789cstuw:p:g:",long_options,0)
+  if v5 == -1 {
+    if v15 == (char *)0x0 {
+      if v14[0] != (char *)0x0 goto label_1d7c;
+    }
+    elsev8 = (char *)dcgettext(0,"invalid width",5), v9 = xdectoumax(v15,0,0x9c4,"",v8,0), v5 = (int4)v9, Unique100006a0 = v5 if v14[0] != (char *)0x0 {v8 = (char *)dcgettext(0,"invalid width",5), v9 = xdectoumax(v14[0],0,(int8)v5,"",v8,0), EAX = (int4)v9
+      goto label_1c4f;
+    }EAX = (dat_216120 * 0xbb) / 200
+    goto label_1c4f;
+  }
+  if 0x77 < v5 goto label_1d6a;99 <= v5) {
+    switch(v5) {
+      case 99:crown = 1
+        break;
+      default:
+        goto label_1d6a;
+      case 0x67:v14[0] = dat_20b0a0
+        break;
+      case 0x70:set_prefix(dat_20b0a0)
+        break;
+      case 0x73:split = 1
+        break;
+      case 0x74:tagged = 1
+        break;
+      case 0x75:uniform = 1
+        break;
+      case 0x77:v15 = dat_20b0a0
+      
+    }
+  }
+  if v5 == -0x83 {version_etc(dat_20b088,"fmt","GNU coreutils",dat_20b010,"Ross Paterson",0), exit(0)
+  }v5 == -0x82) {
+    usage(0);
+    v7 = v6;
+    v13 = a1;
+    v2 = dat_216128;
+label_1ba7:
+    dat_216128 = v2;
+    a1 = v13;
+    v8 = dat_216128;
+    if ((uint4)((int4)v7[1] - 0x30U) <= 9) {
+      v15 = &v7[1];
+      a1 = &v13[1];
+      a0 = a0 + -1;
+      *a1 = *v13;
+    }
+  }
+label_1d6a:
+  if ((uint4)(v5 - 0x30U) <= 9) {
+    v15 = (char *)CONCAT44(v15._4_4_,v5);
+    v10 = dcgettext(0,"invalid option -- %c; -WIDTH is recognized only when it is the first\noption; use -w N instead",5);
+    error(0,0,v10,v5);
+  }
+  usage(1);
+label_1d7c:
+  v8 = (char *)dcgettext(0,"invalid width",5);
+  v9 = xdectoumax(v14[0],0,0x4b,"",v8,0);
+  EAX = (int4)v9;
+  EAX = EAX + 10;
+label_1c4f:
+  if (dat_20b098 == a0) {
+    v4 = fmt(dat_20b090,"-");
+  }
+  else {
+    v1 = 0;
+    v4 = 1;
+    v5 = dat_20b098;
+    if (a0 <= dat_20b098) goto label_1ceb;
+    do {
+      v8 = (char *)a1[v5];
+      if ((*v8 == '-') && (v8[1] == '\0')) {
+        v1 = 1;
+        v3 = fmt(dat_20b090,v8);
+        v4 = (bool)(v4 & v3);
+      }
+      else {
+        f = fopen(v8,"r");
+        if (f == (_IO_FILE *)0x0) {
+          v15 = quotearg_style(4,v8);
+          v10 = dcgettext(0,"cannot open %s for reading",5);
+          v11 = (void *)__errno_location();
+          v4 = 0;
+          error(0,*v11,v10,v15);
+        }
+        else {
+          v3 = fmt(f,v8);
+          v4 = (bool)(v4 & v3);
+        }
+      }
+      v5 = dat_20b098 + 1;
+      Unique10000690 = v5;
+    } while (v5 < a0);
+    if (!v1) goto label_1ceb;
+  }
+  v5 = rpl_fclose(dat_20b090);
+  if (v5 != 0) {
+    v10 = dcgettext(0,"closing standard input",5);
+    v11 = (void *)__errno_location();
+    error(1,*v11,0x7613,v10);
+    (*dat_20afd0)(main,v15,v14,__libc_csu_init,__libc_csu_fini,v12);
+    do {
+    } while( true );
+  }
+label_1ceb:
+  return v4 ^ 1;
+}
+
+--- metrics (reference | kuna) ---
+  loc           187 | 142 
+  gotos           3 | 8   
+  labels          3 | 5   
+  switches        1 | 1   
+  cases           7 | 7   
+  ifs            17 | 9   
+  loops           2 | 4   
+  ternaries       0 | 0   
+  casts           0 | 0   
+
+--- signals (candidate 'reference is better' hints) ---
+  * ref has fewer gotos (3 vs 8)
+  * ref has fewer labels (3 vs 5)
+  * kuna emitted a recovery-failure marker

--- a/docs/features/fmt0-main-85c389/proposal.md
+++ b/docs/features/fmt0-main-85c389/proposal.md
@@ -1,0 +1,77 @@
+# [PROPOSAL] angr-fmt0-main-85c389: structure irreducible (multi-entry) loops
+
+**Status:** draft proposal — awaiting human go/no-go. **Do not implement before approval.**
+
+- **Opportunity:** `test_decompiling_fmt0_main :: main`
+- **Binary:** `/home/mahaloz/github/angr-dev/binaries/tests/x86_64/fmt_0` (GNU coreutils `fmt`), `main` @ `0x4019b0`, x86_64
+- **Reference:** angr 9.2.213
+- **Proposed option:** `irreducibleloops` (change_kind: `structure-recovery`)
+- **Scope:** **large** (scope-decider verdict in `record.json`)
+
+## The problem
+
+kuna emits **syntactically invalid C** for `fmt`'s `main` because `main` contains an
+**irreducible (multi-entry) loop**: the `-WIDTH` first-arg special case `goto`s into the
+`getopt_long` option-parsing loop body. kuna's Ghidra collapse-based structurer resolves
+irreducibility only by emitting gotos, and additionally produces a while-block whose
+condition carries side-effecting multi-statements that the S9 printer renders as incomplete
+`while (...` lines. angr recovers a clean, valid `while(true){ ...; if(v==-1) break; ... }`.
+
+Full evidence: [`analysis.md`](analysis.md), side-by-side: [`angr-vs-kuna.txt`](angr-vs-kuna.txt).
+
+## angr reference
+
+- `angr/analyses/decompiler/region_identifier.py` — `RegionIdentifier` (already ported,
+  read-only, as kuna `kuna_regionid`/`kuna_regiongraph` under `s7_regions/`).
+- `angr/analyses/decompiler/structuring/` — the SAILR/Phoenix condition-based structurer
+  (`PhoenixStructurer`) with `_refine_cyclic` / goto-and-loop refinement that handles
+  multi-entry loops by node duplication / condition recovery. **Not yet ported.**
+
+## Why this is not a single Action/Rule
+
+`loweredswitch` works by **manufacturing a missing S2 `JumpTable`** that the existing
+structurer already consumes. Here the structurer *itself* is wrong on irreducible loops —
+there is no artifact to pre-build. Closing the gap requires new structuring infrastructure
+across S7 (region structuring), S8 (`blockaction.rs`), and S9 (`printc.rs`), > 3 anchor
+files and > 1 new module. The decider verdict (verbatim in `record.json`):
+
+> "The gap is a failure of the S7/S8 structurer+printer on an irreducible (multi-entry)
+> loop, not a missing consumable artifact … Both options need new pass infrastructure and
+> touch S7 structuring/S8/S9 emit far beyond a single gated early-return …"
+
+## Proposed multi-step implementation plan
+
+1. **Promote `kuna_regiongraph`/`kuna_regionid` from read-only to emit-capable.** Add a
+   SAILR/Phoenix-style condition-based structuring + goto/loop-refinement layer on top of the
+   existing `RegionIdentifier` so it yields a *structured* tree (proper loops with
+   break/continue, recovered if-conditions, labeled gotos only for residual irreducible
+   edges) — not just a region dump.
+2. **Lower the structured region tree into kuna's `sblocks` (`BlockGraph`)** — or into a
+   sibling structured representation consumable by a new printer path.
+3. **Add an S9 printer path** (`printc.rs::emitBlock*`) for the new node kinds so `print C`
+   walks it and emits valid C (proper `while`/`break`, labeled gotos for true irreducibility).
+4. **Gate the whole alternate path behind `option irreducibleloops on`, default OFF.** Only
+   functions whose region tree is detected cyclic **and** multi-entry route through the new
+   path; everything else keeps the collapse structurer and **byte-identical** default output.
+5. **Testcase + speed.** Add `tests/stages/ghangr-fmt0-main-85c389.xml` (off = current
+   invalid rendering / fix = valid `while(true)` loop) and record the per-function decompile
+   wall-time off vs on for `main`.
+
+## Speed / risk assessment
+
+- **Default path unchanged** (gated OFF → byte-identical; parity preserved). Low parity risk.
+- **Routed path** adds the region-structuring + condition-recovery layer per eligible
+  function; cost is bounded to detected irreducible functions but must be measured (the
+  pipeline speed budget is +5% default; if over, ship default-OFF opt-in).
+- **Engineering risk: high.** This is essentially porting angr's structuring backend (or a
+  reduced irreducible-loop subset of it) and a new printer path — multi-PR, the largest of the
+  angr-port surfaces. Recommend scoping a **minimal first cut**: handle only single-extra-entry
+  loops via node duplication of the entry block (the `fmt` shape), behind the option, before
+  attempting the general SAILR structurer.
+
+## Recommendation
+
+Approve as a multi-PR effort, or de-scope to "duplicate the single extra loop-entry block so
+the collapse structurer sees a reducible loop" as a first, smaller PR (still > 1 anchor file
+in S8, hence still proposal-gated). Either way: human go/no-go before any implementation
+worker is spent.

--- a/docs/features/fmt0-main-85c389/record.json
+++ b/docs/features/fmt0-main-85c389/record.json
@@ -1,0 +1,30 @@
+{
+  "opportunity": "test_decompiling_fmt0_main::main",
+  "test_name": "test_decompiling_fmt0_main",
+  "binary": "/home/mahaloz/github/angr-dev/binaries/tests/x86_64/fmt_0",
+  "selector": "main",
+  "func_addr": "0x4019b0",
+  "angr_version": "9.2.213",
+  "option": "irreducibleloops",
+  "change_kind": "structure-recovery",
+  "source_decompiler": "angr",
+  "inspiration": "test_decompiling_fmt0_main; angr RegionIdentifier + PhoenixStructurer (SAILR) condition-based structuring / cyclic refinement; main",
+  "scope": "large",
+  "proposal": true,
+  "parity": "n/a (proposal, no implementation)",
+  "decisions": [
+    {
+      "question": "Can this gap be closed by one small option-gated Action/Rule, or is it LARGE (proposal fork)?",
+      "decider": "Plan subagent (opus)",
+      "verdict": {
+        "scope": "large",
+        "reason": "The gap is a failure of the S7/S8 structurer+printer on an irreducible (multi-entry) loop, not a missing consumable artifact. Fixing it requires either replacing/augmenting the Ghidra collapse-based BlockGraph structurer (blockaction.rs, 3635 lines whose only irreducibility response is markUnstructured->gotos) or wiring the parallel, read-only kuna_regionid/kuna_regiongraph port (4218 lines) to actually drive the sblocks tree and a new condition-based printer path. Both options need new pass infrastructure and touch S7 structuring/S8/S9 emit far beyond a single gated early-return, blowing the >3 anchor-file and >1 new-module limits. This cannot be modeled as a single manufacture-an-artifact Action.",
+        "owning_stage": "S7 (region structuring) / S8 (block structuring) with an S9 (emit) printer path",
+        "why_not_single_action": "loweredswitch works because it MANUFACTURES a missing S2 JumpTable artifact that the existing collapse structurer already knows how to render as a switch - the structurer was already correct, only the input was missing. Here the structurer itself is wrong on irreducible loops: there is no S2/S7 artifact you can pre-build that makes Ghidra's collapse engine emit a valid multi-entry loop, because the collapse algorithm fundamentally resolves irreducibility by marking edges unstructured (the gotos and the broken incomplete while( side-effecting condition blocks seen in the output). No early-return-gated manufacture step can substitute for the missing SAILR/Phoenix condition-based structuring+goto/loop-refinement that angr uses.",
+        "proposed_option_name": "irreducibleloops",
+        "implementation_sketch": "Promote kuna_regiongraph/kuna_regionid from a read-only console surface to an emit-capable producer with a SAILR/Phoenix condition-based structuring/goto-refinement layer; lower the structured region tree into sblocks (BlockGraph) or a sibling structured rep; add an S9 printer path for the new node types; gate the whole alternate path behind option irreducibleloops (default OFF, byte-identical) routing only detected cyclic+multi-entry functions; add the binary->func testcase and record speed. Spans S7+S8+S9, multiple new modules, >3 anchor files.",
+        "speed_risk": "Moderate: default path unchanged (gated OFF, byte-identical), but the regionid/condition-structuring layer adds work for functions routed onto it; must measure per-function decompile time on the irreducible path."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# [PROPOSAL] angr-fmt0-main-85c389: structure irreducible (multi-entry) loops

**Status:** draft proposal — awaiting human go/no-go. **Do not implement before approval.**

- **Opportunity:** `test_decompiling_fmt0_main :: main`
- **Binary:** `/home/mahaloz/github/angr-dev/binaries/tests/x86_64/fmt_0` (GNU coreutils `fmt`), `main` @ `0x4019b0`, x86_64
- **Reference:** angr 9.2.213
- **Proposed option:** `irreducibleloops` (change_kind: `structure-recovery`)
- **Scope:** **large** (scope-decider verdict in `record.json`)

## The problem

kuna emits **syntactically invalid C** for `fmt`'s `main` because `main` contains an
**irreducible (multi-entry) loop**: the `-WIDTH` first-arg special case `goto`s into the
`getopt_long` option-parsing loop body. kuna's Ghidra collapse-based structurer resolves
irreducibility only by emitting gotos, and additionally produces a while-block whose
condition carries side-effecting multi-statements that the S9 printer renders as incomplete
`while (...` lines. angr recovers a clean, valid `while(true){ ...; if(v==-1) break; ... }`.

Full evidence: [`analysis.md`](analysis.md), side-by-side: [`angr-vs-kuna.txt`](angr-vs-kuna.txt).

## angr reference

- `angr/analyses/decompiler/region_identifier.py` — `RegionIdentifier` (already ported,
  read-only, as kuna `kuna_regionid`/`kuna_regiongraph` under `s7_regions/`).
- `angr/analyses/decompiler/structuring/` — the SAILR/Phoenix condition-based structurer
  (`PhoenixStructurer`) with `_refine_cyclic` / goto-and-loop refinement that handles
  multi-entry loops by node duplication / condition recovery. **Not yet ported.**

## Why this is not a single Action/Rule

`loweredswitch` works by **manufacturing a missing S2 `JumpTable`** that the existing
structurer already consumes. Here the structurer *itself* is wrong on irreducible loops —
there is no artifact to pre-build. Closing the gap requires new structuring infrastructure
across S7 (region structuring), S8 (`blockaction.rs`), and S9 (`printc.rs`), > 3 anchor
files and > 1 new module. The decider verdict (verbatim in `record.json`):

> "The gap is a failure of the S7/S8 structurer+printer on an irreducible (multi-entry)
> loop, not a missing consumable artifact … Both options need new pass infrastructure and
> touch S7 structuring/S8/S9 emit far beyond a single gated early-return …"

## Proposed multi-step implementation plan

1. **Promote `kuna_regiongraph`/`kuna_regionid` from read-only to emit-capable.** Add a
   SAILR/Phoenix-style condition-based structuring + goto/loop-refinement layer on top of the
   existing `RegionIdentifier` so it yields a *structured* tree (proper loops with
   break/continue, recovered if-conditions, labeled gotos only for residual irreducible
   edges) — not just a region dump.
2. **Lower the structured region tree into kuna's `sblocks` (`BlockGraph`)** — or into a
   sibling structured representation consumable by a new printer path.
3. **Add an S9 printer path** (`printc.rs::emitBlock*`) for the new node kinds so `print C`
   walks it and emits valid C (proper `while`/`break`, labeled gotos for true irreducibility).
4. **Gate the whole alternate path behind `option irreducibleloops on`, default OFF.** Only
   functions whose region tree is detected cyclic **and** multi-entry route through the new
   path; everything else keeps the collapse structurer and **byte-identical** default output.
5. **Testcase + speed.** Add `tests/stages/ghangr-fmt0-main-85c389.xml` (off = current
   invalid rendering / fix = valid `while(true)` loop) and record the per-function decompile
   wall-time off vs on for `main`.

## Speed / risk assessment

- **Default path unchanged** (gated OFF → byte-identical; parity preserved). Low parity risk.
- **Routed path** adds the region-structuring + condition-recovery layer per eligible
  function; cost is bounded to detected irreducible functions but must be measured (the
  pipeline speed budget is +5% default; if over, ship default-OFF opt-in).
- **Engineering risk: high.** This is essentially porting angr's structuring backend (or a
  reduced irreducible-loop subset of it) and a new printer path — multi-PR, the largest of the
  angr-port surfaces. Recommend scoping a **minimal first cut**: handle only single-extra-entry
  loops via node duplication of the entry block (the `fmt` shape), behind the option, before
  attempting the general SAILR structurer.

## Recommendation

Approve as a multi-PR effort, or de-scope to "duplicate the single extra loop-entry block so
the collapse structurer sees a reducible loop" as a first, smaller PR (still > 1 anchor file
in S8, hence still proposal-gated). Either way: human go/no-go before any implementation
worker is spent.
