### PR TITLE
[PROPOSAL] angr-optimized-memcpy-6301a9: recover unrolled-guard jump tables (MSVC optimized memcpy)

### DIFF
--- a/docs/features/optimized-memcpy-6301a9/analysis.md
+++ b/docs/features/optimized-memcpy-6301a9/analysis.md
@@ -1,0 +1,90 @@
+# optimized-memcpy-6301a9 — analysis
+
+**angr testcase:** `test_decompiling_optimized_memcpy` :: `0x42cca0`
+**Binary:** `i386/windows/736cb27201273f6c4f83da362c9595b50d12333362e02bc7a77dd327cc6b045a`
+(an MSVC CRT `memcpy`/`memmove`, Duff's-device style)
+**angr:** 9.2.213
+
+## What angr does better
+
+The angr test asserts `d.codegen.text.count("switch") == 7`: angr recovers **all 7
+jump-table switches** in this optimized memcpy. The function is built from seven
+`jmp dword [reg*scale + const_table]` dispatches, where each table
+(`0x42cda8`, `0x42ce24`, `0x42cd28`, `0x42cfb0`, `0x42ceb4`, `0x42cf60`, …) holds
+*absolute* target addresses (PE has a fixed image base + relocations).
+
+kuna (driven on a self-contained bytechunk of the function at `0x42cca0`, since the
+i386 PE loader can't open the file directly — see *Loader note*) recovers **only 1**
+switch — the single plain-stride table `switch(a2 & 3)`. The other **6** indirect
+jumps fail recovery and degrade to:
+
+```c
+/* WARNING: Treating indirect jump as call */
+v1 = (void *)(**(code **)(v2 * 4 + 0x42cda8))();
+return v1;
+```
+
+i.e. `FlowInfo::truncateIndirectJump` (`s2_lift/flow.rs:2719`) converts the
+unrecovered `BRANCHIND` to a `CALLIND`. Side-by-side capture:
+[`angr-vs-kuna.txt`](angr-vs-kuna.txt).
+
+## The exact construct
+
+The one table that recovers is a plain `reg*4 + table`. The six that fail all have a
+**transformed switch index** *and* a guard that is duplicated across the unrolled
+Duff's-device ladder's merge points:
+
+| dispatch | index transform |
+|---|---|
+| `v2 * -4 + 0x42cf60`        | negative stride |
+| `(a2 - 4) * 4 + 0x42ce24`   | offset |
+| `((uint4)v4 & 3) * 4 + 0x42ceb4` | mask |
+| `(a2 & 3) * 4 + 0x42cfb0`   | mask |
+| `(v2 * 4) + 0x42cda8`       | plain, but guarded at an unrolled merge |
+| `((uint4)a0 & 3) * 4 + 0x42cd28` | mask |
+
+## Owning stage and root cause
+
+**Stage:** S2 lift, switch-model sub-stage — jump-table recovery
+(`decompiler/crates/kuna-decomp/src/s2_lift/jumptable.rs`).
+
+The index transforms themselves are **not** the blocker: `JumpBasicModel`'s
+`find_unnormalized_basic` / `circlerange_pull_back` (a real `CircleRange` value-set)
+/ `build_addresses_basic` (a live `EmulateFunction`) are all ported and already
+handle `INT_ADD`/`INT_SUB`/`INT_AND`/`ZEXT`/`SEXT` index pull-backs.
+
+The blocker is the **bound**. `JumpBasic::analyzeGuards` (`jumptable.rs:1897`) calls
+[`check_unrolled_guard`](../../../decompiler/crates/kuna-decomp/src/s2_lift/jumptable.rs)
+(`jumptable.rs:2075`) for guard blocks with `size_in() > 1` — exactly the
+Duff's-device unrolled-ladder merge points here. That method is a documented
+`// SEAM(structuring)` **stub** (its own comment: *"the switch still recovers via the
+straight-line path (the unrolled guard only adds an extra range constraint)"*). For
+this MSVC memcpy that assumption is false: the unrolled/duplicated `cbranch` guard is
+the **sole** source of the table bound. With it stubbed, `analyzeGuards` returns
+without the bounding guard, the value-set range stays unbounded, `findNormalized`
+can't size the table, and recovery degrades to `truncateIndirectJump → CALLIND`.
+
+`check_unrolled_guard` needs `checkCommonCbranch` + the `BlockBasic` SSA helpers
+`findMultiequal` / `noInterveningStatement` / `unblockedMulti` / `liftVerifyUnroll`,
+all `// SEAM(W7)` in `substrate/block.rs` (header lines 52–56).
+
+## Hypothesis for the kuna change
+
+Port `check_unrolled_guard` (`checkCommonCbranch` + `findMultiequal` /
+`liftVerifyUnroll` / `noInterveningStatement` / `unblockedMulti`) so the unrolled-guard
+range constraint is recovered and the six transformed-index tables size and recover
+natively — yielding angr-like 7-switch output. This is **core S2/S7 recovery** (it
+edits `analyzeGuards`/`findNormalized` beyond a gated early-return and ports new
+`BlockBasic` SSA infrastructure across `jumptable.rs` + `block.rs` + `funcdata`), so it
+is a **LARGE** feature under Hard Rule 7 → this bundle is a `[PROPOSAL]`, not an
+implementation. See [`proposal.md`](proposal.md).
+
+## Loader note
+
+kuna's loader does not open this i386 Windows PE directly
+(`could not build an architecture … unsupported/!recognized binary`), so the
+reproduction and any stage test use a self-contained `bytechunk` of the function +
+its in-`.text` jump tables (the tables and most targets live within
+`[0x42cca0, 0x42d040)`; the lone external tail-call to `0x439674` is stubbed `c3`).
+The loader gap is tracked separately (multi-format loader PRs #32/#35/#38/#40) and is
+out of scope here.

--- a/docs/features/optimized-memcpy-6301a9/angr-vs-kuna.txt
+++ b/docs/features/optimized-memcpy-6301a9/angr-vs-kuna.txt
@@ -1,0 +1,344 @@
+### angr (reference, recovers 7 switches) ###
+
+--- angr ---
+extern unsigned int g_42ce14[4];
+extern unsigned int g_42cfb0[4];
+extern unsigned int g_45acd0;
+
+void* sub_42cca0(void* a0, void* a1, unsigned int a2)
+{
+    void* v2;  // esi
+    void* v3;  // edi
+    unsigned int v12;  // ecx
+    unsigned int v13;  // edx
+    unsigned int v14;  // ecx
+    void* node;  // esi
+    void* iter;  // edi
+    unsigned int v6;  // ecx
+    unsigned int v7;  // edx
+    unsigned int v8;  // ecx
+    unsigned int v9;  // ecx
+    void* cur;  // edi
+    void* ptr3;  // esi
+    void* v0;  // [bp-0x14]
+    void* v1;  // [bp-0x10]
+
+    v2 = a1;
+    v3 = a0;
+    if (v3 > v2 && v3 < a2 + v2)
+    {
+        node = a2 + v2 - 4;
+        iter = a2 + v3 - 4;
+        if (!((char)iter & 3))
+        {
+            v6 = a2 >> 2;
+            v7 = a2 & 3;
+        }
+        else
+        {
+            switch (a2)
+            {
+            case 0:
+                break;
+            case 1:
+                goto LABEL_42cfc8;
+            case 2:
+                goto LABEL_42cfd8;
+            case 3:
+                goto LABEL_42cfec;
+            default:
+                v8 = a2 - (iter & 3);
+                switch (iter & 3)
+                {
+                case 1:
+                    v7 = 3 & v8;
+                    *((char *)&iter[3]) = (char)node[3];
+                    node -= 1;
+                    v6 = v8 >> 2;
+                    iter -= 1;
+                    break;
+                case 2:
+                    v7 = 3 & v8;
+                    *((char *)&iter[3]) = (char)node[3];
+                    v6 = v8 >> 2;
+                    *((char *)&iter[2]) = (char)node[2];
+                    node -= 2;
+                    iter -= 2;
+                    break;
+                case 3:
+                    v7 = 3 & v8;
+                    *((char *)&iter[3]) = (char)node[3];
+                    *((char *)&iter[2]) = (char)node[2];
+                    v6 = v8 >> 2;
+                    *((char *)&iter[1]) = (char)node[1];
+                    node -= 3;
+                    iter -= 3;
+                    break;
+                }
+            }
+        }
+        switch (v6)
+        {
+        case 0:
+            *((int *)(28 + (char *)iter + 4 * v9)) = *((int *)(28 + (char *)node + 4 * v9));
+        case 1:
+            *((int *)(24 + (char *)iter + 4 * v9)) = *((int *)(24 + (char *)node + 4 * v9));
+            break;
+        case 2:
+            *((int *)(20 + (char *)iter + 4 * v9)) = *((int *)(20 + (char *)node + 4 * v9));
+            goto LABEL_42cf7c;
+        case 3:
+LABEL_42cf7c:
+            *((int *)(16 + (char *)iter + 4 * v9)) = *((int *)(16 + (char *)node + 4 * v9));
+            goto LABEL_42cf84;
+        case 4:
+LABEL_42cf84:
+            *((int *)(12 + (char *)iter + 4 * v9)) = *((int *)(12 + (char *)node + 4 * v9));
+            goto LABEL_42cf8c;
+        case 5:
+LABEL_42cf8c:
+            *((int *)(8 + (char *)iter + 4 * v9)) = *((int *)(8 + (char *)node + 4 * v9));
+            goto LABEL_42cf94;
+        case 6:
+LABEL_42cf94:
+            *((int *)(4 + (char *)iter + 4 * v9)) = *((int *)(4 + (char *)node + 4 * v9));
+            goto LABEL_42cfa7;
+        case 7:
+LABEL_42cfa7:
+            goto g_42cfb0[v7];
+        default:
+            for (; v6; node += 0xfffffffc)
+            {
+                v6 -= 1;
+                *((int *)iter) = *((int *)node);
+                iter += 0xfffffffc;
+            }
+            switch (v7)
+            {
+            case 0:
+                return a0;
+            case 1:
+LABEL_42cfc8:
+                *((char *)&iter[3]) = (char)node[3];
+                return a0;
+            case 2:
+LABEL_42cfd8:
+                *((char *)&iter[3]) = (char)node[3];
+                *((char *)&iter[2]) = (char)node[2];
+                return a0;
+            case 3:
+LABEL_42cfec:
+                *((char *)&iter[3]) = (char)node[3];
+                *((char *)&iter[2]) = (char)node[2];
+                *((char *)&iter[1]) = (char)node[1];
+                return a0;
+            }
+        }
+    }
+    cur = v3;
+    ptr3 = v2;
+    if (a2 >= 0x100)
+    {
+        cur = v3;
+        ptr3 = v2;
+        if (g_45acd0)
+        {
+            v1 = v3;
+            v0 = v2;
+            cur = v1;
+            ptr3 = v0;
+            if ((v3 & 15) == (v2 & 15))
+                return sub_439674();
+        }
+    }
+    if (!((char)cur & 3))
+    {
+        v12 = a2 >> 2;
+        v13 = a2 & 3;
+    }
+    else
+    {
+        switch (a2)
+        {
+        case 0:
+            return a0;
+        case 1:
+            *((char *)cur) = *((char *)ptr3);
+            return a0;
+        case 2:
+            *((char *)cur) = *((char *)ptr3);
+            *((char *)&cur[1]) = (char)ptr3[1];
+            return a0;
+        case 3:
+            *((char *)cur) = *((char *)ptr3);
+            *((char *)&cur[1]) = (char)ptr3[1];
+            *((char *)&cur[2]) = (char)ptr3[2];
+            return a0;
+        default:
+            v14 = a2 - 4 + (cur & 3);
+            switch (cur & 3)
+            {
+            case 0:
+                break;
+            case 1:
+                v13 = 3 & v14;
+                *((char *)cur) = *((char *)ptr3);
+                *((char *)&cur[1]) = (char)ptr3[1];
+                v12 = v14 >> 2;
+                *((char *)&cur[2]) = (char)ptr3[2];
+                ptr3 += 3;
+                cur += 3;
+                break;
+            case 2:
+                v13 = 3 & v14;
+                *((char *)cur) = *((char *)ptr3);
+                v12 = v14 >> 2;
+                *((char *)&cur[1]) = (char)ptr3[1];
+                ptr3 += 2;
+                cur += 2;
+                break;
+            case 3:
+                v13 = 3 & v14;
+                *((char *)cur) = *((char *)ptr3);
+                ptr3 += 1;
+                v12 = v14 >> 2;
+                cur += 1;
+                break;
+            }
+        }
+    }
+    switch (v12)
+    {
+    case 7:
+        *((int *)(-28 + (char *)cur + 4 * v12)) = *((int *)(-28 + (char *)ptr3 + 4 * v12));
+    case 6:
+        *((int *)(-24 + (char *)cur + 4 * v12)) = *((int *)(-24 + (char *)ptr3 + 4 * v12));
+        break;
+    case 5:
+        *((int *)(-20 + (char *)cur + 4 * v12)) = *((int *)(-20 + (char *)ptr3 + 4 * v12));
+        goto LABEL_42cde0;
+    case 4:
+LABEL_42cde0:
+        *((int *)(-16 + (char *)cur + 4 * v12)) = *((int *)(-16 + (char *)ptr3 + 4 * v12));
+        goto LABEL_42cde8;
+    case 3:
+LABEL_42cde8:
+        *((int *)(-12 + (char *)cur + 4 * v12)) = *((int *)(-12 + (char *)ptr3 + 4 * v12));
+        goto LABEL_42cdf0;
+    case 2:
+LABEL_42cdf0:
+        *((int *)(-8 + (char *)cur + 4 * v12)) = *((int *)(-8 + (char *)ptr3 + 4 * v12));
+        goto LABEL_42cdf8;
+    case 1:
+LABEL_42cdf8:
+        *((int *)(-4 + (char *)cur + 4 * v12)) = *((int *)(-4 + (char *)ptr3 + 4 * v12));
+        goto LABEL_42ce0b;
+    case 0:
+LABEL_42ce0b:
+        goto g_42ce14[v13];
+    default:
+        for (; v12; ptr3 += 4)
+        {
+            v12 -= 1;
+            *((int *)cur) = *((int *)ptr3);
+            cur += 4;
+        }
+        goto g_42ce14[v13];
+    }
+}
+
+
+--- kuna (addr mode) ---
+
+### kuna (bytechunk @0x42cca0, recovers ONLY 1 switch; 6 indirect jumps degrade to call) ###
+
+===KUNA_DUMP_BEGIN /tmp/probe/memcpy_probe.xml===
+
+void * memcpy_opt(void *a0,void *a1,uint4 a2)
+
+{
+  void *v1;
+  uint4 v2; // ecx
+  void *v3;
+  void *v4;
+  void *v5; // edi
+  
+  if ((a1 < a0) && (a0 < (void *)(a2 + (int4)a1))) {
+    v1 = (void *)((a2 - 4) + (int4)a1);
+    v4 = (void *)((a2 - 4) + (int4)a0);
+    if (((uint4)v4 & 3) != 0) {
+      if (a2 <= 3) {
+                    /* WARNING: Treating indirect jump as call */
+        v1 = (void *)(**(code **)(a2 * 4 + 0x42cfb0))();
+        return v1;
+      }
+                    /* WARNING: Treating indirect jump as call */
+      v1 = (void *)(**(code **)(((uint4)v4 & 3) * 4 + 0x42ceb4))();
+      return v1;
+    }
+    v2 = a2 >> 2;
+    if (v2 <= 7) {
+                    /* WARNING: Treating indirect jump as call */
+      v1 = (void *)(**(code **)(v2 * -4 + 0x42cf60))();
+      return v1;
+    }
+    while (v2 != 0) {
+      v5 = &v4[-1];
+      v3 = &v1[-1];
+      *v4 = *v1;
+      v2 = v2 - 1;
+      v1 = v3;
+      v4 = v5;
+    }
+                    /* WARNING: Treating indirect jump as call */
+    v1 = (void *)(**(code **)((a2 & 3) * 4 + 0x42cfb0))();
+    return v1;
+  }
+  if (((0x100 <= a2) && (dat_45acd0 != 0)) && (((uint4)a0 & 0xf) == ((uint4)a1 & 0xf))) {
+    return (void *)(a2 + (int4)a1);
+  }
+  if (((uint4)a0 & 3) == 0) {
+    v2 = a2 >> 2;
+    v1 = a0;
+    if (v2 <= 7) {
+                    /* WARNING: Treating indirect jump as call */
+      v1 = (void *)(**(code **)(v2 * 4 + 0x42cda8))();
+      return v1;
+    }
+    while (v2 != 0) {
+      v3 = &v1[1];
+      v4 = &a1[1];
+      *v1 = *a1;
+      v2 = v2 - 1;
+      a1 = v4;
+      v1 = v3;
+    }
+    switch(a2 & 3) {
+      case 0:
+        return a0;
+      case 1:
+        *(void *)v1 = *(void *)a1;
+        return a0;
+      case 2:
+        *(void *)v1 = *(void *)a1;
+        *(void *)((int4)v1 + 1) = *(void *)((int4)a1 + 1);
+        return a0;
+      case 3:
+        *(void *)v1 = *(void *)a1;
+        *(void *)((int4)v1 + 1) = *(void *)((int4)a1 + 1);
+        *(void *)((int4)v1 + 2) = *(void *)((int4)a1 + 2);
+        return a0;
+      
+    }
+  }
+  if (a2 <= 3) {
+                    /* WARNING: Treating indirect jump as call */
+    v1 = (void *)(**(code **)((a2 - 4) * 4 + 0x42ce24))();
+    return v1;
+  }
+                    /* WARNING: Treating indirect jump as call */
+  v1 = (void *)(**(code **)(((uint4)a0 & 3) * 4 + 0x42cd28))();
+  return v1;
+}
+
+===KUNA_DUMP_MID===

--- a/docs/features/optimized-memcpy-6301a9/proposal.md
+++ b/docs/features/optimized-memcpy-6301a9/proposal.md
@@ -1,0 +1,83 @@
+# [PROPOSAL] optimized-memcpy-6301a9 — recover unrolled-guard jump tables (MSVC optimized memcpy)
+
+**Status:** proposal (large feature — needs human go/no-go before implementation)
+**angr testcase:** `test_decompiling_optimized_memcpy` :: `0x42cca0`
+**Binary:** `i386/windows/736cb27201273f6c4f83da362c9595b50d12333362e02bc7a77dd327cc6b045a`
+**Proposed option:** `unrolledguard on|off`
+
+## The problem
+
+On the MSVC CRT optimized memcpy (`0x42cca0`, Duff's device), angr recovers **7**
+jump-table switches; kuna recovers **1** and degrades the other **6** to
+`/* WARNING: Treating indirect jump as call */`. Full analysis + side-by-side:
+[`analysis.md`](analysis.md) / [`angr-vs-kuna.txt`](angr-vs-kuna.txt).
+
+The six failing tables share one root cause (see analysis): their bound comes from a
+Duff's-device **unrolled/duplicated `cbranch` guard** at a block-merge point, and
+kuna's `JumpBasic::check_unrolled_guard` (`s2_lift/jumptable.rs:2075`) is a documented
+`// SEAM(structuring)` **stub**. The value-set / index-transform / table-emulation
+path is already ported and works — only the unrolled-guard bound is missing.
+
+## angr reference
+
+angr's `JumpTableResolver` (in `angr/analyses/cfg`) resolves these as bounded jump
+tables; the structurer then emits `switch` per table. The kuna-equivalent is Ghidra's
+`JumpBasic::checkUnrolledGuard` / `checkCommonCbranch` (`jumptable.cc:1257`-ish) plus
+the `BlockBasic` SSA helpers it depends on.
+
+## Why this is LARGE (Hard Rule 7)
+
+A decider subagent investigated and confirmed **large**:
+
+- It is **not** a self-contained `kuna_*.rs` Action/Rule. The fix edits S2
+  jumptable-recovery core (`analyzeGuards`/`findNormalized` in `jumptable.rs`) **beyond
+  a single gated early-return**.
+- It requires **new infrastructure**: porting the unported `BlockBasic` SSA helpers
+  `findMultiequal` / `noInterveningStatement` / `unblockedMulti` / `liftVerifyUnroll`
+  (all `// SEAM(W7)` in `substrate/block.rs`).
+- It touches **>3 ported-core anchor files** (`jumptable.rs`, `block.rs`, `funcdata`,
+  plus option/arch wiring) and is not cleanly gateable default-off (it changes core
+  recovery, not an opt-in rendering pass).
+- The rejected alternative — a `kuna_loweredswitch.rs`-style *manufacturing* Action
+  that reads the absolute tables from the loadimage — is **even larger**: it duplicates
+  working recovery, and the Duff's-device targets are mid-block, forcing CFG block
+  splitting plus its own bounds inference.
+
+## Proposed implementation plan (multi-step)
+
+1. **Port the W7 `BlockBasic` SSA helpers** `findMultiequal` / `noInterveningStatement`
+   / `unblockedMulti` / `liftVerifyUnroll` in `substrate/block.rs` (faithful C++
+   transcription; standard W7 SSA-helper effort).
+2. **Port `checkCommonCbranch` + fill `check_unrolled_guard`** in `jumptable.rs` to
+   detect the duplicated guard across the unrolled merge and contribute the bounding
+   range constraint into `analyzeGuards`.
+3. **Gate** behind a new arch flag + `option unrolledguard on|off`
+   (`change_kind = structure-recovery`), default-off while developing; correct the
+   stale `jumptable.rs` module-header SEAM note that misdescribes the chain as unported.
+4. **Stage test** `tests/stages/ghangr-optimized-memcpy-6301a9.xml`: the bytechunk of
+   `0x42cca0` + its in-`.text` tables; pass 1 (`option unrolledguard off`) asserts the
+   `Treating indirect jump as call` degradation and `switch(` count == 1; pass 2
+   (default/on) asserts the recovered switches (target: 7, matching angr).
+5. **Ablation + speed**: `kuna test --all --baseline docs/baseline.json` must stay
+   PARITY OK; measure decompile wall-time off vs on (jump-table recovery + extra SSA
+   walks can be non-trivial; if over the speed budget, ship opt-in).
+
+## Speed / risk assessment
+
+- **Risk (correctness):** editing core jump-table recovery can regress the existing 1
+  recovered switch and the broader datatest jump-table corpus. `make test` /
+  `make test-stages` parity is the hard gate. Validate the bound across all six
+  transformed tables (negative stride `-4`, offset `(a2-4)*4`, masks `&3`).
+- **Risk (scope):** the W7 SSA helpers are reused well beyond this case, so the port
+  should be done carefully/faithfully, not pattern-matched to this one function.
+- **Speed:** the extra guard/SSA analysis runs only on functions with `size_in()>1`
+  guard blocks; expected to be modest, but must be measured (Hard Rule 6).
+
+## Recommended option name
+
+`unrolledguard` (the construct is "jump table bounded by an unrolled/duplicated cbranch
+guard"), `change_kind = structure-recovery`, `source_decompiler = angr`,
+`inspiration = "test_decompiling_optimized_memcpy; JumpBasic::checkUnrolledGuard / angr JumpTableResolver; 0x42cca0"`.
+
+---
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/optimized-memcpy-6301a9/record.json
+++ b/docs/features/optimized-memcpy-6301a9/record.json
@@ -1,0 +1,28 @@
+{
+  "opportunity": "test_decompiling_optimized_memcpy::0x42cca0",
+  "test_name": "test_decompiling_optimized_memcpy",
+  "binary": "/home/mahaloz/github/angr-dev/binaries/tests/i386/windows/736cb27201273f6c4f83da362c9595b50d12333362e02bc7a77dd327cc6b045a",
+  "selector": "0x42cca0",
+  "func_addr": "0x42cca0",
+  "angr_version": "9.2.213",
+  "option": "unrolledguard",
+  "change_kind": "structure-recovery",
+  "source_decompiler": "angr",
+  "inspiration": "test_decompiling_optimized_memcpy; JumpBasic::checkUnrolledGuard / angr JumpTableResolver; 0x42cca0",
+  "scope": "large",
+  "proposal": true,
+  "decisions": [
+    {
+      "question": "Is closing this gap (kuna recovering the 6 failed MSVC-memcpy jump tables to reach angr's 7 switches) small (one option-gated Action/Rule) or large (proposal fork)?",
+      "decider": "general-purpose subagent (opus)",
+      "decision": "large",
+      "approach": "Complete core JumpBasic recovery: port check_unrolled_guard (checkCommonCbranch + findMultiequal/liftVerifyUnroll/noInterveningStatement/unblockedMulti) and its BlockBasic SSA deps. NOT the loweredswitch-style manufacturing Action.",
+      "reasoning": "The JumpBasic chain is mostly ported and works (analyze_guards, find_normalized, calc_range, circlerange_pull_back value-set, recover_model_basic, build_addresses_basic via live EmulateFunction, find_unnormalized_basic which already handles the INT_ADD/SUB/AND/ZEXT/SEXT index transforms). The single hole is check_unrolled_guard (jumptable.rs:2075), a // SEAM(structuring) stub reached from analyze_guards (line ~1897/1927) when a guard block has size_in()>1 — the Duff's-device unrolled-ladder merge points in this memcpy. Stubbed, analyze_guards returns without the bounding guard, the range stays unbounded, find_normalized can't size the table, and recovery degrades to truncateIndirectJump->CALLIND. Filling it is LARGE under Hard Rule 7: it edits S2 jumptable-core analyze_guards/find_normalized beyond a gated early-return AND requires new infrastructure (the unported // SEAM(W7) BlockBasic SSA helpers findMultiequal/noInterveningStatement/unblockedMulti/liftVerifyUnroll in block.rs), i.e. >1 new surface across >3 core anchor files. Candidate 2 (a loweredswitch-style manufacturing Action) is even larger: it duplicates working recovery and the mid-block Duff's-device targets force CFG block-splitting plus its own bounds inference and loadimage table reads.",
+      "risks": "Porting findMultiequal/liftVerifyUnroll/noInterveningStatement faithfully is the standard W7 SSA-helper effort and touches block.rs/funcdata; the bound must be verified across all 6 transformed tables (negative stride -4, offset (a2-4)*4, mask &3). Because it edits core recovery (not an opt-in Action) it cannot be cleanly gated default-off, so make test / test-stages parity (and not regressing the 1 already-recovered switch) is the gate."
+    }
+  ],
+  "kuna_baseline_switch_count": 1,
+  "angr_switch_count": 7,
+  "parity": "OK",
+  "default_on": false
+}


### PR DESCRIPTION
# [PROPOSAL] optimized-memcpy-6301a9 — recover unrolled-guard jump tables (MSVC optimized memcpy)

**Status:** proposal (large feature — needs human go/no-go before implementation)
**angr testcase:** `test_decompiling_optimized_memcpy` :: `0x42cca0`
**Binary:** `i386/windows/736cb27201273f6c4f83da362c9595b50d12333362e02bc7a77dd327cc6b045a`
**Proposed option:** `unrolledguard on|off`

## The problem

On the MSVC CRT optimized memcpy (`0x42cca0`, Duff's device), angr recovers **7**
jump-table switches; kuna recovers **1** and degrades the other **6** to
`/* WARNING: Treating indirect jump as call */`. Full analysis + side-by-side:
[`analysis.md`](analysis.md) / [`angr-vs-kuna.txt`](angr-vs-kuna.txt).

The six failing tables share one root cause (see analysis): their bound comes from a
Duff's-device **unrolled/duplicated `cbranch` guard** at a block-merge point, and
kuna's `JumpBasic::check_unrolled_guard` (`s2_lift/jumptable.rs:2075`) is a documented
`// SEAM(structuring)` **stub**. The value-set / index-transform / table-emulation
path is already ported and works — only the unrolled-guard bound is missing.

## angr reference

angr's `JumpTableResolver` (in `angr/analyses/cfg`) resolves these as bounded jump
tables; the structurer then emits `switch` per table. The kuna-equivalent is Ghidra's
`JumpBasic::checkUnrolledGuard` / `checkCommonCbranch` (`jumptable.cc:1257`-ish) plus
the `BlockBasic` SSA helpers it depends on.

## Why this is LARGE (Hard Rule 7)

A decider subagent investigated and confirmed **large**:

- It is **not** a self-contained `kuna_*.rs` Action/Rule. The fix edits S2
  jumptable-recovery core (`analyzeGuards`/`findNormalized` in `jumptable.rs`) **beyond
  a single gated early-return**.
- It requires **new infrastructure**: porting the unported `BlockBasic` SSA helpers
  `findMultiequal` / `noInterveningStatement` / `unblockedMulti` / `liftVerifyUnroll`
  (all `// SEAM(W7)` in `substrate/block.rs`).
- It touches **>3 ported-core anchor files** (`jumptable.rs`, `block.rs`, `funcdata`,
  plus option/arch wiring) and is not cleanly gateable default-off (it changes core
  recovery, not an opt-in rendering pass).
- The rejected alternative — a `kuna_loweredswitch.rs`-style *manufacturing* Action
  that reads the absolute tables from the loadimage — is **even larger**: it duplicates
  working recovery, and the Duff's-device targets are mid-block, forcing CFG block
  splitting plus its own bounds inference.

## Proposed implementation plan (multi-step)

1. **Port the W7 `BlockBasic` SSA helpers** `findMultiequal` / `noInterveningStatement`
   / `unblockedMulti` / `liftVerifyUnroll` in `substrate/block.rs` (faithful C++
   transcription; standard W7 SSA-helper effort).
2. **Port `checkCommonCbranch` + fill `check_unrolled_guard`** in `jumptable.rs` to
   detect the duplicated guard across the unrolled merge and contribute the bounding
   range constraint into `analyzeGuards`.
3. **Gate** behind a new arch flag + `option unrolledguard on|off`
   (`change_kind = structure-recovery`), default-off while developing; correct the
   stale `jumptable.rs` module-header SEAM note that misdescribes the chain as unported.
4. **Stage test** `tests/stages/ghangr-optimized-memcpy-6301a9.xml`: the bytechunk of
   `0x42cca0` + its in-`.text` tables; pass 1 (`option unrolledguard off`) asserts the
   `Treating indirect jump as call` degradation and `switch(` count == 1; pass 2
   (default/on) asserts the recovered switches (target: 7, matching angr).
5. **Ablation + speed**: `kuna test --all --baseline docs/baseline.json` must stay
   PARITY OK; measure decompile wall-time off vs on (jump-table recovery + extra SSA
   walks can be non-trivial; if over the speed budget, ship opt-in).

## Speed / risk assessment

- **Risk (correctness):** editing core jump-table recovery can regress the existing 1
  recovered switch and the broader datatest jump-table corpus. `make test` /
  `make test-stages` parity is the hard gate. Validate the bound across all six
  transformed tables (negative stride `-4`, offset `(a2-4)*4`, masks `&3`).
- **Risk (scope):** the W7 SSA helpers are reused well beyond this case, so the port
  should be done carefully/faithfully, not pattern-matched to this one function.
- **Speed:** the extra guard/SSA analysis runs only on functions with `size_in()>1`
  guard blocks; expected to be modest, but must be measured (Hard Rule 6).

## Recommended option name

`unrolledguard` (the construct is "jump table bounded by an unrolled/duplicated cbranch
guard"), `change_kind = structure-recovery`, `source_decompiler = angr`,
`inspiration = "test_decompiling_optimized_memcpy; JumpBasic::checkUnrolledGuard / angr JumpTableResolver; 0x42cca0"`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
