### PR TITLE
[PROPOSAL] angr-true-1804-x86-64-8a690c: condition-aware if/else tail dedup (S8 structuring)

### DIFF
--- a/docs/features/true-1804-x86-64-8a690c/analysis.md
+++ b/docs/features/true-1804-x86-64-8a690c/analysis.md
@@ -1,0 +1,101 @@
+# Analysis — `test_decompiling_true_1804_x86_64 :: usage`
+
+- **Opportunity:** `test_decompiling_true_1804_x86_64::usage`
+- **Binary:** `/home/mahaloz/github/angr-dev/binaries/tests/x86_64/true_ubuntu1804`
+- **Function:** `usage` (x86_64 @ `0x401610`)
+- **angr version:** 9.2.213
+- **Owning stage:** S7/S8 — `blockaction` (Stage 16, *Structuring*): the
+  CollapseStructure/TraceDAG region-collapse engine + ConditionalExecution
+  (`condexe`) + goto/schema selection.
+
+## What angr does better
+
+The full side-by-side is in `angr-vs-kuna.txt`. Metrics (reference | kuna):
+
+| metric | angr | kuna |
+|---|---|---|
+| loc | 112 | 121 |
+| gotos | 2 | 3 |
+| labels | 2 | 3 |
+| ifs | 6 | 9 |
+| loops | 2 | 2 |
+
+The pipeline "recovery-failure marker" signal here is a **false positive** — it
+fires on the `/* WARNING: Subroutine does not return */` comment kuna emits before
+the tail-call `exit(a0)`, which is a normal Ghidra no-return annotation, not a
+structuring abort. The real gap is two structuring-quality differences:
+
+### 1. Duplicated if/else tail (the dominant difference)
+
+kuna's trailing block is:
+
+```c
+label_17b8:
+  v4 = *(int8 *)&v6[0x18];          // angr: v28
+  if (v4 == 0) {
+    __printf_chk(1, "...online help...", ...);   // (a)
+    v3 = setlocale(5,0);                          // (b)
+    if (v3 != 0) {
+      v1 = strncmp(v3,"en_",3);                   // (c)
+      if (v1 != 0) { v4 = 0x4764; goto label_18e8; }
+    }
+    v4 = 0x4764; v3 = " invocation";
+    __printf_chk(1, "...Full documentation...", ...);   // (d)
+  }
+  else {
+    __printf_chk(1, "...online help...", ...);   // (a)  DUPLICATE
+    v3 = setlocale(5,0);                          // (b)  DUPLICATE
+    if (v3 != 0) {
+      v1 = strncmp(v3,"en_",3);                   // (c)  DUPLICATE
+      if (v1 != 0) {
+label_18e8:
+        __printf_chk(1, "...Report translation bugs...", ...);
+      }
+    }
+    __printf_chk(1, "...Full documentation...", ...);   // (d)  DUPLICATE
+    v3 = ""; if (v4 == 0x4764) v3 = " invocation";
+  }
+```
+
+The online-help printf `(a)`, the `setlocale` `(b)`, the `strncmp` `(c)` and the
+Full-documentation printf `(d)` are emitted **twice** — once in each arm of
+`if (v28 == 0)`. angr emits each of them **once** and threads the two genuinely
+distinct continuations through shared labels:
+
+```c
+    if (v28) { ...; goto LABEL_401822_or_4018e8; }
+    else     { ...; LABEL_4018e8: report_bugs; LABEL_401822: full_documentation; }
+```
+
+This is angr's structurer doing condition-aware **region deduplication** (its
+"ITE region converter" / condition-processing): two predecessors are converged onto
+one labelled successor instead of cloning the shared continuation. kuna inherits
+Ghidra's collapse-based structurer, which clones the shared tail into both arms — so
+it pays an extra `if`, extra lines, and one extra goto/label.
+
+### 2. Loop shape
+
+The inlined `rep cmps` / strcmp loop is emitted by kuna as
+
+```c
+  do { ... goto label_17af } while (v15);
+label_17af:
+  if ((!v14 && !v15) == v14) goto label_17b8;
+```
+
+(a goto *out* of the loop) where angr renders a do/while terminated by a `break`.
+This is again `blockaction` goto-vs-`break` schema selection.
+
+## Hypothesis / why this is not a one-Action fix
+
+Both differences are products of the **structurer itself**, not of the
+pre-structuring dataflow. There is no lifted-CFG artifact that "shares" the
+duplicated tail — sharing requires CollapseStructure/TraceDAG to converge two
+predecessors onto one labelled block, a decision that lives *inside* the collapse
+engine. Unlike `kuna_loweredswitch` (which fabricates an S2 `BRANCHIND`+`JumpTable`
+and lets the *unchanged* structurer render it), there is no manufacturable upstream
+artifact here. Closing the gap means a condition-aware ITE-dedup region converter —
+a new pass *type* touching `s8_structure`/`blockaction` region collapse.
+
+→ **Scope: LARGE.** Routed to a draft `[PROPOSAL]` PR per Hard rule 7; see
+`proposal.md`.

--- a/docs/features/true-1804-x86-64-8a690c/angr-vs-kuna.txt
+++ b/docs/features/true-1804-x86-64-8a690c/angr-vs-kuna.txt
@@ -1,0 +1,263 @@
+==============================================================================
+test_decompiling_true_1804_x86_64 :: usage   (angr 9.2.213 @ 0x401610)
+==============================================================================
+
+--- angr ---
+typedef struct struct_0 {
+    char field_0;
+    char padding_1[15];
+    unsigned long long field_10;
+} struct_0;
+
+typedef struct FILE {
+} FILE;
+
+extern FILE *stdout;
+
+void usage(int a0)
+{
+    unsigned long long v13;  // r13
+    unsigned long long v14;  // r12
+    struct_0 *cur;  // rdx
+    unsigned long long v24;  // rdi
+    unsigned long v25;  // cc_ndep
+    unsigned long v26;  // 4132
+    unsigned long v27;  // 4135
+    unsigned long long v28;  // r12
+    char *v30;  // rax
+    unsigned long long v15;  // rbx
+    char *v32;  // rax
+    char *v33;  // rax
+    unsigned long ptr;  // fs
+    char *v19;  // rax
+    char *v20;  // rax
+    unsigned long long v22;  // rdi
+    int v0;  // [bp-0xa8], Other Possible Types: char
+    unsigned long long v1;  // [bp-0x70]
+    unsigned long long v2;  // [bp-0x68]
+    unsigned long long v3;  // [bp-0x60]
+    unsigned long long v4;  // [bp-0x58]
+    unsigned long long v5;  // [bp-0x50]
+    unsigned long long flag;  // [bp-0x48]
+    unsigned long long choice;  // [bp-0x40]
+    unsigned long v8;  // [bp-0x30]
+    unsigned long long v9;  // [bp-0x20]
+    unsigned long long v10;  // [bp-0x10]
+    unsigned long long v11;  // [bp-0x8]
+
+    v11 = v13;
+    v10 = v14;
+    v9 = v15;
+    v8 = *((long long *)(40 + ptr));
+    __printf_chk(1, dcgettext(NULL, "Usage: %s [ignored command line arguments]\n  or:  %s OPTION\n", 5));
+    __printf_chk(1, "%s\n\n", dcgettext(NULL, "Exit with a status code indicating success.", 5));
+    v19 = dcgettext(NULL, "      --help     display this help and exit\n", 5);
+    fputs_unlocked(v19, stdout);
+    v20 = dcgettext(NULL, "      --version  output version information and exit\n", 5);
+    fputs_unlocked(v20, stdout);
+    __printf_chk(1, dcgettext(NULL, "\nNOTE: your shell may have its own version of %s, which usually supersedes\nthe version described here.  Please refer to your shell's documentation\nfor details about the options it supports.\n", 5));
+    v22 = "coreutils";
+    flag = 0;
+    choice = 0;
+    cur = &v0;
+    v0 = (int)_INSERT(v0 CONCAT 0, 0, "[");
+    *((char **)&(&v0)[48]) = "sha256sum";
+    *((char **)&(&v0)[16]) = "coreutils";
+    *((char **)&(&v0)[8]) = "test invocation";
+    v2 = "sha384sum";
+    *((char **)&(&v0)[24]) = "Multi-call invocation";
+    v4 = "sha512sum";
+    *((char **)&(&v0)[32]) = "sha224sum";
+    *((char **)&(&v0)[40]) = "sha2 utilities";
+    v1 = "sha2 utilities";
+    v3 = "sha2 utilities";
+    v5 = "sha2 utilities";
+    while (true)
+    {
+        cur = &cur->field_10;
+        if (!v22)
+            break;
+        v24 = v22;
+        do
+        {
+            if (false)
+                break;
+        } while (*((char *)v24) == 116);
+        v26 = _ccall(7, 20, v22, 0, v25);
+        v27 = _ccall(20, v22, 0, v25);
+        if (!(char)((char)v26 - 0) - ((char)v27 & 1))
+            break;
+        v22 = cur->field_10;
+    }
+    v28 = *((long long *)&cur->padding_1[7]);
+    if (v28)
+    {
+        __printf_chk(1, dcgettext(NULL, "\n%s online help: <%s>\n", 5));
+        v30 = setlocale(5, NULL);
+        if (!v30 || !strncmp(v30, "en_", 3))
+            goto LABEL_401822;
+        goto LABEL_4018e8;
+    }
+    else
+    {
+        __printf_chk(1, dcgettext(NULL, "\n%s online help: <%s>\n", 5));
+        v32 = setlocale(5, NULL);
+        if (v32 && strncmp(v32, "en_", 3))
+        {
+            v28 = "true";
+LABEL_4018e8:
+            v33 = dcgettext(NULL, "Report any translation bugs to <https://translationproject.org/team/>\n", 5);
+            fputs_unlocked(v33, stdout);
+LABEL_401822:
+            __printf_chk(1, dcgettext(NULL, "Full documentation <%s%s>\n", 5));
+        }
+        else
+        {
+            __printf_chk(1, dcgettext(NULL, "Full documentation <%s%s>\n", 5));
+        }
+    }
+    __printf_chk(1, dcgettext(NULL, "or available locally via: info '(coreutils) %s%s'\n", 5));
+    exit(a0); /* do not return */
+}
+
+
+--- kuna (name mode) ---
+void usage(unsigned int a0)
+
+{
+  int4 v1; // eax
+  uint1 *v10; // rsi
+  uint1 *v11;
+  uint1 *v12; // rdi
+  int8 v13; // fs_offset
+  bool v14; // cf
+  bool v15;
+  uint1 v16; // df
+  char *v17; // stack - 0xa0
+  char *v18; // stack - 0x98
+  char *v19; // stack - 0x90
+  unsigned long v2; // rax
+  char *v20; // stack - 0x88
+  char *v21; // stack - 0x80
+  char *v22; // stack - 0x78
+  char *v23; // stack - 0x70
+  char *v24; // stack - 0x68
+  char *v25; // stack - 0x60
+  char *v26; // stack - 0x58
+  char *v27; // stack - 0x50
+  unsigned long v28; // stack - 0x48
+  unsigned long v29; // stack - 0x40
+  char *v3;
+  unsigned long v30; // stack - 0x30
+  int8 v4;
+  void *v5; // rdx
+  void *v6; // rdx
+  unsigned long v7; // stack - 0xa8
+  void *v8; // rsp
+  uint1 *v9; // rsi
+  
+  v16 = 0;
+  v8 = &v7;
+  v30 = *(void *)(v13 + 0x28);
+  v2 = dcgettext(0,"Usage: %s [ignored command line arguments]\n  or:  %s OPTION\n",5);
+  __printf_chk(1,v2,dat_2070c0,dat_2070c0);
+  v2 = dcgettext(0,"Exit with a status code indicating success.",5);
+  __printf_chk(1,0x4769,v2);
+  v2 = dcgettext(0,"      --help     display this help and exit\n",5);
+  fputs_unlocked(v2,Unique10000399);
+  v2 = dcgettext(0,"      --version  output version information and exit\n",5);
+  fputs_unlocked(v2,Unique100003a1);
+  v2 = dcgettext(0,"\nNOTE: your shell may have its own version of %s, which usually supersedes\nthe version described here.  Please refer to your shell\'s documentation\nfor details about the options it supports.\n",5);
+  __printf_chk(1,v2,0x4764);
+  v3 = "coreutils";
+  v28 = 0;
+  v29 = 0;
+  v7 = 0x476e;
+  v22 = "sha256sum";
+  v18 = "coreutils";
+  v17 = "test invocation";
+  v24 = "sha384sum";
+  v19 = "Multi-call invocation";
+  v26 = "sha512sum";
+  v20 = "sha224sum";
+  v21 = "sha2 utilities";
+  v23 = "sha2 utilities";
+  v25 = "sha2 utilities";
+  v27 = "sha2 utilities";
+  while( true ) {
+    v5 = &v6[0x10];
+    v14 = 0;
+    if (v11 == (uint1 *)0x0) break;
+    v4 = 5;
+    v9 = (uint1 *)0x4764;
+    v15 = 0;
+    do {
+      if (v4 == 0) goto label_17af;
+      v4 = v4 + -1;
+      v12 = &v11[(uint8)v16 * -2 + 1];
+      v10 = &v9[(uint8)v16 * -2 + 1];
+      v14 = *v9 < *v11;
+      v15 = *v9 == *v11;
+    } while (v15);
+label_17af:
+    if ((!v14 && !v15) == v14) goto label_17b8;
+    v11 = *(uint1 **)&v6[0x20];
+  }
+label_17b8:
+  v4 = *(int8 *)&v6[0x18];
+  if (v4 == 0) {
+    v2 = dcgettext(0,"\n%s online help: <%s>\n",5);
+    __printf_chk(1,v2,"GNU coreutils","https://www.gnu.org/software/coreutils/");
+    v3 = (char *)setlocale(5,0);
+    if (v3 != (char *)0x0) {
+      v1 = strncmp(v3,"en_",3);
+      if (v1 != 0) {
+        v4 = 0x4764;
+        goto label_18e8;
+      }
+    }
+    v4 = 0x4764;
+    v3 = " invocation";
+    v2 = dcgettext(0,"Full documentation <%s%s>\n",5);
+    __printf_chk(1,v2,"https://www.gnu.org/software/coreutils/",0x4764);
+  }
+  else {
+    v2 = dcgettext(0,"\n%s online help: <%s>\n",5);
+    __printf_chk(1,v2,"GNU coreutils","https://www.gnu.org/software/coreutils/");
+    v3 = (char *)setlocale(5,0);
+    if (v3 != (char *)0x0) {
+      v1 = strncmp(v3,"en_",3);
+      if (v1 != 0) {
+label_18e8:
+        v2 = dcgettext(0,"Report any translation bugs to <https://translationproject.org/team/>\n",5);
+        fputs_unlocked(v2,Unique100003a9);
+      }
+    }
+    v2 = dcgettext(0,"Full documentation <%s%s>\n",5);
+    __printf_chk(1,v2,"https://www.gnu.org/software/coreutils/",0x4764);
+    v3 = "";
+    if (v4 == 0x4764) {
+      v3 = " invocation";
+    }
+  }
+  v2 = dcgettext(0,"or available locally via: info \'(coreutils) %s%s\'\n",5);
+  __printf_chk(1,v2,v4,v3);
+                    /* WARNING: Subroutine does not return */
+  exit(a0);
+}
+
+--- metrics (reference | kuna) ---
+  loc           112 | 121 
+  gotos           2 | 3   
+  labels          2 | 3   
+  switches        0 | 0   
+  cases           0 | 0   
+  ifs             6 | 9   
+  loops           2 | 2   
+  ternaries       0 | 0   
+  casts           0 | 0   
+
+--- signals (candidate 'reference is better' hints) ---
+  * ref has fewer gotos (2 vs 3)
+  * ref has fewer labels (2 vs 3)
+  * kuna emitted a recovery-failure marker

--- a/docs/features/true-1804-x86-64-8a690c/proposal.md
+++ b/docs/features/true-1804-x86-64-8a690c/proposal.md
@@ -1,0 +1,89 @@
+# [PROPOSAL] `dedup-ite-tail` — condition-aware if/else tail deduplication (S8 structuring)
+
+**Opportunity:** `test_decompiling_true_1804_x86_64::usage`
+**Binary:** `/home/mahaloz/github/angr-dev/binaries/tests/x86_64/true_ubuntu1804` — `usage` (x86_64 @ `0x401610`)
+**angr:** 9.2.213 · **Scope:** LARGE (Hard rule 7) · **Proposed option:** `dedup-ite-tail` (default-off) · **Proposed ElementId:** 4100
+
+## The problem
+
+On `usage`, angr's decompilation is materially cleaner than kuna's
+(loc 112 vs 121, gotos 2 vs 3, labels 2 vs 3, ifs 6 vs 9). The full analysis is
+in [`analysis.md`](./analysis.md); the side-by-side is in
+[`angr-vs-kuna.txt`](./angr-vs-kuna.txt). Two structuring-quality differences:
+
+1. **Duplicated if/else tail (dominant).** kuna's trailing
+   `if (v28 == 0) { A } else { B }` duplicates a shared prefix and suffix across
+   *both* arms — the `__printf_chk("...online help...")` call, the `setlocale(5,0)`
+   call, the `strncmp(...,"en_",3)` check, and the `__printf_chk("...Full
+   documentation...")` call all appear twice. angr emits each once and converges the
+   two distinct continuations through shared labels (`LABEL_4018e8`/`LABEL_401822`).
+2. **Loop shape.** kuna emits the inlined `rep cmps` loop with a `goto` out of the
+   loop body; angr renders it as a `do/while` terminated by a `break`.
+
+Both are decisions of the **structurer**, i.e. kuna's S7/S8 `blockaction`
+CollapseStructure/TraceDAG region-collapse engine and its goto-vs-`break` schema
+selection (`decompiler/crates/kuna-decomp/src/s8_structure/blockaction.rs`).
+
+## Why this is not a single gated Action (the scope call)
+
+A decider subagent (verbatim verdict recorded in `record.json → decisions`)
+returned **`scope: large`, `proposal_required: true`**. Reasoning:
+
+- The duplication is produced by the structurer **cloning a shared continuation**
+  instead of converging two predecessors onto one labelled block. There is no
+  pre-structuring dataflow form that "shares" the tail — sharing it is a
+  condition-aware ITE region-dedup capability that lives *inside*
+  CollapseStructure/TraceDAG.
+- Unlike `kuna_loweredswitch` (which fabricates an S2 `BRANCHIND`+`JumpTable` and
+  lets the **unchanged** structurer render it), there is **no manufacturable upstream
+  CFG artifact** that makes Ghidra's collapse engine share the continuation.
+- Closing the gap therefore requires a new pass *type* touching S8
+  `blockaction` region collapse — exactly Hard rule 7's "new infrastructure" and
+  "touch S7/S8 structuring beyond a single gated early-return" triggers.
+
+## angr reference
+
+- angr's structurer condition-processing / ITE region handling — the
+  `RegionSimplifier` / condition-deduplication path in
+  `angr/analyses/decompiler/region_simplifiers/` and the structurer's
+  `_make_ites` / condition-node merging that converges shared continuations onto
+  labelled successors rather than cloning them. (kuna already has the analysis-only
+  region tree from the RegionIdentifier port: `kuna_regionid` / `kuna_regiongraph`,
+  S7 — a natural substrate.)
+
+## Proposed implementation plan (multi-step — for human go/no-go)
+
+1. **Detection (S7, analysis-only).** Using the existing `kuna_regionid` region
+   tree, identify an `if/else` region whose two arms share a maximal common
+   *prefix* and/or *suffix* of statement-equivalent blocks (same PcodeOp sequence,
+   modulo the condition varnode). Bound it (small fixed cap on hoisted blocks) to
+   keep it safe and fast.
+2. **Transform (S8, gated).** Behind `option dedup-ite-tail` (default-off), rewrite
+   the region so the shared prefix/suffix is emitted once and the divergent middles
+   are reached via labelled blocks — i.e. teach the collapse engine (or a
+   pre-collapse normalizer feeding it) to converge the predecessors. This is the
+   genuinely new region-collapse logic.
+3. **Loop schema (optional, separable).** A follow-up gated tweak to
+   goto-vs-`break` selection for the `rep cmps` loop; can ship separately.
+4. **Verify & gate.** New `tests/stages/ghangr-true-1804-x86-64-8a690c.xml`
+   (off=current duplicated tail, on=deduplicated). `kuna test --all` ablation must
+   stay PARITY OK with the option default-off; measure target decompile speed
+   off-vs-on (structurer changes are the risk).
+
+## Speed / risk assessment
+
+- **Risk: HIGH.** Region-collapse changes are the most correctness-sensitive part of
+  the pipeline — a wrong convergence emits invalid C. Must stay default-off until an
+  ablation over the full datatest corpus is clean.
+- **Speed:** detection is O(region · block-eq) over a bounded window; expected
+  small, but must be measured per Hard rule 6 because it runs in the structurer.
+- **Generality:** the shared-prefix/suffix-across-if-arms shape is common in
+  gettext/`--help`-style code (coreutils family) and in canary/cleanup epilogues, so
+  the pass should generalize beyond this single function — but that breadth is also
+  why it must be gated and corpus-ablated before any default-on consideration.
+
+## Recommendation
+
+Approve as a **draft proposal**. On go, re-dispatch an implementation worker on this
+branch to build the S7 detector + S8 gated region converter as `dedup-ite-tail`
+(ElementId 4100, default-off), with the stage test and full ablation.

--- a/docs/features/true-1804-x86-64-8a690c/record.json
+++ b/docs/features/true-1804-x86-64-8a690c/record.json
@@ -1,0 +1,28 @@
+{
+  "opportunity": "test_decompiling_true_1804_x86_64::usage",
+  "test_name": "test_decompiling_true_1804_x86_64",
+  "binary": "/home/mahaloz/github/angr-dev/binaries/tests/x86_64/true_ubuntu1804",
+  "selector": "usage",
+  "func_addr": "0x401610",
+  "angr_version": "9.2.213",
+  "option": "dedup-ite-tail",
+  "flag": "dedup_ite_tail",
+  "element_id": 4100,
+  "change_kind": "structure-recovery",
+  "source_decompiler": "angr",
+  "inspiration": "test_decompiling_true_1804_x86_64; angr structurer condition-processing / ITE region deduplication (RegionSimplifier); usage",
+  "scope": "large",
+  "proposal": true,
+  "default_on": false,
+  "summary": "On usage(), angr deduplicates the trailing if/else tail (shared online-help printf + setlocale + strncmp + Full-documentation printf emitted once and converged via labels) and emits the rep-cmps loop with a break instead of a goto, beating kuna 112loc/2goto/2label/6if vs 121/3/3/9. Both are products of kuna's S8 blockaction CollapseStructure/TraceDAG region-collapse engine cloning shared continuations rather than converging predecessors onto one labelled block. There is no manufacturable upstream CFG artifact (unlike kuna_loweredswitch's synthetic BRANCHIND+JumpTable), so closing the gap needs a new condition-aware ITE region-dedup pass touching S7/S8 structuring => LARGE / proposal per Hard rule 7.",
+  "decisions": [
+    {
+      "agent": "decider",
+      "question": "Can closing the usage() tail-duplication / loop-goto structuring gap (kuna 121loc/3goto/3label/9if vs angr 112loc/2goto/2label/6if) be done as a SINGLE option-gated Action/Rule modeled on kuna_loweredswitch.rs, or does it require S7/S8 structuring-region changes / new infrastructure?",
+      "scope": "large",
+      "decision": "Both differences are products of kuna's S8 blockaction structurer (CollapseStructure/TraceDAG/NodeJoin and its goto-vs-break schema selection), not of the pre-structuring dataflow. The duplicated if/else tail exists because Ghidra's collapse-based structurer clones a shared continuation instead of converging two predecessors onto one labeled block; sharing it is a condition-aware ITE region-dedup capability (angr's structurer) that has no schema in Ghidra's goto-and-collapse engine and cannot be manufactured as an upstream CFG artifact the way kuna_loweredswitch fabricates a BRANCHIND+JumpTable. Fixing it means a new pass type touching s8_structure/blockaction.rs region collapse - exactly HARD RULE 7's new-infrastructure and S7/S8-structuring triggers.",
+      "recommended_option_name": "dedup-ite-tail",
+      "proposal_required": true
+    }
+  ]
+}


### PR DESCRIPTION
# [PROPOSAL] `dedup-ite-tail` — condition-aware if/else tail deduplication (S8 structuring)

**Opportunity:** `test_decompiling_true_1804_x86_64::usage`
**Binary:** `/home/mahaloz/github/angr-dev/binaries/tests/x86_64/true_ubuntu1804` — `usage` (x86_64 @ `0x401610`)
**angr:** 9.2.213 · **Scope:** LARGE (Hard rule 7) · **Proposed option:** `dedup-ite-tail` (default-off) · **Proposed ElementId:** 4100

## The problem

On `usage`, angr's decompilation is materially cleaner than kuna's
(loc 112 vs 121, gotos 2 vs 3, labels 2 vs 3, ifs 6 vs 9). The full analysis is
in [`analysis.md`](./analysis.md); the side-by-side is in
[`angr-vs-kuna.txt`](./angr-vs-kuna.txt). Two structuring-quality differences:

1. **Duplicated if/else tail (dominant).** kuna's trailing
   `if (v28 == 0) { A } else { B }` duplicates a shared prefix and suffix across
   *both* arms — the `__printf_chk("...online help...")` call, the `setlocale(5,0)`
   call, the `strncmp(...,"en_",3)` check, and the `__printf_chk("...Full
   documentation...")` call all appear twice. angr emits each once and converges the
   two distinct continuations through shared labels (`LABEL_4018e8`/`LABEL_401822`).
2. **Loop shape.** kuna emits the inlined `rep cmps` loop with a `goto` out of the
   loop body; angr renders it as a `do/while` terminated by a `break`.

Both are decisions of the **structurer**, i.e. kuna's S7/S8 `blockaction`
CollapseStructure/TraceDAG region-collapse engine and its goto-vs-`break` schema
selection (`decompiler/crates/kuna-decomp/src/s8_structure/blockaction.rs`).

## Why this is not a single gated Action (the scope call)

A decider subagent (verbatim verdict recorded in `record.json → decisions`)
returned **`scope: large`, `proposal_required: true`**. Reasoning:

- The duplication is produced by the structurer **cloning a shared continuation**
  instead of converging two predecessors onto one labelled block. There is no
  pre-structuring dataflow form that "shares" the tail — sharing it is a
  condition-aware ITE region-dedup capability that lives *inside*
  CollapseStructure/TraceDAG.
- Unlike `kuna_loweredswitch` (which fabricates an S2 `BRANCHIND`+`JumpTable` and
  lets the **unchanged** structurer render it), there is **no manufacturable upstream
  CFG artifact** that makes Ghidra's collapse engine share the continuation.
- Closing the gap therefore requires a new pass *type* touching S8
  `blockaction` region collapse — exactly Hard rule 7's "new infrastructure" and
  "touch S7/S8 structuring beyond a single gated early-return" triggers.

## angr reference

- angr's structurer condition-processing / ITE region handling — the
  `RegionSimplifier` / condition-deduplication path in
  `angr/analyses/decompiler/region_simplifiers/` and the structurer's
  `_make_ites` / condition-node merging that converges shared continuations onto
  labelled successors rather than cloning them. (kuna already has the analysis-only
  region tree from the RegionIdentifier port: `kuna_regionid` / `kuna_regiongraph`,
  S7 — a natural substrate.)

## Proposed implementation plan (multi-step — for human go/no-go)

1. **Detection (S7, analysis-only).** Using the existing `kuna_regionid` region
   tree, identify an `if/else` region whose two arms share a maximal common
   *prefix* and/or *suffix* of statement-equivalent blocks (same PcodeOp sequence,
   modulo the condition varnode). Bound it (small fixed cap on hoisted blocks) to
   keep it safe and fast.
2. **Transform (S8, gated).** Behind `option dedup-ite-tail` (default-off), rewrite
   the region so the shared prefix/suffix is emitted once and the divergent middles
   are reached via labelled blocks — i.e. teach the collapse engine (or a
   pre-collapse normalizer feeding it) to converge the predecessors. This is the
   genuinely new region-collapse logic.
3. **Loop schema (optional, separable).** A follow-up gated tweak to
   goto-vs-`break` selection for the `rep cmps` loop; can ship separately.
4. **Verify & gate.** New `tests/stages/ghangr-true-1804-x86-64-8a690c.xml`
   (off=current duplicated tail, on=deduplicated). `kuna test --all` ablation must
   stay PARITY OK with the option default-off; measure target decompile speed
   off-vs-on (structurer changes are the risk).

## Speed / risk assessment

- **Risk: HIGH.** Region-collapse changes are the most correctness-sensitive part of
  the pipeline — a wrong convergence emits invalid C. Must stay default-off until an
  ablation over the full datatest corpus is clean.
- **Speed:** detection is O(region · block-eq) over a bounded window; expected
  small, but must be measured per Hard rule 6 because it runs in the structurer.
- **Generality:** the shared-prefix/suffix-across-if-arms shape is common in
  gettext/`--help`-style code (coreutils family) and in canary/cleanup epilogues, so
  the pass should generalize beyond this single function — but that breadth is also
  why it must be gated and corpus-ablated before any default-on consideration.

## Recommendation

Approve as a **draft proposal**. On go, re-dispatch an implementation worker on this
branch to build the S7 detector + S8 gated region converter as `dedup-ite-tail`
(ElementId 4100, default-off), with the stage test and full ablation.
