### PR TITLE
[PROPOSAL] angr-morton-my-message-callback-bfd2fa: SAILR-style goto-reduction (tail duplication)

### DIFF
--- a/decompiler/docs/features/morton-my-message-callback-bfd2fa/angr-vs-kuna.txt
+++ b/decompiler/docs/features/morton-my-message-callback-bfd2fa/angr-vs-kuna.txt
@@ -1,0 +1,191 @@
+==============================================================================
+test_decompiling_morton_my_message_callback :: my_message_callback   (angr 9.2.213 @ 0x403de7)
+==============================================================================
+
+--- angr ---
+typedef struct struct_0 {
+    char padding_0[8];
+    long long field_8;
+    char *field_10;
+    char padding_18[8];
+    char field_20;
+} struct_0;
+
+extern char *cfg;
+extern char g_40d00a;
+extern char g_41316f;
+extern long long last_mid;
+extern char process_messages;
+
+void my_message_callback(long long a0, unsigned long long a1, struct_0 *a2, unsigned long long a3)
+{
+    unsigned long len;  // rax
+    unsigned long len;  // rax
+    unsigned long len;  // rax
+    unsigned long long v0;  // [bp-0x78]
+    unsigned long long v1;  // [bp-0x68]
+    unsigned int v2;  // [bp-0x50]
+    unsigned int v3;  // [bp-0x4c]
+    unsigned int v4;  // [bp-0x48]
+    unsigned int v5;  // [bp-0x44]
+    char *tok;  // [bp-0x40]
+    unsigned long tok;  // [bp-0x38]
+    unsigned long v8;  // [bp-0x30]
+    unsigned long v9;  // [bp-0x28]
+    unsigned long ptr;  // [bp-0x20]
+
+    v1 = a1;
+    v0 = a3;
+    tok = strtok(a2->field_10, " ");
+    tok = strtok(NULL, &g_40d00a);
+    v8 = "Invalid Topic";
+    v9 = "Invalid Command";
+    ptr = malloc(strlen(cfg) + 44);
+    v2 = 0;
+    v3 = 0;
+    v4 = 0;
+    v5 = 0;
+    if (process_messages != 1)
+    {
+        free(ptr);
+        return;
+    }
+    if (g_41316f && a2->field_20)
+        mosquitto_publish(a0, &last_mid, a2->field_8, 0, 0, 1, 1);
+    if (tok && !mosquitto_pub_topic_check(tok))
+    {
+        if (!tok)
+        {
+            v5 = mosquitto_publish(a0, 0, "app/error", strlen(v9) & 4294967295, v9, 1, 0);
+            free(ptr);
+            return;
+        }
+        if (!strcmp(tok, "temperature"))
+        {
+            v2 = generate_random(68, 82);
+            len = strlen(cfg);
+            snprintf(ptr, len + 43, "%s recorded a temperature of %d degrees", cfg, v2);
+        }
+        else if (!strcmp(tok, "humidity"))
+        {
+            v3 = generate_random(50, 100);
+            len = strlen(cfg);
+            snprintf(ptr, len + 34, "%s recorded a humidity of %d%%", cfg, v3);
+        }
+        else if (!strcmp(tok, "UV"))
+        {
+            v4 = generate_random(0, 11);
+            len = strlen(cfg);
+            snprintf(ptr, len + 32, "%s recorded a UV index of %d", cfg, v4);
+        }
+        else
+        {
+            v5 = mosquitto_publish(a0, 0, "app/error", strlen(v9) & 4294967295, v9, 1, 0);
+            free(ptr);
+            return;
+        }
+        puts(ptr);
+        v5 = mosquitto_publish(a0, 0, tok, strlen(ptr) & 4294967295, ptr, 1, 0);
+        if (!v5)
+        {
+            free(ptr);
+            return;
+        }
+        printf("Error Publishing rc = %i\n", v5);
+        mosquitto_publish(a0, 0, "app/error", strlen(v8) & 4294967295, v8, 1, 0);
+        free(ptr);
+        return;
+    }
+    v5 = mosquitto_publish(a0, 0, "app/error", strlen(v8) & 4294967295, v8, 1, 0);
+    if (v5)
+        printf("Error Publishing rc = %d\n", v5);
+    free(ptr);
+    return;
+}
+
+
+--- kuna (name mode) ---
+void my_message_callback(unsigned long a0,unsigned long a1,int8 a2)
+
+{
+  int4 v1; // eax
+  uint4 v2; // eax
+  char *v3; // rax
+  int8 v4; // rax
+  uint8 v5; // rax
+  char *v6; // rax
+  
+  v3 = (char *)strtok(*(void *)(a2 + 0x10),0xd008);
+  v4 = strtok(0,0xd00a);
+  v5 = strlen(dat_13040);
+  v6 = malloc(v5 + 0x2c);
+  if (dat_13010 == '\x01') {
+    if ((dat_1316f != '\0') && (*(char *)(a2 + 0x20) != '\0')) {
+      mosquitto_publish(a0,0x13238,*(void *)(a2 + 8),0,0,1);
+    }
+    if ((v4 == 0) || (v1 = mosquitto_pub_topic_check(v4), v1 != 0)) {
+      v5 = strlen("Invalid Topic");
+      v2 = mosquitto_publish(a0,0,"app/error",v5 & 0xffffffff,"Invalid Topic",1);
+      if (v2 != 0) {
+        printf("Error Publishing rc = %d\n",(uint8)v2);
+      }
+    }
+    else if (v3 == (char *)0x0) {
+      v5 = strlen("Invalid Command");
+      mosquitto_publish(a0,0,"app/error",v5 & 0xffffffff,"Invalid Command",1);
+    }
+    else {
+      v1 = strcmp(v3,"temperature");
+      if (v1 == 0) {
+        v2 = generate_random(0x44,0x52);
+        v5 = strlen(dat_13040);
+        snprintf(v6,v5 + 0x2b,"%s recorded a temperature of %d degrees",Unique1000034a,(uint8)v2);
+      }
+      else {
+        v1 = strcmp(v3,"humidity");
+        if (v1 == 0) {
+          v2 = generate_random(0x32,100);
+          v5 = strlen(dat_13040);
+          snprintf(v6,v5 + 0x22,"%s recorded a humidity of %d%%",Unique10000352,(uint8)v2);
+        }
+        else {
+          v1 = strcmp(v3,"UV");
+          if (v1 != 0) {
+            v5 = strlen("Invalid Command");
+            mosquitto_publish(a0,0,"app/error",v5 & 0xffffffff,"Invalid Command",1);
+            goto label_41d6;
+          }
+          v2 = generate_random(0,0xb);
+          v5 = strlen(dat_13040);
+          snprintf(v6,v5 + 0x20,"%s recorded a UV index of %d",Unique1000035a,(uint8)v2);
+        }
+      }
+      puts(v6);
+      v5 = strlen(v6);
+      v2 = mosquitto_publish(a0,0,v4,v5 & 0xffffffff,v6,1);
+      if (v2 != 0) {
+        printf("Error Publishing rc = %i\n",(uint8)v2);
+        v5 = strlen("Invalid Topic");
+        mosquitto_publish(a0,0,"app/error",v5 & 0xffffffff,"Invalid Topic",1);
+      }
+    }
+  }
+label_41d6:
+  free(v6);
+  return;
+}
+
+--- metrics (reference | kuna) ---
+  loc            96 | 67  
+  gotos           0 | 1   
+  labels          0 | 1   
+  switches        0 | 0   
+  cases           0 | 0   
+  ifs             9 | 9   
+  loops           0 | 0   
+  ternaries       0 | 0   
+  casts           0 | 0   
+
+--- signals (candidate 'reference is better' hints) ---
+  * ref has fewer gotos (0 vs 1)
+  * ref has fewer labels (0 vs 1)

--- a/docs/features/morton-my-message-callback-bfd2fa/analysis.md
+++ b/docs/features/morton-my-message-callback-bfd2fa/analysis.md
@@ -1,0 +1,104 @@
+# morton / my_message_callback — angr-vs-kuna gap analysis
+
+- **angr testcase:** `test_decompiling_morton_my_message_callback`
+- **binary:** `/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/morton`
+- **selector:** `my_message_callback` (`x86_64`, func @ `0x403de7`)
+- **angr version:** 9.2.213
+
+## The measured difference
+
+| metric | reference (angr) | kuna |
+|---|---|---|
+| loc | 96 | 67 |
+| **gotos** | **0** | **1** |
+| **labels** | **0** | **1** |
+| ifs | 9 | 9 |
+| loops | 0 | 0 |
+| switches / cases / ternaries / casts | 0 | 0 |
+
+The pipeline's own "reference is better" signals reduce to exactly two, and they are the
+same fact twice:
+
+```
+* ref has fewer gotos (0 vs 1)
+* ref has fewer labels (0 vs 1)
+```
+
+So the **single concrete structural difference** is one residual `goto` + its `label:`.
+
+## Where the goto comes from
+
+The function is an if/else-if cascade over the parsed command token
+(`temperature` / `humidity` / `UV` / else=*Invalid Command*) followed by a **common
+epilogue** `free(v6); return;`. The "Invalid Command" arm has to skip the rest of the
+body (`puts(v6)`, the publish, the error handling) and jump straight to that shared
+epilogue. kuna renders this as:
+
+```c
+        else {
+          v1 = strcmp(v3,"UV");
+          if (v1 != 0) {
+            v5 = strlen("Invalid Command");
+            mosquitto_publish(a0,0,"app/error",v5 & 0xffffffff,"Invalid Command",1);
+            goto label_41d6;          // <-- the residual goto
+          }
+          ...
+        }
+      ...
+label_41d6:
+  free(v6);
+  return;
+```
+
+angr emits **zero** gotos for the identical CFG by **duplicating the `free(ptr); return;`
+epilogue** into each arm that reaches it (it has several `free(ptr); return;` early-return
+tails), turning the cross-edge into a structured early return instead of a goto:
+
+```c
+        else
+        {
+            v5 = mosquitto_publish(a0, 0, "app/error", strlen(v9) & 4294967295, v9, 1, 0);
+            free(ptr);
+            return;                    // duplicated tail, no goto
+        }
+        puts(ptr);
+        ...
+```
+
+## Owning stage
+
+This goto is produced by **S8 structuring** — `decompiler/crates/kuna-decomp/src/s8_structure/blockaction.rs`,
+the **verbatim port of Ghidra's `CollapseStructure` / `BlockTrace` / `TraceDAG`**. The
+module header says so explicitly:
+
+> The schema-precedence order ... is *output-determining*: it decides which gotos get
+> emitted when several structurings are possible ... Likewise `LoopBody` ordering ... and
+> the `TraceDAG` bad-edge scoring ... are tie-breakers that decide *which* edge becomes a
+> goto — transcribed verbatim.
+
+Ghidra's algorithm collapses the CFG by schema-matching and, **when stuck, removes
+("gotos") an edge** chosen by the DAG trace. There is no schema in the cascade that
+duplicates a small return tail to *avoid* that goto — that is precisely the class of
+transform angr's structurer (the Phoenix/SAILR "goto-reduction via tail duplication and
+condition restructuring" passes) adds *on top of* the base structuring.
+
+## Hypothesis for the kuna change (and why it is large)
+
+Matching angr means adding a **new structuring transform**: detect a goto edge whose
+target is a small, side-effect-light epilogue (here `free(v6); return;`) and **duplicate
+that tail into the goto source**, eliminating the unstructured edge. That is:
+
+- a **new pass *type*** (return/epilogue tail-duplication), not modelable as a single
+  `Action`/`Rule` like `kuna_loweredswitch.rs`;
+- it **touches S8/S7 structuring/region code** (the `CollapseStructure` collapse loop and
+  the `BlockGraph` topology) well beyond a single gated early-return;
+- it must reason about block duplication, statement cost, and re-running the collapse —
+  multi-step, with real correctness risk.
+
+Per **Hard rule 7**, this is a **large** gap → proposal, not a one-shot option. See
+`proposal.md`. This is the same SAILR-structurer family as the irreducible-loop gap
+(proposal PR #46) and is best done as a deliberate, human-approved structuring effort.
+
+No existing option covers goto/structuring reduction (checked `kuna catalog --json`: the
+catalog has no structuring/goto-elimination entry; closest are presentation/dataflow
+folds, none of which touch the `CollapseStructure` goto set).

--- a/docs/features/morton-my-message-callback-bfd2fa/proposal.md
+++ b/docs/features/morton-my-message-callback-bfd2fa/proposal.md
@@ -1,0 +1,128 @@
+# [PROPOSAL] angr-morton-my-message-callback: SAILR-style goto-reduction by epilogue tail-duplication
+
+**Status:** draft proposal — needs human go/no-go before an implementation worker is spent.
+**Scope:** large (per Hard rule 7 and the recorded decider verdict).
+
+## The problem
+
+On `my_message_callback` in `morton` (x86_64, @ `0x403de7`) the **only** structural
+difference between angr and kuna is a single residual `goto` + `label:`:
+
+| metric | angr | kuna |
+|---|---|---|
+| gotos | **0** | **1** |
+| labels | **0** | **1** |
+| ifs | 9 | 9 |
+| loops / switches | 0 | 0 |
+
+kuna:
+
+```c
+        else {
+          v1 = strcmp(v3,"UV");
+          if (v1 != 0) {
+            v5 = strlen("Invalid Command");
+            mosquitto_publish(a0,0,"app/error",v5 & 0xffffffff,"Invalid Command",1);
+            goto label_41d6;
+          }
+          ...
+        }
+      ...
+label_41d6:
+  free(v6);
+  return;
+```
+
+angr (zero gotos) — it **duplicates** the shared `free(ptr); return;` epilogue into each
+arm that reaches it, so the cross-edge becomes a structured early return:
+
+```c
+        else
+        {
+            v5 = mosquitto_publish(a0, 0, "app/error", strlen(v9) & 4294967295, v9, 1, 0);
+            free(ptr);
+            return;
+        }
+        puts(ptr);
+        ...
+```
+
+See `analysis.md` and `angr-vs-kuna.txt` for the full side-by-side.
+
+## The angr reference pass / class
+
+This is angr's **goto-reduction via tail duplication** (the Phoenix/SAILR family in
+`angr.analyses.decompiler` — the region-simplification + `DuplicationOptimizer` /
+`GotoSimplifier` style transforms). angr's structurer is *allowed* to duplicate small,
+side-effect-bounded tails (a `return`, a `free(x); return`) to eliminate an unstructured
+edge; its quality metric explicitly trades a few duplicated statements for zero gotos.
+
+## Why this is large (owning stage: S8 structuring)
+
+The goto is produced by `decompiler/crates/kuna-decomp/src/s8_structure/blockaction.rs`,
+the **verbatim port of Ghidra's `CollapseStructure` / `TraceDAG` / `BlockTrace`**. Its
+header states the schema-precedence order and the DAG bad-edge scoring are
+"output-determining ... transcribed verbatim" — they *choose* which edge becomes a goto.
+Ghidra has **no schema that duplicates a tail to avoid a goto**; that transform simply
+does not exist in the collapse algorithm.
+
+Matching angr therefore requires a **new structuring transform**, not a gated `Action`
+that manufactures an artifact for the existing structurer (the way `kuna_loweredswitch.rs`
+manufactures an S2 BRANCHIND/JumpTable). Concretely it must:
+
+1. identify unstructured ("goto") edges after `CollapseStructure` whose **target** is a
+   small epilogue block (statement-count ≤ threshold, no incoming side effects that would
+   change semantics if duplicated, e.g. a `free(p); return;`);
+2. **duplicate** that target's statements into the goto source (a CFG/`BlockGraph` mutation
+   — clone the `BlockBasic`, its ops, and rewire edges), then drop the unstructured edge;
+3. re-run / locally re-collapse the structuring so the duplicated tail folds into the arm
+   as a structured early return;
+4. preserve def/use and ordering (the duplicated `free`/`return` are real p-code ops, so
+   this is *not* a pure print-time rewrite).
+
+That is a **new pass type touching S8 structuring/region code beyond a single gated
+early-return** — two independent triggers of Hard rule 7. The decider verdict (recorded in
+`record.json`) is `scope: large`.
+
+## Proposed implementation plan (multi-step — for the approved worker)
+
+- **New module** `kuna_gotoreduce.rs` (S8) — a post-`CollapseStructure` `Action`,
+  option-gated, default-OFF.
+- **Anchor edits (minimal, `// (kuna)`):** register the action in `universalaction.rs` /
+  the relevant `coreaction*` registration; option flag on the architecture struct
+  (reset-default off); `options.rs`; `stages.toml` `settableTable` row.
+- **Core mechanics:** add a `BlockGraph` helper to clone a `BlockCopy`/`BlockBasic` tail
+  and rewire the floating edge (this is the genuinely new, risky piece — it mutates the
+  structured block tree the verbatim engine produced).
+- **Bounds / fail-safe:** cap duplicated statement count (e.g. ≤ 4 ops, single-exit,
+  ends in `return`), bail on any block with multiple non-goto predecessors that would
+  change semantics, mirroring loweredswitch's fail-safe cap.
+- **Tests:** `tests/stages/ghangr-morton-my-message-callback-bfd2fa.xml` two-pass
+  (off=goto present, on=goto gone); plus a synthetic minimal CFG fixture.
+
+## Speed / risk assessment
+
+- **Risk: high.** This mutates the structured block tree after a verbatim-ported engine.
+  Incorrect duplication can change semantics (duplicating a block with side effects reached
+  by more than the goto source) or desync def/use. The bounds above contain it but need
+  careful adversarial testing across the datatest corpus.
+- **Ablation risk:** likely non-zero — tail-duplication changes rendering on many
+  functions that currently use a clean shared-epilogue goto, so this is expected to ship
+  **default-OFF opt-in** even if correct.
+- **Speed:** an extra post-structuring scan + occasional re-collapse; expected small but
+  must be measured against the +5% budget on the target.
+- **Same family** as the irreducible-loop SAILR gap (proposal PR #46) — worth coordinating
+  so kuna grows one coherent goto-reduction layer rather than point fixes.
+
+## Proposed option name
+
+`gotoreduce` (`change_kind = structure-recovery`, `source_decompiler = angr`,
+`inspiration = test_decompiling_morton_my_message_callback; SAILR/Phoenix goto-reduction (tail duplication); my_message_callback`).
+
+## Recommendation
+
+**Go** if the team wants kuna to start matching angr/SAILR on goto count (high-value,
+broadly applicable, but real structuring risk) — staff it as a deliberate S8 effort with a
+full adversarial test pass. **No-go / defer** if structuring-quality parity with angr is
+out of scope right now; the gap is cosmetic (one goto, semantics already correct) and the
+implementation cost/risk is disproportionate to this single function.

--- a/docs/features/morton-my-message-callback-bfd2fa/record.json
+++ b/docs/features/morton-my-message-callback-bfd2fa/record.json
@@ -1,0 +1,28 @@
+{
+  "opportunity": "test_decompiling_morton_my_message_callback::my_message_callback",
+  "test_name": "test_decompiling_morton_my_message_callback",
+  "binary": "/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/morton",
+  "selector": "my_message_callback",
+  "func_addr": "0x403de7",
+  "arch": "x86_64",
+  "angr_version": "9.2.213",
+  "option": "gotoreduce",
+  "change_kind": "structure-recovery",
+  "source_decompiler": "angr",
+  "inspiration": "test_decompiling_morton_my_message_callback; SAILR/Phoenix goto-reduction (tail duplication / DuplicationOptimizer); my_message_callback",
+  "scope": "large",
+  "proposal": true,
+  "gap_summary": "kuna emits 1 goto + 1 label to a shared `free(v6); return;` epilogue; angr emits 0 gotos by tail-duplicating the epilogue into each arm. The only structural diff (9 ifs / 0 loops / 0 switches both).",
+  "owning_stage": "S8 (s8_structure/blockaction.rs — verbatim CollapseStructure/TraceDAG)",
+  "decisions": [
+    {
+      "question": "Is closing this goto-reduction gap a small (single Action/Rule) feature or large (proposal-required)?",
+      "decider_verdict": {
+        "scope": "large",
+        "reason": "Eliminating the goto requires SAILR/Phoenix tail-duplication of the shared epilogue into each arm — a new CFG-rewriting transform inside/after the verbatim CollapseStructure engine, not a single gated early-return Action like loweredswitch.",
+        "owning_stage": "S8",
+        "why_not_small": "Needs a new goto-reduction/tail-duplication pass type touching S8 structuring beyond a gated early-return; cannot manufacture an S2 artifact for the existing structurer the way loweredswitch does."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# [PROPOSAL] angr-morton-my-message-callback: SAILR-style goto-reduction by epilogue tail-duplication

**Status:** draft proposal — needs human go/no-go before an implementation worker is spent.
**Scope:** large (per Hard rule 7 and the recorded decider verdict).

## The problem

On `my_message_callback` in `morton` (x86_64, @ `0x403de7`) the **only** structural
difference between angr and kuna is a single residual `goto` + `label:`:

| metric | angr | kuna |
|---|---|---|
| gotos | **0** | **1** |
| labels | **0** | **1** |
| ifs | 9 | 9 |
| loops / switches | 0 | 0 |

kuna:

```c
        else {
          v1 = strcmp(v3,"UV");
          if (v1 != 0) {
            v5 = strlen("Invalid Command");
            mosquitto_publish(a0,0,"app/error",v5 & 0xffffffff,"Invalid Command",1);
            goto label_41d6;
          }
          ...
        }
      ...
label_41d6:
  free(v6);
  return;
```

angr (zero gotos) — it **duplicates** the shared `free(ptr); return;` epilogue into each
arm that reaches it, so the cross-edge becomes a structured early return:

```c
        else
        {
            v5 = mosquitto_publish(a0, 0, "app/error", strlen(v9) & 4294967295, v9, 1, 0);
            free(ptr);
            return;
        }
        puts(ptr);
        ...
```

See `analysis.md` and `angr-vs-kuna.txt` for the full side-by-side.

## The angr reference pass / class

This is angr's **goto-reduction via tail duplication** (the Phoenix/SAILR family in
`angr.analyses.decompiler` — the region-simplification + `DuplicationOptimizer` /
`GotoSimplifier` style transforms). angr's structurer is *allowed* to duplicate small,
side-effect-bounded tails (a `return`, a `free(x); return`) to eliminate an unstructured
edge; its quality metric explicitly trades a few duplicated statements for zero gotos.

## Why this is large (owning stage: S8 structuring)

The goto is produced by `decompiler/crates/kuna-decomp/src/s8_structure/blockaction.rs`,
the **verbatim port of Ghidra's `CollapseStructure` / `TraceDAG` / `BlockTrace`**. Its
header states the schema-precedence order and the DAG bad-edge scoring are
"output-determining ... transcribed verbatim" — they *choose* which edge becomes a goto.
Ghidra has **no schema that duplicates a tail to avoid a goto**; that transform simply
does not exist in the collapse algorithm.

Matching angr therefore requires a **new structuring transform**, not a gated `Action`
that manufactures an artifact for the existing structurer (the way `kuna_loweredswitch.rs`
manufactures an S2 BRANCHIND/JumpTable). Concretely it must:

1. identify unstructured ("goto") edges after `CollapseStructure` whose **target** is a
   small epilogue block (statement-count ≤ threshold, no incoming side effects that would
   change semantics if duplicated, e.g. a `free(p); return;`);
2. **duplicate** that target's statements into the goto source (a CFG/`BlockGraph` mutation
   — clone the `BlockBasic`, its ops, and rewire edges), then drop the unstructured edge;
3. re-run / locally re-collapse the structuring so the duplicated tail folds into the arm
   as a structured early return;
4. preserve def/use and ordering (the duplicated `free`/`return` are real p-code ops, so
   this is *not* a pure print-time rewrite).

That is a **new pass type touching S8 structuring/region code beyond a single gated
early-return** — two independent triggers of Hard rule 7. The decider verdict (recorded in
`record.json`) is `scope: large`.

## Proposed implementation plan (multi-step — for the approved worker)

- **New module** `kuna_gotoreduce.rs` (S8) — a post-`CollapseStructure` `Action`,
  option-gated, default-OFF.
- **Anchor edits (minimal, `// (kuna)`):** register the action in `universalaction.rs` /
  the relevant `coreaction*` registration; option flag on the architecture struct
  (reset-default off); `options.rs`; `stages.toml` `settableTable` row.
- **Core mechanics:** add a `BlockGraph` helper to clone a `BlockCopy`/`BlockBasic` tail
  and rewire the floating edge (this is the genuinely new, risky piece — it mutates the
  structured block tree the verbatim engine produced).
- **Bounds / fail-safe:** cap duplicated statement count (e.g. ≤ 4 ops, single-exit,
  ends in `return`), bail on any block with multiple non-goto predecessors that would
  change semantics, mirroring loweredswitch's fail-safe cap.
- **Tests:** `tests/stages/ghangr-morton-my-message-callback-bfd2fa.xml` two-pass
  (off=goto present, on=goto gone); plus a synthetic minimal CFG fixture.

## Speed / risk assessment

- **Risk: high.** This mutates the structured block tree after a verbatim-ported engine.
  Incorrect duplication can change semantics (duplicating a block with side effects reached
  by more than the goto source) or desync def/use. The bounds above contain it but need
  careful adversarial testing across the datatest corpus.
- **Ablation risk:** likely non-zero — tail-duplication changes rendering on many
  functions that currently use a clean shared-epilogue goto, so this is expected to ship
  **default-OFF opt-in** even if correct.
- **Speed:** an extra post-structuring scan + occasional re-collapse; expected small but
  must be measured against the +5% budget on the target.
- **Same family** as the irreducible-loop SAILR gap (proposal PR #46) — worth coordinating
  so kuna grows one coherent goto-reduction layer rather than point fixes.

## Proposed option name

`gotoreduce` (`change_kind = structure-recovery`, `source_decompiler = angr`,
`inspiration = test_decompiling_morton_my_message_callback; SAILR/Phoenix goto-reduction (tail duplication); my_message_callback`).

## Recommendation

**Go** if the team wants kuna to start matching angr/SAILR on goto count (high-value,
broadly applicable, but real structuring risk) — staff it as a deliberate S8 effort with a
full adversarial test pass. **No-go / defer** if structuring-quality parity with angr is
out of scope right now; the gap is cosmetic (one goto, semantics already correct) and the
implementation cost/risk is disproportionate to this single function.
