### PR TITLE
[PROPOSAL] angr-newburry-main-57ccb1: SUID-guard goto is the SAILR goto-reduction family (large)

### DIFF
--- a/docs/features/newburry-main-57ccb1/analysis.md
+++ b/docs/features/newburry-main-57ccb1/analysis.md
@@ -1,0 +1,112 @@
+# newburry/main — angr-vs-kuna analysis (newburry-main-57ccb1)
+
+- **angr testcase:** `test_decompiling_newburry_main :: main`
+- **Binary:** `/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/newbury` (lighttpd `server.c::main`)
+- **angr version:** 9.2.213, function @ `0x40f696`
+- **Selector:** `main` (arch x86_64)
+
+## The gap (one concrete structural difference)
+
+Metrics (reference = angr | kuna):
+
+| metric | angr | kuna |
+|---|---|---|
+| gotos | **0** | **1** |
+| labels | **0** | **1** |
+| ifs | 20 | 16 |
+| loops | 6 | 6 |
+| ternaries | 1 | 1 |
+
+The **only** structural defect is a single `goto` + `label`. Everything else
+matches (both 6 loops, ~equal if/ternary counts). kuna's output is otherwise
+clean and correct.
+
+### kuna (abridged)
+
+```c
+  v2 = getuid();
+  if (v2 == 0) {
+label_f6ec:
+    setlocale(2,0x43620);
+    tzset();
+    do { ... big body / server loop ... } while (dat_5f278 != 0);   // BODY
+  }
+  else {
+    v2 = geteuid();
+    v3 = getuid();
+    if (v2 == v3) {
+      v2 = getegid();
+      v3 = getgid();
+      if (v2 == v3) goto label_f6ec;       // <-- forward goto INTO the then-branch's BODY
+    }
+    v2 = -1;
+    fputs("Are you nuts ? Don\'t apply a SUID bit to this binary\n",dat_5f140);
+  }
+  return v2;
+```
+
+### angr (abridged)
+
+```c
+  if (getuid()) {
+      v1 = geteuid();
+      if (v1 != getuid() || !(getegid() == getgid())) {
+          fputs("Are you nuts ? ...", stderr);
+          return 4294967295;               // exceptional path nested + early-return
+      }
+  }
+  setlocale(2, "C");                        // BODY is the fall-through JOIN
+  tzset();
+  while (true) { ... big body / server loop ... }
+```
+
+## What angr does better
+
+The SUID self-check has a body region **BODY** (`setlocale; tzset; <server loop>`)
+that is reached from **two predecessors**:
+
+1. the `getuid() == 0` path, and
+2. the "euid==uid && egid==gid all pass" path.
+
+- **kuna** (verbatim Ghidra `CollapseStructure`/`TraceDAG`) nests BODY inside the
+  first `if`-then and reaches it from the second path via a **forward `goto` into
+  that branch** (`goto label_f6ec`). Syntactically valid, but a goto + label.
+- **angr** (SAILR/Phoenix condition-based structurer) **inverts the guard
+  conditions** so the *exceptional* `fputs; return -1` path becomes the nested
+  branch, and **BODY becomes the fall-through join** after the guard. No goto, no
+  label.
+
+## Owning stage
+
+- **S8 structuring** — `decompiler/crates/kuna-decomp/src/s8_structure/blockaction.rs`
+  (verbatim port of Ghidra `CollapseStructure` / `TraceDAG`). The goto is emitted
+  here when the collapse cannot find a structured form for a multi-predecessor
+  join, so it falls back to a goto edge.
+- The would-be fix layer is **S7 region identification**
+  (`s7_regions/kuna_regionid.rs`), kuna's port of angr's `RegionIdentifier`, which
+  is currently a **read-only console surface** (`region tree`) and does **not**
+  drive emit.
+
+## Hypothesis for the kuna change (why it is LARGE)
+
+To reproduce angr's output you must **invert the guard conditions** so the
+exceptional path nests and the shared BODY becomes the fall-through join, then
+re-parent BODY out of the first `if`-then. This is **condition-based block-graph
+restructuring**, not a value-level Action/Rule:
+
+- It cannot be done as a single gated early-return in `blockaction.rs` — that file
+  can only *suppress* work, it cannot *synthesize* a new guard inversion and
+  re-parent a join.
+- The canonical small template (`kuna_loweredswitch.rs`) is an **S2 pcode-level**
+  Action and is not applicable to block-graph restructuring.
+- It is the **same root** as the known `gotoreduce` gap
+  (morton/my_message_callback, proposal **PR #54**) and the `irreducibleloops`
+  family (**PR #46**): all need kuna's read-only `RegionIdentifier` promoted into a
+  real **emit-path SAILR/Phoenix condition-based structurer**. That is a new pass
+  *type* / infrastructure → trips **Hard rule 7** (new pass type + touches S8/S7
+  structuring beyond a gated early-return).
+
+**Scope decider verdict:** `large` · family `gotoreduce` · recommended action
+`propose`. See `record.json` `decisions`.
+
+→ Filed as a `[PROPOSAL]` draft PR. No implementation in this session.

--- a/docs/features/newburry-main-57ccb1/angr-vs-kuna.txt
+++ b/docs/features/newburry-main-57ccb1/angr-vs-kuna.txt
@@ -1,0 +1,374 @@
+==============================================================================
+test_decompiling_newburry_main :: main   (angr 9.2.213 @ 0x40f696)
+==============================================================================
+
+--- angr ---
+typedef struct FILE {
+} FILE;
+
+extern unsigned long long connection_joblist;
+extern unsigned int g_45f1f0;
+extern unsigned int g_45f1f4;
+extern char graceful_restart;
+extern unsigned int graceful_shutdown;
+extern uint128_t graceful_sockets;
+extern uint128_t inherited_sockets;
+extern unsigned long long log_epoch_secs;
+extern int oneshot_fd;
+extern unsigned long long oneshot_fdn;
+extern int oneshot_fdout;
+extern unsigned int optind;
+extern FILE *stderr;
+
+unsigned int main(unsigned int a0, long long a1)
+{
+    unsigned int v1;  // eax
+    unsigned int v2;  // eax
+    int v11;  // xmm1
+    unsigned long long v12;  // rax
+    unsigned int v13;  // edx
+    unsigned long long index;  // rax
+    unsigned long long v15;  // rax
+    unsigned int v16;  // edx
+    unsigned long long v17;  // rax
+    unsigned long long pos;  // rax
+    unsigned long long v19;  // rax
+    unsigned int v20;  // r12d
+    void* ptr;  // rbp
+    unsigned int v21;  // edx
+    unsigned long long v22;  // rax
+    unsigned long long off;  // rax
+    unsigned long long v24;  // rax
+    unsigned int v25;  // edx
+    unsigned long long v26;  // rax
+    unsigned long long idx4;  // rax
+    unsigned long long v28;  // rax
+    int v29;  // xmm3
+    int v30;  // xmm4
+    long long v4;  // rdi
+    long long v5;  // rsi
+    long long v6;  // rdx
+    long long v7;  // rcx
+    long long v8;  // r8
+    long long v9;  // r9
+    unsigned long t;  // rax
+
+    if (getuid())
+    {
+        v1 = geteuid();
+        if (v1 != getuid() || !((v2 = (unsigned int)(unsigned long long)getegid(), (unsigned int)(unsigned long long)getegid() == (unsigned int)(unsigned long long)getgid())))
+        {
+            fputs("Are you nuts ? Don't apply a SUID bit to this binary\n", stderr);
+            return 4294967295;
+        }
+    }
+    setlocale(2, "C");
+    tzset();
+    while (true)
+    {
+        ptr = calloc(1, 456);
+        if (!ptr)
+            log_failed_assert("server.c", 231, "assertion failed: srv"); /* do not return */
+        *((unsigned long long *)&ptr[40]) = buffer_init();
+        connection_joblist = ptr + 64;
+        strftime_cache_reset(v4, v5, v6, v7, v8, v9);
+        li_rand_reseed(v4, v5, v6, v7, v8, v9);
+        t = time(NULL);
+        *((unsigned long *)&ptr[416]) = t;
+        log_epoch_secs = t;
+        *((unsigned long long *)&ptr[152]) = log_error_st_init(v4, v5, v6, v7, v8, v9);
+        config_init(ptr);
+        *((unsigned long long *)&ptr[168]) = 0;
+        *((unsigned long long *)&ptr[176]) = 0;
+        *((void* *)&ptr[32]) = plugins_call_handle_request_env;
+        *((unsigned long long *)&ptr[184]) = 0;
+        *((int *)&ptr[444]) = -1;
+        if (*((int *)&graceful_restart))
+        {
+            v11 = (int)graceful_sockets;
+            v12 = 0;
+            *((void*)&graceful_sockets) = 0;
+            ptr[368] = v11;
+            v13 = (int)ptr[380];
+            *((uint128_t *)&ptr[384]) = inherited_sockets;
+            *((void*)&inherited_sockets) = 0;
+            while (true)
+            {
+                index = v12;
+                if (v13 <= (unsigned int)index)
+                    break;
+                v15 = index + 1;
+                *((void* *)(*((long long *)((long long)ptr[368] + index * 8)) + 128)) = ptr;
+                v12 = v15;
+            }
+            v16 = (int)ptr[396];
+            v17 = 0;
+            while (true)
+            {
+                pos = v17;
+                if (v16 <= (unsigned int)pos)
+                    break;
+                v19 = pos + 1;
+                *((void* *)(*((long long *)((long long)ptr[384] + pos * 8)) + 128)) = ptr;
+                v17 = v19;
+            }
+            optind = 1;
+        }
+        v20 = server_main_setup(ptr, a0, a1);
+        if (v20 > 0)
+        {
+            server_main_loop(ptr);
+            if (graceful_shutdown || *((int *)&graceful_restart))
+                server_graceful_state(ptr);
+            if (graceful_shutdown == 2)
+            {
+                log_error((long long)ptr[152], "server.c", 1972, "server stopped after idle timeout");
+            }
+            else if (!oneshot_fd)
+            {
+                log_error((long long)ptr[152], "server.c", 1976, "server stopped by UID = %d PID = %d", g_45f1f4, g_45f1f0);
+            }
+        }
+        remove_pid_file(ptr);
+        config_log_error_close(ptr);
+        if (*((int *)&graceful_restart))
+        {
+            v21 = (int)ptr[380];
+            v22 = 0;
+            while (true)
+            {
+                off = v22;
+                if (v21 <= (unsigned int)off)
+                    break;
+                v24 = off + 1;
+                *((unsigned long *)(*((long long *)((long long)ptr[368] + off * 8)) + 128)) = 0;
+                v22 = v24;
+            }
+            v25 = (int)ptr[396];
+            v26 = 0;
+            while (true)
+            {
+                idx4 = v26;
+                if (v25 <= (unsigned int)idx4)
+                    break;
+                v28 = idx4 + 1;
+                *((unsigned long *)(*((long long *)((long long)ptr[384] + idx4 * 8)) + 128)) = 0;
+                v26 = v28;
+            }
+            v29 = (int)(int128_t)ptr[368];
+            v30 = (int)(int128_t)ptr[384];
+            ptr[368] = 0;
+            *((void*)&graceful_sockets) = v29;
+            *((void*)&inherited_sockets) = v30;
+            ptr[384] = 0;
+        }
+        else
+        {
+            network_close(ptr);
+        }
+        request_pool_free(v4, v5, v6, v7, v8, v9);
+        connections_free(ptr);
+        plugins_free(ptr);
+        if (oneshot_fd > 0)
+        {
+            if (oneshot_fdn)
+            {
+                fdevent_fdnode_event_del((long long)ptr[16]);
+                fdevent_unregister((long long)ptr[16], oneshot_fd);
+                oneshot_fdn = 0;
+            }
+            close(oneshot_fd);
+        }
+        if (oneshot_fdout >= 0)
+            close(oneshot_fdout);
+        if ((int)ptr[444] >= 0)
+            close((int)ptr[444]);
+        buffer_free((long long)ptr[40]);
+        fdevent_free((long long)ptr[16]);
+        config_free(ptr);
+        free((long long)ptr[64]);
+        free((long long)ptr[80]);
+        free((long long)ptr[96]);
+        stat_cache_free(v4, v5, v6, v7, v8, v9);
+        li_rand_cleanup(v4, v5, v6, v7, v8, v9);
+        chunkqueue_chunk_pool_free(v4, v5, v6, v7, v8, v9);
+        log_error_st_free((long long)ptr[152]);
+        free(ptr);
+        if (v20 < 0)
+        {
+            return v20;
+        }
+        else if (*((int *)&graceful_restart))
+        {
+            do
+            { } while (fdevent_waitpid(4294967295, 0, 0) > 0);
+            if (!*((int *)&graceful_restart))
+                return v20;
+        }
+        else
+        {
+            return v20;
+        }
+    }
+}
+
+
+--- kuna (name mode) ---
+int4 main(int4 a0,char **a1)
+
+{
+  server *srv; // rax
+  uint4 v1;
+  int4 v2; // eax
+  int4 v3; // eax
+  unsigned long v4; // rax
+  log_error_st *v5; // rax
+  int8 v6; // rax
+  
+  v2 = getuid();
+  if (v2 == 0) {
+label_f6ec:
+    setlocale(2,0x43620);
+    tzset();
+    do {
+      srv = calloc(1,0x1c8);
+      if (srv == (server *)0x0) {
+        log_failed_assert("server.c",0xe7,"assertion failed: srv");
+      }
+      v4 = buffer_init();
+      *(void *)((int8)srv + 0x28) = v4;
+      Unique00008f00 = (void *)((int8)srv + 0x40);
+      strftime_cache_reset();
+      li_rand_reseed();
+      RAX = time(0);
+      *(void *)((int8)srv + 0x1a0) = RAX;
+      v5 = log_error_st_init();
+      *(log_error_st **)((int8)srv + 0x98) = v5;
+      config_init(srv);
+      *(void *)((int8)srv + 0xa8) = 0;
+      *(void *)((int8)srv + 0xb0) = 0;
+      *(code **)((int8)srv + 0x20) = plugins_call_handle_request_env;
+      *(void *)((int8)srv + 0xb8) = 0;
+      *(void *)((int8)srv + 0x1bc) = 0xffffffff;
+      if (dat_5f278 != 0) {
+        dat_5f290 = 0;
+        dat_5f298 = 0;
+        *(void *)((int8)srv + 0x170) = Unique10000578;
+        *(void *)((int8)srv + 0x178) = dat_5f298;
+        v1 = *(uint4 *)((int8)srv + 0x17c);
+        *(void *)((int8)srv + 0x180) = dat_5f280;
+        *(void *)((int8)srv + 0x188) = dat_5f288;
+        dat_5f280 = 0;
+        dat_5f288 = 0;
+        for (v6 = 0; (uint4)v6 < v1; v6 = v6 + 1) {
+          *(server **)(*(int8 *)(*(int8 *)((int8)srv + 0x170) + v6 * 8) + 0x80) = srv;
+        }
+        v1 = *(uint4 *)((int8)srv + 0x18c);
+        for (v6 = 0; (uint4)v6 < v1; v6 = v6 + 1) {
+          *(server **)(*(int8 *)(*(int8 *)((int8)srv + 0x180) + v6 * 8) + 0x80) = srv;
+        }
+        dat_5f108 = 1;
+      }
+      v2 = server_main_setup(srv,a0,a1);
+      if (1 <= v2) {
+        server_main_loop(srv);
+        if ((dat_5f274 != 0) || (dat_5f278 != 0)) {
+          server_graceful_state(srv);
+        }
+        if (dat_5f274 == 2) {
+          log_error(*(void **)((int8)srv + 0x98),"server.c",0x7b4,"server stopped after idle timeout");
+        }
+        else if (dat_5f2b0 == 0) {
+          log_error(*(void **)((int8)srv + 0x98),"server.c",0x7b8,"server stopped by UID = %d PID = %d",(uint8)dat_5f1f4,(uint8)dat_5f1f0);
+        }
+      }
+      remove_pid_file(srv);
+      config_log_error_close(srv);
+      if (dat_5f278 == 0) {
+        network_close(srv);
+      }
+      else {
+        v1 = *(uint4 *)((int8)srv + 0x17c);
+        for (v6 = 0; (uint4)v6 < v1; v6 = v6 + 1) {
+          *(void *)(*(int8 *)(*(int8 *)((int8)srv + 0x170) + v6 * 8) + 0x80) = 0;
+        }
+        v1 = *(uint4 *)((int8)srv + 0x18c);
+        for (v6 = 0; (uint4)v6 < v1; v6 = v6 + 1) {
+          *(void *)(*(int8 *)(*(int8 *)((int8)srv + 0x180) + v6 * 8) + 0x80) = 0;
+        }
+        Unique10000480 = *(void *)((int8)srv + 0x170);
+        Unique10000488 = *(void *)((int8)srv + 0x178);
+        Unique10000498 = *(void *)((int8)srv + 0x180);
+        Unique100004a0 = *(void *)((int8)srv + 0x188);
+        *(void *)((int8)srv + 0x170) = 0;
+        *(void *)((int8)srv + 0x178) = 0;
+        *(void *)((int8)srv + 0x180) = 0;
+        *(void *)((int8)srv + 0x188) = 0;
+      }
+      request_pool_free();
+      connections_free(srv);
+      plugins_free(srv);
+      if (1 <= dat_5f2b0) {
+        if (dat_5f2a8 != 0) {
+          fdevent_fdnode_event_del(*(void *)((int8)srv + 0x10));
+          fdevent_unregister(*(fdevents **)((int8)srv + 0x10),dat_5f2b0);
+          dat_5f2a8 = 0;
+        }
+        close(dat_5f2b0);
+      }
+      if (0 <= dat_5f018) {
+        close();
+      }
+      if (0 <= *(int4 *)((int8)srv + 0x1bc)) {
+        close();
+      }
+      buffer_free(*(anon_struct **)((int8)srv + 0x28));
+      fdevent_free(*(fdevents **)((int8)srv + 0x10));
+      config_free(srv);
+      free(*(void **)((int8)srv + 0x40));
+      free(*(void **)((int8)srv + 0x50));
+      free(*(void **)((int8)srv + 0x60));
+      stat_cache_free();
+      li_rand_cleanup();
+      chunkqueue_chunk_pool_free();
+      log_error_st_free(*(log_error_st **)((int8)srv + 0x98));
+      free(srv);
+      if (v2 < 0) {
+        return v2;
+      }
+      if (dat_5f278 == 0) {
+        return v2;
+      }
+      do {
+        v3 = fdevent_waitpid(-1,(int4 *)0x0,0);
+      } while (0 < v3);
+    } while (dat_5f278 != 0);
+  }
+  else {
+    v2 = geteuid();
+    v3 = getuid();
+    if (v2 == v3) {
+      v2 = getegid();
+      v3 = getgid();
+      if (v2 == v3) goto label_f6ec;
+    }
+    v2 = -1;
+    fputs("Are you nuts ? Don\'t apply a SUID bit to this binary\n",dat_5f140);
+  }
+  return v2;
+}
+
+--- metrics (reference | kuna) ---
+  loc           205 | 141 
+  gotos           0 | 1   
+  labels          0 | 1   
+  switches        0 | 0   
+  cases           0 | 0   
+  ifs            20 | 16  
+  loops           6 | 6   
+  ternaries       1 | 1   
+  casts           0 | 0   
+
+--- signals (candidate 'reference is better' hints) ---
+  * ref has fewer gotos (0 vs 1)
+  * ref has fewer labels (0 vs 1)

--- a/docs/features/newburry-main-57ccb1/proposal.md
+++ b/docs/features/newburry-main-57ccb1/proposal.md
@@ -1,0 +1,109 @@
+# [PROPOSAL] angr-newburry-main-57ccb1 — eliminate the SUID-guard goto via condition-based join restructuring
+
+**Status:** draft proposal — needs human go/no-go before any implementation worker is spent.
+
+**Opportunity:** `test_decompiling_newburry_main :: main`
+(`/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/newbury`, lighttpd `server.c::main`, x86_64 @ `0x40f696`).
+
+**Proposed option name:** `gotoreduce` (shared with the sibling proposal — see below; do **not** mint a per-binary option).
+
+## The problem
+
+kuna's `newburry/main` differs from angr's by exactly **one goto + one label**
+(all other metrics match: 6 loops, ~20 ifs, 1 ternary). The goto is a forward
+jump *into* a then-branch:
+
+```c
+  if (getuid() == 0) {
+label_f6ec:  setlocale(...); ... do { server loop } while(...);   // BODY
+  } else {
+    ... if (egid==gid) goto label_f6ec;                            // <-- goto into BODY
+    v2 = -1; fputs("Are you nuts ...", stderr);
+  }
+  return v2;
+```
+
+angr emits zero gotos by **inverting the SUID-check guards** so the exceptional
+`fputs; return -1` path is nested and the shared **BODY** (`setlocale; ...; server
+loop`) becomes the fall-through join:
+
+```c
+  if (getuid()) {
+      if (geteuid() != getuid() || !(getegid() == getgid())) {
+          fputs("Are you nuts ...", stderr); return -1;
+      }
+  }
+  setlocale(...); while (true) { server loop }                     // BODY = fall-through
+```
+
+Full side-by-side: [`angr-vs-kuna.txt`](./angr-vs-kuna.txt). Root-cause analysis:
+[`analysis.md`](./analysis.md).
+
+## Why it is LARGE (Hard rule 7)
+
+The goto is produced in **S8 structuring**,
+`decompiler/crates/kuna-decomp/src/s8_structure/blockaction.rs` — a verbatim port
+of Ghidra's `CollapseStructure`/`TraceDAG`. Reproducing angr's output requires
+**condition-based block-graph restructuring**: invert the guard predicates so the
+exceptional path nests, then re-parent the multi-predecessor BODY out of the first
+`if`-then to become the fall-through join. That is a **new pass type** mutating the
+BlockGraph, not a value-level Action/Rule and not a gated early-return:
+
+- A gated early-return in `blockaction.rs` can only *suppress* the goto fallback;
+  it cannot *synthesize* a guard inversion or re-parent a join — so it would yield
+  invalid/garbled C, not angr's structure.
+- The canonical small template (`kuna_loweredswitch.rs`) is an **S2 pcode** Action,
+  inapplicable to block-graph structuring.
+
+This is the **same root** as two already-filed proposals:
+
+- **`kuna-gotoreduce-gap`** — morton/my_message_callback, **PR #54**: 1 goto+label
+  to a shared *epilogue*; angr *tail-duplicates*. Ruled large (new S8 pass type).
+- **`kuna-irreducible-loop-gap`** — fmt0/main family, **PR #46**: needs promoting
+  kuna's read-only `RegionIdentifier` (`s7_regions/kuna_regionid.rs`) into a real
+  **emit-path SAILR/Phoenix condition-based structurer**.
+
+The pipeline record states this whole goto-reduction family shares **one** root and
+should be closed by **one separately-funded project**, not point fixes. This
+`newburry/main` case is another member: it is a *join-fall-through via guard
+inversion* variant (vs. morton's *tail-duplication* variant), but both are emitted
+by the same `CollapseStructure` fallback and both need the same SAILR emit-path
+structurer.
+
+## Proposed implementation plan (when the family project is funded)
+
+This is **not** a standalone implementation — it folds into the shared SAILR
+emit-path structurer that closes `gotoreduce` (PR #54) and `irreducibleloops`
+(PR #46). The pieces specific to this case:
+
+1. **Promote `s7_regions/kuna_regionid.rs`** from a read-only console surface into
+   an emit-driving structurer (the shared family prerequisite).
+2. Add a **condition-based goto-elimination** transform over the region/block
+   graph that recognizes a multi-predecessor join `J` reached by (a) a then-branch
+   and (b) a forward goto from a sibling branch, where the non-goto remainder of
+   the sibling is a *terminating* path (returns/exits). Transform: invert the
+   sibling's guard chain (de Morgan) so the terminating path nests, hoist `J` to be
+   the fall-through join after the merged guard, and drop the goto+label.
+3. Gate the whole structurer behind the **`gotoreduce`** option (default OFF while
+   developing), early-returning to byte-identical output when off.
+4. Verify on the family corpus (morton, newburry, and the irreducible-loop set)
+   under one option to avoid per-binary option sprawl.
+
+## Speed / risk assessment
+
+- **Risk:** high — block-graph restructuring is the most semantically delicate part
+  of the pipeline; an incorrect guard inversion produces *wrong* C, not just ugly C.
+  Must be guarded by strict shape preconditions (terminating sibling remainder,
+  single join, no intervening side effects on the inverted predicate evaluation
+  order) and validated against the full 675-assertion datatest corpus.
+- **Speed:** an S8 graph pass over already-collapsed structure; expected within the
+  +5% budget, but must be measured on the family corpus (newburry/main is a large
+  function — good speed canary). Not measured in this proposal (no implementation).
+- **Default:** even if the family ablation is clean, this stays **opt-in** until the
+  shared structurer is proven across the whole family.
+
+## Recommendation
+
+Do **not** dispatch a standalone implementation worker for `newburry/main`. Fold it
+into the funded **`gotoreduce` / SAILR emit-path structurer** project (PR #54 / PR
+#46). Track this binary as a *regression target* for that project.

--- a/docs/features/newburry-main-57ccb1/record.json
+++ b/docs/features/newburry-main-57ccb1/record.json
@@ -1,0 +1,27 @@
+{
+  "opportunity": "test_decompiling_newburry_main::main",
+  "test_name": "test_decompiling_newburry_main",
+  "binary": "/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/newbury",
+  "selector": "main",
+  "func_addr": "0x40f696",
+  "angr_version": "9.2.213",
+  "option": "gotoreduce",
+  "change_kind": "structure-recovery",
+  "source_decompiler": "angr",
+  "inspiration": "test_decompiling_newburry_main; SAILR/Phoenix RegionIdentifier condition-based structurer (guard inversion + join fall-through); main",
+  "scope": "large",
+  "proposal": true,
+  "is_member_of_known_family": "gotoreduce",
+  "decisions": [
+    {
+      "question": "Is closing the newburry/main goto+label gap small (one option-gated Action/Rule) or large (new S8/S7 structuring infrastructure)?",
+      "decider_verdict": {
+        "scope": "large",
+        "owning_stage": "S8",
+        "rationale": "The lone goto+label is emitted by blockaction.rs, a verbatim port of Ghidra CollapseStructure/TraceDAG. Matching angr requires INVERTING the guard conditions so the exceptional fputs;return -1 path nests and BODY becomes the fall-through join — condition-based block-graph restructuring (the SAILR/Phoenix layer), not a value-level Action. loweredswitch is an S2 pcode Rule, not a structuring template, so it doesn't apply. No existing schema inverts a guard or re-parents a join, and a single gated early-return can't synthesize that shape byte-identically. This is the same root as gotoreduce/irreducible-loop: it needs the separately-funded SAILR emit-path structurer (promoting read-only kuna_regionid into the emit path). Per Hard rule 7 and the family directive, STOP-and-propose.",
+        "is_member_of_known_family": "gotoreduce",
+        "recommended_action": "propose"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# [PROPOSAL] angr-newburry-main-57ccb1 — eliminate the SUID-guard goto via condition-based join restructuring

**Status:** draft proposal — needs human go/no-go before any implementation worker is spent.

**Opportunity:** `test_decompiling_newburry_main :: main`
(`/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/newbury`, lighttpd `server.c::main`, x86_64 @ `0x40f696`).

**Proposed option name:** `gotoreduce` (shared with the sibling proposal — see below; do **not** mint a per-binary option).

## The problem

kuna's `newburry/main` differs from angr's by exactly **one goto + one label**
(all other metrics match: 6 loops, ~20 ifs, 1 ternary). The goto is a forward
jump *into* a then-branch:

```c
  if (getuid() == 0) {
label_f6ec:  setlocale(...); ... do { server loop } while(...);   // BODY
  } else {
    ... if (egid==gid) goto label_f6ec;                            // <-- goto into BODY
    v2 = -1; fputs("Are you nuts ...", stderr);
  }
  return v2;
```

angr emits zero gotos by **inverting the SUID-check guards** so the exceptional
`fputs; return -1` path is nested and the shared **BODY** (`setlocale; ...; server
loop`) becomes the fall-through join:

```c
  if (getuid()) {
      if (geteuid() != getuid() || !(getegid() == getgid())) {
          fputs("Are you nuts ...", stderr); return -1;
      }
  }
  setlocale(...); while (true) { server loop }                     // BODY = fall-through
```

Full side-by-side: [`angr-vs-kuna.txt`](./angr-vs-kuna.txt). Root-cause analysis:
[`analysis.md`](./analysis.md).

## Why it is LARGE (Hard rule 7)

The goto is produced in **S8 structuring**,
`decompiler/crates/kuna-decomp/src/s8_structure/blockaction.rs` — a verbatim port
of Ghidra's `CollapseStructure`/`TraceDAG`. Reproducing angr's output requires
**condition-based block-graph restructuring**: invert the guard predicates so the
exceptional path nests, then re-parent the multi-predecessor BODY out of the first
`if`-then to become the fall-through join. That is a **new pass type** mutating the
BlockGraph, not a value-level Action/Rule and not a gated early-return:

- A gated early-return in `blockaction.rs` can only *suppress* the goto fallback;
  it cannot *synthesize* a guard inversion or re-parent a join — so it would yield
  invalid/garbled C, not angr's structure.
- The canonical small template (`kuna_loweredswitch.rs`) is an **S2 pcode** Action,
  inapplicable to block-graph structuring.

This is the **same root** as two already-filed proposals:

- **`kuna-gotoreduce-gap`** — morton/my_message_callback, **PR #54**: 1 goto+label
  to a shared *epilogue*; angr *tail-duplicates*. Ruled large (new S8 pass type).
- **`kuna-irreducible-loop-gap`** — fmt0/main family, **PR #46**: needs promoting
  kuna's read-only `RegionIdentifier` (`s7_regions/kuna_regionid.rs`) into a real
  **emit-path SAILR/Phoenix condition-based structurer**.

The pipeline record states this whole goto-reduction family shares **one** root and
should be closed by **one separately-funded project**, not point fixes. This
`newburry/main` case is another member: it is a *join-fall-through via guard
inversion* variant (vs. morton's *tail-duplication* variant), but both are emitted
by the same `CollapseStructure` fallback and both need the same SAILR emit-path
structurer.

## Proposed implementation plan (when the family project is funded)

This is **not** a standalone implementation — it folds into the shared SAILR
emit-path structurer that closes `gotoreduce` (PR #54) and `irreducibleloops`
(PR #46). The pieces specific to this case:

1. **Promote `s7_regions/kuna_regionid.rs`** from a read-only console surface into
   an emit-driving structurer (the shared family prerequisite).
2. Add a **condition-based goto-elimination** transform over the region/block
   graph that recognizes a multi-predecessor join `J` reached by (a) a then-branch
   and (b) a forward goto from a sibling branch, where the non-goto remainder of
   the sibling is a *terminating* path (returns/exits). Transform: invert the
   sibling's guard chain (de Morgan) so the terminating path nests, hoist `J` to be
   the fall-through join after the merged guard, and drop the goto+label.
3. Gate the whole structurer behind the **`gotoreduce`** option (default OFF while
   developing), early-returning to byte-identical output when off.
4. Verify on the family corpus (morton, newburry, and the irreducible-loop set)
   under one option to avoid per-binary option sprawl.

## Speed / risk assessment

- **Risk:** high — block-graph restructuring is the most semantically delicate part
  of the pipeline; an incorrect guard inversion produces *wrong* C, not just ugly C.
  Must be guarded by strict shape preconditions (terminating sibling remainder,
  single join, no intervening side effects on the inverted predicate evaluation
  order) and validated against the full 675-assertion datatest corpus.
- **Speed:** an S8 graph pass over already-collapsed structure; expected within the
  +5% budget, but must be measured on the family corpus (newburry/main is a large
  function — good speed canary). Not measured in this proposal (no implementation).
- **Default:** even if the family ablation is clean, this stays **opt-in** until the
  shared structurer is proven across the whole family.

## Recommendation

Do **not** dispatch a standalone implementation worker for `newburry/main`. Fold it
into the funded **`gotoreduce` / SAILR emit-path structurer** project (PR #54 / PR
#46). Track this binary as a *regression target* for that project.
