### PR TITLE
regionstructure Inc 4: switch-case recovery

### DIFF
--- a/decompiler/crates/kuna-decomp/src/s8_structure/region_structurer.rs
+++ b/decompiler/crates/kuna-decomp/src/s8_structure/region_structurer.rs
@@ -37,10 +37,28 @@
 //!    ([`s9_emit::printc`](crate::printc)) and `ActionFinalStructure`'s
 //!    `mark_unstructured` are happy.
 //!
-//! Loops, if/else (ITE), switches and short-circuit folding are **later
-//! increments**; in Inc 1 they fall back to virtualized gotos (honest-partial,
-//! never a panic).  Because the virtualize fallback always removes one edge, the
-//! loop always converges to a single structured root — there is no "stuck" state.
+//! # Increment 4 scope (switch-case recovery)
+//!
+//! [`match_acyclic_switch_cases`](RegionStructurer::match_acyclic_switch_cases)
+//! recovers resolved jump-table switches natively: it matches the `f_switch_out`
+//! head (the kuna analog of angr
+//! `phoenix._match_acyclic_switch_cases_address_computed` →
+//! `_switch_build_cases` → `_make_switch_cases_core`), resolves the recovered
+//! [`JumpTable`](crate::jumptable::JumpTable) via the precomputed
+//! `switch_blocks`/`switch_case_edges` maps (the same data Ghidra's
+//! `CollapseStructure::ruleBlockSwitch` consumes), and folds it into a
+//! [`BlockSwitch`](crate::block::BlockKind::Switch) carrying the
+//! [`CaseOrder`](crate::block::CaseOrder) descriptors
+//! `ActionFinalStructure::finalize_switch_printing` expects.  This is what lets a
+//! switch region structure natively instead of forcing the whole function back to
+//! `CollapseStructure` — the prerequisite for loop+switch (getopt-style) functions
+//! getting the loop win once the cyclic schemas land.
+//!
+//! Loops (the cyclic schemas) and short-circuit folding are **later increments**;
+//! a region the matched schemas cannot fold falls back to virtualized gotos
+//! (honest-partial, never a panic).  Because the virtualize fallback always removes
+//! one edge, the loop always converges to a single structured root — there is no
+//! "stuck" state.
 //!
 //! # Honest-partial safety
 //!

--- a/decompiler/crates/kuna-decomp/src/s8_structure/region_structurer.rs
+++ b/decompiler/crates/kuna-decomp/src/s8_structure/region_structurer.rs
@@ -119,11 +119,66 @@ pub fn run_region_structurer(data: &mut Funcdata) -> KunaResult<bool> {
     let mut ri = crate::s7_regions::kuna_regionid::KunaRegionIdentifier::new();
     let _ = ri.build_from_block_graph(data).and_then(|()| ri.compute().map(|_| ()));
 
+    // ---- 1b. Precompute the switch/jump-table maps over bblocks (Inc 4) -------
+    // The switch-case schema (`match_acyclic_switch_cases`) needs the same two maps
+    // `ActionBlockStructure::apply` builds for `CollapseStructure`: `switch_blocks`
+    // (the bblocks switch BlockBasic → `Funcdata::jumpvec` slot, C++ `BlockSwitch(ind)`'s
+    // `ind->getJumptable()`) and `switch_case_edges` (the per-switch case-edge topology
+    // `(switch_bb, target_bb) → (outindex, isdefault)`, C++ `BlockSwitch::addCase`'s
+    // `getInIndex`/`isDefaultBranch`).  Built here against `data` (whose switch
+    // in/out edges structuring never severs) before the `sblocks_mut` borrow.
+    let (switch_blocks, switch_case_edges) = compute_switch_maps(data);
+
     // ---- 2. Structure the seeded sblocks graph -------------------------------
     let sroot = data.sblocks_root();
     let graph = data.sblocks_mut();
-    let mut st = RegionStructurer::new(graph, sroot);
+    let mut st = RegionStructurer::new(graph, sroot)
+        .with_switch_maps(switch_blocks, switch_case_edges);
     st.structure()
+}
+
+/// Precompute the bblocks switch-block → jumpvec-slot map and the per-switch
+/// case-edge topology map over `data` (Inc 4).
+///
+/// A mirror of the precomputation in
+/// [`ActionBlockStructure::apply`](crate::blockaction::ActionBlockStructure) so the
+/// region structurer's switch schema feeds [`BlockGraph::new_block_switch`] exactly
+/// the maps Ghidra's `CollapseStructure::ruleBlockSwitch` does.  A bblocks
+/// `BlockBasic` is a switch block when it `is_switch_out` and its tail BRANCHIND
+/// has a recovered `JumpTable` (`find_jump_table_index`); the case-edge map records
+/// each switch's first out-edge to every target as `(outindex, isdefault)` (C++
+/// `getInIndex` returns the first matching in-edge).
+#[allow(clippy::type_complexity)]
+fn compute_switch_maps(
+    data: &Funcdata,
+) -> (
+    std::collections::BTreeMap<BlockId, usize>,
+    std::collections::BTreeMap<(BlockId, BlockId), (int4, bool)>,
+) {
+    let mut switch_blocks: std::collections::BTreeMap<BlockId, usize> =
+        std::collections::BTreeMap::new();
+    let nbb = data.bblocks_get_size();
+    for i in 0..nbb {
+        let bb = data.bblocks_get_block(i);
+        if data.bblocks_ref().block(bb).is_switch_out() {
+            if let Some(indop) = data.bb_op_tail(bb) {
+                if let Some(jt_idx) = data.find_jump_table_index(indop) {
+                    switch_blocks.insert(bb, jt_idx);
+                }
+            }
+        }
+    }
+    let mut switch_case_edges: std::collections::BTreeMap<(BlockId, BlockId), (int4, bool)> =
+        std::collections::BTreeMap::new();
+    for &sbb in switch_blocks.keys() {
+        let nout = data.bblocks_ref().block(sbb).size_out();
+        for j in 0..nout {
+            let target = data.bblocks_ref().block(sbb).get_out(j);
+            let isdef = data.bblocks_ref().block(sbb).is_default_branch(j);
+            switch_case_edges.entry((sbb, target)).or_insert((j, isdef));
+        }
+    }
+    (switch_blocks, switch_case_edges)
 }
 
 /// The acyclic sequence + virtualize structuring engine, operating on the
@@ -134,11 +189,35 @@ struct RegionStructurer<'a> {
     graph: &'a mut BlockGraph,
     /// The root BlockGraph node id (its `list` holds the live components).
     graph_id: BlockId,
+    /// The bblocks switch BlockBasic → `Funcdata::jumpvec` slot map (Inc 4), keyed
+    /// by the bblocks id each `sblocks` `BlockCopy` exit-leaf's `copy` references
+    /// (C++ `BlockSwitch(ind)`'s `ind->getJumptable()`).  Empty ⇒ no switch schema.
+    switch_blocks: std::collections::BTreeMap<BlockId, usize>,
+    /// The per-switch case-edge topology `(switch_bb, target_bb) → (outindex,
+    /// isdefault)` over bblocks (Inc 4), fed to [`BlockGraph::new_block_switch`]
+    /// (C++ `BlockSwitch::addCase`).
+    switch_case_edges: std::collections::BTreeMap<(BlockId, BlockId), (int4, bool)>,
 }
 
 impl<'a> RegionStructurer<'a> {
     fn new(graph: &'a mut BlockGraph, graph_id: BlockId) -> RegionStructurer<'a> {
-        RegionStructurer { graph, graph_id }
+        RegionStructurer {
+            graph,
+            graph_id,
+            switch_blocks: std::collections::BTreeMap::new(),
+            switch_case_edges: std::collections::BTreeMap::new(),
+        }
+    }
+
+    /// Attach the precomputed switch/jump-table maps (Inc 4 switch schema).
+    fn with_switch_maps(
+        mut self,
+        switch_blocks: std::collections::BTreeMap<BlockId, usize>,
+        switch_case_edges: std::collections::BTreeMap<(BlockId, BlockId), (int4, bool)>,
+    ) -> Self {
+        self.switch_blocks = switch_blocks;
+        self.switch_case_edges = switch_case_edges;
+        self
     }
 
     /// Number of live top-level components in the structuring graph
@@ -167,6 +246,16 @@ impl<'a> RegionStructurer<'a> {
                 return Ok(false);
             }
 
+            // (a0) acyclic switch-case schema (phoenix._match_acyclic_switch_cases*,
+            //      Inc 4).  Must run before the sequence/ITE schemas (which already
+            //      refuse `is_switch_out` nodes), mirroring Ghidra's pass order where
+            //      a nested switch resolves before its surrounding structure.  Emits
+            //      a `BlockSwitch` carrying the `CaseOrder` descriptors
+            //      `ActionFinalStructure::finalize_switch_printing` expects, so the
+            //      switch-finalization/rendering path is unchanged.
+            if self.match_acyclic_switch_cases()? {
+                continue;
+            }
             // (a) acyclic sequence schema (phoenix._match_acyclic_sequence).
             if self.match_acyclic_sequence()? {
                 continue;
@@ -380,6 +469,246 @@ impl<'a> RegionStructurer<'a> {
         let graph_id = self.graph_id;
         self.graph.new_block_if(graph_id, bl, clause);
         Ok(true)
+    }
+
+    // -----------------------------------------------------------------------
+    // (a0) acyclic switch-case schema — phoenix._match_acyclic_switch_cases*
+    //      (Inc 4).  kuna structural form: the switch is a node flagged
+    //      `f_switch_out` whose out-edges (case + default + exit) carry the jump
+    //      table's edge labels (built by `seed_sblocks_copy`); the recovered
+    //      `JumpTable` lives in `Funcdata::jumpvec`, resolved via the precomputed
+    //      `switch_blocks`/`switch_case_edges` maps.  No claripy / AIL
+    //      condition-processor is needed — the case topology *is* the edge set.
+    //      This is the kuna analog of angr
+    //      `phoenix._match_acyclic_switch_cases_address_computed` →
+    //      `_switch_build_cases` → `_make_switch_cases_core`, realized over kuna's
+    //      `BlockSwitch` builder (the same path Ghidra's `ruleBlockSwitch` drives).
+    // -----------------------------------------------------------------------
+
+    /// Find a structured switch region and fold it into a
+    /// [`BlockSwitch`](crate::block::BlockKind::Switch).
+    ///
+    /// Port of angr `phoenix._match_acyclic_switch_cases` (the
+    /// `*_address_computed` resolved-jump-table arm kuna already has the data for).
+    /// The topological match mirrors Ghidra `CollapseStructure::ruleBlockSwitch`:
+    /// a `f_switch_out` head whose cases each have a single in-edge from the head
+    /// and at most one out-edge to a common exit block.  Returns `Ok(true)` once a
+    /// switch is folded (or a skip-edge is virtualized to a goto, which makes
+    /// progress); honest-partial: a switch we cannot match falls through to the
+    /// virtualize fallback (never a panic, never a whole-function abort).
+    fn match_acyclic_switch_cases(&mut self) -> KunaResult<bool> {
+        if self.switch_blocks.is_empty() {
+            return Ok(false); // no recovered jump table ⇒ no switch schema
+        }
+        let n = self.size();
+        for i in 0..n {
+            let bl = self.component(i);
+            if self.try_switch_cases(bl)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Attempt to fold the switch rooted at `bl` (port of Ghidra
+    /// `CollapseStructure::ruleBlockSwitch`, `blockaction.cc:1649`, realized in the
+    /// region structurer).  Mirrors the exact case/exit/skip topology checks; on a
+    /// clean match emits `BlockSwitch` via [`BlockGraph::new_block_switch`].
+    fn try_switch_cases(&mut self, bl: BlockId) -> KunaResult<bool> {
+        if !self.graph.block(bl).is_switch_out() {
+            return Ok(false);
+        }
+        // Only proceed if this switch has a recovered jump table (`getJumptable()`
+        // ≠ 0); else there is no case-label source and `new_block_switch` would be
+        // meaningless — leave it to virtualize (honest partial).
+        let jt_index = match self.switch_jt_index(bl) {
+            Some(j) => j,
+            None => return Ok(false),
+        };
+
+        let sizeout = self.graph.block(bl).size_out();
+        let mut exitblock: Option<BlockId> = None;
+
+        // --- Find the "obvious" exit block (ruleBlockSwitch first loop) ---------
+        for i in 0..sizeout {
+            let curbl = self.graph.block(bl).get_out(i);
+            if curbl == bl {
+                exitblock = Some(curbl); // exit back to top of switch (loop)
+                break;
+            }
+            if self.graph.block(curbl).size_out() > 1 {
+                exitblock = Some(curbl);
+                break;
+            }
+            if self.graph.block(curbl).size_in() > 1 {
+                exitblock = Some(curbl);
+                break;
+            }
+        }
+
+        if exitblock.is_none() {
+            // Every immediate block has sizeIn==1 and sizeOut<=1.
+            for i in 0..sizeout {
+                let curbl = self.graph.block(bl).get_out(i);
+                if self.graph.block(curbl).is_goto_in(0) {
+                    return Ok(false); // in cannot be a goto
+                }
+                if self.graph.block(curbl).is_switch_out() {
+                    return Ok(false); // resolve nested switch first
+                }
+                if self.graph.block(curbl).size_out() == 1 {
+                    if self.graph.block(curbl).is_goto_out(0) {
+                        return Ok(false); // out cannot be goto
+                    }
+                    let curout = self.graph.block(curbl).get_out(0);
+                    if let Some(e) = exitblock {
+                        if e != curout {
+                            return Ok(false);
+                        }
+                    } else {
+                        exitblock = Some(curout);
+                    }
+                }
+            }
+        } else if let Some(e) = exitblock {
+            // A determined exit block: no in/out gotos on it, and every case must
+            // fall through only to it.
+            for i in 0..self.graph.block(e).size_in() {
+                if self.graph.block(e).is_goto_in(i) {
+                    return Ok(false);
+                }
+            }
+            for i in 0..self.graph.block(e).size_out() {
+                if self.graph.block(e).is_goto_out(i) {
+                    return Ok(false);
+                }
+            }
+            for i in 0..sizeout {
+                let curbl = self.graph.block(bl).get_out(i);
+                if curbl == e {
+                    continue; // switch can go straight to the exit
+                }
+                if self.graph.block(curbl).size_in() > 1 {
+                    return Ok(false); // only the switch may fall into a case
+                }
+                if self.graph.block(curbl).is_goto_in(0) {
+                    return Ok(false);
+                }
+                if self.graph.block(curbl).size_out() > 1 {
+                    return Ok(false); // at most one exit from a case
+                }
+                if self.graph.block(curbl).size_out() == 1 {
+                    if self.graph.block(curbl).is_goto_out(0) {
+                        return Ok(false);
+                    }
+                    if self.graph.block(curbl).get_out(0) != e {
+                        return Ok(false); // which must be the exit block
+                    }
+                }
+                if self.graph.block(curbl).is_switch_out() {
+                    return Ok(false); // nested switch first
+                }
+            }
+        }
+
+        // --- Skip-to-exit handling (checkSwitchSkips) ---------------------------
+        // If a non-default case edge goes straight to the exit while the default
+        // does not, virtualize those skip edges to gotos (progress) and bail this
+        // round; the next round re-matches.  Returns Ok(true) (progress made).
+        if !self.check_switch_skips(bl, exitblock)? {
+            return Ok(true);
+        }
+
+        // --- Collect the case components (ruleBlockSwitch tail) ----------------
+        let mut cases: Vec<BlockId> = vec![bl];
+        for i in 0..sizeout {
+            let curbl = self.graph.block(bl).get_out(i);
+            if Some(curbl) == exitblock {
+                continue; // the exit is not a case
+            }
+            cases.push(curbl);
+        }
+
+        let graph_id = self.graph_id;
+        let switch_case_edges = std::mem::take(&mut self.switch_case_edges);
+        let res = self.graph.new_block_switch(
+            graph_id,
+            &cases,
+            exitblock.is_some(),
+            jt_index,
+            &switch_case_edges,
+        );
+        self.switch_case_edges = switch_case_edges;
+        // new_block_switch can fail if the exit-leaf is not a BlockCopy (should not
+        // happen for a real switch head, but keep it honest-partial: report no
+        // match so the fallback virtualizes rather than aborting the run).
+        match res {
+            Ok(_) => Ok(true),
+            Err(_) => Ok(false),
+        }
+    }
+
+    /// Resolve this switch head's `Funcdata::jumpvec` slot via its exit-leaf
+    /// `BlockCopy`'s `copy` (the bblocks BlockBasic carrying the BRANCHIND) against
+    /// the precomputed `switch_blocks` map (C++ `BlockSwitch(ind)`'s
+    /// `ind->getJumptable()`).  `None` ⇒ no recovered table for this head.
+    fn switch_jt_index(&self, bl: BlockId) -> Option<usize> {
+        let leaf = self.graph.get_exit_leaf(bl)?;
+        let bb = self.graph.block(leaf).get_copy()?;
+        self.switch_blocks.get(&bb).copied()
+    }
+
+    /// Convert any non-default switch edge that skips straight to the exit into a
+    /// goto (port of Ghidra `CollapseStructure::checkSwitchSkips`,
+    /// `blockaction.cc:1607`).  Returns `Ok(false)` (and marks the gotos) when such
+    /// skip edges exist alongside a default that does not go to the exit — the
+    /// switch then re-matches next round; otherwise `Ok(true)` (clean to fold).
+    fn check_switch_skips(
+        &mut self,
+        switchbl: BlockId,
+        exitblock: Option<BlockId>,
+    ) -> KunaResult<bool> {
+        let exitblock = match exitblock {
+            Some(e) => e,
+            None => return Ok(true),
+        };
+        let sizeout = self.graph.block(switchbl).size_out();
+        let mut defaultnottoexit = false;
+        let mut anyskiptoexit = false;
+        for edgenum in 0..sizeout {
+            if self.graph.block(switchbl).get_out(edgenum) == exitblock {
+                if !self.graph.block(switchbl).is_default_branch(edgenum) {
+                    anyskiptoexit = true;
+                }
+            } else if self.graph.block(switchbl).is_default_branch(edgenum) {
+                defaultnottoexit = true;
+            }
+        }
+        if !anyskiptoexit {
+            return Ok(true);
+        }
+        if !defaultnottoexit
+            && self.graph.block(switchbl).get_type() == crate::block::BlockType::MultiGoto
+        {
+            if let crate::block::BlockKind::MultiGoto { defaultswitch, .. } =
+                self.graph.block(switchbl).kind()
+            {
+                if *defaultswitch {
+                    defaultnottoexit = true;
+                }
+            }
+        }
+        if !defaultnottoexit {
+            return Ok(true);
+        }
+        for edgenum in 0..sizeout {
+            if self.graph.block(switchbl).get_out(edgenum) == exitblock
+                && !self.graph.block(switchbl).is_default_branch(edgenum)
+            {
+                self.graph.set_goto_branch(switchbl, edgenum)?;
+            }
+        }
+        Ok(false)
     }
 
     // -----------------------------------------------------------------------

--- a/docs/baseline-stages.json
+++ b/docs/baseline-stages.json
@@ -1,7 +1,7 @@
 {
   "data_footer": [
-    190,
-    190
+    196,
+    196
   ],
   "passing": [
     "data:BRANCHFLIP #1: default pipeline keeps the negated `== 0` guard (opt-in is default-off)",
@@ -190,6 +190,12 @@
     "data:regionstructure #2: the else clause is structured, both passes",
     "data:regionstructure #3: the join sequence + tail return is recovered, both passes",
     "data:regionstructure #4: ZERO gotos  -  region structurer matches Ghidra's acyclic structuring (parity)",
+    "data:regionstructure-switch #1: the switch head is recovered, both passes",
+    "data:regionstructure-switch #2: case 0, both passes",
+    "data:regionstructure-switch #3: case 3 (middle of the dense table), both passes",
+    "data:regionstructure-switch #4: case 6 (last case), both passes",
+    "data:regionstructure-switch #5: the default case is recovered, both passes",
+    "data:regionstructure-switch #6: ZERO gotos  -  region structurer recovers the switch natively (parity with Ghidra)",
     "data:tee-O2 tail-jumps #1: indirect-jump-as-call marker (pass 1 off only)",
     "data:tee-O2 tail-jumps #2: unresolved GOT-pointer indirect call (pass 1 off only)",
     "data:tee-O2 tail-jumps #3: tail call resolves to named setlocale (pass 2 on only)",

--- a/tests/stages/regionstructure-switch.xml
+++ b/tests/stages/regionstructure-switch.xml
@@ -1,0 +1,90 @@
+<decompilertest>
+<binaryimage arch="x86:LE:64:default:gcc">
+<!--
+    Region-based (Phoenix/SAILR) structurer, Increment 4  -  acyclic switch-case
+    recovery.  Option `regionstructure` (default OFF).  This proves the region
+    structurer recovers a resolved jump-table switch NATIVELY (emits a
+    `BlockSwitch` from its own `match_acyclic_switch_cases` schema) instead of
+    whole-function-falling-back to Ghidra's `CollapseStructure` on switch code  -
+    the prerequisite for loop+switch functions (getopt-style) getting the loop
+    win once Inc 3's cyclic schemas land.
+
+    `dispatch` is a dense 7-way jump-table switch (x86-64, GCC -O1, no-PIE; the
+    bytes [0x401106, 0x401149) of a linked executable, the jump table at
+    0x402008, the one global `g` at 0x40402c).  Source:
+
+        volatile int g;
+        int dispatch(int sel, int x) {
+            int r;
+            switch (sel) {                       // dense table, sel = 0..6
+                case 0: r = x + 10; break;
+                case 1: r = x - 7;  break;
+                case 2: r = x * 3;  break;
+                case 3: r = x ^ 5;  break;
+                case 4: r = x | 8;  break;
+                case 5: r = x & 12; break;
+                case 6: r = x << 1; break;
+                default: r = 0;     break;
+            }
+            g = r;
+            return r;
+        }
+
+    Under `option regionstructure on`, `ActionBlockStructure` swaps Ghidra's
+    `CollapseStructure` for the region structurer
+    (`s8_structure::region_structurer`).  Its Inc 4 switch schema
+    (`match_acyclic_switch_cases`, the kuna analog of angr
+    `phoenix._match_acyclic_switch_cases_address_computed` ->
+    `_switch_build_cases` -> `_make_switch_cases_core`) matches the `f_switch_out`
+    head, resolves the recovered `JumpTable` via the precomputed
+    `switch_blocks`/`switch_case_edges` maps (the same data
+    `CollapseStructure::ruleBlockSwitch` consumes), and folds it into a
+    `BlockSwitch` carrying the `CaseOrder` descriptors
+    `ActionFinalStructure::finalize_switch_printing` expects  -  so the existing
+    switch finalization/rendering path runs unchanged.
+
+    Parity proof: the region-driven switch recovery is byte-identical to Ghidra's
+    `CollapseStructure` on this switch  -  pass 1 (off) and pass 2 (on) emit the
+    SAME C, both ZERO gotos.  Per the Inc 1 finding, Ghidra's switch recovery is
+    already good, so the OUTPUT MATCHES Ghidra rather than beating it; the POINT
+    of Inc 4 is the region structurer handling switches NATIVELY (so it no longer
+    whole-function-falls-back on switch+loop code).  See
+    docs/region-structurer-roadmap.md (Inc 4 row).
+
+    Stage model: S8 "structuring".  `option regionstructure off` (default) is
+    byte-identical to the existing pipeline; `on` swaps in the region structurer.
+    The asserted invariants hold across BOTH passes, so the counts are 2x the
+    per-pass count.
+-->
+<bytechunk space="ram" offset="0x401106" readonly="true">
+f30f1efa89f083ff06773189ff3eff24
+fd0820400083c00a8905082f0000c383
+e807ebf48d0476ebef83f005ebea83c8
+08ebe583e00cebe001c0ebdcb8000000
+00ebd5
+</bytechunk>
+<bytechunk space="ram" offset="0x402008" readonly="true">
+1b114000000000002511400000000000
+2a114000000000002f11400000000000
+341140000000000039114000000000
+003e11400000000000
+</bytechunk>
+<symbol space="ram" offset="0x401106" name="dispatch"/>
+</binaryimage>
+<script>
+  <com>option regionstructure off</com>
+  <com>lo fu dispatch</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>option regionstructure on</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="regionstructure-switch #1: the switch head is recovered, both passes" min="2" max="2">switch\(a0\) \{</stringmatch>
+<stringmatch name="regionstructure-switch #2: case 0, both passes" min="2" max="2">    case 0:</stringmatch>
+<stringmatch name="regionstructure-switch #3: case 3 (middle of the dense table), both passes" min="2" max="2">    case 3:</stringmatch>
+<stringmatch name="regionstructure-switch #4: case 6 (last case), both passes" min="2" max="2">    case 6:</stringmatch>
+<stringmatch name="regionstructure-switch #5: the default case is recovered, both passes" min="2" max="2">    default:</stringmatch>
+<stringmatch name="regionstructure-switch #6: ZERO gotos  -  region structurer recovers the switch natively (parity with Ghidra)" min="0" max="0">goto </stringmatch>
+</decompilertest>


### PR DESCRIPTION
## regionstructure Inc 4 — acyclic switch-case recovery (`BlockSwitch`)

Increment 4 of the region-structurer roadmap (`docs/region-structurer-roadmap.md`,
Inc 4 row). Builds on Inc 1 (merged, #71); parallel to Inc 3 (loops). **Default-OFF,
parity-safe.**

### What this does

Makes the region structurer (option `regionstructure`, default-OFF) recover resolved
jump-table switches **natively** — emitting a `BlockSwitch` from its own schema —
instead of whole-function-falling-back to Ghidra's `CollapseStructure` whenever a
function contains a switch. This is the prerequisite for loop+switch (getopt-style)
functions getting the loop win once the cyclic schemas land: the structurer no longer
bails on the switch and surrenders the whole function.

Port of angr `phoenix._match_acyclic_switch_cases_address_computed` →
`_switch_build_cases` → `_make_switch_cases_core`, realized in kuna's structural idiom
(the same topology Ghidra `CollapseStructure::ruleBlockSwitch` drives — exactly how
Inc 1's ITE schema reuses `ruleBlockIfElse` rather than angr's claripy form).

### Implementation (all in `region_structurer.rs`)

- `run_region_structurer` precomputes the `switch_blocks` (switch `BlockBasic` →
  `Funcdata::jumpvec` slot) and `switch_case_edges` (`(switch_bb, target_bb) →
  (outindex, isdefault)`) maps over `bblocks` — the same data
  `ActionBlockStructure::apply` already builds for `CollapseStructure` — and threads
  them into `RegionStructurer` via `with_switch_maps`.
- `match_acyclic_switch_cases` / `try_switch_cases` match the `f_switch_out` head,
  apply the exact `ruleBlockSwitch` case/exit/skip topology checks (plus a
  `check_switch_skips` port), and fold the switch into a `BlockSwitch` via the existing
  `BlockGraph::new_block_switch`, carrying the `CaseOrder` descriptors
  `ActionFinalStructure::finalize_switch_printing` expects — so the switch
  finalization/rendering path runs **unchanged**.
- Wired into `structure()` **before** the sequence/ITE schemas (which already refuse
  `is_switch_out` nodes), mirroring Ghidra's pass order. Honest-partial: a switch it
  can't match falls through to the virtualize-to-goto fallback — never panics, never
  whole-function-aborts.

All additions are self-contained new functions; **`blockaction.rs` is untouched**, to
minimize merge conflict with the concurrent Inc 3 loop work.

### Proof

`tests/stages/regionstructure-switch.xml` — a dense 7-way jump-table switch on a
loadable x86-64 ELF. With `regionstructure on` the structurer emits a proper
`switch(){case...}` (a `BlockSwitch`), byte-identical to Ghidra and zero gotos; OFF is
unchanged. Verified (via trace) that the `BlockSwitch` comes from the region
structurer's own schema, **not** the `CollapseStructure` fall-back.

Bonus loop+switch: a `do/while` + inner switch function stays byte-identical OFF vs ON
(no regression). The loop region falls back to `CollapseStructure` until Inc 3's cyclic
schemas merge; the switch inside it now structures natively either way.

Per the Inc 1 finding, Ghidra's switch recovery is already good, so the output
**matches** Ghidra rather than beating it — the point is the region structurer handling
switches natively.

### Gates

- `make test` — **PARITY OK** (675/675 byte-identical; `docs/baseline.json` untouched).
- `make test-stages` — **PARITY OK** (196/196; `docs/baseline-stages.json` regenerated, +6).
- `make rust-test` — green.
- `kuna catalog --check` — OK; `docs/assertions.md` unchanged (Inc 4 extends the existing
  `regionstructure` option, no new option).
- Speed: ON vs OFF decompile within noise (~1–2 ms on the switch testcase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBrckq3YYAzBLq5k4KpWac
