### PR TITLE
[PROPOSAL] angr-tr-o2-parse-str-7b9159: cyclic loop-refinement structuring (parse_str 37→11 gotos)

### DIFF
--- a/docs/features/tr-o2-parse-str-7b9159/analysis.md
+++ b/docs/features/tr-o2-parse-str-7b9159/analysis.md
@@ -1,0 +1,85 @@
+# Analysis — `tr_O2.o::parse_str` (angr vs kuna)
+
+- **angr testcase:** `test_decompiling_tr_O2_parse_str` (`angr/tests/analyses/decompiler/test_decompiler.py:3582`)
+- **Binary:** `tests/x86_64/decompiler/tr_O2.o`  ·  **Function:** `parse_str` @ `0x400a20`  ·  arch `x86_64`
+- **angr version:** 9.2.213
+- The angr assertion is weak — `line_count > 20` ("it was failing structuring"). kuna already
+  emits 354 lines, so kuna *passes that literal assertion*. The real gap surfaced by the
+  pipeline is **structuring quality**.
+
+## What angr does better
+
+angr's SAILR/Phoenix structurer renders `parse_str` as a clean nested loop:
+
+```c
+v23 = *(ptr6);
+if (v23) {
+    v24 = 0; v25 = 0; v26 = ptr6;
+    while (true) {
+        ...
+        if (v23 != 92) {
+            *(ptr4) = v23; v23 = v29; v24 = v28;
+            if (!v23) break;
+        } else {
+            ...
+            switch ((char)v33) { case 0: ... case 7: ... }
+        }
+    }
+}
+```
+
+| metric | angr (reference) | kuna |
+|---|---|---|
+| gotos | **11** | **37** |
+| labels | **8** | **21** |
+| loc | 417 | 354 |
+| switches / cases | 1 / 16 | 1 / 16 |
+| ifs | 33 | 32 |
+| loops | 5 | 7 |
+
+Both recover the same `switch` (16 cases) — the `loweredswitch`/jumptable side is already at
+parity. The divergence is purely **goto/label density**: angr structures the function body into
+`while(true){ if/else; switch }` with `break`/fall-through; kuna falls back to a goto web.
+
+## The exact construct
+
+kuna's distinct goto-target histogram (`grep -oE 'goto label_[0-9a-f]+'`):
+
+```
+ 12  goto label_400af2     <- the loop back-edge / continuation merge (the `do {...} while(...)` tail)
+  3  goto label_400e9c     <- shared error/cleanup epilogue
+  3  goto label_400ba0     <- shared inner dispatch merge
+  2  goto label_400fb0
+  ~16 other distinct shared-block targets, ×1 each
+```
+
+The dominant pattern is **`goto label_400af2` ×12** — every `switch` case body and several
+branches jump to the single loop-tail block (`*v17 = v23; ... } while (a0[...] == 0)`), i.e. a
+**loop-continuation merge**. angr hoists this merge into the loop body so the cases fall through
+to the latch naturally (no `goto`), producing `while(true){...}`. The rest are
+shared-successor merges that angr resolves with condition-region structuring + tail duplication.
+
+## Owning stage
+
+S7 **region recovery** / S8 **structuring** (`docs/stage-mapping.md`):
+`s7_regions/kuna_regiongraph.rs` (`KunaRegionIdentifier`, `region_structurer`),
+`s8_structure/kuna_gotoreduce.rs`, `s8_structure/kuna_loopbreak_recovery.rs`. The real pass
+order is in `infra/universalaction.rs` + the `coreaction_*.rs` files.
+
+## Hypothesis & why it is not a single-Action fix
+
+The clean output is a **cyclic** structuring result (loop refinement: hoisting the
+continuation merge into the loop body, `continue`/fall-through synthesis, condition-aware loop
+successor recovery). kuna's existing structuring options were tried on this exact target and
+**none change it** (goto count stays 37 with each, or all, enabled):
+
+- `gotoreduce` — tail-duplicate `if(cond) goto T` for small single-successor tails (acyclic).
+- `loopbreak_recovery` — loop-exit `goto` → `break` (acyclic exit edges only).
+- `regionstructure` — `region_structurer` is explicitly **acyclic** (sequence + ITE schemas +
+  edge-virtualization); it does not perform cyclic loop refinement.
+
+So closing this gap needs **new cyclic loop-refinement infrastructure** in S7/S8 (a
+DreamStructurer/SAILR-style condition-region pass over loops), not a single Action/Rule like
+`kuna_loweredswitch.rs`. Even eliminating all 12 back-edge gotos leaves ~25 vs angr's 11.
+
+**Conclusion: LARGE → proposal fork (Hard Rule 7).** See `proposal.md`.

--- a/docs/features/tr-o2-parse-str-7b9159/angr-vs-kuna.txt
+++ b/docs/features/tr-o2-parse-str-7b9159/angr-vs-kuna.txt
@@ -1,0 +1,800 @@
+==============================================================================
+test_decompiling_tr_O2_parse_str :: parse_str   (angr 9.2.213 @ 0x400a20)
+==============================================================================
+
+--- angr ---
+typedef struct struct_0 {
+    char padding_0[8];
+    void* field_8;
+} struct_0;
+
+extern unsigned long long char_class_name[4];
+
+long long parse_str(char *ptr6, struct_0 *ptr)
+{
+    unsigned long len;  // rax
+    unsigned long v21;  // rbp
+    unsigned int v30;  // r15d
+    char *ptr4;  // rbx
+    unsigned long long ptr5;  // r13
+    unsigned int v33;  // edx
+    unsigned long long v34;  // r13
+    unsigned int v35;  // eax
+    unsigned long v36;  // rsi
+    unsigned int v37;  // r8d
+    unsigned int v38;  // esi
+    unsigned int v39;  // eax
+    void* v22;  // r12
+    unsigned long v40;  // rdx
+    unsigned long v42;  // rax
+    unsigned long long i;  // r13
+    unsigned long long v44;  // r14
+    char v45;  // bl
+    unsigned long long v46;  // rdx
+    unsigned long long v47;  // rax
+    unsigned long long v48;  // r15
+    unsigned long long v49;  // rax
+    char v23;  // al
+    unsigned long v50;  // rax
+    void* ptr;  // rax
+    char v52;  // dl
+    void* ptr8;  // rdx
+    unsigned long long v54;  // r15
+    unsigned long long v55;  // rax
+    unsigned long long v56;  // r15
+    unsigned long long v57;  // r15
+    unsigned int v24;  // ecx
+    char v59;  // bl
+    void* ptr;  // rax
+    void* ptr9;  // rdx
+    long long v62;  // r13
+    long long v63;  // r13
+    char *v64;  // r14
+    unsigned long long v65;  // rdx
+    void* ptr;  // rax
+    void* ptr10;  // rdx
+    unsigned long long v68;  // r15
+    unsigned int v25;  // r14d
+    unsigned long v69;  // r13
+    char *v70;  // rdx
+    void* v71;  // rax
+    void* v72;  // rax
+    char *v74;  // rsi
+    char *v75;  // rsi
+    char *j;  // r13
+    char *v26;  // r10
+    unsigned long long v27;  // rdx
+    unsigned long v28;  // rsi
+    unsigned int v29;  // r9d
+    unsigned long v0;  // [bp-0xd8]
+    unsigned long v1;  // [bp-0xd0]
+    unsigned long v2;  // [bp-0xc8]
+    char *v3;  // [bp-0xc0]
+    unsigned int v4;  // [bp-0xb0], Other Possible Types: unsigned long long
+    char *v5;  // [bp-0xa8], Other Possible Types: unsigned int, unsigned long long
+    char *v6;  // [bp-0xa0]
+    unsigned long v7;  // [bp-0x98]
+    char *ptr7;  // [bp-0x90]
+    unsigned long long v9;  // [bp-0x88]
+    unsigned long long v10;  // [bp-0x80]
+    char v11;  // [bp-0x72]
+    char v12;  // [bp-0x71]
+    unsigned long long v13;  // [bp-0x70]
+    unsigned long long v14;  // [bp-0x68]
+    char v15;  // [bp-0x60]
+    unsigned long ptr;  // [bp-0x58]
+    void* ptr;  // [bp-0x50]
+    unsigned long long v18;  // [bp-0x48]
+
+    len = strlen(ptr6);
+    ptr = xmalloc(len);
+    v21 = ptr;
+    ptr = xcalloc(len, 1);
+    v22 = ptr;
+    v23 = *(ptr6);
+    if (v23)
+    {
+        v24 = 0;
+        v25 = 0;
+        v26 = ptr6;
+        while (true)
+        {
+            v27 = v25;
+            v28 = v24 + 1;
+            v25 += 1;
+            v29 = v26[v28];
+            v30 = v28;
+            ptr4 = v21 + v27;
+            if (v23 != 92)
+            {
+                *(ptr4) = v23;
+                v23 = v29;
+                v24 = v28;
+                if (!v23)
+                    break;
+            }
+            else
+            {
+                ptr5 = v22 + v27;
+                *((char *)ptr5) = 1;
+                if ((char)v29)
+                {
+                    v33 = v29 - 48;
+                    v34 = v29 & 255;
+                    switch ((char)v33)
+                    {
+                    case 0: case 1: case 2: case 3: case 4: case 5: case 6: case 7:
+                        v36 = v24 + 2;
+                        v34 = v33;
+                        v37 = v26[v36];
+                        v35 = v36;
+                        v38 = v37 - 48;
+                        if (v38 <= 7)
+                        {
+                            v34 = v38 + (unsigned int)v34 * 8;
+                            v39 = v26[3 + v24];
+                            v40 = v39 - 48;
+                            v4 = v39;
+                            v35 = v30 + 2;
+                            if ((unsigned int)v40 <= 7)
+                            {
+                                if ((unsigned int)v40 + (char)v34 * 8 <= 255)
+                                {
+                                    v34 = v40 + v34 * 8;
+                                    v35 = v24 + 4;
+                                    break;
+                                }
+                                else
+                                {
+                                    v6 = v26;
+                                    v11 = v29;
+                                    v5 = v37;
+                                    v3 = dcgettext(NULL, "warning: the ambiguous octal escape \\%c%c%c is being\n\tinterpreted as the 2-byte sequence \\0%c%c, %c", 5);
+                                    v2 = v4;
+                                    v1 = v5;
+                                    v0 = v11;
+                                    error(0, 0, v3);
+                                    v35 = v30 + 2;
+                                    v26 = v6;
+                                    break;
+                                }
+                            }
+                        }
+                        break;
+                    case 44:
+                        v34 = 92;
+                        v35 = v24 + 2;
+                        break;
+                    case 49:
+                        v34 = 7;
+                        goto LABEL_400aef;
+                    case 50:
+                        v34 = 8;
+                        v35 = v24 + 2;
+                        break;
+                    case 54:
+                        v34 = 12;
+                        v35 = v24 + 2;
+                        break;
+                    case 62:
+                        v34 = 10;
+                        v35 = v24 + 2;
+                        break;
+                    case 66:
+                        v34 = 13;
+                        v35 = v24 + 2;
+                        break;
+                    case 68:
+                        v34 = 9;
+                        v35 = v24 + 2;
+                        break;
+                    case 70:
+                        v34 = 11;
+                        v35 = v24 + 2;
+                        break;
+                    default:
+LABEL_400aef:
+                        v35 = v24 + 2;
+                        break;
+                    }
+                }
+                else
+                {
+                    v5 = v26;
+                    v4 = v24;
+                    error(0, 0, dcgettext(NULL, "warning: an unescaped backslash at end of string is not portable", 5));
+                    *((char *)ptr5) = 0;
+                    v26 = v5;
+                    v34 = 92;
+                    v35 = v4 + 1;
+                }
+                v42 = v35;
+                *(ptr4) = v34;
+                v24 = v42;
+                v23 = v26[v42];
+                if (!v23)
+                    break;
+            }
+        }
+        v5 = v25;
+        v18 = v5;
+        if (v25 > 2)
+        {
+            i = 2;
+            v44 = 0;
+            do
+            {
+                v45 = *((char *)(v21 + v44 + 1));
+                v4 = v44 + 1;
+                v11 = *((char *)(v21 + v44));
+                if (*((char *)(v21 + v44)) != 91 || (*((char *)&v6) = *((char *)((char *)v22 + v44)), *((char *)((char *)v22 + v44))))
+                {
+LABEL_400b30:
+                    if (v45 != 45 || (*((char *)&v6) = *((char *)((char *)v22 + v4)), *((char *)((char *)v22 + v4))))
+                    {
+                        append_normal_char(ptr);
+                        v44 = v4;
+                        goto LABEL_400b4c;
+                    }
+                    else
+                    {
+                        v59 = *((char *)(v21 + i));
+                        if (v59 < v11)
+                        {
+                            v71 = make_printable_char(v11);
+                            v72 = make_printable_char(v59);
+                            error(0, 0, dcgettext(NULL, "range-endpoints of '%s-%s' are in reverse collating sequence order", 5));
+                            free(v71);
+                            free(v72);
+                            free(v21);
+                            free(v22);
+                            return *((char *)&v6);
+                        }
+                        ptr = xmalloc(32);
+                        *((void* *)&ptr[8]) = NULL;
+                        ptr9 = ptr->field_8;
+                        *((unsigned int *)ptr) = 1;
+                        *((char *)&ptr[16]) = v11;
+                        *((char *)&ptr[17]) = v59;
+                        if (!ptr9)
+                            __assert_fail(); /* do not return */
+                        *((void* *)&ptr9[8]) = ptr;
+                        v44 += 3;
+                        ptr->field_8 = ptr;
+                        goto LABEL_400b4c;
+                    }
+                }
+                else
+                {
+                    if ((v45 == 58 || v45 == 61) && !*((char *)v22 + v4) && (v46 = v5 - 1, v46 > i))
+                    {
+                        v47 = i;
+                        while (true)
+                        {
+                            v48 = v47;
+                            v49 = v47 + 1;
+                            if (*((char *)(v21 + v47)) == v45 && *((char *)(v21 + v48 + 1)) == 93 && !*(-1 + (char *)v22 + v49) && !*(1 + (char *)v22 + v48))
+                                break;
+                            v47 = v49;
+                            if (v46 <= v47)
+                                goto LABEL_400ba0;
+                        }
+                        v50 = v48 - v44;
+                        ptr7 = v21 + i;
+                        v7 = v50 - 2;
+                        if (v50 == 2)
+                        {
+                            v75 = "missing character class name '[::]'";
+                            if (v45 != 58)
+                                v75 = "missing equivalence class character '[==]'";
+                            error(0, 0, dcgettext(NULL, v75, 5));
+                            free(v21);
+                            free(v22);
+                            return *((char *)&v6);
+                        }
+                        if (v45 != 58)
+                        {
+                            if (v7 != 1)
+                            {
+                                if ((char)star_digits_closebracket(&ptr, i))
+                                    goto LABEL_400ba0;
+                                v69 = make_printable_str(ptr7, v7);
+                                v70 = dcgettext(NULL, "%s: equivalence class operand must be a single character", 5);
+                                goto LABEL_400dc5;
+                            }
+                            else
+                            {
+                                ptr = xmalloc(32);
+                                *((void* *)&ptr[8]) = NULL;
+                                v52 = *(ptr7);
+                                *((unsigned int *)ptr) = 3;
+                                *((char *)&ptr[16]) = v52;
+                                ptr8 = ptr->field_8;
+                                if (!ptr8)
+                                    __assert_fail(); /* do not return */
+LABEL_401087:
+                                *((void* *)&ptr8[8]) = ptr;
+                                v44 = v48 + 2;
+                                ptr->field_8 = ptr;
+                            }
+LABEL_400b4c:
+                            i = v44 + 2;
+                            if (i < v5)
+                                continue;
+                        }
+                        else
+                        {
+                            v10 = v44;
+                            v9 = i;
+                            v12 = v45;
+                            v13 = v48;
+                            v54 = 0;
+                            do
+                            {
+                                if (!strncmp(ptr7, char_class_name[v54], v7) && v7 == strlen(char_class_name[v54]))
+                                {
+                                    v48 = v13;
+                                    ptr = xmalloc(32);
+                                    *((void* *)&ptr[8]) = NULL;
+                                    ptr8 = ptr->field_8;
+                                    *((unsigned int *)ptr) = 2;
+                                    *((unsigned int *)&ptr[16]) = v54;
+                                    if (!ptr8)
+                                        __assert_fail(); /* do not return */
+                                    goto LABEL_401087;
+                                }
+                            } while ((v54 += 1, v54 != 12));
+                            i = v9;
+                            v44 = v10;
+                            v45 = v12;
+                            if (!(char)star_digits_closebracket(&ptr, i))
+                            {
+                                v69 = make_printable_str(ptr7, v7);
+                                quote(v69);
+                                v74 = "invalid character class %s";
+LABEL_401031:
+                                v70 = dcgettext(NULL, v74, 5);
+LABEL_400dc5:
+                                error(0, 0, v70);
+                                free(v69);
+                                free(v21);
+                                free(v22);
+                                return *((char *)&v6);
+                            }
+                        }
+                    }
+LABEL_400ba0:
+                    if (*((char *)(v21 + i)) != 42 || *((char *)v22 + i) || (v55 = v44 + 3, v56 = v55, v5 <= v55) || !((v57 = v56, !*((char *)((char *)v22 + v57)))))
+                        goto LABEL_400b30;
+                    if (*((char *)(v21 + v57)) != 93)
+                    {
+                        if (v5 <= v57 + 1)
+                            goto LABEL_400b30;
+                        continue;
+                    }
+                }
+                v62 = v57 - v4;
+                v63 = v62 - 2;
+                if (v62 != 2)
+                {
+                    v64 = v21 + v55;
+                    if (!(int)xstrtoumax(v64, &v15, (*(v64) != 48) * 2 + 8, &v14, 0) && !((v65 = v14, v65 == 18446744073709551615 || v15 != v64 + v63)))
+                        goto LABEL_400c49;
+                    v69 = make_printable_str(v64, v63);
+                    quote(v69);
+                    v74 = "invalid repeat count %s in [c*n] construct";
+                    goto LABEL_401031;
+                }
+                v14 = 0;
+                v65 = 0;
+LABEL_400c49:
+                v4 = v65;
+                ptr = xmalloc(32);
+                *((void* *)&ptr[8]) = NULL;
+                *((unsigned long long *)&ptr[24]) = v4;
+                ptr10 = ptr->field_8;
+                *((unsigned int *)ptr) = 4;
+                *((char *)&ptr[16]) = v45;
+                if (!ptr10)
+                    append_repeated_char.part.0(); /* do not return */
+                v44 = v57 + 1;
+                *((void* *)&ptr10[8]) = ptr;
+                i = v44 + 2;
+                ptr->field_8 = ptr;
+            } while (i < v5);
+            v68 = v44;
+        }
+        else
+        {
+            v68 = 0;
+        }
+        j = v21 + v68;
+        if (v5 > v68)
+        {
+            do
+            {
+                append_normal_char(ptr, *(j));
+                j += 1;
+            } while (v21 + v5 != j);
+        }
+    }
+    *((char *)&v6) = 1;
+    free(v21);
+    free(v22);
+    return *((char *)&v6);
+}
+
+
+--- kuna (name mode) ---
+uint1 parse_str(uint1 *a0,int8 a1)
+
+{
+  uint1 *v1;
+  uint4 v10; // eax
+  int4 v12;
+  uint4 v14;
+  uint8 v15; // rdx
+  int8 v16;
+  uint1 *v17;
+  int8 v18; // stack - 0x68
+  char *v19; // stack - 0x60
+  char *v2;
+  int8 v20; // stack - 0x58
+  uint1 v23;
+  uint4 v24; // r13d
+  void *v25;
+  void *v26;
+  unsigned long v27;
+  void *v28;
+  void *v29;
+  uint1 v3;
+  int8 v30;
+  int8 v31;
+  void *v32; // stack - 0xa8
+  int8 v33; // stack - 0x50
+  void *v34; // stack - 0x48
+  int8 v35; // stack - 0x40
+  char v4;
+  int8 v5;
+  int8 v6;
+  void *v7;
+  void *v8;
+  uint1 v9; // al
+  
+label_400f2b:
+  v11 = (uint8)(uint8)(v12 + 2);
+  v1 = &a0[(int8)v11];
+  if (8 <= (uint4)((int4)(char)*v1 - 0x30U)) goto label_400af2;
+  v10 = v12 + 3;
+  v11 = (uint8)(uint8)v10;
+  v24 = ((int4)(char)*v1 - 0x30U) + v14 * 8;
+  v23 = (uint1)v24;
+  v10 = (int4)(char)a0[(int8)v11];
+  v14 = v10 - 0x30;
+  v10 = v12 + 3;
+  v11 = (uint8)(uint8)v10;
+  if (8 <= v14) goto label_400af2;
+  v10 = v24 & 0xff;
+  v10 = v14 + v10 * 8;
+  if ((int4)v10 > 0xff) {
+    v11 = (unsigned long)dcgettext(0,0x404090,5);
+    error(0,0,v11);
+    v10 = v12 + 3;
+    v11 = (uint8)(uint8)v10;
+    goto label_400af2;
+  }
+  v23 = (char)v14 + v23 * '\b';
+  v10 = v12 + 4;
+  v11 = (uint8)(uint8)v10;
+  goto label_400af2;
+label_400fb0:
+  v22 = *(void *)(v30 * 8 + 0x405f00);
+  v10 = strncmp(v29,v22,v8);
+  if ((v10 != 0) || (v11 = (void *)strlen(v22), (void *)v8 != v11)) goto label_400fda;
+  v11 = (void *)xmalloc(0x20);
+  *(void *)&v11[2] = 0;
+  v16 = *(int8 *)(a1 + 8);
+  *v11 = 2;
+  v11[4] = (int4)v30;
+  if (v16 == 0) goto label_40121b;
+label_401087:
+  *(void **)(v16 + 8) = v11;
+  v28 = &v7[2];
+  *(void **)(a1 + 8) = v11;
+  goto label_400b4c;
+label_400fda:
+  v30 = v30 + 1;
+  if (v30 == 0xc) goto label_400fe4;
+  goto label_400fb0;
+label_400fe4:
+  v9 = star_digits_closebracket(&v20,v25);
+  if (v9 == '\0') {
+    v11 = (unsigned long)make_printable_str(v29,v8);
+    v27 = v11;
+    v11 = (unsigned long)quote(v11);
+    v21 = 0x403ba8;
+    v22 = v11;
+label_401031:
+    v11 = (unsigned long)dcgettext(0,v21,5);
+label_400dc5:
+    error(0,0,v11,v22);
+    free(v27);
+    goto label_400e9c;
+  }
+label_400ba0:
+  if ((v25[v5] == '*') && (v25[v6] == '\0')) {
+    for (v29 = &v26[3]; (v29 < v32 && (v29[v6] == '\0')); v29 = &v29[1]) {
+      if (v29[v5] == ']') {
+        v26 = &v29[0xfffffffffffffffe - (int8)v28];
+        if (v26 == (void *)0x0) {
+          v18 = 0;
+          v30 = 0;
+        }
+        else {
+          v2 = &(&v26[3])[v5];
+          v10 = xstrtoumax(v2,&v19,(*v2 != '0') * '\x02' + '\b',&v18,0);
+          if (((v10 != 0) || (v18 == -1)) || (v30 = v18, v19 != &v2[(int8)v26])) {
+            v11 = (unsigned long)make_printable_str(v2,v26);
+            v27 = v11;
+            v11 = (unsigned long)quote(v11);
+            v21 = 0x4041d8;
+            v22 = v11;
+            goto label_401031;
+          }
+        }
+        v11 = (void *)xmalloc(0x20);
+        *(void *)&v11[2] = 0;
+        *(int8 *)&v11[6] = v30;
+        v30 = *(int8 *)(a1 + 8);
+        *v11 = 4;
+        *(uint1 *)&v11[4] = v23;
+        if (v30 == 0) goto label_401216;
+        *(void **)(v30 + 8) = v11;
+        v25 = &v29[3];
+        *(void **)(a1 + 8) = v11;
+        v26 = &v29[1];
+        goto label_400c9c;
+      }
+    }
+  }
+label_400b30:
+  if ((v23 == 0x2d) && (v28[v6] == '\0')) {
+    v23 = v25[v5];
+    if (v23 < v3) {
+      v11 = (unsigned long)make_printable_char(v3);
+      v22 = v11;
+      v11 = (unsigned long)make_printable_char(v23);
+      v27 = v11;
+      v11 = (unsigned long)dcgettext(0,0x404208,5);
+      error(0,0,v11,v22,v27);
+      free(v22);
+      free(v27);
+      v4 = 0;
+      goto label_400e9c;
+    }
+    v11 = (void *)xmalloc(0x20);
+    *(void *)&v11[2] = 0;
+    v30 = *(int8 *)(a1 + 8);
+    *v11 = 1;
+    *(uint1 *)&v11[4] = v3;
+    *(uint1 *)((int8)v11 + 0x11) = v23;
+    if (v30 == 0) {
+      __assert_fail(0x403b9d,0x403b62,0x2a7,0x403fb8);
+      goto label_401211;
+    }
+    *(void **)(v30 + 8) = v11;
+    v28 = &v26[3];
+    *(void **)(a1 + 8) = v11;
+  }
+  else {
+    append_normal_char(a1);
+  }
+label_400b4c:
+  v25 = &v28[2];
+  v26 = v28;
+label_400c9c:
+  if (v32 <= v25) {
+    while( true ) {
+      v25 = &v26[v5];
+      if (v26 < v32) {
+        do {
+          v4 = *v25;
+          v25 = &v25[1];
+          append_normal_char(a1,v4);
+        } while (&v32[v5] != v25);
+      }
+label_400cd6:
+      v4 = 1;
+label_400e9c:
+      free(v5);
+      free(v6);
+      if (v35 == *(int8 *)(v31 + 0x28)) break;
+label_401211:
+      __stack_chk_fail();
+label_401216:
+      append_repeated_char.part.0();
+label_40121b:
+      __assert_fail(0x403b9d,0x403b62,0x2bd,0x404010);
+label_40123a:
+      v26 = (void *)0x0;
+    }
+    v9 = v4;
+    return v9;
+  }
+  goto label_400b5b;
+  v35 = *(int8 *)(v31 + 0x28);
+  v11 = (unsigned long)strlen();
+  v22 = v11;
+  v11 = (int8)xmalloc(v11);
+  v5 = (int8)v11;
+  v20 = (int8)v11;
+  v11 = (int8)xcalloc(v22,1);
+  v6 = (int8)v11;
+  v33 = (int8)v11;
+  if (*a0 == 0) goto label_400cd6;
+  v26 = (void *)0x0;
+  v13 = 0;
+  v3 = *a0;
+  do {
+    do {
+      v9 = v3;
+      v15 = (uint8)v26 & 0xffffffff;
+      v12 = (int4)v13;
+      v13 = (uint8)(v12 + 1);
+      v26 = (void *)(uint8)((int4)v26 + 1);
+      v3 = a0[v13];
+      v17 = (uint1 *)(v5 + v15);
+      if (v9 == 0x5c) {
+        v25 = (void *)(v6 + v15);
+        *v25 = 1;
+        if (v3 == 0) goto label_4010eb;
+        v14 = (uint4)v3 - 0x30;
+        v23 = (uint1)v14;
+        v10 = v14 & 0xff;
+        switch(v10) {
+          case 0:
+          case 1:
+          case 2:
+          case 3:
+          case 4:
+          case 5:
+          case 6:
+          case 7:
+            goto label_400f2b;
+          default:
+label_400aef:
+            v23 = v3;
+            v10 = v12 + 2;
+            v11 = (uint8)(uint8)v10;
+            goto label_400af2;
+          case 0x2c:
+            v23 = 0x5c;
+            v10 = v12 + 2;
+            v11 = (uint8)(uint8)v10;
+            goto label_400af2;
+          case 0x31:
+            v3 = 7;
+            goto label_400aef;
+          case 0x32:
+            v23 = 8;
+            v10 = v12 + 2;
+            v11 = (uint8)(uint8)v10;
+            goto label_400af2;
+          case 0x36:
+            v23 = 0xc;
+            v10 = v12 + 2;
+            v11 = (uint8)(uint8)v10;
+            goto label_400af2;
+          case 0x3e:
+            v23 = 10;
+            v10 = v12 + 2;
+            v11 = (uint8)(uint8)v10;
+            goto label_400af2;
+          case 0x42:
+            v23 = 0xd;
+            v10 = v12 + 2;
+            v11 = (uint8)(uint8)v10;
+            goto label_400af2;
+          case 0x44:
+            v23 = 9;
+            v10 = v12 + 2;
+            v11 = (uint8)(uint8)v10;
+            goto label_400af2;
+          case 0x46:
+            v23 = 0xb;
+            v10 = v12 + 2;
+            v11 = (uint8)(uint8)v10;
+            goto label_400af2;
+          
+        }
+      }
+      *v17 = v9;
+    } while (v3 != 0);
+    do {
+      v11 = (void *)((uint8)v26 & 0xffffffff);
+      v32 = (void *)v11;
+      v34 = (void *)v11;
+      if ((uint4)v26 <= 2) goto label_40123a;
+      v26 = (void *)0x0;
+      v25 = (void *)0x2;
+label_400b5b:
+      v3 = v26[v5];
+      v28 = &v26[1];
+      v23 = v26[v5 + 1];
+      v17 = (uint1 *)(uint8)v23;
+      if ((v3 != 0x5b) || (v26[v6] != '\0')) goto label_400b30;
+      v4 = 0;
+      if (((v23 != 0x3a) && (v23 != 0x3d)) || ((v28[v6] != '\0' || (&v32[-1] <= v25)))) goto label_400ba0;
+      v11 = (void *)v25;
+      while( true ) {
+        v7 = (void *)v11;
+        v29 = (void *)((int8)v11 + 1);
+        if ((((*(uint1 *)((int8)v11 + v5) == v23) && (*(char *)((int8)v11 + v5 + 1) == ']')) && (v29[v6 + -1] == '\0')) && (*(char *)((int8)v11 + v6 + 1) == '\0')) break;
+        v11 = (void *)v29;
+        if (&v32[-1] <= v29) goto label_400ba0;
+      }
+      v29 = &v25[v5];
+      v11 = (void *)((int8)v11 + (0xfffffffffffffffe - (int8)v26));
+      v8 = (void *)v11;
+      if (v11 == (void *)0x0) {
+        v22 = 0x404140;
+        if (v23 != 0x3a) {
+          v22 = 0x404168;
+        }
+        v11 = (unsigned long)dcgettext(0,v22,5);
+        error(0,0,v11);
+        goto label_400e9c;
+      }
+      if (v23 == 0x3a) {
+        v11 = (void *)0x0;
+        v30 = (int8)v11;
+        goto label_400fb0;
+      }
+      if (v11 != (void *)0x1) {
+        v9 = star_digits_closebracket(&v20,v25);
+        if (v9 == '\0') {
+          v11 = (unsigned long)make_printable_str(v29,v8);
+          v22 = v11;
+          v11 = (unsigned long)dcgettext(0,0x404198,5);
+          v27 = v22;
+          goto label_400dc5;
+        }
+        goto label_400ba0;
+      }
+      v11 = (void *)xmalloc(0x20);
+      *(void *)&v11[2] = 0;
+      v4 = *v29;
+      *v11 = 3;
+      *(void *)&v11[4] = v4;
+      v16 = *(int8 *)(a1 + 8);
+      if (v16 != 0) goto label_401087;
+      v12 = 0x403ff0;
+      __assert_fail(0x403b9d,0x403b62,0x2e7);
+label_4010eb:
+      v11 = (unsigned long)dcgettext(0,0x4040f8,5);
+      error(0,0,v11);
+      *v25 = 0;
+      v23 = 0x5c;
+      v11 = (uint8)(uint8)(v12 + 1);
+label_400af2:
+      *v17 = v23;
+      v13 = (uint8)v11;
+      v3 = a0[(int8)v11];
+    } while (a0[(int8)v11] == 0);
+  } while( true );
+}
+
+--- metrics (reference | kuna) ---
+  loc           417 | 354 
+  gotos          11 | 37  
+  labels          8 | 21  
+  switches        1 | 1   
+  cases          16 | 16  
+  ifs            33 | 32  
+  loops           5 | 7   
+  ternaries       0 | 0   
+  casts           0 | 0   
+
+--- signals (candidate 'reference is better' hints) ---
+  * ref has fewer gotos (11 vs 37)
+  * ref has fewer labels (8 vs 21)

--- a/docs/features/tr-o2-parse-str-7b9159/angr.txt
+++ b/docs/features/tr-o2-parse-str-7b9159/angr.txt
@@ -1,0 +1,420 @@
+typedef struct struct_0 {
+    char padding_0[8];
+    void* field_8;
+} struct_0;
+
+extern unsigned long long char_class_name[4];
+
+long long parse_str(char *ptr6, struct_0 *ptr)
+{
+    unsigned long len;  // rax
+    unsigned long v21;  // rbp
+    unsigned int v30;  // r15d
+    char *ptr4;  // rbx
+    unsigned long long ptr5;  // r13
+    unsigned int v33;  // edx
+    unsigned long long v34;  // r13
+    unsigned int v35;  // eax
+    unsigned long v36;  // rsi
+    unsigned int v37;  // r8d
+    unsigned int v38;  // esi
+    unsigned int v39;  // eax
+    void* v22;  // r12
+    unsigned long v40;  // rdx
+    unsigned long v42;  // rax
+    unsigned long long i;  // r13
+    unsigned long long v44;  // r14
+    char v45;  // bl
+    unsigned long long v46;  // rdx
+    unsigned long long v47;  // rax
+    unsigned long long v48;  // r15
+    unsigned long long v49;  // rax
+    char v23;  // al
+    unsigned long v50;  // rax
+    void* ptr;  // rax
+    char v52;  // dl
+    void* ptr8;  // rdx
+    unsigned long long v54;  // r15
+    unsigned long long v55;  // rax
+    unsigned long long v56;  // r15
+    unsigned long long v57;  // r15
+    unsigned int v24;  // ecx
+    char v59;  // bl
+    void* ptr;  // rax
+    void* ptr9;  // rdx
+    long long v62;  // r13
+    long long v63;  // r13
+    char *v64;  // r14
+    unsigned long long v65;  // rdx
+    void* ptr;  // rax
+    void* ptr10;  // rdx
+    unsigned long long v68;  // r15
+    unsigned int v25;  // r14d
+    unsigned long v69;  // r13
+    char *v70;  // rdx
+    void* v71;  // rax
+    void* v72;  // rax
+    char *v74;  // rsi
+    char *v75;  // rsi
+    char *j;  // r13
+    char *v26;  // r10
+    unsigned long long v27;  // rdx
+    unsigned long v28;  // rsi
+    unsigned int v29;  // r9d
+    unsigned long v0;  // [bp-0xd8]
+    unsigned long v1;  // [bp-0xd0]
+    unsigned long v2;  // [bp-0xc8]
+    char *v3;  // [bp-0xc0]
+    unsigned int v4;  // [bp-0xb0], Other Possible Types: unsigned long long
+    char *v5;  // [bp-0xa8], Other Possible Types: unsigned int, unsigned long long
+    char *v6;  // [bp-0xa0]
+    unsigned long v7;  // [bp-0x98]
+    char *ptr7;  // [bp-0x90]
+    unsigned long long v9;  // [bp-0x88]
+    unsigned long long v10;  // [bp-0x80]
+    char v11;  // [bp-0x72]
+    char v12;  // [bp-0x71]
+    unsigned long long v13;  // [bp-0x70]
+    unsigned long long v14;  // [bp-0x68]
+    char v15;  // [bp-0x60]
+    unsigned long ptr;  // [bp-0x58]
+    void* ptr;  // [bp-0x50]
+    unsigned long long v18;  // [bp-0x48]
+
+    len = strlen(ptr6);
+    ptr = xmalloc(len);
+    v21 = ptr;
+    ptr = xcalloc(len, 1);
+    v22 = ptr;
+    v23 = *(ptr6);
+    if (v23)
+    {
+        v24 = 0;
+        v25 = 0;
+        v26 = ptr6;
+        while (true)
+        {
+            v27 = v25;
+            v28 = v24 + 1;
+            v25 += 1;
+            v29 = v26[v28];
+            v30 = v28;
+            ptr4 = v21 + v27;
+            if (v23 != 92)
+            {
+                *(ptr4) = v23;
+                v23 = v29;
+                v24 = v28;
+                if (!v23)
+                    break;
+            }
+            else
+            {
+                ptr5 = v22 + v27;
+                *((char *)ptr5) = 1;
+                if ((char)v29)
+                {
+                    v33 = v29 - 48;
+                    v34 = v29 & 255;
+                    switch ((char)v33)
+                    {
+                    case 0: case 1: case 2: case 3: case 4: case 5: case 6: case 7:
+                        v36 = v24 + 2;
+                        v34 = v33;
+                        v37 = v26[v36];
+                        v35 = v36;
+                        v38 = v37 - 48;
+                        if (v38 <= 7)
+                        {
+                            v34 = v38 + (unsigned int)v34 * 8;
+                            v39 = v26[3 + v24];
+                            v40 = v39 - 48;
+                            v4 = v39;
+                            v35 = v30 + 2;
+                            if ((unsigned int)v40 <= 7)
+                            {
+                                if ((unsigned int)v40 + (char)v34 * 8 <= 255)
+                                {
+                                    v34 = v40 + v34 * 8;
+                                    v35 = v24 + 4;
+                                    break;
+                                }
+                                else
+                                {
+                                    v6 = v26;
+                                    v11 = v29;
+                                    v5 = v37;
+                                    v3 = dcgettext(NULL, "warning: the ambiguous octal escape \\%c%c%c is being\n\tinterpreted as the 2-byte sequence \\0%c%c, %c", 5);
+                                    v2 = v4;
+                                    v1 = v5;
+                                    v0 = v11;
+                                    error(0, 0, v3);
+                                    v35 = v30 + 2;
+                                    v26 = v6;
+                                    break;
+                                }
+                            }
+                        }
+                        break;
+                    case 44:
+                        v34 = 92;
+                        v35 = v24 + 2;
+                        break;
+                    case 49:
+                        v34 = 7;
+                        goto LABEL_400aef;
+                    case 50:
+                        v34 = 8;
+                        v35 = v24 + 2;
+                        break;
+                    case 54:
+                        v34 = 12;
+                        v35 = v24 + 2;
+                        break;
+                    case 62:
+                        v34 = 10;
+                        v35 = v24 + 2;
+                        break;
+                    case 66:
+                        v34 = 13;
+                        v35 = v24 + 2;
+                        break;
+                    case 68:
+                        v34 = 9;
+                        v35 = v24 + 2;
+                        break;
+                    case 70:
+                        v34 = 11;
+                        v35 = v24 + 2;
+                        break;
+                    default:
+LABEL_400aef:
+                        v35 = v24 + 2;
+                        break;
+                    }
+                }
+                else
+                {
+                    v5 = v26;
+                    v4 = v24;
+                    error(0, 0, dcgettext(NULL, "warning: an unescaped backslash at end of string is not portable", 5));
+                    *((char *)ptr5) = 0;
+                    v26 = v5;
+                    v34 = 92;
+                    v35 = v4 + 1;
+                }
+                v42 = v35;
+                *(ptr4) = v34;
+                v24 = v42;
+                v23 = v26[v42];
+                if (!v23)
+                    break;
+            }
+        }
+        v5 = v25;
+        v18 = v5;
+        if (v25 > 2)
+        {
+            i = 2;
+            v44 = 0;
+            do
+            {
+                v45 = *((char *)(v21 + v44 + 1));
+                v4 = v44 + 1;
+                v11 = *((char *)(v21 + v44));
+                if (*((char *)(v21 + v44)) != 91 || (*((char *)&v6) = *((char *)((char *)v22 + v44)), *((char *)((char *)v22 + v44))))
+                {
+LABEL_400b30:
+                    if (v45 != 45 || (*((char *)&v6) = *((char *)((char *)v22 + v4)), *((char *)((char *)v22 + v4))))
+                    {
+                        append_normal_char(ptr);
+                        v44 = v4;
+                        goto LABEL_400b4c;
+                    }
+                    else
+                    {
+                        v59 = *((char *)(v21 + i));
+                        if (v59 < v11)
+                        {
+                            v71 = make_printable_char(v11);
+                            v72 = make_printable_char(v59);
+                            error(0, 0, dcgettext(NULL, "range-endpoints of '%s-%s' are in reverse collating sequence order", 5));
+                            free(v71);
+                            free(v72);
+                            free(v21);
+                            free(v22);
+                            return *((char *)&v6);
+                        }
+                        ptr = xmalloc(32);
+                        *((void* *)&ptr[8]) = NULL;
+                        ptr9 = ptr->field_8;
+                        *((unsigned int *)ptr) = 1;
+                        *((char *)&ptr[16]) = v11;
+                        *((char *)&ptr[17]) = v59;
+                        if (!ptr9)
+                            __assert_fail(); /* do not return */
+                        *((void* *)&ptr9[8]) = ptr;
+                        v44 += 3;
+                        ptr->field_8 = ptr;
+                        goto LABEL_400b4c;
+                    }
+                }
+                else
+                {
+                    if ((v45 == 58 || v45 == 61) && !*((char *)v22 + v4) && (v46 = v5 - 1, v46 > i))
+                    {
+                        v47 = i;
+                        while (true)
+                        {
+                            v48 = v47;
+                            v49 = v47 + 1;
+                            if (*((char *)(v21 + v47)) == v45 && *((char *)(v21 + v48 + 1)) == 93 && !*(-1 + (char *)v22 + v49) && !*(1 + (char *)v22 + v48))
+                                break;
+                            v47 = v49;
+                            if (v46 <= v47)
+                                goto LABEL_400ba0;
+                        }
+                        v50 = v48 - v44;
+                        ptr7 = v21 + i;
+                        v7 = v50 - 2;
+                        if (v50 == 2)
+                        {
+                            v75 = "missing character class name '[::]'";
+                            if (v45 != 58)
+                                v75 = "missing equivalence class character '[==]'";
+                            error(0, 0, dcgettext(NULL, v75, 5));
+                            free(v21);
+                            free(v22);
+                            return *((char *)&v6);
+                        }
+                        if (v45 != 58)
+                        {
+                            if (v7 != 1)
+                            {
+                                if ((char)star_digits_closebracket(&ptr, i))
+                                    goto LABEL_400ba0;
+                                v69 = make_printable_str(ptr7, v7);
+                                v70 = dcgettext(NULL, "%s: equivalence class operand must be a single character", 5);
+                                goto LABEL_400dc5;
+                            }
+                            else
+                            {
+                                ptr = xmalloc(32);
+                                *((void* *)&ptr[8]) = NULL;
+                                v52 = *(ptr7);
+                                *((unsigned int *)ptr) = 3;
+                                *((char *)&ptr[16]) = v52;
+                                ptr8 = ptr->field_8;
+                                if (!ptr8)
+                                    __assert_fail(); /* do not return */
+LABEL_401087:
+                                *((void* *)&ptr8[8]) = ptr;
+                                v44 = v48 + 2;
+                                ptr->field_8 = ptr;
+                            }
+LABEL_400b4c:
+                            i = v44 + 2;
+                            if (i < v5)
+                                continue;
+                        }
+                        else
+                        {
+                            v10 = v44;
+                            v9 = i;
+                            v12 = v45;
+                            v13 = v48;
+                            v54 = 0;
+                            do
+                            {
+                                if (!strncmp(ptr7, char_class_name[v54], v7) && v7 == strlen(char_class_name[v54]))
+                                {
+                                    v48 = v13;
+                                    ptr = xmalloc(32);
+                                    *((void* *)&ptr[8]) = NULL;
+                                    ptr8 = ptr->field_8;
+                                    *((unsigned int *)ptr) = 2;
+                                    *((unsigned int *)&ptr[16]) = v54;
+                                    if (!ptr8)
+                                        __assert_fail(); /* do not return */
+                                    goto LABEL_401087;
+                                }
+                            } while ((v54 += 1, v54 != 12));
+                            i = v9;
+                            v44 = v10;
+                            v45 = v12;
+                            if (!(char)star_digits_closebracket(&ptr, i))
+                            {
+                                v69 = make_printable_str(ptr7, v7);
+                                quote(v69);
+                                v74 = "invalid character class %s";
+LABEL_401031:
+                                v70 = dcgettext(NULL, v74, 5);
+LABEL_400dc5:
+                                error(0, 0, v70);
+                                free(v69);
+                                free(v21);
+                                free(v22);
+                                return *((char *)&v6);
+                            }
+                        }
+                    }
+LABEL_400ba0:
+                    if (*((char *)(v21 + i)) != 42 || *((char *)v22 + i) || (v55 = v44 + 3, v56 = v55, v5 <= v55) || !((v57 = v56, !*((char *)((char *)v22 + v57)))))
+                        goto LABEL_400b30;
+                    if (*((char *)(v21 + v57)) != 93)
+                    {
+                        if (v5 <= v57 + 1)
+                            goto LABEL_400b30;
+                        continue;
+                    }
+                }
+                v62 = v57 - v4;
+                v63 = v62 - 2;
+                if (v62 != 2)
+                {
+                    v64 = v21 + v55;
+                    if (!(int)xstrtoumax(v64, &v15, (*(v64) != 48) * 2 + 8, &v14, 0) && !((v65 = v14, v65 == 18446744073709551615 || v15 != v64 + v63)))
+                        goto LABEL_400c49;
+                    v69 = make_printable_str(v64, v63);
+                    quote(v69);
+                    v74 = "invalid repeat count %s in [c*n] construct";
+                    goto LABEL_401031;
+                }
+                v14 = 0;
+                v65 = 0;
+LABEL_400c49:
+                v4 = v65;
+                ptr = xmalloc(32);
+                *((void* *)&ptr[8]) = NULL;
+                *((unsigned long long *)&ptr[24]) = v4;
+                ptr10 = ptr->field_8;
+                *((unsigned int *)ptr) = 4;
+                *((char *)&ptr[16]) = v45;
+                if (!ptr10)
+                    append_repeated_char.part.0(); /* do not return */
+                v44 = v57 + 1;
+                *((void* *)&ptr10[8]) = ptr;
+                i = v44 + 2;
+                ptr->field_8 = ptr;
+            } while (i < v5);
+            v68 = v44;
+        }
+        else
+        {
+            v68 = 0;
+        }
+        j = v21 + v68;
+        if (v5 > v68)
+        {
+            do
+            {
+                append_normal_char(ptr, *(j));
+                j += 1;
+            } while (v21 + v5 != j);
+        }
+    }
+    *((char *)&v6) = 1;
+    free(v21);
+    free(v22);
+    return *((char *)&v6);
+}

--- a/docs/features/tr-o2-parse-str-7b9159/kuna.txt
+++ b/docs/features/tr-o2-parse-str-7b9159/kuna.txt
@@ -1,0 +1,357 @@
+uint1 parse_str(uint1 *a0,int8 a1)
+
+{
+  uint1 *v1;
+  uint4 v10; // eax
+  int4 v12;
+  uint4 v14;
+  uint8 v15; // rdx
+  int8 v16;
+  uint1 *v17;
+  int8 v18; // stack - 0x68
+  char *v19; // stack - 0x60
+  char *v2;
+  int8 v20; // stack - 0x58
+  uint1 v23;
+  uint4 v24; // r13d
+  void *v25;
+  void *v26;
+  unsigned long v27;
+  void *v28;
+  void *v29;
+  uint1 v3;
+  int8 v30;
+  int8 v31;
+  void *v32; // stack - 0xa8
+  int8 v33; // stack - 0x50
+  void *v34; // stack - 0x48
+  int8 v35; // stack - 0x40
+  char v4;
+  int8 v5;
+  int8 v6;
+  void *v7;
+  void *v8;
+  uint1 v9; // al
+  
+label_400f2b:
+  v11 = (uint8)(uint8)(v12 + 2);
+  v1 = &a0[(int8)v11];
+  if (8 <= (uint4)((int4)(char)*v1 - 0x30U)) goto label_400af2;
+  v10 = v12 + 3;
+  v11 = (uint8)(uint8)v10;
+  v24 = ((int4)(char)*v1 - 0x30U) + v14 * 8;
+  v23 = (uint1)v24;
+  v10 = (int4)(char)a0[(int8)v11];
+  v14 = v10 - 0x30;
+  v10 = v12 + 3;
+  v11 = (uint8)(uint8)v10;
+  if (8 <= v14) goto label_400af2;
+  v10 = v24 & 0xff;
+  v10 = v14 + v10 * 8;
+  if ((int4)v10 > 0xff) {
+    v11 = (unsigned long)dcgettext(0,0x404090,5);
+    error(0,0,v11);
+    v10 = v12 + 3;
+    v11 = (uint8)(uint8)v10;
+    goto label_400af2;
+  }
+  v23 = (char)v14 + v23 * '\b';
+  v10 = v12 + 4;
+  v11 = (uint8)(uint8)v10;
+  goto label_400af2;
+label_400fb0:
+  v22 = *(void *)(v30 * 8 + 0x405f00);
+  v10 = strncmp(v29,v22,v8);
+  if ((v10 != 0) || (v11 = (void *)strlen(v22), (void *)v8 != v11)) goto label_400fda;
+  v11 = (void *)xmalloc(0x20);
+  *(void *)&v11[2] = 0;
+  v16 = *(int8 *)(a1 + 8);
+  *v11 = 2;
+  v11[4] = (int4)v30;
+  if (v16 == 0) goto label_40121b;
+label_401087:
+  *(void **)(v16 + 8) = v11;
+  v28 = &v7[2];
+  *(void **)(a1 + 8) = v11;
+  goto label_400b4c;
+label_400fda:
+  v30 = v30 + 1;
+  if (v30 == 0xc) goto label_400fe4;
+  goto label_400fb0;
+label_400fe4:
+  v9 = star_digits_closebracket(&v20,v25);
+  if (v9 == '\0') {
+    v11 = (unsigned long)make_printable_str(v29,v8);
+    v27 = v11;
+    v11 = (unsigned long)quote(v11);
+    v21 = 0x403ba8;
+    v22 = v11;
+label_401031:
+    v11 = (unsigned long)dcgettext(0,v21,5);
+label_400dc5:
+    error(0,0,v11,v22);
+    free(v27);
+    goto label_400e9c;
+  }
+label_400ba0:
+  if ((v25[v5] == '*') && (v25[v6] == '\0')) {
+    for (v29 = &v26[3]; (v29 < v32 && (v29[v6] == '\0')); v29 = &v29[1]) {
+      if (v29[v5] == ']') {
+        v26 = &v29[0xfffffffffffffffe - (int8)v28];
+        if (v26 == (void *)0x0) {
+          v18 = 0;
+          v30 = 0;
+        }
+        else {
+          v2 = &(&v26[3])[v5];
+          v10 = xstrtoumax(v2,&v19,(*v2 != '0') * '\x02' + '\b',&v18,0);
+          if (((v10 != 0) || (v18 == -1)) || (v30 = v18, v19 != &v2[(int8)v26])) {
+            v11 = (unsigned long)make_printable_str(v2,v26);
+            v27 = v11;
+            v11 = (unsigned long)quote(v11);
+            v21 = 0x4041d8;
+            v22 = v11;
+            goto label_401031;
+          }
+        }
+        v11 = (void *)xmalloc(0x20);
+        *(void *)&v11[2] = 0;
+        *(int8 *)&v11[6] = v30;
+        v30 = *(int8 *)(a1 + 8);
+        *v11 = 4;
+        *(uint1 *)&v11[4] = v23;
+        if (v30 == 0) goto label_401216;
+        *(void **)(v30 + 8) = v11;
+        v25 = &v29[3];
+        *(void **)(a1 + 8) = v11;
+        v26 = &v29[1];
+        goto label_400c9c;
+      }
+    }
+  }
+label_400b30:
+  if ((v23 == 0x2d) && (v28[v6] == '\0')) {
+    v23 = v25[v5];
+    if (v23 < v3) {
+      v11 = (unsigned long)make_printable_char(v3);
+      v22 = v11;
+      v11 = (unsigned long)make_printable_char(v23);
+      v27 = v11;
+      v11 = (unsigned long)dcgettext(0,0x404208,5);
+      error(0,0,v11,v22,v27);
+      free(v22);
+      free(v27);
+      v4 = 0;
+      goto label_400e9c;
+    }
+    v11 = (void *)xmalloc(0x20);
+    *(void *)&v11[2] = 0;
+    v30 = *(int8 *)(a1 + 8);
+    *v11 = 1;
+    *(uint1 *)&v11[4] = v3;
+    *(uint1 *)((int8)v11 + 0x11) = v23;
+    if (v30 == 0) {
+      __assert_fail(0x403b9d,0x403b62,0x2a7,0x403fb8);
+      goto label_401211;
+    }
+    *(void **)(v30 + 8) = v11;
+    v28 = &v26[3];
+    *(void **)(a1 + 8) = v11;
+  }
+  else {
+    append_normal_char(a1);
+  }
+label_400b4c:
+  v25 = &v28[2];
+  v26 = v28;
+label_400c9c:
+  if (v32 <= v25) {
+    while( true ) {
+      v25 = &v26[v5];
+      if (v26 < v32) {
+        do {
+          v4 = *v25;
+          v25 = &v25[1];
+          append_normal_char(a1,v4);
+        } while (&v32[v5] != v25);
+      }
+label_400cd6:
+      v4 = 1;
+label_400e9c:
+      free(v5);
+      free(v6);
+      if (v35 == *(int8 *)(v31 + 0x28)) break;
+label_401211:
+      __stack_chk_fail();
+label_401216:
+      append_repeated_char.part.0();
+label_40121b:
+      __assert_fail(0x403b9d,0x403b62,0x2bd,0x404010);
+label_40123a:
+      v26 = (void *)0x0;
+    }
+    v9 = v4;
+    return v9;
+  }
+  goto label_400b5b;
+  v35 = *(int8 *)(v31 + 0x28);
+  v11 = (unsigned long)strlen();
+  v22 = v11;
+  v11 = (int8)xmalloc(v11);
+  v5 = (int8)v11;
+  v20 = (int8)v11;
+  v11 = (int8)xcalloc(v22,1);
+  v6 = (int8)v11;
+  v33 = (int8)v11;
+  if (*a0 == 0) goto label_400cd6;
+  v26 = (void *)0x0;
+  v13 = 0;
+  v3 = *a0;
+  do {
+    do {
+      v9 = v3;
+      v15 = (uint8)v26 & 0xffffffff;
+      v12 = (int4)v13;
+      v13 = (uint8)(v12 + 1);
+      v26 = (void *)(uint8)((int4)v26 + 1);
+      v3 = a0[v13];
+      v17 = (uint1 *)(v5 + v15);
+      if (v9 == 0x5c) {
+        v25 = (void *)(v6 + v15);
+        *v25 = 1;
+        if (v3 == 0) goto label_4010eb;
+        v14 = (uint4)v3 - 0x30;
+        v23 = (uint1)v14;
+        v10 = v14 & 0xff;
+        switch(v10) {
+          case 0:
+          case 1:
+          case 2:
+          case 3:
+          case 4:
+          case 5:
+          case 6:
+          case 7:
+            goto label_400f2b;
+          default:
+label_400aef:
+            v23 = v3;
+            v10 = v12 + 2;
+            v11 = (uint8)(uint8)v10;
+            goto label_400af2;
+          case 0x2c:
+            v23 = 0x5c;
+            v10 = v12 + 2;
+            v11 = (uint8)(uint8)v10;
+            goto label_400af2;
+          case 0x31:
+            v3 = 7;
+            goto label_400aef;
+          case 0x32:
+            v23 = 8;
+            v10 = v12 + 2;
+            v11 = (uint8)(uint8)v10;
+            goto label_400af2;
+          case 0x36:
+            v23 = 0xc;
+            v10 = v12 + 2;
+            v11 = (uint8)(uint8)v10;
+            goto label_400af2;
+          case 0x3e:
+            v23 = 10;
+            v10 = v12 + 2;
+            v11 = (uint8)(uint8)v10;
+            goto label_400af2;
+          case 0x42:
+            v23 = 0xd;
+            v10 = v12 + 2;
+            v11 = (uint8)(uint8)v10;
+            goto label_400af2;
+          case 0x44:
+            v23 = 9;
+            v10 = v12 + 2;
+            v11 = (uint8)(uint8)v10;
+            goto label_400af2;
+          case 0x46:
+            v23 = 0xb;
+            v10 = v12 + 2;
+            v11 = (uint8)(uint8)v10;
+            goto label_400af2;
+          
+        }
+      }
+      *v17 = v9;
+    } while (v3 != 0);
+    do {
+      v11 = (void *)((uint8)v26 & 0xffffffff);
+      v32 = (void *)v11;
+      v34 = (void *)v11;
+      if ((uint4)v26 <= 2) goto label_40123a;
+      v26 = (void *)0x0;
+      v25 = (void *)0x2;
+label_400b5b:
+      v3 = v26[v5];
+      v28 = &v26[1];
+      v23 = v26[v5 + 1];
+      v17 = (uint1 *)(uint8)v23;
+      if ((v3 != 0x5b) || (v26[v6] != '\0')) goto label_400b30;
+      v4 = 0;
+      if (((v23 != 0x3a) && (v23 != 0x3d)) || ((v28[v6] != '\0' || (&v32[-1] <= v25)))) goto label_400ba0;
+      v11 = (void *)v25;
+      while( true ) {
+        v7 = (void *)v11;
+        v29 = (void *)((int8)v11 + 1);
+        if ((((*(uint1 *)((int8)v11 + v5) == v23) && (*(char *)((int8)v11 + v5 + 1) == ']')) && (v29[v6 + -1] == '\0')) && (*(char *)((int8)v11 + v6 + 1) == '\0')) break;
+        v11 = (void *)v29;
+        if (&v32[-1] <= v29) goto label_400ba0;
+      }
+      v29 = &v25[v5];
+      v11 = (void *)((int8)v11 + (0xfffffffffffffffe - (int8)v26));
+      v8 = (void *)v11;
+      if (v11 == (void *)0x0) {
+        v22 = 0x404140;
+        if (v23 != 0x3a) {
+          v22 = 0x404168;
+        }
+        v11 = (unsigned long)dcgettext(0,v22,5);
+        error(0,0,v11);
+        goto label_400e9c;
+      }
+      if (v23 == 0x3a) {
+        v11 = (void *)0x0;
+        v30 = (int8)v11;
+        goto label_400fb0;
+      }
+      if (v11 != (void *)0x1) {
+        v9 = star_digits_closebracket(&v20,v25);
+        if (v9 == '\0') {
+          v11 = (unsigned long)make_printable_str(v29,v8);
+          v22 = v11;
+          v11 = (unsigned long)dcgettext(0,0x404198,5);
+          v27 = v22;
+          goto label_400dc5;
+        }
+        goto label_400ba0;
+      }
+      v11 = (void *)xmalloc(0x20);
+      *(void *)&v11[2] = 0;
+      v4 = *v29;
+      *v11 = 3;
+      *(void *)&v11[4] = v4;
+      v16 = *(int8 *)(a1 + 8);
+      if (v16 != 0) goto label_401087;
+      v12 = 0x403ff0;
+      __assert_fail(0x403b9d,0x403b62,0x2e7);
+label_4010eb:
+      v11 = (unsigned long)dcgettext(0,0x4040f8,5);
+      error(0,0,v11);
+      *v25 = 0;
+      v23 = 0x5c;
+      v11 = (uint8)(uint8)(v12 + 1);
+label_400af2:
+      *v17 = v23;
+      v13 = (uint8)v11;
+      v3 = a0[(int8)v11];
+    } while (a0[(int8)v11] == 0);
+  } while( true );
+}

--- a/docs/features/tr-o2-parse-str-7b9159/proposal.md
+++ b/docs/features/tr-o2-parse-str-7b9159/proposal.md
@@ -1,0 +1,84 @@
+# [PROPOSAL] Cyclic loop-refinement structuring (`loop_refine_structure`)
+
+**Status:** draft proposal — awaiting human go/no-go. **Do NOT implement until approved.**
+
+## The problem
+
+On `tr_O2.o::parse_str` (x86_64, the angr `test_decompiling_tr_O2_parse_str` opportunity) kuna
+produces correct but goto-heavy C: **37 gotos / 21 labels** where angr's SAILR/Phoenix
+structurer produces **11 gotos / 8 labels** for the same function — a clean nested
+`while(true){ if/else; switch }`. Same `switch` (16 cases), same overall logic; the gap is
+purely structuring quality. See `analysis.md` and `angr-vs-kuna.txt`.
+
+The dominant excess is **`goto label_400af2` ×12** — every `switch`-case body and several
+branches jump to a single loop-tail/continuation block. angr hoists this continuation merge
+into the loop body so the cases fall through to the latch (no `goto`). The remaining ~25 gotos
+are shared-successor merges resolved by angr's condition-region structuring + tail duplication.
+
+## Why this is not a single option-gated Action (the proposal gate)
+
+kuna's existing structuring passes were measured on this exact target and **none change the
+output** (goto count stays 37 with each, or all three, enabled):
+
+| option | what it does | why it doesn't fire here |
+|---|---|---|
+| `gotoreduce` | tail-dup `if(cond) goto T` for small single-successor tails | acyclic tail dup only; the merge is the loop latch |
+| `loopbreak_recovery` | loop-exit `goto` → `break` | exit edges only, not continuation merges |
+| `regionstructure` | `region_structurer`: acyclic sequence + ITE schemas + edge-virtualization | explicitly **acyclic** — no cyclic loop refinement |
+
+The fix is **cyclic loop refinement** — a new structuring pass type over `KunaRegionIdentifier`
+loop regions. That is, by the Hard-Rule-7 criteria: (a) a new pass *type*/infrastructure, not
+one Action/Rule; (b) it touches S7/S8 structuring beyond a single gated early-return. **LARGE.**
+
+The decider subagent independently returned `scope: large` (verbatim in `record.json`).
+
+## angr reference
+
+angr SAILR/Phoenix **`LoopRefinement`** + `RegionIdentifier` cyclic structuring
+(DreamStructurer-style condition regions over loops): it identifies the loop region, refines
+the loop body so continuation-merge predecessors fall through to the latch (synthesizing
+`continue`/fall-through), and applies condition-based refinement to collapse shared-successor
+gotos before any edge is virtualized. kuna already has the **acyclic** half
+(`region_structurer`, the W7 `KunaRegionIdentifier` port); this proposal adds the **cyclic**
+half on top of it.
+
+## Proposed multi-step implementation plan
+
+Option name: **`loop_refine_structure`** (default-OFF; gated P0 assertion). Increments:
+
+1. **Loop-region continuation analysis (read-only).** Over `KunaRegionIdentifier`'s loop
+   regions, identify the single continuation-merge block (the latch's dominant predecessor
+   merge) and the set of predecessor edges that `goto` it. Emit observability
+   (`region` console sub-queries), no output change. *(~1 increment.)*
+2. **Continuation hoisting / `continue` synthesis.** Restructure the loop body so those
+   predecessors fall through to the latch (or emit `continue`) instead of `goto <latch>`,
+   gated by `loop_refine_structure on`. Target: eliminate the 12× `goto label_400af2`.
+   *(~1–2 increments; the riskiest — must preserve SSA/region invariants.)*
+3. **Condition-region refinement for shared-successor merges.** Port the SAILR condition-based
+   refinement that collapses the remaining ~13 single-use shared-successor gotos into nested
+   `if/else` before virtualization. *(~1–2 increments.)*
+4. **Default decision + ablation.** Run the full `kuna test --all` ablation; ship default-OFF
+   opt-in unless 0/675 upstream assertions change *and* the speed gate passes. Add a stage test
+   (`tests/stages/ghangr-tr-o2-parse-str-7b9159.xml`) asserting goto-count reduction / the
+   `while(true)` form.
+
+Estimated **3–5 increments / multiple PRs** — hence the proposal gate.
+
+## Speed / risk assessment
+
+- **Risk: high.** Cyclic structuring surgery over loop regions risks SSA/phi and region-tree
+  invariant breakage; it can change output for *many* functions, so the ablation must be clean
+  before any default-ON. Strictly default-OFF opt-in until proven.
+- **Speed:** a region-tree walk + local restructuring is roughly linear in region count; the
+  budget concern is the extra structuring pass on every function when ON. Must be measured per
+  increment (Hard Rule 6); keep OFF by default regardless until measured within budget.
+- **Blast radius:** S7/S8 only; no loader/lift changes. Same family as the parked
+  `gotoreduce`-tail-duplication and irreducible-loop proposals (see `docs/PROGRESS.md`).
+
+## Recommendation
+
+File this as a draft `[PROPOSAL]` PR and park the opportunity. On human approval, dispatch an
+implementation worker per increment (start with increment 1, the read-only analysis) on this
+branch.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/tr-o2-parse-str-7b9159/record.json
+++ b/docs/features/tr-o2-parse-str-7b9159/record.json
@@ -1,0 +1,36 @@
+{
+  "opportunity": "test_decompiling_tr_O2_parse_str::parse_str",
+  "test_name": "test_decompiling_tr_O2_parse_str",
+  "binary": "/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/tr_O2.o",
+  "selector": "parse_str",
+  "func_addr": "0x400a20",
+  "angr_version": "9.2.213",
+  "scope": "large",
+  "proposal": true,
+  "option": "loop_refine_structure",
+  "change_kind": "structure-recovery",
+  "source_decompiler": "angr",
+  "inspiration": "test_decompiling_tr_O2_parse_str; angr SAILR/Phoenix LoopRefinement + RegionIdentifier cyclic structuring (DreamStructurer-style condition regions over loops); parse_str",
+  "gap_metrics": {
+    "ref_gotos": 11,
+    "kuna_gotos": 37,
+    "ref_labels": 8,
+    "kuna_labels": 21,
+    "ref_loc": 417,
+    "kuna_loc": 354,
+    "dominant_goto": "label_400af2 x12 (loop continuation/back-edge merge)"
+  },
+  "existing_options_tried": ["gotoreduce", "loopbreak_recovery", "regionstructure"],
+  "existing_options_effect": "none change the target; goto count stays 37 with each or all enabled",
+  "decisions": [
+    {
+      "question": "Is closing the parse_str goto/label gap (37->11) a single option-gated Action (small) or new structuring infrastructure (large)?",
+      "decider_model": "opus",
+      "scope": "large",
+      "rationale": "The dominant excess (goto label_400af2 x12) is a loop-continuation/back-edge merge - a CYCLIC structuring problem - and angr's clean while(true){...} comes from its cyclic loop-refinement + condition-region structuring, not a single rule. kuna's existing acyclic schemas (region_structurer is explicitly 'no loops': acyclic sequence/ITE + edge-virtualization) and the two tail-duplication passes (gotoreduce, loopbreak_recovery) already model the SAILR/Phoenix acyclic family and provably don't fire here, so closing the gap needs new cyclic-structuring infrastructure in S7/S8 - not expressible as one Action/Rule like kuna_loweredswitch.rs. Even eliminating all 12 back-edge gotos leaves ~25 vs angr's 11, so no single narrow Action meaningfully approaches angr's output.",
+      "which_gate_triggered": "needs a new pass type / must touch S7-S8 structuring beyond a single gated early-return (cyclic loop-refinement is not modelable as one Action/Rule)",
+      "angr_reference_pass": "angr SAILR/Phoenix LoopRefinement + RegionIdentifier cyclic structuring (DreamStructurer-style condition regions over loops)",
+      "recommended_next": "STOP at design; file a [PROPOSAL] draft PR for a cyclic loop-refinement structuring pass building on KunaRegionIdentifier/region_structurer, scoped as a multi-increment S7/S8 effort."
+    }
+  ]
+}


### PR DESCRIPTION
## [PROPOSAL] Cyclic loop-refinement structuring (`loop_refine_structure`)

**Draft proposal — awaiting human go/no-go. No engine changes; analysis bundle only.**

On `tr_O2.o::parse_str` (x86_64; the angr `test_decompiling_tr_O2_parse_str` opportunity) kuna
emits correct but goto-heavy C — **37 gotos / 21 labels** vs angr's **11 / 8** for the same
function (same `switch`, 16 cases; same logic). The dominant excess is `goto label_400af2` ×12:
a loop-continuation/back-edge merge that angr hoists into the loop body to produce a clean
`while(true){ if/else; switch }`.

Closing it requires **cyclic loop refinement** — a new S7/S8 structuring pass type, not a single
`Action`/`Rule`. kuna's existing structuring options (`gotoreduce`, `loopbreak_recovery`,
`regionstructure` — the acyclic Phoenix/SAILR family) were measured on this exact target and
**none change it** (goto count stays 37). A decider subagent independently returned
`scope: large`, triggering the proposal fork (Hard Rule 7).

This branch name previously hosted the now-closed ET_REL-loading proposal (PR #34); that gap is
since handled by `relocobjects` (PR #37), which is precisely why the `.o` now decompiles and the
*structuring* gap is visible. This proposal supersedes it.

See [`docs/features/tr-o2-parse-str-7b9159/proposal.md`](docs/features/tr-o2-parse-str-7b9159/proposal.md)
for the multi-increment plan, [`analysis.md`](docs/features/tr-o2-parse-str-7b9159/analysis.md)
for the measured gap, and `angr-vs-kuna.txt` for the side-by-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
