### PR TITLE
[PROPOSAL] angr-ternary-propagation-2-eda7a8: collapse value-producing diamond into a ternary (loader-blocked)

### DIFF
--- a/docs/features/ternary-propagation-2-eda7a8/analysis.md
+++ b/docs/features/ternary-propagation-2-eda7a8/analysis.md
@@ -1,0 +1,103 @@
+# Analysis — `test_ternary_propagation_2::print_only_size` (angr ternary propagation)
+
+## Opportunity
+
+- angr testcase: `test_ternary_propagation_2`, function `print_only_size`
+- Binary: `/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/du.o` (ELF **ET_REL** `.o`, x86-64)
+- angr version: 9.2.213
+
+## What angr does better
+
+angr collapses a value-producing control-flow **diamond** into a single C **ternary**:
+
+```c
+long long print_only_size(unsigned long long a0)
+{
+    char *v2;
+    ...
+    v2 = (a0 == 18446744073709551615 ? dcgettext(NULL, "Infinity", 5) : human_readable());
+    fputs_unlocked(v2, stdout);
+    return ...;
+}
+```
+
+The underlying shape (from the disassembly) is:
+
+```
+if (rdi == -1)              ; cmp rdi,-1 / je
+    v = dcgettext(NULL,"Infinity",5);
+else
+    v = human_readable(...);
+fputs_unlocked(v, stdout);  ; both arms converge here
+```
+
+i.e. an `if/else` whose **both arms are side-effecting CALLs** that each assign the
+merge variable `v`, followed by a single use of `v`. angr's region simplification
+("ternary propagation") rewrites this into `v = cond ? f() : g()`.
+
+## What kuna does
+
+**kuna produces no output at all.** Loading *any* function in `du.o` — even the trivial
+`timetostr` stub — fails immediately at `load function` time:
+
+```
+/home/.../du.o successfully loaded: x86:LE:64:default:gcc
+Execution error: Unable to load 512 bytes at r0x00405290
+```
+
+So this is a **whole-file loader failure**, not a per-function or structuring problem.
+The full side-by-side is in `angr-vs-kuna.txt`.
+
+## Root cause (two independent gaps)
+
+### Gap 1 — loader (the immediate blocker)
+
+`du.o` is an ET_REL object, loaded by the **`relocobjects`** feature
+(`kuna-analysis/src/s1_loader/elf_reloc.rs` + `loadimage_object.rs`, default-on, DIV-7).
+That loader lays the `SHF_ALLOC` sections at a synthetic base and binds *undefined*
+symbols into a synthetic "extern area" above them. Per the code's own comment
+(`elf_reloc.rs:239`):
+
+> Pure data externs (e.g. `stdout`, referenced by PC32 to an extern slot) …
+
+are given a synthetic address (here `0x405290`) but the synthesized load image provides
+**no backing bytes** for that extern region. `print_only_size` references `stdout` via
+`R_X86_64_PC32` (`mov rbp, [rip+disp] # stdout`), so any read through the extern region
+aborts the whole load with `Unable to load 512 bytes at r0x00405290`
+(`loadimage_object.rs:598`). The object additionally uses `R_X86_64_REX_GOTPCREL`
+relocations in other functions which the loader logs as
+`unhandled kind GotRelative (skipped)`.
+
+Owning stage/tier: **S1 loader** (`relocobjects`).
+
+Fix sketch: back the synthetic data-extern region with zero bytes (so reads through a
+data extern like `stdout` succeed) and/or handle `R_X86_64_REX_GOTPCREL` by materialising
+a GOT slot that points at the extern. This is the angr CLE "extern object" backing-page
+behaviour.
+
+### Gap 2 — structuring (the named angr advantage)
+
+Even with a working loader, kuna (like Ghidra) would render the diamond as a literal
+`if/else`, **not** a ternary. Ghidra deliberately emits `?:` only from its
+`RuleConditionalMove` — a *single, side-effect-free* `MULTIEQUAL`. Here both arms contain
+side-effecting CALLs (`dcgettext`, `human_readable`), so no existing rule fires.
+
+Producing angr's ternary needs a new **S8 structuring** rewrite that recognises an
+`if (c) { v = f(); } else { v = g(); }` diamond merging into a single use of `v`, and
+rewrites it to `v = c ? f() : g();` — comparable in spirit to the existing S8 readability
+rewrites `kuna_branchflip.rs` / `kuna_gotoreduce.rs`, but harder: it must fold two
+assignment arms plus their merge into one statement and likely add `?:` emit support for
+the side-effecting case.
+
+Owning stage: **S8 structuring** (real pass order in `universalaction.rs` /
+`s8_structure/coreaction_*`).
+
+## Hypothesis / why this is a PROPOSAL, not a one-pass feature
+
+Closing this opportunity requires **two independent pieces across two tiers** (S1 loader +
+S8 structuring), each non-trivial, plus new `?:` emit support — and the named target cannot
+even be loaded until the loader piece lands, so no end-to-end before/after witness exists
+today and a firing stage test could only be synthesized from a contrived externless
+bytechunk. This exceeds the worker's "one option-gated `kuna_*.rs` Action/Rule" budget on
+multiple axes, so per Hard rule 7 it is routed to a `[PROPOSAL]` draft PR for human go/no-go
+rather than implemented. See `proposal.md`.

--- a/docs/features/ternary-propagation-2-eda7a8/angr-vs-kuna.txt
+++ b/docs/features/ternary-propagation-2-eda7a8/angr-vs-kuna.txt
@@ -1,0 +1,54 @@
+==============================================================================
+test_ternary_propagation_2 :: print_only_size   (angr 9.2.213 @ 0x400280)
+==============================================================================
+
+--- angr ---
+typedef struct FILE {
+} FILE;
+
+extern unsigned long stdout;
+
+long long print_only_size(unsigned long long a0)
+{
+    char *v2;  // rax
+    unsigned long v3;  // fs
+    unsigned long v0;  // [bp-0x10]
+
+    v2 = (a0 == 18446744073709551615 ? dcgettext(NULL, "Infinity", 5) : human_readable());
+    fputs_unlocked(v2, stdout);
+    return v0 - *((long long *)(40 + v3));
+}
+
+
+--- kuna (addr mode) ---
+  (no output: addr-mode: no C output for '0x400280' in /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/du.o; decompiler said:
+[decomp]> load file /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/du.o
+/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/du.o successfully loaded: x86:LE:64:default:gcc
+[decomp]> read symbols
+[decomp]> load addr 0x400280
+Execution error: Unable to load 512 bytes at r0x00405290
+[decomp]> decompile
+Execution error: No function selected
+[decomp]> openfile write /tmp/kuna_c_19l2hlgo.c
+[decomp]> print C
+Execution error: No function selected
+[decomp]> closefile
+[decomp]> quit
+
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/du.o: reloc at 0x4026c0+0x8d: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/du.o: reloc at 0x4026c0+0x34c: unhandled kind GotRelative (skipped) (name-mode: no C output for 'print_only_size' in /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/du.o; decompiler said:
+[decomp]> load file /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/du.o
+/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/du.o successfully loaded: x86:LE:64:default:gcc
+[decomp]> read symbols
+[decomp]> load function print_only_size
+Execution error: Unable to load 512 bytes at r0x00405290
+[decomp]> decompile
+Execution error: No function selected
+[decomp]> openfile write /tmp/kuna_c_jm5tb05l.c
+[decomp]> print C
+Execution error: No function selected
+[decomp]> closefile
+[decomp]> quit
+
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/du.o: reloc at 0x4026c0+0x8d: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/du.o: reloc at 0x4026c0+0x34c: unhandled kind GotRelative (skipped)))

--- a/docs/features/ternary-propagation-2-eda7a8/proposal.md
+++ b/docs/features/ternary-propagation-2-eda7a8/proposal.md
@@ -1,0 +1,91 @@
+# [PROPOSAL] angr ternary propagation — `ternary_propagate`
+
+Close the angr-vs-kuna gap on `test_ternary_propagation_2::print_only_size`: angr renders a
+value-producing `if/else` diamond as a single C ternary (`v = cond ? f() : g()`), while kuna
+today **produces no output at all** for the target object. This proposal documents the gap and
+a multi-step plan, and asks for a human go/no-go before an implementation worker is spent.
+
+See `analysis.md` for the full evidence and `angr-vs-kuna.txt` for the side-by-side.
+
+## The problem
+
+Target function `print_only_size` in `du.o` (ET_REL `.o`, x86-64):
+
+```c
+// angr
+v2 = (a0 == -1 ? dcgettext(NULL, "Infinity", 5) : human_readable());
+fputs_unlocked(v2, stdout);
+```
+
+The shape is an `if/else` whose **both arms are side-effecting CALLs** assigning a merge
+variable that is then used once. angr's region simplification collapses it into `?:`.
+
+## Why this is large (not a single option-gated pass)
+
+The scope decider (Plan agent, Opus) returned **`scope: large`**, verbatim in `record.json`.
+Two independent gaps across two tiers must both be closed:
+
+### Step 1 — Loader prerequisite (S1, `relocobjects`)
+
+kuna cannot load `du.o` at all: loading any function fails with
+`Unable to load 512 bytes at r0x00405290`. The `relocobjects` ET_REL loader
+(`kuna-analysis/src/s1_loader/elf_reloc.rs`, `loadimage_object.rs`) binds undefined **data**
+externs (e.g. `stdout`, referenced via `R_X86_64_PC32`) to a synthetic extern region with
+**no backing bytes**, and a read through that region aborts the whole load. The object also
+uses `R_X86_64_REX_GOTPCREL` relocs that the loader logs as `unhandled kind GotRelative
+(skipped)`.
+
+Plan: back the synthetic data-extern region with zero bytes so reads through a data extern
+succeed, and materialise a GOT slot for `R_X86_64_REX_GOTPCREL` that points at the extern
+(the angr CLE "extern object" backing-page behaviour). Gate behind the existing
+`relocobjects` capability or a new loader sub-option; verify `du.o` (and the other
+GOTPCREL-using `.o`s in the corpus) decompile.
+
+This is the angr reference: CLE's `ExternObject` / relocation backend, mirrored by
+`elf_reloc.rs`.
+
+### Step 2 — Ternary structuring (S8) — the named angr advantage
+
+Even once loaded, kuna (like Ghidra) renders the diamond as a literal `if/else`. Ghidra emits
+`?:` only from `RuleConditionalMove` — a single **side-effect-free** `MULTIEQUAL`; here both
+arms contain side-effecting CALLs, so nothing fires.
+
+Plan: a new S8 structuring/print-tree pass (a `kuna_ternary_propagate.rs` Action modelled on
+`kuna_branchflip.rs` / `kuna_gotoreduce.rs`) that recognises an `if (c) { v = f(); } else
+{ v = g(); }` block merging into a single use of `v`, and rewrites it to `v = c ? f() : g();`.
+Requires extending kuna's emit to render a side-effecting `?:` (today `?:` only comes from
+`RuleConditionalMove`). angr reference: its `RegionSimplifier` / "ternary propagation" pass.
+
+### Scope budget exceeded
+
+- **>1 new module** (loader change + a new S8 module).
+- **Two tiers**: S1 loader (kuna-analysis) + S8 structuring (kuna-decomp).
+- **S8 beyond a single gated early-return**: folds two assignment arms + the merge into one
+  statement, plus new side-effecting `?:` emit.
+- **No end-to-end witness today**: the named target can't be loaded until Step 1 lands, so the
+  before/after demo on `du.o` is empty and a firing stage test could only be a contrived
+  externless bytechunk.
+
+## Speed / risk assessment
+
+- **Loader (Step 1):** low runtime risk — the loader runs once at `load file`; backing the
+  extern region with zeros is O(region size). Risk is *correctness*: data externs would read as
+  zero (not the real libc value), which is acceptable (angr does the same — externs are opaque).
+- **Structuring (Step 2):** a gated S8 rewrite; default-OFF while developed, ablation-gated to
+  default-ON only if 0/675 datatests change and the target speed budget (+5%) holds. Ternary
+  folding of side-effecting calls must preserve evaluation order (only fold when the merge use
+  dominates and no intervening side effects reorder) — the main correctness risk.
+
+## Proposed option
+
+`ternary_propagate` — S8 structure-recovery, `source_decompiler = "angr"`,
+`inspiration = "test_ternary_propagation_2; RegionSimplifier ternary propagation; print_only_size"`,
+default-OFF opt-in until ablation+speed clear it. The loader prerequisite (Step 1) may ship as a
+separate `relocobjects` extension or its own option, sequenced first.
+
+## Recommendation
+
+Two-PR sequence: **(1)** loader extension so ET_REL `.o`s with data externs / GOTPCREL load
+(unblocks this and other `du.o`-style targets); **(2)** the `ternary_propagate` S8 rewrite. A
+human should approve before an implementation worker is dispatched, since neither piece fits a
+single option-gated session and they are independently useful.

--- a/docs/features/ternary-propagation-2-eda7a8/record.json
+++ b/docs/features/ternary-propagation-2-eda7a8/record.json
@@ -1,0 +1,23 @@
+{
+  "opportunity": "test_ternary_propagation_2::print_only_size",
+  "test_name": "test_ternary_propagation_2",
+  "binary": "/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/du.o",
+  "selector": "print_only_size",
+  "func_addr": "0x400280",
+  "angr_version": "9.2.213",
+  "option": "ternary_propagate",
+  "change_kind": "structure-recovery",
+  "source_decompiler": "angr",
+  "inspiration": "test_ternary_propagation_2; RegionSimplifier ternary propagation; print_only_size",
+  "scope": "large",
+  "proposal": true,
+  "decisions": [
+    {
+      "question": "Is reconstructing angr's ternary-propagation (collapsing a control-flow diamond whose two arms are side-effecting CALLs into a single `?:` assignment) on `du.o` a SMALL one-option pass or a LARGE proposal-gated feature?",
+      "scope": "large",
+      "decision": "This needs two independent pieces across two tiers: a loader fix (back the synthetic data-extern region with zero bytes plus handle GOTPCREL) so `du.o` can load at all, and a genuinely new S8 structuring behavior that rewrites two side-effecting CALL arms plus their merge into one ternary statement — likely requiring new side-effecting `?:` emit support that Ghidra/kuna deliberately omit (RuleConditionalMove only covers a single side-effect-free MULTIEQUAL). That exceeds a single gated early-return in S8 and is >1 new module, so it fails the SMALL rule on multiple axes. The loader prerequisite also means the named target can't be demoed before/after and a firing test would have to be a contrived externless bytechunk, removing the end-to-end witness a small one-session change relies on.",
+      "recommended_action": "proposal",
+      "proposed_option_name": "ternary_propagate"
+    }
+  ]
+}


### PR DESCRIPTION
# [PROPOSAL] angr ternary propagation — `ternary_propagate`

Close the angr-vs-kuna gap on `test_ternary_propagation_2::print_only_size`: angr renders a
value-producing `if/else` diamond as a single C ternary (`v = cond ? f() : g()`), while kuna
today **produces no output at all** for the target object. This proposal documents the gap and
a multi-step plan, and asks for a human go/no-go before an implementation worker is spent.

See `analysis.md` for the full evidence and `angr-vs-kuna.txt` for the side-by-side.

## The problem

Target function `print_only_size` in `du.o` (ET_REL `.o`, x86-64):

```c
// angr
v2 = (a0 == -1 ? dcgettext(NULL, "Infinity", 5) : human_readable());
fputs_unlocked(v2, stdout);
```

The shape is an `if/else` whose **both arms are side-effecting CALLs** assigning a merge
variable that is then used once. angr's region simplification collapses it into `?:`.

## Why this is large (not a single option-gated pass)

The scope decider (Plan agent, Opus) returned **`scope: large`**, verbatim in `record.json`.
Two independent gaps across two tiers must both be closed:

### Step 1 — Loader prerequisite (S1, `relocobjects`)

kuna cannot load `du.o` at all: loading any function fails with
`Unable to load 512 bytes at r0x00405290`. The `relocobjects` ET_REL loader
(`kuna-analysis/src/s1_loader/elf_reloc.rs`, `loadimage_object.rs`) binds undefined **data**
externs (e.g. `stdout`, referenced via `R_X86_64_PC32`) to a synthetic extern region with
**no backing bytes**, and a read through that region aborts the whole load. The object also
uses `R_X86_64_REX_GOTPCREL` relocs that the loader logs as `unhandled kind GotRelative
(skipped)`.

Plan: back the synthetic data-extern region with zero bytes so reads through a data extern
succeed, and materialise a GOT slot for `R_X86_64_REX_GOTPCREL` that points at the extern
(the angr CLE "extern object" backing-page behaviour). Gate behind the existing
`relocobjects` capability or a new loader sub-option; verify `du.o` (and the other
GOTPCREL-using `.o`s in the corpus) decompile.

This is the angr reference: CLE's `ExternObject` / relocation backend, mirrored by
`elf_reloc.rs`.

### Step 2 — Ternary structuring (S8) — the named angr advantage

Even once loaded, kuna (like Ghidra) renders the diamond as a literal `if/else`. Ghidra emits
`?:` only from `RuleConditionalMove` — a single **side-effect-free** `MULTIEQUAL`; here both
arms contain side-effecting CALLs, so nothing fires.

Plan: a new S8 structuring/print-tree pass (a `kuna_ternary_propagate.rs` Action modelled on
`kuna_branchflip.rs` / `kuna_gotoreduce.rs`) that recognises an `if (c) { v = f(); } else
{ v = g(); }` block merging into a single use of `v`, and rewrites it to `v = c ? f() : g();`.
Requires extending kuna's emit to render a side-effecting `?:` (today `?:` only comes from
`RuleConditionalMove`). angr reference: its `RegionSimplifier` / "ternary propagation" pass.

### Scope budget exceeded

- **>1 new module** (loader change + a new S8 module).
- **Two tiers**: S1 loader (kuna-analysis) + S8 structuring (kuna-decomp).
- **S8 beyond a single gated early-return**: folds two assignment arms + the merge into one
  statement, plus new side-effecting `?:` emit.
- **No end-to-end witness today**: the named target can't be loaded until Step 1 lands, so the
  before/after demo on `du.o` is empty and a firing stage test could only be a contrived
  externless bytechunk.

## Speed / risk assessment

- **Loader (Step 1):** low runtime risk — the loader runs once at `load file`; backing the
  extern region with zeros is O(region size). Risk is *correctness*: data externs would read as
  zero (not the real libc value), which is acceptable (angr does the same — externs are opaque).
- **Structuring (Step 2):** a gated S8 rewrite; default-OFF while developed, ablation-gated to
  default-ON only if 0/675 datatests change and the target speed budget (+5%) holds. Ternary
  folding of side-effecting calls must preserve evaluation order (only fold when the merge use
  dominates and no intervening side effects reorder) — the main correctness risk.

## Proposed option

`ternary_propagate` — S8 structure-recovery, `source_decompiler = "angr"`,
`inspiration = "test_ternary_propagation_2; RegionSimplifier ternary propagation; print_only_size"`,
default-OFF opt-in until ablation+speed clear it. The loader prerequisite (Step 1) may ship as a
separate `relocobjects` extension or its own option, sequenced first.

## Recommendation

Two-PR sequence: **(1)** loader extension so ET_REL `.o`s with data externs / GOTPCREL load
(unblocks this and other `du.o`-style targets); **(2)** the `ternary_propagate` S8 rewrite. A
human should approve before an implementation worker is dispatched, since neither piece fits a
single option-gated session and they are independently useful.
