### PR TITLE
[PROPOSAL] angr-ret-dedupe-fakeret-1-fb25cd: ET_REL undefined-external tail-call (qsort) gap

### DIFF
--- a/docs/features/ret-dedupe-fakeret-1-fb25cd/analysis.md
+++ b/docs/features/ret-dedupe-fakeret-1-fb25cd/analysis.md
@@ -1,0 +1,104 @@
+# Analysis — `test_ret_dedupe_fakeret_1::sort_found_occurs`
+
+angr testcase: `test_ret_dedupe_fakeret_1` (angr 9.2.213)
+Binary: `binaries/tests/x86_64/decompiler/ptx.o` (ET_REL, x86-64)
+Function: `sort_found_occurs` (`.text+0x440`, 37 bytes)
+
+## What the function is
+
+```asm
+sort_found_occurs:
+  mov  rsi, [rip+number_of_occurs]   ; .bss global, R_X86_64_PC32
+  test rsi, rsi
+  jne  .L
+  ret                                ; early exit
+.L:
+  mov  rdi, [rip+occurs_table]       ; .bss global
+  lea  rcx, [rip+compare_occurs]     ; local fn
+  mov  edx, 0x30
+  jmp  qsort                         ; TAIL CALL — R_X86_64_PLT32, qsort UNDEFINED extern
+```
+
+It is a guarded **tail call**: `if (n) jmp qsort` else `ret`.
+
+## What angr produces (the win the test asserts)
+
+```c
+void sort_found_occurs(void) {
+    if (number_of_occurs)
+        qsort(occurs_table, number_of_occurs, 48, compare_occurs);
+    return;
+}
+```
+
+Assertion: `re.search(r"if\(.+?\).*qsort\(.*\);.*return", text)`.
+
+angr's `ReturnDeduplicator` (`optimization_passes/ret_deduplicator.py`,
+`STAGE = DURING_REGION_IDENTIFICATION`) folds `if (c) { …; return x; } return x;`
+into `if (c) { … } return x;`. The tail-call `jmp qsort` is structured into
+`qsort(); return;`, creating a second `return` that the deduplicator then merges.
+
+## What kuna produces
+
+**On the real `ptx.o` (and a byte-equivalent `.o` I built): kuna emits NO C at all.**
+
+```
+[decomp]> load function sort_found_occurs
+Execution error: Unable to load 512 bytes at r0x00402000   (resp. r0x00407210 in ptx.o)
+[decomp]> decompile
+Execution error: No function selected
+```
+
+Root cause (reproduced independently with my own `gcc -O2 -c` object — identical
+failure): `qsort` is an **undefined external** in an ET_REL `.o` (there is no PLT
+thunk in a relocatable object). kuna's ET_REL loader maps undefined externals to
+an empty synthetic region, and the S1 decoder **follows the direct tail-call
+`jmp qsort` as intraprocedural flow** into that region, then fails to fetch 512
+code bytes there. The function never decompiles.
+
+**On a properly *linked* ELF (PLT present), kuna already does the right thing:**
+
+```c
+void sub_401170(void) {
+  if (dat_404040 == 0) {
+    return;
+  }
+                    /* WARNING: Treating indirect jump as call */
+  (*dat_404018)(dat_404038,dat_404040,0x30,compare_occurs);
+  return;
+}
+```
+
+Here the `jmp qsort@plt` lands on a real PLT stub (`jmp *GOT`), kuna's flow
+analysis classifies it as a call ("Treating indirect jump as call"), and the
+structurer emits the **already-deduplicated** guard-clause form:
+`if (!c) return; qsort_equiv(); return;` — semantically identical to angr's
+`if (c) { qsort(); } return;`.
+
+## Conclusion: the nominal feature does not reproduce as a kuna defect
+
+1. **There is no return-duplication defect in kuna to fix.** angr's
+   `ReturnDeduplicator` targets `if(c){…return x;} return x;`. kuna never emits
+   that shape here — on a loadable binary it already produces the deduplicated
+   guard-clause form (one guard `return` + one tail `return`, which is the
+   *output* of deduplication, not the bug). Porting a return-deduplicator would
+   be a no-op on this function.
+
+2. **The actual reason kuna loses to angr on `ptx.o` is a loader/flow gap, not a
+   structuring gap:** kuna cannot decode a direct `jmp` to an **undefined external
+   symbol** in an ET_REL object (it decodes into the empty external region and
+   aborts). Closing it requires either:
+   - **(loader)** synthesizing a real call/return thunk for undefined externals
+     referenced by direct branches in ET_REL objects (the known ET_REL
+     undefined-symbol gap — `relocobjects`/`docs/divergences.md` DIV-7 track), or
+   - **(flow)** classifying a direct `jmp <undefined-external>` as a tail-call
+     (CALL + RETURN terminator) at decode time so the decoder stops instead of
+     falling into the external region.
+
+   Both are **cross-tier** (loader + S1/S2 decode/flow), multi-step, and not
+   modelable as a single Action/Rule like `kuna_loweredswitch.rs`. Per Hard
+   rule 7 this is **large / proposal-gate**, not a one-option implementation.
+
+Stage ownership (for the proposal): S1 decode-table / S2 flow classification
+(the "post-call terminator" family, cf. `gh6882-sparcstructret`) coupled with the
+ET_REL loader's undefined-symbol resolution (`kuna-analysis` loader tier).

--- a/docs/features/ret-dedupe-fakeret-1-fb25cd/angr-vs-kuna.txt
+++ b/docs/features/ret-dedupe-fakeret-1-fb25cd/angr-vs-kuna.txt
@@ -1,0 +1,45 @@
+==============================================================================
+test_ret_dedupe_fakeret_1 :: sort_found_occurs   (angr 9.2.213 @ 0x400440)
+==============================================================================
+
+--- angr ---
+extern unsigned long number_of_occurs;
+
+void sort_found_occurs(void)
+{
+    if (number_of_occurs)
+        qsort();
+    return;
+}
+
+
+--- kuna (addr mode) ---
+  (no output: addr-mode: no C output for '0x400440' in /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/ptx.o; decompiler said:
+[decomp]> load file /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/ptx.o
+/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/ptx.o successfully loaded: x86:LE:64:default:gcc
+[decomp]> read symbols
+[decomp]> load addr 0x400440
+Execution error: Unable to load 512 bytes at r0x00407210
+[decomp]> decompile
+Execution error: No function selected
+[decomp]> openfile write /tmp/kuna_c_yn5wslq9.c
+[decomp]> print C
+Execution error: No function selected
+[decomp]> closefile
+[decomp]> quit
+
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/ptx.o: reloc at 0x404280+0x7d: unhandled kind GotRelative (skipped) (name-mode: no C output for 'sort_found_occurs' in /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/ptx.o; decompiler said:
+[decomp]> load file /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/ptx.o
+/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/ptx.o successfully loaded: x86:LE:64:default:gcc
+[decomp]> read symbols
+[decomp]> load function sort_found_occurs
+Execution error: Unable to load 512 bytes at r0x00407210
+[decomp]> decompile
+Execution error: No function selected
+[decomp]> openfile write /tmp/kuna_c_3m9e3mlq.c
+[decomp]> print C
+Execution error: No function selected
+[decomp]> closefile
+[decomp]> quit
+
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/ptx.o: reloc at 0x404280+0x7d: unhandled kind GotRelative (skipped)))

--- a/docs/features/ret-dedupe-fakeret-1-fb25cd/proposal.md
+++ b/docs/features/ret-dedupe-fakeret-1-fb25cd/proposal.md
@@ -1,0 +1,111 @@
+# [PROPOSAL] ET_REL undefined-external tail-call recovery (`etrel_extern_tailcall`)
+
+**Opportunity:** angr `test_ret_dedupe_fakeret_1::sort_found_occurs`
+**Binary:** `binaries/tests/x86_64/decompiler/ptx.o` (ET_REL, x86-64)
+**Status:** proposal — needs human go/no-go before implementation.
+
+## The problem
+
+`sort_found_occurs` is a guarded **tail call**:
+
+```asm
+  mov  rsi, [number_of_occurs]
+  test rsi, rsi
+  jne  .L
+  ret
+.L:
+  mov  rdi, [occurs_table]
+  lea  rcx, [compare_occurs]
+  mov  edx, 0x30
+  jmp  qsort          ; R_X86_64_PLT32, qsort is an UNDEFINED external
+```
+
+angr decompiles it to (and the test asserts) `if (number_of_occurs) qsort(...); return;`.
+
+**kuna emits NO C at all on `ptx.o`:**
+
+```
+[decomp]> load function sort_found_occurs
+Execution error: Unable to load 512 bytes at r0x00407210
+[decomp]> decompile
+Execution error: No function selected
+```
+
+Reproduced independently with a byte-equivalent object built from
+`gcc -O2 -c` (identical `Unable to load 512 bytes` abort). See
+[`analysis.md`](./analysis.md) and [`angr-vs-kuna.txt`](./angr-vs-kuna.txt).
+
+## Root cause (cross-tier)
+
+`qsort` is an **undefined external** in a relocatable object — a `.o` has no PLT
+thunk. kuna's ET_REL loader maps undefined externals to an **empty synthetic
+region**, and the **S1 decoder follows the direct `jmp qsort` as intraprocedural
+flow** into that region, then fails to fetch 512 code bytes. The function never
+reaches any Action/Rule pass.
+
+On a properly **linked** ELF (real PLT stub present) kuna already does the right
+thing — it classifies the `jmp qsort@plt` as a call and emits the
+already-deduplicated guard-clause form `if (!c) return; qsort_equiv(); return;`,
+which is semantically identical to angr's `if (c) { qsort(); } return;`.
+
+## Why angr's nominal feature is *already covered* (negative result)
+
+angr closes this with `ReturnDeduplicator` (`optimization_passes/ret_deduplicator.py`),
+which folds `if (c) { …; return x; } return x;` → `if (c) { … } return x;`.
+**kuna never produces that pattern here** — on a loadable binary it already emits
+the deduplicated guard-clause form. Porting a return-deduplicator would be a
+verified **no-op** on `sort_found_occurs`. So the *structuring* feature the test
+name suggests is not the real gap; the real gap is the ET_REL undefined-external
+tail-call decode failure above.
+
+## Why this is large (proposal, not a one-shot Action)
+
+The function aborts in **S1 decode**, before any Action/Rule runs — a structuring
+Rule (the `kuna_loweredswitch.rs` template) has nothing to operate on. Closing it
+is cross-tier and not modelable as a single gated Action:
+
+1. **Loader tier (`kuna-analysis`):** when an undefined external is the target of
+   a **direct branch** (call *or* jmp) in an ET_REL object, synthesize a real
+   call/return **thunk** (a 1-instruction `RETURN`/external stub with code bytes)
+   instead of an empty region, and resolve the symbol name (`qsort`). This is the
+   `relocobjects`/DIV-7 ET_REL undefined-symbol track.
+2. **Flow tier (S1/S2):** classify a direct `jmp <undefined-external>` as a
+   **tail call** (CALL + RETURN terminator) at decode time, so the decoder stops
+   instead of falling into the external region. Mirrors the `gh6882-sparcstructret`
+   "post-call terminator" family but needs loader knowledge of "target is an
+   undefined external".
+
+Either path touches the loader **and** the S1/S2 decode/flow layer (>1 module,
+cross-tier), exceeding the one-Action/one-option budget.
+
+## Proposed plan (if approved)
+
+1. Loader: detect undefined-external symbols that are direct-branch targets in
+   ET_REL objects; allocate them a minimal code thunk (`RET`/external marker) in a
+   mapped region and attach the symbol name. Gate behind `option etrel_extern_tailcall on`.
+2. Flow: ensure the direct `jmp <thunk>` is classified as a tail call so the
+   structurer emits `extern_fn(args); return;`. Reuse the existing
+   "Treating indirect jump as call" path that already works for linked PLT.
+3. Symbol naming: surface `qsort` (and `compare_occurs`, `number_of_occurs`,
+   `occurs_table`) from the `.o` symbol table so the call renders `qsort(...)`.
+4. Stage test `tests/stages/ghangr-ret-dedupe-fakeret-1-fb25cd.xml`: pass 1
+   (option off) asserts the load failure / empty body; pass 2 (option on) asserts
+   `qsort(` + the `if (...) ... return` structure. (May need a bytechunk that
+   models the undefined-external thunk, since the failure is loader-level.)
+
+## Speed / risk
+
+- **Risk:** medium. Touches the ET_REL loader's region layout (undefined-symbol
+  handling) and S1 decode flow — both are shared, so the option must be
+  default-OFF and byte-identical when off. Synthesizing thunks risks perturbing
+  unrelated ET_REL decompilations if not tightly scoped to direct-branch targets.
+- **Speed:** expected negligible (a per-undefined-symbol thunk allocation at load;
+  no extra per-op work). To be measured in the implementation worker.
+- **Scope guard:** keep the loader change minimal and behind the option; do not
+  generalize beyond direct-branch undefined-external targets in ET_REL objects.
+
+## Proposed option
+
+`etrel_extern_tailcall` (default-OFF), `change_kind = structure-recovery`,
+`source_decompiler = angr`,
+`inspiration = "test_ret_dedupe_fakeret_1; ReturnDeduplicator / CFGFast tail-call + extern resolution; sort_found_occurs"`.

--- a/docs/features/ret-dedupe-fakeret-1-fb25cd/record.json
+++ b/docs/features/ret-dedupe-fakeret-1-fb25cd/record.json
@@ -1,0 +1,23 @@
+{
+  "opportunity": "test_ret_dedupe_fakeret_1::sort_found_occurs",
+  "test_name": "test_ret_dedupe_fakeret_1",
+  "binary": "/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/ptx.o",
+  "selector": "sort_found_occurs",
+  "func_addr": "0x400440",
+  "angr_version": "9.2.213",
+  "option": "etrel_extern_tailcall",
+  "change_kind": "structure-recovery",
+  "source_decompiler": "angr",
+  "inspiration": "test_ret_dedupe_fakeret_1; ReturnDeduplicator / CFGFast tail-call + extern resolution; sort_found_occurs",
+  "scope": "large",
+  "proposal": true,
+  "parity": "OK",
+  "decisions": [
+    {
+      "question": "Route: implement a single option-gated ret-deduplication Action, open a proposal, or declare negative?",
+      "decision": "large / proposal",
+      "reasoning": "(i) No single-Action/Rule, single-option decompiler feature closes this gap: the function never decompiles on ptx.o because the S1 decoder aborts (Unable to load 512 bytes) before any Action/Rule pass runs, so a structuring Rule has nothing to operate on. (ii) The nominal ret-deduplication feature is already covered - on a linked ELF kuna emits the deduplicated guard-clause form `if(!c) return; qsort_equiv(); return;`, semantically identical to angr's target; porting angr's ReturnDeduplicator would be a verified no-op since kuna never produces the `if(c){...return x;} return x;` pattern it folds. (iii) The real defect is a cross-tier loader/flow gap (undefined external mapped to an empty region + the decoder following a direct `jmp` to an undefined external as intraprocedural flow); fixes (loader thunk synthesis, or decode-time tail-call terminator classification) span the loader and S1/S2 and are multi-step - proposal-scope, adjacent to the relocobjects/DIV-7 ET_REL track.",
+      "decider": "general-purpose subagent (Opus 4.8)"
+    }
+  ]
+}


### PR DESCRIPTION
# [PROPOSAL] ET_REL undefined-external tail-call recovery (`etrel_extern_tailcall`)

**Opportunity:** angr `test_ret_dedupe_fakeret_1::sort_found_occurs`
**Binary:** `binaries/tests/x86_64/decompiler/ptx.o` (ET_REL, x86-64)
**Status:** proposal — needs human go/no-go before implementation.

## The problem

`sort_found_occurs` is a guarded **tail call**:

```asm
  mov  rsi, [number_of_occurs]
  test rsi, rsi
  jne  .L
  ret
.L:
  mov  rdi, [occurs_table]
  lea  rcx, [compare_occurs]
  mov  edx, 0x30
  jmp  qsort          ; R_X86_64_PLT32, qsort is an UNDEFINED external
```

angr decompiles it to (and the test asserts) `if (number_of_occurs) qsort(...); return;`.

**kuna emits NO C at all on `ptx.o`:**

```
[decomp]> load function sort_found_occurs
Execution error: Unable to load 512 bytes at r0x00407210
[decomp]> decompile
Execution error: No function selected
```

Reproduced independently with a byte-equivalent object built from
`gcc -O2 -c` (identical `Unable to load 512 bytes` abort). See
[`analysis.md`](./analysis.md) and [`angr-vs-kuna.txt`](./angr-vs-kuna.txt).

## Root cause (cross-tier)

`qsort` is an **undefined external** in a relocatable object — a `.o` has no PLT
thunk. kuna's ET_REL loader maps undefined externals to an **empty synthetic
region**, and the **S1 decoder follows the direct `jmp qsort` as intraprocedural
flow** into that region, then fails to fetch 512 code bytes. The function never
reaches any Action/Rule pass.

On a properly **linked** ELF (real PLT stub present) kuna already does the right
thing — it classifies the `jmp qsort@plt` as a call and emits the
already-deduplicated guard-clause form `if (!c) return; qsort_equiv(); return;`,
which is semantically identical to angr's `if (c) { qsort(); } return;`.

## Why angr's nominal feature is *already covered* (negative result)

angr closes this with `ReturnDeduplicator` (`optimization_passes/ret_deduplicator.py`),
which folds `if (c) { …; return x; } return x;` → `if (c) { … } return x;`.
**kuna never produces that pattern here** — on a loadable binary it already emits
the deduplicated guard-clause form. Porting a return-deduplicator would be a
verified **no-op** on `sort_found_occurs`. So the *structuring* feature the test
name suggests is not the real gap; the real gap is the ET_REL undefined-external
tail-call decode failure above.

## Why this is large (proposal, not a one-shot Action)

The function aborts in **S1 decode**, before any Action/Rule runs — a structuring
Rule (the `kuna_loweredswitch.rs` template) has nothing to operate on. Closing it
is cross-tier and not modelable as a single gated Action:

1. **Loader tier (`kuna-analysis`):** when an undefined external is the target of
   a **direct branch** (call *or* jmp) in an ET_REL object, synthesize a real
   call/return **thunk** (a 1-instruction `RETURN`/external stub with code bytes)
   instead of an empty region, and resolve the symbol name (`qsort`). This is the
   `relocobjects`/DIV-7 ET_REL undefined-symbol track.
2. **Flow tier (S1/S2):** classify a direct `jmp <undefined-external>` as a
   **tail call** (CALL + RETURN terminator) at decode time, so the decoder stops
   instead of falling into the external region. Mirrors the `gh6882-sparcstructret`
   "post-call terminator" family but needs loader knowledge of "target is an
   undefined external".

Either path touches the loader **and** the S1/S2 decode/flow layer (>1 module,
cross-tier), exceeding the one-Action/one-option budget.

## Proposed plan (if approved)

1. Loader: detect undefined-external symbols that are direct-branch targets in
   ET_REL objects; allocate them a minimal code thunk (`RET`/external marker) in a
   mapped region and attach the symbol name. Gate behind `option etrel_extern_tailcall on`.
2. Flow: ensure the direct `jmp <thunk>` is classified as a tail call so the
   structurer emits `extern_fn(args); return;`. Reuse the existing
   "Treating indirect jump as call" path that already works for linked PLT.
3. Symbol naming: surface `qsort` (and `compare_occurs`, `number_of_occurs`,
   `occurs_table`) from the `.o` symbol table so the call renders `qsort(...)`.
4. Stage test `tests/stages/ghangr-ret-dedupe-fakeret-1-fb25cd.xml`: pass 1
   (option off) asserts the load failure / empty body; pass 2 (option on) asserts
   `qsort(` + the `if (...) ... return` structure. (May need a bytechunk that
   models the undefined-external thunk, since the failure is loader-level.)

## Speed / risk

- **Risk:** medium. Touches the ET_REL loader's region layout (undefined-symbol
  handling) and S1 decode flow — both are shared, so the option must be
  default-OFF and byte-identical when off. Synthesizing thunks risks perturbing
  unrelated ET_REL decompilations if not tightly scoped to direct-branch targets.
- **Speed:** expected negligible (a per-undefined-symbol thunk allocation at load;
  no extra per-op work). To be measured in the implementation worker.
- **Scope guard:** keep the loader change minimal and behind the option; do not
  generalize beyond direct-branch undefined-external targets in ET_REL objects.

## Proposed option

`etrel_extern_tailcall` (default-OFF), `change_kind = structure-recovery`,
`source_decompiler = angr`,
`inspiration = "test_ret_dedupe_fakeret_1; ReturnDeduplicator / CFGFast tail-call + extern resolution; sort_found_occurs"`.
