### PR TITLE
[PROPOSAL] angr-ifelseflatten-clientloop-171db8: ET_REL undefined-extern data reads hard-fail the loader

### DIFF
--- a/docs/features/ifelseflatten-clientloop-171db8/analysis.md
+++ b/docs/features/ifelseflatten-clientloop-171db8/analysis.md
@@ -1,0 +1,80 @@
+# analysis — ifelseflatten-clientloop-171db8
+
+**Opportunity:** `test_ifelseflatten_clientloop :: client_request_tun_fwd`
+**Binary:** `/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o` (x86_64 ELF **ET_REL** object)
+**Selector:** `client_request_tun_fwd` @ `0x405170` (.text+0x5170, 641 bytes)
+
+## TL;DR — the opportunity is mislabeled
+
+This is **not** an "if-else flattening" structuring gap. **kuna emits zero output** for this
+function: it hard-fails in the **loader**, long before any S7/S8 structuring runs. The real,
+underlying angr-vs-kuna gap is a **loader/analysis-tier** one, so it cannot be closed by the
+single decompiler Action/Rule (`kuna_<slug>.rs`, stages S2–S9) this worker is scoped to.
+Per Hard rule 7 this is a **large / different-tier** change → **PROPOSAL** (see `proposal.md`).
+
+## What angr does
+
+angr decompiles the function cleanly (see `angr-vs-kuna.txt`). The construct the test name
+points at is the deeply-nested `if (!v8) { ...; if (!v8) { ... } }` chain over the
+`sshpkt_start` / `sshpkt_put_*` / `sshpkt_send` calls, with a shared `sshpkt_fatal` /
+`__stack_chk_fail` failure tail. Critically, angr reaches that output at all because its CLE
+loader backs the **extern object** (undefined external symbols) with a **zero-filled, readable**
+region — so a read of an undefined-extern global just returns 0 and decompilation proceeds.
+
+## What kuna does
+
+```
+[decomp]> load function client_request_tun_fwd
+Execution error: Unable to load 512 bytes at r0x0040cb60
+[decomp]> decompile
+Execution error: No function selected
+```
+
+No C output, in both addr-mode (`0x405170`) and name-mode.
+
+## Root cause (pinned)
+
+The function body contains:
+
+```asm
+5276:  cmpl   $0x1, 0x0(%rip)        # options+0x1373   (R_X86_64_PC32 -> options)
+```
+
+`options` is an **undefined external data global** (ELF `SHN_UNDEF`, `STT_NOTYPE`, `st_value==0`).
+kuna's ET_REL loader assigns each *undefined* referenced symbol a **16-byte synthetic slot** in an
+"extern area" above the laid-out sections, but **adds no readable backing segment** for that area:
+
+- `decompiler/crates/kuna-analysis/src/s1_loader/elf_reloc.rs:144` — `extern_cursor = align_up(cursor + 0x1000, 0x1000)`
+- `decompiler/crates/kuna-analysis/src/s1_loader/elf_reloc.rs:282` — `*extern_cursor = extern_cursor.wrapping_add(16)` (16-byte slot, no segment)
+
+The extern slots feed `funcsyms` (named **call targets**, resolved by name — no bytes ever read),
+which is fine for *function* externs (`sshlog`, `tun_open`, …). But `options` is read as **data**:
+`options+0x1373` resolves to ≈`0x40cb60`, which is `0x1373` bytes past the 16-byte slot and not
+covered by any `Segment`. The LoadImage fill (`loadimage_object.rs:597`) takes the
+"initial address not mapped" path and returns `Unable to load 512 bytes at r0x0040cb60`.
+
+The skipped-reloc warnings the pipeline prints (`unhandled kind GotRelative (skipped)` at
+`0x400785` etc.) are in **other** functions and are unrelated to this hard-fail.
+
+## Owning stage
+
+**S1 / code-data-partition** (the loader), `kuna-analysis` crate — the same tier as the existing
+`relocobjects` (DIV-7) and `i386_pie_plt` options. `relocobjects` already binds undefined externs
+as call targets; what is missing is **backing the synthetic extern area with zero-filled readable
+memory** so undefined-extern *data* reads return 0 instead of aborting.
+
+## Why this is not the assigned (ifelseflatten) feature
+
+The assigned deliverable is a decompiler structuring Action/Rule. There is **no kuna output to
+restructure** here — the pipeline dies in the loader. Shipping a `kuna_ifelseflatten*.rs` Action
+would never execute on this input and would not touch the actual fault. After the loader fix lands,
+whether a genuine *structural* ifelseflatten gap remains is unknown and would be a **separate**
+feature. Hence: proposal for the loader fix.
+
+## Hypothesis for the fix
+
+Add a **zero-filled, readable** segment covering the synthetic extern area in
+`elf_reloc::layout_relocatable` (so any read inside the extern region returns 0), gated by a new
+loader option (env-var bridge, like `relocobjects`). Re-run `compare --entry
+test_ifelseflatten_clientloop` to confirm kuna then produces output, and re-assess any remaining
+structural delta. Risk is contained to the ET_REL path (linked ET_EXEC/ET_DYN images are untouched).

--- a/docs/features/ifelseflatten-clientloop-171db8/angr-vs-kuna.txt
+++ b/docs/features/ifelseflatten-clientloop-171db8/angr-vs-kuna.txt
@@ -1,0 +1,126 @@
+==============================================================================
+test_ifelseflatten_clientloop :: client_request_tun_fwd   (angr 9.2.213 @ 0x405170)
+==============================================================================
+
+--- angr ---
+extern char g_501380;
+extern unsigned long got.sys_tun_infilter;
+extern unsigned long got.sys_tun_outfilter;
+
+long long client_request_tun_fwd(long long a0, unsigned int a1, unsigned long long a2, unsigned int a3, long long a4, long long a5)
+{
+    unsigned int ptr[73];  // rax
+    unsigned int v7[73];  // rbx
+    unsigned int v8;  // eax
+    unsigned long long v0;  // [bp-0x78]
+    unsigned long long v1;  // [bp-0x70]
+    unsigned long long v2;  // [bp-0x60]
+    unsigned long v3;  // [bp-0x50]
+    unsigned long flag;  // [bp-0x48]
+
+    flag = 0;
+    if (!a1)
+        return 0;
+    v2 = a2;
+    sshlog("clientloop.c", "client_request_tun_fwd", 1627, 0, 5, 0, "Requesting tun unit %d in mode %d");
+    if ((int)tun_open(a2 & 4294967295, a1, &flag) == 4294967295)
+    {
+        sshlog("clientloop.c", "client_request_tun_fwd", 1631, 0, 2, 0, "Tunnel device open failed.");
+        return 0;
+    }
+    v3 = flag;
+    sshlog("clientloop.c", "client_request_tun_fwd", 1634, 0, 5, 0, "Tunnel forwarding using interface %s");
+    v2 = "tun";
+    v1 = 0x8000;
+    v0 = 0x200000;
+    ptr = channel_new(a0, "tun", 3);
+    ptr[72] = 1;
+    v7 = ptr;
+    if (*((int *)&g_501380) == 1)
+        channel_register_filter(a0, v7[1], got.sys_tun_infilter, got.sys_tun_outfilter, 0, 0);
+    if (a4)
+        channel_register_open_confirm(a0, v7[1], a4, a5);
+    v8 = sshpkt_start(a0, 90);
+    if (!v8)
+    {
+        v8 = sshpkt_put_cstring(a0, "tun@openssh.com");
+        if (!v8)
+        {
+            v8 = sshpkt_put_u32(a0, v7[1]);
+            if (!v8)
+            {
+                v8 = sshpkt_put_u32(a0, v7[45]);
+                if (!v8)
+                {
+                    v8 = sshpkt_put_u32(a0, v7[47]);
+                    if (!v8)
+                    {
+                        v8 = sshpkt_put_u32(a0, a1);
+                        if (!v8)
+                        {
+                            v8 = sshpkt_put_u32(a0, a3);
+                            if (!v8)
+                            {
+                                v8 = sshpkt_send(a0);
+                                if (!v8)
+                                    return flag;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    sshpkt_fatal(a0, v8, "%s: send reply", "client_request_tun_fwd");
+    __stack_chk_fail(); /* do not return */
+}
+
+
+--- kuna (addr mode) ---
+  (no output: addr-mode: no C output for '0x405170' in /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o; decompiler said:
+[decomp]> load file /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o
+/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o successfully loaded: x86:LE:64:default:gcc
+[decomp]> read symbols
+[decomp]> load addr 0x405170
+Execution error: Unable to load 512 bytes at r0x0040cb60
+[decomp]> decompile
+Execution error: No function selected
+[decomp]> openfile write /tmp/kuna_c_m222ctq1.c
+[decomp]> print C
+Execution error: No function selected
+[decomp]> closefile
+[decomp]> quit
+
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0x785: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0x7cc: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0x9fd: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0xa09: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0xa1d: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0xa31: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0xa45: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0xa6d: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0xa81: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/git (name-mode: no C output for 'client_request_tun_fwd' in /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o; decompiler said:
+[decomp]> load file /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o
+/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o successfully loaded: x86:LE:64:default:gcc
+[decomp]> read symbols
+[decomp]> load function client_request_tun_fwd
+Execution error: Unable to load 512 bytes at r0x0040cb60
+[decomp]> decompile
+Execution error: No function selected
+[decomp]> openfile write /tmp/kuna_c_qdxb6ntv.c
+[decomp]> print C
+Execution error: No function selected
+[decomp]> closefile
+[decomp]> quit
+
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0x785: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0x7cc: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0x9fd: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0xa09: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0xa1d: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0xa31: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0xa45: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0xa6d: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader] /home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o: reloc at 0x400000+0xa81: unhandled kind GotRelative (skipped)
+[kuna ET_REL loader]))

--- a/docs/features/ifelseflatten-clientloop-171db8/proposal.md
+++ b/docs/features/ifelseflatten-clientloop-171db8/proposal.md
@@ -1,0 +1,75 @@
+# [PROPOSAL] angr-ifelseflatten-clientloop-171db8 — back the ET_REL synthetic extern area with zero-filled readable memory
+
+**Status:** draft proposal — needs human go/no-go before an implementation worker is spent.
+
+**Opportunity:** `test_ifelseflatten_clientloop :: client_request_tun_fwd`
+**Binary:** `clientloop.o` (x86_64 ELF **ET_REL**), selector `client_request_tun_fwd` @ `0x405170`.
+
+## The problem
+
+The opportunity is **mislabeled**. It is not an if-else flattening / structuring gap. **kuna
+produces zero output** for `client_request_tun_fwd`: it hard-fails in the **loader** with
+`Unable to load 512 bytes at r0x0040cb60`, before any S2–S9 decompiler pass runs. angr decompiles
+the function fully. Full root-cause in [`analysis.md`](analysis.md) and side-by-side in
+[`angr-vs-kuna.txt`](angr-vs-kuna.txt).
+
+**Mechanism.** The function reads an **undefined external data global**:
+`cmpl $0x1, options+0x1373` (`options` is ELF `SHN_UNDEF`/`STT_NOTYPE`). kuna's ET_REL loader
+(`kuna-analysis/src/s1_loader/elf_reloc.rs:282`) gives each undefined extern only a **16-byte
+synthetic slot with no readable backing segment**. The slots work as named *call targets*
+(functions resolved by name, no bytes read), but a *data* read at `options+0x1373` (≈`0x40cb60`)
+lands in unbacked memory → `loadimage_object.rs:597` "initial address not mapped" → abort.
+
+## angr reference
+
+angr's CLE loader backs its **extern object** with a **zero-filled, readable** region, so reads
+of undefined-extern globals return 0 and decompilation proceeds. This is the existing
+`relocobjects` (DIV-7) loader feature's missing complement: `relocobjects` binds extern *call
+targets*; it does not back extern *data* reads.
+
+## Why this is out of scope for one decompiler Action/Rule (Hard rule 7)
+
+The fix lives in the **loader** (`kuna-analysis` crate, stage **S1 / code-data-partition**), not in
+a `kuna_<slug>.rs` decompiler Action/Rule (S2–S9). It requires new memory-backing infrastructure
+(a synthetic zero-filled segment), it touches a different tier than the assigned structuring
+feature, and there is no kuna output to restructure until it lands. A decider subagent ratified
+this as `scope: large`, `outcome: proposal`.
+
+## Proposed implementation plan (for the approved implementation worker)
+
+1. **New loader option** (env-var bridge, mirroring `relocobjects` / `i386_pie_plt`):
+   `externdatazerofill` (working name). Default decision deferred to ablation (likely default-ON as
+   a pure capability — like `relocobjects` — since linked images never take the ET_REL path).
+2. **Back the extern area** in `elf_reloc::layout_relocatable`: after `extern_cursor`/`extern_order`
+   are finalized, emit one zero-filled, **readable** `Segment` (and a read-only `SectionInfo`) that
+   spans `[extern_base, extern_cursor)` rounded up to a page — so any read inside the synthetic
+   extern region returns 0 instead of aborting. Keep the slot stride large enough (or size the
+   backing generously, e.g. page-granular) that an in-struct offset like `options+0x1373` stays
+   inside the backed region.
+3. **Gate** the new backing behind the option (`KUNA_*` env var read at load time, like
+   `KUNA_RELOC_OBJECTS`); off ⇒ byte-identical to today (still hard-fails, preserving parity).
+4. **Verify**: re-run `compare --entry test_ifelseflatten_clientloop`; confirm kuna now produces
+   output. Add a firing stage test once there is output to assert on.
+5. **Re-assess the *structural* delta** (the original "ifelseflatten" question) only after output
+   exists — it is a **separate** follow-up feature if a real gap remains.
+
+## Speed / risk assessment
+
+- **Risk: low/contained.** The change only affects the ET_REL (`.o`) path; linked ET_EXEC/ET_DYN
+  images keep the PT_LOAD loader and are byte-identical. Gated off ⇒ no behavior change ⇒
+  `make test` / `docs/baseline.json` parity preserved.
+- **Speed: negligible.** One extra synthetic segment at load time; no per-function cost. Must still
+  be measured per Hard rule 6 in the implementation worker.
+- **Subtlety:** sizing the extern backing. A 16-byte-per-symbol stride is too small for struct
+  globals read at large offsets (`options+0x1373`); the backing must cover realistic in-object
+  offsets (page-granular backing, or widen the per-extern reservation). The implementation worker
+  should pick the bound and document it.
+
+## Proposed option name
+
+`externdatazerofill` (alt: `relocexterndata`). LLM-discoverable `settableTable` row, `stage="S1"`,
+`source_decompiler="angr"`, `inspiration="test_ifelseflatten_clientloop; CLE extern object zero-fill; client_request_tun_fwd"`,
+`change_kind="structure-recovery"`.
+
+---
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/ifelseflatten-clientloop-171db8/record.json
+++ b/docs/features/ifelseflatten-clientloop-171db8/record.json
@@ -1,0 +1,26 @@
+{
+  "opportunity": "test_ifelseflatten_clientloop::client_request_tun_fwd",
+  "test_name": "test_ifelseflatten_clientloop",
+  "binary": "/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/clientloop.o",
+  "selector": "client_request_tun_fwd",
+  "func_addr": "0x405170",
+  "arch_override": "x86_64",
+  "angr_version": "9.2.213",
+  "scope": "large",
+  "proposal": true,
+  "option": "externdatazerofill",
+  "change_kind": "structure-recovery",
+  "source_decompiler": "angr",
+  "inspiration": "test_ifelseflatten_clientloop; CLE extern object zero-fill; client_request_tun_fwd",
+  "mislabeled": "Opportunity is not an if-else flattening gap; kuna emits zero output (loader hard-fail 'Unable to load 512 bytes at r0x0040cb60') on an undefined-extern data read 'cmpl $0x1, options+0x1373'. Root cause: ET_REL synthetic extern area (elf_reloc.rs:282) is a 16-byte slot with no readable backing segment. Fix is loader/analysis-tier, not a kuna_<slug>.rs decompiler Action/Rule.",
+  "decisions": [
+    {
+      "question": "Worker can only ship one decompiler Action/Rule for 'ifelseflatten', but the gap is a loader-tier hard-fail in kuna-analysis. small/large? implement/proposal/negative?",
+      "decider": "general-purpose (opus)",
+      "scope": "large",
+      "outcome": "proposal",
+      "option_name_suggestion": "externdatazerofill",
+      "justification": "The worker's only sanctioned deliverable is a single option-gated decompiler Action/Rule in a new kuna_<slug>.rs module (stages S2-S9), but the gap is a hard-fail in the LOADER (kuna-analysis crate, s1_loader/elf_reloc.rs) where undefined-extern DATA reads land in unbacked synthetic memory and abort decompilation before any structuring runs -- so there is literally no output to flatten. Per Hard rule 7 this is explicitly out of scope: it touches a different tier (loader/analysis) and requires new memory-backing infrastructure (a zero-filled readable segment over the synthetic extern area), not something modelable as one Action/Rule. It is not a negative result either, because the fix is plausible, well-localized, and analogous to the existing env-var-bridged relocobjects loader option, so the loop should not abandon the lead -- it should escalate for human go/no-go. A PROPOSAL draft PR is the correct outcome: document the loader root cause, propose the option-gated zero-fill backing, and note that whether a genuine ifelseflatten structural gap remains is unknown and would be a separate, later feature once the loader unblocks output. Shipping a kuna_ifelseflatten.rs Action now would be wrong because it could never execute on this input and would not address the actual fault."
+    }
+  ]
+}


### PR DESCRIPTION
# [PROPOSAL] angr-ifelseflatten-clientloop-171db8 — back the ET_REL synthetic extern area with zero-filled readable memory

**Status:** draft proposal — needs human go/no-go before an implementation worker is spent.

**Opportunity:** `test_ifelseflatten_clientloop :: client_request_tun_fwd`
**Binary:** `clientloop.o` (x86_64 ELF **ET_REL**), selector `client_request_tun_fwd` @ `0x405170`.

## The problem

The opportunity is **mislabeled**. It is not an if-else flattening / structuring gap. **kuna
produces zero output** for `client_request_tun_fwd`: it hard-fails in the **loader** with
`Unable to load 512 bytes at r0x0040cb60`, before any S2–S9 decompiler pass runs. angr decompiles
the function fully. Full root-cause in [`analysis.md`](analysis.md) and side-by-side in
[`angr-vs-kuna.txt`](angr-vs-kuna.txt).

**Mechanism.** The function reads an **undefined external data global**:
`cmpl $0x1, options+0x1373` (`options` is ELF `SHN_UNDEF`/`STT_NOTYPE`). kuna's ET_REL loader
(`kuna-analysis/src/s1_loader/elf_reloc.rs:282`) gives each undefined extern only a **16-byte
synthetic slot with no readable backing segment**. The slots work as named *call targets*
(functions resolved by name, no bytes read), but a *data* read at `options+0x1373` (≈`0x40cb60`)
lands in unbacked memory → `loadimage_object.rs:597` "initial address not mapped" → abort.

## angr reference

angr's CLE loader backs its **extern object** with a **zero-filled, readable** region, so reads
of undefined-extern globals return 0 and decompilation proceeds. This is the existing
`relocobjects` (DIV-7) loader feature's missing complement: `relocobjects` binds extern *call
targets*; it does not back extern *data* reads.

## Why this is out of scope for one decompiler Action/Rule (Hard rule 7)

The fix lives in the **loader** (`kuna-analysis` crate, stage **S1 / code-data-partition**), not in
a `kuna_<slug>.rs` decompiler Action/Rule (S2–S9). It requires new memory-backing infrastructure
(a synthetic zero-filled segment), it touches a different tier than the assigned structuring
feature, and there is no kuna output to restructure until it lands. A decider subagent ratified
this as `scope: large`, `outcome: proposal`.

## Proposed implementation plan (for the approved implementation worker)

1. **New loader option** (env-var bridge, mirroring `relocobjects` / `i386_pie_plt`):
   `externdatazerofill` (working name). Default decision deferred to ablation (likely default-ON as
   a pure capability — like `relocobjects` — since linked images never take the ET_REL path).
2. **Back the extern area** in `elf_reloc::layout_relocatable`: after `extern_cursor`/`extern_order`
   are finalized, emit one zero-filled, **readable** `Segment` (and a read-only `SectionInfo`) that
   spans `[extern_base, extern_cursor)` rounded up to a page — so any read inside the synthetic
   extern region returns 0 instead of aborting. Keep the slot stride large enough (or size the
   backing generously, e.g. page-granular) that an in-struct offset like `options+0x1373` stays
   inside the backed region.
3. **Gate** the new backing behind the option (`KUNA_*` env var read at load time, like
   `KUNA_RELOC_OBJECTS`); off ⇒ byte-identical to today (still hard-fails, preserving parity).
4. **Verify**: re-run `compare --entry test_ifelseflatten_clientloop`; confirm kuna now produces
   output. Add a firing stage test once there is output to assert on.
5. **Re-assess the *structural* delta** (the original "ifelseflatten" question) only after output
   exists — it is a **separate** follow-up feature if a real gap remains.

## Speed / risk assessment

- **Risk: low/contained.** The change only affects the ET_REL (`.o`) path; linked ET_EXEC/ET_DYN
  images keep the PT_LOAD loader and are byte-identical. Gated off ⇒ no behavior change ⇒
  `make test` / `docs/baseline.json` parity preserved.
- **Speed: negligible.** One extra synthetic segment at load time; no per-function cost. Must still
  be measured per Hard rule 6 in the implementation worker.
- **Subtlety:** sizing the extern backing. A 16-byte-per-symbol stride is too small for struct
  globals read at large offsets (`options+0x1373`); the backing must cover realistic in-object
  offsets (page-granular backing, or widen the per-extern reservation). The implementation worker
  should pick the bound and document it.

## Proposed option name

`externdatazerofill` (alt: `relocexterndata`). LLM-discoverable `settableTable` row, `stage="S1"`,
`source_decompiler="angr"`, `inspiration="test_ifelseflatten_clientloop; CLE extern object zero-fill; client_request_tun_fwd"`,
`change_kind="structure-recovery"`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
