### PR TITLE
[PROPOSAL] angr-ifelseflatten-iprule-85ca2b: port IfElseFlattener (+ ET_REL no-return boundary prerequisite)

### DIFF
--- a/docs/features/ifelseflatten-iprule-85ca2b/analysis.md
+++ b/docs/features/ifelseflatten-iprule-85ca2b/analysis.md
@@ -1,0 +1,92 @@
+# Analysis — test_ifelseflatten_iprule :: flush_rule (angr 9.2.213)
+
+Binary: `/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/iprule.o` (ET_REL `.o`, x86-64)
+Function: `flush_rule` @ file offset `0x1310`, size 253 bytes (`0x1310`–`0x140d`).
+angr method: `test_ifelseflatten_iprule` (structuring algo `sailr`).
+
+## What the angr test asserts
+
+The first `if` in `flush_rule` must be a **single-scope early return**:
+`if (...) return -1;` with **no `else`** and the return value `-1`. This is produced by angr's
+`IfElseFlattener` region simplifier
+(`angr/analyses/decompiler/region_simplifiers/ifelse.py`): when a `ConditionNode`'s
+true-branch is *statement-terminating* (all endpoints return/abort) and the false-branch is
+not, it drops the `else` and re-parents the false-node as a **follower** of the `if`. The net
+effect is the classic early-return flattening:
+
+```
+if (cond) { ...; return X; } else { body }   ==>   if (cond) { ...; return X; } body
+```
+
+angr's rendering of `flush_rule`:
+
+```c
+unsigned int flush_rule(struct_0 *ptr) {
+    ...
+    if (ptr->field_0 - 28 < 0)
+        return 4294967295;          // -1, single-scope early return  <-- the assertion
+    parse_rtattr(&v1, 24, &ptr[1].padding_8[3]);
+    ...
+}
+```
+
+## What kuna produces (and the real, dominant gap)
+
+kuna does **not** render a clean `flush_rule`. The decompiled body of `flush_rule` **merges
+in the entire neighbouring function** `iprule_list_flush_or_save` (0x1410, 2059 bytes) — the
+output contains `__isoc99_sscanf`, `matches(...)`, `rtnl_ruledump_req`, `new_json_obj`,
+`rtnl_dump_filter_nc`, and dozens of `label_4018xx` blocks that belong to the neighbour, not
+to `flush_rule`. (15 neighbour-only call sites leak into the body.)
+
+### Root cause of the merge — fall-through past `call __stack_chk_fail`
+
+`flush_rule` is self-contained in the raw disassembly: every `jcc`/`jmp` stays inside
+`0x1310`–`0x1408`, there is a `ret` at `0x13f3`, and the canary-fail path ends at
+
+```
+1408: e8 00 00 00 00   call __stack_chk_fail   ; R_X86_64_PLT32 __stack_chk_fail-0x4
+140d: 0f 1f 00         nopl (%rax)              ; padding
+1410: <iprule_list_flush_or_save begins>
+```
+
+`__stack_chk_fail` is no-return, so flow should stop after `0x1408`. But in this ET_REL `.o`:
+1. the call is encoded `e8 00 00 00 00` (rel32 = 0) with the target supplied **only** by the
+   `R_X86_64_PLT32` relocation, so without relocation resolution kuna does not even know the
+   callee is `__stack_chk_fail`; and
+2. the no-return fact is not propagated to the flow-follower, so kuna assumes the call returns,
+   continues at `0x140d`, walks through the `nopl` padding, and **decodes straight into
+   `iprule_list_flush_or_save` at `0x1410`** — merging the two functions.
+
+kuna already *has* the pieces (`relocobjects` loads ET_REL; the known-no-return list normalizes
+`__stack_chk_fail` → `stack_chk_fail`; `noreturn_disc`/`noreturn_propagate` exist), but with all
+of them enabled via the CLI the merge persists (15 leaks unchanged), and the full
+`scripts.pipeline.compare` run reproduces the merge too. So the no-return fact is **not reaching
+the ET_REL relocated call site** before the function's extent is decoded.
+
+### Secondary gap — the if-else-flatten itself
+
+Even setting the merge aside, the `flush_rule` *portion* of kuna's output structures the entry
+condition as `if (field_0 >= 0x1c) { body } ... return -1` rather than angr's inverted
+early-return `if (field_0 - 28 < 0) return -1; body`. Producing angr's form requires porting the
+`IfElseFlattener` region simplifier — an **S7/S8 structured-tree transform**, not a peephole.
+
+## Owning stages
+
+- The merge: **S1 loader / analysis-tier** (ET_REL relocation resolution + no-return propagation
+  to relocated call sites) — `kuna-analysis` `s1_loader::noreturn` / `s1_noreturn_propagate` +
+  `relocobjects`. Not modelable as one S2 `Action`/`Rule`.
+- The early-return form: **S7/S8 structuring** (`s8_structure` / region simplifiers) — a port of
+  angr `IfElseFlattener`.
+
+## Conclusion (scope)
+
+This opportunity is **mis-framed as a single if-else-flatten Action/Rule** and is in reality two
+entangled, large gaps:
+
+1. an **ET_REL function-boundary merge** (no-return fact not propagated to a relocation-resolved
+   `call __stack_chk_fail`), which alone prevents `flush_rule` from ever matching angr; and
+2. a **structural if-else-flatten** region simplifier (S7/S8) port.
+
+Neither is a single option-gated `Action`/`Rule` (Hard rule 7: touching S7 structuring/region
+code, and a new analysis-tier pass type, are both *large*), and they are entangled so that fixing
+only the structurer would still leave `flush_rule` merged. See `proposal.md`.

--- a/docs/features/ifelseflatten-iprule-85ca2b/angr-vs-kuna.txt
+++ b/docs/features/ifelseflatten-iprule-85ca2b/angr-vs-kuna.txt
@@ -1,0 +1,478 @@
+==============================================================================
+test_ifelseflatten_iprule :: flush_rule   (angr 9.2.213 @ 0x401310)
+==============================================================================
+
+--- angr ---
+typedef struct struct_0 {
+    unsigned int field_0;
+    unsigned int field_4;
+    char padding_8[8];
+    char field_10;
+} struct_0;
+
+extern char g_402b30;
+extern char g_402b34;
+
+unsigned int flush_rule(struct_0 *ptr)
+{
+    char v5;  // al
+    char v0;  // [bp-0x128]
+    char v1;  // [bp-0xe8]
+    unsigned long long v2;  // [bp-0xb8]
+    long long v3;  // [bp-0x40]
+
+    if (ptr->field_0 - 28 < 0)
+        return 4294967295;
+    parse_rtattr(&v1, 24, &ptr[1].padding_8[3]);
+    af_bit_len(ptr->field_10);
+    if (!(char)filter_nlmsg.isra.0(ptr, &v1))
+        return 0;
+    if (v3)
+    {
+        v5 = rta_getattr_u8(v3);
+        if (((v5 ^ *((int *)&g_402b30)) & *((int *)&g_402b34)))
+            return 0;
+    }
+    if (!v2)
+        return 0;
+    ptr->field_4 = 65569;
+    if ((int)rtnl_open(&v0, 0) >= 0)
+    {
+        if ((int)rtnl_talk(&v0, ptr, 0) >= 0)
+        {
+            rtnl_close(&v0);
+            return 0;
+        }
+        return 4294967294;
+    }
+    return 4294967295;
+}
+
+
+--- kuna (name mode) ---
+void * flush_rule(int4 *a0,int4 *a1)
+
+{
+  unsigned long v1;
+  uint4 v10; // ebx
+  uint8 v11;
+  int4 v12 [16];
+  int4 v13 [12];
+  unsigned short v14; // stack - 0x170
+  unsigned int v15; // stack - 0x174
+  int4 v2;
+  void *v22;
+  code *v23;
+  int8 v24;
+  uint1 v25; // df
+  unsigned short v26; // stack - 0x16e
+  unsigned int v27; // stack - 0x16c
+  int8 v28; // stack - 0x168
+  int8 v29; // stack - 0xb8
+  void *v3;
+  int8 v31; // stack - 0x20
+  char v4; // al
+  uint4 v5; // eax
+  unsigned long v6; // rax
+  int8 v7; // rcx
+  int4 v8; // edx
+  int4 v9; // ebx
+  
+label_401864:
+  v17 = &a1[2];
+  v10 = v10 - 1;
+  v11 = (uint8)v10;
+  if (v10 != 0) {
+    dat_4028d0 = 1;
+    v5 = __isoc99_sscanf(*(void *)&a1[2],0x40324c,0x402918);
+    if (v5 == 2) goto label_40153d;
+    invarg(0x403252,*(void *)&a1[2]);
+label_4018b0:
+    v4 = matches(v17,0x40319e);
+    if (v4 == '\0') {
+      v17 = &a1[2];
+      v10 = (int4)v11 - 1;
+      v11 = (uint8)v10;
+      if (v10 == 0) goto label_401817;
+      v5 = get_u64(v22,*(void *)&a1[2],0);
+      if (v5 == 0) {
+        Unique1000063e = CONCAT44(v27,CONCAT22(v26,v14));
+        goto label_40153d;
+      }
+label_401903:
+      invarg(0x4031a5,*(void *)&a1[2]);
+    }
+    v9 = (int4)v11;
+    v4 = matches(*(void *)a1,0x4031c6);
+    if (v4 == '\0') {
+label_401927:
+      v17 = &a1[2];
+      v10 = v9 - 1;
+      v11 = (uint8)v10;
+      if (v10 != 0) {
+        v5 = rtnl_rttable_a2n(v22,*(void *)&a1[2]);
+        if (v5 != 0) goto label_401987;
+        Unique1000062e = CONCAT22(v26,v14);
+        goto label_40153d;
+      }
+      goto label_401817;
+    }
+    goto label_401997;
+  }
+  goto label_401817;
+  v25 = 0;
+  v16 = v12;
+  v18 = v12;
+  v19 = v12;
+  v31 = *(int8 *)(v24 + 0x28);
+  v17 = a0;
+  if (0 <= *a0 + -0x1c) {
+    a1 = v13;
+    parse_rtattr(a1,0x18,&a0[7]);
+    af_bit_len((char)a0[4]);
+    v4 = filter_nlmsg.isra.0();
+    v6 = (void *)0;
+    if ((v4 == '\0') || ((v30 != (int4 *)0x0 && (v4 = rta_getattr_u8(), v5 = (uint4)v4, v5 = v5 ^ dat_402b30, v17 = v30, (dat_402b34 & v5) != 0)))) goto label_4013d1;
+    v17 = v30;
+    v6 = (void *)0;
+    if (v29 == 0) goto label_4013d1;
+    a0[1] = 0x10021;
+    a1 = (int4 *)0x0;
+    v5 = rtnl_open();
+    v17 = v16;
+    v22 = v12;
+    if (0 <= (int4)v5) {
+      v5 = rtnl_talk(v12,a0,0);
+      if ((int4)v5 < 0) {
+        v6 = (void *)0xfffffffe;
+        a1 = a0;
+        v17 = v18;
+        v22 = v12;
+      }
+      else {
+        rtnl_close();
+        a1 = a0;
+        v17 = v19;
+        v6 = (void *)0;
+        v22 = v12;
+      }
+      goto label_4013d1;
+    }
+  }
+  v6 = (void *)0xffffffff;
+label_4013d1:
+  if (v31 == *(int8 *)(v24 + 0x28)) {
+    return v6;
+  }
+  __stack_chk_fail();
+  v11 = (uint8)v17 & 0xffffffff;
+  v28 = *(int8 *)(v24 + 0x28);
+  v5 = 2;
+  v2 = dat_4050c0;
+  if (dat_4050c0 == 0) {
+    v2 = v5;
+  }
+  if ((v8 == 2) && (0 < (int4)v17)) {
+    __fprintf_chk(dat_405000,1,0x403028);
+    v6 = (void *)0xffffffff;
+    goto label_4015ca;
+  }
+  if (v8 == 1) {
+    v23 = flush_rule;
+  }
+  else if (v8 == 2) {
+    v5 = save_rule_prep();
+    v23 = save_rule;
+    if (v5 != 0) {
+      v6 = (void *)0xffffffff;
+      goto label_4015ca;
+    }
+  }
+  else {
+    v23 = print_rule;
+  }
+  v7 = 0x51;
+  v20 = (void *)0x4028c0;
+  while (v7 != 0) {
+    v21 = &v20[(uint8)v25 * -2 + 1];
+    *v20 = 0;
+    v7 = v7 + -1;
+    v20 = v21;
+  }
+  if ((int4)v17 == 0) goto label_401540;
+  v22 = (void *)&v14;
+label_4014d1:
+  v4 = matches(*(void *)a1,0x4030cf);
+  v10 = (uint4)v11;
+  if (((v4 == '\0') || (v4 = matches(*(void *)a1,0x4030da), v4 == '\0')) || (v4 = matches(*(void *)a1,0x4030e0), v4 == '\0')) {
+    v17 = &a1[2];
+    v10 = v10 - 1;
+    v11 = (uint8)v10;
+    if (v10 == 0) goto label_401817;
+    v5 = get_u32(v22,*(void *)&a1[2],0);
+    if (v5 != 0) goto label_40181c;
+    dat_4028e4 = 1;
+    Unique10000622 = CONCAT22(v26,v14);
+  }
+  else {
+    v17 = *(int4 **)a1;
+    v5 = strcmp(v17,0x4030c3);
+    if (v5 == 0) {
+      dat_4028c0 = 1;
+      v17 = a1;
+    }
+    else {
+      v5 = strcmp(v17,0x403106);
+      if ((v5 == 0) || (v5 = strcmp(v17,0x40310a), v5 == 0)) {
+        v17 = &a1[2];
+        v10 = v10 - 1;
+        v11 = (uint8)v10;
+        if (v10 == 0) goto label_401817;
+        v5 = rtnl_dsfield_a2n(v22,*(void *)&a1[2]);
+        if (v5 != 0) {
+          invarg(0x403112,*(void *)&a1[2]);
+          goto label_401963;
+        }
+        dat_4028dc = 1;
+        Unique1000062a = CONCAT22(v26,v14);
+      }
+      else {
+        v5 = strcmp(v17,0x403128);
+        if (v5 == 0) {
+          v17 = &a1[2];
+          v10 = v10 - 1;
+          v11 = (uint8)v10;
+          if (v10 == 0) goto label_401817;
+          v1 = *(void *)&a1[2];
+          v6 = (void *)strchr(v1,0x2f);
+          v3 = v6;
+          if (v6 == (void *)0x0) {
+            v5 = get_u32(&v15,v1,0);
+            if (v5 != 0) goto label_401807;
+            Unique100009f8 = v15;
+          }
+          else {
+            *v6 = 0;
+            v5 = get_u32(&v15,*(void *)&a1[2],0);
+            if (v5 != 0) {
+label_401807:
+              invarg(0x40312f,*(void *)&a1[2]);
+              goto label_401817;
+            }
+            a1 = (int4 *)&v3[1];
+            dat_4028e8 = v15;
+            v5 = get_u32(v22,a1,0);
+            if (v5 != 0) goto label_401978;
+            Unique10000626 = CONCAT22(v26,v14);
+          }
+        }
+        else {
+          v5 = strcmp(v17,0x403217);
+          if ((v5 == 0) || (v5 = strcmp(v17,0x40321b), v5 == 0)) {
+            v17 = &a1[2];
+            v10 = v10 - 1;
+            v11 = (uint8)v10;
+            if (v10 == 0) goto label_401817;
+            v5 = get_ifname(0x4028f8,*(void *)&a1[2]);
+            if (v5 != 0) goto label_401968;
+            dat_4028c8 = 1;
+          }
+          else {
+            v5 = strcmp(v17,0x40321f);
+            if (v5 != 0) goto label_40182c;
+            v17 = &a1[2];
+            v10 = v10 - 1;
+            v11 = (uint8)v10;
+            if (v10 == 0) goto label_401817;
+            v5 = get_ifname(0x402908,*(void *)&a1[2]);
+            if (v5 != 0) {
+              invarg(0x403223,*(void *)&a1[2]);
+              goto label_401903;
+            }
+            dat_4028cc = 1;
+          }
+        }
+      }
+    }
+  }
+label_40153d:
+  v11 = (uint8)(v10 - 1);
+  a1 = &v17[2];
+  if (v10 - 1 == 0) {
+label_401540:
+    v5 = rtnl_ruledump_req(0x405030,v2);
+    if ((int4)v5 < 0) {
+      perror(0x403372);
+      v6 = (void *)0x1;
+    }
+    else {
+      new_json_obj(dat_4052c0);
+      v5 = rtnl_dump_filter_nc(0x405030,v23,dat_4052e0,0);
+      if ((int4)v5 < 0) {
+        __fprintf_chk(dat_405000,1,0x40338b);
+        v6 = (void *)0x1;
+      }
+      else {
+        delete_json_obj();
+        v6 = (void *)0x0;
+      }
+    }
+label_4015ca:
+    if (v28 == *(int8 *)(v24 + 0x28)) {
+      return v6;
+    }
+label_401963:
+    __stack_chk_fail();
+label_401968:
+    invarg(0x402f48,*(void *)&a1[2]);
+label_401978:
+    invarg(0x403148,a1);
+label_401987:
+    invarg(0x40330b,*(void *)&a1[2]);
+label_401997:
+    v9 = (int4)v11;
+    v4 = matches(*(void *)a1,0x4031c0);
+    if (v4 == '\0') goto label_401927;
+    v4 = matches(*(void *)a1,0x4030c7);
+    if (v4 != '\0') goto label_4019fb;
+    do {
+      v17 = &a1[2];
+      v10 = (int4)v11 - 1;
+      v11 = (uint8)v10;
+      if (v10 == 0) goto label_401817;
+      v5 = get_prefix(0x402920,*(void *)&a1[2],v2);
+      if (v5 == 0) goto label_40153d;
+      invarg(0x40332a,*(void *)&a1[2]);
+label_4019fb:
+      v4 = matches(*(void *)a1,0x403326);
+    } while (v4 == '\0');
+    v4 = matches(*(void *)a1,0x403178);
+    if (v4 == '\0') {
+      v17 = &a1[2];
+      v10 = (int4)v11 - 1;
+      v11 = (uint8)v10;
+      if (v10 == 0) goto label_401817;
+      dat_402b34 = 0xffffffff;
+      v5 = rtnl_rtprot_a2n(v22,*(void *)&a1[2]);
+      if (v5 != 0) {
+        v16 = *(int4 **)&a1[2];
+        v5 = strcmp(v16,0x403341);
+        if (v5 != 0) {
+          invarg(0x403345,v16);
+          goto label_401acd;
+        }
+        v26 = 0;
+        v14 = 0;
+        dat_402b34 = 0;
+      }
+      Unique10000632 = CONCAT22(v26,v14);
+    }
+    else {
+      v17 = *(int4 **)a1;
+      v5 = strcmp(v17,0x403270);
+      if (v5 == 0) {
+        v17 = &a1[2];
+        v10 = (int4)v11 - 1;
+        v11 = (uint8)v10;
+        if (v10 == 0) goto label_401817;
+        v5 = inet_proto_a2n(*(void *)&a1[2]);
+        v16 = a1;
+        if (0 <= (int4)v5) {
+          Unique10000a06 = v4;
+          goto label_40153d;
+        }
+label_401acd:
+        v17 = &a1[2];
+        invarg(0x403278,*(void *)&v16[2]);
+        a1 = v16;
+      }
+      v5 = strcmp(v17,0x403291);
+      if (v5 == 0) {
+        v17 = &a1[2];
+        v10 = (int4)v11 - 1;
+        v11 = (uint8)v10;
+        if (v10 == 0) goto label_401817;
+        v5 = __isoc99_sscanf(*(void *)&a1[2],0x403297,v22);
+        if (v5 == 1) {
+label_401b8f:
+          v26 = v14;
+        }
+        else if (v5 != 2) {
+          invarg(0x40329f,*(void *)&a1[2]);
+          goto label_401b8f;
+        }
+        Unique10000636 = CONCAT22(v26,v14);
+      }
+      else {
+        v5 = strcmp(v17,0x4032b3);
+        if (v5 != 0) {
+          v4 = matches(v17,0x403359);
+          if (v4 != '\0') goto label_401c02;
+          while( true ) {
+            v17 = &a1[2];
+            v5 = (int4)v11 - 1;
+            v11 = (uint8)v5;
+            if (v5 == 0) break;
+            while( true ) {
+              v10 = (uint4)v11;
+              v5 = get_prefix(0x402a28,*(void *)v17,v2);
+              if (v5 == 0) goto label_40153d;
+              invarg(0x40335d,*(void *)v17);
+label_401c02:
+              v4 = matches(*(void *)a1,0x4030cc);
+              if (v4 == '\0') break;
+              v17 = a1;
+            }
+          }
+label_401817:
+          incomplete_command();
+label_40181c:
+          invarg(0x4030e9,*(void *)&a1[2]);
+label_40182c:
+          v10 = (uint4)v11;
+          v5 = strcmp(v17,0x40323c);
+          if (v5 != 0) {
+            v5 = strcmp(v17,0x403243);
+            if (v5 == 0) goto label_401864;
+            goto label_4018b0;
+          }
+          dat_4028c4 = 1;
+          v17 = a1;
+          goto label_40153d;
+        }
+        v17 = &a1[2];
+        v10 = (int4)v11 - 1;
+        v11 = (uint8)v10;
+        if (v10 == 0) goto label_401817;
+        v5 = __isoc99_sscanf(*(void *)&a1[2],0x403297,v22);
+        if (v5 == 1) {
+label_401bab:
+          v26 = v14;
+        }
+        else if (v5 != 2) {
+          invarg(0x4032b9,*(void *)&a1[2]);
+          goto label_401bab;
+        }
+        Unique1000063a = CONCAT22(v26,v14);
+      }
+    }
+    goto label_40153d;
+  }
+  goto label_4014d1;
+}
+
+--- metrics (reference | kuna) ---
+  loc            41 | 408 
+  gotos           0 | 46  
+  labels          0 | 23  
+  switches        0 | 0   
+  cases           0 | 0   
+  ifs             7 | 68  
+  loops           0 | 4   
+  ternaries       0 | 0   
+  casts           0 | 0   
+
+--- signals (candidate 'reference is better' hints) ---
+  * ref has fewer gotos (0 vs 46)
+  * ref has fewer labels (0 vs 23)
+  * ref is 90% shorter (41 vs 408 loc)

--- a/docs/features/ifelseflatten-iprule-85ca2b/proposal.md
+++ b/docs/features/ifelseflatten-iprule-85ca2b/proposal.md
@@ -1,0 +1,93 @@
+# [PROPOSAL] angr if-else-flatten (`IfElseFlattener`) + an ET_REL no-return boundary prerequisite
+
+**Opportunity:** `test_ifelseflatten_iprule :: flush_rule` (angr 9.2.213), binary
+`x86_64/decompiler/iprule.o` (ET_REL `.o`), function `flush_rule` @ `0x1310`.
+**Proposed option name:** `ifelseflatten`.
+**Scope (decider verdict):** *large* — this is **not** a single option-gated `Action`/`Rule`. It
+must go through human go/no-go before any implementation worker is spent. See `analysis.md` for
+the full reproduction and root-cause evidence; `angr-vs-kuna.txt` is the captured side-by-side.
+
+## The problem
+
+angr renders `flush_rule` with an early-return as its first statement:
+
+```c
+if (ptr->field_0 - 28 < 0)
+    return 4294967295;      // -1, single scope, NO else
+parse_rtattr(...);
+...
+```
+
+The `test_ifelseflatten_iprule` assertion is precisely that the *first* `if` is a single-scope
+`if (...) return -1;` with no `else`. This is produced by angr's **`IfElseFlattener`** region
+simplifier (`angr/analyses/decompiler/region_simplifiers/ifelse.py`): for a `ConditionNode` whose
+true-branch is statement-terminating (all endpoints return/abort) and whose false-branch is not,
+it drops the `else` and re-parents the false node as a *follower* of the `if` —
+`if(c){...return} else {body}` ⇒ `if(c){...return} body`.
+
+kuna has **no** equivalent structured-tree transform, so it emits the un-flattened
+`if (cond) { body } ... return -1` form instead.
+
+## Why this target additionally needs a prerequisite fix (the blocker)
+
+`flush_rule` is *also* mis-recovered: kuna **merges the whole neighbouring function**
+`iprule_list_flush_or_save` (0x1410, 2059 bytes) into `flush_rule`'s body (15 neighbour-only call
+sites leak in — `__isoc99_sscanf`, `matches`, `rtnl_ruledump_req`, `new_json_obj`, …).
+
+Root cause (verified): `flush_rule`'s canary-fail path ends with
+
+```
+1408: e8 00 00 00 00   call __stack_chk_fail   ; R_X86_64_PLT32 __stack_chk_fail-0x4
+140d: 0f 1f 00         nopl (%rax)              ; padding
+1410: <iprule_list_flush_or_save>
+```
+
+`__stack_chk_fail` is no-return, but in this ET_REL `.o` the no-return fact is **not propagated to
+the relocation-resolved call site**, so kuna assumes the call returns, walks the `nopl` padding,
+and decodes straight into the next function. kuna already has the pieces (`relocobjects`, the
+known-no-return list normalizes `__stack_chk_fail`→`stack_chk_fail`, `noreturn_disc` /
+`noreturn_propagate`), yet enabling all of them leaves the merge unchanged (15 leaks) — and the
+full `scripts.pipeline.compare` reproduces it. So **even a perfect `IfElseFlattener` could not
+make `flush_rule` match angr**: it would still be a merged blob.
+
+## Proposed plan (multi-step — hence a proposal)
+
+**Step A — boundary prerequisite (analysis/loader tier).** Make the known/discovered no-return
+fact reach relocation-resolved call sites in ET_REL objects so `call __stack_chk_fail` terminates
+the flow-follower and `flush_rule`'s extent stops at `0x140d`. This is in `kuna-analysis`
+(`s1_loader::noreturn` / `s1_noreturn_propagate` + `relocobjects` interaction), *not* an S2
+`Action`/`Rule`. This step is what unblocks `flush_rule` as a discrete function.
+
+**Step B — `IfElseFlattener` port (S7/S8 structuring).** Add a gated structured-tree region
+simplifier (option `ifelseflatten`, default-OFF) that, for an `if/else` whose `if`-branch is
+statement-terminating and whose `else`-branch is not, drops the `else` and re-parents it as a
+follower of the `if`. This is a new structuring-tree pass type, touching S7/S8 region code — over
+the single-Action bar by itself.
+
+## Validation target recommendation
+
+`flush_rule` should **not** be the firing-test target while Step A is unlanded. The if-else-flatten
+capability is real and recurring; use an already-renderable witness for the firing stage test —
+the sibling angr testcases `test_ifelseflatten_clientloop` (`clientloop.o`,
+`client_request_tun_fwd`) and `test_ifelseflatten_certtool_common` (`certtool-common.o`) — and
+verify whether they suffer the same ET_REL merge before picking. Land Step A first if `flush_rule`
+must be the witness.
+
+## Speed / risk assessment
+
+- **Step A** changes function extents → affects every ET_REL `.o` with a tail `__stack_chk_fail`
+  (or other no-return) call. Risk: shrinking functions is generally correctness-positive but could
+  perturb the datatest corpus; must run the full ablation. Default-OFF until proven.
+- **Step B** is an emit-time structured-tree rewrite; risk is localized to `if/else`-with-returning
+  branch shapes. Default-OFF; only flip to default-ON if the 675-assertion ablation is clean and the
+  decompile speed delta is within the +5% budget. Speed impact expected small (one extra
+  tree walk).
+- **Anchors:** Step B needs a new module + a structuring registration; Step A needs analysis-tier
+  wiring. Combined, this exceeds the one-Action / ≤3-anchor / ≤1-module single-feature contract.
+
+## Decision requested
+
+Human go/no-go on: (1) approving the `IfElseFlattener` port as a gated structuring pass, and
+(2) whether to also schedule the ET_REL no-return-propagation prerequisite (required for the
+`flush_rule` target specifically; not required for clientloop/certtool-common if those render
+discretely). On approval, re-dispatch an implementation worker on this branch.

--- a/docs/features/ifelseflatten-iprule-85ca2b/record.json
+++ b/docs/features/ifelseflatten-iprule-85ca2b/record.json
@@ -1,0 +1,35 @@
+{
+  "opportunity": "test_ifelseflatten_iprule::flush_rule",
+  "test_name": "test_ifelseflatten_iprule",
+  "binary": "/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/iprule.o",
+  "selector": "flush_rule",
+  "func_addr": "0x1310",
+  "arch": "x86_64",
+  "angr_version": "9.2.213",
+  "option": "ifelseflatten",
+  "change_kind": "structure-recovery",
+  "source_decompiler": "angr",
+  "inspiration": "test_ifelseflatten_iprule; angr IfElseFlattener (region_simplifiers/ifelse.py); flush_rule",
+  "scope": "large",
+  "proposal": true,
+  "decisions": [
+    {
+      "question": "Is closing test_ifelseflatten_iprule::flush_rule a small single option-gated Action/Rule, or large (proposal/negative)?",
+      "decider_verdict": "scope: large; verdict: PROPOSAL",
+      "decider_reasoning": "The target flush_rule is blocked by TWO genuinely independent gaps, and neither alone yields a firing stage test. The if-else-flatten capability (porting angr's IfElseFlattener) is by definition 'large' under the worker's rules - it touches S7/S8 region/structuring code beyond a single gated early-return, which is exactly the STOP-and-PROPOSAL trigger. Critically, even a perfect if-else-flatten Rule could not produce a firing test on flush_rule, because the orthogonal ET_REL no-return-propagation merge bug means kuna never renders flush_rule as a discrete function in the first place (15 neighbour-only call sites leak in from the merged iprule_list_flush_or_save). That merge fix is an analysis/loader-tier change, not an S2 Action/Rule, so it cannot be folded into the one-option-gated-Action contract either. This is the classic 'needs deeper restructuring than one option-gated pass' situation that the rules flag - but the work is large-but-coherent rather than impossible: the if-else-flatten capability is real, recurring, and human-approvable (other witnesses: clientloop, certtool-common), and the boundary-merge prerequisite is a well-characterized root cause an implementation worker could later land. A NEGATIVE result would correctly capture that THIS target can't get a firing test today, but it would discard a coherent, recurring capability plus a precisely-diagnosed prerequisite that a human is well-positioned to scope and greenlight. Therefore the right move is a draft [PROPOSAL] PR that surfaces both the if-else-flatten capability and its boundary-merge blocker for human go/no-go, explicitly noting that a different (already-renderable) target should be chosen for the firing test rather than flush_rule."
+    }
+  ],
+  "gaps": [
+    {
+      "id": "boundary-merge",
+      "tier": "analysis/loader",
+      "summary": "kuna merges neighbouring iprule_list_flush_or_save into flush_rule because the no-return fact for `call __stack_chk_fail` (R_X86_64_PLT32, rel32=0) is not propagated to the relocation-resolved call site in this ET_REL .o; flow falls through nopl padding into 0x1410.",
+      "evidence": "15 neighbour-only call sites leak into flush_rule's body even with relocobjects+noreturn_known+noreturn_disc+noreturn_propagate all on; full scripts.pipeline.compare reproduces."
+    },
+    {
+      "id": "ifelseflatten",
+      "tier": "S7/S8 structuring",
+      "summary": "kuna lacks angr's IfElseFlattener: it emits `if(cond){body} ... return -1` instead of the single-scope early-return `if(!cond) return -1; body`."
+    }
+  ]
+}


### PR DESCRIPTION
# [PROPOSAL] angr if-else-flatten (`IfElseFlattener`) + an ET_REL no-return boundary prerequisite

**Opportunity:** `test_ifelseflatten_iprule :: flush_rule` (angr 9.2.213), binary
`x86_64/decompiler/iprule.o` (ET_REL `.o`), function `flush_rule` @ `0x1310`.
**Proposed option name:** `ifelseflatten`.
**Scope (decider verdict):** *large* — this is **not** a single option-gated `Action`/`Rule`. It
must go through human go/no-go before any implementation worker is spent. See `analysis.md` for
the full reproduction and root-cause evidence; `angr-vs-kuna.txt` is the captured side-by-side.

## The problem

angr renders `flush_rule` with an early-return as its first statement:

```c
if (ptr->field_0 - 28 < 0)
    return 4294967295;      // -1, single scope, NO else
parse_rtattr(...);
...
```

The `test_ifelseflatten_iprule` assertion is precisely that the *first* `if` is a single-scope
`if (...) return -1;` with no `else`. This is produced by angr's **`IfElseFlattener`** region
simplifier (`angr/analyses/decompiler/region_simplifiers/ifelse.py`): for a `ConditionNode` whose
true-branch is statement-terminating (all endpoints return/abort) and whose false-branch is not,
it drops the `else` and re-parents the false node as a *follower* of the `if` —
`if(c){...return} else {body}` ⇒ `if(c){...return} body`.

kuna has **no** equivalent structured-tree transform, so it emits the un-flattened
`if (cond) { body } ... return -1` form instead.

## Why this target additionally needs a prerequisite fix (the blocker)

`flush_rule` is *also* mis-recovered: kuna **merges the whole neighbouring function**
`iprule_list_flush_or_save` (0x1410, 2059 bytes) into `flush_rule`'s body (15 neighbour-only call
sites leak in — `__isoc99_sscanf`, `matches`, `rtnl_ruledump_req`, `new_json_obj`, …).

Root cause (verified): `flush_rule`'s canary-fail path ends with

```
1408: e8 00 00 00 00   call __stack_chk_fail   ; R_X86_64_PLT32 __stack_chk_fail-0x4
140d: 0f 1f 00         nopl (%rax)              ; padding
1410: <iprule_list_flush_or_save>
```

`__stack_chk_fail` is no-return, but in this ET_REL `.o` the no-return fact is **not propagated to
the relocation-resolved call site**, so kuna assumes the call returns, walks the `nopl` padding,
and decodes straight into the next function. kuna already has the pieces (`relocobjects`, the
known-no-return list normalizes `__stack_chk_fail`→`stack_chk_fail`, `noreturn_disc` /
`noreturn_propagate`), yet enabling all of them leaves the merge unchanged (15 leaks) — and the
full `scripts.pipeline.compare` reproduces it. So **even a perfect `IfElseFlattener` could not
make `flush_rule` match angr**: it would still be a merged blob.

## Proposed plan (multi-step — hence a proposal)

**Step A — boundary prerequisite (analysis/loader tier).** Make the known/discovered no-return
fact reach relocation-resolved call sites in ET_REL objects so `call __stack_chk_fail` terminates
the flow-follower and `flush_rule`'s extent stops at `0x140d`. This is in `kuna-analysis`
(`s1_loader::noreturn` / `s1_noreturn_propagate` + `relocobjects` interaction), *not* an S2
`Action`/`Rule`. This step is what unblocks `flush_rule` as a discrete function.

**Step B — `IfElseFlattener` port (S7/S8 structuring).** Add a gated structured-tree region
simplifier (option `ifelseflatten`, default-OFF) that, for an `if/else` whose `if`-branch is
statement-terminating and whose `else`-branch is not, drops the `else` and re-parents it as a
follower of the `if`. This is a new structuring-tree pass type, touching S7/S8 region code — over
the single-Action bar by itself.

## Validation target recommendation

`flush_rule` should **not** be the firing-test target while Step A is unlanded. The if-else-flatten
capability is real and recurring; use an already-renderable witness for the firing stage test —
the sibling angr testcases `test_ifelseflatten_clientloop` (`clientloop.o`,
`client_request_tun_fwd`) and `test_ifelseflatten_certtool_common` (`certtool-common.o`) — and
verify whether they suffer the same ET_REL merge before picking. Land Step A first if `flush_rule`
must be the witness.

## Speed / risk assessment

- **Step A** changes function extents → affects every ET_REL `.o` with a tail `__stack_chk_fail`
  (or other no-return) call. Risk: shrinking functions is generally correctness-positive but could
  perturb the datatest corpus; must run the full ablation. Default-OFF until proven.
- **Step B** is an emit-time structured-tree rewrite; risk is localized to `if/else`-with-returning
  branch shapes. Default-OFF; only flip to default-ON if the 675-assertion ablation is clean and the
  decompile speed delta is within the +5% budget. Speed impact expected small (one extra
  tree walk).
- **Anchors:** Step B needs a new module + a structuring registration; Step A needs analysis-tier
  wiring. Combined, this exceeds the one-Action / ≤3-anchor / ≤1-module single-feature contract.

## Decision requested

Human go/no-go on: (1) approving the `IfElseFlattener` port as a gated structuring pass, and
(2) whether to also schedule the ET_REL no-return-propagation prerequisite (required for the
`flush_rule` target specifically; not required for clientloop/certtool-common if those render
discretely). On approval, re-dispatch an implementation worker on this branch.
