### PR TITLE
[PROPOSAL] angr-who-condensing-opt-reversion-72e518: SAILR CrossJumpReverter (non-return cross-jump tail) to revert ISC condensing

### DIFF
--- a/docs/features/who-condensing-opt-reversion-72e518/analysis.md
+++ b/docs/features/who-condensing-opt-reversion-72e518/analysis.md
@@ -1,0 +1,101 @@
+# who-condensing-opt-reversion — analysis
+
+**angr testcase:** `test_who_condensing_opt_reversion :: scan_entries`
+**Binary:** `/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/who.o` (x86_64)
+**Function:** `scan_entries` (entry `0x401250`)
+**angr version:** 9.2.213
+
+## What angr does better
+
+The angr test asserts `goto count == 0` for `scan_entries`. With its "full" preset
+angr reaches **zero gotos**; **kuna emits exactly one** (`goto label_4012b5`). The angr
+test docstring is explicit about the mechanism:
+
+> This testcase verifies that all the Irreducible Statement Condensing (ISC) optimizations
+> are reverted by the **ReturnDuplicatorLow** and the **CrossJumpReverter** optimization
+> passes. … there is some special ordering to edge virtualization … The default edge
+> virtualization order (post-ordering) will lead to two gotos. virtualizing
+> `0x401361 -> 0x4012b5` will lead to only one goto … Either way, these gotos can be
+> eliminated by the **CrossJumpReverter** duplicating the statement at the end of the goto,
+> after ReturnDuplicatorLow has fixed up the return statements.
+
+These are the SAILR (Basque et al., USENIX Security 2024) de-optimization passes that
+*revert* compiler "Irreducible Statement Condensing".
+
+## The exact construct (the one structural difference)
+
+Inside the case-cascade of the `do { … } while(true)` loop, kuna renders:
+
+```c
+else if (need_deadprocs && v1 == 8) {
+    print_deadprocs(a1);
+    goto label_4012b5;            // <-- the residual goto
+}
+...
+else {
+label_4012b5:
+    v1 = *a1;                     // <-- the shared, condensed tail
+}
+if (v1 == 2) { v5 = ...; }
+a1 = &a1[0xc0];
+...
+```
+
+`label_4012b5` is a **single block `v1 = *a1;`** that **falls through** to `if (v1 == 2)`
+and the loop continuation. The compiler *condensed* two identical `v1 = *a1;` tails — the
+`need_deadprocs` case's and the skip/else path's — into **one shared block reached by a
+`goto`**. Reverting the condensing = duplicate `v1 = *a1;` back into the `need_deadprocs`
+branch so both paths fall straight through to `if (v1 == 2)`:
+
+```c
+else if (need_deadprocs && v1 == 8) {
+    print_deadprocs(a1);
+    v1 = *a1;                     // duplicated; no goto
+}
+```
+
+This is the **CrossJumpReverter** case: a duplication of a **NON-return, fall-through
+cross-jump tail** (contrast gotoreduce, which only duplicates tails that end in `return`).
+
+## Owning stage
+
+S8 structuring / goto-reduction (the SAILR de-optimization family), running after
+`ActionFinalStructure` on the structured (sblocks) tree — the same neighbourhood as the
+existing `kuna_gotoreduce.rs` (`docs/stage-mapping.md` → S8). The reversion is a
+print-tree / structured-block surgery, downstream of `CollapseStructure`/`TraceDAG`.
+
+## Why no existing option closes it (measured)
+
+`scan_entries` decompiled with each of `gotoreduce`, `regionstructure`,
+`loopbreak_recovery`, `foldcallret` (alone and combined) **still emits 1 goto**:
+
+| options | gotos |
+|---|---|
+| (default) | 1 |
+| `gotoreduce on` | 1 |
+| `regionstructure on` | 1 |
+| `loopbreak_recovery on` | 1 |
+| all four on | 1 |
+
+`gotoreduce` declines because its `return_tail_chain()` requires the tail to end in
+`return`; this tail (`v1 = *a1`) falls through to a successor. So the gap is **not covered**
+by an existing option.
+
+## Hypothesis for the kuna change (and why it is LARGE)
+
+A SAILR **CrossJumpReverter** pass that duplicates a small NON-return, fall-through
+cross-jump tail into its `goto` source. Unlike `gotoreduce`'s return-tail duplication
+(`kuna_inline_return_tail`, a closed path), the fall-through case must additionally prove a
+**convergence/post-dominance precondition** — that the `goto`-source if-block's own
+structured fall-through reaches the *same* successor as the target's fall-through — and
+needs **new structured-tree surgery** (`kuna_inline_crossjump_tail`) that `gotoreduce` does
+not provide. The angr test further names a *second* pass (`ReturnDuplicatorLow`) and a
+*specific edge-virtualization ordering* as prerequisites for this function reaching zero.
+
+A scope-decider subagent (recorded verbatim in `record.json`) ruled this **large**: it
+trips Hard Rule 7 on (1) new structured-tree-surgery *infrastructure* (a new pass type, not
+modelable as one Action like `kuna_loweredswitch.rs`), (2) a likely multi-pass/edge-ordering
+dependency, and (3) the convergence-precondition machinery `gotoreduce` intentionally lacks.
+A wrong precondition check would silently emit **incorrect C** (worse than the one harmless
+goto). Therefore this opportunity goes through a draft `[PROPOSAL]` PR for human go/no-go
+rather than being implemented in a single worker session — see `proposal.md`.

--- a/docs/features/who-condensing-opt-reversion-72e518/angr-vs-kuna.txt
+++ b/docs/features/who-condensing-opt-reversion-72e518/angr-vs-kuna.txt
@@ -1,0 +1,209 @@
+==============================================================================
+test_who_condensing_opt_reversion :: scan_entries   (angr 9.2.213 @ 0x401250)
+==============================================================================
+
+--- angr ---
+typedef struct struct_0 {
+    unsigned short field_0;
+    char padding_2[338];
+    unsigned int field_154;
+} struct_0;
+
+extern char include_heading;
+extern char my_line_only;
+extern char need_boottime;
+extern char need_clockchange;
+extern char need_deadprocs;
+extern char need_initspawn;
+extern char need_login;
+extern char need_runlevel;
+extern char need_users;
+
+char * scan_entries(unsigned long long a0, struct_0 *cur)
+{
+    char *v1;  // rax
+    char v2;  // r12b
+    char *iter;  // r13
+    long long v4;  // r14
+    unsigned long long v5;  // rbp
+    unsigned long long v6;  // rbp
+    char *v7;  // rax
+    unsigned long long v8;  // rbp
+
+    if (include_heading)
+        v1 = print_heading();
+    v2 = my_line_only;
+    if (my_line_only)
+    {
+        iter = ttyname(0);
+        if (!iter)
+            return iter;
+        v1 = strncmp(iter, "/dev/", 5);
+        if (!(unsigned int)v1)
+            iter += 5;
+    }
+    v4 = -0x8000000000000000;
+    v5 = a0 - 1;
+    if (!a0)
+        return v1;
+    while (true)
+    {
+        v6 = v5;
+        if (v2 && strncmp(iter, &cur->padding_2[6], 32))
+        {
+LABEL_4012b5:
+            v7 = cur->field_0;
+        }
+        else
+        {
+            v7 = cur->field_0;
+            if (!(!need_users || !cur->padding_2[42] || *((unsigned short *)&v7) != 7))
+            {
+                print_user(cur, v4);
+                v7 = cur->field_0;
+            }
+            else if (!(!need_runlevel || *((unsigned short *)&v7) != 1))
+            {
+                print_runlevel(cur);
+                v7 = cur->field_0;
+            }
+            else if (!(!need_boottime || *((unsigned short *)&v7) != 2))
+            {
+                print_boottime.isra.0(cur->field_154);
+                v7 = cur->field_0;
+            }
+            else if (!(!need_clockchange || *((unsigned short *)&v7) != 3))
+            {
+                print_clockchange.isra.0(cur->field_154);
+                v7 = cur->field_0;
+            }
+            else if (!(!need_initspawn || *((unsigned short *)&v7) != 5))
+            {
+                print_initspawn(cur);
+                v7 = cur->field_0;
+            }
+            else if (!(!need_login || *((unsigned short *)&v7) != 6))
+            {
+                print_login(cur);
+                v7 = cur->field_0;
+            }
+            else if (need_deadprocs && *((unsigned short *)&v7) == 8)
+            {
+                print_deadprocs(cur);
+                goto LABEL_4012b5;
+            }
+        }
+        if (*((unsigned short *)&v7) == 2)
+            v4 = cur->field_154;
+        cur = &cur[1].padding_2[38];
+        v8 = v6 - 1;
+        if (v6 < 1)
+            break;
+        v2 = my_line_only;
+        v5 = v8;
+    }
+    return v7;
+}
+
+
+--- kuna (name mode) ---
+void scan_entries(int8 a0,int2 *a1)
+
+{
+  int2 v1;
+  int4 v2; // eax
+  char v3;
+  int8 v4; // rax
+  int8 v5; // r14
+  
+  if (dat_401732 != '\0') {
+    print_heading();
+  }
+  v3 = dat_401728;
+  if (dat_401728 != '\0') {
+    v4 = ttyname(0);
+    if (v4 == 0) {
+      return;
+    }
+    v2 = strncmp(v4,0x4018ef,5);
+    if (v2 == 0) {
+      v4 = v4 + 5;
+    }
+  }
+  v5 = -0x8000000000000000;
+  if (a0 == 0) {
+    return;
+  }
+  do {
+    a0 = a0 + -1;
+    if ((v3 == '\0') || (v2 = strncmp(v4,&a1[4],0x20), v2 == 0)) {
+      v1 = *a1;
+      if ((dat_401729 == '\0') || (((char)a1[0x16] == '\0' || (v1 != 7)))) {
+        if ((dat_40172a == '\0') || (v1 != 1)) {
+          if ((dat_40172f == '\0') || (v1 != 2)) {
+            if ((dat_40172b == '\0') || (v1 != 3)) {
+              if ((dat_40172c == '\0') || (v1 != 5)) {
+                if ((dat_40172d == '\0') || (v1 != 6)) {
+                  if ((dat_40172e != '\0') && (v1 == 8)) {
+                    print_deadprocs(a1);
+                    goto label_4012b5;
+                  }
+                }
+                else {
+                  print_login(a1);
+                  v1 = *a1;
+                }
+              }
+              else {
+                print_initspawn(a1);
+                v1 = *a1;
+              }
+            }
+            else {
+              print_clockchange.isra.0(*(void *)&a1[0xaa]);
+              v1 = *a1;
+            }
+          }
+          else {
+            print_boottime.isra.0(*(void *)&a1[0xaa]);
+            v1 = *a1;
+          }
+        }
+        else {
+          print_runlevel(a1);
+          v1 = *a1;
+        }
+      }
+      else {
+        print_user(a1,v5);
+        v1 = *a1;
+      }
+    }
+    else {
+label_4012b5:
+      v1 = *a1;
+    }
+    if (v1 == 2) {
+      v5 = (int8)*(int4 *)&a1[0xaa];
+    }
+    a1 = &a1[0xc0];
+    if (a0 == 0) {
+      return;
+    }
+    v3 = dat_401728;
+  } while( true );
+}
+
+--- metrics (reference | kuna) ---
+  loc            98 | 84  
+  gotos           1 | 1   
+  labels          1 | 1   
+  switches        0 | 0   
+  cases           0 | 0   
+  ifs            15 | 15  
+  loops           1 | 1   
+  ternaries       0 | 0   
+  casts           0 | 0   
+
+--- signals (candidate 'reference is better' hints) ---
+  (none -- structurally comparable)

--- a/docs/features/who-condensing-opt-reversion-72e518/proposal.md
+++ b/docs/features/who-condensing-opt-reversion-72e518/proposal.md
@@ -1,0 +1,107 @@
+# [PROPOSAL] CrossJumpReverter: revert ISC condensing of a non-return cross-jump tail
+
+**Opportunity:** `test_who_condensing_opt_reversion :: scan_entries`
+**Binary:** `who.o` (x86_64), function `scan_entries` (entry `0x401250`)
+**Proposed option:** `crossjumpreverter` (default-OFF, opt-in while developing)
+**angr reference:** SAILR `CrossJumpReverter` (+ `ReturnDuplicatorLow`),
+`angr/analyses/decompiler/optimization_passes/cross_jump_reverter.py`,
+Basque et al., USENIX Security 2024 ("SAILR").
+
+## The problem
+
+kuna emits **one** `goto` in `scan_entries`; angr's "full" preset emits **zero**. The goto
+is a residual of compiler **Irreducible Statement Condensing (ISC)**: two identical
+`v1 = *a1;` tails (the `need_deadprocs` case's and the cascade's skip/else path's) were
+condensed by the compiler into **one shared basic block** reached by a `goto`:
+
+```c
+else if (need_deadprocs && v1 == 8) { print_deadprocs(a1); goto label_4012b5; }
+...
+else { label_4012b5: v1 = *a1; }      // shared, condensed tail; falls through to:
+if (v1 == 2) { ... }
+```
+
+The SAILR de-optimization reverts the condensing by **duplicating the shared tail back**
+into the goto source, so both paths fall straight through and the goto/label vanish.
+
+This is the **CrossJumpReverter** case — a duplication of a **NON-return, fall-through**
+cross-jump tail. It is distinct from the already-shipped `gotoreduce` option, whose
+`return_tail_chain()` only fires when the tail ends in `return`. Measured: no existing
+kuna option (`gotoreduce`, `regionstructure`, `loopbreak_recovery`, `foldcallret`, in any
+combination) removes this goto — it stays at 1. See `analysis.md` for the table and the
+full side-by-side (`angr-vs-kuna.txt`).
+
+## Why this is LARGE (the proposal gate)
+
+A scope-decider subagent ruled this **large** (verdict + justification recorded verbatim in
+`record.json`). It trips Hard Rule 7 on three counts:
+
+1. **New pass *type* / structured-tree-surgery infrastructure.** `gotoreduce`'s
+   `kuna_inline_return_tail` appends duplicated `BlockCopy` leaves to an `if` true-clause
+   for a tail that ends in `return` — a *closed* path, no fall-through to reconcile, no
+   edge rewiring. A cross-jump tail **falls through** to a shared successor (`if (v1 == 2)`),
+   so the reverter needs a *new* surgery (`kuna_inline_crossjump_tail`) that duplicates a
+   non-return block and reconciles the fall-through — machinery `gotoreduce` deliberately
+   lacks.
+2. **A convergence/post-dominance precondition.** Duplicating is only correct when the
+   goto-source if-block's own structured fall-through already converges on the *same*
+   successor as the target's fall-through. Establishing that is a real dominator/convergence
+   analysis over the **structured tree**, not the bounded single-successor *bblock* walk
+   `return_tail_chain` performs. **A wrong precondition silently emits incorrect C** — a
+   correctness defect far worse than the single harmless goto it removes.
+3. **A likely multi-pass / edge-ordering dependency.** The angr test docstring states
+   `scan_entries` reaches zero gotos only via **two** passes (`ReturnDuplicatorLow` +
+   `CrossJumpReverter`) *and* a **specific edge-virtualization ordering** (post-order gives
+   two gotos; virtualizing `0x401361 -> 0x4012b5` gives one, which the reverter then
+   removes). kuna's verbatim `CollapseStructure`/`TraceDAG` structurer does not virtualize
+   edges the way angr's region structurer does, so the goto *shape* kuna hands a reverter is
+   not the shape angr's reverter consumes — there is no guarantee a single bounded Action
+   lands on this exact goto.
+
+This is the same SAILR tail-duplication family already parked as a proposal for the
+return-tail gotoreduce gap (`docs/baseline`/PROGRESS history; sibling in-flight worker
+branches `feat/angr-*ret-dup*`, `feat/angr-incorrect-duplication-chcon-*`). The
+CrossJumpReverter (non-return) variant is the missing third leg.
+
+## Proposed implementation plan (for human go/no-go)
+
+1. **New module `kuna_crossjumpreverter.rs`** (S8, an `ActionCrossJumpReverter` modeled on
+   `kuna_gotoreduce.rs`), gated by a new `crossjumpreverter` option
+   (`revert_cross_jumps` flag on the seam `Architecture`, default-off; gated early-return so
+   default output is byte-identical).
+2. **Detection.** Over the structured (sblocks) tree, find every `if (cond) goto T` where
+   `T` is a small (≤ N ops, no `CALL`/`STORE`) **non-return** block that falls through to a
+   successor `S`.
+3. **Convergence precondition.** Prove the goto-source if-block's structured fall-through is
+   exactly `S` (a post-dominator/convergence check on the structured tree). Decline
+   otherwise — this is the correctness-critical step.
+4. **Surgery `kuna_inline_crossjump_tail`.** Duplicate `T`'s ops (print-tree `BlockCopy`
+   leaves — no p-code cloned, SSA untouched) into the `if` true-clause in place of the
+   `goto`; clear `T`'s label when no unstructured edge still targets it.
+5. **Edge-virtualization-ordering investigation.** Determine whether kuna's structurer
+   presents the right single-goto shape; if not, scope the additional ordering work (this is
+   the part that may force a *second* gated pass and is the chief risk to a clean default-ON
+   ablation).
+6. **Validation.** New `tests/stages/ghangr-who-condensing-opt-reversion-72e518.xml`
+   (two-pass: off ⇒ the goto, default/on ⇒ zero gotos), full `kuna test --all` ablation,
+   speed measurement on `scan_entries`, and a `docs/divergences.md` DIV entry **only if** the
+   ablation is clean and the option ships default-ON.
+
+## Speed / risk assessment
+
+- **Risk: HIGH for correctness** (precondition #3). Must be conservative — decline on any
+  doubt; bound tail size; never duplicate side-effecting ops.
+- **Risk: MEDIUM for completeness** — the structurer-shape/edge-ordering dependency (point 3
+  above) may mean one Action does not reach zero gotos on this function, requiring follow-up.
+- **Speed:** a bounded, post-structuring print-tree pass should be cheap (comparable to
+  `gotoreduce`); to be measured during implementation. Ships **default-OFF opt-in** until
+  the ablation is proven clean and within the speed budget.
+
+## Proposed option name
+
+`crossjumpreverter` (`change_kind = structure-recovery`,
+`inspiration = "test_who_condensing_opt_reversion; CrossJumpReverter/ReturnDuplicatorLow; scan_entries"`).
+
+---
+On approval, re-dispatch an implementation worker on this branch
+(`feat/angr-who-condensing-opt-reversion-72e518`).

--- a/docs/features/who-condensing-opt-reversion-72e518/record.json
+++ b/docs/features/who-condensing-opt-reversion-72e518/record.json
@@ -1,0 +1,27 @@
+{
+  "opportunity": "test_who_condensing_opt_reversion::scan_entries",
+  "test_name": "test_who_condensing_opt_reversion",
+  "binary": "/home/mahaloz/github/angr-dev/binaries/tests/x86_64/decompiler/who.o",
+  "selector": "scan_entries",
+  "func_addr": "0x401250",
+  "angr_version": "9.2.213",
+  "option": "crossjumpreverter",
+  "change_kind": "structure-recovery",
+  "source_decompiler": "angr",
+  "inspiration": "test_who_condensing_opt_reversion; CrossJumpReverter/ReturnDuplicatorLow; scan_entries",
+  "scope": "large",
+  "proposal": true,
+  "gap_summary": "kuna emits 1 goto; angr 'full' preset emits 0. The goto is a residual of compiler Irreducible Statement Condensing (ISC): two identical `v1 = *a1;` tails condensed into one shared block reached by `goto label_4012b5`. Reverting = duplicate the non-return, fall-through cross-jump tail back into the `need_deadprocs` goto source (SAILR CrossJumpReverter).",
+  "owning_stage": "S8 structuring / goto-reduction (SAILR de-optimization family), after ActionFinalStructure on the sblocks tree",
+  "existing_option_coverage": "none — gotoreduce/regionstructure/loopbreak_recovery/foldcallret (alone or combined) all leave 1 goto; gotoreduce only duplicates return-terminated tails, not this fall-through tail",
+  "decisions": [
+    {
+      "question": "Is a single-Action crossjumpreverter SMALL, or LARGE (proposal)?",
+      "verdict": "large",
+      "justification": "The existing `gotoreduce` works only because its tail ends in `return`: `kuna_inline_return_tail` appends duplicated `BlockCopy` leaves to the `if` true-clause and drops the goto, and the printer re-emits them ending in `return` — a *closed* path with no fall-through to reconcile. The cross-jump case is categorically different: the duplicated `v1=*a1` tail must *fall through into the shared `if(v1==2)` successor*, which only renders correctly if the goto-source if-block's own structured fall-through already converges on that exact block. Establishing that is a real convergence/post-dominance precondition over the structured tree (not the bounded single-successor *bblock* walk `return_tail_chain` does), and a correct surgery (`kuna_inline_crossjump_tail`) does not exist — `kuna_inline_return_tail` deliberately does *not* rewire edges or touch the if's existing successor, exactly the part a fall-through duplication must get right. Worse, the angr testcase itself states this function reaches zero gotos only via TWO passes (ReturnDuplicatorLow + CrossJumpReverter) *and* a specific edge-virtualization ordering; kuna's verbatim CollapseStructure/TraceDAG structurer does not virtualize edges the way angr's region structurer does, so the goto shape kuna hands a reverter is not the shape angr's reverter consumes — there is no guarantee one new bounded Action lands on this single goto. This trips at least three of Hard Rule 7's triggers: new structured-tree surgery infrastructure (new pass *type*, not modelable like `kuna_loweredswitch.rs`), a likely dependency on a second pass/edge-ordering, and the convergence-precondition machinery that gotoreduce intentionally lacks.",
+      "biggest_risk": "An incorrect convergence/post-dominance check would silently emit wrong C — duplicating `v1=*a1` into a branch whose actual structured fall-through is NOT `if(v1==2)` changes control flow, a correctness defect far worse than the one harmless goto it removes.",
+      "proposal_should_request": "A draft [PROPOSAL] PR for a SAILR CrossJumpReverter pass: a `kuna_inline_crossjump_tail` structured-tree surgery (non-return fall-through duplication with a tree-level convergence/post-dominator precondition) plus an investigation of whether the angr-stated edge-virtualization ordering / ReturnDuplicatorLow co-dependency means this needs more than one option-gated pass to actually reach zero gotos on scan_entries.",
+      "decider": "general-purpose subagent (opus)"
+    }
+  ]
+}


### PR DESCRIPTION
# [PROPOSAL] CrossJumpReverter: revert ISC condensing of a non-return cross-jump tail

**Opportunity:** `test_who_condensing_opt_reversion :: scan_entries`
**Binary:** `who.o` (x86_64), function `scan_entries` (entry `0x401250`)
**Proposed option:** `crossjumpreverter` (default-OFF, opt-in while developing)
**angr reference:** SAILR `CrossJumpReverter` (+ `ReturnDuplicatorLow`),
`angr/analyses/decompiler/optimization_passes/cross_jump_reverter.py`,
Basque et al., USENIX Security 2024 ("SAILR").

## The problem

kuna emits **one** `goto` in `scan_entries`; angr's "full" preset emits **zero**. The goto
is a residual of compiler **Irreducible Statement Condensing (ISC)**: two identical
`v1 = *a1;` tails (the `need_deadprocs` case's and the cascade's skip/else path's) were
condensed by the compiler into **one shared basic block** reached by a `goto`:

```c
else if (need_deadprocs && v1 == 8) { print_deadprocs(a1); goto label_4012b5; }
...
else { label_4012b5: v1 = *a1; }      // shared, condensed tail; falls through to:
if (v1 == 2) { ... }
```

The SAILR de-optimization reverts the condensing by **duplicating the shared tail back**
into the goto source, so both paths fall straight through and the goto/label vanish.

This is the **CrossJumpReverter** case — a duplication of a **NON-return, fall-through**
cross-jump tail. It is distinct from the already-shipped `gotoreduce` option, whose
`return_tail_chain()` only fires when the tail ends in `return`. Measured: no existing
kuna option (`gotoreduce`, `regionstructure`, `loopbreak_recovery`, `foldcallret`, in any
combination) removes this goto — it stays at 1. See `analysis.md` for the table and the
full side-by-side (`angr-vs-kuna.txt`).

## Why this is LARGE (the proposal gate)

A scope-decider subagent ruled this **large** (verdict + justification recorded verbatim in
`record.json`). It trips Hard Rule 7 on three counts:

1. **New pass *type* / structured-tree-surgery infrastructure.** `gotoreduce`'s
   `kuna_inline_return_tail` appends duplicated `BlockCopy` leaves to an `if` true-clause
   for a tail that ends in `return` — a *closed* path, no fall-through to reconcile, no
   edge rewiring. A cross-jump tail **falls through** to a shared successor (`if (v1 == 2)`),
   so the reverter needs a *new* surgery (`kuna_inline_crossjump_tail`) that duplicates a
   non-return block and reconciles the fall-through — machinery `gotoreduce` deliberately
   lacks.
2. **A convergence/post-dominance precondition.** Duplicating is only correct when the
   goto-source if-block's own structured fall-through already converges on the *same*
   successor as the target's fall-through. Establishing that is a real dominator/convergence
   analysis over the **structured tree**, not the bounded single-successor *bblock* walk
   `return_tail_chain` performs. **A wrong precondition silently emits incorrect C** — a
   correctness defect far worse than the single harmless goto it removes.
3. **A likely multi-pass / edge-ordering dependency.** The angr test docstring states
   `scan_entries` reaches zero gotos only via **two** passes (`ReturnDuplicatorLow` +
   `CrossJumpReverter`) *and* a **specific edge-virtualization ordering** (post-order gives
   two gotos; virtualizing `0x401361 -> 0x4012b5` gives one, which the reverter then
   removes). kuna's verbatim `CollapseStructure`/`TraceDAG` structurer does not virtualize
   edges the way angr's region structurer does, so the goto *shape* kuna hands a reverter is
   not the shape angr's reverter consumes — there is no guarantee a single bounded Action
   lands on this exact goto.

This is the same SAILR tail-duplication family already parked as a proposal for the
return-tail gotoreduce gap (`docs/baseline`/PROGRESS history; sibling in-flight worker
branches `feat/angr-*ret-dup*`, `feat/angr-incorrect-duplication-chcon-*`). The
CrossJumpReverter (non-return) variant is the missing third leg.

## Proposed implementation plan (for human go/no-go)

1. **New module `kuna_crossjumpreverter.rs`** (S8, an `ActionCrossJumpReverter` modeled on
   `kuna_gotoreduce.rs`), gated by a new `crossjumpreverter` option
   (`revert_cross_jumps` flag on the seam `Architecture`, default-off; gated early-return so
   default output is byte-identical).
2. **Detection.** Over the structured (sblocks) tree, find every `if (cond) goto T` where
   `T` is a small (≤ N ops, no `CALL`/`STORE`) **non-return** block that falls through to a
   successor `S`.
3. **Convergence precondition.** Prove the goto-source if-block's structured fall-through is
   exactly `S` (a post-dominator/convergence check on the structured tree). Decline
   otherwise — this is the correctness-critical step.
4. **Surgery `kuna_inline_crossjump_tail`.** Duplicate `T`'s ops (print-tree `BlockCopy`
   leaves — no p-code cloned, SSA untouched) into the `if` true-clause in place of the
   `goto`; clear `T`'s label when no unstructured edge still targets it.
5. **Edge-virtualization-ordering investigation.** Determine whether kuna's structurer
   presents the right single-goto shape; if not, scope the additional ordering work (this is
   the part that may force a *second* gated pass and is the chief risk to a clean default-ON
   ablation).
6. **Validation.** New `tests/stages/ghangr-who-condensing-opt-reversion-72e518.xml`
   (two-pass: off ⇒ the goto, default/on ⇒ zero gotos), full `kuna test --all` ablation,
   speed measurement on `scan_entries`, and a `docs/divergences.md` DIV entry **only if** the
   ablation is clean and the option ships default-ON.

## Speed / risk assessment

- **Risk: HIGH for correctness** (precondition #3). Must be conservative — decline on any
  doubt; bound tail size; never duplicate side-effecting ops.
- **Risk: MEDIUM for completeness** — the structurer-shape/edge-ordering dependency (point 3
  above) may mean one Action does not reach zero gotos on this function, requiring follow-up.
- **Speed:** a bounded, post-structuring print-tree pass should be cheap (comparable to
  `gotoreduce`); to be measured during implementation. Ships **default-OFF opt-in** until
  the ablation is proven clean and within the speed budget.

## Proposed option name

`crossjumpreverter` (`change_kind = structure-recovery`,
`inspiration = "test_who_condensing_opt_reversion; CrossJumpReverter/ReturnDuplicatorLow; scan_entries"`).

---
On approval, re-dispatch an implementation worker on this branch
(`feat/angr-who-condensing-opt-reversion-72e518`).
