### PR TITLE
Metadata: MSVC RTTI vftable + virtual-method naming (s1_rtti R3)

### DIFF
--- a/decompiler/crates/kuna-analysis/src/s1_rtti/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/s1_rtti/mod.rs
@@ -23,6 +23,19 @@
 //! so the decompiled output labels the metadata graph and the class names
 //! (`Box`, `Shape`) surface as recovered symbols.
 //!
+//! # vftable discovery + virtual-method naming (R3)
+//!
+//! On top of the class-name recovery, the pass walks each recovered class's vftable
+//! ([`vftable::walk_vftable`], the port of `VfTableModel.getVfTableCount`): from the
+//! `<Class>::vftable` base it reads each pointer-width slot (an **absolute VA on both
+//! arches** — vftable slots are NOT the `IBO32` displacements the COL/RTTI graph uses),
+//! bounding the array at the first NULL / non-`.text` slot. For each surviving slot it
+//! emits a virtual-method **function** [`SymFact`] named `<Class>::vftable_<i>` (the
+//! MSVC metadata carries the class name but not per-method names, so the slot index is
+//! the disambiguator), and marks the slot array read-only ([`AnalysisOutput::readonly`]).
+//! So the virtual dispatch — `(**(code **)*plVar1)()`, an unnamed `DAT_*` vtable slot
+//! before — now resolves to a named function (`Box::vftable_0` = `Box::area`).
+//!
 //! # x86 vs x64 — the one place a port goes wrong (§3.1f)
 //!
 //! The inter-structure references are **raw VAs on x86** but **32-bit image-base
@@ -42,6 +55,7 @@
 
 pub mod models;
 pub mod refkind;
+pub mod vftable;
 
 use object::read::pe::{ImageNtHeaders, PeFile32, PeFile64};
 use object::read::Object;
@@ -54,6 +68,7 @@ use models::{
     ImageBytes, TypeDescriptor,
 };
 use refkind::{End, RefKind};
+use vftable::{walk_vftable, TextRanges};
 
 /// The byte distance from a reference-to-a-`TypeDescriptor` back to the
 /// `CompleteObjectLocator` that names it: the COL's `pTypeDescriptor` field is at
@@ -97,6 +112,9 @@ impl AnalysisPass for RttiPass {
             return out;
         };
         let img = ImageBytes::new(ctx.file);
+        // The executable-section ranges that bound a vftable's slot walk (R3): a slot
+        // is a virtual-method entry only while it points into one of these.
+        let text = TextRanges::new(ctx.file);
 
         // 1. Find the common `type_info` vftable: the pointer every RTTI0
         //    TypeDescriptor's leading `pVFTable` field shares. We discover it by
@@ -139,7 +157,7 @@ impl AnalysisPass for RttiPass {
                 if col.p_type_descriptor != td.addr {
                     continue;
                 }
-                emit_for_col(&img, &rk, &col, type_info_vftable, &mut out);
+                emit_for_col(&img, &rk, &text, &col, type_info_vftable, &mut out);
             }
         }
 
@@ -232,6 +250,7 @@ fn pick_common_type_info_vftable(descriptors: &[TypeDescriptor]) -> Option<u64> 
 fn emit_for_col(
     img: &ImageBytes,
     rk: &RefKind,
+    text: &TextRanges,
     col: &CompleteObjectLocator,
     type_info_vftable: u64,
     out: &mut AnalysisOutput,
@@ -263,12 +282,18 @@ fn emit_for_col(
         name: format!("{self_class}::RTTI_Complete_Object_Locator"),
         kind: SymKind::Data,
     });
-    if let Some(vftable) = recover_vftable(img, rk, col, type_info_vftable) {
+    if let Some(vftable_base) = recover_vftable(img, rk, col, type_info_vftable) {
         out.symbols.push(SymFact {
-            addr: vftable,
+            addr: vftable_base,
             name: format!("{self_class}::vftable"),
             kind: SymKind::Data,
         });
+        // R3: walk the vftable's slots, naming each virtual-method function
+        // `<Class>::vftable_<i>` and marking the slot array read-only. The virtual
+        // dispatch (an unnamed `DAT_*` slot before) now resolves to a named function.
+        if let Some(vt) = walk_vftable(img, rk, text, vftable_base) {
+            emit_vftable_methods(&self_class, &vt, rk, out);
+        }
     }
 
     // Each base class reachable through the hierarchy: label its TypeDescriptor.
@@ -292,6 +317,31 @@ fn emit_type_descriptor_label(class: &str, td_addr: u64, out: &mut AnalysisOutpu
         name: format!("{class}::RTTI_Type_Descriptor"),
         kind: SymKind::Data,
     });
+}
+
+/// Emit the per-slot virtual-method facts for a recovered vftable (R3):
+///   - one `Function` [`SymFact`] per slot, named `<Class>::vftable_<i>` at the slot's
+///     target VA (the virtual method the dispatch jumps to);
+///   - the slot array's VMA range as read-only ([`AnalysisOutput::readonly`]).
+/// The `SymFact{Function}` commit is an idempotent ADD (`find_function`-gated), so a
+/// slot target that already carries a real `.symtab`/import name keeps it; only a
+/// never-symboled virtual method takes the `<Class>::vftable_<i>` name.
+fn emit_vftable_methods(
+    class: &str,
+    vt: &vftable::VfTable,
+    rk: &RefKind,
+    out: &mut AnalysisOutput,
+) {
+    for (i, &fn_addr) in vt.slots.iter().enumerate() {
+        out.symbols.push(SymFact {
+            addr: fn_addr,
+            name: format!("{class}::vftable_{i}"),
+            kind: SymKind::Function,
+        });
+    }
+    // The slot array itself is constant data — mark it read-only so a load of a vtable
+    // slot can fold (the `out.readonly` commit arm ORs `Varnode::readonly` over it).
+    out.readonly.push(vt.range(rk));
 }
 
 /// Recover the class's vftable VMA from a validated COL: a vftable's `meta` slot

--- a/decompiler/crates/kuna-analysis/src/s1_rtti/vftable.rs
+++ b/decompiler/crates/kuna-analysis/src/s1_rtti/vftable.rs
@@ -1,0 +1,200 @@
+//! The MSVC vftable walk — the kuna port of Ghidra's
+//! `VfTableModel.getVfTableCount` (`Ghidra/Features/MicrosoftCodeAnalyzer/.../rtti/`).
+//!
+//! A validated [`CompleteObjectLocator`](super::models::CompleteObjectLocator) (COL)
+//! sits in memory immediately *before* its class's vftable: the pointer-width word
+//! at `vftable_base − ptr_size` (the "meta" slot) holds the COL's own VA, so the
+//! vftable starts one pointer after the slot that references the COL. From that base
+//! this module walks the vftable's function-pointer slots and bounds the array.
+//!
+//! # Slot ABI — full VAs on BOTH arches (the x64 subtlety, §3.1)
+//!
+//! Unlike the COL/RTTI inter-structure references — which are `IBO32` image-base
+//! displacements on x64 ([`super::refkind::RefKind::resolve_ref`]) — a **vftable
+//! slot is an absolute, pointer-width virtual address on every arch** (8 bytes on
+//! x64, 4 on x86). The runtime dereferences these as real function pointers, so the
+//! walk reads each with [`RefKind::read_ptr`], NOT `resolve_ref`. Conflating the two
+//! is the classic x64 RTTI port error; the vftable is the one place inside the graph
+//! that is NOT IBO32.
+//!
+//! # Bounding the array (port of `getVfTableCount`)
+//!
+//! Walk `ptr_size`-stride slots from the base; a slot is a valid virtual-method
+//! entry while its full-VA value is **non-NULL** and **points into an executable
+//! (`.text`) section** of the image. The first slot that fails either gate — NULL,
+//! or a target outside `.text` (e.g. the next COL/RTTI struct in `.rdata`, or the
+//! object's data) — terminates the table (faithful to Ghidra's `isPointer` +
+//! function-start boundary check). A vftable with zero valid slots is rejected
+//! (`None`): a real polymorphic class has at least one virtual method.
+//!
+//! Each surviving slot VA is a virtual-method **function** the pass names
+//! `<Class>::vftable_<i>` (the MSVC metadata graph carries the class name in the
+//! RTTI0 `TypeDescriptor` but NOT per-method names, so the slot index is the faithful
+//! disambiguator — the documented scope vs Ghidra's script-tier method demangling).
+
+use object::read::{Object, ObjectSection};
+use object::SectionKind;
+
+use super::models::ImageBytes;
+use super::refkind::RefKind;
+
+/// The executable (`.text`) address ranges of a loaded image, used to gate a
+/// vftable slot: a slot is a virtual-method entry only if its target VA lands in
+/// one of these ranges (a function pointer into code, not a data/RTTI pointer).
+///
+/// Built once per pass run from the parsed [`object::File`] — every section that is
+/// `SectionKind::Text` or carries the PE `IMAGE_SCN_MEM_EXECUTE` characteristic
+/// (the same executable-section test [`crate::s1_loader::pe_iat`] uses).
+pub struct TextRanges {
+    /// `(start, end)` half-open VMA ranges of every executable section, sorted.
+    ranges: Vec<(u64, u64)>,
+}
+
+impl TextRanges {
+    /// Collect the executable-section ranges from `file`. Empty (matches nothing) if
+    /// the image exposes no executable section.
+    pub fn new(file: &object::File) -> Self {
+        let mut ranges: Vec<(u64, u64)> = Vec::new();
+        for sec in file.sections() {
+            let exec = sec.kind() == SectionKind::Text
+                || matches!(
+                    sec.flags(),
+                    object::SectionFlags::Coff { characteristics }
+                        if characteristics & object::pe::IMAGE_SCN_MEM_EXECUTE != 0
+                );
+            if !exec {
+                continue;
+            }
+            let start = sec.address();
+            let size = sec.size();
+            if size == 0 {
+                continue;
+            }
+            ranges.push((start, start.saturating_add(size)));
+        }
+        ranges.sort_by_key(|&(s, _)| s);
+        TextRanges { ranges }
+    }
+
+    /// Is `vma` inside any executable section? (A vftable slot must point into code.)
+    pub fn contains(&self, vma: u64) -> bool {
+        self.ranges.iter().any(|&(s, e)| vma >= s && vma < e)
+    }
+}
+
+/// A recovered vftable: its base VMA and the per-slot virtual-method function VAs
+/// (in table order; each points into `.text`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VfTable {
+    /// VMA of the vftable's first slot (the value an object's vptr holds).
+    pub base: u64,
+    /// The virtual-method function VAs, slot 0..N (each points into `.text`).
+    pub slots: Vec<u64>,
+}
+
+impl VfTable {
+    /// The half-open VMA range the slot array occupies: `[base, base + len*ptr)`.
+    /// Used to mark the table read-only (`out.readonly`).
+    pub fn range(&self, rk: &RefKind) -> (u64, u64) {
+        let end = self.base + (self.slots.len() as u64) * (rk.ptr_size() as u64);
+        (self.base, end)
+    }
+}
+
+/// Walk the vftable that begins at `base`, bounding it at the first NULL / non-`.text`
+/// slot, and return it. `None` if the table has zero valid virtual-method slots (the
+/// candidate `base` is not really a vftable). A generous slot cap (`MAX_SLOTS`) guards
+/// a runaway walk over a malformed / coincidental base.
+///
+/// Each slot is read as a full pointer-width VA ([`RefKind::read_ptr`]) — vftable
+/// slots are absolute pointers on both x86 and x64 (NOT IBO32, unlike the COL/RTTI
+/// inter-structure refs); see the module docs.
+pub fn walk_vftable(
+    img: &ImageBytes,
+    rk: &RefKind,
+    text: &TextRanges,
+    base: u64,
+) -> Option<VfTable> {
+    /// Upper bound on virtual-method slots walked from one base — far beyond any real
+    /// class's vtable, a guard against a coincidental base with no NULL terminator.
+    const MAX_SLOTS: usize = 4096;
+
+    let ptr = rk.ptr_size() as u64;
+    let mut slots = Vec::new();
+    let mut slot_addr = base;
+    for _ in 0..MAX_SLOTS {
+        let Some(bytes) = img.read(slot_addr, rk.ptr_size()) else {
+            break; // ran off the end of the loaded image
+        };
+        let target = rk.read_ptr(bytes);
+        // Boundary: NULL slot, or a target that is not code. Either terminates the
+        // table (the next word is the following struct / NULL pad, not a method).
+        if target == 0 || !text.contains(target) {
+            break;
+        }
+        slots.push(target);
+        slot_addr += ptr;
+    }
+    if slots.is_empty() {
+        return None;
+    }
+    Some(VfTable { base, slots })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::s1_rtti::refkind::End;
+
+    /// A synthetic x64 image: a `.text` at 0x140001000 (0x80 bytes) and a `.rdata`
+    /// holding a 2-slot vftable @0x140002010 → [0x140001040, 0x140001050], then a
+    /// NULL terminator, then a non-text pointer.
+    fn x64_img() -> (Vec<u8>, RefKind, TextRanges) {
+        let ib = 0x1_4000_0000u64;
+        let rk = RefKind::new(true, ib, End::Little);
+        let mut rdata = vec![0u8; 0x100]; // .rdata @ 0x140002000
+        let put_u64 =
+            |v: &mut [u8], off: usize, x: u64| v[off..off + 8].copy_from_slice(&x.to_le_bytes());
+        // vftable @ 0x2010: slot0 -> 0x140001040, slot1 -> 0x140001050, slot2 NULL.
+        put_u64(&mut rdata, 0x10, ib + 0x1040);
+        put_u64(&mut rdata, 0x18, ib + 0x1050);
+        // 0x20 stays NULL (terminator).
+        // A non-text pointer right after (into .rdata) — also a boundary if reached.
+        put_u64(&mut rdata, 0x28, ib + 0x2000);
+        let ranges = TextRanges { ranges: vec![(ib + 0x1000, ib + 0x1080)] };
+        (rdata, rk, ranges)
+    }
+
+    #[test]
+    fn walks_to_null_boundary() {
+        let (rdata, rk, ranges) = x64_img();
+        let ib = 0x1_4000_0000u64;
+        let img = ImageBytes::from_spans(vec![(ib + 0x2000, &rdata)]);
+        let vt = walk_vftable(&img, &rk, &ranges, ib + 0x2010).unwrap();
+        assert_eq!(vt.base, ib + 0x2010);
+        assert_eq!(vt.slots, vec![ib + 0x1040, ib + 0x1050]);
+        assert_eq!(vt.range(&rk), (ib + 0x2010, ib + 0x2020));
+    }
+
+    #[test]
+    fn rejects_base_with_no_code_slot() {
+        let (rdata, rk, ranges) = x64_img();
+        let ib = 0x1_4000_0000u64;
+        let img = ImageBytes::from_spans(vec![(ib + 0x2000, &rdata)]);
+        // 0x2028 holds a .rdata pointer (not into .text) -> zero valid slots.
+        assert_eq!(walk_vftable(&img, &rk, &ranges, ib + 0x2028), None);
+    }
+
+    #[test]
+    fn one_slot_table() {
+        let ib = 0x1_4000_0000u64;
+        let rk = RefKind::new(true, ib, End::Little);
+        let mut rdata = vec![0u8; 0x40];
+        rdata[0x00..0x08].copy_from_slice(&(ib + 0x1004).to_le_bytes());
+        // 0x08 NULL terminator.
+        let ranges = TextRanges { ranges: vec![(ib + 0x1000, ib + 0x1080)] };
+        let img = ImageBytes::from_spans(vec![(ib + 0x2010, &rdata)]);
+        let vt = walk_vftable(&img, &rk, &ranges, ib + 0x2010).unwrap();
+        assert_eq!(vt.slots, vec![ib + 0x1004]);
+    }
+}

--- a/decompiler/crates/kuna-analysis/tests/fixtures/README.md
+++ b/decompiler/crates/kuna-analysis/tests/fixtures/README.md
@@ -449,12 +449,12 @@ docker run --rm -v "$PWD":/w -w /w kuna-dev bash -lc '
     $F/msvc_rtti.cpp -o $F/msvc_rtti_x86.exe'
 ```
 
-Pinned VMAs (from `x86_64-w64-mingw32-objdump -s -j .rdata/.data` + `-p` ImageBase):
+Pinned VMAs (from `x86_64-w64-mingw32-objdump -s -j .rdata/.data -d -j .text` + `-p` ImageBase):
 
-| | ImageBase | Box `TypeDescriptor` (RTTI0) | Shape `TypeDescriptor` | Box `CompleteObjectLocator` (RTTI4) | Box vftable |
-|---|---|---|---|---|---|
-| **x64** | `0x140000000` | `0x140003010` (`.?AUBox@@`) | `0x140003030` (`.?AVShape@@`/`.?AUShape@@`) | `0x140002020` | `0x140002010` |
-| **x86** | `0x400000` | `0x403010` (`.?AUBox@@`) | `0x403030` (`.?AUShape@@`) | `0x402010` | `0x40200c` |
+| | ImageBase | Box `TypeDescriptor` (RTTI0) | Shape `TypeDescriptor` | Box `CompleteObjectLocator` (RTTI4) | Box vftable | Box vftable slot 0 (`Box::area`) |
+|---|---|---|---|---|---|---|
+| **x64** | `0x140000000` | `0x140003010` (`.?AUBox@@`) | `0x140003030` (`.?AVShape@@`/`.?AUShape@@`) | `0x140002020` | `0x140002010` | `0x140001040` |
+| **x86** | `0x400000` | `0x403010` (`.?AUBox@@`) | `0x403030` (`.?AUShape@@`) | `0x402010` | `0x40200c` | `0x401030` |
 
 With `--option rtti on` the recovery labels the Box `TypeDescriptor`
 `Box::RTTI_Type_Descriptor`, the COL `Box::RTTI_Complete_Object_Locator`, the vftable
@@ -463,6 +463,18 @@ With `--option rtti on` the recovery labels the Box `TypeDescriptor`
 absent (the parity proof). The `.?A…@@` names demangle through the existing MSVC
 demangler via the Ghidra `RttiUtil` `??_R0…@8` wrap (clang renders `struct` classes
 as `.?AU…`; both `V`/`U` recover the bare name).
+
+**vftable discovery + virtual-method naming (R3).** Each recovered class's vftable is
+walked from its `Box::vftable` base (`VfTableModel.getVfTableCount`), bounding the slot
+array at the first NULL / non-`.text` slot. The Box vftable holds exactly one slot —
+`Box::area` (`return side*side;`, the pinned slot-0 target above: `0x140001040` x64 /
+`0x401030` x86) — which R3 names `Box::vftable_0` (a `SymKind::Function`) and marks the
+slot array read-only. The slots are **absolute VAs on both arches** (NOT the `IBO32`
+displacements the COL/RTTI inter-struct refs use): the x64 vftable cell at `0x140002010`
+holds the full 8-byte `0x140001040`, the x86 cell at `0x40200c` the 4-byte `0x401030`.
+`kuna-console/tests/verify_rtti.rs` asserts `Box::vftable_0` exists AND a function symbol
+resolves at the slot-0 target VA (the virtual dispatch now points at a named method),
+absent with `rtti off`.
 
 ## Mach-O (Apple) fixtures — the multi-format loader (PR-6+7, the Mach-O headline)
 

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -178,6 +178,22 @@ impl ConsoleProgram {
         }
     }
 
+    /// (kuna) The basename of the FunctionSymbol installed at code-space VMA `vma`, or
+    /// `None` if no function is mapped there. Resolves across scopes
+    /// (`find_function_across_scopes`, the no-return/FID arm's resolver), so it sees a
+    /// namespaced virtual-method function (e.g. `Box::vftable_0` in scope `Box`).
+    ///
+    /// The verification seam for the MSVC-RTTI **vftable** e2e (R3): a vtable slot's
+    /// target VA should now resolve to a named virtual method — the virtual dispatch
+    /// `(**(code **)*p)()` points at this function instead of a bare `DAT_*`.
+    pub fn function_named_at(&self, vma: u64) -> Option<String> {
+        let code_space = Rc::clone(self.arch().manage().get_default_code_space()?);
+        let addr = Address::new(code_space, vma);
+        let db = &self.arch().symboltab;
+        let (sid, _) = db.find_function_across_scopes(&addr)?;
+        Some(db.symbol(sid).get_name().to_string())
+    }
+
     /// Read the binaryimage's loader symbols into the symbol table as
     /// FunctionSymbols (C++ `Architecture::readLoaderSymbols`, `architecture.cc:347`,
     /// called by `testfunction.cc:160` / `consolemain.cc:104` after load).
@@ -932,6 +948,26 @@ fn commit_analysis_output(
                     .set_attribute(sid, kuna_decomp::varnode::varnode_flags::namelock);
             }
         }
+    }
+
+    // 1b. Extra read-only address ranges a pass discovered (`out.readonly`) — e.g.
+    //     the MSVC RTTI vftable slot arrays (`s1_rtti` R3). OR `Varnode::readonly`
+    //     over each `[first, last_open)` range in the symbol-table property map, the
+    //     same `symboltab->setPropertyRange(Varnode::readonly, *iter)` the loader's
+    //     section-derived read-only ranges use (bootstrap_program). With `option
+    //     readonly` on this lets a load of a vtable slot fold to its constant; the
+    //     ranges are additive and only ever WIDEN the read-only set. PE `.rdata` is
+    //     already read-only from its section flags, so this is belt-and-suspenders
+    //     there; it is load-bearing for any pass that marks a range the loader did
+    //     not. Empty on every default run (only the gated real-binary passes emit).
+    for &(first, last_open) in &out.readonly {
+        let begin = Address::new(Rc::clone(code_space), first);
+        let end = Address::new(Rc::clone(code_space), last_open);
+        prog.arch_mut().symboltab.set_property_range(
+            kuna_decomp::varnode::varnode_flags::readonly,
+            &begin,
+            &end,
+        );
     }
 
     // 2. Discovered entry points (stripped targets): name + add_function +

--- a/decompiler/crates/kuna-console/tests/verify_rtti.rs
+++ b/decompiler/crates/kuna-console/tests/verify_rtti.rs
@@ -12,16 +12,30 @@
 //!
 //! ```text
 //!   before (default, --option rtti off):  .rdata is raw bytes; the vtable is an
-//!                                          unnamed DAT_<addr>; no `Box`/`Shape`
-//!                                          class names exist in the symbol table.
+//!                                          unnamed DAT_<addr>; the virtual dispatch
+//!                                          `(**(code **)*p)()` jumps to an unnamed
+//!                                          slot; no `Box`/`Shape` class names exist.
 //!   after  (--option rtti on):            the TypeDescriptors are labelled
 //!                                          `Box::RTTI_Type_Descriptor` /
 //!                                          `Shape::RTTI_Type_Descriptor`, the COL
-//!                                          `Box::RTTI_Complete_Object_Locator`, and
-//!                                          the vftable `Box::vftable` — so `Box` and
-//!                                          `Shape` surface as recovered C++ class
-//!                                          names.
+//!                                          `Box::RTTI_Complete_Object_Locator`, the
+//!                                          vftable `Box::vftable`, AND each vftable
+//!                                          slot a named virtual-method function
+//!                                          `Box::vftable_0` (R3, at the slot's target
+//!                                          VA) — so the virtual dispatch resolves to
+//!                                          a named method and `Box`/`Shape` surface
+//!                                          as recovered C++ class names.
 //! ```
+//!
+//! ## vftable discovery + virtual-method naming (R3)
+//!
+//! On top of the class names, `s1_rtti` R3 walks each vftable from its
+//! `<Class>::vftable` base (`VfTableModel.getVfTableCount`), bounding the slot array
+//! at the first NULL / non-`.text` slot, and names each slot's target a virtual-method
+//! function `<Class>::vftable_<i>` + marks the slot array read-only. The Box vftable
+//! here has exactly one slot — `Box::area` (`side*side`) — at the pinned target VMA
+//! (`0x140001040` x64 / `0x401030` x86). The slots are absolute VAs on BOTH arches
+//! (NOT the `IBO32` displacements the COL/RTTI graph uses).
 //!
 //! ## Why clang, not `cl.exe`
 //!
@@ -48,6 +62,14 @@
 use std::path::PathBuf;
 
 use kuna_console::engine::{bootstrap_from_object, ConsoleProgram};
+
+/// Pinned target VMA of the Box vftable's first (and only) slot — `Box::area`
+/// (`return side*side;`) — in each fixture. Read from `objdump -s -j .rdata`
+/// (`tests/fixtures/README.md`, the `msvc_rtti.cpp` entry): the x64 vftable @
+/// `0x140002010` slot 0 holds `0x140001040`; the x86 vftable @ `0x40200c` slot 0
+/// holds `0x401030`. (Slots are absolute VAs on both arches — NOT IBO32.)
+const BOX_AREA_VMA_X64: u64 = 0x1_4000_1040;
+const BOX_AREA_VMA_X86: u64 = 0x0040_1030;
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
@@ -88,8 +110,9 @@ fn bootstrap_rtti(fixture: &str, on: bool) -> Option<ConsoleProgram> {
 }
 
 /// The recovered-symbol assertions shared by the x64 and x86 arms: with `rtti on`,
-/// both class names + their RTTI/vftable labels are present.
-fn assert_recovered(prog: &ConsoleProgram) {
+/// both class names + their RTTI/vftable labels are present, AND (R3) the Box vftable
+/// slot at `box_area_vma` resolves to a named virtual-method function.
+fn assert_recovered(prog: &ConsoleProgram, box_area_vma: u64) {
     // Both class names recovered, with the Type Descriptor label.
     assert!(
         prog.has_symbol_named("Box::RTTI_Type_Descriptor"),
@@ -108,22 +131,47 @@ fn assert_recovered(prog: &ConsoleProgram) {
         prog.has_symbol_named("Box::vftable"),
         "rtti on: the Box vftable must be labelled"
     );
+
+    // R3 — vftable discovery + per-slot virtual-method naming. The Box vftable has
+    // one slot (`Box::area`); R3 names it `Box::vftable_0`. The name must exist in
+    // the symbol table AND a function symbol must be installed AT the slot's target
+    // VA — the virtual dispatch `(**(code **)*p)()` now points at a NAMED function
+    // (`Box::vftable_0`), not a bare `DAT_*` slot.
+    assert!(
+        prog.has_symbol_named("Box::vftable_0"),
+        "rtti on: the first Box vftable slot must be named Box::vftable_0 (R3)"
+    );
+    assert_eq!(
+        prog.function_named_at(box_area_vma).as_deref(),
+        Some("vftable_0"),
+        "rtti on: the vftable slot's target VA {box_area_vma:#x} must resolve to the \
+         named virtual-method function (R3 — the virtual dispatch is now named)"
+    );
 }
 
 /// The default-off parity assertion: with `rtti off`, NONE of the recovered names
-/// exist — the symbol table is byte-identical to a no-rtti run.
-fn assert_absent(prog: &ConsoleProgram) {
+/// exist — the symbol table is byte-identical to a no-rtti run. The vftable slot's
+/// target VA carries no recovered virtual-method symbol either.
+fn assert_absent(prog: &ConsoleProgram, box_area_vma: u64) {
     for name in [
         "Box::RTTI_Type_Descriptor",
         "Shape::RTTI_Type_Descriptor",
         "Box::RTTI_Complete_Object_Locator",
         "Box::vftable",
+        "Box::vftable_0",
     ] {
         assert!(
             !prog.has_symbol_named(name),
             "rtti off: `{name}` must NOT be present (default-off parity)"
         );
     }
+    // The vftable slot is an unnamed `DAT_*`/undiscovered slot with the option off:
+    // no `vftable_*` virtual-method function is installed at its target VA.
+    assert_ne!(
+        prog.function_named_at(box_area_vma).as_deref(),
+        Some("vftable_0"),
+        "rtti off: the vftable slot target must NOT be a named virtual method"
+    );
 }
 
 /// AFTER (x64, the dominant case — IBO32 image-base-relative refs): with
@@ -134,7 +182,7 @@ fn x64_recovers_class_names_with_option_on() {
     let Some(prog) = bootstrap_rtti("msvc_rtti_x64.exe", true) else {
         return;
     };
-    assert_recovered(&prog);
+    assert_recovered(&prog, BOX_AREA_VMA_X64);
 }
 
 /// BEFORE (x64, the default-off gate): with the option OFF, no class name is
@@ -144,7 +192,7 @@ fn x64_class_names_absent_with_option_off() {
     let Some(prog) = bootstrap_rtti("msvc_rtti_x64.exe", false) else {
         return;
     };
-    assert_absent(&prog);
+    assert_absent(&prog, BOX_AREA_VMA_X64);
 }
 
 /// AFTER (x86, the raw-VA path — full virtual-address refs, RTTI0 name at offset 8):
@@ -154,7 +202,7 @@ fn x86_recovers_class_names_with_option_on() {
     let Some(prog) = bootstrap_rtti("msvc_rtti_x86.exe", true) else {
         return;
     };
-    assert_recovered(&prog);
+    assert_recovered(&prog, BOX_AREA_VMA_X86);
 }
 
 /// BEFORE (x86, default-off): no class name recovered with the option off.
@@ -163,5 +211,5 @@ fn x86_class_names_absent_with_option_off() {
     let Some(prog) = bootstrap_rtti("msvc_rtti_x86.exe", false) else {
         return;
     };
-    assert_absent(&prog);
+    assert_absent(&prog, BOX_AREA_VMA_X86);
 }

--- a/docs/analysis-port-log.md
+++ b/docs/analysis-port-log.md
@@ -4914,3 +4914,76 @@ needed (no settable added — a clean, option-free merge).
 - **Changed:** `kuna-analysis/src/lib.rs` (`pub mod s1_pdb`),
   `tests/fixtures/README.md` (the `pdb_min.exe` recipe + pinned record),
   `docs/analysis-port-log.md`.
+
+### Increment 60 — MSVC RTTI vftable discovery + virtual-method naming (s1_rtti R3)
+
+**The RTTI line's third increment (PR R3, per `docs/metadata-analyzers-design.md` §3.1
++ §5).** Increment 57 (R1+R2) recovered the C++ class names and labelled the metadata
+graph (`<Class>::RTTI_*`) + the vftable base (`<Class>::vftable`). R3 walks the vftable
+itself — the kuna analog of Ghidra's `VfTableModel.getVfTableCount` — so each virtual
+method is named and the virtual *dispatch* resolves to a named function. **NO new
+`--option`** (reuses the existing `rtti` flag): no catalog/count change.
+
+**The before/after, on the same polymorphic-C++ PEs (`tests/fixtures/msvc_rtti_x{64,86}.exe`,
+`Box : Shape` with a virtual `area()`):**
+
+```
+                                  the virtual dispatch / vtable slot
+--option rtti off (default)    →  the vtable is an unnamed DAT_<addr>; the virtual
+                                  call `(**(code **)*p)()` jumps to an unnamed slot.
+--option rtti on               →  Box::vftable labelled; its one slot named the
+                                  virtual-method function Box::vftable_0 (at the slot
+                                  target VA 0x140001040 x64 / 0x401030 x86 = Box::area),
+                                  the slot array marked read-only — so the virtual
+                                  dispatch now resolves to a NAMED method.
+```
+
+**The walk (port of `VfTableModel.getVfTableCount`, `s1_rtti/vftable.rs`):** from the
+`<Class>::vftable` base (already recovered in R1 from the COL's meta-pointer slot),
+read each pointer-width slot and bound the array at the first **NULL / non-`.text`**
+slot (a slot is a virtual-method entry only while it points into an executable
+section). For each surviving slot emit a `SymKind::Function` `SymFact` named
+`<Class>::vftable_<i>` (the MSVC metadata carries the class name but NOT per-method
+names — the slot index is the faithful disambiguator vs Ghidra's script-tier method
+demangling), and mark the slot array read-only (`out.readonly`).
+
+**The x64 vftable-slot subtlety (faithful to the design):** a vftable slot is an
+**absolute pointer-width VA on BOTH arches** — NOT the `IBO32` image-base displacement
+the COL/RTTI *inter-structure* refs use on x64. The walk reads each with
+`RefKind::read_ptr` (8 bytes x64 / 4 bytes x86), never `resolve_ref`. Verified against
+the real fixtures: the x64 cell at `0x140002010` holds the full 8-byte `0x140001040`,
+the x86 cell at `0x40200c` the 4-byte `0x401030` (`objdump -s -j .rdata -d -j .text`).
+
+**The `out.readonly` commit arm (newly load-bearing).** `out.readonly` was merged but
+never applied; `commit_analysis_output` grew a step-1b arm that ORs `Varnode::readonly`
+over each `[first, last_open)` range via `symboltab.set_property_range` (the same call
+the loader's section-derived ranges use). Belt-and-suspenders on PE `.rdata` (already
+read-only from its section flags), load-bearing for any pass that marks a range the
+loader did not. Empty on every default run (only the gated real-binary passes emit).
+
+**Module layout:** `kuna-analysis/src/s1_rtti/vftable.rs` (the `VfTableModel` port:
+`TextRanges` executable-section view + `walk_vftable` slot bounder + `VfTable`), wired
+into `s1_rtti/mod.rs` (`emit_vftable_methods` + the `TextRanges` build in `run`). A new
+`ConsoleProgram::function_named_at(vma)` accessor (resolves the FunctionSymbol at a code
+VA across scopes) is the verification seam for "the slot now points at a named method".
+
+**e2e (RAN, not skipped):** `kuna-console/tests/verify_rtti.rs` extended — with
+`--option rtti on` it asserts `Box::vftable_0` exists AND `function_named_at(slot-0
+target VA)` resolves to the named virtual method (the virtual dispatch is now named);
+with `rtti off` both are absent (default-off parity). The pinned slot-0 target VMAs
+(`0x140001040` x64 / `0x401030` x86 = `Box::area`) are read from
+`objdump -s -j .rdata -d -j .text` (`tests/fixtures/README.md`). Built the `.sla`
+(`make specs`) so the 4 tests run; all 4 pass. 3 new `vftable.rs` unit tests
+(null-boundary walk / reject-no-code-slot / one-slot table).
+
+**Gates:** `make test` **675/675 PARITY OK**; `make test-stages` **235/235 PARITY OK**;
+`make rust-test` **green** incl. `verify_rtti` (4/4 ran) + the new vftable units.
+`kuna catalog --check` **OK** (no settable added — reuses the `rtti` flag).
+Default-off + real-binary-path-only ⇒ the parity oracles are structurally untouched.
+
+- **New:** `kuna-analysis/src/s1_rtti/vftable.rs` (the `VfTableModel` port + tests).
+- **Changed:** `kuna-analysis/src/s1_rtti/mod.rs` (`pub mod vftable`,
+  `emit_vftable_methods`, `TextRanges` in `run`), `kuna-console/src/engine.rs`
+  (`function_named_at` + the `out.readonly` commit arm), `kuna-console/tests/verify_rtti.rs`
+  (the R3 vftable assertions), `tests/fixtures/README.md` (the pinned slot-0 VMAs + R3
+  note), `docs/analysis-port-log.md`.


### PR DESCRIPTION
## What

PR **R3** of kuna's MSVC RTTI analyzer (`docs/metadata-analyzers-design.md` §3.1 + §5), extending the merged **R1+R2** class-name recovery. **NO new `--option`** — reuses the existing `rtti` flag, so **no catalog/count change**. Default-off, PE-only, real-binary-path only.

Adds `s1_rtti/vftable.rs` (the port of Ghidra's `VfTableModel.getVfTableCount`): for each recovered class's vftable (already located in R1 from the `CompleteObjectLocator` meta-pointer slot), walk the `ptr_size` slots from the `<Class>::vftable` base, bounding the array at the first **NULL / non-`.text`** slot. For each surviving slot emit a virtual-method **function** (`SymKind::Function`) named `<Class>::vftable_<i>`, and mark the slot array read-only.

## Before / after

On the polymorphic-C++ fixtures (`msvc_rtti_x{64,86}.exe`, `Box : Shape` with a virtual `area()`):

```
                                 the virtual dispatch / vtable slot
--option rtti off (default)   →  the vtable is an unnamed DAT_<addr>; the virtual call
                                 (**(code **)*p)() jumps to an unnamed slot.
--option rtti on              →  Box::vftable labelled; its one slot named the
                                 virtual-method function Box::vftable_0 (at the slot
                                 target VA 0x140001040 x64 / 0x401030 x86 = Box::area);
                                 the slot array marked read-only — so the virtual
                                 dispatch now resolves to a NAMED method.
```

R1+R2 already gave the class names (`Box::RTTI_Type_Descriptor`, `Shape::RTTI_Type_Descriptor`, `Box::RTTI_Complete_Object_Locator`, `Box::vftable`). R3 adds the per-slot virtual methods + the resolved virtual dispatch.

## The x64 vftable-slot subtlety

A vftable slot is an **absolute pointer-width VA on BOTH arches** — NOT the `IBO32` image-base displacement the COL/RTTI inter-structure refs use on x64. The walk reads each slot with `RefKind::read_ptr` (8 B x64 / 4 B x86), never `resolve_ref`. Verified against the real fixtures: the x64 cell @`0x140002010` holds the full 8-byte `0x140001040`, the x86 cell @`0x40200c` the 4-byte `0x401030`.

Also wires the **`out.readonly` commit arm** (it was merged but never applied): `commit_analysis_output` now ORs `Varnode::readonly` over each range via `set_property_range` (the loader's section-range call). Empty on every default run.

## e2e (RAN, not skipped)

`kuna-console/tests/verify_rtti.rs` extended — with `--option rtti on` it asserts `Box::vftable_0` exists AND a function symbol resolves at the slot-0 target VA (the virtual dispatch is now named); with `rtti off` both are absent (default-off parity). New `ConsoleProgram::function_named_at(vma)` accessor is the verification seam. Pinned slot-0 VMAs from `objdump -s -j .rdata -d -j .text` (`tests/fixtures/README.md`). Built the `.sla` (`make specs`) so all 4 tests run; all pass. 3 new `vftable.rs` unit tests.

## Gates

- `make test` — **675/675 PARITY OK**
- `make test-stages` — **235/235 PARITY OK**
- `make rust-test` — **green** (exit 0), incl. `verify_rtti` 4/4 (ran, not skipped) + the new vftable units
- `kuna catalog --check` — **OK** (no settable added — reuses the `rtti` flag)

Default-off + real-binary-path-only ⇒ the parity oracles are structurally untouched.

Increment **60** in `docs/analysis-port-log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvRnfTgYKoZvS2TEvdYpWb