### PR TITLE
flow: wire flowoptions/max_instructions into FlowInfo (upstream followFlow parity)

### DIFF
--- a/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
@@ -459,6 +459,18 @@ pub fn build_and_follow_flow_with_override_and_protos(
 fn follow_flow_on_fd(arch: &mut Architecture, fd: Funcdata) -> KunaResult<Funcdata> {
     let env = ArchFlowEnv { arch: arch as *const Architecture };
     let mut flow = FlowInfo::new(fd, &env);
+    // C++ Funcdata::followFlow (decompiler/cpp/funcdata_op.cc:765): after the
+    // FlowInfo is constructed (and its range set), followFlow applies the global
+    // flow options and the instruction bound:
+    //   uint4 fl = 0; fl |= glb->flowoptions;   // Global flow options
+    //   flow.setFlags(fl);
+    //   flow.setMaximumInstructions(glb->max_instructions);
+    // `flowoptions` defaults to `error_toomanyinstructions` and
+    // `max_instructions` to 100000 (`resetDefaultsInternal`); the console
+    // options `maxinstruction` / `errortoomanyinstructions` / `unimplemented` /
+    // `jumpload` mutate them (options.cc ports in `p0_knowledge/options.rs`).
+    flow.set_flags(arch.flowoptions);
+    flow.set_maximum_instructions(arch.max_instructions);
     // C++ followFlow: generateOps() then generateBlocks().  The jump-table
     // recovery loop runs inside generateOps (via the action sub-pipeline).
     {

--- a/decompiler/crates/kuna-decomp/tests/decompile_e2e.rs
+++ b/decompiler/crates/kuna-decomp/tests/decompile_e2e.rs
@@ -439,3 +439,85 @@ fn option_command_mutates_the_real_architecture() {
     set(arch, "setaction", "decompile").expect("option setaction decompile");
     assert_eq!(arch.current_action_name(), "decompile");
 }
+
+/// The `maxinstruction` option is LIVE: flow-following honors
+/// `glb->max_instructions` / `glb->flowoptions` exactly as C++
+/// `Funcdata::followFlow` wires them into the `FlowInfo`
+/// (`decompiler/cpp/funcdata_op.cc:765`: `flow.setFlags(glb->flowoptions);
+/// flow.setMaximumInstructions(glb->max_instructions);`).
+///
+/// Drives the bound end-to-end through `OptionDatabase::set` +
+/// `decompile_func` (the same path the console `option maxinstruction N`
+/// takes), exercising both halves of the `FlowInfo::processInstruction`
+/// too-many-instructions policy (`flow.cc:409`):
+///
+///   * with the default `error_toomanyinstructions` flow option, exceeding the
+///     bound is the faithful fatal error `"Flow exceeded maximum allowable
+///     instructions"`;
+///   * with `option errortoomanyinstructions off`, the same bound TRUNCATES
+///     flow (artificial halt) and the function still decompiles.
+#[test]
+fn maxinstruction_option_bounds_flow_following() {
+    use kuna_decomp::flow::flow_flags;
+
+    // gp is a MIPS datatest whose function body is far more than 2 instructions.
+    let dt = parse_datatest("gp").expect("parse gp");
+    let registry = build_registry();
+    let mut xarch = bootstrap(&dt).expect("bootstrap gp");
+    let arch = xarch.sleigh_mut().base_mut().expect("Architecture base");
+
+    // The constructor defaults (C++ `resetDefaultsInternal`, architecture.cc:1420).
+    assert_eq!(arch.flowoptions, flow_flags::error_toomanyinstructions);
+    assert_eq!(arch.max_instructions, 100000);
+
+    // test_gp is the datatest's real (byte-backed) function; the other symbols
+    // (printf/populate) are call targets without loaded bytes.
+    let sym = dt
+        .symbols
+        .iter()
+        .find(|s| s.name == "test_gp")
+        .expect("gp has the test_gp <symbol>");
+    let space =
+        Rc::clone(arch.manage().get_space_by_name(&sym.space).expect("symbol space exists"));
+    let entry = Address::new(space, sym.offset);
+
+    let options = OptionDatabase::new();
+    let set = |arch: &mut Architecture, name: &str, p1: &str| -> KunaResult<String> {
+        let id = registry.find_element(name, 0);
+        assert!(id != 0, "option element `{name}` is not registered");
+        options.set(arch, id, p1, "", "")
+    };
+
+    // (1) `option maxinstruction 2` + the default error_toomanyinstructions
+    //     flow option: following flow past the bound must abort with the
+    //     faithful C++ error (flow.cc:411).
+    set(arch, "maxinstruction", "2").expect("option maxinstruction 2");
+    let err = match decompile_func(arch, &sym.name, entry.clone(), 0) {
+        Ok(_) => panic!("decompile under `option maxinstruction 2` must fail"),
+        Err(e) => e,
+    };
+    assert!(
+        format!("{err}").contains("Flow exceeded maximum allowable instructions"),
+        "wrong error under the instruction bound: {err}"
+    );
+
+    // (2) `option errortoomanyinstructions off`: the same tiny bound now
+    //     truncates flow with an artificial halt (flow.cc:414) instead of
+    //     erroring, and the truncated function still prints sane C.
+    set(arch, "errortoomanyinstructions", "off")
+        .expect("option errortoomanyinstructions off");
+    let fd = decompile_func(arch, &sym.name, entry.clone(), 0)
+        .expect("truncated flow should still decompile");
+    let c = print_c(arch, &fd);
+    assert!(is_structurally_sane(&c, &sym.name), "truncated-flow C is not sane:\n{c}");
+
+    // (3) Restore the error flag and the default bound: the full function
+    //     decompiles again, proving the failure in (1) was the bound itself.
+    set(arch, "errortoomanyinstructions", "on")
+        .expect("option errortoomanyinstructions on");
+    set(arch, "maxinstruction", "100000").expect("option maxinstruction 100000");
+    let fd = decompile_func(arch, &sym.name, entry, 0)
+        .expect("decompile under the default bound");
+    let c = print_c(arch, &fd);
+    assert!(is_structurally_sane(&c, &sym.name), "default-bound C is not sane:\n{c}");
+}


### PR DESCRIPTION
# flow: wire flowoptions/max_instructions into FlowInfo (upstream followFlow parity)

## The dropped bound

kuna faithfully ported the *option* plumbing for Ghidra's max-instructions bound but never wired it into flow analysis, so the entire chain was dead code:

- `FlowInfo::set_maximum_instructions` (`decompiler/crates/kuna-decomp/src/s2_lift/flow.rs:574`) had **zero callers**, so `insn_max` stayed at its constructor default `!0u32` (flow.rs:524) forever.
- The ported enforcement in `FlowInfo::process_instruction` (flow.rs:1288-1302 — the `"Flow exceeded maximum allowable instructions"` error / truncation-halt policy, C++ `flow.cc:409`) was therefore unreachable.
- `Architecture::reset_defaults_internal` (`infra/architecture.rs:951-952`) ports `flowoptions = error_toomanyinstructions` and `max_instructions = 100000` (C++ `architecture.cc:1420`), and the `maxinstruction` / `errortoomanyinstructions` / `unimplemented` / `jumpload` `OptionDatabase` entries mutate them — all previously no-ops.

## Upstream anchor

C++ `Funcdata::followFlow` (`decompiler/cpp/funcdata_op.cc:765` at `GHIDRA_REV`):

```cpp
  uint4 fl = 0;
  fl |= glb->flowoptions;	// Global flow options
  FlowInfo flow(*this,obank,bblocks,qlst);
  flow.setRange(baddr,eaddr);
  flow.setFlags(fl);
  flow.setMaximumInstructions(glb->max_instructions);
  flow.generateOps();
```

kuna's analog `follow_flow_on_fd` (`infra/decompile_drive.rs`) omitted the `setFlags`/`setMaximumInstructions` pair. This PR adds the two calls in the same place — right after the `FlowInfo` is constructed, before `generate_ops`:

```rust
    flow.set_flags(arch.flowoptions);
    flow.set_maximum_instructions(arch.max_instructions);
```

`follow_flow_on_fd` already holds the real engine `&mut Architecture` (the same instance `OptionDatabase::set` mutates — verified against the console `IfcOption` path), so no ArchSeam copy is needed. It is the **sole** production `FlowInfo` construction site (fresh build + restart re-flow both route through it), so this is the complete `followFlow` parity fix.

## What this makes live

`option maxinstruction N` (and `option errortoomanyinstructions on|off`) now actually bound flow-following, e.g.:

```
$ kuna decompile ./a.out main --option maxinstruction 5
Execution error: Flow exceeded maximum allowable instructions
```

This is the safety bound Ghidra relies on to abort runaway flow-follows; making it live is PR B of the decompile-all hang workstream (`tests/hang-repro/`).

## Why the gates are unaffected

The only default-on behavior change is the 100000-instruction cap (previously infinite): no corpus function is near 100k instructions, and no datatest/stage test sets `maxinstruction`, `unimplemented`, `jumpload`, or `errortoomanyinstructions` (grep-verified), so the applied `flowoptions` default (`error_toomanyinstructions`) only changes behavior past the cap.

- `make test`: **675/675, PARITY OK**
- `make test-stages`: **240/240, PARITY OK**
- `make rust-test`: green

## Test

New `maxinstruction_option_bounds_flow_following` in `decompiler/crates/kuna-decomp/tests/decompile_e2e.rs` drives the bound end-to-end through `OptionDatabase::set` + `decompile_func` (the console `option` path) on the `gp` corpus fixture, exercising **both** halves of the `processInstruction` policy:

1. `option maxinstruction 2` + default `error_toomanyinstructions` → the faithful fatal error;
2. `option errortoomanyinstructions off` + the same bound → flow truncates with an artificial halt and the function still prints structurally-sane C;
3. flag + default bound restored → the full function decompiles again (proving the failure in (1) was the bound itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J
