### PR TITLE
loweredswitch: fix non-converging condconst<->repair fixpoint on stripped-ELF functions (the decompile-all hang)

### DIFF
--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -133,35 +133,36 @@ fn decompile_all_emits_json_for_main() {
     );
 }
 
-/// The per-function watchdog (`--max-fn-seconds`) bounds the known
-/// non-converging function of the stripped-ELF hang repro: the invocation that
-/// used to spin FOREVER (100% CPU, no output) must now terminate, exit 0, and
-/// record the function as a per-function `error` in otherwise-valid JSON.
+/// The past-pathological function of the stripped-ELF hang repro now
+/// CONVERGES: `sub_1bd04` @ 0x1bd04 used to spin forever (100% CPU, no output)
+/// in a condconst↔lowered-switch-repair fixpoint tug-of-war
+/// (`kuna_repair_lowered_switch_inputs` mis-classified the constant that
+/// `ActionConditionalConst` legitimately installed on the synthetic BRANCHIND
+/// as a broken input, re-pointing it at the register def every heritage pass).
+/// With the repair's healthy-input test accepting heritage-known Varnodes the
+/// pipeline converges, so the DEFAULT watchdog budget must never fire here:
+/// the function decompiles with non-null `code` and null `error`.
 ///
-/// The 300s outer cap is deliberately generous (slow debug builds / shared-
-/// machine load); the watchdog itself is asked for 10s.
+/// This is the convergence-regression gate: if the fixpoint bug returns, the
+/// default 120s budget turns it into a per-function error (failing the
+/// `"error": null` assertion) inside the generous 300s outer cap — visible,
+/// never a hung CI.  The watchdog *mechanism* stays covered deterministically
+/// by `kuna-decomp`'s `repeatapply_deadline_bounds_nonconverging_action` unit
+/// test (an already-expired deadline bounding a never-converging repeatapply
+/// loop).
 #[test]
-fn decompile_all_watchdog_bounds_pathological_function() {
+fn decompile_all_converges_on_past_pathological_function() {
     let bin = hang_repro();
     let res = run_kuna_with_timeout(
-        &[
-            "decompile-all",
-            &bin,
-            "--addr",
-            "0x1bd04",
-            "--json",
-            "--max-fn-seconds",
-            "10",
-            "--sleighpath",
-            &specs(),
-        ],
+        &["decompile-all", &bin, "--addr", "0x1bd04", "--json", "--sleighpath", &specs()],
         Duration::from_secs(300),
     );
     let (stdout, stderr, ok) = match res {
         Some(t) => t,
         None => panic!(
             "kuna decompile-all did not terminate within the 300s outer bound — \
-             the --max-fn-seconds watchdog is not firing on the hang repro"
+             the 0x1bd04 convergence fix has regressed AND the default \
+             --max-fn-seconds watchdog is not firing"
         ),
     };
     if !ok {
@@ -172,16 +173,23 @@ fn decompile_all_watchdog_bounds_pathological_function() {
         panic!("kuna decompile-all failed: {stderr}");
     }
     // Shape assertions (no JSON dep): a well-formed single-function document
-    // whose one record errored out on the budget, with no code emitted.
+    // whose one record decompiled cleanly (non-null code, null error).
     let trimmed = stdout.trim();
     assert!(trimmed.starts_with('{') && trimmed.ends_with('}'), "output is not a JSON object:\n{stdout}");
     assert!(stdout.contains("\"count\": 1"), "expected count 1:\n{stdout}");
     assert!(stdout.contains("\"address_hex\": \"0x1bd04\""), "missing the 0x1bd04 record:\n{stdout}");
     assert!(
-        stdout.contains("\"error\": \"per-function decompile budget exceeded (10 s)\""),
-        "expected the watchdog budget error:\n{stdout}"
+        stdout.contains("\"error\": null"),
+        "sub_1bd04 must decompile cleanly now (the convergence fix regressed?):\n{stdout}"
     );
-    assert!(stdout.contains("\"code\": null"), "a budget-exceeded function must have null code:\n{stdout}");
+    assert!(
+        stdout.contains("\"code\": \""),
+        "sub_1bd04 must emit code (the convergence fix regressed?):\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("budget exceeded"),
+        "the watchdog must not fire on the fixed function:\n{stdout}"
+    );
 }
 
 /// Watchdog control: a healthy function in the SAME hang-repro binary

--- a/decompiler/crates/kuna-decomp/src/infra/action/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/action/tests.rs
@@ -615,3 +615,35 @@ fn dummy_rule_registers_and_dispatches_only_on_its_opcode() {
     assert!(pool.clone_filtered(&ActionGroupList::from_names(["analysis"])).is_some());
     assert!(pool.clone_filtered(&ActionGroupList::from_names(["other"])).is_none());
 }
+
+#[test]
+fn repeatapply_deadline_bounds_nonconverging_action() {
+    // (kuna decompile-all watchdog) The cooperative per-function deadline must
+    // bound a repeatapply loop whose child NEVER stops reporting changes — the
+    // exact shape of the stripped-ELF `decompile-all` hang (a `mainloop` child
+    // reported one change per iteration forever).  With an already-expired
+    // deadline the `Action::perform` repeat gate and the `ActionGroup::apply`
+    // scheduling boundary must both bail out after at most one body pass
+    // instead of looping on the huge budget.
+    let mut fd = build_fd();
+    let log: Log = Rc::new(RefCell::new(Vec::new()));
+    // A budget so large that, without the deadline, the loop would effectively
+    // run forever (1<<30 change-reporting passes).
+    let budget = Rc::new(RefCell::new(1 << 30));
+    let mut group = ActionGroup::new(ruleflags::rule_repeatapply, "grp");
+    group.add_action(CountdownAction::boxed("g", "act", budget.clone(), log.clone()));
+
+    let mut ctx = ActionContext::new();
+    ctx.deadline = Some(std::time::Instant::now()); // already expired
+    let total = group.perform(&mut fd, &mut ctx);
+    // The child applied at most twice (the group body may schedule the first
+    // pass before probing, and the repeat gate stops the loop), not 2^30 times.
+    assert!(
+        log.borrow().len() <= 2,
+        "expired deadline must stop the repeatapply loop, got {} applies",
+        log.borrow().len()
+    );
+    // Whatever ran is reported as the change count (the drive then turns the
+    // expiry into a per-function error).
+    assert!(total <= 2);
+}

--- a/decompiler/crates/kuna-decomp/src/substrate/funcdata_block.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/funcdata_block.rs
@@ -2188,11 +2188,21 @@ impl Funcdata {
             if self.obank().get(indop).map(|o| o.code()) != Some(OpCode::CPUI_BRANCHIND) {
                 continue;
             }
-            // If input 0 already names a live, non-free Varnode, leave it.
+            // If input 0 already names a live, non-free Varnode, leave it.  A
+            // constant is "heritage known" (C++ `Varnode::isHeritageKnown()` =
+            // insert|constant|annotation) and must count as healthy: on the
+            // hang-repro stripped-ELF corpus `ActionConditionalConst` legitimately
+            // proves the switch variable constant down the guarding edge and
+            // replaces this very input with the constant.  Classifying that
+            // constant as broken re-pointed the BRANCHIND back at the register
+            // SSA def on every heritage pass, and condconst re-replaced it on
+            // every mainloop iteration — the two actions toggled the same input
+            // forever and the repeatapply mainloop never converged (the
+            // `decompile-all` infinite hang on stripped openssh/bash binaries).
             let in0 = self.obank().get(indop).and_then(|o| o.get_in(0));
             let healthy = in0
                 .and_then(|v| self.vbank().get(v))
-                .map(|v| v.is_written() || v.is_input())
+                .map(|v| v.is_written() || v.is_input() || v.is_heritage_known())
                 .unwrap_or(false);
             if healthy {
                 continue;

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -119,14 +119,18 @@ large/multi-part features go through a `[PROPOSAL]` draft PR for human go/no-go)
 ## Known issues
 
 - **Fixpoint non-convergence on certain fully-stripped x86-64 ELF binaries**
-  (underlying bug OPEN). On some stripped binaries (openssh/bash) ONE pathological
-  function's decompile pipeline never converges (heritage/dead-code restart cycling —
-  99 instructions, infinite loop, 100% CPU). The `decompile-all` **watchdog is shipped**
-  (`--max-fn-seconds`, default 120 s), so `kuna decompile-all` now isolates the
-  pathological function as a per-function `error` record and finishes the batch instead
-  of hanging forever. Single-function repro:
-  `kuna decompile-all tests/hang-repro/ssh-sk-helper --addr 0x1bd04`; offending binaries
-  + full writeup: **`tests/hang-repro/README.md`**.
+  (FIXED). The `loweredswitch` repair hook (`kuna_repair_lowered_switch_inputs`)
+  mis-classified the constant `ActionConditionalConst` legitimately installed on a
+  synthetic BRANCHIND as a broken input and re-pointed it at the register def on
+  every heritage pass — a condconst↔repair tug-of-war that kept the repeatapply
+  `mainloop` reporting one change forever (infinite loop, 100% CPU). Fixed by
+  accepting heritage-known Varnodes (C++ `Varnode::isHeritageKnown()`:
+  insert|constant|annotation) as healthy. The full known-hang set (9 stripped
+  openssh binaries + bash `-O2`) now completes under the default `decompile-all`
+  watchdog (`--max-fn-seconds`, default 120 s), which remains as a defensive
+  bound. Past repro: `kuna decompile-all tests/hang-repro/ssh-sk-helper --addr
+  0x1bd04` (now converges in well under a second); binaries + original writeup:
+  **`tests/hang-repro/README.md`**.
 
 ## Tests
 

--- a/tests/hang-repro/README.md
+++ b/tests/hang-repro/README.md
@@ -1,13 +1,21 @@
 # kuna hang repro — infinite loop on fully-stripped x86-64 ELF binaries
 
-**Status:** underlying convergence bug OPEN; **watchdog shipped**. Without a watchdog,
-`kuna decompile-all` hung **indefinitely** (100% CPU, never returns) on certain
-fully-stripped x86-64 ELF binaries. Discovered 2026-07-02 while running kuna as a
-backend in the `decbench` decompiler benchmark. `decompile-all` now carries a
-per-function watchdog (`--max-fn-seconds N`, default 120, `0` disables): the
-pathological function is cut off and recorded as its own `error` record
-(`"per-function decompile budget exceeded"`) and the batch completes. The
-non-convergence itself is still unfixed — the repro below is the testbed for that fix.
+**Status:** **FIXED** (convergence bug root-caused and fixed); **watchdog shipped**
+and kept as a defensive bound. Without a watchdog, `kuna decompile-all` hung
+**indefinitely** (100% CPU, never returns) on certain fully-stripped x86-64 ELF
+binaries. Discovered 2026-07-02 while running kuna as a backend in the `decbench`
+decompiler benchmark. `decompile-all` carries a per-function watchdog
+(`--max-fn-seconds N`, default 120, `0` disables). The non-convergence itself is
+fixed: the `loweredswitch` post-heritage repair
+(`Funcdata::kuna_repair_lowered_switch_inputs`) mis-classified the constant that
+`ActionConditionalConst` legitimately installed on the synthetic BRANCHIND as a
+broken input (its healthy test was `is_written()||is_input()`, and a constant is
+neither) and re-pointed the BRANCHIND at the register def on every heritage pass —
+so condconst re-replaced it on every repeatapply `mainloop` iteration, forever. The
+fix accepts heritage-known Varnodes (C++ `Varnode::isHeritageKnown()` =
+insert|constant|annotation, `varnode.hh:299`) as healthy. The repro below now
+converges in well under a second and is pinned by the regression test named at the
+bottom.
 
 **Diagnosis so far:** the hang is ONE pathological function's decompile pipeline, not
 discovery — on `ssh-sk-helper` all 843 functions enumerate fine, but `sub_1bd04` @
@@ -18,8 +26,9 @@ heritage (`Heritage::heritage` → `LocationMap::add`) and dead-code elimination
 ```bash
 timeout 90 decompiler/target/release/kuna decompile-all \
     tests/hang-repro/ssh-sk-helper --addr 0x1bd04 --json --max-fn-seconds 0
-# exit 124 (hang) — with the watchdog disabled.  With the default watchdog it
-# returns in ~120s with `"error": "per-function decompile budget exceeded (120 s)"`.
+# BEFORE the fix: exit 124 (hang) with the watchdog disabled; with the default
+# watchdog it returned in ~120s with the per-function budget error.
+# AFTER the fix: converges in well under a second, `code` non-null, `error` null.
 ```
 
 ## Symptom
@@ -47,12 +56,13 @@ stripped: no `.symtab`, no DWARF; x86-64 PIE; from openssh-portable built at `-O
 # from the kuna repo root, after `make` (binary at decompiler/target/release/kuna)
 timeout 120 decompiler/target/release/kuna decompile-all \
     tests/hang-repro/ssh-sk-helper --json
-# EXPECTED (bug): times out at 120s (exit 124), no JSON produced, 100% CPU throughout.
-# A healthy binary of this size returns in seconds.
+# BEFORE the fix (bug): timed out at 120s (exit 124), no JSON, 100% CPU throughout.
+# AFTER the fix: whole-binary JSON in seconds.
 ```
 
-Confirmed: kuna ran **>120s with no return** on `ssh-sk-helper`. Same for
-`ssh-pkcs11-helper`.
+Confirmed pre-fix: kuna ran **>120s with no return** on `ssh-sk-helper`. Same for
+`ssh-pkcs11-helper` (its `sub_21e9b` was the same bug — post-fix it decompiles in
+~0.2s).
 
 ## Full list of known-hanging inputs (from the benchmark)
 
@@ -63,23 +73,27 @@ All are **fully stripped, x86-64 ELF PIE**. openssh-portable @ `-O0`:
 The two smallest (`ssh-sk-helper`, `ssh-pkcs11-helper`) are checked in here; the rest
 follow the same pattern (large, stripped openssh/bash binaries).
 
-## Notes for whoever fixes the underlying bug
+## Root cause (as fixed)
 
-- The trigger appears to be **stripped input** (no symbols → kuna does its own
-  function discovery/CFG recovery). The *unstripped* variants of the same programs
-  did **not** hang in the benchmark; only the stripped ones did.
-- It's an **infinite loop**, not merely slow: 4+ hours at 100% CPU with no progress.
-- Localized by gdb backtrace sampling to `sub_1bd04` @ `0x1bd04` in `ssh-sk-helper`
-  (99 instructions): the action pipeline cycles between
-  `s3_dataflow::heritage::Heritage::heritage` → `LocationMap::add` and
-  `s9_emit::coreaction_render::ActionDeadCode::apply`, under
-  `ActionRestartGroup::apply` inside `decompile_func_full_with_override_dyn`
-  (`infra/decompile_drive.rs`) — a heritage/dead-code fixpoint that never converges.
+- The trigger was **stripped input** (no symbols → kuna's own function discovery)
+  *plus* the kuna-owned `loweredswitch` feature: it synthesizes a `BRANCHIND` +
+  trivial `JumpTable` out of a comparison cascade, and its post-heritage repair
+  hook re-pointed the BRANCHIND at the register def whenever the input was not
+  `is_written()||is_input()` — which wrongly included the **constant** that
+  `ActionConditionalConst` installs when the cascade's own guard proves the switch
+  variable constant down the dominating edge.
+- The gdb symptom (cycling `Heritage::heritage` → `LocationMap::add` /
+  `ActionDeadCode::apply` under `ActionRestartGroup::apply`) was the repeatapply
+  `mainloop` re-running every iteration off condconst's eternally-counted change;
+  no restart was ever requested, so no restart bound could trip.
+- The fix (one predicate, `substrate/funcdata_block.rs`): the repair also accepts
+  heritage-known Varnodes (C++ `Varnode::isHeritageKnown()`, `varnode.hh:299`).
 - The per-function **watchdog** (`--max-fn-seconds`, cooperative deadline probes at
-  the action/rule-pool/heritage loop boundaries) makes the batch survive; the real
-  fix is making that fixpoint converge. Regression test:
-  `decompiler/crates/kuna-cli/tests/decompile_all_cli.rs`
-  (`decompile_all_watchdog_bounds_pathological_function`).
+  the action/rule-pool/heritage loop boundaries) remains as a defensive bound.
+  Regression tests: `decompiler/crates/kuna-cli/tests/decompile_all_cli.rs`
+  (`decompile_all_converges_on_past_pathological_function`) pins the convergence;
+  `kuna-decomp`'s `repeatapply_deadline_bounds_nonconverging_action` unit test pins
+  the watchdog mechanism deterministically.
 
 Provenance: decbench `projects/sailr/openssh-portable.toml` and `bash.toml`,
 decompiled from the stripped copy the benchmark hands each decompiler.


### PR DESCRIPTION
Root-causes and fixes the non-converging decompiler fixpoint behind the `kuna decompile-all` infinite hang on fully-stripped x86-64 ELFs (openssh/bash). The defensive watchdog (PR #118) bounded the symptom; this PR removes the cause.

## The instrumented evidence (the cycling action)

Temporary env-gated tracing (`KUNA_TRACE_ACTIONS=1`, removed before commit) around `ActionGroup::apply` on the deterministic single-function repro (`sub_1bd04` @ 0x1bd04 in `tests/hang-repro/ssh-sk-helper`, watchdog disabled):

```
861672  [trace] group=mainloop child=condconst res=1      <-- forever, 1 change per iteration
     4  [trace] group=mainloop child=activeparam res=2
     2  [trace] group=mainloop child=returnrecovery res=5
     ...everything else converges
```

`ActionConditionalConst` reported exactly one change on **every** `mainloop` (repeatapply) iteration, forever — so the mainloop never converged, and every iteration re-ran `ActionHeritage` (a fresh heritage pass, hence the `Heritage::heritage -> LocationMap::add` leaves in the gdb stack samples) and `ActionDeadCode` (the other observed leaf). Neither restart counter tripped because no restart was ever requested — the loop was pure repeatapply.

Finer tracing (per-rewrite + a trap in `op_set_input` on BRANCHIND ops, with backtrace) pinned the two sides of the tug-of-war:

```
347608  [condconst] replace opc=CPUI_BRANCHIND at 0x1bd82 var=register:0x0(RAX) value=0x6
329183  [setinput] action=heritage  BRANCHIND slot=0 new=221v5 (register:0x0)  cur=[const:0x6 free=true]
329183  [setinput] action=condconst BRANCHIND slot=0 new=fresh const:0x6       cur=[221v5 register:0x0]
     1  [setinput] action=lowerswitchinstall BRANCHIND slot=0 new=1633v3 (register:0x0)
```

with the heritage-side backtrace landing in **`Funcdata::kuna_repair_lowered_switch_inputs`** (`substrate/funcdata_block.rs`), the kuna-owned post-heritage repair hook of the `loweredswitch` feature, called from `ActionHeritage::apply` right after `op_heritage`.

The cycle:

1. The `loweredswitch` feature (kuna-owned, default-on since #110) synthesizes a `BRANCHIND(RAX)` + trivial `JumpTable` out of a comparison cascade at 0x1bd82.
2. `ActionConditionalConst` (faithful port of `coreaction.cc` `ActionConditionalConst::apply`) legitimately proves the switch variable constant (`== 6`) down the guarding edge that dominates the BRANCHIND and replaces the input with the constant — one counted change. (Upstream does the identical rewrite and converges; upstream never sees this BRANCHIND at all since it is kuna-synthesized.)
3. On the next iteration, `kuna_repair_lowered_switch_inputs`'s "healthy input" test — `is_written() || is_input()` — classified the **constant** as a broken input (a constant is neither), and "repaired" the BRANCHIND back to the register SSA def.
4. condconst re-proves and re-replaces; goto 3. Forever.

## The fix (one predicate)

`decompiler/crates/kuna-decomp/src/substrate/funcdata_block.rs`:

```diff
             let healthy = in0
                 .and_then(|v| self.vbank().get(v))
-                .map(|v| v.is_written() || v.is_input())
+                .map(|v| v.is_written() || v.is_input() || v.is_heritage_known())
                 .unwrap_or(false);
```

The upstream anchor for the missing class is `varnode.hh:299` (GHIDRA_REV cef869af04c4):

```cpp
/// Return \b true if this Varnode is linked into the SSA tree
bool isHeritageKnown(void) const { return ((flags&(Varnode::insert|Varnode::constant|Varnode::annotation))!=0); }
```

— the exact predicate upstream heritage uses to protect such inputs from renaming (`heritage.cc:2495`, `renameRecurse`: `if (vnin->isHeritageKnown()) continue; // not free`). A constant is a *known, not-free* value everywhere in the upstream pipeline; the kuna-owned repair helper (which exists to fix a genuinely nulled/free input after dead-code sweeps a widened read) was the only place that treated it as damage. Note the divergence is in a kuna-owned feature helper, not in the ported heritage/deadcode code — the ported passes behaved faithfully throughout.

With the fix, `sub_1bd04` converges in **0.17 s** (was: infinite) and renders the (correct, degenerate) `switch(6)` the constant proof implies.

## Sweep of the full known-hang set (release build, `timeout 600`, default watchdog)

| binary | before | after: wall | functions | errors |
|---|---|---|---|---|
| O0 openssh `ssh` | infinite hang | 126.3 s | 1933 | 2 |
| O0 openssh `sshd` | infinite hang | 123.3 s | 2146 | 4 |
| O0 openssh `ssh-add` | infinite hang | 25.6 s | 1032 | 1 |
| O0 openssh `ssh-agent` | infinite hang | 26.5 s | 924 | 1 |
| O0 openssh `ssh-keygen` | infinite hang | 38.3 s | 1240 | 1 |
| O0 openssh `ssh-keyscan` | infinite hang | 33.2 s | 1313 | 1 |
| O0 openssh `ssh-keysign` | infinite hang | 46.8 s | 1273 | 1 |
| O0 openssh `ssh-pkcs11-helper` | infinite hang | 17.9 s | 912 | 1 |
| O0 openssh `ssh-sk-helper` | infinite hang | 15.3 s | 843 | 1 |
| O2 `bash` | infinite hang | 230.3 s | 2538 | 16 |

Every `error` in the table is the pre-existing `"decompile pipeline reached an un-ported seam"` kind — **zero** `"per-function decompile budget exceeded"` records anywhere (the watchdog never fired). Wall times were measured with a concurrent `cargo test` compile loading the machine, so they are conservative.

sub_21e9b (ssh-pkcs11-helper), which blew the 120 s budget in PR #118's verification: **same bug** — with the fix it decompiles in 0.24 s (single-function run, default budget).

## Tests

- `decompile_all_watchdog_bounds_pathological_function` -> renamed `decompile_all_converges_on_past_pathological_function`: 0x1bd04 must now produce non-null `code` + `error: null` under the **default** budget (a regression of the fixpoint bug turns into a visible per-function budget error inside the 300 s outer cap, never a hung CI).
- The watchdog mechanism itself stays covered deterministically by a new `kuna-decomp` unit test, `repeatapply_deadline_bounds_nonconverging_action`: an already-expired `ActionContext::deadline` must bound a repeatapply group whose child reports changes forever (budget 2^30) to at most 2 applies — the exact loop shape of the hang, no wall-clock flakiness.
- `decompile_all_watchdog_quiet_on_healthy_function` unchanged.

## Gates

- `make test` — **675/675, PARITY OK** (no datatest output changed: the repair path is scoped to synthetic lowered-switch tables, which the corpus never creates).
- `make test-stages` — **240/240, PARITY OK**.
- `make rust-test` — green (full workspace, `--no-fail-fast`, exit 0; includes the new unit test and the re-pointed CLI e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J
