### PR TITLE
s8/structure: BlockList/BlockIf are complex — fix invalid C in while-conditions (upstream isComplex parity, decbench F3)

### DIFF
--- a/decompiler/crates/kuna-base/src/xml.rs
+++ b/decompiler/crates/kuna-base/src/xml.rs
@@ -1630,7 +1630,7 @@ mod tests {
                 count += 1;
             }
         }
-        // 83 datatests + 73 stage testcases (incl. ghangr-dd-argmatch-to-argument-noea / gotoreduce,
+        // 83 datatests + 74 stage testcases (incl. ghangr-dd-argmatch-to-argument-noea / gotoreduce,
         // ghangr-missing-function-call-1101b1, ghangr-tee-o2-tail-jumps-4a1f49 / tailcalljump,
         // branchflip-negated-guard / branchflip,
         // regionstructure-seq + regionstructure-loop + regionstructure-switch +
@@ -1649,8 +1649,9 @@ mod tests {
         // and ghangr-switchmultipred-memmove / switchmultipred, angr
         // test_decompiling_abnormal_switch_case_case3,
         // and ghangr-optimized-memcpy-6301a9 / unrolledguard, angr
-        // test_decompiling_optimized_memcpy)
-        assert_eq!(count, 156, "corpus file count drifted");
+        // test_decompiling_optimized_memcpy,
+        // and ghdec-whiledo-complex / decbench F3 whiledo isComplex parity)
+        assert_eq!(count, 157, "corpus file count drifted");
     }
 
     /// ~20 representative SLEIGH spec files across varied processors

--- a/decompiler/crates/kuna-decomp/src/s8_structure/blockaction.rs
+++ b/decompiler/crates/kuna-decomp/src/s8_structure/blockaction.rs
@@ -45,9 +45,12 @@
 //!     `dataflow_changecount` driver, transcribed exactly.
 //!   - **`FlowBlock::isComplex`** ([`is_complex`]): the C++ base default returns
 //!     `true`; `BlockBasic::isComplex` counts statements against
-//!     `max_implied_ref` (data-flow).  The port returns the base default (`true`)
-//!     and seam-notes the statement count.  This only affects whether a whileDo
-//!     uses *overflow syntax* and whether `ruleBlockOr` fires — recorded as a loss.
+//!     `max_implied_ref` (data-flow).  The statement count is precomputed by
+//!     [`ActionBlockStructure`] over the live op lists (`Funcdata::bb_is_complex`
+//!     → `complex_blocks`) and [`is_complex`] reproduces the upstream virtual
+//!     dispatch exactly (only BlockCopy/BlockCondition resolve further; every
+//!     other subtype is unconditionally complex).  This decides whether a
+//!     whileDo uses *overflow syntax* and whether `ruleBlockOr` fires.
 //!
 //! The structuring [`Action`]s whose body is a single call into a `BlockGraph`
 //! method that `block.cc` defers to W7/W8 ([`ActionFinalStructure`] →
@@ -1990,23 +1993,45 @@ impl<'a> CollapseStructure<'a> {
     }
 
     /// Is structuring block `bl` too complex to be a condition clause (C++
-    /// `FlowBlock::isComplex` virtual dispatch: `BlockList`/`BlockCopy` delegate
-    /// down to the front `BlockBasic`, whose statement count is the real test;
-    /// the base returns `true`).
+    /// `FlowBlock::isComplex` virtual dispatch)?
     ///
-    /// Resolves `bl` to its front-leaf BlockCopy and reads the precomputed
-    /// per-BlockBasic complexity (`complex_blocks`, keyed by the `copy` pointer).
-    /// A block that does not resolve to a BlockCopy/BlockBasic (e.g. an empty
-    /// graph node) falls back to the conservative `true`.
+    /// Faithful to the upstream override set (`decompiler/cpp/block.hh`):
+    ///   * base `FlowBlock::isComplex` (block.hh:254) returns `true` — every
+    ///     graph subtype without an override (**BlockList, BlockIf, ...**) is
+    ///     unconditionally complex;
+    ///   * `BlockBasic::isComplex` (block.cc:2403) is the statement-count test,
+    ///     precomputed over the live op lists into `complex_blocks` (keyed by
+    ///     the bblocks id);
+    ///   * `BlockCopy::isComplex` (block.hh:549) delegates to the copied block
+    ///     — the `complex_blocks` lookup through the `copy` pointer;
+    ///   * `BlockCondition::isComplex` (block.hh:649) delegates to
+    ///     `getBlock(0)`.
+    ///
+    /// Note this is *not* a front-leaf descent: a compound condition block
+    /// (e.g. the BlockList a `ruleBlockWhileDo` condition can collapse to) is
+    /// complex regardless of how trivial its front `BlockBasic` is — that is
+    /// what forces the valid `while(true){...; if (cond) break;}` overflow
+    /// syntax instead of inlining statements into the `while(...)` parens.
     pub(crate) fn is_complex(&self, bl: BlockId) -> bool {
-        // C++ virtual chain: getFrontLeaf descends getBlock(0) to the t_copy leaf.
-        let leaf = match self.graph.get_front_leaf(bl) {
-            Some(l) => l,
-            None => return true, // base FlowBlock::isComplex
-        };
-        match self.graph.block(leaf).get_copy() {
-            Some(basic) => self.complex_blocks.contains(&basic),
-            None => true,
+        let mut bl = bl;
+        loop {
+            match self.graph.block(bl).get_type() {
+                // BlockCopy::isComplex -> copy->isComplex() (block.hh:549): the
+                // copied BlockBasic's statement-count verdict (block.cc:2403),
+                // precomputed in `complex_blocks`.
+                BlockType::Copy => {
+                    return match self.graph.block(bl).get_copy() {
+                        Some(basic) => self.complex_blocks.contains(&basic),
+                        None => true,
+                    };
+                }
+                // BlockCondition::isComplex -> getBlock(0)->isComplex()
+                // (block.hh:649).
+                BlockType::Condition => bl = self.graph.block(bl).get_block(0),
+                // Everything else inherits the base FlowBlock::isComplex
+                // default `true` (block.hh:254).
+                _ => return true,
+            }
         }
     }
 

--- a/decompiler/crates/kuna-decomp/src/s8_structure/blockaction/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/s8_structure/blockaction/tests.rs
@@ -768,14 +768,16 @@ fn cj_cutdown_keeps_multiequal_when_extra_pred_remains() {
 }
 
 // ---------------------------------------------------------------------------
-// is_complex resolution (BlockBasic::isComplex via the BlockCopy `copy` pointer)
+// is_complex resolution (the FlowBlock::isComplex virtual dispatch: only
+// BlockBasic/BlockCopy/BlockCondition override; base block.hh:254 is `true`)
 // ---------------------------------------------------------------------------
 
 #[test]
 fn is_complex_resolves_through_block_copy() {
     // Build a structuring graph holding a single BlockCopy leaf whose `copy`
-    // points at a (synthetic) bblocks BlockBasic id.  is_complex must descend the
-    // front leaf, read the copy pointer, and consult the precomputed set.
+    // points at a (synthetic) bblocks BlockBasic id.  is_complex must read the
+    // copy pointer (BlockCopy::isComplex, block.hh:549) and consult the
+    // precomputed set (BlockBasic::isComplex, block.cc:2403).
     let mut g = BlockGraph::new();
     let root = g.arena.insert(FlowBlock::new_kind(BlockKind::Graph));
     g.root = Some(root);
@@ -798,9 +800,88 @@ fn is_complex_resolves_through_block_copy() {
 
 #[test]
 fn is_complex_falls_back_to_true_for_non_copy_leaf() {
-    // A plain graph node (no BlockCopy descendant) cannot resolve to a basic
-    // block, so the C++ base FlowBlock::isComplex default (`true`) applies.
+    // A plain graph node has no isComplex override, so the C++ base
+    // FlowBlock::isComplex default (`true`, block.hh:254) applies.
     let (mut g, root, b) = build_graph(1);
     let cs = CollapseStructure::new(&mut g, root);
     assert!(cs.is_complex(b[0]), "non-copy leaf -> conservative true");
+}
+
+#[test]
+fn is_complex_blocklist_is_unconditionally_complex() {
+    // A BlockList has NO isComplex override upstream -> base `true`
+    // (block.hh:254) even when its front leaf is a trivial (non-complex)
+    // BlockBasic.  The buggy front-leaf descent scored such a list non-complex,
+    // which skipped the whileDo overflow syntax and inlined the list's
+    // statements (including embedded returns) into the `while(...)` parens —
+    // invalid C (decbench O0-iproute2-ip-lookup_flag_data_by_name).
+    let mut g = BlockGraph::new();
+    let root = g.arena.insert(FlowBlock::new_kind(BlockKind::Graph));
+    g.root = Some(root);
+    let basic = g.new_block_basic(root);
+    let copyleaf = g.new_block_copy(root, basic); // trivial front leaf
+    let tail = g.new_block(root);
+    g.add_edge(copyleaf, tail);
+    let list = g.new_block_list(root, &[copyleaf, tail]).expect("new_block_list");
+
+    // `basic` is NOT in complex_blocks -> the front leaf alone would say false.
+    let cs = CollapseStructure::new(&mut g, root);
+    assert!(!cs.is_complex(copyleaf), "the front leaf itself is not complex");
+    assert!(cs.is_complex(list), "a BlockList is unconditionally complex (base isComplex)");
+}
+
+#[test]
+fn is_complex_blockif_is_unconditionally_complex() {
+    // A BlockIf has no isComplex override either -> base `true` (block.hh:254).
+    let mut g = BlockGraph::new();
+    let root = g.arena.insert(FlowBlock::new_kind(BlockKind::Graph));
+    g.root = Some(root);
+    let basic = g.new_block_basic(root);
+    let cond = g.new_block_copy(root, basic); // trivial condition leaf
+    let clause = g.new_block(root);
+    let exit = g.new_block(root);
+    g.add_edge(cond, clause);
+    g.add_edge(cond, exit);
+    g.add_edge(clause, exit);
+    let ifblk = g.new_block_if(root, cond, clause);
+
+    let cs = CollapseStructure::new(&mut g, root);
+    assert!(cs.is_complex(ifblk), "a BlockIf is unconditionally complex (base isComplex)");
+}
+
+#[test]
+fn is_complex_condition_delegates_to_component_zero() {
+    // BlockCondition::isComplex -> getBlock(0)->isComplex() (block.hh:649):
+    // only the FIRST component's verdict matters.
+    let mut g = BlockGraph::new();
+    let root = g.arena.insert(FlowBlock::new_kind(BlockKind::Graph));
+    g.root = Some(root);
+    let basic1 = g.new_block_basic(root);
+    let basic2 = g.new_block_basic(root);
+    let b1 = g.new_block_copy(root, basic1);
+    let b2 = g.new_block_copy(root, basic2);
+    let clause = g.new_block(root);
+    let exit = g.new_block(root);
+    g.add_edge(b1, b2);
+    g.add_edge(b1, clause);
+    g.add_edge(b2, clause);
+    g.add_edge(b2, exit);
+    let cond = g.new_block_condition(root, b1, b2).expect("new_block_condition");
+
+    // Mark only the SECOND component's basic complex: the condition still
+    // delegates to component 0 -> not complex.
+    let mut complex = std::collections::BTreeSet::new();
+    complex.insert(basic2);
+    let cs = CollapseStructure::new(&mut g, root).with_complex_blocks(complex);
+    assert!(
+        !cs.is_complex(cond),
+        "BlockCondition delegates to getBlock(0), ignoring the second component"
+    );
+    drop(cs);
+
+    // Marking the FIRST component's basic complex flips the answer.
+    let mut complex = std::collections::BTreeSet::new();
+    complex.insert(basic1);
+    let cs = CollapseStructure::new(&mut g, root).with_complex_blocks(complex);
+    assert!(cs.is_complex(cond), "complex getBlock(0) -> the condition is complex");
 }

--- a/decompiler/crates/kuna-decomp/src/s8_structure/region_structurer.rs
+++ b/decompiler/crates/kuna-decomp/src/s8_structure/region_structurer.rs
@@ -811,21 +811,33 @@ impl<'a> RegionStructurer<'a> {
     /// Is `bl` too complex to be folded as a *cascading* condition clause (C++
     /// `FlowBlock::isComplex` virtual dispatch)?
     ///
-    /// The base returns `true`; `BlockList`/`BlockCopy` delegate down to the front
-    /// `BlockBasic`, whose statement count is the real test.  Resolves `bl` to its
-    /// front-leaf `BlockCopy` and reads the precomputed per-BlockBasic complexity
-    /// (`complex_blocks`, keyed by the `copy` pointer).  A block that does not
-    /// resolve to a `BlockCopy`/`BlockBasic` falls back to the conservative `true`
-    /// (so it never participates in a fold — honest-partial).  Identical to
+    /// Faithful to the upstream override set (`decompiler/cpp/block.hh`): the
+    /// base `FlowBlock::isComplex` (block.hh:254) returns `true` — every graph
+    /// subtype without an override (BlockList, BlockIf, ...) is unconditionally
+    /// complex; only `BlockCopy` (block.hh:549, delegates to the copied
+    /// `BlockBasic`, whose statement-count verdict `BlockBasic::isComplex`
+    /// block.cc:2403 is precomputed in `complex_blocks`) and `BlockCondition`
+    /// (block.hh:649, delegates to `getBlock(0)`) resolve further.  Identical to
     /// [`CollapseStructure::is_complex`](crate::blockaction::CollapseStructure).
     fn is_complex(&self, bl: BlockId) -> bool {
-        let leaf = match self.graph.get_front_leaf(bl) {
-            Some(l) => l,
-            None => return true, // base FlowBlock::isComplex
-        };
-        match self.graph.block(leaf).get_copy() {
-            Some(basic) => self.complex_blocks.contains(&basic),
-            None => true,
+        use crate::block::BlockType;
+        let mut bl = bl;
+        loop {
+            match self.graph.block(bl).get_type() {
+                // BlockCopy::isComplex -> copy->isComplex() (block.hh:549).
+                BlockType::Copy => {
+                    return match self.graph.block(bl).get_copy() {
+                        Some(basic) => self.complex_blocks.contains(&basic),
+                        None => true,
+                    };
+                }
+                // BlockCondition::isComplex -> getBlock(0)->isComplex()
+                // (block.hh:649).
+                BlockType::Condition => bl = self.graph.block(bl).get_block(0),
+                // Everything else inherits the base FlowBlock::isComplex
+                // default `true` (block.hh:254).
+                _ => return true,
+            }
         }
     }
 

--- a/docs/baseline-stages.json
+++ b/docs/baseline-stages.json
@@ -1,7 +1,7 @@
 {
   "data_footer": [
-    235,
-    235
+    245,
+    245
   ],
   "passing": [
     "data:BRANCHFLIP #1: default pipeline keeps the negated `== 0` guard (opt-in is default-off)",
@@ -211,6 +211,11 @@
     "data:regionstructure shortcircuit #1: the cascading b==0xc9 / a<=299 conditions fold to one compound and (both passes)",
     "data:regionstructure shortcircuit #2: the inner a<=299 condition is NOT left as a separate nested if (both passes)",
     "data:regionstructure shortcircuit #3: an unrelated single-condition else-if is unchanged (both passes)",
+    "data:regionstructure-edgeorder #1: else-arm constant assignment recovered, both passes",
+    "data:regionstructure-edgeorder #2: then-arm constant assignment recovered, both passes",
+    "data:regionstructure-edgeorder #3: post-test guard recovered, both passes",
+    "data:regionstructure-edgeorder #4: function returns the accumulator, both passes",
+    "data:regionstructure-edgeorder #5: regionedgeorder on is byte-identical to off (parity invariant)",
     "data:regionstructure-loop #1: do-while recovered (BlockDoWhile), both passes",
     "data:regionstructure-loop #2: for/while recovered (BlockWhileDo), both passes",
     "data:regionstructure-loop #3: inf-loop-with-break recovered (BlockInfLoop), both passes",
@@ -220,11 +225,6 @@
     "data:regionstructure-loop-refine #3: early-return secondary exit preserved, both passes",
     "data:regionstructure-loop-refine #4: break secondary exit + post-loop return both recovered (2 sites x 2 passes), both passes",
     "data:regionstructure-loop-refine #5: ZERO gotos - regionlooprefine on is byte-identical to off (parity invariant)",
-    "data:regionstructure-edgeorder #1: else-arm constant assignment recovered, both passes",
-    "data:regionstructure-edgeorder #2: then-arm constant assignment recovered, both passes",
-    "data:regionstructure-edgeorder #3: post-test guard recovered, both passes",
-    "data:regionstructure-edgeorder #4: function returns the accumulator, both passes",
-    "data:regionstructure-edgeorder #5: regionedgeorder on is byte-identical to off (parity invariant)",
     "data:regionstructure-switch #1: the switch head is recovered, both passes",
     "data:regionstructure-switch #2: case 0, both passes",
     "data:regionstructure-switch #3: case 3 (middle of the dense table), both passes",
@@ -243,7 +243,12 @@
     "data:tee-O2 tail-jumps #3: tail call resolves to named setlocale (pass 2 on only)",
     "data:tee-O2 tail-jumps #4: the recovered tail call is logged (pass 2 on only)",
     "data:unrolledguard #1: option off, the interleaved dispatches degrade to computed calls (bug reproduced); option on adds ZERO new ones (7 pass1 + 0 pass2)",
-    "data:unrolledguard #2: option on recovers every interleaved table as a switch (1 off + 16 on = 17)"
+    "data:unrolledguard #2: option on recovers every interleaved table as a switch (1 off + 16 on = 17)",
+    "data:whiledo-complex #1: compound while condition forces overflow syntax (valid C)",
+    "data:whiledo-complex #2: no statement is inlined inside a while-parens condition (plain form absent)",
+    "data:whiledo-complex #3: the bound check is a proper if statement in the loop body",
+    "data:whiledo-complex #4: the loop exit is a proper break statement",
+    "data:whiledo-complex #5: the bound-check return is a statement, not condition text"
   ],
   "returncode": 0,
   "unit_footer": null

--- a/tests/stages/README.md
+++ b/tests/stages/README.md
@@ -96,6 +96,7 @@ writeup, not here.
 
 | `gh9218-inputvarnodeadjust.xml` | [GH-9218](https://github.com/NationalSecurityAgency/ghidra/issues/9218) | S6 storage reconciliation (`stack-frame-layout`, overlapping input varnodes) | `option inputvarnodeadjust on\|off` |
 | `ghangr-ite-region-converter-missing-5db28e.xml` | angr `test_ite_region_converter_missing_break_statement` (StackCanarySimplifier) | S7 region recovery (`edge-virtualization`, strip the -fstack-protector canary epilogue so the shared-return goto is eliminated) | `option stackguard on\|off` |
+| `ghdec-whiledo-complex.xml` | decbench `O0-iproute2-ip-lookup_flag_data_by_name` (invalid C: statement inside `while(...)` parens) | S8 structure recovery (whileDo overflow-syntax decision; `FlowBlock::isComplex` virtual-dispatch parity, porting-divergence correctness fix, no option) | default (upstream `isComplex`: BlockList/BlockIf unconditionally complex) |
 
 Infrastructure testcases (no GH issue; they regression-test the kuna stage machinery
 itself): `kuna-console.xml` (registry + `stage list/map/status`), `kuna-assert.xml`

--- a/tests/stages/ghdec-whiledo-complex.xml
+++ b/tests/stages/ghdec-whiledo-complex.xml
@@ -1,0 +1,67 @@
+<decompilertest>
+<binaryimage arch="x86:LE:64:default:gcc">
+<!--
+    decbench campaign case O0-iproute2-ip-lookup_flag_data_by_name (F3):
+    kuna emitted syntactically INVALID C for a while loop whose condition
+    block is a compound graph.
+
+    The function is a linear-search loop (iproute2 ip, x86-64 gcc -O0):
+
+        for (i = 0; i <= 12; i++)
+            if (!strcmp(name, table[i*3])) return &table[i*3];
+        return 0;
+
+    During S8 structuring the loop header (the bound check "if (0xd <= i)
+    return 0;") collapses with the strcmp block into a BlockList that becomes
+    the WhileDo CONDITION block.  Upstream Ghidra guards exactly this with
+    FlowBlock::isComplex (decompiler/cpp/block.hh:254 base returns true; only
+    BlockBasic block.cc:2403, BlockCopy block.hh:549 and BlockCondition
+    block.hh:649 override), so a BlockList/BlockIf condition is unconditionally
+    complex, which sets the whiledo OVERFLOW syntax and prints the valid form
+
+        while( true ) { <cond stmts>; if (<branch>) break; <body> }
+
+    kuna's ported is_complex instead resolved EVERY block type down to its
+    front BlockBasic leaf (get_front_leaf), so a compound condition whose
+    front leaf is trivial scored non-complex, overflow syntax was skipped, and
+    the whole BlockList - including the embedded return - was inlined into the
+    while(...) parentheses as a comma expression:
+
+        while (
+        if 0xd <= v2 {return 0
+        }v1 = ..., strcmp(a0,v1) != 0) { ... }
+
+    which no C parser accepts (decbench GED 19 vs ghidra 5 on this function).
+
+    Stage model: S8 structure recovery, loop-shape sub-stage
+    (CollapseStructure::rule_block_while_do overflow decision in
+    s8_structure/blockaction.rs; duplicated helper in region_structurer.rs;
+    rendering consequence in s9_emit/printc.rs emit_block_while_do).
+
+    No option: this is a porting-divergence CORRECTNESS fix (invalid C is
+    never desired) restoring the upstream virtual dispatch, on by default.
+    Single pass asserts the correct output: the loop uses the overflow
+    syntax "while( true )", the bound check is a proper statement in the
+    loop body, and NO statement text appears inside a "while (" condition
+    (the plain-form spelling never occurs in this function).
+-->
+<bytechunk space="ram" offset="0x14c77">
+f30f1efa554889e54883ec2048897de8c745fc00000000eb518b55fc4889d04801c04801d048
+c1e0034889c2488d0576060c00488b1402488b45e84889d64889c7e803a2ffff85c0751c8b55
+fc4889d04801c04801d048c1e003488d1548060c004801d0eb0f8345fc01837dfc0c76a9b800
+000000c9c3
+</bytechunk>
+<symbol space="ram" offset="0x14c77" name="lookup_flag_data_by_name"/>
+</binaryimage>
+<script>
+  <com>lo fu lookup_flag_data_by_name</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="whiledo-complex #1: compound while condition forces overflow syntax (valid C)" min="1" max="1">while\( true \)</stringmatch>
+<stringmatch name="whiledo-complex #2: no statement is inlined inside a while-parens condition (plain form absent)" min="0" max="0">while \(</stringmatch>
+<stringmatch name="whiledo-complex #3: the bound check is a proper if statement in the loop body" min="1" max="1">if \(0xd &lt;= </stringmatch>
+<stringmatch name="whiledo-complex #4: the loop exit is a proper break statement" min="1" max="1">break;</stringmatch>
+<stringmatch name="whiledo-complex #5: the bound-check return is a statement, not condition text" min="1" max="1">return 0;</stringmatch>
+</decompilertest>


### PR DESCRIPTION
decbench campaign **F3** (`docs/decbench/features.md`), triage case `O0-iproute2-ip-lookup_flag_data_by_name` (`docs/decbench/triage/`): a **correctness fix** for kuna emitting **syntactically invalid C**.

## Symptom

When a while-loop's condition block collapses to a *compound* graph (a BlockList/BlockIf — here the loop's bound check `if (0xd <= v2) return 0;` concatenated with the strcmp block), kuna inlined the whole compound — statements, embedded `return` and all — **inside the `while (...)` parentheses** as a comma expression:

```c
  v2 = 0;
  while (
  if 0xd <= v2 {return 0
  }v1 = *(char **)((uint8)v2 * 0x18 + 0xd5320), strcmp(a0,v1) != 0) {
    v2 = v2 + 1;
  }
```

No C parser accepts this. Joern's recovered CFG is garbage, so the case scored GED **19** while kuna's own ancestor Ghidra scores **5** on the same function (bucket `kuna-specific`).

## Root cause: a porting divergence in `is_complex`

Upstream guards exactly this in `CollapseStructure::ruleBlockWhileDo` (`decompiler/cpp/blockaction.cc:1538`): `bool overflow = bl->isComplex();` — and `FlowBlock::isComplex()` is **virtual** with a deliberately narrow override set (verified at the pinned `GHIDRA_REV`, `docs/UPSTREAM.md`):

| upstream | behavior |
|---|---|
| `FlowBlock::isComplex` (block.hh:254) | base — returns **`true`** |
| `BlockBasic::isComplex` (block.cc:2403) | the real statement-count test |
| `BlockCopy::isComplex` (block.hh:549) | delegates to the copied block |
| `BlockCondition::isComplex` (block.hh:649) | delegates to `getBlock(0)` |

**BlockList and BlockIf do NOT override** → they are *unconditionally complex* → `ruleBlockWhileDo` sets overflow syntax → the valid form `while( true ) { <cond stmts>; if (<branch>) break; <body> }`.

kuna's port instead resolved **every** block type down to its front `BlockBasic` leaf:

```rust
// s8_structure/blockaction.rs:2001 (and the duplicated copy region_structurer.rs:821)
let leaf = match self.graph.get_front_leaf(bl) { ... };   // descends ANY graph type
match self.graph.block(leaf).get_copy() {
    Some(basic) => self.complex_blocks.contains(&basic),  // tests only the front leaf
    None => true,
}
```

so a compound condition whose front leaf is trivial (the 1-statement bound check) scored `is_complex = false`, the overflow syntax was skipped, and `emit_block_while_do` (s9_emit/printc.rs) took the plain `while (cond)` path under `COMMA_SEPARATE`.

## Fix

Reproduce the upstream virtual dispatch faithfully in **both** copies of the helper (`CollapseStructure::is_complex`, `RegionStructurer::is_complex`):

```rust
loop {
    match self.graph.block(bl).get_type() {
        // BlockCopy::isComplex -> copy->isComplex() (block.hh:549): the copied
        // BlockBasic's statement-count verdict (block.cc:2403) from complex_blocks.
        BlockType::Copy => return match self.graph.block(bl).get_copy() {
            Some(basic) => self.complex_blocks.contains(&basic),
            None => true,
        },
        // BlockCondition::isComplex -> getBlock(0)->isComplex() (block.hh:649).
        BlockType::Condition => bl = self.graph.block(bl).get_block(0),
        // Everything else inherits the base default `true` (block.hh:254).
        _ => return true,
    }
}
```

This is **default behavior, no option**: invalid C is never desired — it lands like a porting bug fix. It fixes the whole **class** (any while whose condition block is compound), and the same wrong verdict that gated `ruleBlockOr` / the region structurer's short-circuit fold (which could swallow a statement-bearing BlockList into an `if (... && ...)` condition).

## Before / after (the triage case, stripped `ip` @ 0x14c77)

After — valid C, byte-shape identical to what Ghidra renders:

```c
  v2 = 0;
  while( true ) {
    if (0xd <= v2) {
      return 0;
    }
    v1 = *(char **)((uint8)v2 * 0x18 + 0xd5320);
    if (strcmp(a0,v1) == 0) break;
    v2 = v2 + 1;
  }
  return (uint8)v2 * 0x18 + 0xd5320;
```

**GED (scripts.decbench.rescore, --siblings):**

| case | before | after | delta |
|---|---|---|---|
| O0-iproute2-ip-lookup_flag_data_by_name | 19.0 | **5.0** (= ghidra) | **-14.0** |
| O2-noinline sibling (already overflow-form) | 5.0 | 5.0 | 0.0 |

## Tests

- **Unit** (`blockaction/tests.rs`): BlockList/BlockIf are unconditionally complex even with a trivial front leaf; BlockCondition delegates to component 0 (and ignores component 1); the existing Copy/plain tests still pass unchanged.
- **Stage test** `tests/stages/ghdec-whiledo-complex.xml`: the real 119 bytes of the ip function as a bytechunk; 5 assertions (overflow form `while( true )` present, the plain `while (` spelling absent, bound check/`break`/`return 0` are proper statements). **0/5 on unfixed main, 5/5 with the fix**; `docs/baseline-stages.json` regenerated (also fixes the stale 235 footer → 245); the pinned XML corpus count (`kuna-base/src/xml.rs`) bumped 156 → 157.

## Gates

- `make test` — **675/675, PARITY OK** (the corpus is pinned to correct output and is *unaffected* — the dispatch fix is exactly as narrow as upstream's)
- `make test-stages` — **245/245, PARITY OK**
- `make rust-test` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J
