### PR TITLE
decbench: ghidra-beats-kuna analysis + runtime-choice registry (docs)

### DIFF
--- a/docs/decbench/runtime-choices.md
+++ b/docs/decbench/runtime-choices.md
@@ -1,0 +1,102 @@
+# Runtime-choice registry
+
+Some decompiler behaviors are **not universally better** — they win on the majority of
+functions but lose on a specific *source shape*. kuna keeps the majority-winning behavior
+as the default and exposes the alternative as a per-run `--option`, so an agent (or a human)
+can flip it **per function** when the source shape calls for it. This registry documents
+each such lever: the default, when to flip it, and the source-shape signal that tells you to.
+
+Discovered by the decbench ghidra-beats-kuna analysis (`docs/decbench/triage-ghidra/`, the
+`--option X off` divergence-revert experiment) and the angr campaign. See `docs/decbench-loop.md`
+for the loop; `kuna catalog --json` is the machine-readable option surface an agent reads.
+
+A behavior belongs here **only if both renderings are valid** and the choice is a genuine
+tradeoff. A behavior whose non-default output is *invalid or wrong* is a bug, not a choice —
+those are listed at the bottom as "not runtime choices" so they don't get mis-filed.
+
+## The levers
+
+### `taildup` — tail duplication (default: ON)
+
+- **What ON does (the majority win):** duplicates a shared bare-return/epilogue block into
+  each predecessor, eliminating a `goto` and linearizing the code. Goto-free output reads
+  cleaner on the bulk of functions — why it's default-on (DIV-14).
+- **When to flip OFF:** the function has a **shared cleanup / free-chain epilogue** reached
+  from many predecessors — several early-exit error checks that all free/dispose the *same*
+  locals and `return` (the C `goto out;` idiom). There, tail duplication forks the single
+  cleanup into N source-absent copies; keeping it merged (`taildup off`) matches the source
+  and Ghidra.
+- **Source-shape signal:** multiple early-exit error checks → one `free(a); free(b); return r;`
+  cleanup block with many predecessors.
+- **Evidence:** `kex_choose_conf` (openssh ssh, O2-noinline) — `taildup off` recovers Ghidra's
+  merged epilogue (GED 54 → ~0). `--option taildup off`.
+- Related: the `returndup` angr feature (below) auto-detects this shape from the other
+  direction (splitting a merged return); here the existing `taildup` lever already closes it.
+
+### `iteregion` — recover `?:` ternaries from assignment diamonds (default: OFF)
+
+- **What ON does:** rewrites an `if/else { x = a } { x = b }` two-arm assignment diamond into
+  `x = cond ? a : b`. Ghidra's printer has no ternary, so this is a kuna-added S9 form.
+- **When to flip ON:** the source **likely used a ternary** — format/print/flag code full of
+  `cond ? "%s," : "%s"` style expressions (each compiles to a register-assignment diamond).
+  On such code the source CFG is flat (no branch), so the ternary matches and the if/else
+  diamond does not.
+- **When to leave OFF (the default):** the source likely used an explicit `if/else` — then the
+  diamond is *correct* and a ternary would diverge. Default-off because the wrong guess hurts.
+- **Source-shape signal:** many two-arm same-destination assignment diamonds converging on a
+  call argument (print/format/flag builders). Evidence: `print_link_flags` (iproute2 ip).
+- Shipped by decbench feature F5 (PR TBD). `--option iteregion on`.
+
+### `cstyle-null-cmp` — terse null/bool comparisons (default: OFF)
+
+- **What ON does:** renders pointer/bool comparisons as `if (x)` / `if (!x)` instead of the
+  explicit `if (x != 0)` / `if (x == 0)`. Matches the angr/IDA/source terse convention.
+- **When to flip ON:** you want output that matches the terse majority convention and the
+  Joern-based GED metric (the explicit `!= 0` form expands into extra CFG nodes and is
+  penalized even when the control flow is identical — see `shell_initialize`,
+  `compspec_dispose`). It is a **pure rendering style**, no control-flow change.
+- **When to leave OFF (the default):** you want explicit comparisons for review clarity
+  (kuna/Ghidra house style). Default-off keeps the explicit form.
+- Shipped by decbench feature F6 (PR TBD). `--option cstyle-null-cmp on` *(name TBD)*.
+
+### Speed-gated opt-ins (default: OFF for cost, not correctness)
+
+These win on quality where they trigger but carry heavy per-function cost, so they stay
+off by default and an agent flips them on when it needs the recovery on a specific function
+(see `docs/divergences.md`, `[[kuna-default-on-sweep]]`):
+
+- **`switchguardbound`** — extend jump-table bound analysis across a guard. "Incredibly slow"
+  (PR #60); flip on for a specific "Too many branches" computed-call failure.
+- **`unrolledguard`** — recover MSVC unrolled-memcpy jump tables. **~3.9×** on the recovered
+  function; flip on for that specific optimized-memcpy switch shape.
+
+## How an agent uses this
+
+1. `kuna catalog --json` lists every option with its `default`, `use_when`, and `summary`.
+2. When the default output looks wrong for a *known source shape* above, re-decompile that one
+   function with the lever flipped: `kuna decompile <bin> <fn> --option <lever> <value>`
+   (or `kuna decompile-all <bin> --addr 0x… --option <lever> <value>`).
+3. The choice is **per function** — never flip a lever globally to chase one function; the
+   default is the default because it wins on the rest.
+
+## Not runtime choices (bugs — fix on-default, do not flip)
+
+Recorded here so the divergence-revert experiment doesn't mis-file them as choices. In each
+the non-default output is *invalid or strictly wrong*, so there is no valid tradeoff to expose.
+
+- **`regionstructure` nested-`if`-in-`while`-condition** (`overwrite_database`, cronie crond):
+  the SAILR region structurer folds a loop body containing a nested `if` into the `while`
+  condition, emitting **uncompilable C** — the same defect class PR #122 fixed for
+  while-conditions, surviving when the body has a nested `if`. `regionstructure off` is only a
+  workaround (it disables SAILR entirely, regressing the majority). The real fix is on-default:
+  fall back to `while(true){ …; if(cond) break; }` when the refined body can't reduce to a pure
+  expression condition. Tracked as a follow-up correctness PR (F7).
+
+## Benchmark caveat (not a kuna behavior at all)
+
+Some ghidra-beats-kuna GED gaps are **decbench scoring artifacts**, not kuna choices:
+`compspec_dispose` / `dispose_variable` (bash) use **K&R old-style** function definitions
+(`f(x) TYPE x; { … }`), which degenerate Joern's source-CFG parse to ~1 node at benchmark time
+— so Ghidra's *also*-degenerate stub matched (GED 0) while kuna's correct ~19-node CFG was
+charged its full size. The decbench `GED_MIN_SOURCE_NODES` fix (decbench PR #6) excludes these
+degenerate-source cases on the next benchmark run.

--- a/docs/decbench/triage-ghidra/O2-noinline-bash-bash-compspec_dispose.md
+++ b/docs/decbench/triage-ghidra/O2-noinline-bash-bash-compspec_dispose.md
@@ -1,0 +1,123 @@
+---
+case_id: O2-noinline-bash-bash-compspec_dispose
+status: metric-artifact
+gap_survives: false
+recorded_kuna_ged: 72
+divergence_lever: null
+proposed_new_option: null
+runtime_choice: false
+angr_feature: null
+---
+
+## Current kuna vs ghidra
+
+Current kuna (default flags, benchmark surface `decompile-all --addr 0x9dc30`) fully and
+correctly recovers the function — the `refcount--`, the outer `if (refcount==0)` guard, the
+eight `FREE()`-macro-expanded `if (ptr != 0) sh_xfree(ptr, ...)` guards, and the tail
+`free(cs)`. This is a faithful reconstruction of the source.
+
+```c
+// CURRENT KUNA  — ~30 LOC, 9 ifs (1 outer + 8 inner), 0 gotos, 0 labels, 0 loops, 0 switch
+void compspec_dispose(int4 *a0)
+{
+  *a0 = *a0 + -1;
+  if (*a0 == 0) {
+    if (*(int8 *)&a0[6]  != 0) { sh_xfree(*(int8 *)&a0[6], "pcomplib.c",0x4e); }
+    if (*(int8 *)&a0[8]  != 0) { sh_xfree(*(int8 *)&a0[8], "pcomplib.c",0x4f); }
+    if (*(int8 *)&a0[10] != 0) { sh_xfree(*(int8 *)&a0[10],"pcomplib.c",0x50); }
+    if (*(int8 *)&a0[0xc]!= 0) { sh_xfree(*(int8 *)&a0[0xc],"pcomplib.c",0x51); }
+    if (*(int8 *)&a0[0xe]!= 0) { sh_xfree(*(int8 *)&a0[0xe],"pcomplib.c",0x52); }
+    if (*(int8 *)&a0[0x10]!=0) { sh_xfree(*(int8 *)&a0[0x10],"pcomplib.c",0x53); }
+    if (*(int8 *)&a0[0x12]!=0) { sh_xfree(*(int8 *)&a0[0x12],"pcomplib.c",0x54); }
+    if (*(int8 *)&a0[0x14]!=0) { sh_xfree(*(int8 *)&a0[0x14],"pcomplib.c",0x55); }
+                    /* WARNING: tailcalljump: recovered tail call -> introduced call to 0x0009e530 */
+    sh_xfree(a0,"pcomplib.c",0x57);
+    return;
+  }
+  return;
+}
+```
+
+Ghidra's stored output for this address is **degenerate garbage** — it recovered *nothing*
+of the function and emitted an infinite self-recursive stub:
+
+```c
+// GHIDRA  — 2 real body lines, 0 ifs, 0 loops. A degenerate self-call stub. Recovered nothing.
+void compspec_dispose(void)
+{
+  compspec_dispose();
+  return;
+}
+```
+
+Stored GED scores (`results/full_run/O2-noinline/bash/evaluated/bash.toml`):
+
+| decompiler | ged.compspec_dispose | recovered the function? |
+|---|---|---|
+| ghidra | **0.0** | no — degenerate self-call stub |
+| ida    | **72.0** | yes — full 8-guard recovery |
+| kuna   | **72.0** | yes — full 8-guard recovery |
+
+The two decompilers that actually recovered the function (kuna **and** IDA) both score 72;
+only ghidra's garbage output scores 0. On the neighbouring `compspec_copy` (which ghidra
+*did* recover), all three agree (66/66/66). That is the tell: ghidra's 0 here is not a win,
+it is a spurious match between two degenerate graphs.
+
+## Divergence experiment
+
+No divergence lever is responsible for this gap, and none closes it — the symptom is on the
+*metric/source-parse* side, not on kuna's output shape.
+
+- kuna's output shows no divergence symptom to chase (no extra gotos/labels, no switch, no
+  noreturn overrun). The only divergence marker present is the single `tailcalljump` WARNING
+  comment on the tail `free(cs)`.
+- I flipped the one relevant lever, **`tailcalljump off`**, as a control. It makes kuna
+  *dramatically worse*: without tail-call recognition kuna decodes straight through the
+  tail-jump at 0x9e530 into the internal `free`/allocator body (mh_magic checks, `memset
+  0xcf` scrub loops, an unrolled duff's-device switch, several gotos). The clean 30-line
+  function balloons to ~200 lines of allocator internals. So the **default-ON** kuna output
+  is already the correct, minimal, source-matching one — there is no lever to flip toward
+  ghidra, and every lever move is away from source.
+
+I confirmed the metric mechanism directly with pyjoern + `cfgutils.similarity.vj_ged`
+(the exact tooling `decbench/metrics/ged.py` uses), parsing the **healthy** source CFG from
+the preprocessed `pcomplib.i`:
+
+```
+SOURCE compspec_dispose : nodes=18  edges=41   (a real, non-degenerate CFG)
+GHIDRA output           : nodes=1   edges=0    (degenerate stub)   -> GED(source, ghidra) = 101
+KUNA   output           : nodes=19  edges=26   (correct recovery)  -> GED(source, kuna)   = 35
+```
+
+With a *correct* source parse the result **flips**: kuna 35 decisively beats ghidra 101.
+
+## Analysis / runtime-choice verdict
+
+**Metric artifact — degenerate/unstable source-CFG parse.** kuna's decompilation is correct
+and strictly better than ghidra's; the 72-vs-0 is a scoring artifact, not a quality gap.
+
+Root cause: `decbench/metrics/ged.py` scores `GED(source_cfg, decompiled_cfg)`, and the
+source CFG is built by pyjoern/Joern from the preprocessed `.i`. The source definition is
+**K&R old-style** (`compspec_dispose(cs) COMPSPEC *cs; { ... }`). For ghidra to have scored
+**0**, the benchmark-time source CFG had to have collapsed to ~1 node (GED(1-node,1-node)=0),
+i.e. Joern failed/degenerated on that K&R definition at benchmark time. Ghidra's own output
+is *also* a ~1-node degenerate stub, so garbage-vs-garbage matched perfectly (GED 0). kuna
+and IDA produced the real ~19-node CFG and were charged the full size of their (correct!)
+graphs against the collapsed source — hence both land on exactly 72.
+
+My re-parse of the same source produced a healthy 18-node CFG (Joern version/parse
+instability on the K&R form is exactly why benchmark and re-run disagree), and under that
+healthy parse kuna (35) beats ghidra (101). So:
+
+- **Not already-fixed by session-1**: this function was already fully recovered on old kuna;
+  F1/#120/#122 did not touch it. The score is unchanged because the output was always good.
+- **Not a divergence-lever / new-runtime-choice**: kuna's default output already matches the
+  true (macro-expanded) source shape; no existing or proposed option moves it toward ghidra,
+  and `tailcalljump off` moves it strongly away.
+- **Not a genuine bug**: kuna is not worse than IDA (both 72) and is *better* than ghidra
+  (whose output is non-functional garbage).
+
+The `gap_survives=false`: current kuna produces a strictly superior, correct decompilation;
+the ghidra-beats-kuna number is an artifact of a degenerate/unstable source-CFG parse
+(source_nodes collapsed to ~1 at benchmark time) coinciding with ghidra's degenerate output.
+A fair re-score inverts it. There is nothing to fix in kuna.

--- a/docs/decbench/triage-ghidra/O2-noinline-bash-bash-dispose_variable.md
+++ b/docs/decbench/triage-ghidra/O2-noinline-bash-bash-dispose_variable.md
@@ -1,0 +1,95 @@
+---
+case_id: O2-noinline-bash-bash-dispose_variable
+status: metric-artifact
+gap_survives: false
+recorded_kuna_ged: 32
+divergence_lever: null
+proposed_new_option: null
+runtime_choice: false
+angr_feature: null
+---
+
+## Current kuna vs ghidra
+
+Recorded scores in `results/full_run/O2-noinline/bash/evaluated/bash.toml`:
+`ghidra.ged=0.0`, `ida.ged=32.0`, `kuna.ged=32.0`. Note **IDA scores the same 32 as
+kuna** — only ghidra scores 0.
+
+**Source** (`O0/bash/compiled/variables.i`, `dispose_variable`): guard `if(var==0) return;`,
+then `if((attr&0x20000)==0) dispose_variable_value(var);`, `if(var->exportstr) sh_xfree(...)`,
+`sh_xfree(var->name,...)`, `if(attr&1) array_needs_making=1;`, `sh_xfree(var,...)`. Source CFG
+(header-stripped, current extractor): **9 nodes / 13 edges**.
+
+**Current kuna** (fresh `decompile-all --addr 0x53c10`) — ~18 LOC, 0 gotos, 0 labels, 4 ifs
+(outer guard + 3 inner), 0 loops. A **complete, faithful** decompilation:
+
+```c
+void dispose_variable(void *a0)
+{
+  if (a0 != (void *)0x0) {
+    if ((*(uint4 *)&a0[5] & 0x20000) == 0) {
+      sub_51c40(a0[1]);                        // -> dispose_variable_value(var)
+    }
+    if (a0[2] != 0) {
+      sh_xfree(a0[2],"variables.c",0xed1);     // var->exportstr
+    }
+    sh_xfree(*a0,"variables.c",0xed3);         // var->name
+    if ((*(uint1 *)&a0[5] & 1) != 0) {
+      dat_138450 = 1;                          // array_needs_making = 1
+    }
+    /* WARNING: tailcalljump: recovered tail call -> introduced call to 0x0009e530 */
+    sh_xfree(a0,"variables.c",0xed8);          // sh_xfree(var)
+    return;
+  }
+  return;
+}
+```
+
+**Ghidra** (stored `ghidra_bash.c`, the only definition of the name) — a **degenerate
+self-recursive stub**, objectively useless (1 CFG node):
+
+```c
+void dispose_variable(void)
+{
+  dispose_variable();
+  return;
+}
+```
+
+kuna reproduces every branch and free of the source; ghidra recovered nothing. IDA's output
+(0x53c10) is essentially identical to kuna's (same nested ifs, same tail-call-as-return) and
+also scores 32.
+
+## Divergence experiment
+
+Not applicable — no divergence lever was tested because kuna's output is not the problem.
+kuna's output is already the correct/complete shape (and matches IDA). Flipping any of the 19
+default-ON options could only perturb an already-good result; there is no ghidra shape to
+recover toward (ghidra's shape is garbage). Winning lever: **none**.
+
+## Analysis / runtime-choice verdict
+
+Root cause is the **GED metric's source-side CFG in the scored run, not kuna**.
+
+- GED = `vj_ged(source_cfg, decompiled_cfg)`; lower is better; 0 = perfect (`decbench/metrics/ged.py`).
+- Reproducing GED against the **correct** header-stripped source CFG (9 nodes / 13 edges)
+  gives the *opposite, correct* ranking: **kuna GED = 4** (9 nodes / 11 edges, near-perfect
+  structural match) vs **ghidra GED = 36** (its 1-node stub is 36 edits from source). So on a
+  sound metric kuna decisively beats ghidra here.
+- The recorded scores (ghidra 0, kuna/ida 32) are only possible if the **source CFG used in
+  the original scoring was degenerate (~1 node)**. That is exactly the failure mode
+  `scripts/reeval_ged.py` documents: original GED source CFGs were extracted from the full
+  preprocessed `.i` (80-98% inlined system headers), Joern timed out / produced degenerate
+  graphs, so a 1-node degenerate source matches ghidra's 1-node stub (GED~0) and penalizes any
+  full decompilation (kuna/ida ~32 insertions). `reeval_ged.py` re-scores against
+  header-stripped sources to fix this, and **`results/full_run/ged_new.json` is absent** — the
+  fix was never applied to this tree, so `bash.toml` still carries the broken original numbers.
+
+Signature of a metric artifact: kuna == IDA (both full, correct) are equally punished while the
+uniquely-degenerate output (ghidra) is rewarded; the "gap" tracks a broken reference CFG, not
+any kuna divergence, inflation, or regression. Nothing about session-1 (F1/#120/#122) or any
+default-ON angr divergence is implicated — kuna's output was already correct at benchmark time
+and remains correct now.
+
+Verdict: **metric-artifact**, `gap_survives=false`. No lever, no new option, no angr feature,
+`runtime_choice=false`. On a correctly-computed GED, kuna already wins this function.

--- a/docs/decbench/triage-ghidra/O2-noinline-bzip2-bzip2recover-bsGetBit.md
+++ b/docs/decbench/triage-ghidra/O2-noinline-bzip2-bzip2recover-bsGetBit.md
@@ -1,0 +1,120 @@
+---
+case_id: O2-noinline-bzip2-bzip2recover-bsGetBit
+status: already-fixed
+gap_survives: false
+recorded_kuna_ged: 72
+divergence_lever: null
+proposed_new_option: null
+runtime_choice: false
+angr_feature: null
+---
+## Current kuna vs ghidra
+
+Current kuna (`decompile-all --addr 0x1be0`, F1 listing default ON): 18 code lines,
+0 gotos, 0 labels, 3 ifs, 0 loops, 3 returns.
+
+```c
+uint4 sub_1be0(void *a0)
+
+{
+  int4 v1; // eax
+  
+  if (1 <= *(int4 *)((int8)a0 + 0xc)) {
+    v1 = *(int4 *)((int8)a0 + 0xc) + -1;
+    *(int4 *)((int8)a0 + 0xc) = v1;
+    return *(int4 *)&a0[1] >> ((uint1)v1 & 0x1f) & 1;
+  }
+  v1 = getc(*a0);
+  if (v1 == -1) {
+    if (*(int4 *)__errno_location() == 0) {
+      return 2;
+    }
+                    /* WARNING: Subroutine does not return */
+    sub_1ab0();
+  }
+  *(int4 *)&a0[1] = v1;
+  *(void *)((int8)a0 + 0xc) = 7;
+  return v1 >> 7 & 1;
+}
+```
+
+Ghidra: 18 code lines, 0 gotos, 0 labels, 3 ifs, 0 loops, 3 returns.
+
+```c
+uint bsGetBit(undefined8 *param_1)
+
+{
+  int *piVar1;
+  int iVar2;
+  
+  if (0 < *(int *)((long)param_1 + 0xc)) {
+    iVar2 = *(int *)((long)param_1 + 0xc) + -1;
+    *(int *)((long)param_1 + 0xc) = iVar2;
+    return *(int *)(param_1 + 1) >> ((byte)iVar2 & 0x1f) & 1;
+  }
+  iVar2 = getc((FILE *)*param_1);
+  if (iVar2 == -1) {
+    piVar1 = __errno_location();
+    if (*piVar1 == 0) {
+      return 2;
+    }
+                    /* WARNING: Subroutine does not return */
+    FUN_00101ab0();
+  }
+  *(int *)(param_1 + 1) = iVar2;
+  *(undefined4 *)((long)param_1 + 0xc) = 7;
+  return iVar2 >> 7 & 1;
+}
+```
+
+The two are structurally identical — same guard, same early return in the guarded
+block, same `getc` / `iVar2 == -1` / nested errno guard / early `return 2`, same
+`/* WARNING: Subroutine does not return */` noreturn cut on `sub_1ab0` /
+`FUN_00101ab0`, same two field stores and final shifted return. Remaining diffs are
+pure rendering: type spellings (`uint4/int4/int8/uint1` vs `uint/int/long/byte`),
+variable names, `1 <= x` vs `0 < x`, and kuna inlining `__errno_location()` where
+ghidra spills it to `piVar1` (one statement). None of these change the CFG.
+
+## Divergence experiment
+
+The recorded GED-72 gap was produced by OLD kuna 0.1.0, which decompiled without the
+listing enabled, so the internal noreturn wrapper `sub_1ab0` (bzip2's `panic`/error
+abort) was NOT concluded no-return. I reproduced that stale state on current kuna with
+`--option noreturn_propagate off`:
+
+```c
+uint8 sub_1be0(void *a0)
+{
+  ...
+  sub_1ab0();
+  if (*(char *)&v6[2] == 'w') {          // <-- entire bsClose body falls through
+    ...
+    do { v4 = v4 + 1; v5 = v5 * 2; } while (v4 != 8);   // loop
+    ...
+    if (putc(v5 & 0xff,v1) == -1) goto label_1cc0;      // goto + label
+    ...
+  }
+  ...
+  /* WARNING: tailcalljump: recovered tail call -> 0x00001160 */
+  free(v6);
+  return v2;
+}
+```
+
+With `noreturn_propagate off` the function balloons to ~50 lines with a do/while loop,
+a `goto label_1cc0`, and code from the following functions (bsClose, plus a
+strlen/`.bz2` suffix check) swallowed in via the un-cut fall-through after `sub_1ab0()`.
+That inflated, wrong-CFG shape is exactly the GED-72 the benchmark recorded.
+
+Flipping any divergence lever OFF only *opens* the gap — the default-ON configuration
+is the one that matches ghidra. No lever needs flipping.
+
+## Analysis / runtime-choice verdict
+
+Root cause: **F1 (decompile-all now enables the listing so `noreturn_propagate`
+collapses swallowed no-return tails)**. Old kuna 0.1.0 ran the benchmark without the
+listing, so `sub_1ab0` was not concluded no-return; the fall-through past it merged the
+whole next function (bsClose et al.) into bsGetBit, inflating GED to 72. Current kuna
+(listing default ON, `noreturn_propagate` default-ON) cuts the tail at `sub_1ab0()`
+exactly like ghidra, yielding a byte-for-CFG-identical structure. The gap is closed;
+this is already-fixed, not a runtime choice or a bug.

--- a/docs/decbench/triage-ghidra/O2-noinline-cronie-crond-overwrite_database.md
+++ b/docs/decbench/triage-ghidra/O2-noinline-cronie-crond-overwrite_database.md
@@ -1,0 +1,128 @@
+---
+case_id: O2-noinline-cronie-crond-overwrite_database
+status: genuine-bug
+gap_survives: true
+recorded_kuna_ged: 13
+divergence_lever: regionstructure
+proposed_new_option: null
+runtime_choice: false
+angr_feature: null
+---
+## Current kuna vs ghidra
+
+Source (`database.i`, `overwrite_database`) is a plain top-tested loop:
+
+```c
+for (u = old_db->head; u != NULL; u = nu) {
+  if (DebugFlags & 0x10) printf("\t%s\n", u->name);
+  nu = u->next;
+  unlink_user(old_db, u);
+  free_user(u);
+}
+*old_db = *new_db;
+```
+
+**Current kuna (all defaults ON) — INVALID C:**
+
+```c
+void sub_5780(int8 *a0,int8 *a1)
+{
+  int8 *v1;
+  int8 v2;
+  int8 *v3;
+
+  if ((dat_112a0 & 0x10) != 0) {
+    __printf_chk(1,"unlinking old database:\n");
+  }
+  v3 = (int8 *)*a0;
+  if ((int8 *)*a0 != (int8 *)0x0) {
+    while (
+    if (dat_112a0 & 0x10) != 0 {__printf_chk(1,0xc801,v3[2])
+    }v1 = (int8 *)*v3, sub_5750(a0,v3), sub_8050(v3), v1 != (int8 *)0x0) {
+      v3 = v1;
+    }
+  }
+  v2 = a1[1];
+  *a0 = *a1;
+  a0[1] = v2;
+  a0[2] = a1[2];
+  return;
+}
+```
+
+The `while ( ... )` **condition contains an `if` statement plus a comma-expression body**. This does not compile — it is the classic invalid-C-in-`while`-condition shape. LOC ~24, gotos 0, but the single loop is malformed.
+
+**Ghidra — clean top-tested `while`, VALID:**
+
+```c
+void overwrite_database(undefined8 *param_1,undefined8 *param_2)
+{
+  undefined8 *puVar1;
+  undefined8 uVar2;
+  undefined8 *puVar3;
+
+  if (((byte)DAT_001112a0 & 0x10) != 0) {
+    __printf_chk(1,"unlinking old database:\n");
+  }
+  puVar3 = (undefined8 *)*param_1;
+  while (puVar3 != (undefined8 *)0x0) {
+    if (((byte)DAT_001112a0 & 0x10) != 0) {
+      __printf_chk(1,&DAT_0010c801,puVar3[2]);
+    }
+    puVar1 = (undefined8 *)*puVar3;
+    FUN_00105750(param_1,puVar3);
+    FUN_00108050(puVar3);
+    puVar3 = puVar1;
+  }
+  uVar2 = param_2[1];
+  *param_1 = *param_2;
+  param_1[1] = uVar2;
+  param_1[2] = param_2[2];
+  return;
+}
+```
+
+LOC ~26, gotos 0, 2 `if`, 1 clean `while`. GED 0 vs source.
+
+## Divergence experiment
+
+Levers flipped OFF (single `--addr 0x5780`, `timeout 120`):
+
+| lever | result |
+|---|---|
+| `regionlooprefine` off | still INVALID (identical to default) |
+| `loopbreak_recovery` off | still INVALID |
+| `branchflip` off | still INVALID |
+| **`regionstructure` off** | **VALID C** (see below) |
+
+`regionstructure` OFF is the necessary lever — the loop refinement is gated inside the SAILR region structurer, so `regionlooprefine`/`loopbreak_recovery` off alone do nothing while `regionstructure` is on.
+
+**`regionstructure` off — VALID, but do-while shape (not ghidra's top-tested while):**
+
+```c
+  v3 = (int8 *)*a0;
+  if ((int8 *)*a0 != (int8 *)0x0) {
+    while( true ) {
+      if ((dat_112a0 & 0x10) != 0) {
+        __printf_chk(1,0xc801,v3[2]);
+      }
+      v1 = (int8 *)*v3;
+      sub_5750(a0,v3);
+      sub_8050(v3);
+      if (v1 == (int8 *)0x0) break;
+      v3 = v1;
+    }
+  }
+```
+
+Valid C, same body/operations as ghidra, but wraps the loop as `if (v3 != 0) { while(true){ ... if(v1==0) break; ...} }` (Ghidra's native structurer form) instead of ghidra's rotated top-tested `while (v3 != 0)`.
+
+## Analysis / runtime-choice verdict
+
+**genuine-bug** (invalid-C-in-`while`-condition class, `#122`, not fully fixed for this loop shape).
+
+Root cause: the SAILR region structurer (`regionstructure`, default-on, which drives the cyclic loop-refinement `regionlooprefine`) is *trying* to produce exactly ghidra's clean top-tested `while (v3 != 0)` — that intent is correct and is what wins on the majority. But on this shape its rendering **folds the entire loop body, including a nested `if` statement, into the `while` condition**, emitting uncompilable C (a statement inside an expression context). This is the same defect class `#122` addressed for while-conditions; it survives here because the body contains a nested `if`.
+
+This is NOT a runtime choice: a runtime choice requires both renderings to be valid so an agent can pick per source-shape. Here the default output is **invalid C** — never defensible on any function, majority or not. The fix belongs on-default: when the refined loop body cannot be reduced to a pure expression condition (e.g. it contains a nested `if`), `regionstructure` must fall back to the `while(true){ ...; if(cond) break; }` form it already emits correctly when the feature is off — rather than splicing a statement into the condition. `regionstructure off` is only a workaround (it disables SAILR entirely, regressing the majority), which is why `runtime_choice=false`.
+
+kuna is uniquely worse here: ghidra, and kuna-with-`regionstructure`-off, both produce valid C for this trivial `for` loop; only the on-default path is uncompilable, inflating the Joern GED.

--- a/docs/decbench/triage-ghidra/O2-noinline-diffutils-diff-sip.md
+++ b/docs/decbench/triage-ghidra/O2-noinline-diffutils-diff-sip.md
@@ -1,0 +1,113 @@
+---
+case_id: O2-noinline-diffutils-diff-sip
+status: angr-feature-pending
+gap_survives: true
+recorded_kuna_ged: 347
+divergence_lever: null
+proposed_new_option: null
+runtime_choice: false
+angr_feature: noreturn-robustness
+---
+## Current kuna vs ghidra
+
+Current kuna default (F1 listing surface, all 19 divergences on): **99 LOC, 13 ifs, 1 while, 1 do-loop, 1 goto**.
+Ghidra: **43 LOC, 4 ifs, 1 else, 0 gotos**.
+
+The divergence is entirely one spot: the `if (_Var3 < 0)` branch after `lseek`, which calls the
+internal wrapper `FUN_0010e1f0` = `pfatal_with_name` (0xe1f0). Ghidra concludes that call does not
+return and truncates; kuna does not, and decompiles ~56 lines of dead fall-through as if reachable.
+
+Ghidra (clean — the whole `_Var3 < 0` arm is a single no-return call):
+```c
+bool sip(int *param_1,char param_2)
+{
+  ...
+    if (param_2 == '\0') {
+      iVar1 = thunk_FUN_0010f700(*param_1,0);
+      FUN_0010bf50(param_1);
+      __n = *(size_t *)(param_1 + 0x2c);
+      if (iVar1 != 0) {
+        _Var3 = lseek(*param_1,-__n,1);
+        if (_Var3 < 0) {
+                    /* WARNING: Subroutine does not return */
+          FUN_0010e1f0(*(undefined8 *)(param_1 + 2));
+        }
+        param_1[0x2c] = 0;
+        param_1[0x2d] = 0;
+        *(undefined1 *)((long)param_1 + 0x121) = 0;
+      }
+      pvVar4 = memchr(*(void **)(param_1 + 0x28),0,__n);
+      return pvVar4 != (void *)0x0;
+    }
+  ...
+}
+```
+
+Current kuna (inflated — sub_e1f0 is NOT no-return, so the fall-through blob is decompiled):
+```c
+        if ((int8)lseek(v1,-v3,1) <= -1) {
+          v6 = *(uint4 **)&a0[2];
+          sub_e1f0();                       // <-- ghidra: no-return; kuna: keeps going
+          if ((int4)*v6 < 0) {
+            return (uint8)*v6;
+          }
+          if ((v6[10] & 0xf000) != 0x8000) { ... }
+          else {
+            v4 = *(uint8 *)&v6[0x10];
+            ...
+            if ((v5 < v4) || (0x7ffffffffffffffe < v5)) {
+              sub_16300();                  // taildup'd no-return tail
+            }
+            ...
+            do { ... } while (v5 == v4);    // ~40 more lines of dead fall-through
+          }
+          ...
+          return v4;
+        }
+        a0[0x2c] = 0; ...                    // ghidra's post-if cleanup, now the else-arm
+```
+
+## Divergence experiment
+
+Symptom is a no-return overrun, so the candidate levers are the noreturn family — all default-ON:
+
+| lever flipped OFF | sip LOC | effect |
+|---|---|---|
+| (default, all on)      | 99  | baseline gap |
+| noreturn_propagate off | 471 | **much worse** |
+| noreturn_extern off    | 99  | no change |
+| noreturn_externmatch off | 99 | no change |
+
+No lever closes the gap toward ghidra. `noreturn_propagate` is already on and already helping —
+turning it off explodes sip to 471 LOC, proving the propagation is the only thing keeping the
+overrun to 56 lines instead of hundreds. The remaining gap is upstream of propagation: the
+wrapper `pfatal_with_name` is never *concluded* no-return in the first place, so there is no fact
+to propagate. Winning lever: **none**.
+
+## Analysis / runtime-choice verdict
+
+Root cause: **kuna fails to conclude the internal wrapper `pfatal_with_name` (sub_e1f0) is
+no-return.** That wrapper's tail is `error(2, errno, "%s", name)` — glibc `error()` with a
+non-zero status calls `exit()`, so the call (and the whole wrapper) never returns. Ghidra's
+discovered-no-return analysis flags the `error(2,...)` call ("Subroutine does not return"),
+concludes `pfatal_with_name` is non-returning, and propagates that to every call site (sip, and
+11 other callers), truncating the fall-through. kuna's own decompile of sub_e1f0 confirms the
+miss: it emits code *after* the `error(2,...)` call plus a trailing `return;`, i.e. it walked the
+fall-through bytes into the next function and found a reachable RET, so it decided the wrapper
+returns.
+
+Because pfatal_with_name is treated as returning, at sip's `_Var3 < 0` site kuna keeps decoding
+the bytes after the call (the cold error path / next-function fall-through) as live code — the
+`v6` blob with its `do…while` and extra branches — inflating 43 LOC → 99 LOC and driving the
+GED to 347.
+
+This is **not** a runtime choice. kuna's correct behavior here matches ghidra AND the source
+(pfatal_with_name genuinely never returns); there is no majority of functions where treating it
+as returning is better. It is a robustness gap in no-return conclusion, exactly the pending
+angr feature `noreturn-robustness`: an internal no-return wrapper (tail-calling a
+conditionally-exiting libc primitive like `error(status!=0,…)`) is still not concluded no-return
+even with the listing on and `noreturn_propagate` active. Closing that — recognizing
+`error`/`error_at_line` with a non-zero status as no-return, or a stronger discovered-no-return
+pass that stops the fall-through walk at a call with no reachable RET of its own — establishes the
+fact that `noreturn_propagate` then carries to sip and its 11 sibling call sites, collapsing the
+inflated blob to ghidra's shape.

--- a/docs/decbench/triage-ghidra/O2-noinline-findutils-find-entry_free.md
+++ b/docs/decbench/triage-ghidra/O2-noinline-findutils-find-entry_free.md
@@ -1,0 +1,86 @@
+---
+case_id: O2-noinline-findutils-find-entry_free
+status: already-fixed
+gap_survives: false
+recorded_kuna_ged: 27
+divergence_lever: null
+proposed_new_option: null
+runtime_choice: false
+angr_feature: null
+---
+## Current kuna vs ghidra
+
+Source (`sharefile.i:8334`), the ground truth GED scores against:
+```c
+static void entry_free (void *pv) {
+  struct SharefileEntry *p = pv;
+  if (p->fp) {
+    if (0 != rpl_fclose(p->fp))
+      fatal_nontarget_file_error(*__errno_location(), p->name);  // noreturn
+  }
+  free(p->name);
+  free(p);
+}
+```
+
+Current kuna (`decompile-all --addr 0xe490`, all defaults):
+```c
+void sub_e490(void *a0)
+{
+  unsigned int v1; // eax
+  if (*(int8 *)((int8)a0 + 0x18) != 0) {
+    if (sub_17850() != 0) {
+      __errno_location();
+                    /* WARNING: Subroutine does not return */
+      sub_e410(*(void *)CONCAT44(dat_4,v1),*(void *)((int8)a0 + 0x10));
+    }
+  }
+  free(*(void **)((int8)a0 + 0x10));
+                    /* WARNING: tailcalljump: recovered tail call -> introduced call to 0x000069b0 */
+  free(a0);
+  return;
+}
+```
+LOC ~13, gotos 0, labels 0, ifs 2 (nested), loops 0, switch 0.
+
+Ghidra:
+```c
+void entry_free(void *param_1)
+{
+  int iVar1;
+  int *piVar2;
+  if (*(long *)((long)param_1 + 0x18) != 0) {
+    iVar1 = FUN_00117850();
+    if (iVar1 != 0) {
+      piVar2 = __errno_location();
+                    /* WARNING: Subroutine does not return */
+      FUN_0010e410(*piVar2,*(undefined8 *)((long)param_1 + 0x10));
+    }
+  }
+  free(*(void **)((long)param_1 + 0x10));
+  free(param_1);
+  return;
+}
+```
+LOC ~13, gotos 0, labels 0, ifs 2 (nested), loops 0, switch 0.
+
+Control flow is **identical**: same outer `if(p->fp!=0)`, same inner `if(rpl_fclose!=0)`, same noreturn `fatal_nontarget_file_error`/`sub_e410` call, same trailing `free(p->name); free(p); return`. Both mark `sub_e410`/`FUN_0010e410` `/* Subroutine does not return */`. The only residual (expression-level, non-CFG) differences:
+- kuna renders the errno arg as `*(void *)CONCAT44(dat_4,v1)` (lost the `__errno_location()` -> eax link, spurious `dat_4:eax` concat) where ghidra shows the clean `*piVar2`. A data-flow rendering nit, not a control-flow node.
+- kuna adds a `/* tailcalljump: ... */` comment on the final `free(a0)` (tail-call recovered as a normal call — the correct, ghidra-matching shape). A comment, stripped by Joern's CFG.
+
+Current kuna is structurally `~=` ghidra; the recorded GED-27 gap does not reproduce.
+
+## Divergence experiment
+
+- **`--option noreturn_propagate off`** (reproduces OLD kuna 0.1.0 pre-F1): output EXPLODES. Because `sub_e410` (fatal_nontarget_file_error) is no longer concluded no-return, decompilation runs off the end of `entry_free` and swallows the **next** function `sharefile_init` @0xe4d0 — the body fills with `malloc(0x10)`, `strdup`, `sub_1ac70(0xb,0,...)`, a `branchflip` warning, and a nested free-chain that belongs to sharefile_init, with a bogus `uint4 * sub_e490(...)` signature. This is exactly the inflated shape that scored GED 27. **This is the closed gap.**
+- **`--option tailcalljump off`**: removes the tailcalljump comment but renders the final free as `(*dat_3df78)(a0)` with `/* Treating indirect jump as call */` — strictly *worse* / less ghidra-like. tailcalljump default-ON is correct here; not a lever to flip.
+
+Winning lever to close the 27-gap: **none needed** — it is closed by the F1 default (decompile-all enables the listing, so the default-ON `noreturn_propagate` fires on the internal no-return wrapper and collapses the swallowed `sharefile_init`).
+
+## Analysis / runtime-choice verdict
+
+**Root cause of the stale 27:** the benchmark ran kuna 0.1.0, where `decompile-all` did not enable the listing, so `noreturn_propagate` could not conclude `fatal_nontarget_file_error` (`sub_e410`) no-return. Decompilation overran the function boundary and merged in `sharefile_init`, massively inflating the CFG (the swallowed-function symptom). Ghidra concludes the no-return itself and stops cleanly at GED 0.
+
+**Fix already merged:** session-1 **F1** made `decompile-all` enable the listing by default, so the default-ON `noreturn_propagate` now fires and `entry_free` terminates at the correct boundary. The `noreturn_propagate off` experiment above reproduces the old blown-up output exactly, confirming F1 is the closer. Not a runtime choice, not a bug — a stale benchmark number.
+
+`gap_survives=false`, `status=already-fixed`. The tiny residual `CONCAT44(dat_4,v1)` errno-arg artifact is an expression-rendering nit that no divergence lever toggles and does not affect the CFG; it is far below the recorded 27 and does not warrant action here.

--- a/docs/decbench/triage-ghidra/O2-noinline-iproute2-ip-check_duparg.md
+++ b/docs/decbench/triage-ghidra/O2-noinline-iproute2-ip-check_duparg.md
@@ -1,0 +1,87 @@
+---
+case_id: O2-noinline-iproute2-ip-check_duparg
+status: already-fixed
+gap_survives: false
+recorded_kuna_ged: 116
+divergence_lever: null
+proposed_new_option: null
+runtime_choice: false
+angr_feature: null
+---
+## Current kuna vs ghidra
+
+Both are structurally identical: 11 LOC, 1 `if`, 1 early `return`, 1 no-return call
+(`duparg2`) with the `WARNING: Subroutine does not return` comment. 0 gotos, 0 labels,
+0 loops, 0 switch on both sides. The only differences are cosmetic type spelling
+(`uint4 *`/`uint8`/`uint1` vs `uint *`/`ulong`/`byte`) and variable names — both
+normalized away by the Joern-stripped GED view.
+
+Current kuna (`decompile-all --addr 0x688b0`, F1 listing default on):
+```c
+void sub_688b0(uint4 *a0,uint4 a1,unsigned long a2,unsigned long a3)
+
+{
+  if ((*a0 >> ((uint8)a1 & 0x3f) & 1) == 0) {
+    *a0 = *a0 | (uint4)(1L << ((uint1)a1 & 0x3f));
+    return;
+  }
+                    /* WARNING: Subroutine does not return */
+  duparg2(a2,a3);
+}
+```
+
+Ghidra:
+```c
+void check_duparg(uint *param_1,uint param_2,undefined8 param_3,undefined8 param_4)
+
+{
+  if ((*param_1 >> ((ulong)param_2 & 0x3f) & 1) == 0) {
+    *param_1 = *param_1 | (uint)(1L << ((byte)param_2 & 0x3f));
+    return;
+  }
+                    /* WARNING: Subroutine does not return */
+  duparg2(param_3,param_4);
+}
+```
+
+Source (`iplink_geneve.i`) confirms the shape — guarded early-return, then a no-return
+`duparg2`:
+```c
+static void check_duparg(__u64 *attrs, int type, const char *key, const char *argv)
+{
+ if (!(((*attrs) & (1L << (type))) != 0)) {
+  *attrs |= (1L << type);
+  return;
+ }
+ duparg2(key, argv);   /* no-return */
+}
+```
+
+## Divergence experiment
+
+Not a "flip-off closes the gap" case — the current default already matches ghidra. To
+reproduce the recorded GED-116 output (the OLD kuna 0.1.0 the benchmark ran, before F1)
+I flipped the responsible lever OFF:
+
+- `--option noreturn_propagate off` -> kuna no longer concludes `duparg2` is no-return,
+  falls through past the call, and pulls in a ~90-line overrun from the following
+  function (the gtp/geneve parse loop: `strcmp` chains, `addattr*`, `__stack_chk_fail`,
+  labels `label_68bb3`/`label_68bb8`/...). That inflated body is exactly what scored 116.
+
+No lever needs flipping to reach ghidra's form on current kuna — the default is correct.
+
+## Analysis / runtime-choice verdict
+
+Root cause of the stale gap: the benchmark ran kuna 0.1.0 with `decompile-all` not
+enabling the disassembly listing, so `noreturn_propagate` could not conclude the internal
+wrapper `duparg2` (which tail-calls the exit path) was no-return. Kuna therefore treated
+the `duparg2` call as returning, decompiled the fall-through, and absorbed the next
+function's body — an ~11-line function ballooning to ~90 lines of unrelated control flow,
+GED 116.
+
+Session-1's F1 fix makes `decompile-all` (the benchmark surface) enable the listing by
+default, so `noreturn_propagate` now runs and correctly marks `duparg2` no-return. Current
+kuna collapses to the exact ghidra shape (11 LOC, one guard, no overrun). This is a plain
+already-fixed case attributable to F1 (listing-on so `noreturn_propagate` is effective);
+the gap does not survive on current main. No runtime choice, no pending angr feature, no
+metric artifact.

--- a/docs/decbench/triage-ghidra/O2-noinline-openssh-portable-ssh-kex_choose_conf.md
+++ b/docs/decbench/triage-ghidra/O2-noinline-openssh-portable-ssh-kex_choose_conf.md
@@ -1,0 +1,128 @@
+---
+case_id: O2-noinline-openssh-portable-ssh-kex_choose_conf
+status: divergence-lever
+gap_survives: true
+recorded_kuna_ged: 54
+divergence_lever: taildup
+proposed_new_option: null
+runtime_choice: true
+angr_feature: null
+---
+
+## Current kuna vs ghidra
+
+The source `kex_choose_conf` (openssh `kex.c`) is the textbook C error-cleanup idiom:
+seven `goto out;` early-exits, all converging on ONE shared epilogue
+
+```c
+ out:
+	kex_prop_free(my);
+	kex_prop_free(peer);
+	return r;
+```
+
+Ghidra reproduces this *exactly* (GED 0): every early exit is `goto LAB_0019a6c7;` and
+`LAB_0019a6c7:` is the single shared cleanup (`FUN_0019a160(local_98); FUN_0019a160(puVar11);
+return`). Counts: **217 LOC, 5 gotos, 7 labels, 2 returns** (the 2nd return is the
+`__stack_chk_fail` tail).
+
+Current kuna (DEFAULT, `taildup` ON) — the `taildup` divergence DUPLICATES that shared
+return-tail at each early-exit site instead of jumping to it. Result: **0 real gotos, 0
+labels, 6 returns** (204 LOC). Each exit inlines its own copy of the cleanup:
+
+```c
+            if (v6 != 0) {
+              *(void *)(v2 + 0x98) = *(void *)(v13 + (int8)v9);
+              *(void *)(v13 + (int8)v9) = 0;
+                    /* WARNING: taildup: duplicated return-call tail to remove goto */
+              sub_9a160(v20);        // <- copy 1 of the shared epilogue
+              sub_9a160(v12);
+              v6 = v14;
+              return v6;
+            }
+            ...
+              if (v6 != 0) {
+                *(void *)(v2 + 0x98) = v9[v13];
+                v9[v13] = 0;
+                sub_9a160(v20);      // <- copy 2 of the same epilogue
+                sub_9a160(v12);
+                v6 = v14;
+                return v6;
+              }
+            ...
+            if (v14 != 0) {
+              ...
+              sub_9a160(v20);        // <- copy 3 ...
+              sub_9a160(v12);
+              v6 = v14;
+              return v6;
+            }
+```
+
+The duplicated cleanup blocks are extra CFG nodes that the source (and ghidra) do not have —
+that inflation is the GED 54. kuna is here *more* linearized than ghidra, not less; the
+metric is against SOURCE, and the source is goto-shaped, so kuna's goto-removal moves it away.
+
+kuna with `--option taildup off` — restores the single shared epilogue, matching ghidra:
+**192 LOC, 4 gotos, 1 label (`label_9a6c7:`), 1 return**:
+
+```c
+            if (v6 != 0) {
+              *(void *)(v2 + 0x98) = *(void *)(v13 + (int8)v9);
+              *(void *)(v13 + (int8)v9) = 0;
+              goto label_9a6c7;
+            }
+            ...
+              if (v6 != 0) { ...; goto label_9a6c7; }
+            ...
+            if (v14 != 0) { ...; goto label_9a6c7; }
+            ...
+label_9a6c7:
+  sub_9a160(v20);
+  sub_9a160(v12);
+  v6 = v14;
+  return v6;
+}
+```
+
+This is structurally the same shape as ghidra's `LAB_0019a6c7` epilogue and the source's
+`out:` label (`branchflip`'s arm-swaps remain but are CFG-neutral for GED — same nodes/edges).
+
+## Divergence experiment
+
+| run | LOC | real gotos | labels | returns | shape vs ghidra/source |
+|---|---|---|---|---|---|
+| ghidra (target, GED 0) | 217 | 5 | 7 | 2 | shared `out:` epilogue + gotos |
+| kuna default (taildup ON) | 204 | 0 | 0 | 6 | epilogue DUPLICATED 6x (the GED 54) |
+| kuna `--option taildup off` | 192 | 4 | 1 | 1 | shared `label_9a6c7:` epilogue + gotos — MATCHES |
+
+Winning lever: **`taildup` OFF**. It alone collapses the six duplicated return-tails back
+into the single shared cleanup label + gotos, reproducing the source/ghidra structure.
+`branchflip` warnings persist but only swap if/else arms (no node/edge change → not the GED
+driver); no other lever was needed.
+
+## Analysis / runtime-choice verdict
+
+Root cause: kuna's default-on `taildup` (angr/SAILR-derived tail duplication — "duplicated
+return-call tail to remove goto"). It rewrites a shared bare-return epilogue reached from many
+predecessors into a private copy per predecessor, eliminating the `goto`. This is genuinely
+the better majority choice for angr-style output: goto-free, linear code reads cleaner on the
+bulk of functions, which is exactly why we turned it on by default (DIV/[[kuna-default-on-sweep]]).
+
+But this function is the canonical counter-shape: a C error-handling body where every failure
+check does `goto out;` into ONE cleanup+return (the `kex_prop_free(my); kex_prop_free(peer);
+return r;` free-chain). Ghidra keeps that epilogue merged and therefore matches the source CFG
+exactly (GED 0); kuna's tail duplication forks it into six copies and pays GED 54 for extra,
+source-absent cleanup nodes.
+
+This is a RUNTIME CHOICE, not a bug: ghidra's form is recoverable today via `--option taildup
+off`, and `taildup` stays default-on because it wins on the majority (goto-free linearization).
+Source-shape signal telling an agent to flip it off: the function has multiple early-exit
+error checks that all free/dispose the same locals and `return` (a shared cleanup / free-chain
+epilogue with many predecessors — the `goto out;` idiom). On that shape, keeping the epilogue
+merged (`taildup off`) matches source and ghidra; on ordinary functions leave it on.
+
+(Thematically this is the same target the pending `returndup` angr feature would auto-detect —
+"shared bare-epilogue return kept merged; dispose/free-chain shape" — but no pending feature is
+required here: the existing `taildup` lever already closes the gap, so this is filed as a
+divergence-lever, not angr-feature-pending.)

--- a/docs/decbench/triage-ghidra/O2-noinline-openssh-portable-ssh-keygen-try_read_key.md
+++ b/docs/decbench/triage-ghidra/O2-noinline-openssh-portable-ssh-keygen-try_read_key.md
@@ -1,0 +1,71 @@
+---
+case_id: O2-noinline-openssh-portable-ssh-keygen-try_read_key
+status: already-fixed
+gap_survives: false
+recorded_kuna_ged: 46
+divergence_lever: null
+proposed_new_option: null
+runtime_choice: false
+angr_feature: null
+---
+## Current kuna vs ghidra
+
+Current kuna (`decompile-all --addr 0xc4d0`, F1 listing default ON) — body 12 lines, 2 ifs, 0 gotos, 0 labels, 0 loops, 0 switch:
+
+```c
+int8 sub_c4d0(unsigned long a0)
+{
+  int8 v1; // rax
+
+  v1 = sub_22ca0(0xe);
+  if (v1 == 0) {
+                    /* WARNING: Subroutine does not return */
+    sub_3b8d0("ssh-keygen.c","try_read_key",0x379,0,1,0);
+  }
+  if (sub_27180(v1,a0) == 0) {
+    return v1;
+  }
+  sub_22830(v1);
+  return 0;
+}
+```
+
+Ghidra — body 12 lines, 2 ifs, 0 gotos, 0 labels, 0 loops, 0 switch:
+
+```c
+long try_read_key(undefined8 param_1)
+{
+  int iVar1;
+  long lVar2;
+
+  lVar2 = FUN_00122ca0(0xe);
+  if (lVar2 == 0) {
+                    /* WARNING: Subroutine does not return */
+    FUN_0013b8d0("ssh-keygen.c","try_read_key",0x379,0,1,0,"sshkey_new failed",0);
+  }
+  iVar1 = FUN_00127180(lVar2,param_1);
+  if (iVar1 == 0) {
+    return lVar2;
+  }
+  FUN_00122830(lVar2);
+  return 0;
+}
+```
+
+Source (`ssh-keygen.i:22243`) is the same three-block shape: `sshkey_new` → `if NULL sshfatal()` (noreturn) → `if (sshkey_read()==0) return ret` → `sshkey_free; return NULL`.
+
+Structurally the two are identical. The only nits are cosmetic: ghidra materializes the `sub_27180` result into `iVar1` before the `if` (kuna inlines the call into the condition), and kuna prints 6 of the 8 `sshfatal` args. Both emit the "Subroutine does not return" warning on the fatal call. Current-kuna GED to source is ~0, not 46.
+
+## Divergence experiment
+
+The recorded GED-46 came from the OLD benchmark kuna 0.1.0, which ran `decompile-all` WITHOUT the listing enabled, so `noreturn_propagate` could not conclude `sub_3b8d0` (openssh `sshfatal`) is noreturn. I reproduced that exact regression by flipping the lever OFF on current kuna:
+
+`--option noreturn_propagate off` → kuna fails to treat `sub_3b8d0` as noreturn, flow falls through the fatal call, and it swallows the *entire following function* (`hash_to_blob` @ 0xc650) into try_read_key: a ~90-line blob with a `while(true)`, `goto label_c7bc`, raw `v15[-1]=...` stack spills, `branchflip`/`tailcalljump` warnings, and dozens of stack temporaries. That inflated blob is the GED-46 output.
+
+Default ON (current) → the clean 12-line function above. No lever needs flipping to reach ghidra; the correct output IS the default.
+
+## Analysis / runtime-choice verdict
+
+Root cause: the gap was the pre-session-1 benchmark surface. `kuna decompile-all` (old) did not enable the "listing," so the `noreturn_propagate` divergence had no listing to work from and could not mark the internal `sshfatal` wrapper (`sub_3b8d0`) as no-return. Without that fact, decompilation ran off the end of `try_read_key` into `hash_to_blob`, inflating the function to GED 46.
+
+Session-1 PR **F1** (decompile-all now enables the listing so `noreturn_propagate` collapses swallowed functions) closes this. On current kuna the fatal call is correctly no-return, the function terminates at its true boundary, and the output is structurally identical to ghidra (and to source). This is not a runtime choice or a lever-flip: the default-ON `noreturn_propagate` + F1 listing is the win, and flipping the lever OFF is what re-opens the gap. Classification: already-fixed (F1). gap_survives=false.

--- a/docs/decbench/triage-ghidra/O2-noinline-openssh-portable-sshd-session_auth_agent_req.md
+++ b/docs/decbench/triage-ghidra/O2-noinline-openssh-portable-sshd-session_auth_agent_req.md
@@ -1,0 +1,128 @@
+---
+case_id: O2-noinline-openssh-portable-sshd-session_auth_agent_req
+status: angr-feature-pending
+gap_survives: true
+recorded_kuna_ged: 47
+divergence_lever: null
+proposed_new_option: null
+runtime_choice: false
+angr_feature: noreturn-robustness
+---
+
+## Current kuna vs ghidra
+
+Address confusion resolved first: ghidra loaded the image at base `0x100000`, so its
+`FUN_00186cd0` / `DAT_00223458` / `FUN_00188250` are the real `0x86cd0` / `0x123458` /
+`0x88250` (kuna's `sub_86cd0` etc.). Same functions — kuna's call-target resolution is
+correct. The `// Function: ... @ 0x2c310` marker is decbench normalizing the entry back to
+file-relative; the `FUN_*` names in the body keep the +0x100000 image base.
+
+### ghidra (clean, ~15 LOC body, 2 ifs, 0 loops, 0 gotos)
+```c
+undefined8 session_auth_agent_req(undefined8 param_1,long param_2)
+{
+  int iVar1;
+  undefined8 uVar2;
+  iVar1 = FUN_00188250();
+  if (iVar1 != 0) {
+                    /* WARNING: Subroutine does not return */
+    FUN_00186cd0(param_1,iVar1,"%s: parse packet","session_auth_agent_req");
+  }
+  if ((*(int *)(DAT_00223458 + 4) != 0) && (DAT_00223a24 != 0)) {
+    if (DAT_00225940 != 0) { return 0; }
+    DAT_00225940 = 1;
+    uVar2 = FUN_0012bfc0(param_1,*(undefined8 *)(param_2 + 0x10));
+    return uVar2;
+  }
+  FUN_0017ed20("session.c","session_auth_agent_req",0x88a,1,5,0,"agent forwarding disabled");
+  return 0;
+}
+```
+Ghidra marks the `sshpkt_fatal` call (`FUN_00186cd0`) no-return, so the `iVar1 != 0` arm
+terminates and the function ends cleanly. GED 0 vs source.
+
+### current kuna (67 LOC, 7 ifs, 3 loops, 0 gotos) — MERGED with `session_env_req`
+```c
+unsigned long sub_2c310(unsigned long a0,int8 a1)
+{
+  ...
+  v1 = sub_88250();
+  if (v1 == 0) {
+    if ((*(int4 *)(dat_123458 + 4) != 0) && (dat_123a24 != 0)) {
+      if (dat_125940 == 0) {
+        v4 = *(void *)(a1 + 0x10);
+        dat_125940 = 1;
+        return sub_2bfc0(a0,v4);          /* tailcalljump */
+      }
+      return 0;
+    }
+    v11 = 0x2c414;
+    sub_7ed20("session.c","session_auth_agent_req",0x88a,1,5,0);
+    return 0;
+  }
+  ...
+  sub_86cd0(a0,v6,"%s: parse packet","session_auth_agent_req");  /* NOT treated no-return */
+  v9 = *(void *)(v7 + 0x28);              /* <-- falls through into session_env_req body */
+  ...                                     /* env-var loop, sub_7f0f0, sub_8e8d0 ... */
+  sub_7ed20("session.c","session_env_req",v4,0,6,0);
+  free(v8);
+  free(v5);
+  return 0;
+  ...
+  sub_86cd0(v4,v2,"%s: parse packet","session_env_req");
+                    /* WARNING: Subroutine does not return */
+  __stack_chk_fail();
+}
+```
+The whole body of `session_env_req` (@0x2c4e0) — the `SSH_ENV`/`accept_env` loop,
+`free(v8)`, `free(v5)`, `__stack_chk_fail()` — is swallowed into `sub_2c310`. 67 vs ~15
+lines; that inflation is the GED 47.
+
+## Divergence experiment
+
+The symptom is a no-return overrun / adjacent-function merge. Tested the two relevant
+default-on levers with a single `--addr 0x2c310` decompile:
+
+| lever flipped OFF | LOC | still merged (`session_env_req` present)? |
+|---|---|---|
+| (default, all on) | 67 | yes |
+| `noreturn_propagate off` | 67 | yes |
+| `noreturn_extern off` | 67 | yes |
+
+**No lever closes the gap** — and it can't. All 19 levers are default-*on* angr features;
+flipping one *off* can only remove behavior, never *add* a no-return conclusion. `noreturn_extern`
+/ `noreturn_externmatch` apply to UND/PLT externs — this is an *internal* fatal wrapper.
+`noreturn_propagate` propagates a conclusion but requires the callee to be concluded no-return
+first, which is exactly the step that fails here. Winning lever: **none**.
+
+## Analysis / runtime-choice verdict
+
+Root cause is a **cascading internal no-return recognition failure**, three deep:
+
+1. `0x869f0` (the `fatal`/`sshfatal` core) has **zero `ret`** in `0x869f0..0x86cd0`. It ends
+   in `notrack jmp *%rax` (0x86a6e — an indirect tail-jump into a cleanup/`cleanup_exit`→`_exit`
+   handler) and contains a backward loop (`jmp 86aea`). It is genuinely no-return, but its
+   terminator is an **indirect jump**, not a `ret` and not a `call` to a syntactically-known
+   noreturn (`exit`/`abort`). Kuna's noreturn detector doesn't conclude no-return through the
+   indirect tail-jump, so `sub_869f0` is left as returning.
+2. `0x86cd0` = `sshpkt_fatal` (variadic: reg-saves + va_list, then `call 869f0` at 0x86d60
+   with NOP padding, no `ret`). Because kuna thinks `sub_869f0` returns, `sub_86cd0` "falls
+   through" the NOP pad into the *next* function at `0x86d70` (a socket-write) and is
+   decompiled as a returning function — so `sub_86cd0` itself is never concluded no-return.
+3. `session_auth_agent_req`'s `sub_86cd0(...,"%s: parse packet",...)` call is therefore not
+   no-return, so the error arm doesn't terminate; flow overruns and merges the adjacent
+   `session_env_req` (@0x2c4e0). GED 47.
+
+Ghidra concludes all three no-return (it resolves the indirect tail-jump / reach analysis),
+gets GED 0. This is **not** a runtime choice and **not** a divergence: kuna's default output
+is simply missing analysis ghidra has — but it maps exactly to a known, enumerated pending
+session-2 angr feature, `noreturn-robustness` ("internal no-return wrapper still not concluded
+no-return even with listing on — looping/cold-tail/reach cases"). The tell here is the
+*indirect tail-jump + backward loop with no `ret`* terminator of the fatal core. Once kuna's
+noreturn analysis is robust to that shape, `sub_869f0`→`sub_86cd0`→`session_auth_agent_req`
+all conclude no-return (with `noreturn_propagate`, on by default under F1's listing) and the
+`session_env_req` merge collapses, converging to ghidra's ~15-line form.
+
+Not `genuine-bug`: a specific pending feature (`noreturn-robustness`) covers it, rather than
+"no divergence explains it." Not a metric-artifact: the source CFG is real and the inflation
+is a true structural over-extension, not a rendering/`!= 0` artifact.

--- a/docs/decbench/triage-ghidra/O2-noinline-openssh-portable-sshd-session_close_single_x11.md
+++ b/docs/decbench/triage-ghidra/O2-noinline-openssh-portable-sshd-session_close_single_x11.md
@@ -1,0 +1,121 @@
+---
+case_id: O2-noinline-openssh-portable-sshd-session_close_single_x11
+status: angr-feature-pending
+gap_survives: true
+recorded_kuna_ged: 58
+divergence_lever: null
+proposed_new_option: null
+runtime_choice: false
+angr_feature: noreturn-robustness
+---
+
+## Current kuna vs ghidra
+
+The GED-58 gap **survives on current kuna** (F1 listing default on, `noreturn_propagate`
+default on). kuna's `session_close_single_x11` is the correct ghidra body **plus the entire
+next function `session_tty_list @ 0x2d420` swallowed onto its tail**. The swallow is
+byte-for-byte identical to ghidra's standalone `session_tty_list` (the `DAT_00225540` /
+`strncmp("/dev/",..)` / `strrchr` / `notty` block).
+
+Ghidra (`session_close_single_x11 @ 0x2d200`, ~44 LOC, 1 `if`, 1 `while`, 0 gotos):
+
+```c
+undefined8 session_close_single_x11(undefined8 param_1,ulong param_2)
+{
+  ...
+  lVar2 = FUN_0012aa90(param_2 & 0xffffffff);
+  if (lVar2 == 0) {
+                    /* WARNING: Subroutine does not return */
+    FUN_0017a7b0("session.c","session_close_single_x11",0x92a,1,1,0,"no x11 channel %d",
+                 param_2 & 0xffffffff);          // <-- sshfatal, concluded NO-RETURN -> flow stops
+  }
+  __ptr = *(int **)(lVar2 + 0xc0);
+  ...                                            // loop + free-chain
+  free(*(void **)(lVar2 + 0xa0));
+  *(undefined8 *)(lVar2 + 0xa0) = 0;
+  return 0;
+}                                                // <-- function ENDS here; 0x2d420 is a new fn
+```
+
+Current kuna (`sub_2d200`, ~66-75 LOC, extra `do/while` + 3 extra `if`, 1 branchflip):
+
+```c
+unsigned long sub_2d200(unsigned long a0,int4 a1)
+{
+  ...
+  v3 = sub_2aa90(a1);
+  if (v3 != 0) {                                 // ghidra's guard, branch-flipped
+    ...                                          // loop + free-chain  (CORRECT)
+    return 0;
+  }
+  sub_7a7b0("session.c","session_close_single_x11",0x92a,1,1,0);  // sshfatal -- NOT no-return
+  v2 = 0;                                        // <-- FALL-THROUGH into session_tty_list
+  v6 = '\0';
+  dat_125540 = '\0';
+  if (0 < dat_125970) {                          // ---- all of this is session_tty_list @0x2d420
+    do {
+      ... strncmp((char*)v1,"/dev/",5) ... strrchr ...
+    } while (v2 < dat_125970);
+    if (v6 != '\0') { return 0x125540; }
+  }
+  sub_c9bb0(0x125540,0xd6c49,0x400);
+  return 0x125540;
+}
+```
+
+(Note also: kuna's decl list is missing `v5` although `v5` is used throughout — a cosmetic
+`dedupvardecls` artifact, secondary to the swallow.)
+
+## Divergence experiment
+
+The symptom is a no-return overrun (cold `fatal` path falls through and merges the next
+function), so I flipped the noreturn / call-tail levers OFF. **None closes the gap** —
+`session_tty_list` is still swallowed in every variant:
+
+| lever flipped off | swallow gone? | LOC |
+|---|---|---|
+| `noreturn_propagate` off | no | ~70 |
+| `noreturn_extern` off | no | 75 |
+| `noreturn_externmatch` off | no | 75 |
+| `foldcallret` off | no | 77 |
+| `tailcalljump` off | no | 75 |
+
+This is expected: the defect is a **missing no-return conclusion**, not an over-eager
+default-on transform. Levers flipped OFF only *revert* transforms; they cannot *add* the
+no-return fact that would terminate the flow. So the winning lever is **none**.
+
+## Analysis / runtime-choice verdict
+
+Root cause is a **transitive internal-no-return chain that kuna never concludes**, verified
+against the raw bytes (`objdump`):
+
+- `_exit@plt` (0xcbf0) — known no-return leaf.
+- `cleanup_exit` (0x12e40) — every path ends in `call _exit@plt` (0x12e92), with a
+  `jmp 12e90` retry loop around it; it never returns.
+- `sshfatal` (0x7a7b0) — saves varargs, `call 7eaa0` (do_log), `call 12e40`
+  (cleanup_exit), then **no `ret`** — just `nopl` padding and the next function's `endbr64`.
+  No-return because it tail-calls cleanup_exit.
+- `session_close_single_x11` (0x2d200) — calls `sshfatal` in the "no x11 channel" cold
+  path; the flow should terminate there.
+
+Ghidra walks this chain (`_exit` -> `cleanup_exit` -> `sshfatal`) and prints
+`WARNING: Subroutine does not return` at the call site, so it ends the function at
+`return 0` and `session_tty_list @ 0x2d420` becomes its own function. kuna, even with
+F1's listing enabled and `noreturn_propagate` default-on, does **not** conclude
+`cleanup_exit`/`sshfatal` are no-return, so it decodes straight through the `call sshfatal`
+into 0x2d420's bytes and merges the two functions — inflating the GED by 58.
+
+The same bug recurses one level down and is directly observable: kuna's own decode of
+`sub_7a7b0` (sshfatal) *itself* swallows `record_hostkey @ 0x7a850` after its
+`call cleanup_exit`, for the identical reason. So the failing analysis is the intermediate
+wrapper `cleanup_exit` (0x12e40): its no-return-ness requires reasoning that **all** paths
+end in `_exit@plt` despite a back-edge loop (`jmp 12e90`) and cold error-handling tail. That
+is exactly the pending **noreturn-robustness** shape ("internal no-return wrapper still not
+concluded no-return even with listing on — looping / cold-tail / reach cases").
+
+Not a runtime choice and not a divergence-lever case: kuna is uniquely worse here purely
+because an upstream/robustness analysis is incomplete, and no default-off flip would recover
+ghidra's form (you cannot toggle *on* a conclusion the analysis never reached). The fix is
+strengthening kuna's no-return conclusion to be transitive through wrappers whose only
+exit is a call to a no-return function even in the presence of a loop-back / cold tail — the
+`noreturn-robustness` session-2 angr feature. Until then the gap stands.

--- a/docs/decbench/triage-ghidra/O2-noinline-openssh-portable-sshd-sshd_hostkey_sign.md
+++ b/docs/decbench/triage-ghidra/O2-noinline-openssh-portable-sshd-sshd_hostkey_sign.md
@@ -1,0 +1,138 @@
+---
+case_id: O2-noinline-openssh-portable-sshd-sshd_hostkey_sign
+status: angr-feature-pending
+gap_survives: true
+recorded_kuna_ged: 73
+divergence_lever: null
+proposed_new_option: null
+runtime_choice: false
+angr_feature: noreturn-robustness
+---
+
+## Current kuna vs ghidra
+
+Ghidra: clean ~45 LOC. It concludes the internal log-and-die wrapper `FUN_0017a7b0`
+(= source `sshfatal`) is no-return — every call site carries
+`/* WARNING: Subroutine does not return */` — so each of the four branches terminates and
+the function ends at `return 0`.
+
+```c
+undefined8
+sshd_hostkey_sign(long param_1,long param_2,undefined8 param_3, ... )
+{
+  undefined4 uVar1;
+  int iVar2;
+  undefined8 uVar3;
+
+  uVar1 = *(undefined4 *)(param_1 + 0x83c);
+  if (DAT_00223018 == 0) {
+    if (param_2 == 0) {
+      iVar2 = FUN_001648a0(DAT_00223024,param_3,param_4,param_5,param_6,param_7,param_8);
+      if (iVar2 != 0) {
+        uVar3 = FUN_00150a60(iVar2);
+                    /* WARNING: Subroutine does not return */
+        FUN_0017a7b0("sshd.c","sshd_hostkey_sign",0x93d,1,1,uVar3,"agent sign failed",uVar3);
+      }
+    }
+    else {
+      iVar2 = FUN_0015ddd0(param_2, ... ,uVar1);
+      if (iVar2 < 0) {
+                    /* WARNING: Subroutine does not return */
+        FUN_0017a7b0("sshd.c","sshd_hostkey_sign",0x938,1,1,0,"privkey sign failed",param_4);
+      }
+    }
+  }
+  else if (param_2 == 0) {
+    iVar2 = FUN_0013f110(param_1,param_3, ... ,uVar1);
+    if (iVar2 < 0) {
+                    /* WARNING: Subroutine does not return */
+      FUN_0017a7b0("sshd.c","sshd_hostkey_sign",0x932,1,1,0,"pubkey sign failed",param_1);
+    }
+  }
+  else {
+    iVar2 = FUN_0013f110(param_1,param_2, ... ,uVar1);
+    if (iVar2 < 0) {
+                    /* WARNING: Subroutine does not return */
+      FUN_0017a7b0("sshd.c","sshd_hostkey_sign",0x92d,1,1,0,"privkey sign failed",param_6);
+    }
+  }
+  return 0;
+}
+```
+
+kuna (current main, `decompile-all --addr 0x11230`, F1 listing default-ON): **153 LOC, 3 gotos,
+3 labels**, and it *overruns the function boundary* — `sub_7a7b0` (the same `sshfatal` wrapper)
+is treated as **returning**, so control falls through past every fatal call into the adjacent
+function's body (`check_ip_options` @ 0x11490): `getpeername`/`getsockopt`, a `__snprintf_chk`
+loop, the `"Connection from %.100s ..."` string, and a trailing `__stack_chk_fail()`. The tail
+references undeclared locals (`v5`, `v13`, `v14`, `v15`, `v16`, `v19`) — invalid C.
+
+```c
+uint8 sub_11230(int8 a0,char *a1, ... )
+{
+  ... 20+ locals ...
+  v4 = (uint8)*(uint4 *)(a0 + 0x83c);
+    /* WARNING: branchflip: flipped negated guard for linearity ... */
+  if (dat_123018 != 0) {
+    ...
+      v4 = sub_7a7b0("sshd.c","sshd_hostkey_sign",0x92d,1,1,0);
+      goto label_112d0;              // <-- sshfatal treated as RETURNING
+    ...
+    v4 = sub_7a7b0("sshd.c","sshd_hostkey_sign",0x932,1,1,0);
+label_113f0:
+    *(uint8 *)((int8)v9 + -8) = v4;  // falls through into next function's frame setup
+    ...
+  }
+  ...
+  sub_7a7b0("sshd.c","check_ip_options",0x5a0,0,1,0);   // <-- spilled into check_ip_options
+  goto label_11668;
+  ...
+  v3 = getpeername(v3,&v10[-0x408],&v10[-0x40c]);        // <-- adjacent function body
+  ...
+label_11668:
+    /* WARNING: Subroutine does not return */
+  *(void *)&v11[-8] = 0x1166d;
+  __stack_chk_fail();
+}
+```
+
+Source (O0 `sshd.i`, `sshd_hostkey_sign`): four branches, each ending in `sshfatal(...)` on the
+error path, then `return 0`. `sshfatal` is a no-return log-and-die wrapper (logs, then
+`cleanup_exit`/`exit`).
+
+## Divergence experiment
+
+The symptom is a **no-return overrun** (a no-return call rendered as returning), so the only
+relevant levers are the ones that *add* no-return knowledge; flipping them OFF can only make the
+overrun worse or leave it unchanged.
+
+- `--option noreturn_propagate off`  ->  **153 LOC, identical overrun.** No change: kuna never
+  concluded `sub_7a7b0` no-return in the first place, so turning propagation off does nothing.
+- No `--option X off` among the 19 default-ON divergences reduces the gap — the fix is *more*
+  no-return knowledge, not reverting a divergence. `branchflip` fires cosmetically at the top
+  but is orthogonal to the overrun.
+
+Winning lever: **none.** The F1 listing default is already ON in `decompile-all` (that is the
+benchmark surface here), yet the gap survives it.
+
+## Analysis / runtime-choice verdict
+
+Root cause: kuna fails to conclude the **internal** function `sub_7a7b0` (= `sshfatal`,
+FUN_0017a7b0) is no-return. `sshfatal` is a multi-level wrapper — it logs and then reaches
+`cleanup_exit`/`exit`, so its no-return-ness must be discovered by analyzing `sshfatal` (and the
+`cleanup_exit` it tail-calls) and propagating. Ghidra's flow analysis reaches that conclusion and
+marks every call site "Subroutine does not return"; kuna's analysis does not, even with the
+listing enabled and `noreturn_propagate` default-ON. Because the four `sshfatal` calls are then
+treated as returning, control falls straight through the function epilogue into the next
+function's body (`check_ip_options` @ 0x11490), producing the 153-line invalid-C overrun that
+scores GED 73 against ghidra's 45-line 0.
+
+This is not a divergence-lever case: no default-ON angr option, flipped OFF, recovers ghidra's
+shape — flipping the no-return levers off leaves the overrun byte-identical. It is not a
+metric-artifact: the source CFG is a real four-branch tree and kuna's output is genuinely wrong
+(undeclared variables, wrong function boundary). It is not a plain default-fixable bug in the
+usual sense either — it is exactly the gap the pending session-2 **`noreturn-robustness`** angr
+feature targets: *"internal no-return wrapper still not concluded no-return even with listing on"*
+(the reach/cold-tail/multi-level-wrapper case). Once kuna robustly concludes internal
+log-fatal wrappers like `sshfatal` are no-return, `noreturn_propagate` (already default-ON) will
+collapse each branch and the overrun disappears, converging on ghidra's form.

--- a/docs/decbench/triage-ghidra/O2-openssh-portable-ssh-keyscan-sshfatal.md
+++ b/docs/decbench/triage-ghidra/O2-openssh-portable-ssh-keyscan-sshfatal.md
@@ -1,0 +1,75 @@
+---
+case_id: O2-openssh-portable-ssh-keyscan-sshfatal
+status: already-fixed
+gap_survives: false
+recorded_kuna_ged: 132
+divergence_lever: null
+proposed_new_option: null
+runtime_choice: false
+angr_feature: null
+---
+## Current kuna vs ghidra
+
+Current kuna (`decompile-all --addr 0x9d00`, F1 listing default ON):
+```c
+void sub_9d00(void)
+
+{
+  unsigned long v1; // stack + 0x8
+  
+  sub_28100();
+                    /* WARNING: Subroutine does not return */
+  sub_239f0(0xff);
+}
+```
+LOC 5, gotos 0, ifs 0, loops 0, switches 0, calls 2, one "does not return" warning.
+
+Ghidra:
+```c
+void sshfatal(void)
+
+{
+  FUN_00128100();
+                    /* WARNING: Subroutine does not return */
+  FUN_001239f0(0xff);
+}
+```
+LOC 4, gotos 0, ifs 0, loops 0, switches 0, calls 2, one "does not return" warning.
+
+The two are structurally identical: `sshlogv`-equivalent call, then the noreturn
+`cleanup_exit(255)` (`sub_239f0(0xff)` / `FUN_001239f0(0xff)`) tail-called after the
+`/* WARNING: Subroutine does not return */` comment. Function/callee names differ only in
+symbolication (`sub_*` vs `FUN_*`), which GED normalizes. The one residual delta is kuna's
+extra unused `unsigned long v1; // stack + 0x8` declaration (a spurious stack slot) — worth
+~1 GED node, nowhere near 132. Effective current GED ≈ 0–2.
+
+## Divergence experiment
+
+This case is already-fixed, so no lever needed to *close* the gap — but I ran the reverse to
+confirm the mechanism. Flipping the F1 default off (`--option noreturn_propagate off`)
+re-opens the entire gap: kuna stops treating `sub_239f0` as no-return, falls through past the
+`cleanup_exit(255)` tail, and swallows the *following* functions (`confree`, `keyprint_one`,
+…) into one giant body — ~150 LOC, multiple nested `if`/`else`, a `while (strsep(...))` loop,
+two `tailcalljump` recovered tail-calls, and even a bogus recursive `sub_9d00(...)` call. That
+inflated shape is precisely what the OLD kuna 0.1.0 emitted and what scored the recorded
+GED 132.
+
+- `noreturn_propagate off` -> reverts to the 150-LOC swallowed body (reproduces the old gap).
+- default (`noreturn_propagate on` via F1 listing) -> the 5-LOC body matching ghidra.
+
+No *other* lever is relevant; this is a single-mechanism case.
+
+## Analysis / runtime-choice verdict
+
+Root cause: the recorded 132 was produced by pre-session-1 kuna 0.1.0, where `decompile-all`
+did NOT enable the "listing" and therefore `noreturn_propagate` never concluded that
+`sub_239f0` (`cleanup_exit`, invoked with `0xff` = exit status 255) does not return. Without
+that fact the flow-follower ran off the end of the function and merged the adjacent code
+(`confree` and friends) into `sshfatal`, exploding the node count.
+
+Session-1's **F1** change (decompile-all now enables the listing, so `noreturn_propagate` fires
+on the benchmark surface) closes this: the no-return conclusion truncates the body right after
+the tail call, and kuna now emits the same two-call stub as ghidra, with the same
+"Subroutine does not return" annotation. This is a clean **already-fixed** case — the gap does
+not survive on current main. Not a runtime choice and not a bug; the only remaining nit is a
+harmless extra unused local declaration that does not move the metric meaningfully.

--- a/docs/decbench/triage-ghidra/O2-tar-tar-simple_flush_write.md
+++ b/docs/decbench/triage-ghidra/O2-tar-tar-simple_flush_write.md
@@ -1,0 +1,130 @@
+---
+case_id: O2-tar-tar-simple_flush_write
+status: angr-feature-pending
+gap_survives: true
+recorded_kuna_ged: 59
+divergence_lever: null
+proposed_new_option: null
+runtime_choice: false
+angr_feature: noreturn-robustness
+---
+
+## Source (buffer.c:1851, GED oracle)
+
+```c
+static void
+simple_flush_write (size_t level __attribute__((unused)))
+{
+  ssize_t status;
+  status = _flush_write ();
+  if (status != record_size)
+    archive_write_error (status);      /* noreturn: loops forever */
+  else
+    { records_written++; bytes_written += status; }
+}
+```
+
+`archive_write_error` (sub_da70 @ 0xda70) is genuinely no-return — it contains an
+unconditional infinite loop and never falls off the end:
+
+```c
+void sub_da70(unsigned long a0) {
+  if (dat_82a69 != '\0') goto label_da9d;
+  do {
+    sub_da10(*dat_82828,a0,dat_82b98);
+label_da9d:
+    v2 = (void *)__errno_location(); v1 = *v2;
+    sub_cc30(); *v2 = v1;
+  } while( true );          // <- no exit edge: noreturn
+}
+```
+
+## Current kuna vs ghidra
+
+Ghidra (13 LOC, 0 gotos, 1 if, 0 loops) — concludes sub_da70 is no-return and truncates,
+matching the source exactly (GED 0):
+
+```c
+void simple_flush_write(void)
+{
+  long lVar1;
+  lVar1 = FUN_0010c180();                       // _flush_write()
+  if (DAT_00182b98 == lVar1) {                  // status == record_size
+    DAT_00181f30 = DAT_00181f30 + 1;            // records_written++
+    DAT_001821a0 = (double)lVar1 + DAT_001821a0;// bytes_written += status
+    return;
+  }
+                    /* WARNING: Subroutine does not return */
+  FUN_0010da70(lVar1);                          // archive_write_error(status) [noreturn]
+}
+```
+
+Current kuna (80 LOC, 2 gotos, 3 labels, 13 ifs, 1 loop) — does NOT conclude sub_da70 is
+no-return, so it treats the call as returning and the decoder falls through the call site
+straight into the next function's bytes (the fopen / __isoc99_fscanf /
+"contains invalid volume number" body of `_gnu_flush_write`), inflating the function:
+
+```c
+void sub_dac0(void)
+{
+  ...
+  v2 = sub_c180();
+  if (dat_82b98 == v2) {
+    dat_81f30 = dat_81f30 + 1;
+    dat_821a0 = (float8)v2 + dat_821a0;
+    return;
+  }
+  sub_da70();                 // <- treated as RETURNING; should end the function here
+  sub_10cf0();                // <- fall-through garbage: bytes of the NEXT function
+  dat_82164 = 0;
+  if (dat_81f20 == '\0') goto label_db3c;
+  if (dat_82170 == 0) goto label_db3c;
+  ...
+  v3 = fopen(dat_82a48,"r");
+  if ((__isoc99_fscanf(v3,0x669e4,0x7f010) != 1) || (dat_7f010 < 0)) {
+    ...
+    error(0,0,dcgettext(0,"%s: contains invalid volume number",5),v4);
+    sub_16fd0();
+  }
+  ... (~55 more lines of unrelated body) ...
+}
+```
+
+## Divergence experiment
+
+The symptom is a no-return over-run (decoder falls through a call that never returns), so I
+flipped every no-return-related default-ON lever OFF. None collapse the blob; the
+`sub_10cf0`/fopen fall-through survives every time:
+
+| lever off            | LOC | collapsed? |
+|----------------------|-----|-----------|
+| (default, all on)    | 80  | no        |
+| noreturn_propagate   | 79  | no        |
+| noreturn_extern      | 80  | no        |
+| noreturn_externmatch | 80  | no        |
+| tailcalljump         | 160 | no (worse)|
+
+Winning lever: **none.** This gap is not caused by a default-ON divergence being *too
+aggressive* — it is the opposite. The fix requires kuna to conclude MORE no-return facts,
+which no OFF flip can provide.
+
+## Analysis / verdict
+
+Root cause: kuna's internal-function no-return analysis fails to conclude that
+`archive_write_error` (sub_da70) is no-return. That function is no-return because it contains
+an **unconditional infinite loop** (`do { … } while(true)` with no break/return edge), not
+because it tail-calls a known-no-return extern like `exit`/`abort`. Kuna concludes no-return
+for functions that reach a known-no-return *sink*; the "loops forever / cold tail with no
+return edge" case is not caught. Because the fact is never established, `noreturn_propagate`
+(default-on, and the F1 listing IS enabled on this `decompile-all` surface) has nothing to
+propagate — the call to sub_da70 is modeled as returning, the decoder continues past the
+call into the adjacent function's bytes, and the function balloons from ghidra's 13 LOC to
+80 LOC (GED 59).
+
+This is precisely the `noreturn-robustness` angr-feature bucket: an internal no-return
+wrapper still not concluded no-return even with the listing on — specifically the *looping*
+sub-case. It is not a runtime choice (kuna is unambiguously worse than ghidra here and there
+is no shape where the fall-through is desirable), and it is not toggled by any existing
+option. The pending session-2 no-return-robustness work (detect functions with no return
+edge — infinite-loop tails, all-paths-reach-noreturn — and mark them no-return so
+noreturn_propagate can truncate the caller) closes this case. gap_survives = true.


### PR DESCRIPTION
Docs-only. The ghidra-beats-kuna half of the decbench campaign, plus the **runtime-choice registry** — the deliverable for "find where a choice must be made at runtime, document it, make it agent-flippable."

## What

Since kuna **is** a line-faithful Ghidra port, ghidra scoring a perfect GED 0 while kuna doesn't means kuna has *diverged*. I sampled the 152 ghidra-perfect-vs-kuna cases (14 across the top margins), and each triage ran the **`--option X off` divergence-revert experiment** against *current* (post-session-1) kuna to isolate the cause. Tally:

| bucket | n | meaning |
|---|---|---|
| already-fixed | 5 | closed by session-1 (F1 listing default / #120 / #122) — the benchmark ran the old kuna 0.1.0 |
| noreturn-robustness (F2) | 5 | internal fatal wrappers not concluded no-return: `error(nonzero,…)`, transitive `sshfatal`, infinite-loop `archive_write_error` |
| **runtime-choice lever** | 1 | `kex_choose_conf` → **`taildup`**: flip off for shared free-chain cleanup epilogues; taildup wins on the majority so it stays default-on |
| genuine bug | 1 | `overwrite_database` → `regionstructure` folds a nested-`if` loop body into the `while`-condition → **invalid C**, a residual of #122 (follow-up F7) |
| metric-artifact | 2 | `compspec_dispose`/`dispose_variable` — K&R old-style defs degenerate Joern's source CFG; decbench #6's `GED_MIN_SOURCE_NODES` excludes these next run |

## `docs/decbench/runtime-choices.md` — the registry

Documents each divergence where **both renderings are valid** and the choice is a genuine per-source-shape tradeoff: the default, when to flip, and the **source-shape signal** an agent keys on. Covers **`taildup`** (the shipped lever found here), **`iteregion`** + **`cstyle-null-cmp`** (the F5/F6 flippables), and the speed-gated opt-ins (`switchguardbound`, `unrolledguard`). Plus a **"not runtime choices"** section (the regionstructure bug) so the divergence experiment never mis-files a bug as a choice, and a benchmark-caveat note on the K&R Joern artifacts.

This is the machine-readable-adjacent companion to `kuna catalog --json`: an agent reads the catalog for options, and this registry for *when* to flip them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J