### PR TITLE
kuna-cli: default funcstart_patterns ON for non-x86-64 (ARM Cortex-M function discovery, DIV-20)

### DIFF
--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -42,6 +42,7 @@ use std::rc::Rc;
 
 use kuna_base::address::Address;
 use kuna_console::engine::{bootstrap_from_object, ConsoleProgram};
+use object::Object; // `File::architecture()` (ARM-discovery default, decbench)
 use kuna_decomp::decompile_drive::{
     decompile_func_full_with_override_dyn, extract_variables, print_c, VarInfo,
 };
@@ -301,6 +302,32 @@ fn load_program(args: &Args, default_listing: bool) -> Result<ConsoleProgram, St
         prog.arch_mut()
             .set_kuna_option("listing", "on")
             .map_err(|e| format!("option listing: {}", e.explain()))?;
+    }
+
+    // (kuna, decbench ARM) Oracle 5 — the always-on prologue-pattern scan folded into
+    // function discovery — is x86-64-only, so on a STRIPPED **non-x86-64** binary the ELF
+    // entry point is the ONLY discovered function (ARM Cortex-M `betaflight`: 1 of ~469;
+    // it has no recursive-descent Listing sweep at the analyzer tier).  The
+    // `funcstart_patterns` pass IS the primary discovery source there — it applies the
+    // full ARM/AArch64/MIPS/PPC/RISC-V `<patternpairs>` (pre/post) prologue matcher over
+    // the code — so default it ON for non-x86-64 on the `decompile-all` surface (the
+    // benchmark/LLM path), unless the caller named it explicitly.  x86-64 keeps it OFF
+    // (oracle 5 + the entry oracles suffice, and the aggressive scan can over-produce
+    // there); only this driver changes, the engine default
+    // (`analysis_funcstart_patterns = false`) and the console/datatest surfaces are
+    // untouched.  See DIV-20 (`docs/divergences.md`).
+    if default_listing && !args.options.iter().any(|(name, _)| name == "funcstart_patterns") {
+        let non_x86_64 = std::fs::read(&binary)
+            .ok()
+            .and_then(|b| {
+                object::File::parse(&*b).ok().map(|f| f.architecture() != object::Architecture::X86_64)
+            })
+            .unwrap_or(false);
+        if non_x86_64 {
+            prog.arch_mut()
+                .set_kuna_option("funcstart_patterns", "on")
+                .map_err(|e| format!("option funcstart_patterns: {}", e.explain()))?;
+        }
     }
 
     // Analysis-/printer-tier `--option`s must be applied to the architecture

--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -37,6 +37,22 @@ fn specs() -> String {
     repo_root().join("specs").to_str().unwrap().to_string()
 }
 
+/// A small **ARM 32-bit** (Thumb) ELF fixture — the non-x86-64 discovery surface
+/// where `decompile-all` defaults `funcstart_patterns` ON (DIV-20).
+fn arm_thumb() -> String {
+    repo_root()
+        .join("decompiler/crates/kuna-analysis/tests/fixtures/arm_thumb_linked_le32")
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Parse the `"count": N` field out of the decompile-all `--json` header.
+fn json_count(stdout: &str) -> Option<usize> {
+    let i = stdout.find("\"count\":")? + "\"count\":".len();
+    stdout[i..].trim_start().split(|c: char| !c.is_ascii_digit()).next()?.parse().ok()
+}
+
 /// Run the built `kuna` binary, returning `(stdout, stderr, success)`.
 fn run_kuna(args: &[&str]) -> (String, String, bool) {
     let out = Command::new(env!("CARGO_BIN_EXE_kuna"))
@@ -130,6 +146,47 @@ fn decompile_all_emits_json_for_main() {
     assert!(
         stdout.contains("\"kind\": \"arg\"") && stdout.contains("\"arg_index\": 0"),
         "expected a parameter with arg_index 0:\n{stdout}"
+    );
+}
+
+/// DIV-20: on a **non-x86-64** binary, `decompile-all` defaults
+/// `funcstart_patterns` ON — the primary function-discovery source when oracle 5
+/// (the x86-64-only prologue scan) does not apply. Without it a stripped ARM binary
+/// discovers only the ELF entry; with it the prologue `<patternpairs>` matcher finds
+/// more. The default must match an explicit `--option funcstart_patterns on` and beat
+/// `off`.
+#[test]
+fn arm_decompile_all_defaults_funcstart_patterns_on() {
+    let bin = arm_thumb();
+    let sp = specs();
+    let run = |extra: &[&str]| -> Option<usize> {
+        let mut args = vec!["decompile-all", bin.as_str(), "--json", "--sleighpath", sp.as_str()];
+        args.extend_from_slice(extra);
+        let (stdout, stderr, ok) = run_kuna(&args);
+        if !ok {
+            if is_specs_skip(&stderr) {
+                return None;
+            }
+            panic!("kuna decompile-all failed on the ARM fixture: {stderr}");
+        }
+        Some(json_count(&stdout).expect("count in json"))
+    };
+    let Some(default_cnt) = run(&[]) else {
+        eprintln!("arm funcstart default: skipping (no `.sla`; run `make specs`)");
+        return;
+    };
+    let off_cnt = run(&["--option", "funcstart_patterns", "off"]).expect("second run");
+    let on_cnt = run(&["--option", "funcstart_patterns", "on"]).expect("third run");
+    // The non-x86-64 default injects the pass: it discovers strictly more than `off`,
+    // and matches the explicit `on`.
+    assert!(
+        default_cnt > off_cnt,
+        "ARM decompile-all default should discover MORE than funcstart_patterns off \
+         (default={default_cnt}, off={off_cnt}) — the DIV-20 injection did not fire"
+    );
+    assert_eq!(
+        default_cnt, on_cnt,
+        "ARM default must equal explicit `funcstart_patterns on` (default={default_cnt}, on={on_cnt})"
     );
 }
 

--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -737,3 +737,31 @@ gh558-experiment protocol: run the 204+675 upstream assertions, list every chang
   e2e gates (which stay green with the rule on). Real-binary behavior verified on the decbench
   openssh corpus (ssh_tun_confirm, sshd_hostkey_sign).
 - **Date**: 2026-07-05.
+
+## DIV-20: `decompile-all` defaults `funcstart_patterns` ON for non-x86-64 (ARM discovery)
+
+- **Flip**: the **`decompile-all` driver** (`kuna-cli/src/decompile_all.rs::load_program`)
+  now injects `option funcstart_patterns on` when the binary's architecture is **not**
+  x86-64, unless the caller names `funcstart_patterns` explicitly. A driver default, not an
+  engine default: `analysis_funcstart_patterns` still resets to `false`, and `kuna functions`,
+  `kuna decompile` (subprocess), the console, and the datatest harness are unchanged.
+- **Problem**: kuna's analyzer tier has **no disassembled Listing / recursive-descent sweep**,
+  so function discovery relies on the entry oracles + arch idioms + the always-on prologue
+  scan (**oracle 5**). Oracle 5 is **x86-64-only**. On a STRIPPED **non-x86-64** binary
+  (ARM Cortex-M firmware — the decbench `cps` project: betaflight, chibios, nuttx, u-boot, …)
+  the ELF entry point is therefore the ONLY discovered function, so the whole binary
+  decompiles to 1 function and scores as a total decompiler-failure.
+- **Fix**: the `funcstart_patterns` pass (`s1_entry::full_pattern_starts`) IS the primary
+  discovery source for these arches — it applies the full ARM/AArch64/MIPS/PPC/RISC-V
+  `<patternpairs>` (pre/post) prologue matcher over the code (Thumb `push {…}` etc.). Enabling
+  it by default on `decompile-all` for non-x86-64 lifts ARM Cortex-M discovery from **1** to
+  **hundreds** of functions (betaflight `STM32F405` 1 → 469, chibios 1 → 47), each decompiled
+  in Thumb mode. Still short of Ghidra (recursive descent finds more — betaflight 1822), but
+  the binaries go from unusable to usable.
+- **x86-64 untouched**: the injection fires only when `File::architecture() != X86_64`, so
+  every x86-64 result is byte-identical (oracle 5 + the entry oracles already discover them,
+  and the aggressive pattern scan is kept off there where it can over-produce). `docs/baseline.json`
+  and the datatest/console paths are unaffected (they never build this surface).
+- **Testcase**: `kuna-cli/tests/decompile_all_cli.rs` (the non-x86-64 default-on injection) +
+  the real ARM Cortex-M behavior on the decbench `cps` corpus.
+- **Date**: 2026-07-05.


### PR DESCRIPTION
The decbench `decompiler-failure` cases are **ARM Cortex-M Thumb firmware** (the `cps` project: betaflight, chibios, nuttx, u-boot, …). kuna decodes the Thumb entry point fine but discovers only **1 function** — so the whole binary is a total failure.

## Root cause

kuna's analyzer tier has **no disassembled Listing / recursive-descent sweep**, so function discovery relies on the entry oracles + arch idioms + the always-on prologue scan (**oracle 5**) — which is **x86-64-only**. On a stripped non-x86-64 binary, the ELF entry is therefore the only discovered function.

## Fix

The `funcstart_patterns` pass (`s1_entry::full_pattern_starts`) already ports the **full ARM/AArch64/MIPS/PPC/RISC-V `<patternpairs>` prologue matcher** — it's just default-OFF. It's the *primary* discovery source for these arches, so `decompile-all` now defaults it **ON for non-x86-64** (unless the caller names it).

| binary | before | after | Ghidra |
|---|---|---|---|
| betaflight `STM32F405` | 1 | **469** | 1822 |
| chibios | 1 | **47** | 135 |

Each is decompiled in Thumb mode. kuna is still short of Ghidra (recursive descent finds more — a documented follow-up), but the ARM binaries go from **unusable to usable**.

## Safety

The injection fires only when `File::architecture() != X86_64`, so every x86-64 result is **byte-identical** (oracle 5 + the entry oracles already discover them; the aggressive scan is kept off there). A driver default (DIV-20) — the engine default (`analysis_funcstart_patterns = false`) and the console/datatest surfaces are untouched.

## Gates

- `make test` **675/675 PARITY OK** (byte-identical), `make test-stages` **254/254 PARITY OK**, `make rust-test` green.
- New test `arm_decompile_all_defaults_funcstart_patterns_on` (fixture `arm_thumb_linked_le32`: default discovers more than `off`, matches explicit `on`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J