### PR TITLE
analysis: recursive-descent function discovery — close the ARM Ghidra gap (betaflight 469→1470)

### DIFF
--- a/decompiler/crates/kuna-analysis/src/passes.rs
+++ b/decompiler/crates/kuna-analysis/src/passes.rs
@@ -368,7 +368,26 @@ pub fn run_listing_consumers(
     let Ok(file) = object::File::parse(bytes) else {
         return Vec::new();
     };
-    let seeds = listing_seeds(&file, bytes);
+    let mut seeds = listing_seeds(&file, bytes);
+    // (kuna, recursive-descent discovery) When the prologue-pattern pass is active
+    // (`funcstart_patterns`, default-ON for non-x86-64 on `decompile-all`, DIV-20),
+    // seed the recursive-descent walk with its `<patternpairs>` function starts too — not
+    // just the entry oracles. On a STRIPPED ARM binary the entry oracles seed only the ELF
+    // entry, so the walk discovers ~nothing; seeded with the prologue starts it explores
+    // the CALL graph out of every discovered function and finds call-only targets that
+    // have no recognizable prologue (Ghidra's disassembler-driven recursive descent).
+    // betaflight STM32F405: the walk grows 1 -> 1470 discovered functions (Ghidra 1822).
+    // Gated by the same flag, so x86-64 (funcstart_patterns off) is unchanged.
+    if arch.analysis_funcstart_patterns {
+        let execs = crate::s1_entry::executable_sections(&file);
+        seeds.extend(
+            crate::s1_entry::full_pattern_starts(&file)
+                .into_iter()
+                .filter(|&vma| crate::s1_entry::in_executable_section(&execs, vma)),
+        );
+        seeds.sort_unstable();
+        seeds.dedup();
+    }
     let seed_names = funcsym_names(&file);
     let funcsym_seeds = crate::s1_entry::existing_function_addrs(&file, bytes);
     let listing = crate::listing::Listing::build_with_meta(
@@ -406,6 +425,19 @@ pub fn run_listing_consumers(
             listing.exec_ranges(),
         );
         out.push(("aif", aif_out));
+    }
+
+    // (kuna, recursive-descent discovery) Promote the walk's discovered functions — the
+    // CALL targets it followed from the (prologue-seeded) roots — to committed function
+    // entries. This is the commit step that turns the `walk.rs` two-level worklist
+    // recursive descent into actual functions (Ghidra's disassembler-driven
+    // CreateFunctionCmd analog); the commit arm names them `sub_<addr>` and dedups against
+    // the already-committed set. Gated by `funcdisc_recursive` → the same
+    // `analysis_funcstart_patterns` flag, so x86-64 (funcstart_patterns off) is byte-identical.
+    if arch.analysis_funcstart_patterns {
+        let mut rd_out = AnalysisOutput::default();
+        rd_out.entries = listing.functions().map(|(&vma, _)| vma).collect();
+        out.push(("funcdisc_recursive", rd_out));
     }
     out
 }

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -429,6 +429,11 @@ fn analysis_pass_enabled(arch: &Architecture, pass_id: &str) -> bool {
         // `analysis_funcstart_patterns` flag is load-bearing for the default-off
         // contract.
         "funcstart_patterns" => arch.analysis_funcstart_patterns,
+        // (kuna) The recursive-descent discovery commit — promotes the Listing walk's
+        // followed CALL targets to functions. Coupled to the same flag as the prologue
+        // seeds that feed it (default-OFF; DIV-20 turns it on for non-x86-64 on the
+        // decompile-all surface). x86-64 keeps it off ⇒ byte-identical there.
+        "funcdisc_recursive" => arch.analysis_funcstart_patterns,
         "arm_markers" => arch.analysis_arm_markers,
         "mips_gp" => arch.analysis_mips_gp,
         "mips_isa" => arch.analysis_mips_isa,

--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -755,9 +755,16 @@ gh558-experiment protocol: run the 204+675 upstream assertions, list every chang
   discovery source for these arches — it applies the full ARM/AArch64/MIPS/PPC/RISC-V
   `<patternpairs>` (pre/post) prologue matcher over the code (Thumb `push {…}` etc.). Enabling
   it by default on `decompile-all` for non-x86-64 lifts ARM Cortex-M discovery from **1** to
-  **hundreds** of functions (betaflight `STM32F405` 1 → 469, chibios 1 → 47), each decompiled
-  in Thumb mode. Still short of Ghidra (recursive descent finds more — betaflight 1822), but
-  the binaries go from unusable to usable.
+  **hundreds** of functions, each decompiled in Thumb mode.
+- **Recursive descent** (the same flag): kuna's Listing already runs a two-level
+  recursive-descent walk (`listing/walk.rs`: CALL targets become new function entries), but
+  (a) it was seeded only with the entry oracles — 1 root on a stripped ARM binary — and
+  (b) its discoveries were never committed as functions. When `funcstart_patterns` is on we now
+  (a) seed the walk with the prologue starts too, so it explores the CALL graph out of every
+  discovered function, and (b) commit its discoveries (`funcdisc_recursive`, gated by the same
+  flag → the Ghidra disassembler-driven `CreateFunctionCmd` analog). This finds the call-only
+  targets that have no recognizable prologue: **betaflight `STM32F405` 469 → 1470** (Ghidra 1822
+  — 81%, up from 26%), chibios/cleanflight/crazyflie similarly. Analysis stays ~4 s.
 - **x86-64 untouched**: the injection fires only when `File::architecture() != X86_64`, so
   every x86-64 result is byte-identical (oracle 5 + the entry oracles already discover them,
   and the aggressive pattern scan is kept off there where it can over-produce). `docs/baseline.json`


### PR DESCRIPTION
Closes most of the remaining ARM function-discovery gap by wiring up the recursive descent kuna already had but wasn't using.

## The finding

kuna's Listing **already runs a two-level recursive-descent walk** (`listing/walk.rs` — a CALL target becomes a new function entry). But two things starved it:
1. it was seeded only with the **entry oracles** — 1 root on a stripped ARM binary — so from that single root it discovered nothing (measured: `walk_funcs=1`);
2. its discoveries were **never committed** as functions (only `s1_entry` emits entries).

## The fix (both gated by `analysis_funcstart_patterns` — DIV-20's non-x86-64 default)

1. **Seed the walk with the prologue starts** (`full_pattern_starts`) too, so it explores the CALL graph out of *every* discovered function → the walk grows **1 → 1470** on betaflight.
2. **Commit the walk's discoveries** (`funcdisc_recursive`) — the Ghidra disassembler-driven `CreateFunctionCmd` analog. This promotes the call-only targets that have no recognizable prologue.

## Result

| binary | prologue-only (#132) | + recursive descent | Ghidra |
|---|---|---|---|
| betaflight STM32F405 | 469 (26%) | **1470 (81%)** | 1822 |

Each is a real Thumb function (`sub_8009ef8` = 136 LOC). Whole-binary analysis stays ~4 s.

## Safety

x86-64 keeps `funcstart_patterns` off → `funcdisc_recursive` off → **byte-identical** (b2sum 164=164). `make test` **675/675 PARITY OK**, `make test-stages` **254/254 PARITY OK**, `make rust-test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J