### PR TITLE
feat(ghidra): Phase 1 — kuna as Ghidra's decompiler core (protocol + extension + docs)

### DIFF
--- a/decompiler/Cargo.lock
+++ b/decompiler/Cargo.lock
@@ -180,6 +180,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "kuna-ghidra"
+version = "0.1.0"
+dependencies = [
+ "kuna-base",
+ "kuna-sleigh",
+]
+
+[[package]]
 name = "kuna-harness"
 version = "0.1.0"
 dependencies = [

--- a/decompiler/crates/kuna-ghidra/Cargo.toml
+++ b/decompiler/crates/kuna-ghidra/Cargo.toml
@@ -1,0 +1,30 @@
+# kuna-ghidra: the ghidra-mode process front-end (the native side of the
+# Ghidra GUI <-> decompiler stdin/stdout protocol; upstream's `decompile`
+# binary, built from ghidra_process.cc / ghidra_arch.cc).
+#
+# Phase 1 (see docs/ghidra-integration.md): wire-protocol complete, engine
+# stubbed.  Deliberately does NOT depend on kuna-decomp — the engine bridge
+# (Funcdata encode, ScopeGhidra, TypeFactoryGhidra, ...) is phase 2.
+
+[package]
+name = "kuna-ghidra"
+description = "kuna Rust port: ghidra-mode process front-end (Ghidra's `decompile` binary)"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+kuna-base.workspace = true
+# The tspec <sleigh> element decode (ELEM_SLEIGH / ATTRIB_UNIQBASE /
+# TruncationTag / register_translate_ids) — the GhidraTranslate::initialize
+# subset of translate.cc lives in kuna-sleigh.
+kuna-sleigh.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "kuna_ghidra"
+path = "src/bin/kuna_ghidra.rs"

--- a/decompiler/crates/kuna-ghidra/src/bin/kuna_ghidra.rs
+++ b/decompiler/crates/kuna-ghidra/src/bin/kuna_ghidra.rs
@@ -1,0 +1,44 @@
+//! The `kuna_ghidra` binary: kuna's ghidra-mode process (upstream's
+//! `decompile` executable) — port of `main()` at
+//! `decompiler/cpp/ghidra_process.cc:518-537`.
+//!
+//! No arguments are parsed; the process communicates exclusively over
+//! stdin/stdout and silently waits for the first command burst (there is
+//! no startup handshake — the Java side only waits 200 ms and checks
+//! liveness before sending registerProgram).
+//!
+//! Departures from the C++ main, all deliberate:
+//! - `signal(SIGSEGV, segvHandler)` / `_Exit(1)` is not ported: safe Rust
+//!   has no expected SIGSEGV, and the OS default termination pops no
+//!   dialog on the platforms kuna targets.
+//! - `_setmode(..., _O_BINARY)` (Windows) is unnecessary: Rust's std
+//!   performs no newline translation on any platform.
+//! - `AttributeId::initialize()` / `ElementId::initialize()` /
+//!   `CapabilityPoint::initializeAll()` are the per-session `IdRegistry`
+//!   and the command dispatch inside [`GhidraProcess`].
+//!
+//! Exit status mirrors upstream: 0 after a deregisterProgram terminates
+//! the loop cleanly (C++ falls off main), 1 when the pipe closes or the
+//! protocol breaks mid-command (the C++ `exit(1)` sites,
+//! ghidra_arch.cc:95-96).
+
+use std::io;
+
+use kuna_ghidra::process::GhidraProcess;
+
+fn main() {
+    let stdin = io::stdin().lock();
+    let stdout = io::stdout().lock();
+    let mut process = GhidraProcess::new(stdin, stdout);
+    // while(status == 0) status = GhidraCapability::readCommand(cin,cout)
+    match process.run() {
+        Ok(_status) => std::process::exit(0),
+        Err(e) => {
+            // Pipe closed => our parent process is probably dead, exit to
+            // avoid a runaway process (ghidra_arch.cc:95-96).  Any other
+            // I/O or unrecovered protocol failure exits the same way.
+            eprintln!("kuna_ghidra: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/decompiler/crates/kuna-ghidra/src/client.rs
+++ b/decompiler/crates/kuna-ghidra/src/client.rs
@@ -1,0 +1,498 @@
+//! The decompiler -> Ghidra query client — a port of the query methods on
+//! `ArchitectureGhidra` (`decompiler/cpp/ghidra_arch.cc:445-896`).
+//!
+//! Every query has identical outer framing (e.g. getRegister,
+//! ghidra_arch.cc:445-459):
+//!
+//! ```text
+//!   {0,0,1,4}                  query open
+//!   {0,0,1,14}                 string stream open
+//!   <packed command_* element>
+//!   {0,0,1,15}                 string stream close
+//!   {0,0,1,5}                  query close
+//!   flush
+//! ```
+//!
+//! then the response is read per query: a packed element via
+//! [`read_all`](crate::protocol::read_all), a plain string stream
+//! (getRegisterName / getUserOpName / getCodeLabel), a bool stream
+//! (isNameUsed), or a byte stream (getBytes / getStringData).  A Java
+//! exception frame (burst 10) surfaces as [`KunaError::Java`] from any of
+//! the response readers.
+//!
+//! Phase-1 scope: the framing and request encodings are complete and
+//! byte-exact; responses are handed back as raw decoded payloads (the
+//! caller's [`Decoder`] holds the packed document / the byte buffers hold
+//! the raw bytes).  The typed decoding into engine structures
+//! (VarnodeData caches, p-code emit, symbol scopes, ...) is the phase-2
+//! engine bridge — see `docs/ghidra-integration.md`.
+//!
+//! IMPORTANT protocol constraint (DecompileProcess.java:472-473,571-572 vs
+//! :512-513 etc.): the Java client services queries only while a
+//! registerProgram / decompileAt / structureGraph / generateSignatures /
+//! debugSignatures command is in flight; issuing a query at any other time
+//! desyncs the protocol.  Enforcing that is the phase-2 session's job.
+
+use std::io::{Read, Write};
+use std::rc::Rc;
+
+use kuna_base::address::Address;
+use kuna_base::address::{ATTRIB_FIRST, ATTRIB_LAST};
+use kuna_base::error::KunaError;
+use kuna_base::marshal::{
+    Decoder, Encoder, PackedEncode, ATTRIB_CONTENT, ATTRIB_ID, ATTRIB_INDEX, ATTRIB_NAME,
+    ATTRIB_SIZE, ATTRIB_TYPE, ELEM_VALUE,
+};
+use kuna_base::space::VarnodeStorage;
+
+use crate::ids::{
+    ATTRIB_MAXSIZE, ELEM_COMMAND_GETBYTES, ELEM_COMMAND_GETCALLFIXUP, ELEM_COMMAND_GETCALLMECH,
+    ELEM_COMMAND_GETCALLOTHERFIXUP, ELEM_COMMAND_GETCODELABEL, ELEM_COMMAND_GETCOMMENTS,
+    ELEM_COMMAND_GETCPOOLREF, ELEM_COMMAND_GETDATATYPE, ELEM_COMMAND_GETEXTERNALREF,
+    ELEM_COMMAND_GETMAPPEDSYMBOLS, ELEM_COMMAND_GETNAMESPACEPATH, ELEM_COMMAND_GETPCODE,
+    ELEM_COMMAND_GETPCODEEXECUTABLE, ELEM_COMMAND_GETREGISTER, ELEM_COMMAND_GETREGISTERNAME,
+    ELEM_COMMAND_GETSTRINGDATA, ELEM_COMMAND_GETTRACKEDREGISTERS, ELEM_COMMAND_GETUSEROPNAME,
+    ELEM_COMMAND_ISNAMEUSED,
+};
+use crate::protocol::{
+    java_alignment, nibble_condense, read_all, read_bool_stream, read_response_end,
+    read_string_stream, read_to_any_burst, read_to_response, string_data_size, write_burst,
+    WireError, WireResult, BURST_BYTES_CLOSE, BURST_BYTES_OPEN, BURST_QUERY_CLOSE,
+    BURST_QUERY_OPEN, BURST_STRING_CLOSE, BURST_STRING_OPEN,
+};
+
+/// The injection variety of a getPcodeInject query — selects the command
+/// element (C++ `InjectPayload::{CALLFIXUP_TYPE, CALLOTHERFIXUP_TYPE,
+/// CALLMECHANISM_TYPE, EXECUTABLEPCODE_TYPE}`, inject.hh; the numeric
+/// values never travel on the wire).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InjectType {
+    /// C++ `CALLFIXUP_TYPE` -> \<command_getcallfixup>.
+    CallFixup,
+    /// C++ `CALLOTHERFIXUP_TYPE` -> \<command_getcallotherfixup>.
+    CallOtherFixup,
+    /// C++ `CALLMECHANISM_TYPE` -> \<command_getcallmech>.
+    CallMechanism,
+    /// C++ `EXECUTABLEPCODE_TYPE` (and the default) ->
+    /// \<command_getpcodeexecutable>.
+    ExecutablePcode,
+}
+
+/// The client half of ghidra mode: owns the two protocol streams and
+/// exposes the typed query methods of `ArchitectureGhidra`
+/// (ghidra_arch.cc:445-896).
+///
+/// Response documents are decoded into a caller-supplied [`Decoder`]
+/// (matching the C++ `Decoder&` out-parameters): the caller constructs a
+/// `PackedDecode` over its `AddrSpaceManager`, whose space indices must
+/// match the tspec the Java side sent (see `crate::translate`).
+#[derive(Debug)]
+pub struct GhidraClient<R: Read, W: Write> {
+    /// The input stream from the client (C++ `sin`).
+    sin: R,
+    /// The output stream to the client (C++ `sout`).
+    sout: W,
+}
+
+impl<R: Read, W: Write> GhidraClient<R, W> {
+    /// Construct over the two protocol streams.
+    pub fn new(sin: R, sout: W) -> Self {
+        GhidraClient { sin, sout }
+    }
+
+    /// Tear down into the underlying streams (test access).
+    pub fn into_inner(self) -> (R, W) {
+        (self.sin, self.sout)
+    }
+
+    /// The shared request framing: query open, string stream holding the
+    /// packed command document, string close, query close, flush.
+    fn send_query_document(&mut self, packed: &[u8]) -> WireResult<()> {
+        write_burst(&mut self.sout, BURST_QUERY_OPEN)?;
+        write_burst(&mut self.sout, BURST_STRING_OPEN)?;
+        self.sout.write_all(packed).map_err(WireError::Io)?;
+        write_burst(&mut self.sout, BURST_STRING_CLOSE)?;
+        write_burst(&mut self.sout, BURST_QUERY_CLOSE)?;
+        self.sout.flush().map_err(WireError::Io)?;
+        Ok(())
+    }
+
+    /// A plain-string response: response header, string stream, response
+    /// end (the tail of getRegisterName / getUserOpName / getCodeLabel).
+    fn read_string_response(&mut self) -> WireResult<Vec<u8>> {
+        read_to_response(&mut self.sin)?;
+        let res = read_string_stream(&mut self.sin)?;
+        read_response_end(&mut self.sin)?;
+        Ok(res)
+    }
+
+    /// Query for the storage location of a named register (C++
+    /// `getRegister`, ghidra_arch.cc:445-459).  The response (an \<addr>
+    /// element) lands in `decoder`; `false` means an empty response.
+    pub fn get_register(&mut self, regname: &str, decoder: &mut dyn Decoder) -> WireResult<bool> {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut encoder = PackedEncode::new(&mut buf);
+            encoder.open_element(&ELEM_COMMAND_GETREGISTER);
+            encoder.write_string(&ATTRIB_NAME, regname.as_bytes());
+            encoder.close_element(&ELEM_COMMAND_GETREGISTER);
+        }
+        self.send_query_document(&buf)?;
+        read_all(&mut self.sin, decoder)
+    }
+
+    /// Query for the name of a register overlapping a storage range (C++
+    /// `getRegisterName`, ghidra_arch.cc:466-485).  Returns the name bytes
+    /// or empty.
+    pub fn get_register_name(&mut self, vndata: &VarnodeStorage) -> WireResult<Vec<u8>> {
+        let space = vndata
+            .space
+            .as_ref()
+            .ok_or_else(|| java_alignment("getRegisterName without an address space"))?;
+        let addr = Address::new(Rc::clone(space), vndata.offset);
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut encoder = PackedEncode::new(&mut buf);
+            encoder.open_element(&ELEM_COMMAND_GETREGISTERNAME);
+            addr.encode_sized(&mut encoder, vndata.size as i32)
+                .map_err(WireError::Kuna)?;
+            encoder.close_element(&ELEM_COMMAND_GETREGISTERNAME);
+        }
+        self.send_query_document(&buf)?;
+        self.read_string_response()
+    }
+
+    /// Query for registers with known values at an address (C++
+    /// `getTrackedRegisters`, ghidra_arch.cc:494-508).  The response
+    /// (\<tracked_pointset>) lands in `decoder`.
+    pub fn get_tracked_registers(
+        &mut self,
+        addr: &Address,
+        decoder: &mut dyn Decoder,
+    ) -> WireResult<bool> {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut encoder = PackedEncode::new(&mut buf);
+            encoder.open_element(&ELEM_COMMAND_GETTRACKEDREGISTERS);
+            addr.encode(&mut encoder).map_err(WireError::Kuna)?;
+            encoder.close_element(&ELEM_COMMAND_GETTRACKEDREGISTERS);
+        }
+        self.send_query_document(&buf)?;
+        read_all(&mut self.sin, decoder)
+    }
+
+    /// Query for the name of a user-defined (CALLOTHER) op (C++
+    /// `getUserOpName`, ghidra_arch.cc:514-532).  An empty result marks the
+    /// end of the init-time index probe loop (ghidra_translate.cc:107-117).
+    pub fn get_user_op_name(&mut self, index: i32) -> WireResult<Vec<u8>> {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut encoder = PackedEncode::new(&mut buf);
+            encoder.open_element(&ELEM_COMMAND_GETUSEROPNAME);
+            encoder.write_signed_integer(&ATTRIB_INDEX, index as i64);
+            encoder.close_element(&ELEM_COMMAND_GETUSEROPNAME);
+        }
+        self.send_query_document(&buf)?;
+        self.read_string_response()
+    }
+
+    /// Query for the p-code of one instruction (C++ `getPcode`,
+    /// ghidra_arch.cc:538-552).  The response (\<inst> with \<op> children,
+    /// or \<unimpl>) lands in `decoder`; `false` (empty response) is the
+    /// caller's BadDataError.
+    pub fn get_pcode(&mut self, addr: &Address, decoder: &mut dyn Decoder) -> WireResult<bool> {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut encoder = PackedEncode::new(&mut buf);
+            encoder.open_element(&ELEM_COMMAND_GETPCODE);
+            addr.encode(&mut encoder).map_err(WireError::Kuna)?;
+            encoder.close_element(&ELEM_COMMAND_GETPCODE);
+        }
+        self.send_query_document(&buf)?;
+        read_all(&mut self.sin, decoder)
+    }
+
+    /// Query for the symbols mapped at an address (C++
+    /// `getMappedSymbolsXML`, ghidra_arch.cc:561-575).  The response
+    /// (\<doc> with \<mapsym>, or \<hole>) lands in `decoder`.
+    pub fn get_mapped_symbols_xml(
+        &mut self,
+        addr: &Address,
+        decoder: &mut dyn Decoder,
+    ) -> WireResult<bool> {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut encoder = PackedEncode::new(&mut buf);
+            encoder.open_element(&ELEM_COMMAND_GETMAPPEDSYMBOLS);
+            addr.encode(&mut encoder).map_err(WireError::Kuna)?;
+            encoder.close_element(&ELEM_COMMAND_GETMAPPEDSYMBOLS);
+        }
+        self.send_query_document(&buf)?;
+        read_all(&mut self.sin, decoder)
+    }
+
+    /// Resolve an external reference (C++ `getExternalRef`,
+    /// ghidra_arch.cc:586-600).  The response (\<function> or \<hole>)
+    /// lands in `decoder`.
+    pub fn get_external_ref(
+        &mut self,
+        addr: &Address,
+        decoder: &mut dyn Decoder,
+    ) -> WireResult<bool> {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut encoder = PackedEncode::new(&mut buf);
+            encoder.open_element(&ELEM_COMMAND_GETEXTERNALREF);
+            addr.encode(&mut encoder).map_err(WireError::Kuna)?;
+            encoder.close_element(&ELEM_COMMAND_GETEXTERNALREF);
+        }
+        self.send_query_document(&buf)?;
+        read_all(&mut self.sin, decoder)
+    }
+
+    /// Query the namespace path for a scope id (C++ `getNamespacePath`,
+    /// ghidra_arch.cc:608-622).  The response (\<parent> with \<val>
+    /// children) lands in `decoder`.
+    pub fn get_namespace_path(&mut self, id: u64, decoder: &mut dyn Decoder) -> WireResult<bool> {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut encoder = PackedEncode::new(&mut buf);
+            encoder.open_element(&ELEM_COMMAND_GETNAMESPACEPATH);
+            encoder.write_unsigned_integer(&ATTRIB_ID, id);
+            encoder.close_element(&ELEM_COMMAND_GETNAMESPACEPATH);
+        }
+        self.send_query_document(&buf)?;
+        read_all(&mut self.sin, decoder)
+    }
+
+    /// Ask whether a symbol name is already used in a namespace range (C++
+    /// `isNameUsed`, ghidra_arch.cc:624-643).  The response is a bool
+    /// stream.
+    pub fn is_name_used(&mut self, nm: &str, start_id: u64, stop_id: u64) -> WireResult<bool> {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut encoder = PackedEncode::new(&mut buf);
+            encoder.open_element(&ELEM_COMMAND_ISNAMEUSED);
+            encoder.write_string(&ATTRIB_NAME, nm.as_bytes());
+            encoder.write_unsigned_integer(&ATTRIB_FIRST, start_id);
+            encoder.write_unsigned_integer(&ATTRIB_LAST, stop_id);
+            encoder.close_element(&ELEM_COMMAND_ISNAMEUSED);
+        }
+        self.send_query_document(&buf)?;
+        read_to_response(&mut self.sin)?;
+        let res = read_bool_stream(&mut self.sin)?;
+        read_response_end(&mut self.sin)?;
+        Ok(res)
+    }
+
+    /// Query the primary symbol name at an address (C++ `getCodeLabel`,
+    /// ghidra_arch.cc:649-667).  Returns the label bytes or empty.
+    pub fn get_code_label(&mut self, addr: &Address) -> WireResult<Vec<u8>> {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut encoder = PackedEncode::new(&mut buf);
+            encoder.open_element(&ELEM_COMMAND_GETCODELABEL);
+            addr.encode(&mut encoder).map_err(WireError::Kuna)?;
+            encoder.close_element(&ELEM_COMMAND_GETCODELABEL);
+        }
+        self.send_query_document(&buf)?;
+        self.read_string_response()
+    }
+
+    /// Query for a data-type by name and id (C++ `getDataType`,
+    /// ghidra_arch.cc:675-690).  The response (\<type>) lands in `decoder`.
+    /// (The id travels as a *signed* integer, matching the C++ encode.)
+    pub fn get_data_type(
+        &mut self,
+        name: &str,
+        id: u64,
+        decoder: &mut dyn Decoder,
+    ) -> WireResult<bool> {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut encoder = PackedEncode::new(&mut buf);
+            encoder.open_element(&ELEM_COMMAND_GETDATATYPE);
+            encoder.write_string(&ATTRIB_NAME, name.as_bytes());
+            // C++ writeSignedInteger(ATTRIB_ID, id) with a uint8 id: the
+            // value is reinterpreted as signed
+            encoder.write_signed_integer(&ATTRIB_ID, id as i64);
+            encoder.close_element(&ELEM_COMMAND_GETDATATYPE);
+        }
+        self.send_query_document(&buf)?;
+        read_all(&mut self.sin, decoder)
+    }
+
+    /// Query all comments for a function matching the property `flags` (C++
+    /// `getComments`, ghidra_arch.cc:700-715).  The response (\<commentdb>)
+    /// lands in `decoder` — always written by Java, possibly empty.
+    pub fn get_comments(
+        &mut self,
+        fad: &Address,
+        flags: u32,
+        decoder: &mut dyn Decoder,
+    ) -> WireResult<bool> {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut encoder = PackedEncode::new(&mut buf);
+            encoder.open_element(&ELEM_COMMAND_GETCOMMENTS);
+            encoder.write_unsigned_integer(&ATTRIB_TYPE, flags as u64);
+            fad.encode(&mut encoder).map_err(WireError::Kuna)?;
+            encoder.close_element(&ELEM_COMMAND_GETCOMMENTS);
+        }
+        self.send_query_document(&buf)?;
+        read_all(&mut self.sin, decoder)
+    }
+
+    /// Query a range of load-image bytes (C++ `getBytes`,
+    /// ghidra_arch.cc:723-760).  `buf.len()` bytes at `inaddr` are fetched
+    /// through the nibble-doubled byte stream; an empty response raises
+    /// `DataUnavailError`.
+    pub fn get_bytes(&mut self, buf: &mut [u8], inaddr: &Address) -> WireResult<()> {
+        let size = buf.len();
+        let mut req: Vec<u8> = Vec::new();
+        {
+            let mut encoder = PackedEncode::new(&mut req);
+            encoder.open_element(&ELEM_COMMAND_GETBYTES);
+            inaddr
+                .encode_sized(&mut encoder, size as i32)
+                .map_err(WireError::Kuna)?;
+            encoder.close_element(&ELEM_COMMAND_GETBYTES);
+        }
+        self.send_query_document(&req)?;
+
+        read_to_response(&mut self.sin)?;
+        let t = read_to_any_burst(&mut self.sin)?;
+        if t == BURST_BYTES_OPEN {
+            let mut dblbuf = vec![0u8; size * 2];
+            self.sin.read_exact(&mut dblbuf).map_err(|_| {
+                // C++ checks gcount and throws the alignment JavaError
+                java_alignment("Could not read expected number of bytes")
+            })?;
+            buf.copy_from_slice(&nibble_condense(&dblbuf));
+        } else if (t & 1) == 1 {
+            let mut errmsg = String::from("GHIDRA has no data in the loadimage at ");
+            if let Some(spc) = inaddr.get_space() {
+                errmsg.push(spc.get_shortcut());
+            }
+            let _ = inaddr.print_raw(&mut errmsg);
+            return Err(WireError::Kuna(KunaError::data_unavail(errmsg)));
+        } else {
+            return Err(java_alignment("Expecting bytes or end of query response"));
+        }
+        let t = read_to_any_burst(&mut self.sin)?;
+        if t != BURST_BYTES_CLOSE {
+            return Err(java_alignment("Expecting byte alignment end"));
+        }
+        read_response_end(&mut self.sin)
+    }
+
+    /// Query string data at an address, pre-translated to UTF-8 by the
+    /// client (C++ `getStringData`, ghidra_arch.cc:774-816).  The C++
+    /// passes a `Datatype*`; phase 1 takes the (name, unsized-id) pair the
+    /// encode actually needs.  On success `buffer` holds the returned bytes
+    /// (including the trailing NUL, as upstream) and the returned bool is
+    /// the truncation flag; an empty response leaves `buffer` empty.
+    pub fn get_string_data(
+        &mut self,
+        buffer: &mut Vec<u8>,
+        addr: &Address,
+        type_name: &str,
+        type_id: u64,
+        max_bytes: i32,
+    ) -> WireResult<bool> {
+        let mut req: Vec<u8> = Vec::new();
+        {
+            let mut encoder = PackedEncode::new(&mut req);
+            encoder.open_element(&ELEM_COMMAND_GETSTRINGDATA);
+            encoder.write_signed_integer(&ATTRIB_MAXSIZE, max_bytes as i64);
+            encoder.write_string(&ATTRIB_TYPE, type_name.as_bytes());
+            encoder.write_unsigned_integer(&ATTRIB_ID, type_id);
+            addr.encode(&mut encoder).map_err(WireError::Kuna)?;
+            encoder.close_element(&ELEM_COMMAND_GETSTRINGDATA);
+        }
+        self.send_query_document(&req)?;
+
+        read_to_response(&mut self.sin)?;
+        let mut is_trunc = false;
+        let mut t = read_to_any_burst(&mut self.sin)?;
+        if t == BURST_BYTES_OPEN {
+            // two raw size-header bytes, one raw truncation-flag byte
+            // (which MAY be a literal 0x00), then size*2 nibble-doubled
+            // bytes whose final pair is the doubled NUL terminator
+            let mut header = [0u8; 3];
+            self.sin
+                .read_exact(&mut header)
+                .map_err(|_| WireError::PipeClosed)?;
+            let size = string_data_size(header[0], header[1]) as usize;
+            is_trunc = header[2] != 0;
+            let mut dblbuf = vec![0u8; size * 2];
+            self.sin
+                .read_exact(&mut dblbuf)
+                .map_err(|_| WireError::PipeClosed)?;
+            *buffer = nibble_condense(&dblbuf);
+            t = read_to_any_burst(&mut self.sin)?;
+            if t != BURST_BYTES_CLOSE {
+                return Err(java_alignment("Expecting byte alignment end"));
+            }
+            t = read_to_any_burst(&mut self.sin)?;
+        }
+        if (t & 1) == 1 {
+            // response end consumed (or empty response: leave buffer empty)
+            Ok(is_trunc)
+        } else {
+            Err(java_alignment("Expecting end of query response"))
+        }
+    }
+
+    /// Retrieve p-code to inject for a named payload (C++ `getPcodeInject`,
+    /// ghidra_arch.cc:833-869) — the four command-element variants selected
+    /// by `inject_type`.  The C++ encodes an `InjectContext` (`<context>`)
+    /// after the name; the engine-side context type is phase 2, so the
+    /// caller supplies `encode_context` to write it (TODO(phase-2): take
+    /// the engine's InjectContext directly).  The response (\<inst> with
+    /// \<op> children) lands in `decoder`.
+    pub fn get_pcode_inject(
+        &mut self,
+        name: &str,
+        inject_type: InjectType,
+        encode_context: impl FnOnce(&mut dyn Encoder) -> Result<(), KunaError>,
+        decoder: &mut dyn Decoder,
+    ) -> WireResult<bool> {
+        let elem = match inject_type {
+            InjectType::CallFixup => &ELEM_COMMAND_GETCALLFIXUP,
+            InjectType::CallOtherFixup => &ELEM_COMMAND_GETCALLOTHERFIXUP,
+            InjectType::CallMechanism => &ELEM_COMMAND_GETCALLMECH,
+            InjectType::ExecutablePcode => &ELEM_COMMAND_GETPCODEEXECUTABLE,
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut encoder = PackedEncode::new(&mut buf);
+            encoder.open_element(elem);
+            encoder.write_string(&ATTRIB_NAME, name.as_bytes());
+            encode_context(&mut encoder).map_err(WireError::Kuna)?;
+            encoder.close_element(elem);
+        }
+        self.send_query_document(&buf)?;
+        read_all(&mut self.sin, decoder)
+    }
+
+    /// Resolve a constant-pool reference (C++ `getCPoolRef`,
+    /// ghidra_arch.cc:877-896).  The response (a cpool record) lands in
+    /// `decoder`.
+    pub fn get_cpool_ref(&mut self, refs: &[u64], decoder: &mut dyn Decoder) -> WireResult<bool> {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut encoder = PackedEncode::new(&mut buf);
+            encoder.open_element(&ELEM_COMMAND_GETCPOOLREF);
+            encoder.write_signed_integer(&ATTRIB_SIZE, refs.len() as i64);
+            for &r in refs {
+                encoder.open_element(&ELEM_VALUE);
+                encoder.write_unsigned_integer(&ATTRIB_CONTENT, r);
+                encoder.close_element(&ELEM_VALUE);
+            }
+            encoder.close_element(&ELEM_COMMAND_GETCPOOLREF);
+        }
+        self.send_query_document(&buf)?;
+        read_all(&mut self.sin, decoder)
+    }
+}

--- a/decompiler/crates/kuna-ghidra/src/ids.rs
+++ b/decompiler/crates/kuna-ghidra/src/ids.rs
@@ -1,0 +1,185 @@
+//! The ghidra-mode protocol marshaling ids — ports of the `ElementId`
+//! tables in `decompiler/cpp/ghidra_arch.cc:30-48` (the query command
+//! elements), `decompiler/cpp/ghidra_process.cc:74` (`ELEM_DOC`), and the
+//! version/settings subset of `decompiler/cpp/signature.cc:29-40`.
+//!
+//! These are PROTOCOL ids: the numbers must match upstream Ghidra exactly
+//! for wire compatibility (the Java side dispatches queries on the numeric
+//! element id, `DecompileProcess.java` query switch).  They therefore use
+//! the upstream numbers, NOT the kuna-invented 4000+ range.
+//!
+//! Cross-checked against the Java tables (`ElementId.java:371-427,433-440`):
+//! every number agrees.  One name skew exists: id 255 is named
+//! `"command_getstringdata"` in C++ but `"command_getstring"` in Java —
+//! only the number travels on the wire, and kuna ports the C++ name.
+//!
+//! kuna-decomp already owns the neighboring signature ids 258-260, 263,
+//! 265-267, 269 (`kuna-decomp/src/infra/signature.rs`) with upstream
+//! numbers; this module adds only the ids the process front-end needs and a
+//! repo-wide grep confirms none of them are otherwise taken.
+
+use kuna_base::marshal::{AttributeId, ElementId, IdRegistry};
+
+// ---------------------------------------------------------------------------
+// ghidra_process.cc
+// ---------------------------------------------------------------------------
+
+/// Marshaling element \<doc> — the decompileAt response document
+/// (C++ `ELEM_DOC`, `decompiler/cpp/ghidra_process.cc:74`).
+pub const ELEM_DOC: ElementId = ElementId::new("doc", 229);
+
+// ---------------------------------------------------------------------------
+// ghidra_arch.cc:30-48 — the query command elements (239-257)
+// ---------------------------------------------------------------------------
+
+/// Query element \<command_isnameused> (`ghidra_arch.cc:30`).
+pub const ELEM_COMMAND_ISNAMEUSED: ElementId = ElementId::new("command_isnameused", 239);
+/// Query element \<command_getbytes> (`ghidra_arch.cc:31`).
+pub const ELEM_COMMAND_GETBYTES: ElementId = ElementId::new("command_getbytes", 240);
+/// Query element \<command_getcallfixup> (`ghidra_arch.cc:32`).
+pub const ELEM_COMMAND_GETCALLFIXUP: ElementId = ElementId::new("command_getcallfixup", 241);
+/// Query element \<command_getcallmech> (`ghidra_arch.cc:33`).
+/// (242 = getcallmech, 243 = getcallotherfixup — verified against both
+/// `ghidra_arch.cc` and `ElementId.java:380-385`.)
+pub const ELEM_COMMAND_GETCALLMECH: ElementId = ElementId::new("command_getcallmech", 242);
+/// Query element \<command_getcallotherfixup> (`ghidra_arch.cc:34`).
+pub const ELEM_COMMAND_GETCALLOTHERFIXUP: ElementId =
+    ElementId::new("command_getcallotherfixup", 243);
+/// Query element \<command_getcodelabel> (`ghidra_arch.cc:35`).
+pub const ELEM_COMMAND_GETCODELABEL: ElementId = ElementId::new("command_getcodelabel", 244);
+/// Query element \<command_getcomments> (`ghidra_arch.cc:36`).
+pub const ELEM_COMMAND_GETCOMMENTS: ElementId = ElementId::new("command_getcomments", 245);
+/// Query element \<command_getcpoolref> (`ghidra_arch.cc:37`).
+pub const ELEM_COMMAND_GETCPOOLREF: ElementId = ElementId::new("command_getcpoolref", 246);
+/// Query element \<command_getdatatype> (`ghidra_arch.cc:38`).
+pub const ELEM_COMMAND_GETDATATYPE: ElementId = ElementId::new("command_getdatatype", 247);
+/// Query element \<command_getexternalref> (`ghidra_arch.cc:39`).
+pub const ELEM_COMMAND_GETEXTERNALREF: ElementId = ElementId::new("command_getexternalref", 248);
+/// Query element \<command_getmappedsymbols> (`ghidra_arch.cc:40`).
+pub const ELEM_COMMAND_GETMAPPEDSYMBOLS: ElementId =
+    ElementId::new("command_getmappedsymbols", 249);
+/// Query element \<command_getnamespacepath> (`ghidra_arch.cc:41`).
+pub const ELEM_COMMAND_GETNAMESPACEPATH: ElementId =
+    ElementId::new("command_getnamespacepath", 250);
+/// Query element \<command_getpcode> (`ghidra_arch.cc:42`).
+pub const ELEM_COMMAND_GETPCODE: ElementId = ElementId::new("command_getpcode", 251);
+/// Query element \<command_getpcodeexecutable> (`ghidra_arch.cc:43`).
+pub const ELEM_COMMAND_GETPCODEEXECUTABLE: ElementId =
+    ElementId::new("command_getpcodeexecutable", 252);
+/// Query element \<command_getregister> (`ghidra_arch.cc:44`).
+pub const ELEM_COMMAND_GETREGISTER: ElementId = ElementId::new("command_getregister", 253);
+/// Query element \<command_getregistername> (`ghidra_arch.cc:45`).
+pub const ELEM_COMMAND_GETREGISTERNAME: ElementId = ElementId::new("command_getregistername", 254);
+/// Query element \<command_getstringdata> (`ghidra_arch.cc:46`; the Java
+/// table names id 255 `"command_getstring"` — same number, C++ name kept).
+pub const ELEM_COMMAND_GETSTRINGDATA: ElementId = ElementId::new("command_getstringdata", 255);
+/// Query element \<command_gettrackedregisters> (`ghidra_arch.cc:47`).
+pub const ELEM_COMMAND_GETTRACKEDREGISTERS: ElementId =
+    ElementId::new("command_gettrackedregisters", 256);
+/// Query element \<command_getuseropname> (`ghidra_arch.cc:48`).
+pub const ELEM_COMMAND_GETUSEROPNAME: ElementId = ElementId::new("command_getuseropname", 257);
+
+// ---------------------------------------------------------------------------
+// signature.cc:29-40 — the version/settings subset
+// ---------------------------------------------------------------------------
+// The signature commands themselves are not implemented in phase 1 (the
+// unknown-command "Bad command" response is the documented degradation
+// path), but the ids are pinned here so the phase-2+ getSignatureSettings
+// wire-glue reuses them.  kuna-decomp/src/infra/signature.rs owns the other
+// eight ids of the 258-269 block with matching upstream numbers.
+
+/// Marshaling element \<major> (C++ `ELEM_MAJOR`, `signature.cc:33`).
+pub const ELEM_MAJOR: ElementId = ElementId::new("major", 261);
+/// Marshaling element \<minor> (C++ `ELEM_MINOR`, `signature.cc:34`).
+pub const ELEM_MINOR: ElementId = ElementId::new("minor", 262);
+/// Marshaling element \<settings> (C++ `ELEM_SETTINGS`, `signature.cc:36`).
+pub const ELEM_SETTINGS: ElementId = ElementId::new("settings", 264);
+/// Marshaling element \<sigsettings> (C++ `ELEM_SIGSETTINGS`,
+/// `signature.cc:39`).
+pub const ELEM_SIGSETTINGS: ElementId = ElementId::new("sigsettings", 268);
+
+// ---------------------------------------------------------------------------
+// Attributes
+// ---------------------------------------------------------------------------
+// Every attribute the query encodings need is already a kuna-base id
+// (kuna-base/src/marshal.rs: ATTRIB_NAME=14, ATTRIB_INDEX=10, ATTRIB_TYPE=22,
+// ATTRIB_ID=9, ATTRIB_SIZE=19, ATTRIB_CONTENT=1, ATTRIB_OFFSET=16,
+// ATTRIB_BIGENDIAN=3, ATTRIB_SPACE=20; kuna-base/src/address.rs:
+// ATTRIB_FIRST=27, ATTRIB_LAST=28; kuna-sleigh/src/translate.rs:
+// ATTRIB_UNIQBASE=46) — with ONE exception:
+
+/// Marshaling attribute "maxsize" (upstream `fspec.cc:27`, id 120), used by
+/// the getStringData query.  kuna's port of this id lives in
+/// `kuna-decomp/src/s4_calls/modelrules.rs:99`, which phase 1 deliberately
+/// does not depend on; the constant is duplicated here with the same
+/// upstream number.  TODO(phase-2): drop this duplicate once kuna-ghidra
+/// links against kuna-decomp for the engine bridge.
+pub const ATTRIB_MAXSIZE: AttributeId = AttributeId::new("maxsize", 120);
+
+/// Register every ghidra-mode protocol id on the given registry (the
+/// explicit stand-in for the C++ static-object registration; follow-up to
+/// [`IdRegistry::with_base_ids`] + `register_translate_ids`, the same
+/// per-module pattern as `kuna-console`'s `build_registry`).
+pub fn register_ghidra_ids(registry: &mut IdRegistry) {
+    registry.register_attribute(&ATTRIB_MAXSIZE);
+    registry.register_element(&ELEM_DOC);
+    registry.register_element(&ELEM_COMMAND_ISNAMEUSED);
+    registry.register_element(&ELEM_COMMAND_GETBYTES);
+    registry.register_element(&ELEM_COMMAND_GETCALLFIXUP);
+    registry.register_element(&ELEM_COMMAND_GETCALLMECH);
+    registry.register_element(&ELEM_COMMAND_GETCALLOTHERFIXUP);
+    registry.register_element(&ELEM_COMMAND_GETCODELABEL);
+    registry.register_element(&ELEM_COMMAND_GETCOMMENTS);
+    registry.register_element(&ELEM_COMMAND_GETCPOOLREF);
+    registry.register_element(&ELEM_COMMAND_GETDATATYPE);
+    registry.register_element(&ELEM_COMMAND_GETEXTERNALREF);
+    registry.register_element(&ELEM_COMMAND_GETMAPPEDSYMBOLS);
+    registry.register_element(&ELEM_COMMAND_GETNAMESPACEPATH);
+    registry.register_element(&ELEM_COMMAND_GETPCODE);
+    registry.register_element(&ELEM_COMMAND_GETPCODEEXECUTABLE);
+    registry.register_element(&ELEM_COMMAND_GETREGISTER);
+    registry.register_element(&ELEM_COMMAND_GETREGISTERNAME);
+    registry.register_element(&ELEM_COMMAND_GETSTRINGDATA);
+    registry.register_element(&ELEM_COMMAND_GETTRACKEDREGISTERS);
+    registry.register_element(&ELEM_COMMAND_GETUSEROPNAME);
+    registry.register_element(&ELEM_MAJOR);
+    registry.register_element(&ELEM_MINOR);
+    registry.register_element(&ELEM_SETTINGS);
+    registry.register_element(&ELEM_SIGSETTINGS);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The verified upstream numbers (`ghidra_arch.cc:30-48` ==
+    /// `ElementId.java:371-427`; `signature.cc:29-40` == `ElementId.java:433-440`).
+    #[test]
+    fn test_protocol_id_numbers_match_upstream() {
+        assert_eq!(ELEM_DOC.get_id(), 229);
+        assert_eq!(ELEM_COMMAND_ISNAMEUSED.get_id(), 239);
+        assert_eq!(ELEM_COMMAND_GETBYTES.get_id(), 240);
+        assert_eq!(ELEM_COMMAND_GETCALLFIXUP.get_id(), 241);
+        assert_eq!(ELEM_COMMAND_GETCALLMECH.get_id(), 242);
+        assert_eq!(ELEM_COMMAND_GETCALLOTHERFIXUP.get_id(), 243);
+        assert_eq!(ELEM_COMMAND_GETCODELABEL.get_id(), 244);
+        assert_eq!(ELEM_COMMAND_GETCOMMENTS.get_id(), 245);
+        assert_eq!(ELEM_COMMAND_GETCPOOLREF.get_id(), 246);
+        assert_eq!(ELEM_COMMAND_GETDATATYPE.get_id(), 247);
+        assert_eq!(ELEM_COMMAND_GETEXTERNALREF.get_id(), 248);
+        assert_eq!(ELEM_COMMAND_GETMAPPEDSYMBOLS.get_id(), 249);
+        assert_eq!(ELEM_COMMAND_GETNAMESPACEPATH.get_id(), 250);
+        assert_eq!(ELEM_COMMAND_GETPCODE.get_id(), 251);
+        assert_eq!(ELEM_COMMAND_GETPCODEEXECUTABLE.get_id(), 252);
+        assert_eq!(ELEM_COMMAND_GETREGISTER.get_id(), 253);
+        assert_eq!(ELEM_COMMAND_GETREGISTERNAME.get_id(), 254);
+        assert_eq!(ELEM_COMMAND_GETSTRINGDATA.get_id(), 255);
+        assert_eq!(ELEM_COMMAND_GETTRACKEDREGISTERS.get_id(), 256);
+        assert_eq!(ELEM_COMMAND_GETUSEROPNAME.get_id(), 257);
+        assert_eq!(ELEM_MAJOR.get_id(), 261);
+        assert_eq!(ELEM_MINOR.get_id(), 262);
+        assert_eq!(ELEM_SETTINGS.get_id(), 264);
+        assert_eq!(ELEM_SIGSETTINGS.get_id(), 268);
+        assert_eq!(ATTRIB_MAXSIZE.get_id(), 120);
+    }
+}

--- a/decompiler/crates/kuna-ghidra/src/lib.rs
+++ b/decompiler/crates/kuna-ghidra/src/lib.rs
@@ -1,0 +1,52 @@
+//! kuna-ghidra: the ghidra-mode process front-end — the native side of the
+//! Ghidra GUI <-> decompiler stdin/stdout protocol.
+//!
+//! Upstream Ghidra's GUI talks to a separate native executable (installed
+//! as `decompile`, built from the CORE+DECCORE+GHIDRA source groups —
+//! `decompiler/cpp/ghidra_process.cc`, `ghidra_arch.cc`,
+//! `ghidra_translate.cc`, ...) over a burst-framed binary protocol on
+//! stdin/stdout: Ghidra sends *commands* (registerProgram, decompileAt,
+//! setOptions, ...) carrying packed/XML documents, and while executing a
+//! command the decompiler sends *queries* back (getPcode, getBytes,
+//! getMappedSymbols, ... — 19 of them) that Ghidra answers from the open
+//! program.  No `.sla` is ever loaded: every instruction's p-code, every
+//! byte, symbol, type and comment arrives over the wire.
+//!
+//! This crate is the kuna port of that front-end, layered as:
+//!
+//! - [`protocol`] — the burst framing (`ghidra_arch.cc:50-248`), generic
+//!   over `Read`/`Write`.
+//! - [`ids`] — the protocol ElementIds (upstream numbers, wire-compatible).
+//! - [`client`] — the 19 typed decompiler->Ghidra queries
+//!   (`ghidra_arch.cc:445-896`).
+//! - [`translate`] — the tspec `<sleigh>` decode into a real
+//!   `AddrSpaceManager` (`ghidra_translate.cc:161-176`), which binds the
+//!   packed protocol's address-space indices.
+//! - [`process`] — the command loop (`ghidra_process.cc`), the `kuna_ghidra`
+//!   binary's engine.
+//!
+//! ## Phase plan (see `docs/ghidra-integration.md`)
+//!
+//! - **Phase 1 (this crate today): wire-protocol complete, engine
+//!   stubbed.**  The full command lifecycle, framing, tspec parse and query
+//!   client are implemented and byte-exact; `decompileAt` answers the
+//!   incomplete-function shape (empty payload + a not-implemented warning)
+//!   so the Ghidra GUI degrades cleanly.  Deliberately no kuna-decomp
+//!   dependency.
+//! - **Phase 2: the engine bridge** — an `ArchitectureGhidra` analog
+//!   backing kuna's loader/translator/scope/type/comment/string/cpool/
+//!   inject/context seams with the query client, plus `Funcdata::encode`
+//!   and the marked-up C output for the decompileAt response.
+//! - **Phase 3: lazy scope/types** (the ScopeGhidra cache/holes model).
+//! - **Phase 4: GUI parity** (structureGraph, signature commands, ...).
+//!
+//! The Ghidra-side extension that spawns this binary lives outside the
+//! cargo workspace; `docs/ghidra-integration.md` documents the pairing,
+//! the targeted Ghidra release, and the deliberate divergences (setOptions
+//! tolerance, malformed-archid handling).
+
+pub mod client;
+pub mod ids;
+pub mod process;
+pub mod protocol;
+pub mod translate;

--- a/decompiler/crates/kuna-ghidra/src/process.rs
+++ b/decompiler/crates/kuna-ghidra/src/process.rs
@@ -1,0 +1,735 @@
+//! The ghidra-mode command loop — a port of `decompiler/cpp/ghidra_process.cc`
+//! (`GhidraCapability::readCommand`, `GhidraCommand::doit`, and the seven
+//! decomp-capability commands, ghidra_process.cc:86-506).
+//!
+//! Lifecycle per command (`doit`, ghidra_process.cc:125-160), preserved
+//! exactly:
+//!
+//! ```text
+//!   write {0,0,1,6}                        response OPEN — before any work
+//!   loadParameters()                       archid as ASCII decimal in a
+//!                                          string stream (every command
+//!                                          except registerProgram), plus
+//!                                          command-specific params
+//!   expect burst 3 (command close)
+//!   rawAction()
+//!   catch DecoderError  -> "Marshaling error: ..."     (warning)
+//!   catch JavaError     -> passJavaException, NO sendResult
+//!   catch RecovError    -> "Recoverable Error: ..."    (warning)
+//!   catch LowlevelError -> "Low-level Error: ..."      (warning)
+//!   sendResult()                           optional payload, then ALWAYS
+//!                                          the 16/17 warnings frame
+//!                                          (possibly empty) — but only
+//!                                          while a session is bound
+//!   write {0,0,1,7}; flush
+//! ```
+//!
+//! Because the response-open burst is written first, any queries a command
+//! issues are nested inside the open command response (the phase-2 engine
+//! bridge relies on this).
+//!
+//! Phase-1 scope (see `docs/ghidra-integration.md`): the protocol side of
+//! all seven decomp commands is complete; `decompileAt` answers with the
+//! incomplete-function shape (an EMPTY 14/15 payload,
+//! ghidra_process.cc:313-334) plus a not-implemented warning, and
+//! `flushNative` has no engine caches to clear yet.  `structureGraph` and
+//! the four signature commands are deliberately NOT registered: the
+//! unknown-command response `{6}{16}"Bad command: <name>"{17}{7}`
+//! (ghidra_process.cc:476-484) is the exact graceful-degradation shape the
+//! Java side expects (DecompInterface.java:341-347).
+
+use std::io::{Read, Write};
+
+use kuna_base::address::Address;
+use kuna_base::error::KunaError;
+use kuna_base::marshal::{Decoder, IdRegistry, PackedDecode};
+use kuna_base::space::AddrSpaceManager;
+
+use crate::protocol::{
+    pass_java_exception, read_string_stream, read_string_stream_optional, read_to_any_burst,
+    write_burst, write_string_stream, WireError, WireResult, BURST_COMMAND_CLOSE,
+    BURST_COMMAND_OPEN, BURST_MESSAGE_CLOSE, BURST_MESSAGE_OPEN, BURST_RESPONSE_CLOSE,
+    BURST_RESPONSE_OPEN, BURST_STRING_CLOSE, BURST_STRING_OPEN,
+};
+use crate::translate::{build_registry, GhidraTranslate};
+
+/// One registered program: the kuna analog of an `ArchitectureGhidra` slot
+/// in the global `archlist` (ghidra_process.cc:76,176-201).
+///
+/// Phase 1 holds the wire-session state only; the engine (`Architecture`
+/// init over the four specs, the query-backed providers) is phase 2.
+struct Session {
+    /// The four registerProgram XML documents, held verbatim for the
+    /// phase-2 engine bridge (C++ parses them in buildSpecFile and clears
+    /// them; kuna keeps them so phase 2 can replay them into the engine).
+    #[allow(dead_code)]
+    pspec: Vec<u8>,
+    #[allow(dead_code)]
+    cspec: Vec<u8>,
+    #[allow(dead_code)]
+    tspec: Vec<u8>,
+    #[allow(dead_code)]
+    corespec: Vec<u8>,
+    /// The session's marshaling id tables (the C++ static registration).
+    #[allow(dead_code)]
+    registry: IdRegistry,
+    /// The parsed tspec — endianness, unique base, and the address-space
+    /// manager whose indices decode wire \<addr> elements.  `None` when the
+    /// tspec failed to parse (recorded as a warning; \<addr> params are
+    /// then consumed without decoding — TODO(phase-2): a parse failure
+    /// should fail registerProgram once the engine init is real).
+    translate: Option<GhidraTranslate>,
+    /// Accumulated warnings, shipped on the 16/17 channel by sendResult
+    /// (C++ `ArchitectureGhidra::warnings`; `printMessage` appends
+    /// `'\n' + message`, ghidra_arch.cc:898-902).
+    warnings: String,
+    /// setAction "tree"/"notree" (C++ `sendsyntaxtree`, default true).
+    send_syntax_tree: bool,
+    /// setAction "c"/"noc" (C++ `sendCcode`, default true).
+    send_c_code: bool,
+    /// setAction "parammeasures"/"noparammeasures" (default false).
+    send_param_measures: bool,
+    /// setAction "jumpload"/"nojumpload" (C++ `FlowInfo::record_jumploads`
+    /// in `ghidra->flowoptions`, default off).
+    record_jumploads: bool,
+    /// The current root action (C++ `allacts.setCurrent`; default
+    /// "decompile").
+    current_action: String,
+}
+
+impl Session {
+    /// Build a session from the four registerProgram documents, parsing the
+    /// tspec leniently (a failure becomes a warning, not a command error).
+    fn new(pspec: Vec<u8>, cspec: Vec<u8>, tspec: Vec<u8>, corespec: Vec<u8>) -> Session {
+        let registry = build_registry();
+        let mut warnings = String::new();
+        let translate = match GhidraTranslate::decode(&tspec, &registry) {
+            Ok(t) => Some(t),
+            Err(e) => {
+                // printMessage semantics: '\n' + message
+                warnings.push('\n');
+                warnings.push_str(&format!(
+                    "kuna ghidra-mode: could not parse tspec <sleigh> element ({}); \
+                     <addr> parameters will not be decoded",
+                    e.explain()
+                ));
+                None
+            }
+        };
+        Session {
+            pspec,
+            cspec,
+            tspec,
+            corespec,
+            registry,
+            translate,
+            warnings,
+            // ArchitectureGhidra constructor defaults (ghidra_arch.cc:912-926)
+            send_syntax_tree: true,
+            send_c_code: true,
+            send_param_measures: false,
+            record_jumploads: false,
+            current_action: "decompile".to_string(),
+        }
+    }
+
+    /// C++ `ArchitectureGhidra::printMessage` (ghidra_arch.cc:898-902).
+    fn print_message(&mut self, message: &str) {
+        self.warnings.push('\n');
+        self.warnings.push_str(message);
+    }
+}
+
+/// Which registered command is executing (the C++ `commandmap` keys,
+/// ghidra_process.cc:496-506, minus structureGraph — see module docs).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CommandKind {
+    RegisterProgram,
+    DeregisterProgram,
+    FlushNative,
+    DecompileAt,
+    SetAction,
+    SetOptions,
+}
+
+/// Per-command scratch state (the C++ `GhidraCommand` subclass members).
+struct CommandState {
+    kind: CommandKind,
+    /// The bound archlist slot (C++ `ghidra` member); `None` until
+    /// loadParameters binds it, and unbound again by deregister (C++ nulls
+    /// `ghidra` after delete, so its sendResult skips the 16/17 frame).
+    slot: Option<usize>,
+    /// 0 = keep looping, 1 = terminate (C++ `status`).
+    status: i32,
+    /// registerProgram result (C++ `RegisterProgram::archid`).
+    archid: i32,
+    /// deregisterProgram / flushNative result (C++ `res`).
+    res: i32,
+    /// setAction / setOptions result (C++ `res` bool).
+    ok: bool,
+    /// registerProgram params.
+    specs: Option<[Vec<u8>; 4]>,
+    /// setAction params.
+    actionstring: Vec<u8>,
+    printstring: Vec<u8>,
+    /// decompileAt param: the decoded address (None if the tspec is
+    /// unavailable) plus its rendered form for messages.
+    addr_text: Option<String>,
+    /// setOptions param: the raw packed \<optionslist> bytes.
+    options_raw: Option<Vec<u8>>,
+}
+
+impl CommandState {
+    fn new(kind: CommandKind) -> CommandState {
+        CommandState {
+            kind,
+            slot: None,
+            status: 0,
+            archid: -1,
+            res: 0,
+            ok: false,
+            specs: None,
+            actionstring: Vec::new(),
+            printstring: Vec::new(),
+            addr_text: None,
+            options_raw: None,
+        }
+    }
+}
+
+/// The ghidra-mode process: the command loop over the two protocol streams
+/// plus the architecture list (C++ `archlist` + `GhidraCapability::
+/// readCommand`, ghidra_process.cc:76,464-486).
+pub struct GhidraProcess<R: Read, W: Write> {
+    sin: R,
+    sout: W,
+    archlist: Vec<Option<Session>>,
+}
+
+impl<R: Read, W: Write> GhidraProcess<R, W> {
+    /// Construct over the two protocol streams (stdin/stdout in the real
+    /// binary; in-memory buffers in tests).
+    pub fn new(sin: R, sout: W) -> Self {
+        GhidraProcess {
+            sin,
+            sout,
+            archlist: Vec::new(),
+        }
+    }
+
+    /// Tear down into the underlying streams (test access to the written
+    /// response bytes).
+    pub fn into_inner(self) -> (R, W) {
+        (self.sin, self.sout)
+    }
+
+    /// Run the process loop until a command terminates it (C++ `main`'s
+    /// `while(status == 0) status = readCommand(...)`,
+    /// ghidra_process.cc:532-535).  Returns the terminating status.
+    pub fn run(&mut self) -> WireResult<i32> {
+        loop {
+            let status = self.read_command()?;
+            if status != 0 {
+                return Ok(status);
+            }
+        }
+    }
+
+    /// Read and execute one command (C++ `GhidraCapability::readCommand`,
+    /// ghidra_process.cc:464-486).  Returns the command's meta-status
+    /// (0 = continue, 1 = terminate).
+    pub fn read_command(&mut self) -> WireResult<i32> {
+        // Align ourselves: scan to the next command-open burst, skipping
+        // anything else (including the dangling params + close burst of a
+        // rejected command).
+        loop {
+            if read_to_any_burst(&mut self.sin)? == BURST_COMMAND_OPEN {
+                break;
+            }
+        }
+        let name_bytes = read_string_stream(&mut self.sin)?;
+        let name = String::from_utf8_lossy(&name_bytes).into_owned();
+        let kind = match name.as_str() {
+            "registerProgram" => CommandKind::RegisterProgram,
+            "deregisterProgram" => CommandKind::DeregisterProgram,
+            "flushNative" => CommandKind::FlushNative,
+            "decompileAt" => CommandKind::DecompileAt,
+            "setAction" => CommandKind::SetAction,
+            "setOptions" => CommandKind::SetOptions,
+            // structureGraph, generateSignatures, debugSignatures,
+            // getSignatureSettings, setSignatureSettings are deliberately
+            // unregistered in phase 1: this response — with NO payload
+            // burst and NO command-close read — is the exact
+            // graceful-degradation contract the Java side expects
+            // (ghidra_process.cc:476-484; DecompInterface.java:341-347).
+            _ => {
+                write_burst(&mut self.sout, BURST_RESPONSE_OPEN)?;
+                write_burst(&mut self.sout, BURST_MESSAGE_OPEN)?;
+                self.sout
+                    .write_all(format!("Bad command: {name}").as_bytes())
+                    .map_err(WireError::Io)?;
+                write_burst(&mut self.sout, BURST_MESSAGE_CLOSE)?;
+                write_burst(&mut self.sout, BURST_RESPONSE_CLOSE)?;
+                self.sout.flush().map_err(WireError::Io)?;
+                return Ok(0);
+            }
+        };
+        self.doit(kind)
+    }
+
+    /// The canonical command lifecycle (C++ `GhidraCommand::doit`,
+    /// ghidra_process.cc:125-160).
+    fn doit(&mut self, kind: CommandKind) -> WireResult<i32> {
+        let mut cmd = CommandState::new(kind);
+        // Command response header — BEFORE any work, so queries nest inside
+        write_burst(&mut self.sout, BURST_RESPONSE_OPEN)?;
+        let result = self.run_command(&mut cmd);
+        match result {
+            Ok(()) => {}
+            // Pipe/IO failures propagate to the process loop (C++ exit(1))
+            Err(e @ (WireError::PipeClosed | WireError::Io(_))) => return Err(e),
+            // catch(JavaError): pass the exception, abort sending results
+            Err(WireError::Kuna(KunaError::Java { type_name, explain })) => {
+                pass_java_exception(&mut self.sout, &type_name, &explain)?;
+                // C++ relies on cin.tie(&cout) flushing before the next
+                // blocking read; Rust must flush explicitly.
+                self.sout.flush().map_err(WireError::Io)?;
+                return Ok(cmd.status);
+            }
+            // catch(DecoderError) / catch(RecovError) / catch(LowlevelError):
+            // classify into a warning (KunaError::Decoder is the standalone
+            // C++ DecoderError; Recov its subclass family; every other
+            // variant derives LowlevelError — see kuna-base error.rs docs)
+            Err(WireError::Kuna(err)) => {
+                let errmsg = match &err {
+                    KunaError::Decoder { .. } => format!("Marshaling error: {}", err.explain()),
+                    KunaError::Recov { .. } => format!("Recoverable Error: {}", err.explain()),
+                    _ => format!("Low-level Error: {}", err.explain()),
+                };
+                self.print_message(cmd.slot, &errmsg);
+            }
+        }
+        self.send_result(&cmd)?;
+        write_burst(&mut self.sout, BURST_RESPONSE_CLOSE)?;
+        self.sout.flush().map_err(WireError::Io)?;
+        Ok(cmd.status)
+    }
+
+    /// loadParameters + the command-close burst + rawAction (the `try`
+    /// body of doit).
+    fn run_command(&mut self, cmd: &mut CommandState) -> WireResult<()> {
+        self.load_parameters(cmd)?;
+        let t = read_to_any_burst(&mut self.sin)?;
+        if t != BURST_COMMAND_CLOSE {
+            return Err(WireError::Kuna(KunaError::java(
+                "alignment",
+                "Missing end of command",
+            )));
+        }
+        self.raw_action(cmd)
+    }
+
+    // -- loadParameters -----------------------------------------------------
+
+    /// The base `GhidraCommand::loadParameters` (ghidra_process.cc:86-103):
+    /// the architecture id as ASCII decimal in a string stream, validated
+    /// against the archlist, then `clearWarnings`.
+    fn bind_session(&mut self, start_msg: &str, end_msg: &str) -> WireResult<usize> {
+        let t = read_to_any_burst(&mut self.sin)?;
+        if t != BURST_STRING_OPEN {
+            return Err(WireError::Kuna(KunaError::java("alignment", start_msg)));
+        }
+        let (payload, code) = crate::protocol::read_id_payload(&mut self.sin)?;
+        if code != BURST_STRING_CLOSE {
+            return Err(WireError::Kuna(KunaError::java("alignment", end_msg)));
+        }
+        let id = parse_arch_id(&payload);
+        if id >= 0 && (id as usize) < self.archlist.len() && self.archlist[id as usize].is_some() {
+            let slot = id as usize;
+            // ghidra->clearWarnings()
+            if let Some(session) = self.archlist[slot].as_mut() {
+                session.warnings.clear();
+            }
+            return Ok(slot);
+        }
+        Err(WireError::Kuna(KunaError::java(
+            "decompiler",
+            "No architecture registered with decompiler",
+        )))
+    }
+
+    fn load_parameters(&mut self, cmd: &mut CommandState) -> WireResult<()> {
+        match cmd.kind {
+            // RegisterProgram::loadParameters (ghidra_process.cc:162-173):
+            // four consecutive string streams, no arch id
+            CommandKind::RegisterProgram => {
+                let pspec = read_string_stream(&mut self.sin)?;
+                let cspec = read_string_stream(&mut self.sin)?;
+                let tspec = read_string_stream(&mut self.sin)?;
+                let corespec = read_string_stream(&mut self.sin)?;
+                cmd.specs = Some([pspec, cspec, tspec, corespec]);
+                Ok(())
+            }
+            // DeregisterProgram::loadParameters (ghidra_process.cc:212-229)
+            CommandKind::DeregisterProgram => {
+                let slot = self.bind_session(
+                    "Expecting deregister id start",
+                    "Expecting deregister id end",
+                )?;
+                cmd.slot = Some(slot);
+                Ok(())
+            }
+            CommandKind::FlushNative => {
+                let slot = self.bind_session("Expecting arch id start", "Expecting arch id end")?;
+                cmd.slot = Some(slot);
+                Ok(())
+            }
+            // DecompileAt::loadParameters (ghidra_process.cc:284-291): base,
+            // then the packed <addr> ingested and decoded
+            CommandKind::DecompileAt => {
+                let slot = self.bind_session("Expecting arch id start", "Expecting arch id end")?;
+                cmd.slot = Some(slot);
+                let raw = read_string_stream_optional(&mut self.sin)?;
+                let session = self.archlist[slot].as_ref().expect("bound session");
+                match (&session.translate, raw) {
+                    (Some(tr), Some(bytes)) => {
+                        let mut decoder = PackedDecode::new(&tr.manager);
+                        decoder.ingest_stream(&bytes).map_err(WireError::Kuna)?;
+                        let addr = Address::decode(&mut decoder).map_err(WireError::Kuna)?;
+                        cmd.addr_text = Some(render_address(&addr));
+                    }
+                    (None, Some(_bytes)) => {
+                        // tspec unavailable: the <addr> was consumed but
+                        // cannot be decoded (lenient skip; the session
+                        // already carries the tspec warning).
+                        // TODO(phase-2): hard-fail once engine init is real.
+                        cmd.addr_text = None;
+                    }
+                    (_, None) => {
+                        // Missing payload: C++ Address::decode on the empty
+                        // decoder raises DecoderError -> "Marshaling error"
+                        return Err(WireError::Kuna(KunaError::decoder(
+                            "Expecting <addr> element",
+                        )));
+                    }
+                }
+                Ok(())
+            }
+            // SetAction::loadParameters (ghidra_process.cc:368-376)
+            CommandKind::SetAction => {
+                let slot = self.bind_session("Expecting arch id start", "Expecting arch id end")?;
+                cmd.slot = Some(slot);
+                cmd.actionstring = read_string_stream(&mut self.sin)?;
+                cmd.printstring = read_string_stream(&mut self.sin)?;
+                Ok(())
+            }
+            // SetOptions::loadParameters (ghidra_process.cc:418-426): base,
+            // then the packed <optionslist> string stream
+            CommandKind::SetOptions => {
+                let slot = self.bind_session("Expecting arch id start", "Expecting arch id end")?;
+                cmd.slot = Some(slot);
+                cmd.options_raw = read_string_stream_optional(&mut self.sin)?;
+                Ok(())
+            }
+        }
+    }
+
+    // -- rawAction ------------------------------------------------------------
+
+    fn raw_action(&mut self, cmd: &mut CommandState) -> WireResult<()> {
+        match cmd.kind {
+            // RegisterProgram::rawAction (ghidra_process.cc:176-201): find a
+            // free slot (the C++ loop keeps the LAST open slot), build the
+            // session, archid = slot index
+            CommandKind::RegisterProgram => {
+                let [pspec, cspec, tspec, corespec] =
+                    cmd.specs.take().expect("registerProgram params");
+                let session = Session::new(pspec, cspec, tspec, corespec);
+                let mut open: Option<usize> = None;
+                for (i, s) in self.archlist.iter().enumerate() {
+                    if s.is_none() {
+                        open = Some(i); // C++ keeps scanning: last open slot
+                    }
+                }
+                let slot = match open {
+                    Some(i) => {
+                        self.archlist[i] = Some(session);
+                        i
+                    }
+                    None => {
+                        self.archlist.push(Some(session));
+                        self.archlist.len() - 1
+                    }
+                };
+                cmd.slot = Some(slot);
+                cmd.archid = slot as i32;
+                Ok(())
+            }
+            // DeregisterProgram::rawAction (ghidra_process.cc:231-251):
+            // free the slot, res=1, status=1 terminates the process loop.
+            // C++ nulls `ghidra` after the delete, so the base sendResult's
+            // 16/17 frame is skipped — mirror by unbinding the slot.
+            CommandKind::DeregisterProgram => {
+                if let Some(slot) = cmd.slot.take() {
+                    cmd.res = 1;
+                    self.archlist[slot] = None;
+                    cmd.status = 1;
+                } else {
+                    cmd.res = 0;
+                }
+                Ok(())
+            }
+            // FlushNative::rawAction (ghidra_process.cc:262-273): phase 1
+            // has no engine caches (global scope / non-core types /
+            // comments / strings / cpool are all phase 2) — nothing to
+            // flush.  TODO(phase-2): clear the provider caches here.
+            CommandKind::FlushNative => {
+                cmd.res = 0;
+                Ok(())
+            }
+            // DecompileAt::rawAction (ghidra_process.cc:293-335): phase 1
+            // emits the incomplete-function shape — an EMPTY 14/15 payload
+            // (exactly what upstream sends when !fd->isProcComplete()) —
+            // plus a warning on the 16/17 channel, which renders as a clean
+            // error in the Ghidra GUI instead of a hang/desync.
+            CommandKind::DecompileAt => {
+                write_burst(&mut self.sout, BURST_STRING_OPEN)?;
+                write_burst(&mut self.sout, BURST_STRING_CLOSE)?;
+                let at = match &cmd.addr_text {
+                    Some(t) => t.clone(),
+                    None => "(address not decoded)".to_string(),
+                };
+                self.print_message(
+                    cmd.slot,
+                    &format!(
+                        "kuna ghidra-mode: engine bridge not yet implemented (phase 1); \
+                         function at {at} not decompiled"
+                    ),
+                );
+                Ok(())
+            }
+            // SetAction::rawAction (ghidra_process.cc:378-406)
+            CommandKind::SetAction => {
+                let slot = cmd.slot.expect("bound session");
+                let actionstring = String::from_utf8_lossy(&cmd.actionstring).into_owned();
+                let printstring = String::from_utf8_lossy(&cmd.printstring).into_owned();
+                let session = self.archlist[slot].as_mut().expect("bound session");
+                if !actionstring.is_empty() {
+                    // allacts.setCurrent: the registered root actions
+                    // (ghidra_process.hh:190-196 plus the "universal" root
+                    // the ActionDatabase always defines)
+                    match actionstring.as_str() {
+                        "decompile" | "normalize" | "jumptable" | "paramid" | "register"
+                        | "firstpass" | "universal" => {
+                            session.current_action = actionstring;
+                        }
+                        _ => {
+                            // C++ setCurrent -> deriveAction -> getGroup(name), which
+                            // throws "Action group does not exist: <name>" for an
+                            // unregistered root (action.cc:1005-1013,1145-1158); match
+                            // its wording so the 16/17 warning the GUI shows is faithful.
+                            return Err(WireError::Kuna(KunaError::lowlevel(format!(
+                                "Action group does not exist: {actionstring}"
+                            ))));
+                        }
+                    }
+                }
+                if !printstring.is_empty() {
+                    match printstring.as_str() {
+                        "tree" => session.send_syntax_tree = true,
+                        "notree" => session.send_syntax_tree = false,
+                        "c" => session.send_c_code = true,
+                        "noc" => session.send_c_code = false,
+                        "parammeasures" => session.send_param_measures = true,
+                        "noparammeasures" => session.send_param_measures = false,
+                        "jumpload" => session.record_jumploads = true,
+                        "nojumpload" => session.record_jumploads = false,
+                        _ => {
+                            return Err(WireError::Kuna(KunaError::lowlevel(format!(
+                                "Unknown print action: {printstring}"
+                            ))))
+                        }
+                    }
+                }
+                cmd.ok = true;
+                Ok(())
+            }
+            // SetOptions::rawAction (ghidra_process.cc:435-445).
+            // DELIBERATE DIVERGENCE (docs/ghidra-integration.md): upstream
+            // decodes the <optionslist> and throws on any unknown option
+            // (OptionDatabase::set -> ParseError -> response 'f' -> Java
+            // IOException "Did not accept decompiler options", killing the
+            // program open).  Phase-1 kuna has no option database yet, and
+            // for drop-in robustness across Ghidra versions it TOLERATES
+            // the whole list: the packed stream is consumed (and counted
+            // when decodable) and the answer is always 't'.
+            CommandKind::SetOptions => {
+                let slot = cmd.slot.expect("bound session");
+                let counted = cmd.options_raw.as_ref().and_then(|raw| {
+                    let session = self.archlist[slot].as_ref().expect("bound session");
+                    count_option_elements(raw, session.translate.as_ref().map(|t| &t.manager))
+                });
+                let msg = match counted {
+                    Some(n) => format!(
+                        "kuna ghidra-mode: setOptions: {n} option element(s) recorded \
+                         but not applied (phase 1)"
+                    ),
+                    None => "kuna ghidra-mode: setOptions accepted but not applied (phase 1)"
+                        .to_string(),
+                };
+                self.print_message(cmd.slot, &msg);
+                cmd.ok = true;
+                Ok(())
+            }
+        }
+    }
+
+    // -- sendResult -----------------------------------------------------------
+
+    /// The per-command payload plus the base `GhidraCommand::sendResult`
+    /// warnings frame (ghidra_process.cc:108-116,203-210,253-260,275-282,
+    /// 408-416,447-455).  The 16/17 frame is written only while a session
+    /// is bound (the C++ `ghidra != nullptr` check).
+    fn send_result(&mut self, cmd: &CommandState) -> WireResult<()> {
+        match cmd.kind {
+            CommandKind::RegisterProgram => {
+                write_string_stream(&mut self.sout, cmd.archid.to_string().as_bytes())?;
+            }
+            CommandKind::DeregisterProgram | CommandKind::FlushNative => {
+                write_string_stream(&mut self.sout, cmd.res.to_string().as_bytes())?;
+            }
+            CommandKind::SetAction | CommandKind::SetOptions => {
+                write_string_stream(&mut self.sout, if cmd.ok { b"t" } else { b"f" })?;
+            }
+            // DecompileAt writes its payload inside rawAction (or none at
+            // all when rawAction was aborted) — nothing here
+            CommandKind::DecompileAt => {}
+        }
+        if let Some(slot) = cmd.slot {
+            if let Some(session) = self.archlist[slot].as_ref() {
+                write_burst(&mut self.sout, BURST_MESSAGE_OPEN)?;
+                self.sout
+                    .write_all(session.warnings.as_bytes())
+                    .map_err(WireError::Io)?;
+                write_burst(&mut self.sout, BURST_MESSAGE_CLOSE)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Route a message to the bound session's warning accumulator; without
+    /// a bound session the message is dropped (the C++ base sendResult
+    /// skips the 16/17 frame entirely when `ghidra` is null).
+    ///
+    /// TODO(phase-2): C++ `RegisterProgram::rawAction` assigns `ghidra` to
+    /// the freshly-`new`'d `ArchitectureGhidra` *before* `init`, so an
+    /// `init` that throws on bad specs still ships its error on the 16/17
+    /// channel — and Java's registerProgram treats a non-empty
+    /// nativeMessage as registration failure (`DecompInterface.java:291-294`).
+    /// Phase 1 never hits this (`Session::new` is infallible; every pre-bind
+    /// error is a `JavaError`), but once phase 2 makes registerProgram's
+    /// engine init fallible, the in-flight session needs a warning sink here
+    /// (bind the slot first, or buffer warnings on `CommandState`) or a
+    /// failed registration would answer with a bare archid and no warning,
+    /// and Java would think it succeeded.
+    fn print_message(&mut self, slot: Option<usize>, message: &str) {
+        if let Some(slot) = slot {
+            if let Some(session) = self.archlist[slot].as_mut() {
+                session.print_message(message);
+            }
+        }
+    }
+}
+
+/// Parse the ASCII-decimal architecture id (C++ `sin >> dec >> id`,
+/// ghidra_process.cc:92): skip whitespace, optional sign, decimal digits,
+/// stopping at the first non-digit.
+///
+/// DELIBERATE DIVERGENCE: on extraction failure C++11 stores 0 AND sets
+/// failbit, after which every read fails and the process exits.  kuna
+/// returns -1, which the caller turns into the "No architecture registered
+/// with decompiler" JavaError — the client sees a clean exception and the
+/// process stays alive (docs/ghidra-integration.md).
+fn parse_arch_id(payload: &[u8]) -> i32 {
+    let mut i = 0usize;
+    while i < payload.len() && (payload[i] as char).is_ascii_whitespace() {
+        i += 1;
+    }
+    let mut negative = false;
+    if i < payload.len() && (payload[i] == b'+' || payload[i] == b'-') {
+        negative = payload[i] == b'-';
+        i += 1;
+    }
+    let mut val: i64 = 0;
+    let mut any = false;
+    while i < payload.len() && payload[i].is_ascii_digit() {
+        any = true;
+        val = val
+            .saturating_mul(10)
+            .saturating_add((payload[i] - b'0') as i64);
+        i += 1;
+    }
+    if !any {
+        return -1;
+    }
+    if negative {
+        val = -val;
+    }
+    val.clamp(i32::MIN as i64, i32::MAX as i64) as i32
+}
+
+/// Render an address for warning messages: the space shortcut plus the C++
+/// `printRaw` form (the shape of upstream's decompileAt/getBytes messages).
+fn render_address(addr: &Address) -> String {
+    let mut s = String::new();
+    if let Some(spc) = addr.get_space() {
+        s.push(spc.get_shortcut());
+    }
+    if addr.print_raw(&mut s).is_err() {
+        s.push_str("invalid_addr");
+    }
+    s
+}
+
+/// Best-effort count of the child elements of the packed \<optionslist>
+/// (option elements hold only strings/ints, so an empty manager decodes
+/// them fine).  `None` when the stream doesn't decode.
+fn count_option_elements(raw: &[u8], manager: Option<&AddrSpaceManager>) -> Option<usize> {
+    let empty;
+    let mgr = match manager {
+        Some(m) => m,
+        None => {
+            empty = AddrSpaceManager::new();
+            &empty
+        }
+    };
+    let mut decoder = PackedDecode::new(mgr);
+    decoder.ingest_stream(raw).ok()?;
+    let root = decoder.open_element().ok()?;
+    if root == 0 {
+        return None;
+    }
+    let mut n = 0usize;
+    while decoder.peek_element().ok()? != 0 {
+        decoder.skip_element().ok()?;
+        n += 1;
+    }
+    decoder.close_element(root).ok()?;
+    Some(n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_arch_id() {
+        assert_eq!(parse_arch_id(b"0"), 0);
+        assert_eq!(parse_arch_id(b"17"), 17);
+        assert_eq!(parse_arch_id(b" 3"), 3);
+        assert_eq!(parse_arch_id(b"5xyz"), 5); // stops at first non-digit
+        assert_eq!(parse_arch_id(b"-2"), -2);
+        assert_eq!(parse_arch_id(b""), -1); // kuna divergence: -1, not 0
+        assert_eq!(parse_arch_id(b"abc"), -1);
+    }
+}

--- a/decompiler/crates/kuna-ghidra/src/protocol.rs
+++ b/decompiler/crates/kuna-ghidra/src/protocol.rs
@@ -1,0 +1,534 @@
+//! The burst framing of the Ghidra client <-> decompiler protocol — a
+//! line-faithful port of the static stream helpers on `ArchitectureGhidra`
+//! (`decompiler/cpp/ghidra_arch.cc:50-248`).
+//!
+//! Every protocol marker ("burst") is written as the four bytes
+//! `{0x00,0x00,0x01,code}` and read tolerantly as *one or more zero bytes,
+//! then 0x01, then the code byte* (`readToAnyBurst`, ghidra_arch.cc:79-98).
+//! Code bytes pair open (even) / close (odd):
+//!
+//! | pair    | meaning                                 |
+//! |---------|-----------------------------------------|
+//! | 2 / 3   | Command (Ghidra -> decompiler)          |
+//! | 4 / 5   | Query (decompiler -> Ghidra)            |
+//! | 6 / 7   | Command response (decompiler -> Ghidra) |
+//! | 8 / 9   | Query response (Ghidra -> decompiler)   |
+//! | 10 / 11 | Exception (either direction)            |
+//! | 12 / 13 | Byte stream                             |
+//! | 14 / 15 | String stream                           |
+//! | 16 / 17 | Native message (warnings/errors)        |
+//!
+//! Payload bytes never contain 0x00 (packed documents are all-nonzero by
+//! construction, marshal.hh:456), which is what lets the leading zero of a
+//! close burst terminate payload accumulation.
+//!
+//! Everything is generic over [`std::io::Read`] / [`std::io::Write`] so the
+//! tests drive it with in-memory buffers.  The C++ helpers call `exit(1)`
+//! when the pipe closes (ghidra_arch.cc:95-96 and copies); library code
+//! must not exit, so EOF surfaces as the distinct [`WireError::PipeClosed`]
+//! which the binary maps to `exit(1)`.
+//!
+//! Phase-1 scope: the framing layer is complete (it is identical in every
+//! later phase); see `docs/ghidra-integration.md`.
+
+use std::io::{Read, Write};
+
+use kuna_base::error::KunaError;
+use kuna_base::marshal::Decoder;
+
+// ---------------------------------------------------------------------------
+// Burst codes (ghidra_arch.cc:50-77; the 16/17 message pair is emitted by
+// GhidraCommand::sendResult, ghidra_process.cc:112-114)
+// ---------------------------------------------------------------------------
+
+/// Command open (Ghidra -> decompiler).
+pub const BURST_COMMAND_OPEN: u8 = 2;
+/// Command close.
+pub const BURST_COMMAND_CLOSE: u8 = 3;
+/// Query open (decompiler -> Ghidra).
+pub const BURST_QUERY_OPEN: u8 = 4;
+/// Query close.
+pub const BURST_QUERY_CLOSE: u8 = 5;
+/// Command response open (decompiler -> Ghidra).
+pub const BURST_RESPONSE_OPEN: u8 = 6;
+/// Command response close.
+pub const BURST_RESPONSE_CLOSE: u8 = 7;
+/// Query response open (Ghidra -> decompiler).
+pub const BURST_QUERY_RESPONSE_OPEN: u8 = 8;
+/// Query response close.
+pub const BURST_QUERY_RESPONSE_CLOSE: u8 = 9;
+/// Exception open (either direction).
+pub const BURST_EXCEPTION_OPEN: u8 = 10;
+/// Exception close.
+pub const BURST_EXCEPTION_CLOSE: u8 = 11;
+/// Byte stream open.
+pub const BURST_BYTES_OPEN: u8 = 12;
+/// Byte stream close.
+pub const BURST_BYTES_CLOSE: u8 = 13;
+/// String stream open.
+pub const BURST_STRING_OPEN: u8 = 14;
+/// String stream close.
+pub const BURST_STRING_CLOSE: u8 = 15;
+/// Native message open (decompiler -> Ghidra).
+pub const BURST_MESSAGE_OPEN: u8 = 16;
+/// Native message close.
+pub const BURST_MESSAGE_CLOSE: u8 = 17;
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// The wire-level error type of the ghidra-mode front-end.
+///
+/// The C++ helpers have three failure modes: pipe closure (`exit(1)`),
+/// protocol misalignment / Java exceptions (`throw JavaError`), and engine
+/// errors (`LowlevelError` etc.).  The latter two are [`KunaError`]s; pipe
+/// closure gets its own variant so the process loop can map it to a clean
+/// process exit instead of a warning.
+#[derive(Debug)]
+pub enum WireError {
+    /// stdin/stdout reached EOF or broke — the parent (Java) process is
+    /// probably dead (the C++ `exit(1)` sites, ghidra_arch.cc:95-96).
+    PipeClosed,
+    /// Any other I/O failure on the streams.
+    Io(std::io::Error),
+    /// A protocol/engine error ([`KunaError::Java`] carries both real Java
+    /// exceptions and the C++-generated "alignment" errors).
+    Kuna(KunaError),
+}
+
+impl std::fmt::Display for WireError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WireError::PipeClosed => write!(f, "pipe closed"),
+            WireError::Io(e) => write!(f, "i/o error: {e}"),
+            WireError::Kuna(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl From<KunaError> for WireError {
+    fn from(e: KunaError) -> WireError {
+        WireError::Kuna(e)
+    }
+}
+
+/// Convenience alias for the wire helpers.
+pub type WireResult<T> = Result<T, WireError>;
+
+/// `throw JavaError("alignment", msg)` — the C++-generated protocol error.
+pub fn java_alignment(msg: &str) -> WireError {
+    WireError::Kuna(KunaError::java("alignment", msg))
+}
+
+/// Map a write/flush error: a broken pipe means the parent died.
+fn write_err(e: std::io::Error) -> WireError {
+    if e.kind() == std::io::ErrorKind::BrokenPipe {
+        WireError::PipeClosed
+    } else {
+        WireError::Io(e)
+    }
+}
+
+/// One byte from the stream — the C++ `istream::get()`, with EOF (`c < 0`)
+/// mapped to [`WireError::PipeClosed`].
+fn get_byte<R: Read>(s: &mut R) -> WireResult<u8> {
+    let mut buf = [0u8; 1];
+    loop {
+        match s.read(&mut buf) {
+            Ok(0) => return Err(WireError::PipeClosed),
+            Ok(_) => return Ok(buf[0]),
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                return Err(WireError::PipeClosed)
+            }
+            Err(e) => return Err(WireError::Io(e)),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The ten static helpers (ghidra_arch.cc:79-248)
+// ---------------------------------------------------------------------------
+
+/// Scan the stream to the next burst marker and return its code byte
+/// (C++ `ArchitectureGhidra::readToAnyBurst`, ghidra_arch.cc:79-98).
+///
+/// Tolerant: arbitrary non-zero garbage before the marker is skipped, and
+/// one *or more* zero bytes are accepted before the 0x01.
+pub fn read_to_any_burst<R: Read>(s: &mut R) -> WireResult<u8> {
+    loop {
+        // do { c = s.get(); } while (c > 0);   -- skip non-zero garbage
+        let mut c = get_byte(s)?;
+        while c > 0 {
+            c = get_byte(s)?;
+        }
+        // while (c == 0) c = s.get();          -- skip the zero run
+        while c == 0 {
+            c = get_byte(s)?;
+        }
+        if c == 1 {
+            return get_byte(s); // the code byte
+        }
+        // (c < 0 is PipeClosed inside get_byte; other values re-scan)
+    }
+}
+
+/// Accumulate payload bytes up to the next burst and return
+/// `(payload, code)`.
+///
+/// This is the shared tail of the two `readStringStream` variants
+/// (ghidra_arch.cc:133-155, 162-176): bytes accumulate while positive; the
+/// first zero starts the close burst.  With `tolerant` set, garbage after
+/// the zero run falls back to the full [`read_to_any_burst`] scan (the
+/// decoder variant resumes with `readToAnyBurst`); otherwise anything but
+/// `0x01 code` is a protocol error (the plain-string variant's strict
+/// terminator check).
+fn read_payload_to_burst<R: Read>(s: &mut R, tolerant: bool) -> WireResult<(Vec<u8>, u8)> {
+    let mut payload: Vec<u8> = Vec::new();
+    let mut c = get_byte(s)?;
+    while c > 0 {
+        payload.push(c);
+        c = get_byte(s)?;
+    }
+    while c == 0 {
+        c = get_byte(s)?;
+    }
+    if c == 1 {
+        let code = get_byte(s)?;
+        return Ok((payload, code));
+    }
+    if tolerant {
+        let code = read_to_any_burst(s)?;
+        return Ok((payload, code));
+    }
+    Err(java_alignment("Expecting string terminator"))
+}
+
+/// Accumulate an already-opened string payload up to the next burst,
+/// tolerantly, returning `(payload, close_code)` — the base
+/// `GhidraCommand::loadParameters` arch-id read (`sin >> dec >> id` then
+/// `readToAnyBurst`, ghidra_process.cc:86-103), which scans to the close
+/// burst with full [`read_to_any_burst`] tolerance.  The caller has already
+/// consumed the opening burst and checks the close code itself (the C++
+/// messages differ per caller).
+pub fn read_id_payload<R: Read>(s: &mut R) -> WireResult<(Vec<u8>, u8)> {
+    read_payload_to_burst(s, true)
+}
+
+/// Read a string-stream burst containing a single `'t'`/`'f'` character
+/// (C++ `readBoolStream`, ghidra_arch.cc:104-126).
+pub fn read_bool_stream<R: Read>(s: &mut R) -> WireResult<bool> {
+    let t = read_to_any_burst(s)?;
+    if t != BURST_STRING_OPEN {
+        return Err(java_alignment("Expecting string"));
+    }
+    let c = get_byte(s)?;
+    let res = c == b't';
+    let mut c2 = if c == 0 { 0 } else { get_byte(s)? };
+    while c2 == 0 {
+        c2 = get_byte(s)?;
+    }
+    if c2 == 1 && get_byte(s)? == BURST_STRING_CLOSE {
+        return Ok(res);
+    }
+    Err(java_alignment("Expecting string terminator"))
+}
+
+/// Read a full string stream into a byte buffer (C++
+/// `readStringStream(istream&,string&)`, ghidra_arch.cc:133-155).
+pub fn read_string_stream<R: Read>(s: &mut R) -> WireResult<Vec<u8>> {
+    let t = read_to_any_burst(s)?;
+    if t != BURST_STRING_OPEN {
+        return Err(java_alignment("Expecting string"));
+    }
+    let (payload, code) = read_payload_to_burst(s, false)?;
+    if code != BURST_STRING_CLOSE {
+        return Err(java_alignment("Expecting string terminator"));
+    }
+    Ok(payload)
+}
+
+/// Read an *optional* string stream: `Some(payload)` if a string burst is
+/// present, `None` if the next burst is any close (odd) code — the framing
+/// of C++ `readStringStream(istream&,Decoder&)` (ghidra_arch.cc:162-176)
+/// minus the decoder ingest, which [`read_string_stream_decoder`] layers on.
+pub fn read_string_stream_optional<R: Read>(s: &mut R) -> WireResult<Option<Vec<u8>>> {
+    let t = read_to_any_burst(s)?;
+    if t == BURST_STRING_OPEN {
+        let (payload, code) = read_payload_to_burst(s, true)?;
+        if code != BURST_STRING_CLOSE {
+            return Err(java_alignment("Expecting XML string end"));
+        }
+        return Ok(Some(payload));
+    }
+    if (t & 1) == 1 {
+        return Ok(None); // empty response
+    }
+    Err(java_alignment("Expecting string or end of query response"))
+}
+
+/// Read a string stream into a stream decoder (C++
+/// `readStringStream(istream&,Decoder&)`, ghidra_arch.cc:162-176).
+/// Returns `false` on an empty (close-burst) response.
+pub fn read_string_stream_decoder<R: Read>(
+    s: &mut R,
+    decoder: &mut dyn Decoder,
+) -> WireResult<bool> {
+    // (The C++ ingests straight off the istream; kuna's Decoder::ingest_stream
+    // takes a slice, so the payload is accumulated first — same bytes, the
+    // packed encoding is NUL-free so the accumulation boundary is identical.)
+    let t = read_to_any_burst(s)?;
+    if t == BURST_STRING_OPEN {
+        let (payload, code) = read_payload_to_burst(s, true)?;
+        decoder.ingest_stream(&payload).map_err(WireError::Kuna)?;
+        if code != BURST_STRING_CLOSE {
+            return Err(java_alignment("Expecting XML string end"));
+        }
+        return Ok(true);
+    }
+    if (t & 1) == 1 {
+        return Ok(false);
+    }
+    Err(java_alignment("Expecting string or end of query response"))
+}
+
+/// Write a burst marker `{0x00,0x00,0x01,code}`.
+pub fn write_burst<W: Write>(s: &mut W, code: u8) -> WireResult<()> {
+    s.write_all(&[0, 0, 1, code]).map_err(write_err)
+}
+
+/// Write a string stream with its protocol markers (C++
+/// `writeStringStream`, ghidra_arch.cc:181-187).
+pub fn write_string_stream<W: Write>(s: &mut W, msg: &[u8]) -> WireResult<()> {
+    write_burst(s, BURST_STRING_OPEN)?;
+    s.write_all(msg).map_err(write_err)?;
+    write_burst(s, BURST_STRING_CLOSE)
+}
+
+/// Consume the query-response header; an exception frame is decoded and
+/// surfaced as [`KunaError::Java`] (C++ `readToResponse`,
+/// ghidra_arch.cc:192-205).
+pub fn read_to_response<R: Read>(s: &mut R) -> WireResult<()> {
+    let t = read_to_any_burst(s)?;
+    if t == BURST_QUERY_RESPONSE_OPEN {
+        return Ok(());
+    }
+    if t == BURST_EXCEPTION_OPEN {
+        let extype = read_string_stream(s)?;
+        let message = read_string_stream(s)?;
+        let _ = read_to_any_burst(s)?; // the exception terminator
+        return Err(WireError::Kuna(KunaError::java(
+            String::from_utf8_lossy(&extype).into_owned(),
+            String::from_utf8_lossy(&message).into_owned(),
+        )));
+    }
+    Err(java_alignment("Expecting query response"))
+}
+
+/// Consume the query-response terminator (C++ `readResponseEnd`,
+/// ghidra_arch.cc:210-216).
+pub fn read_response_end<R: Read>(s: &mut R) -> WireResult<()> {
+    let t = read_to_any_burst(s)?;
+    if t != BURST_QUERY_RESPONSE_CLOSE {
+        return Err(java_alignment("Expecting end of query response"));
+    }
+    Ok(())
+}
+
+/// Read a whole query response into a decoder (C++ `readAll`,
+/// ghidra_arch.cc:223-232).  Returns `false` if the client answered with an
+/// empty response.
+pub fn read_all<R: Read>(s: &mut R, decoder: &mut dyn Decoder) -> WireResult<bool> {
+    read_to_response(s)?;
+    if read_string_stream_decoder(s, decoder)? {
+        read_response_end(s)?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+/// Send an exception frame to the Ghidra client (C++ `passJavaException`,
+/// ghidra_arch.cc:241-248).
+pub fn pass_java_exception<W: Write>(s: &mut W, tp: &str, msg: &str) -> WireResult<()> {
+    write_burst(s, BURST_EXCEPTION_OPEN)?;
+    write_string_stream(s, tp.as_bytes())?;
+    write_string_stream(s, msg.as_bytes())?;
+    write_burst(s, BURST_EXCEPTION_CLOSE)
+}
+
+// ---------------------------------------------------------------------------
+// Byte-stream payload codecs (getBytes / getStringData formats)
+// ---------------------------------------------------------------------------
+
+/// Condense a nibble-doubled byte-stream payload: each source byte `b`
+/// travels as the two bytes `'A'+(b>>4)` and `'A'+(b&0xF)`
+/// (getBytes decode loop, ghidra_arch.cc:743-745; Java encoder
+/// `DecompileProcess.java:867-885`).  `pairs.len()` must be even.
+pub fn nibble_condense(pairs: &[u8]) -> Vec<u8> {
+    debug_assert!(pairs.len().is_multiple_of(2));
+    let mut out = Vec::with_capacity(pairs.len() / 2);
+    for chunk in pairs.chunks_exact(2) {
+        out.push((chunk[0].wrapping_sub(b'A') << 4) | (chunk[1].wrapping_sub(b'A') & 0xF));
+    }
+    out
+}
+
+/// Expand bytes into the nibble-doubled wire form (the Java side of
+/// [`nibble_condense`]; used by the tests' MockJava and by any future
+/// server-side byte responses).
+pub fn nibble_expand(bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        out.push(((b >> 4) & 0xF) + b'A');
+        out.push((b & 0xF) + b'A');
+    }
+    out
+}
+
+/// Decode the getStringData two-byte size header: `size = (b1-0x20) ^
+/// ((b2-0x20)<<6)` (ghidra_arch.cc:793-797; the Java encoder biases each
+/// 6-bit chunk of `len+1` by 0x20, `DecompileProcess.java:894-914`).
+pub fn string_data_size(b1: u8, b2: u8) -> u32 {
+    (b1.wrapping_sub(0x20) as u32) ^ ((b2.wrapping_sub(0x20) as u32) << 6)
+}
+
+/// Encode the getStringData size header (the Java side of
+/// [`string_data_size`]): `sz` is `len+1` and must fit in 12 bits.
+pub fn string_data_size_header(sz: u32) -> [u8; 2] {
+    [
+        ((sz & 0x3f) + 0x20) as u8,
+        (((sz >> 6) & 0x3f) + 0x20) as u8,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn burst(code: u8) -> Vec<u8> {
+        vec![0, 0, 1, code]
+    }
+
+    #[test]
+    fn test_read_to_any_burst_tolerance() {
+        // garbage bytes before the marker are skipped
+        let mut s = Cursor::new([b'x', b'y', 0, 0, 1, 7].to_vec());
+        assert_eq!(read_to_any_burst(&mut s).unwrap(), 7);
+        // one or many zeros are accepted
+        let mut s = Cursor::new([0, 1, 9].to_vec());
+        assert_eq!(read_to_any_burst(&mut s).unwrap(), 9);
+        let mut s = Cursor::new([0, 0, 0, 0, 1, 3].to_vec());
+        assert_eq!(read_to_any_burst(&mut s).unwrap(), 3);
+        // a zero run NOT followed by 0x01 re-scans (0x05 is skipped as garbage)
+        let mut s = Cursor::new([0, 0, 5, 0, 0, 1, 2].to_vec());
+        assert_eq!(read_to_any_burst(&mut s).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_read_to_any_burst_eof_is_pipe_closed() {
+        let mut s = Cursor::new(Vec::<u8>::new());
+        assert!(matches!(
+            read_to_any_burst(&mut s),
+            Err(WireError::PipeClosed)
+        ));
+        // EOF mid-marker
+        let mut s = Cursor::new([0, 0, 1].to_vec());
+        assert!(matches!(
+            read_to_any_burst(&mut s),
+            Err(WireError::PipeClosed)
+        ));
+        // EOF inside a string payload
+        let mut input = burst(BURST_STRING_OPEN);
+        input.extend_from_slice(b"abc");
+        let mut s = Cursor::new(input);
+        assert!(matches!(
+            read_string_stream(&mut s),
+            Err(WireError::PipeClosed)
+        ));
+    }
+
+    #[test]
+    fn test_string_stream_round_trip() {
+        let mut wire = Vec::new();
+        write_string_stream(&mut wire, b"registerProgram").unwrap();
+        let mut s = Cursor::new(wire);
+        assert_eq!(read_string_stream(&mut s).unwrap(), b"registerProgram");
+        // empty payload
+        let mut wire = Vec::new();
+        write_string_stream(&mut wire, b"").unwrap();
+        let mut s = Cursor::new(wire);
+        assert_eq!(read_string_stream(&mut s).unwrap(), b"");
+    }
+
+    #[test]
+    fn test_string_stream_alignment_errors() {
+        // wrong opening burst
+        let mut s = Cursor::new(burst(BURST_BYTES_OPEN));
+        match read_string_stream(&mut s) {
+            Err(WireError::Kuna(KunaError::Java { type_name, explain })) => {
+                assert_eq!(type_name, "alignment");
+                assert_eq!(explain, "Expecting string");
+            }
+            other => panic!("expected alignment error, got {other:?}"),
+        }
+        // wrong close code (strict variant)
+        let mut input = burst(BURST_STRING_OPEN);
+        input.extend_from_slice(b"abc");
+        input.extend_from_slice(&burst(BURST_BYTES_CLOSE));
+        let mut s = Cursor::new(input);
+        match read_string_stream(&mut s) {
+            Err(WireError::Kuna(KunaError::Java { explain, .. })) => {
+                assert_eq!(explain, "Expecting string terminator");
+            }
+            other => panic!("expected alignment error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_bool_stream() {
+        let mut wire = Vec::new();
+        write_string_stream(&mut wire, b"t").unwrap();
+        assert!(read_bool_stream(&mut Cursor::new(wire)).unwrap());
+        let mut wire = Vec::new();
+        write_string_stream(&mut wire, b"f").unwrap();
+        assert!(!read_bool_stream(&mut Cursor::new(wire)).unwrap());
+        // an empty payload reads as false (C++ takes the first burst zero as
+        // the character)
+        let mut wire = Vec::new();
+        write_string_stream(&mut wire, b"").unwrap();
+        assert!(!read_bool_stream(&mut Cursor::new(wire)).unwrap());
+    }
+
+    #[test]
+    fn test_read_to_response_exception_frame() {
+        let mut wire = burst(BURST_EXCEPTION_OPEN);
+        write_string_stream(&mut wire, b"java.lang.Exception").unwrap();
+        write_string_stream(&mut wire, b"boom").unwrap();
+        wire.extend_from_slice(&burst(BURST_EXCEPTION_CLOSE));
+        match read_to_response(&mut Cursor::new(wire)) {
+            Err(WireError::Kuna(KunaError::Java { type_name, explain })) => {
+                assert_eq!(type_name, "java.lang.Exception");
+                assert_eq!(explain, "boom");
+            }
+            other => panic!("expected JavaError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_nibble_codec() {
+        let bytes = [0x00u8, 0x0f, 0xf0, 0xde, 0xad];
+        let pairs = nibble_expand(&bytes);
+        assert_eq!(pairs, b"AAAPPANOKN".to_vec());
+        assert_eq!(nibble_condense(&pairs), bytes.to_vec());
+    }
+
+    #[test]
+    fn test_string_data_size_header() {
+        for sz in [0u32, 1, 63, 64, 100, 0xfff] {
+            let [b1, b2] = string_data_size_header(sz);
+            assert_eq!(string_data_size(b1, b2), sz, "sz={sz}");
+        }
+    }
+}

--- a/decompiler/crates/kuna-ghidra/src/translate.rs
+++ b/decompiler/crates/kuna-ghidra/src/translate.rs
@@ -1,0 +1,213 @@
+//! The tspec \<sleigh> element decode — the address-space subset of
+//! `decompiler/cpp/ghidra_translate.cc` (`GhidraTranslate::initialize` /
+//! `decode`, ghidra_translate.cc:35-43,161-176).
+//!
+//! In ghidra mode no `.sla` file exists: the entire "language" the native
+//! side knows is the stripped-down `<sleigh>` document the Java client
+//! sends at registerProgram (produced by `SleighLanguage.encodeTranslator`,
+//! SleighLanguage.java) — endianness, the unique base, and the address
+//! space list whose per-space `index` attributes are the Java
+//! `AddressSpace.getUnique()` values.  Those indices are the deepest
+//! interop invariant of the packed protocol: `PackedDecode::read_space` /
+//! `PackedEncode::write_space` exchange spaces by exactly these numbers, so
+//! parsing the tspec into a real [`AddrSpaceManager`] (sparse
+//! `insert_space`, kuna-base/src/space.rs) is what gives decompileAt a
+//! working \<addr> decoder.
+//!
+//! The C++ `decodeSpaces` loop cannot be called directly in Rust (the
+//! decoder borrows the manager the loop mutates); the sanctioned stepwise
+//! pattern — a fresh decoder per child element around each
+//! `decode_space`/`insert_space` pair — comes from the kuna-sleigh space
+//! manager test (kuna-sleigh/src/translate.rs:1086-1124).
+//!
+//! Phase-1 scope: the query-side register/user-op caches and
+//! `oneInstruction` (the getPcode path) of C++ GhidraTranslate are the
+//! phase-2 engine bridge; see `docs/ghidra-integration.md`.
+
+use std::rc::Rc;
+
+use kuna_base::error::{KunaError, KunaResult};
+use kuna_base::marshal::{Decoder, IdRegistry, XmlDecode, ATTRIB_BIGENDIAN};
+use kuna_base::space::{AddrSpaceManager, ConstantSpace, ATTRIB_DEFAULTSPACE};
+use kuna_base::xml::xml_tree;
+use kuna_sleigh::translate::{register_translate_ids, TruncationTag, ATTRIB_UNIQBASE, ELEM_SLEIGH};
+
+use crate::ids::register_ghidra_ids;
+
+/// Build the marshaling [`IdRegistry`] a ghidra-mode session needs: the
+/// kuna-base tables, the translate.cc ids (the tspec vocabulary), and the
+/// ghidra protocol ids (the same per-module registration pattern as
+/// `kuna-console`'s `build_registry`).
+pub fn build_registry() -> IdRegistry {
+    let mut registry = IdRegistry::with_base_ids();
+    register_translate_ids(&mut registry);
+    register_ghidra_ids(&mut registry);
+    registry
+}
+
+/// The decoded tspec: what C++ `GhidraTranslate` caches after `initialize`
+/// (ghidra_translate.hh:36-57) — minus the query-backed register/user-op
+/// caches (phase 2).
+#[derive(Debug)]
+pub struct GhidraTranslate {
+    /// The address-space model, indices bound to the Java
+    /// `AddressSpace.getUnique()` numbering.
+    pub manager: AddrSpaceManager,
+    /// The processor endianness (C++ `Translate::setBigEndian`).
+    pub big_endian: bool,
+    /// The starting offset for temporaries in the unique space (C++
+    /// `Translate::setUniqueBase`; Java sends
+    /// `UniqueLayout.SLEIGH_BASE.getOffset(language)`).
+    pub unique_base: u64,
+}
+
+impl GhidraTranslate {
+    /// Parse the \<sleigh> tspec document (C++ `GhidraTranslate::decode`,
+    /// ghidra_translate.cc:161-176):
+    ///
+    /// ```text
+    ///   <sleigh bigendian=... uniqbase=...>
+    ///     <spaces defaultspace=...>
+    ///       <space|space_unique|space_other|space_overlay .../> ...
+    ///     </spaces>
+    ///     <truncate_space space=... size=.../> ...
+    ///   </sleigh>
+    /// ```
+    pub fn decode(tspec: &[u8], registry: &IdRegistry) -> KunaResult<GhidraTranslate> {
+        let document = xml_tree(tspec)?;
+        let root = Rc::clone(document.get_root());
+        if root.get_name() != "sleigh" {
+            return Err(KunaError::lowlevel(format!(
+                "Could not find sleigh tag (got <{}>)",
+                root.get_name()
+            )));
+        }
+
+        let mut manager = AddrSpaceManager::new();
+
+        // openElement(ELEM_SLEIGH); readBool(ATTRIB_BIGENDIAN);
+        // readUnsignedInteger(ATTRIB_UNIQBASE)   (ghidra_translate.cc:164-166)
+        let (big_endian, unique_base) = {
+            let mut dec = XmlDecode::new_with_root(&manager, registry, &root, 0);
+            dec.open_element_id(&ELEM_SLEIGH)?;
+            let be = dec.read_bool_id(&ATTRIB_BIGENDIAN)?;
+            let ub = dec.read_unsigned_integer_id(&ATTRIB_UNIQBASE)?;
+            (be, ub)
+        };
+
+        // decodeSpaces (translate.cc): constant space first, then one child
+        // element per space, then the defaultspace resolution.  Driven
+        // stepwise (fresh decoder per child) per the kuna decode_spaces
+        // aliasing note.
+        manager.insert_space(Rc::new(ConstantSpace::new()))?;
+        let spaces_el = root
+            .get_children()
+            .iter()
+            .find(|c| c.get_name() == "spaces")
+            .cloned()
+            .ok_or_else(|| KunaError::lowlevel("Missing <spaces> in <sleigh> tag"))?;
+        let defname = {
+            let mut dec = XmlDecode::new_with_root(&manager, registry, &spaces_el, 0);
+            dec.open_element()?;
+            String::from_utf8_lossy(&dec.read_string_id(&ATTRIB_DEFAULTSPACE)?).into_owned()
+        };
+        for child in spaces_el.get_children() {
+            let spc = {
+                let mut dec = XmlDecode::new_with_root(&manager, registry, child, 0);
+                manager.decode_space(&mut dec)?
+            };
+            manager.insert_space(spc)?;
+        }
+        let def_index = match manager.get_space_by_name(&defname) {
+            Some(spc) => spc.get_index(),
+            None => {
+                return Err(KunaError::lowlevel(format!(
+                    "Bad 'defaultspace' attribute: {defname}"
+                )))
+            }
+        };
+        manager.set_default_code_space(def_index)?;
+
+        // for(;;) { peek ELEM_TRUNCATE_SPACE; TruncationTag::decode;
+        // truncateSpace(tag); }  (ghidra_translate.cc:168-174)
+        for child in root.get_children() {
+            if child.get_name() != "truncate_space" {
+                continue;
+            }
+            let mut tag = TruncationTag::default();
+            {
+                let mut dec = XmlDecode::new_with_root(&manager, registry, child, 0);
+                tag.decode(&mut dec)?;
+            }
+            manager.truncate_space(tag.get_name(), tag.get_size())?;
+        }
+
+        Ok(GhidraTranslate {
+            manager,
+            big_endian,
+            unique_base,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A realistic tspec, shaped exactly like SleighLanguage.encodeTranslator
+    /// output (single line, XmlEncode(false)): OTHER at unique index 1
+    /// (required by insertSpace), then unique/ram/register.
+    pub const TEST_TSPEC: &[u8] = b"<sleigh bigendian=\"false\" uniqbase=\"0x10000000\">\
+<spaces defaultspace=\"ram\">\
+<space_other name=\"OTHER\" index=\"1\" size=\"8\" bigendian=\"false\" delay=\"0\" physical=\"true\"/>\
+<space_unique name=\"unique\" index=\"2\" size=\"4\" bigendian=\"false\" delay=\"0\" physical=\"true\"/>\
+<space name=\"ram\" index=\"3\" size=\"8\" bigendian=\"false\" delay=\"1\" physical=\"true\"/>\
+<space name=\"register\" index=\"4\" size=\"4\" bigendian=\"false\" delay=\"0\" physical=\"true\"/>\
+</spaces></sleigh>";
+
+    #[test]
+    fn test_decode_tspec() {
+        let registry = build_registry();
+        let tr = GhidraTranslate::decode(TEST_TSPEC, &registry).unwrap();
+        assert!(!tr.big_endian);
+        assert_eq!(tr.unique_base, 0x10000000);
+        let ram = tr.manager.get_space_by_name("ram").expect("ram space");
+        assert_eq!(ram.get_index(), 3);
+        assert_eq!(ram.get_addr_size(), 8);
+        let reg = tr
+            .manager
+            .get_space_by_name("register")
+            .expect("register space");
+        assert_eq!(reg.get_index(), 4);
+        let unique = tr
+            .manager
+            .get_space_by_name("unique")
+            .expect("unique space");
+        assert_eq!(unique.get_index(), 2);
+        // defaultspace resolution
+        let def = tr.manager.get_default_code_space().expect("default space");
+        assert_eq!(def.get_name(), "ram");
+        // constant space auto-inserted at index 0
+        let cspace = tr.manager.get_constant_space().expect("constant space");
+        assert_eq!(cspace.get_index(), 0);
+    }
+
+    #[test]
+    fn test_decode_tspec_truncate_space() {
+        let registry = build_registry();
+        let tspec = b"<sleigh bigendian=\"true\" uniqbase=\"0x100\">\
+<spaces defaultspace=\"ram\">\
+<space name=\"ram\" index=\"1\" size=\"8\" bigendian=\"true\" delay=\"1\" physical=\"true\"/>\
+</spaces><truncate_space space=\"ram\" size=\"4\"/></sleigh>";
+        let tr = GhidraTranslate::decode(tspec, &registry).unwrap();
+        assert!(tr.big_endian);
+        let ram = tr.manager.get_space_by_name("ram").unwrap();
+        assert_eq!(ram.get_addr_size(), 4);
+    }
+
+    #[test]
+    fn test_decode_tspec_rejects_non_sleigh_root() {
+        let registry = build_registry();
+        assert!(GhidraTranslate::decode(b"<x/>", &registry).is_err());
+    }
+}

--- a/decompiler/crates/kuna-ghidra/tests/protocol_e2e.rs
+++ b/decompiler/crates/kuna-ghidra/tests/protocol_e2e.rs
@@ -1,0 +1,468 @@
+//! End-to-end ghidra-mode protocol tests: the command loop and the query
+//! client driven over in-memory buffers by a MockJava that mirrors
+//! `DecompileProcess.java`'s writer (`writeString` =
+//! `{0,0,1,14}+bytes+{0,0,1,15}`, command framing
+//! `{0,0,1,2}...{0,0,1,3}`, query responses `{0,0,1,8}...{0,0,1,9}`).
+//!
+//! The full-session test asserts the response byte stream EXACTLY against
+//! hand-constructed bursts (the shapes of ghidra_process.cc:108-160,
+//! 203-210, 253-260, 275-282, 313-334, 408-416, 447-455, 476-484).
+
+use std::io::Cursor;
+use std::rc::Rc;
+
+use kuna_base::address::Address;
+use kuna_base::error::KunaError;
+use kuna_base::marshal::{
+    ElementId, Encoder, PackedDecode, PackedEncode, ATTRIB_CONTENT, ATTRIB_NAME,
+};
+use kuna_base::space::VarnodeStorage;
+
+use kuna_ghidra::client::GhidraClient;
+use kuna_ghidra::ids::ELEM_COMMAND_GETREGISTER;
+use kuna_ghidra::process::GhidraProcess;
+use kuna_ghidra::protocol::{nibble_expand, string_data_size_header, WireError};
+use kuna_ghidra::translate::{build_registry, GhidraTranslate};
+
+// ---------------------------------------------------------------------------
+// MockJava wire builder
+// ---------------------------------------------------------------------------
+
+/// Byte-stream builder mirroring DecompileProcess.java's writer.
+#[derive(Clone, Default)]
+struct Wire(Vec<u8>);
+
+impl Wire {
+    fn new() -> Wire {
+        Wire(Vec::new())
+    }
+    /// A burst marker `{0,0,1,code}` (DecompileProcess.java:54-63).
+    fn burst(mut self, code: u8) -> Wire {
+        self.0.extend_from_slice(&[0, 0, 1, code]);
+        self
+    }
+    fn raw(mut self, bytes: &[u8]) -> Wire {
+        self.0.extend_from_slice(bytes);
+        self
+    }
+    /// `writeString` (DecompileProcess.java:280-284).
+    fn string(self, s: &[u8]) -> Wire {
+        self.burst(14).raw(s).burst(15)
+    }
+    /// Command open + name (DecompileProcess.java sendCommand family).
+    fn command(self, name: &str) -> Wire {
+        self.burst(2).string(name.as_bytes())
+    }
+    /// Command close.
+    fn end_command(self) -> Wire {
+        self.burst(3)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The four registerProgram documents (tspec shaped exactly like
+// SleighLanguage.encodeTranslator output — single line, XmlEncode(false);
+// OTHER at unique index 1 as insertSpace requires)
+// ---------------------------------------------------------------------------
+
+const TSPEC: &[u8] = b"<sleigh bigendian=\"false\" uniqbase=\"0x10000000\">\
+<spaces defaultspace=\"ram\">\
+<space_other name=\"OTHER\" index=\"1\" size=\"8\" bigendian=\"false\" delay=\"0\" physical=\"true\"/>\
+<space_unique name=\"unique\" index=\"2\" size=\"4\" bigendian=\"false\" delay=\"0\" physical=\"true\"/>\
+<space name=\"ram\" index=\"3\" size=\"8\" bigendian=\"false\" delay=\"1\" physical=\"true\"/>\
+<space name=\"register\" index=\"4\" size=\"4\" bigendian=\"false\" delay=\"0\" physical=\"true\"/>\
+</spaces></sleigh>";
+const PSPEC: &[u8] = b"<processor_spec><programcounter register=\"PC\"/></processor_spec>";
+const CSPEC: &[u8] = b"<compiler_spec><default_proto/></compiler_spec>";
+const CORETYPES: &[u8] = b"<coretypes><type name=\"int\" size=\"4\" metatype=\"int\" id=\"-1\"/>\
+</coretypes>";
+
+/// The tspec-derived translate the mock shares with the process under test.
+fn test_translate() -> GhidraTranslate {
+    let registry = build_registry();
+    GhidraTranslate::decode(TSPEC, &registry).expect("test tspec parses")
+}
+
+/// Encode an `<addr>` for ram:offset the way Java's AddressXML.encode does
+/// (space + offset attributes in a packed document).
+fn packed_ram_addr(tr: &GhidraTranslate, offset: u64) -> Vec<u8> {
+    let ram = Rc::clone(tr.manager.get_space_by_name("ram").expect("ram"));
+    let mut packed = Vec::new();
+    {
+        let mut enc = PackedEncode::new(&mut packed);
+        Address::new(ram, offset).encode(&mut enc).unwrap();
+    }
+    packed
+}
+
+/// A packed `<optionslist>` with two single-param option children
+/// (DecompileOptions.encode / appendOption shape; the ids only need to be
+/// self-consistent for the count).
+fn packed_optionslist() -> Vec<u8> {
+    let optionslist = ElementId::new("optionslist", 201);
+    let readonly = ElementId::new("readonly", 217);
+    let maxinstruction = ElementId::new("maxinstruction", 217 + 1);
+    let mut packed = Vec::new();
+    {
+        let mut enc = PackedEncode::new(&mut packed);
+        enc.open_element(&optionslist);
+        enc.open_element(&readonly);
+        enc.write_string(&ATTRIB_CONTENT, b"on");
+        enc.close_element(&readonly);
+        enc.open_element(&maxinstruction);
+        enc.write_string(&ATTRIB_CONTENT, b"100000");
+        enc.close_element(&maxinstruction);
+        enc.close_element(&optionslist);
+    }
+    packed
+}
+
+// ---------------------------------------------------------------------------
+// (a) full session over the command loop
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_full_session_byte_exact() {
+    let tr = test_translate();
+    let addr_packed = packed_ram_addr(&tr, 0x401000);
+    let options_packed = packed_optionslist();
+
+    let input = Wire::new()
+        // registerProgram: 4 XML string streams, no archid
+        .command("registerProgram")
+        .string(PSPEC)
+        .string(CSPEC)
+        .string(TSPEC)
+        .string(CORETYPES)
+        .end_command()
+        // setOptions: archid + packed <optionslist>
+        .command("setOptions")
+        .string(b"0")
+        .string(&options_packed)
+        .end_command()
+        // setAction: archid + actionstring + printstring
+        .command("setAction")
+        .string(b"0")
+        .string(b"decompile")
+        .string(b"c")
+        .end_command()
+        // decompileAt: archid + packed <addr>
+        .command("decompileAt")
+        .string(b"0")
+        .string(&addr_packed)
+        .end_command()
+        // flushNative: archid only
+        .command("flushNative")
+        .string(b"0")
+        .end_command()
+        // an unregistered (signature) command: archid param is sent by Java
+        // but never read by the Bad-command path — the next command's
+        // burst-2 scan skips it (self-aligning)
+        .command("getSignatureSettings")
+        .string(b"0")
+        .end_command()
+        // deregisterProgram: archid; terminates the loop
+        .command("deregisterProgram")
+        .string(b"0")
+        .end_command();
+
+    let mut process = GhidraProcess::new(Cursor::new(input.0), Vec::new());
+    let mut statuses = Vec::new();
+    for _ in 0..7 {
+        statuses.push(process.read_command().expect("command completes"));
+    }
+    assert_eq!(statuses, vec![0, 0, 0, 0, 0, 0, 1]);
+    let (_, out) = process.into_inner();
+
+    // The rendered form of ram:0x401000 in the decompileAt warning
+    let ram = tr.manager.get_space_by_name("ram").unwrap();
+    let mut addr_text = String::new();
+    addr_text.push(ram.get_shortcut());
+    Address::new(Rc::clone(ram), 0x401000)
+        .print_raw(&mut addr_text)
+        .unwrap();
+
+    let expected = Wire::new()
+        // registerProgram: {6}{14}"0"{15}{16}{17}{7}
+        .burst(6)
+        .string(b"0")
+        .burst(16)
+        .burst(17)
+        .burst(7)
+        // setOptions: "t" + phase-1 warning
+        .burst(6)
+        .string(b"t")
+        .burst(16)
+        .raw(
+            b"\nkuna ghidra-mode: setOptions: 2 option element(s) recorded \
+              but not applied (phase 1)"
+                .as_slice(),
+        )
+        .burst(17)
+        .burst(7)
+        // setAction: "t", empty warnings
+        .burst(6)
+        .string(b"t")
+        .burst(16)
+        .burst(17)
+        .burst(7)
+        // decompileAt: EMPTY payload (incomplete-function shape) + warning
+        .burst(6)
+        .burst(14)
+        .burst(15)
+        .burst(16)
+        .raw(
+            format!(
+                "\nkuna ghidra-mode: engine bridge not yet implemented (phase 1); \
+                 function at {addr_text} not decompiled"
+            )
+            .as_bytes(),
+        )
+        .burst(17)
+        .burst(7)
+        // flushNative: "0"
+        .burst(6)
+        .string(b"0")
+        .burst(16)
+        .burst(17)
+        .burst(7)
+        // Bad command: {6}{16}"Bad command: <name>"{17}{7}, no payload burst
+        .burst(6)
+        .burst(16)
+        .raw(b"Bad command: getSignatureSettings")
+        .burst(17)
+        .burst(7)
+        // deregisterProgram: "1", NO 16/17 frame (C++ nulls ghidra first)
+        .burst(6)
+        .string(b"1")
+        .burst(7);
+
+    assert_eq!(
+        out, expected.0,
+        "response stream mismatch\n got: {:02x?}\nwant: {:02x?}",
+        out, expected.0
+    );
+}
+
+/// The warning-string literals above must not drift: `\` line continuations
+/// inside the source would silently change the bytes.  (This guards the
+/// test itself, comparing against the same strings built without
+/// continuation.)
+#[test]
+fn test_expected_warning_literals() {
+    assert_eq!(
+        b"\nkuna ghidra-mode: setOptions: 2 option element(s) recorded \
+          but not applied (phase 1)"
+            .as_slice()
+            .len(),
+        "\nkuna ghidra-mode: setOptions: 2 option element(s) recorded but not applied (phase 1)"
+            .len()
+    );
+}
+
+/// A command against a deregistered (or never-registered) archid answers
+/// with the exception frame and NO command-response close (the C++
+/// passJavaException path, ghidra_process.cc:142-145).
+#[test]
+fn test_unregistered_archid_passes_java_exception() {
+    let input = Wire::new()
+        .command("flushNative")
+        .string(b"0")
+        .end_command();
+    let mut process = GhidraProcess::new(Cursor::new(input.0), Vec::new());
+    assert_eq!(process.read_command().unwrap(), 0);
+    let (_, out) = process.into_inner();
+    let expected = Wire::new()
+        .burst(6)
+        .burst(10)
+        .string(b"decompiler")
+        .string(b"No architecture registered with decompiler")
+        .burst(11);
+    assert_eq!(out, expected.0);
+}
+
+/// registerProgram with an unparseable tspec still succeeds (lenient phase-1
+/// parse), records a warning, and decompileAt then reports the undecoded
+/// address.
+#[test]
+fn test_bad_tspec_is_lenient() {
+    let input = Wire::new()
+        .command("registerProgram")
+        .string(PSPEC)
+        .string(CSPEC)
+        .string(b"<not_a_sleigh_tag/>")
+        .string(CORETYPES)
+        .end_command()
+        .command("decompileAt")
+        .string(b"0")
+        .string(b"\x50") // some nonzero payload standing in for the <addr>
+        .end_command();
+    let mut process = GhidraProcess::new(Cursor::new(input.0), Vec::new());
+    assert_eq!(process.read_command().unwrap(), 0);
+    assert_eq!(process.read_command().unwrap(), 0);
+    let (_, out) = process.into_inner();
+    let text = String::from_utf8_lossy(&out);
+    assert!(
+        text.contains("could not parse tspec <sleigh> element"),
+        "missing tspec warning in: {text}"
+    );
+    assert!(
+        text.contains("function at (address not decoded) not decompiled"),
+        "missing decompileAt warning in: {text}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (c) the query client against MockJava responses
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_get_register_round_trip() {
+    let tr = test_translate();
+    let reg_space = Rc::clone(tr.manager.get_space_by_name("register").unwrap());
+
+    // MockJava answer: {8} writeString(<packed addr size=8>) {9}
+    let mut packed = Vec::new();
+    {
+        let mut enc = PackedEncode::new(&mut packed);
+        Address::new(Rc::clone(&reg_space), 0)
+            .encode_sized(&mut enc, 8)
+            .unwrap();
+    }
+    let response = Wire::new().burst(8).string(&packed).burst(9);
+
+    let mut client = GhidraClient::new(Cursor::new(response.0), Vec::new());
+    let mut decoder = PackedDecode::new(&tr.manager);
+    assert!(client.get_register("RAX", &mut decoder).unwrap());
+    let (addr, size) = Address::decode_sized(&mut decoder).unwrap();
+    assert_eq!(addr.get_space().unwrap().get_name(), "register");
+    assert_eq!(addr.get_offset(), 0);
+    assert_eq!(size, 8);
+
+    // and the query the client sent must be byte-exact:
+    // {4}{14}<packed command_getregister name="RAX">{15}{5}
+    let (_, sent) = client.into_inner();
+    let mut expected_doc = Vec::new();
+    {
+        let mut enc = PackedEncode::new(&mut expected_doc);
+        enc.open_element(&ELEM_COMMAND_GETREGISTER);
+        enc.write_string(&ATTRIB_NAME, b"RAX");
+        enc.close_element(&ELEM_COMMAND_GETREGISTER);
+    }
+    let expected = Wire::new().burst(4).string(&expected_doc).burst(5);
+    assert_eq!(sent, expected.0);
+}
+
+#[test]
+fn test_query_java_exception_surfaces_as_kuna_java() {
+    let tr = test_translate();
+    let response = Wire::new()
+        .burst(10)
+        .string(b"java.lang.IllegalArgumentException")
+        .string(b"no such register")
+        .burst(11);
+    let mut client = GhidraClient::new(Cursor::new(response.0), Vec::new());
+    let mut decoder = PackedDecode::new(&tr.manager);
+    match client.get_register("XYZZY", &mut decoder) {
+        Err(WireError::Kuna(KunaError::Java { type_name, explain })) => {
+            assert_eq!(type_name, "java.lang.IllegalArgumentException");
+            assert_eq!(explain, "no such register");
+        }
+        other => panic!("expected KunaError::Java, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_get_bytes_nibble_stream_and_data_unavail() {
+    let tr = test_translate();
+    let ram = Rc::clone(tr.manager.get_space_by_name("ram").unwrap());
+
+    // nibble-doubled payload
+    let response = Wire::new()
+        .burst(8)
+        .burst(12)
+        .raw(&nibble_expand(&[0xde, 0xad, 0xbe, 0xef]))
+        .burst(13)
+        .burst(9);
+    let mut client = GhidraClient::new(Cursor::new(response.0), Vec::new());
+    let mut buf = [0u8; 4];
+    client
+        .get_bytes(&mut buf, &Address::new(Rc::clone(&ram), 0x401000))
+        .unwrap();
+    assert_eq!(buf, [0xde, 0xad, 0xbe, 0xef]);
+
+    // empty response => DataUnavailError
+    let response = Wire::new().burst(8).burst(9);
+    let mut client = GhidraClient::new(Cursor::new(response.0), Vec::new());
+    let mut buf = [0u8; 4];
+    match client.get_bytes(&mut buf, &Address::new(ram, 0x401000)) {
+        Err(WireError::Kuna(KunaError::DataUnavail { explain })) => {
+            assert!(
+                explain.starts_with("GHIDRA has no data in the loadimage at "),
+                "{explain}"
+            );
+        }
+        other => panic!("expected DataUnavailError, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_is_name_used_bool_stream() {
+    let response = Wire::new().burst(8).string(b"t").burst(9);
+    let mut client = GhidraClient::new(Cursor::new(response.0), Vec::new());
+    assert!(client.is_name_used("main", 0, 1).unwrap());
+    let response = Wire::new().burst(8).string(b"f").burst(9);
+    let mut client = GhidraClient::new(Cursor::new(response.0), Vec::new());
+    assert!(!client.is_name_used("main", 0, 1).unwrap());
+}
+
+#[test]
+fn test_get_string_data_length_header() {
+    let tr = test_translate();
+    let ram = Rc::clone(tr.manager.get_space_by_name("ram").unwrap());
+    // Java sends sz = len+1 pairs, the last pair the doubled NUL ("AA")
+    let payload = b"hello\0";
+    let header = string_data_size_header(payload.len() as u32);
+    let response = Wire::new()
+        .burst(8)
+        .burst(12)
+        .raw(&header)
+        .raw(&[0]) // truncation flag: false (a literal 0x00 inside the byte burst)
+        .raw(&nibble_expand(payload))
+        .burst(13)
+        .burst(9);
+    let mut client = GhidraClient::new(Cursor::new(response.0), Vec::new());
+    let mut buffer = Vec::new();
+    let trunc = client
+        .get_string_data(
+            &mut buffer,
+            &Address::new(ram, 0x402000),
+            "char",
+            0xcafe,
+            2048,
+        )
+        .unwrap();
+    assert!(!trunc);
+    assert_eq!(buffer, payload.to_vec());
+}
+
+#[test]
+fn test_get_user_op_name_empty_terminates_probe() {
+    let response = Wire::new().burst(8).string(b"").burst(9);
+    let mut client = GhidraClient::new(Cursor::new(response.0), Vec::new());
+    assert_eq!(client.get_user_op_name(3).unwrap(), b"");
+}
+
+#[test]
+fn test_get_register_name_query_shape() {
+    let tr = test_translate();
+    let reg_space = Rc::clone(tr.manager.get_space_by_name("register").unwrap());
+    let vn = VarnodeStorage {
+        space: Some(reg_space),
+        offset: 0x10,
+        size: 8,
+    };
+    let response = Wire::new().burst(8).string(b"RBP").burst(9);
+    let mut client = GhidraClient::new(Cursor::new(response.0), Vec::new());
+    assert_eq!(client.get_register_name(&vn).unwrap(), b"RBP");
+}

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2672,3 +2672,41 @@ Four PRs merged on top of session 1's nine (all three gates verified before each
 Option count 69→72 (returndup, noreturn_error, iteregion). Follow-ups left in
 `docs/decbench/features.md`: F6 `cstyle-null-cmp`, P1 full ITE/expr-folding, P2 ARM Cortex-M,
 and the broader `noreturn_propagate` robustness relaxations (transitive/looping wrappers).
+
+## 2026-07-05 — Ghidra integration Phase 1: the decompiler-process protocol (branch feat/ghidra-mode)
+
+Phase 1 of "kuna as Ghidra's decompiler core": make the **stock, untouched Ghidra GUI**
+spawn kuna instead of the C++ `decompile` binary. Upstream's "ghidra mode" glue
+(`ghidra_process.cc`/`ghidra_arch.cc`/… — the LOSS-002 exclusion) is being reintroduced
+as a new **`kuna-ghidra`** crate speaking Ghidra's burst-framed stdin/stdout protocol,
+plus a Ghidra extension (`integrations/`) that swaps `DecompileProcessFactory.exepath`
+by reflection pre-spawn (the binary ships in the extension's own `os/<platform>/` as
+`kuna_ghidra`). Phase 1 ships the **wire-protocol-complete, engine-stubbed** native side
+(burst framer, command dispatch + `doit()` lifecycle, archid session model, the 19 typed
+callback-query clients, both exception channels, the upstream-numbered protocol element
+ids 229/239–257/261/262/264/268), the extension, and the two permanent design docs:
+
+- **`docs/ghidra-integration.md`** — the kuna plan: architecture + session lifecycle,
+  condensed protocol tables, what kuna already has (bit-exact `marshal.rs`, `EmitMarkup`,
+  the signature engine, the sparse `insert_space` no-`.sla` precedent, `KunaError::Java`)
+  vs the seam inventory with honest difficulty, the GUI response contracts (dual
+  `<function>`, ast↔markup refids, DB symbol-id echo, jumptablelist, parammeasures),
+  the graceful-degradation matrix, testing strategy, and the Phase 1–4 checklists.
+- **`docs/decompiler-core-interface.md`** — the core-agnostic spec of what Ghidra
+  requires from ANY replacement decompiler core (substitution seams ranked, process
+  contract, full wire grammar + choreography, packed-encoding invariants, the 19-query
+  data API, response document contracts, consumer matrix, versioning reality, minimum
+  viable core). Citations verified against Ghidra 12.2-DEV @ f9e13846.
+
+Decisions recorded (with rationale, in the docs): reimplement the native side, never
+fork the Java; **p-code comes from Java per instruction** (no wire query exists for
+disassembly context; listing parity; the contract assumes it) via a faithful
+`GhidraTranslate` port behind a `{Sleigh, GhidraTranslate}` enum seam; symbols/types/
+comments/strings/injects are **pull-only** → lazy `ScopeGhidra`-style query-through
+caches (eager pre-population is impossible — no enumerate query), forcing the Phase-3
+Scope/ArchSeam rework; pin the target Ghidra release but **tolerate unknown `setOptions`
+elements** (upstream bricks the program-open on one stale option — divergence to be
+DIV-logged when the behavior ships in Phase 2). Phases: 2 = engine bridge (Architecture
+from wire specs, GhidraLoadImage/ContextGhidra, minimal `Funcdata::encode`,
+PrintC→EmitMarkup — first real C in the GUI); 3 = lazy providers; 4 = parity
+(rename/retype id echo, structureGraph, parammeasures, BSim signatures, overlays).

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -21,7 +21,7 @@ full what/why/how/validation. The SLEIGH `specs/` and the XML regression corpus
 
 | Path | What |
 |---|---|
-| `decompiler/` | **The engine.** Cargo workspace: `kuna-base`/`kuna-num`/`kuna-sleigh`/`kuna-decomp` (the decompiler), `kuna-analysis` (the program-prep loader/analyzer tier — ELF markup, strings, DWARF, …; the Ghidra "Run Analysis" layer), `kuna-console` (the `decomp_dbg`/`decomp_test_dbg` binaries), `kuna-slacomp` (the SLEIGH compiler, binary `slacomp`), `kuna-cli` (the user-facing `kuna` binary), `kuna-harness`/`kuna-lift-diff` (dev test harness). `kuna-decomp/src/` is organized into stage-named folders (`s1_partition/`…`s9_emit/`, `substrate/`, `p0_knowledge/`, `infra/`) per `docs/stages.md`. See `docs/RUST_PORT.md`. |
+| `decompiler/` | **The engine.** Cargo workspace: `kuna-base`/`kuna-num`/`kuna-sleigh`/`kuna-decomp` (the decompiler), `kuna-analysis` (the program-prep loader/analyzer tier — ELF markup, strings, DWARF, …; the Ghidra "Run Analysis" layer), `kuna-console` (the `decomp_dbg`/`decomp_test_dbg` binaries), `kuna-slacomp` (the SLEIGH compiler, binary `slacomp`), `kuna-cli` (the user-facing `kuna` binary), `kuna-ghidra` (the ghidra-mode process front-end — the `kuna_ghidra` binary that speaks Ghidra's decompiler-process protocol; see `docs/ghidra-integration.md` and `integrations/`), `kuna-harness`/`kuna-lift-diff` (dev test harness). `kuna-decomp/src/` is organized into stage-named folders (`s1_partition/`…`s9_emit/`, `substrate/`, `p0_knowledge/`, `infra/`) per `docs/stages.md`. See `docs/RUST_PORT.md`. |
 | `tests/datatests/` | Upstream XML regression tests (83 files → 675 assertions). The corpus `make test` runs. Vendored. |
 | `tests/stages/` | kuna-owned stage-model issue testcases (`make test-stages`, baseline `docs/baseline-stages.json`). |
 | `tests/golden/` | Differential golden vectors for the workspace test suite (`make rust-test`). |
@@ -30,7 +30,9 @@ full what/why/how/validation. The SLEIGH `specs/` and the XML regression corpus
 | `scripts/` | Python helpers backing the feature `pipeline/` (out of scope for the engine): `decompile.py` (thin library shim) and `paths.py`. The user-facing CLI is the Rust `kuna` binary, not these. |
 | `tools/pipeline/` | Driver + worker for the continuous feature pipeline (`run.sh`, `worker.sh`, `open_pr.sh`, `worker_prompt.md`, `install_gh.sh`). See `docs/pipeline.md`. |
 | `tools/sync_upstream.py` | Port upstream Ghidra changes into kuna (specs + datatests only — the C++ source is gone). |
+| `integrations/` | The Ghidra extension: a plugin that makes the **stock Ghidra GUI** spawn kuna's `kuna_ghidra` binary as its decompiler core (reflection exepath swap; binary ships in the module's `os/<platform>/`). See `docs/ghidra-integration.md`. |
 | `docs/RUST_PORT.md` | **The port summary**: what was ported (decompiler + SLEIGH compiler), why, how, and the validation gates. Detailed port history lives under `docs/rust-port/` (ADRs, `losses.md`, `verification.md`, `plan.md`). |
+| `docs/ghidra-integration.md` | Using kuna as Ghidra's decompiler core (Phases 1–4, seams, wire protocol); the core-agnostic interface spec is `docs/decompiler-core-interface.md`. |
 | `docs/stages.md` | The normative stage model (P0 plane, S1–S9, Band B, feedback edges); full model in `docs/stage-model.md`. |
 | `docs/stage-mapping.md` | Maps every upstream source module to a stage (P0/S1–S9). The live registry is queryable at the console (`stage list/map/catalog`); the Rust implementation is under `decompiler/crates/kuna-decomp/`. |
 | `docs/baseline.json` | Recorded test-pass oracle (parity check) — the **kuna** oracle since DIV-2 (`docs/divergences.md`), no longer pristine-upstream. |

--- a/docs/decompiler-core-interface.md
+++ b/docs/decompiler-core-interface.md
@@ -1,0 +1,425 @@
+# What Ghidra requires from a replacement decompiler core
+
+Ghidra's GUI does not contain a decompiler. It spawns a child process (the "decompiler
+core", upstream binary name `decompile`), drives it over stdin/stdout, answers its
+questions about the program mid-decompile, and renders the typed documents it returns.
+This document specifies that interface completely, from the host's (Java's) side: what
+it takes to substitute **any** decompiler core — not just kuna — behind an untouched
+Ghidra GUI. No kuna knowledge is assumed; kuna's own plan is
+`docs/ghidra-integration.md`.
+
+**Citation convention.** All citations are `file:line` against Ghidra 12.2-DEV at
+commit `f9e13846` (2026-06-16). Java paths are under
+`Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/` unless prefixed;
+C++ paths (the upstream reference implementation of the native side) under
+`Ghidra/Features/Decompiler/src/decompile/cpp/`. `Framework/...` paths are under
+`Ghidra/Framework/`. The Java side is the **normative** contract — the C++ side is
+cited where it is the only precise statement of native-side behavior.
+
+---
+
+## 1. The shape of the interface
+
+One session = one spawned process per open Program. The host sends *commands*; while
+servicing a command the core may send *callback queries* (each answered by the host
+before the command continues); the command ends with a *response*. Everything — specs,
+addresses, symbols, p-code, types, the decompiled output — travels through this one
+pipe. There is no shared memory, no filesystem contract, no network.
+
+The interface has four layers, specified bottom-up in §3–§6:
+
+1. **Burst framing** — 4-byte markers delimiting streams on the raw pipe.
+2. **Packed document encoding** — a nonzero-byte binary element/attribute format
+   carried inside string streams.
+3. **Command / query choreography** — who may talk when, and the exception channels.
+4. **Document schemas** — what the host sends, what it answers, and what it demands
+   back (the response contracts, §8).
+
+## 2. Getting your binary spawned (the substitution seams)
+
+The spawn path is hardcoded and seamless-by-design: `DecompInterface` (the only
+consumer, instantiated with `new` at 29 call sites) calls the static
+`DecompileProcessFactory.get()` (`DecompInterface.java:267`), which resolves the
+executable named `decompile` (`decompile.exe` on Windows) **once** via
+`Application.getOSFile(exeName)` and caches the absolute path in a private static
+field with an early-return guard (`DecompileProcessFactory.java:28,52-55`). No system
+property, environment variable, ExtensionPoint, or service can redirect it (grep
+confirms zero config reads in the package; the only wrapper precedent upstream is a
+commented-out valgrind line, `DecompileProcess.java:98`).
+
+Substitution options, ranked:
+
+1. **Reflection from an extension plugin (recommended).** The process spawns *lazily*
+   on the first decompile, so any plugin constructor in the tool runs before it. Set
+   the private static `exepath` by reflection; `getExePath()` early-returns forever
+   after (`DecompileProcessFactory.java:52-55`). Ghidra runs a flat classpath — every
+   class in the unnamed module (`Framework/Utility/.../GhidraClassLoader.java:34`) — so
+   `setAccessible(true)` needs no `--add-opens`. Ship your binary inside your
+   extension's own `os/<platform>/` under a **distinct filename** and resolve it with
+   the two-arg `Application.getOSFile(moduleName, filename)`
+   (`Framework/Generic/.../Application.java:1000-1003`). Covers all 29 consumers,
+   survives Ghidra upgrades that don't touch the 76-line factory.
+2. **File drop at `build/os/` (release installs, zero code).**
+   `getModuleOSFile` checks `build/os/<platform>/` *before* `os/<platform>/`
+   unconditionally, so a binary at
+   `<install>/Ghidra/Features/Decompiler/build/os/<platform>/decompile` shadows the
+   stock one without deleting it. A distribution patch, not an extension.
+3. **Patch-directory class shadow (release installs only).** Jars in
+   `<install>/Ghidra/patch` precede module jars on the release classpath
+   (`Framework/Utility/.../GhidraLauncher.java:182-183`); ship a rebuilt
+   `DecompileProcessFactory` that consults a property. Version-coupled to the exact
+   release; the dev-mode classpath never adds the patch dir.
+
+**Why an extension shipping `os/<platform>/decompile` can never shadow the stock
+binary**: the single-arg `Application.getOSFile(exactFilename)` searches the *calling
+class's own module first* and only falls back to an all-module scan
+(`Application.java:1013-1026`). The caller is `DecompileProcessFactory`, which lives in
+the Features/Decompiler module — and that module ships its own `decompile`, so the
+short-circuit always wins and the scan (where extensions would be visible) is never
+reached. Extension *jars* cannot class-shadow either: module classpath ordering puts
+Features before Extensions on the flat classloader.
+
+## 3. The process contract
+
+- **Spawn**: `runtime.exec(exepath)` — **zero arguments, inherited environment,
+  nothing else** (`DecompileProcess.java:151`). The process cannot learn anything
+  (language, program, paths) from its invocation; everything arrives on stdin.
+- **Liveness**: the host waits 200 ms, then requires `isAlive()`
+  (`DecompileProcess.java:154-167`). A process that exits during startup gets its
+  stderr shown in an error dialog once (`:168-192`). **Do not print anything to
+  stdout at startup** — there is no greeting, no handshake; the first bytes on the
+  pipe are the host's first command.
+- **Windows**: stdin/stdout must be put in binary mode
+  (`_setmode(_fileno(stdin), _O_BINARY)`, `ghidra_process.cc:524-528` in the reference
+  implementation) — the protocol is 8-bit-clean binary.
+- **Exit rules**: exit(1) immediately on EOF/pipe-close anywhere (the host disposed
+  you; a lingering process is a runaway — `ghidra_arch.cc:95-96`). Install a SIGSEGV
+  handler that `_Exit(1)`s (`ghidra_process.cc:510-527`) so a crash surfaces as a dead
+  process, not a hang. Exit normally after answering `deregisterProgram` (§5) — the
+  host never reuses a deregistered process (`DecompileProcess.java:501-522`).
+- **Timeout is murder, not a message**: on decompile timeout the host disposes the
+  process from a timer thread so its own blocked read throws
+  (`DecompileProcess.java:100-106,564-595`). The core sees only EOF. A user cancel is
+  the same. `timeoutSecs=0` disables the timer (`:597-602`).
+- **Respawn + replay**: after any I/O failure the host respawns and *replays* the
+  session — `registerProgram`, then `setOptions`, `setAction`, the print toggles, and
+  signature settings (`DecompInterface.java:262-361`). The core needs no persistence;
+  it must merely reach equivalent state from the replay.
+- **Threading**: the host serializes all commands (synchronized senders); the core can
+  be single-threaded over the pipe.
+
+## 4. The burst framing
+
+Every protocol marker ("burst") is written as the 4 bytes `{0x00, 0x00, 0x01, code}`
+and must be *read* tolerantly: skip any nonzero garbage, then one-or-more `0x00`
+bytes, then expect `0x01`, then the code byte (`DecompileProcess.java:196-228`;
+`ghidra_arch.cc:79-98`). Both sides' scanners are self-aligning in this way. Codes are
+paired even/odd = open/close, and the host's reader skips stray odd (close) codes
+while hunting a response (`DecompileProcess.java:230-244`).
+
+| pair | meaning | direction |
+|---|---|---|
+| 2 / 3 | command | host → core |
+| 4 / 5 | callback query | core → host |
+| 6 / 7 | command response | core → host |
+| 8 / 9 | query response | host → core |
+| 10 / 11 | exception | both |
+| 12 / 13 | byte-stream payload | both |
+| 14 / 15 | string-stream payload | both |
+| 16 / 17 | native message (warnings) | core → host |
+
+A *string stream* (14/15) carries either raw ASCII text (command names, decimal ids,
+`t`/`f` answers) or a packed document (§6). A *byte stream* (12/13) carries the
+nibble-doubled binary formats of `getBytes`/`getStringData` (§7). Payload bytes
+between 14…15 must never contain `0x00` — that is the packed encoding's job to
+guarantee (§6).
+
+**Size limits** (host-enforced): a query parameter from the core ≤ **64 KiB**
+(`DecompileProcess.java:272`); the main command response ≤ **50 MiB** default
+(option-settable, `:80,414`); a native message ≤ **1 MiB** (`:428`).
+
+## 5. Command choreography
+
+**Dispatch loop** (reference: `ghidra_process.cc:464-486`): scan bursts until a 2;
+read the command name as a string stream; look it up. Unknown command → emit a
+complete, *payload-less* response: `6, 16, "Bad command: <name>", 17, 7`, flush, keep
+looping (`:476-484`) — this exact shape is what makes partial cores degrade gracefully
+(§9).
+
+**Per-command lifecycle** (reference: `GhidraCommand::doit`, `ghidra_process.cc:125-160`):
+
+1. Write the response-open burst **6 first, before reading parameters** — this is why
+   callback queries are legal mid-command: they nest inside the open response.
+2. Read parameters. Every command's first parameter is the session's **archid** as
+   ASCII decimal inside a string stream — *except* `registerProgram`, which has no
+   archid (it creates one) (`ghidra_process.cc:86-103,162-173`).
+3. Consume the command-close burst 3; anything else is an alignment error.
+4. Do the work (queries may flow here, for the commands that allow them — see table).
+5. Write the result payload (see table), then **always** the message frame:
+   `16, <accumulated warning text, possibly empty>, 17` (`ghidra_process.cc:108-116`),
+   then 7, then flush.
+
+Internal errors during step 4 must not kill the response: the reference implementation
+converts recoverable exceptions into warning text and still runs step 5 with an
+empty/absent payload (`ghidra_process.cc:137-155`). If a 16 arrives while the host's
+14/15 payload is still open, the host *abandons the partial payload* and keeps the
+message (`DecompileProcess.java:423-429`) — the designed salvage path for an exception
+thrown mid-encode. Hard protocol errors instead send the exception frame
+`10, <type string>, <message string>, 11` **in place of** the result
+(`ghidra_arch.cc:241-248`; `ghidra_process.cc:142-145`); the type `"alignment"` is
+special-cased by the host into an IOException.
+
+**The command set** (host senders: `DecompileProcess.java:464-700`; the four styles of
+result payload are: decimal string, `t`/`f` string, packed document, or nothing):
+
+| command | params after archid | result payload | callback queries legal? |
+|---|---|---|---|
+| `registerProgram` | *(no archid)* 4 XML string streams: pspec, cspec, tspec, coretypes | new archid, ASCII decimal | **yes** |
+| `deregisterProgram` | — | `1` (or `0` if nothing registered); then the process must exit | no |
+| `flushNative` | — | `0` | no |
+| `decompileAt` | packed `<addr>` (function entry) | packed `<doc>` (§8); **empty 14/15** if the function did not complete | **yes** |
+| `structureGraph` | packed block graph | packed restructured block graph | **yes** |
+| `setAction` | 2 string streams: action name (`decompile`/`normalize`/`jumptable`/`paramid`/`register`/`firstpass` or ""), print config (`tree`/`notree`/`c`/`noc`/`parammeasures`/`noparammeasures`/`jumpload`/`nojumpload` or "") | `t` / `f` | no |
+| `setOptions` | packed `<optionslist>` | `t` / `f` | no |
+| `generateSignatures` | packed `<addr>` | packed `<signatures>` | **yes** |
+| `debugSignatures` | packed `<addr>` | packed debug-signature doc | **yes** |
+| `getSignatureSettings` | — | packed `<sigsettings><major/><minor/><settings/>` | no |
+| `setSignatureSettings` | decimal settings string | `t` / `f` | no |
+
+**The archid session model**: `registerProgram` allocates a slot in a global session
+list and answers its index; every later command names it. Slots are nulled by
+`deregisterProgram` and may be reused (`ghidra_process.cc:176-210,231-251`). In
+practice the host runs one program per process, but the protocol is multi-session.
+An invalid archid is a hard exception (`"No architecture registered with decompiler"`).
+
+**The query legality window is a hard constraint**: the host services callback queries
+only during `registerProgram` and the four timed commands (`decompileAt`,
+`structureGraph`, `generateSignatures`, `debugSignatures`) — for every other command it
+nulls its query decoder/encoder (`DecompileProcess.java:472-473,571-572` vs
+`:512-513,536-537,618-619,657-658,686-687`). A core that lazily queries during
+`setOptions` desyncs the protocol unrecoverably.
+
+**Query choreography** (core side): write `4, 14, <packed command element>, 15, 5`,
+flush; then read either `8, [one optional payload], 9` — or `10, <exception type>,
+<message>, 11`, which means the host's callback threw; the core must abort the current
+command and propagate the exception back out as its own 10/11 frame
+(`ghidra_arch.cc:192-232`; host side `DecompileProcess.java:382-397`). An **empty
+response** (8 immediately followed by 9) is the in-band "not found / no data" signal —
+each query's row in §7 says what that means for it.
+
+**Session lifecycle the host actually drives** (`DecompInterface.java:262-361,774-839`):
+`registerProgram` → `setOptions` → `setAction` + toggles (only non-defaults) →
+[`setSignatureSettings`] → *n* × (`decompileAt` → `flushNative`) → `deregisterProgram`.
+`flushNative` after **every** decompiled function is the cache-coherence mechanism: the
+core must drop every program fact it cached — symbols, sub-scopes, non-core types,
+comments, string decodings, constant-pool records (`ghidra_process.cc:262-273`) —
+because the user may have renamed/retyped anything between requests. Caches live
+*within* one decompilation only.
+
+## 6. The packed document encoding
+
+All non-XML payloads are "packed" documents — a binary element/attribute serialization
+whose defining property is that **every encoded byte is nonzero**
+(`Framework/SoftwareModeling/.../pcode/PackedDecode.java:24-51`; `cpp/marshal.hh:454-504`),
+which is what lets it sit inside `0x00`-delimited string streams: the host ingests
+payload bytes until the first `0x00` (the opening zero of the closing burst).
+
+- **Header byte**: top two bits — `0x40` element-start, `0x80` element-end, `0xC0`
+  attribute; bit `0x20` = extend (one more byte `1iiiiiii` with 7 more id bits → 12-bit
+  ids); low 5 bits = first id bits.
+- **Attribute record**: header, then a type byte `ttttllll` — types 1=boolean
+  (length nibble is the value), 2=signed-positive, 3=signed-negative (magnitude),
+  4=unsigned, 5=address-space (integer = space index), 6=special-space (length nibble:
+  0=stack, 1=join, 2=fspec, 3=iop, 4=spacebase), 7=string (an integer byte-length,
+  then raw UTF-8).
+- **Integers**: big-endian, 7 bits per byte, each byte OR'd with `0x80`; the length
+  nibble is the byte count; length 0 encodes value 0.
+- **Indexed attributes** (join pieces): the index is folded into the attribute id
+  itself (`attribId + index` — `PackedEncode.java:169-174` = `marshal.cc:1188-1195`);
+  decoders compare raw ids against the base. The host **requires join pieces in
+  order** (`Varnode.java:550-556`, the `"piece" attributes must be in order`
+  `DecoderException`).
+- **The space-index binding — the deepest interop invariant**: the wire integer for an
+  address space is the host's `AddressSpace.getUnique()` index, and the core learns
+  the same numbering from the tspec, which writes each space's `index` attribute from
+  `getUnique()` (`SleighLanguage.encodeTranslator`,
+  `Framework/SoftwareModeling/.../sleigh/SleighLanguage.java`). Indices may be
+  **sparse** — the core's space table must tolerate holes. Of the special codes, the
+  host's decoder accepts only stack and join, maps spacebase to null, and rejects
+  fspec/iop (`PackedDecode.readSpace`) — never encode fspec/iop varnodes into response
+  documents.
+- Element ids run 1–291 upstream; the protocol-specific ones a core needs: `doc`=229,
+  the 19 query commands 239–257 (§7), and `major`=261/`minor`=262/`settings`=264/
+  `sigsettings`=268 (`ElementId.java:371-440`; `ghidra_arch.cc:30-48`,
+  `ghidra_process.cc:74`, `cpp/signature.cc:29-40`).
+
+## 7. What `registerProgram` delivers — and the query catalog (the full data API)
+
+`registerProgram` sends exactly four XML documents (the only XML on the wire), in
+order: **pspec** (the raw `.pspec` file text with all newlines stripped —
+`DecompInterface.java:241-254`; safe for all shipped specs), **cspec** (the compiler
+spec, re-encoded single-line, *including the p-code snippet sources for call fixups
+and injects*), **tspec** (a `<sleigh>` element: endianness, `uniqbase`, and the
+address-space list with names/indices/sizes/wordsizes — **not** a `.sla` file), and
+**coretypes** (`DecompileProcess.java:479-485`; `DecompInterface.java:262-302`).
+
+What it does **not** deliver: a language id, processor context, memory contents,
+symbols, or any disassembly capability. **P-code-from-host is therefore structurally
+implied**: with no language identity and no context-register model on the wire, a core
+cannot correctly disassemble raw bytes itself (ARM/Thumb, MIPS16, user overrides); the
+listing the *host* disassembled is fetched instruction-by-instruction via `getPcode`.
+The reference core contains no SLEIGH engine at all (the `ghidra_opt` link excludes
+it, `cpp/Makefile:99-131`).
+
+The 19 callback queries are the complete data API a core ever gets. Framing per §5;
+"empty ⇒" describes the empty-8/9-response meaning. Two queries (`getComments`,
+`getTrackedRegisters`) **always** return a document, even when empty
+(`DecompileProcess.java:727-734,844-853`); for all others an empty response is the
+negative answer.
+
+| query | id | request params | response | notes |
+|---|---|---|---|---|
+| `isNameUsed` | 239 | `name`, `first`/`last` scope ids | raw `t`/`f` byte in 14/15 | host caps the scan at 16 symbols and reports "used" past it |
+| `getBytes` | 240 | `<addr>` + `size` | 12/13 byte stream, each byte nibble-doubled: `('A'+(b>>4)), ('A'+(b&0xF))` | empty ⇒ no backing memory (DataUnavail) |
+| `getCallFixup` | 241 | `name` + `<context>` (baseaddr, calladdr, in/out varnodes) | packed `<inst>` of p-code ops | inject bodies live host-side; core sends context, gets ops |
+| `getCallMech` | 242 | `name` + `<context>` | packed `<inst>` | call-mechanism (uponentry/uponreturn) injects |
+| `getCallOtherFixup` | 243 | `name` + `<context>` | packed `<inst>` | CALLOTHER fixups |
+| `getCodeLabel` | 244 | `<addr>` | plain string | "" = no label |
+| `getComments` | 245 | `type` flag mask + `<addr>` (function entry) | packed `<commentdb>` | **always written**; flags: 1=EOL, 2=PRE, 4=POST, 8=PLATE/header |
+| `getCPoolRef` | 246 | `size` n + n × `<value>` | packed `<cpoolrec>` | JVM/Dalvik constant pool |
+| `getDataType` | 247 | `name` + `id` (signed) | packed `<type>` | empty ⇒ unknown type |
+| `getExternalRef` | 248 | `<addr>` | packed `<doc id><mapsym>` | external/thunk resolution |
+| `getMappedSymbols` | 249 | `<addr>` | packed `<doc id><mapsym>` (function/data/label/external) or `<hole [readonly] [volatile] space first last/>` | THE symbol query; `<hole>` = cache-this-negative-range; empty ⇒ no address |
+| `getNamespacePath` | 250 | `id` (unsigned) | packed `<parent>` of `<val>` per namespace level | lazily rebuilds scope paths |
+| `getPcode` | 251 | `<addr>` | packed `<inst offset=len><addr/>` + `<op>` per p-code op, or `<unimpl offset=len/>` | **one query per instruction**; empty ⇒ undecodable (BadData) — the decompile *continues*, counting toward the bad-data limit |
+| `getPcodeExecutable` | 252 | `name` + `<context>` | packed `<inst>` | executable p-code scripts (e.g. segment resolution) |
+| `getRegister` | 253 | `name` | packed `<addr space offset size>` | unknown name ⇒ host throws (exception frame) |
+| `getRegisterName` | 254 | `<addr>` + size | plain string | "" = not a register |
+| `getStringData` | 255 | `maxsize`, `type` name, `id` + `<addr>` | 12/13 byte stream: 2 bytes encoding sz=len+1 (`byte1=(sz&0x3f)+0x20`, `byte2=((sz>>6)&0x3f)+0x20`), 1 raw truncated-flag byte, then sz nibble-doubled UTF-8 bytes ending in the doubled NUL `"AA"` | host decodes/validates the string in *its* charset settings; empty ⇒ not a string |
+| `getTrackedRegisters` | 256 | `<addr>` | packed `<tracked_pointset>` of known register values | **always written** |
+| `getUserOpName` | 257 | `index` (signed) | plain string | "" = end; the core probes 0,1,2,… at registration to build the CALLOTHER table |
+
+(Verified against both ends: `ghidra_arch.cc:30-48,445-896` and
+`ElementId.java:371-427` + the dispatch at `DecompileProcess.java:315-380,704-916`.
+Note 241=`getcallfixup`, 242=`getcallmech`, 243=`getcallotherfixup`.)
+
+Exceptions from a query (frame 10/11 instead of 8/9) abort the current command; the
+mid-command query that failed is never retried within it.
+
+## 8. The response document contracts
+
+The wire will move any well-formed packed document; the *decoders* are the real
+contract. What each response must contain:
+
+**`decompileAt` → `<doc>` (element id 229).** Decoded by
+`DecompileResults.decodeStream` (`DecompileResults.java:215-264`), which accepts, in
+order:
+
+1. A first `<function>` → decoded as the **HighFunction**
+   (`Framework/SoftwareModeling/.../pcode/HighFunction.java:245-293`). Requirements:
+   - `name` attribute **equal to the host-side function name** (mismatch throws);
+     an `<addr>` child matching the entry point (mismatch throws).
+   - Recognized children — all individually optional: `<prototype>`, `<localdb>`
+     (the local symbol scope: `<mapsym>` entries), `<ast>` (varnodes + p-code ops),
+     `<highlist>` (HighVariables), `<jumptablelist>`, `<override>`/`<scope>`
+     (skipped). **Any other child throws** — emit nothing extra.
+   - **Symbol-id echo**: `<mapsym>` symbols must carry the host database's real symbol
+     ids as delivered by `getMappedSymbols`; ids in the internal
+     `0x4000000000000000` range are reserved and never round-tripped
+     (`HighSymbol.java:39,386-387`). Rename/retype in the GUI is a database write
+     keyed by this id followed by a re-decompile — a wrong id silently breaks it.
+2. A second `<function>` → the **token markup** (the rendered C as a Clang token
+   tree, `ClangMarkup.buildClangTree`). Every token needs `color` (syntax class) and
+   text content; variable/op/statement tokens carry `varref`/`opref` ids that the host
+   resolves **against the first `<function>`'s decoded `<ast>`**
+   (`ClangVariableToken.java:147-163`;
+   `Framework/SoftwareModeling/.../pcode/PcodeSyntaxTree.java:309,365`). Click-to-address,
+   hover, highlight, and rename targeting all ride these ids — markup and ast must be
+   emitted from the same numbering.
+3. Alternatively `<parammeasures>` (action `paramid`) → `HighParamID`.
+
+Anything else at `<doc>` level is "Unknown decompiler tag". The ordering kludge is
+explicit and load-bearing: HighFunction first, markup second. `decompileCompleted()`
+requires hfunc *or* hparamid; the **GUI panel** additionally requires the markup
+(`component/DecompileData.java:56`) — a core that omits the second `<function>` keeps
+scripts and analyzers alive but renders nothing. An **empty** result payload (allowed
+for a failed function) plus warning text in the 16/17 frame produces a clean GUI error.
+
+**`structureGraph`** → the input is a packed block graph (nested `<block>`/`<bhead>`/
+`<edge>`); the output is the structured graph, decoded by `BlockGraph.decode` and
+re-associated with the caller's objects (`DecompInterface.java:732-764`). Pure
+control-flow structuring — no dataflow, no program state; always uses the non-overlay
+codec set.
+
+**`generateSignatures`** → `<signatures>` with `<sig val=…/>` children (+ `unimpl`/
+`baddata` attributes), decoded by `SignatureResult.decode`. `getSignatureSettings` →
+`<sigsettings>` with `<major>`, `<minor>`, `<settings>` integer children.
+
+**Overlay spaces**: for functions in overlay spaces the host transparently swaps in
+overlay-translating codecs on *both* the command and callback channels
+(`DecompInterface.java:84-127,896-909`); the core just sees the underlying space via
+the translated index, plus `<space_overlay>` entries in the tspec.
+
+## 9. Consumer matrix — what breaks when a core is partial
+
+| consumer | what it sends / expects | if missing |
+|---|---|---|
+| **Decompiler panel** (the GUI) | `decompileAt`, style `decompile`, tree+C on; needs *both* `<function>` elements with consistent refids | no render (clean error) |
+| **Rename/retype actions** | HighFunction symbols with real DB ids; re-decompile picks up changes via fresh queries | renames silently fail to stick |
+| **Switch analyzer** (auto-analysis) | `decompileAt` with C *off*, `jumpload` *on*; consumes `<jumptablelist>` | computed jumps stay unrecovered in the listing |
+| **Parameter-ID / call-convention analyzers** | action `paramid` + `parammeasures`; consume `<parammeasures>` | those analyzers no-op |
+| **BSim** | `generateSignatures`, `debugSignatures`, `get`/`setSignatureSettings` | disabled with a friendly "not built with signature module" message (`DecompInterface.java:341-347`) |
+| **FunctionGraph nested layout** | `structureGraph` | that one layout unavailable |
+| **CppExporter, scripts, FlatDecompilerAPI, Debugger unwind** | `decompileAt`; HighFunction and/or the pretty-printed text | per-feature |
+
+The graceful-degradation mechanism is uniform: answer unimplemented commands with the
+exact "Bad command" response shape (§5) and the corresponding feature degrades in
+isolation; everything else keeps working.
+
+## 10. Versioning reality
+
+There is **no handshake**. The interface version (major=6, minor=1,
+`cpp/architecture.cc:35-36`) is exposed only through `getSignatureSettings`, fetched
+lazily, and consumed only by BSim (`Features/BSim/.../FunctionDatabase.java:213-214`).
+Compatibility in practice rests on shipping the core with the matching Ghidra release.
+
+The concrete skew failure mode is **option drift**: `setOptions` sends an
+`<optionslist>` whose elements are only emitted when they differ from the Java-side
+defaults. When Ghidra adds an option (real example: `baddatacount`,
+ELEM_BADDATACOUNT=290, added between 2026-06-01 and the 12.2-DEV head —
+`ElementId.java:293`, `DecompileOptions.java:988-989`), an older reference core throws
+`ParseError("Unknown option")`, `setOptions` answers `f`, and the host fails the whole
+program-open with "Did not accept decompiler options" (`DecompInterface.java:301-303`)
+— one stale non-default option bricks the decompiler view.
+
+**Recommendation for any replacement core**: pin the Ghidra release you target, and —
+diverging from the reference implementation — *tolerate unknown option elements*
+(skip + warn) so option skew degrades to a warning instead of a hard failure.
+Element-id renumbering across releases is the other watch item: protocol ids must
+match the pinned release exactly.
+
+## 11. Minimum viable core
+
+The smallest surface that yields working GUI decompilation:
+
+- **Commands**: `registerProgram` (parse the tspec's space list — sparse indices — and
+  hold the cspec/pspec/coretypes; answer an archid), `setOptions`/`setAction` (may
+  accept-and-ignore; answer `t`), `decompileAt`, `flushNative` (clear caches; answer
+  `0`), `deregisterProgram` (answer `1`; exit). Answer everything else "Bad command".
+- **Queries issued**: `getPcode` (per instruction — the instruction stream *is* this),
+  `getMappedSymbols` at the entry (the function's name/extent; honor `<hole>`
+  semantics for anything else you probe), `getRegister`/`getRegisterName` as your IR
+  needs them, `getUserOpName` 0…n at registration, `getTrackedRegisters` at the entry.
+  Everything else — bytes, strings, types, comments, injects, cpool — is quality, not
+  viability (skipping call fixups will visibly hurt output on real binaries; add
+  `getCallFixup`/`getCallMech` next).
+- **Response**: a `<doc>` with the dual `<function>` contract of §8 — matching
+  name/entry, a decodable `<ast>`, `<localdb>` echoing the delivered symbol ids, and a
+  markup tree whose `varref`/`opref` ids resolve into that ast.
+- **Behavior**: the exact framing choreography of §5 (response-open before params, the
+  always-present 16/17 frame, exception frames), `exit(1)` on EOF, and full state
+  reconstruction from the replay sequence after a respawn.
+
+Everything beyond that — jump tables, param measures, structureGraph, signatures,
+overlay spaces, charset-faithful strings — is incremental parity, feature by feature,
+per the consumer matrix.

--- a/docs/ghidra-integration.md
+++ b/docs/ghidra-integration.md
@@ -1,0 +1,439 @@
+# Using kuna as Ghidra's decompiler core
+
+How kuna replaces the native `decompile` process behind Ghidra's stock GUI — the
+architecture, the wire protocol, what kuna already has, what each phase adds, and the
+response contracts that make the GUI actually work. Audience: kuna developers
+implementing Phases 2–4 (Phase 1 — the protocol-complete, engine-stubbed binary plus the
+extension that spawns it — is on branch `feat/ghidra-mode`).
+
+**Citation convention.** Ghidra sources are cited as `file:line` against the Ghidra
+12.2-DEV checkout at commit `f9e13846` (2026-06-16). Java paths are under
+`Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/` unless otherwise
+noted; C++ paths under `Ghidra/Features/Decompiler/src/decompile/cpp/`. kuna's own
+pinned port anchor is `GHIDRA_REV` `cef869af` (2026-06-01, `docs/UPSTREAM.md`); the one
+protocol-relevant delta between the two revisions is called out in §8. kuna paths are
+relative to `decompiler/crates/`.
+
+The companion document **`docs/decompiler-core-interface.md`** specifies the same
+interface from the *other* side — what Ghidra requires from *any* replacement core, with
+no kuna knowledge assumed. This document is the kuna-specific plan; details of the
+protocol that are fully specified there are only summarized here.
+
+---
+
+## 1. The decision: reimplement the native side, leave Ghidra alone
+
+Ghidra's Java GUI talks to its decompiler through a **child process** named `decompile`,
+spawned lazily on the first decompile request (`DecompInterface.java:267`) and driven
+over stdin/stdout with a burst-framed binary protocol (`DecompileProcess.java:54-63`).
+Upstream, that process is the C++ `ghidra_opt` build — the same DECCORE engine kuna
+ported, linked against a `GHIDRA` glue group (`ghidra_process.cc`, `ghidra_arch.cc`,
+`ghidra_translate.cc`, …) that kuna deliberately excluded from the port (LOSS-002,
+`docs/rust-port/losses.md`).
+
+**kuna reimplements exactly that glue group**: a new **`kuna-ghidra`** crate producing a
+binary that speaks the full decompiler-process protocol, backed by kuna's engine. The
+stock Ghidra GUI and its entire Java side stay byte-for-byte untouched; the only
+Ghidra-side artifact is a tiny extension (`integrations/ghidra/KunaDecompiler/`, §7)
+that points the spawn at our binary.
+
+Rejected alternatives, for the record:
+
+- **Fork `DecompInterface`/the Java chain.** The GUI chain is hardcoded `new` at every
+  link (`DecompilePlugin.java:93` → … → `Decompiler.java:75` → `DecompInterface.java:267`)
+  with ~28 `new DecompInterface()` call sites across the tree and no injection seam.
+  A fork covers only the call sites you rewrite, breaks the "normal Ghidra GUI" goal,
+  and is unmaintainable against upstream.
+- **A shim process wrapping kuna's existing CLI.** The protocol is not
+  request/response: the native side issues **callback queries mid-decompile**
+  (per-instruction p-code, symbols at an address, bytes, types — §4) that a
+  `kuna decompile-all` wrapper cannot answer; and the response is not C text but a
+  typed dual-document (`HighFunction` + token markup with cross-referenced ids, §6)
+  over live program state. There is no shim-shaped solution.
+
+## 2. Architecture and session lifecycle
+
+```
+Ghidra GUI (untouched)                          kuna-ghidra binary
+──────────────────────                          ─────────────────────
+DecompilerProvider/Controller/Manager           main loop: readCommand()
+  → DecompInterface                               ├─ registerProgram  → ArchitectureGhidra-equiv
+    → DecompileProcessFactory.get()               ├─ setOptions/setAction (replayed state)
+      → spawn kuna_ghidra  ◄──── extension        ├─ decompileAt ──┐
+        (stdin/stdout bursts)                     │   queries back ─┘ getPcode/getBytes/…
+                                                  ├─ flushNative   (after every function)
+                                                  └─ deregisterProgram → exit
+```
+
+- **Spawn**: lazy, on first decompile; `runtime.exec(exepath)` with **no arguments and
+  no environment changes** (`DecompileProcess.java:151`); Java waits 200 ms, checks
+  `isAlive()`, and reads stderr into an error dialog if the process died
+  (`DecompileProcess.java:154-192`). There is **no startup handshake** — the process
+  silently waits for the first command.
+- **Session**: `registerProgram` (four XML spec documents → a new engine session,
+  answered with a decimal *archid*) → replayed session state (`setOptions`, `setAction`,
+  print toggles, signature settings — `DecompInterface.java:262-352`) → any number of
+  `decompileAt` + `flushNative` pairs (Java flushes the native caches after **every**
+  decompiled function, `DecompInterface.java:826-832`) → `deregisterProgram`, which
+  answers and then **terminates the process** (C++ sets `status=1`, ending the main
+  loop, `ghidra_process.cc:242-248,533-535`; Java never reuses a deregistered process,
+  `DecompileProcess.java:501-522`).
+- **Timeout is process murder**: on decompile timeout Java disposes the process from a
+  timer thread so the blocked read throws (`DecompileProcess.java:100-106,564-595`).
+  The native side never sees a cancel message — it sees EOF, on which it must `exit(1)`
+  (`ghidra_arch.cc:95-96`).
+- **Respawn + replay**: any IOException marks the process bad; the next request
+  respawns, re-registers the program, and replays options/action/toggles
+  (`DecompInterface.java:354-361,262-352`). The native side needs no persistence — a
+  fresh process must simply reach the same state from the replay.
+
+## 3. The wire protocol, condensed
+
+Full byte-level specification: `docs/decompiler-core-interface.md` §3–§5. Summary:
+
+**Burst framing** (`DecompileProcess.java:54-63`; `ghidra_arch.cc:50-77`): every marker
+is written as `{0x00,0x00,0x01,code}` and read tolerantly (skip garbage, one-or-more
+`0x00`, expect `0x01`, then the code byte — `readToAnyBurst`, `ghidra_arch.cc:79-98`).
+Even codes open, odd codes close.
+
+| pair | meaning | direction |
+|---|---|---|
+| 2 / 3 | command | Java → native |
+| 4 / 5 | callback query | native → Java |
+| 6 / 7 | command response | native → Java |
+| 8 / 9 | query response | Java → native |
+| 10 / 11 | exception | both |
+| 12 / 13 | byte-stream payload | both |
+| 14 / 15 | string-stream payload | both |
+| 16 / 17 | native message (warnings) | native → Java |
+
+String streams (14/15) carry either raw ASCII (command names, decimal archids, the
+`t`/`f` answers) or a **packed** binary document (kuna's bit-exact
+`kuna-base/src/marshal.rs` `PackedEncode`/`PackedDecode`) — every packed byte is
+nonzero, so the closing burst's leading `0x00` terminates ingestion. The only XML on
+the wire is the four `registerProgram` spec strings.
+
+**Commands** (dispatch `ghidra_process.cc:464-486`; every command's first parameter
+after the name is the decimal archid in a string burst, *except* `registerProgram`):
+
+| command | parameters after archid | response payload | queries legal during? |
+|---|---|---|---|
+| `registerProgram` | *(no archid)* pspec, cspec, tspec, coretypes — 4 XML string bursts (`ghidra_process.cc:162-173`) | new archid, ASCII decimal | **yes** |
+| `deregisterProgram` | — | `1`/`0` decimal; then process exit | no |
+| `flushNative` | — | `0` decimal | no |
+| `decompileAt` | packed `<addr>` of the entry | packed `<doc>` (§6); empty 14/15 if incomplete | **yes** |
+| `structureGraph` | packed block graph | packed restructured block graph | **yes** |
+| `setAction` | actionstring, printstring (2 string bursts) | `t`/`f` | no |
+| `setOptions` | packed `<optionslist>` | `t`/`f` | no |
+| `generateSignatures` | packed `<addr>` | packed `<signatures>` | **yes** |
+| `debugSignatures` | packed `<addr>` | packed debug-sig doc | **yes** |
+| `getSignatureSettings` | — | packed `<sigsettings>` | no |
+| `setSignatureSettings` | decimal settings string | `t`/`f` | no |
+
+Choreography invariant: the response-open burst 6 is written **before** parameters are
+read (`GhidraCommand::doit`, `ghidra_process.cc:125-135`), so callback queries nest
+inside the open response; the result payload is followed by the 16/17 warnings frame
+(always present, possibly empty — `ghidra_process.cc:108-116`), then 7, then flush.
+The "queries legal" column is a **hard constraint**: Java nulls its callback
+decoder/encoder for all other commands (`DecompileProcess.java:512-513,536-537,618-619,
+657-658,686-687` vs `:472-473,571-572`) — a query issued during `setOptions` desyncs
+the protocol.
+
+**The 19 callback queries** (native → Java; element ids `ghidra_arch.cc:30-48` =
+`ElementId.java:371-427`; framing: `4, 14 <packed command element> 15, 5, flush`, then
+read `8 payload 9`, or `10 type msg 11` = a Java exception rethrown into the decompile):
+
+| query | id | request params | response transport |
+|---|---|---|---|
+| `isNameUsed` | 239 | name, first (scope id), last | bool: raw `t`/`f` in 14/15 |
+| `getBytes` | 240 | `<addr>` + size | byte burst 12/13, nibble-doubled (`'A'+hi,'A'+lo`); empty ⇒ DataUnavail |
+| `getCallFixup` | 241 | name + `<context>` | packed `<inst>` of ops |
+| `getCallMech` | 242 | name + `<context>` | packed `<inst>` |
+| `getCallOtherFixup` | 243 | name + `<context>` | packed `<inst>` |
+| `getCodeLabel` | 244 | `<addr>` | plain string (label, "" = none) |
+| `getComments` | 245 | type-flag mask + `<addr>` | packed `<commentdb>` — **always written**, possibly empty |
+| `getCPoolRef` | 246 | size n + n×`<value>` | packed cpool record |
+| `getDataType` | 247 | name + id (signed) | packed `<type>`, or empty = not found |
+| `getExternalRef` | 248 | `<addr>` | packed `<doc><mapsym>`, or empty |
+| `getMappedSymbols` | 249 | `<addr>` | packed `<doc><mapsym>` / `<hole>`, or empty |
+| `getNamespacePath` | 250 | id (unsigned) | packed `<parent>` with `<val>` per level |
+| `getPcode` | 251 | `<addr>` | packed `<inst offset><addr/><op>…` or `<unimpl offset>`; empty ⇒ BadDataError, decompile **continues** |
+| `getPcodeExecutable` | 252 | name + `<context>` | packed `<inst>` |
+| `getRegister` | 253 | name | packed `<addr space offset size>` |
+| `getRegisterName` | 254 | `<addr>` + size | plain string ("" = none) |
+| `getStringData` | 255 | maxsize, type name, id + `<addr>` | byte burst: 2-byte biased length of len+1, raw trunc flag, nibble-doubled UTF-8 + doubled NUL |
+| `getTrackedRegisters` | 256 | `<addr>` | packed `<tracked_pointset>` — **always written** |
+| `getUserOpName` | 257 | index (signed) | plain string ("" = end of table) |
+
+Registration-time traffic the client expects: the `getUserOpName` probe loop (index
+0,1,2,… until "") fires during `registerProgram` init (`ghidra_translate.cc:107-117`),
+establishing the CALLOTHER index table.
+
+## 4. P-code comes from Java, per instruction (decided)
+
+kuna ships a full SLEIGH engine and vendors every upstream spec, so the tempting
+shortcut is to disassemble locally and use the wire only for bytes/symbols. **Rejected**
+— Phase 2 ports `GhidraTranslate` faithfully (`ghidra_translate.cc:120-156`: one
+`getPcode` query per instruction, register-name caches, no p-code cache), because:
+
+1. **There is no wire query for low-level disassembly context.** The upstream
+   `ContextGhidra` throws on every context-variable method
+   (`ghidra_context.hh:36-47,60-74`) — disassembly context (ARM/Thumb, MIPS16,
+   context-register state per address) lives only in Java's program database. A local
+   SLEIGH engine would disassemble Thumb code as ARM with no way to know better.
+2. **Listing parity.** What Java disassembled — including user overrides, manual
+   context, length-override instructions — is exactly what gets decompiled. That
+   invariant is the point of the product: the decompiler view always matches the
+   listing view.
+3. **It is what the wire contract assumes.** The spawn passes no arguments to identify
+   a language; the tspec carries only address spaces + endianness + uniqbase, not a
+   language id (`SleighLanguage.encodeTranslator`); and `flushNative`'s cache semantics
+   (Java flushes after every function) are designed around Java being the source of
+   truth for all program facts. A local-SLEIGH kuna would need out-of-band language
+   resolution the protocol simply does not carry.
+
+Consequence for kuna: `Architecture.translate` is today a **concrete `Sleigh`** field
+(`kuna-decomp/src/infra/architecture.rs:836`). Phase 2 introduces a `Translate` seam on
+`Architecture` — an **enum over `{Sleigh, GhidraTranslate}`**, not a `Box<dyn>`, to keep
+`manage()` (the space-manager accessor) concrete and the standalone path untouched. The
+lift stage is already trait-typed at the consumption point
+(`FlowEnvironment::translate() -> &dyn Translate`, called at
+`kuna-decomp/src/s2_lift/flow.rs:1321`), and the trait itself
+(`kuna-sleigh/src/translate.rs:386`) is a faithful port of the C++ virtual. The
+space-manager-without-`.sla` problem is already solved: `insert_space`
+supports the sparse tspec indices (`kuna-base/src/space.rs:2545-2566`) and a unit test
+builds a manager purely from decoded `<space>` elements
+(`kuna-sleigh/src/translate.rs:1086-1124`). Phase 1 already ships the
+`GhidraTranslate::decode` equivalent — `kuna-ghidra/src/translate.rs` parses the tspec
+`<sleigh>` element (endianness, `uniqbase`, the `<space>`/`<space_unique>`/`<space_other>`/
+`<space_overlay>` list, `<truncate_space>`) into a real `AddrSpaceManager`, which is why
+`decompileAt` already decodes real `<addr>` parameters (`ghidra_translate.cc:161-176`).
+Phase 2 only wires that manager into an `Architecture`.
+
+## 5. Symbols, types, comments, strings, injects: pull-only ⇒ lazy caches (decided)
+
+The wire has **no enumerate-the-program query**. Symbols arrive one address at a time
+(`getMappedSymbols`), types one id at a time (`getDataType`), comments per function
+(`getComments`), strings per address (`getStringData`), inject bodies per call site
+(`getPcodeInject` family). Eager pre-population — the pattern kuna's analysis tier uses
+(`ConsoleProgram::commit_pending_analysis`) — is therefore **impossible**, not merely
+inferior: there is nothing to enumerate. kuna needs the upstream lazy model:
+
+- **`ScopeGhidra`** (`database_ghidra.cc`): every lookup checks a local cache, then
+  queries, then materializes the answer — including negative answers as `<hole>` ranges
+  so the same miss is never re-queried, readonly/volatile flags folded into the
+  property map with dirty-tracking, and namespaces rebuilt on demand via
+  `getNamespacePath`.
+- **`TypeFactoryGhidra`** (`typegrp_ghidra.cc:20-36`): one override — `findById` miss →
+  `getDataType` → decode into the local factory.
+- **`CommentDatabaseGhidra`** (`comment_ghidra.cc:30-49`): fill-once-per-function from
+  `getComments`, filtered by the printer's current comment settings.
+- All of it flushed by `flushNative` after every function
+  (`ghidra_process.cc:262-273`): global scope, sub-scopes, non-core types, comments,
+  string decodings, cpool.
+
+This is what forces the Phase-3 seam work on kuna's concrete types: the C++ virtuals
+these classes override were deliberately collapsed in the port (the `Scope`/
+`ScopeInternal` merge, `kuna-decomp/src/p0_knowledge/database.rs:904-922`), and the
+per-function `ArchSeam` snapshot (`substrate/seams.rs:411`, built by
+`build_arch_handle`, `architecture.rs:1529`) assumes all facts are known before the
+decompile starts — mid-decompile discovery must either rebuild those snapshots or route
+queries through them. See the seam inventory (§9) and the Phase 3 checklist (§11).
+
+## 6. Response contracts that make the GUI work
+
+Printing correct C is not enough. The `decompileAt` response is a packed `<doc>`
+(ELEM_DOC=229) whose Java consumption (`DecompileResults.java:215-264`) imposes:
+
+- **Dual `<function>` elements, order load-bearing**: the *first* decodes as the
+  `HighFunction` (prototype, `<localdb>` symbols, `<ast>` varnodes+ops, `<highlist>`,
+  `<jumptablelist>`), the *second* is the Clang token markup — an explicitly-commented
+  "ugly kludge" around duplicate tag names. The GUI renders only if **both** decode
+  (`DecompileData.java:56`); headless consumers survive on the first alone.
+- **Name + entry echo**: `HighFunction.decode` throws on a function-name or
+  entry-address mismatch with the Java-side `Function`
+  (`Framework/SoftwareModeling/.../pcode/HighFunction.java:245-293`).
+- **ast ↔ markup refid consistency**: markup tokens carry `ATTRIB_VARREF`/`ATTRIB_OPREF`
+  that Java resolves *against the first `<function>`'s decoded `<ast>`*
+  (`ClangVariableToken.java:147-163`, `PcodeSyntaxTree.java:309,365`). Click-to-address,
+  hover, highlight, and rename-target resolution all ride on these ids — kuna's
+  `EmitMarkup` `MarkupRef` fields (op time / varnode create-index) must match what
+  `Funcdata::encode` emits into the `<ast>`.
+- **DB symbol-id echo**: `<mapsym>` symbols must carry the *real Ghidra database symbol
+  ids* they were delivered with; ids in the internal `0x4000000000000000` range are
+  never round-tripped (`HighSymbol.java:39,386-387`). Rename/retype is a DB write keyed
+  by that id followed by an event-driven re-decompile
+  (`RenameVariableTask.java:51-57`, `DecompilerProgramListener.java:60,82`) — a wrong id
+  silently breaks rename.
+- **`<jumptablelist>`** feeds the switch analyzer (`DecompilerSwitchAnalysisCmd.java:100`,
+  configured with C-code *off* and jumpload *on* — the list must be emitted even when
+  the markup isn't).
+- **`<parammeasures>`** (action `paramid` + the parammeasures toggle) feeds the
+  Decompiler Parameter ID and calling-convention analyzers
+  (`DecompilerParameterIdCmd.java:325-345`).
+
+## 7. The extension seam (decided)
+
+Primary mechanism — **reflection swap of `DecompileProcessFactory.exepath` from a
+plugin**. The factory caches the resolved path in a private static with an early-return
+(`DecompileProcessFactory.java:28,52-55`); the native process spawns lazily on the first
+decompile (`DecompInterface.java:267`), so any plugin constructor in the tool runs
+inside the pre-spawn window. Ghidra's flat classpath (all classes in the unnamed module,
+`GhidraClassLoader.java:34`) means `setAccessible(true)` works with no `--add-opens`.
+The extension (`integrations/ghidra/KunaDecompiler/`) resolves the binary in two steps:
+first the `-Dkuna.decompiler.exe=<path>` dev override (a JVM system property, for
+pointing at a fresh `cargo build` without reinstalling the extension), then — the normal
+path — the kuna binary shipped in the extension's **own** module `os/` dir under the
+**distinct name `kuna_ghidra`**, resolved with the two-arg
+`Application.getOSFile(moduleName, filename)` (`Application.java:1000-1003`). Naming it
+`decompile` could never work, because the single-arg lookup searches the *calling*
+class's module first and `DecompileProcessFactory` lives in the Decompiler module,
+which ships its own (`Application.java:1013-1026`).
+
+Documented fallbacks (no code, release installs): **build/os file-drop** — a binary at
+`<install>/Ghidra/Features/Decompiler/build/os/<platform>/decompile` shadows the stock
+`os/` copy because `getModuleOSFile` checks `build/os/` first unconditionally; and the
+**patch-dir class shadow** — `<install>/Ghidra/patch` jars precede module jars in
+release mode only (`GhidraLauncher.java:182-183`). Full ranking and the why-nots:
+`docs/decompiler-core-interface.md` §2.
+
+## 8. Version policy (decided)
+
+`kuna-ghidra` targets a **pinned Ghidra release** (the 12.2 vintage). There is no
+protocol handshake — the interface version (major=6/minor=1,
+`cpp/architecture.cc:35-36`) is exposed only through `getSignatureSettings` and only
+BSim reads it. The real skew risk is **option drift**, already live between kuna's
+`GHIDRA_REV` (`cef869af`) and the 12.2-DEV head (`f9e13846`): upstream added a
+`baddatacount` option (ELEM_BADDATACOUNT=290, moving ELEM_UNKNOWN to 291,
+`ElementId.java:293,464`), and an older core receiving that unknown `<optionslist>`
+element throws `ParseError` → `setOptions` answers `f` → Java fails the whole
+program-open with "Did not accept decompiler options" (`DecompInterface.java:301-303`).
+kuna therefore **deliberately diverges from upstream: unknown option elements are
+skipped with a warning instead of failing the command** — one stale option must not
+brick the decompiler view. This is output-invariant for known options; it gets a DIV
+entry in `docs/divergences.md` when the behavior ships (Phase 2, when `setOptions`
+stops being a stub).
+
+A second, smaller **deliberate divergence** hardens the process against a malformed
+archid. Upstream reads the id with `sin >> dec >> id` (`ghidra_process.cc:89-96`); on a
+non-numeric or overflowing payload C++11 leaves the stream in a failed state, and the
+next `readToAnyBurst` sees the failbit and `exit(1)`s the whole process
+(`ghidra_arch.cc:95-96`) — one bad command kills the session. kuna's `parse_arch_id`
+instead returns `-1`, which the caller turns into the ordinary "No architecture
+registered with decompiler" `JavaError`: the client sees a clean exception on that one
+command and the process stays alive for the next.
+
+## 9. What kuna already has vs. the seam inventory
+
+Already in the tree (verified):
+
+| asset | where | state |
+|---|---|---|
+| Packed marshaling, bit-exact | `kuna-base/src/marshal.rs` (`PackedDecode` :1424, `PackedEncode` :2008) | done — the payload codec is the ported one |
+| `KunaError::Java` | `kuna-base/src/error.rs:145-153` | done — the C++ `JavaError` carrier |
+| Token-markup emitter | `kuna-decomp/src/s9_emit/prettyprint.rs:719` (`EmitMarkup`, packed clang doc) | ported, **unreachable** — PrintC hardwires `EmitNoMarkup` (`printc.rs:1015`) |
+| Signature engine | `kuna-decomp/src/infra/signature.rs` + `analyzesigs.rs` | ported; the four signature commands are wire-glue, not engine work |
+| Signature element ids | `signature.rs:73-87` — 258, 259, 260, 263, 265, 266, 267, 269, upstream-numbered | done; the gaps 261/262/264/268 are ours to add |
+| tspec-driven space manager, no `.sla` | `kuna-base/src/space.rs:2545-2566`; `kuna-ghidra/src/translate.rs` (`GhidraTranslate::decode`) | **done in kuna-ghidra** — the tspec `<sleigh>` parse builds a real `AddrSpaceManager`; Phase 2 wires it into an `Architecture` |
+| `LoadImage` trait | `kuna-sleigh/src/loadimage.rs:101`, consumed as `Box<dyn>` everywhere | ready |
+| `ContextDatabase` trait | `kuna-sleigh/src/globalcontext.rs:340` | ready |
+| `Translate` trait + trait-typed lift | `kuna-sleigh/src/translate.rs:386`; `flow.rs:1321` | ready at the consumer; owner is concrete |
+
+Protocol element ids to add (upstream numbers, wire compat — kuna's own 4000+ range is
+for kuna-invented ids only, and none of these are taken): **229** (`doc`), **239–257**
+(the query commands, §3 — note 241=`getcallfixup`, 242=`getcallmech`,
+243=`getcallotherfixup`, verified against `ghidra_arch.cc:30-48` and
+`ElementId.java:377-385`), **261/262/264/268** (`major`/`minor`/`settings`/`sigsettings`).
+
+The engine-seam inventory, with honest difficulty:
+
+| seam | kuna today | work | phase |
+|---|---|---|---|
+| `LoadImage` | trait ready | **trivial** — `GhidraLoadImage::load_fill` = `getBytes` | 2 |
+| `ContextDatabase` | trait ready | **trivial** — `ContextGhidra` implements `getTrackedSet` only (upstream throws on the rest, `ghidra_context.hh:36-47`) | 2 |
+| `Translate` | trait exists; `Architecture.translate: Sleigh` concrete (`architecture.rs:836`) | **enum seam** `{Sleigh, GhidraTranslate}` + the Sleigh-only call surface audit | 2 |
+| `Funcdata::encode` | **missing** (no encode on `substrate/funcdata*.rs`) | port from upstream `funcdata.cc` — minimal `<function>` first | 2 |
+| PrintC → `EmitMarkup` | back-end ported, front-end hardwired (`printc.rs:1015`) | generalize PrintC's `emit` field; wire `doc_function` (`printc.rs:1102`) to the markup path | 2 |
+| Scope / symbol table | polymorphism deliberately collapsed (`database.rs:904-922`) | **redesign** — lazy query-through cache + `<hole>` negatives + namespace path resolution (the `ScopeGhidra` model) | 3 |
+| `TypeFactory` | trait exists; owners name `TypeFactoryImpl` (`architecture.rs:765`, `seams.rs:630`) | trait-plumbing for lazy `findById` | 3 |
+| `CommentDatabase` | full trait ported (`s9_emit/comment.rs:280`) but `Architecture.commentdb` is a minimal stand-in (`architecture.rs:143`) | rewiring, small | 3 |
+| `StringManager` | concrete, no trait (`stringmanage.rs:83`) | one-method extraction for Java-side charset-faithful decode | 3→4 |
+| Inject library | traits exist; owner concrete; SLEIGH inject engine compiles cspec snippets | reuse the SLEIGH engine over the **wire-fed cspec** (the snippets travel inside it) | 3 |
+| `ConstantPool` | trait ready (`infra/cpool.rs:470`) but **unwired** into `Architecture` | wiring + `CPOOLREF` path; JVM/Dalvik only | 4 |
+| ArchSeam snapshot | per-function plain-data snapshot (`seams.rs:411`, `build_arch_handle` `architecture.rs:1529`) | rework so mid-decompile discovery (new symbols/types from queries) reaches the pipeline | 3 |
+
+## 10. Graceful degradation
+
+What breaks when a partial core omits pieces — all failure modes are clean:
+
+| omitted | Java-side behavior | blast radius |
+|---|---|---|
+| signature commands | answered "Bad command" (the `6, 16 "Bad command: <name>" 17, 7` pattern, `ghidra_process.cc:476-484`); Java shows "not built with signature module" (`DecompInterface.java:341-347`) | **BSim only** — GUI unaffected |
+| `structureGraph` | same "Bad command" path | FunctionGraph **nested-layout** view only |
+| empty `decompileAt` payload (function failed) | `decompileCompleted()` false; the 16/17 warnings text becomes the error message | that one function — clean GUI error |
+| second `<function>` (markup) | HighFunction decodes; GUI panel refuses to render (`DecompileData.java:56`) | GUI blank for that function; analyzers/scripts on HighFunction still work |
+| `<parammeasures>` | param-ID / convention analyzers get nothing | those analyzers no-op |
+| `<jumptablelist>` | switch analyzer finds no tables | unrecovered switches in the listing |
+
+## 11. Testing strategy
+
+- **Phase 1 (now): in-crate mock-Java e2e.** A `MockJava` test double owns the other
+  end of the pipe: sends command bursts, answers queries from canned tables, asserts
+  the byte-exact response framing (including the response-open-before-params ordering,
+  the always-present 16/17 frame, and the self-alignment/exception paths). This is the
+  same differential discipline as the port — the protocol spec in
+  `docs/decompiler-core-interface.md` is the oracle.
+- **Phase 2+: DecompileDebug captures as fixtures.** Ghidra's "Debug Function
+  Decompilation" action (`DecompInterface.enableDebug`, `DebugDecompilerAction.java:38-73`)
+  records every callback answer into an `<xml_savefile>` — exactly the document kuna's
+  datatest corpus already consumes. Captures give us *recorded Java-side query answers*
+  to replay against `kuna-ghidra` without a live Ghidra, and `DecompileDebugXmlLoader`
+  (Features/Base) can import them as Programs for the reverse direction.
+- **Live smoke procedure** (manual, per phase): build the extension, install into a
+  Ghidra 12.2 release (or `-Dghidra.external.modules=` in a dev checkout), enable the
+  plugin, open a known binary, decompile; verify the spawned PID is `kuna_ghidra` and —
+  from Phase 2 — that the C, click-to-address, and rename round-trip behave.
+- **Regression floors**: the three standing gates (`make test`, `make test-stages`,
+  `make rust-test`) must stay green — `kuna-ghidra` is additive and must not perturb
+  the standalone engine.
+
+## 12. Phase breakdown
+
+**Phase 1 — wire-protocol-complete, engine-stubbed (this branch).**
+- [x] `kuna-ghidra` crate: burst framer, command registry + `doit()` lifecycle,
+      archlist session model, the 19 typed query clients, exception channels — engine
+      calls stubbed.
+- [x] Protocol element ids 229, 239–257, 261, 262, 264, 268 (upstream numbers).
+- [x] tspec `<sleigh>` parse → real `AddrSpaceManager` (`GhidraTranslate::decode`), so
+      `decompileAt` decodes real `<addr>` parameters.
+- [x] Ghidra extension (`integrations/ghidra/KunaDecompiler/`): plugin + reflection
+      exepath swap, binary shipped as `os/<platform>/kuna_ghidra`.
+- [x] These two documents.
+
+**Phase 2 — engine bridge (first real C in the GUI).**
+- [ ] `ArchitectureGhidra`-equivalent construction path: Architecture from the four
+      wire spec documents (wire the Phase-1 tspec space manager into the engine;
+      cspec/pspec via the existing `set_cspec_xml`/`set_pspec_xml` + `init_post_engine`).
+- [ ] `Translate` enum seam on `Architecture` (`{Sleigh, GhidraTranslate}`);
+      `GhidraTranslate` port (getPcode per instruction, register caches, user-op probe
+      loop).
+- [ ] `GhidraLoadImage` (`load_fill` = `getBytes`); `ContextGhidra::getTrackedSet`.
+- [ ] `Funcdata::encode` — minimal `<function>` (name/addr + `<ast>` + prototype).
+- [ ] PrintC → `EmitMarkup` wiring; `doc_function` markup path; dual-`<function>`
+      `decompileAt` response.
+
+**Phase 3 — lazy providers (correct symbols/types at scale).**
+- [ ] `ScopeGhidra`-equivalent lazy symbol cache: query-through + `<hole>` negatives +
+      property-range side effects + namespace resolution + DB symbol-id fidelity.
+- [ ] `TypeFactory` lazy `findById` trait-plumbing; comments rewiring
+      (`CommentDatabaseGhidra`); injects via the wire-fed cspec snippets.
+- [ ] ArchSeam snapshot rework for mid-decompile discovery; `flushNative` clearing
+      semantics end-to-end.
+
+**Phase 4 — parity.**
+- [ ] `<highlist>`/`<jumptablelist>` fidelity incl. DB symbol-id echo for
+      rename/retype; `structureGraph`; `<parammeasures>`.
+- [ ] The four signature commands (engine already ported) for BSim.
+- [ ] Overlay spaces (Java swaps in overlay codecs transparently —
+      `DecompInterface.java:84-127,896-909`); `getStringData` charset fidelity
+      (Java-side decode instead of `GhidraLoadImage` bytes).

--- a/integrations/ghidra/KunaDecompiler/.gitignore
+++ b/integrations/ghidra/KunaDecompiler/.gitignore
@@ -1,0 +1,20 @@
+# Gradle build state
+.gradle/
+build/
+dist/
+bin/
+
+# IDE metadata (Eclipse GhidraDev / VSCode)
+.classpath
+.project
+.pydevproject
+.settings/
+.vscode/
+
+# Jars dropped into lib/ by buildExtension.gradle's copyDependencies task
+lib/*.jar
+
+# The kuna native binary is a build artifact: it is copied into os/<platform>/
+# from decompiler/target/release/ before packaging (see os/linux_x86_64/README.md)
+os/*/kuna_ghidra
+os/*/kuna_ghidra.exe

--- a/integrations/ghidra/KunaDecompiler/README.md
+++ b/integrations/ghidra/KunaDecompiler/README.md
@@ -1,0 +1,120 @@
+# KunaDecompiler — the kuna core inside the stock Ghidra GUI
+
+A standard Ghidra extension that makes Ghidra spawn **kuna** (the Rust port of the
+Ghidra decompiler, this repository) as its native decompiler process, in place of the
+stock C++ `decompile` binary — the full Ghidra GUI (Decompiler window, analyzers,
+scripts) on top of the kuna engine.
+
+**Status: Phase 1 — protocol skeleton.** The `kuna_ghidra` binary speaks the complete
+Ghidra⇄decompiler wire protocol (burst framing, packed documents, query upcalls), but
+the engine bridge is not yet connected: Ghidra will show a clean per-function error
+message in the Decompiler window instead of decompiled C until Phase 2 lands. See
+[`docs/ghidra-integration.md`](../../../docs/ghidra-integration.md) for the design and
+phase plan. Target Ghidra version: **12.2** (the swap relies on the exact shape of
+`DecompileProcessFactory`; see *How it works* below).
+
+## How it works
+
+Every decompiler consumer in Ghidra funnels process creation through one static
+factory, `ghidra.app.decompiler.DecompileProcessFactory`, which resolves the executable
+once and caches it in a `private static String exepath` field. There is no property,
+env var, or ExtensionPoint to substitute it — so at plugin load,
+`KunaDecompilerPlugin` resolves the `kuna_ghidra` binary shipped in this extension's
+`os/<platform>/` directory (or the `-Dkuna.decompiler.exe` override) and writes that
+field by reflection, before the lazily-spawned first decompiler process exists. A
+Tools-menu checkbox toggles between the kuna core and the stock one at runtime.
+
+## Build the kuna binary
+
+From the kuna repo root:
+
+```bash
+cd decompiler
+cargo build --release -p kuna-ghidra
+cp target/release/kuna_ghidra ../integrations/ghidra/KunaDecompiler/os/linux_x86_64/
+```
+
+The binary is a gitignored build artifact; it must be present under
+`os/linux_x86_64/` **before** building the extension zip so it gets packaged (other
+platforms: see `os/linux_x86_64/README.md`).
+
+## Build & install the extension
+
+### Against a Ghidra release install
+
+Use the Gradle version named by `application.gradle.min` in
+`<GHIDRA_INSTALL_DIR>/Ghidra/application.properties`:
+
+```bash
+cd integrations/ghidra/KunaDecompiler
+gradle -PGHIDRA_INSTALL_DIR=<Absolute path to Ghidra> buildExtension
+# -> dist/ghidra_<version>_<release>_<date>_KunaDecompiler.zip
+```
+
+Then in Ghidra's project window: **File → Install Extensions… → + → select the zip**,
+and restart Ghidra when prompted.
+
+### Against a Ghidra source (dev) checkout
+
+No zip needed — inject this directory as an external module when launching Ghidra
+(this is the seam GhidraDev/VSCode dev launches use,
+`GhidraApplicationLayout.java:174-181`):
+
+```
+-Dghidra.external.modules=/abs/path/to/kuna/integrations/ghidra/KunaDecompiler
+```
+
+added to the launcher's VM args (e.g. the Eclipse/VSCode launch configuration created
+by `gradle prepDev` / the VSCode integration), with the extension's Java compiled into
+the project. During development you can skip copying the binary and instead pass
+`-Dkuna.decompiler.exe=/abs/path/to/kuna/decompiler/target/release/kuna_ghidra`.
+
+## Enable the plugin
+
+Open a program in the CodeBrowser, then **File → Configure → Miscellaneous** (the
+gear/"Configure All Plugins" view) and check **KunaDecompilerPlugin**. On load it
+performs the swap and logs `Decompiler core is now KUNA: <path>` to the application
+log; if the binary is missing it shows an error dialog with the build/copy commands and
+leaves the stock core active.
+
+## Verify
+
+- Run the bundled script `KunaCoreStatus.java` (Script Manager, category *Kuna*): it
+  prints the executable path currently installed in `DecompileProcessFactory` and
+  whether the next decompiler process is the kuna or stock core.
+- Decompile any function: in Phase 1 the Decompiler window shows the kuna phase-1
+  per-function message instead of C — that message coming from the Decompiler window
+  *is* the proof that Ghidra spawned kuna.
+
+## Revert
+
+- **Runtime:** uncheck **Tools → Kuna Decompiler → Use Kuna Core** — future decompiler
+  spawns use the stock binary again. Programs with an already-running decompiler
+  process keep it until that process restarts (reopen the program, or the process is
+  reset after an error/timeout); reopening the program is the reliable nudge.
+- **Plugin off:** un-check the plugin in File → Configure (its dispose restores the
+  stock core), or **File → Install Extensions…** and uncheck KunaDecompiler, then
+  restart Ghidra.
+
+## Alternative: the no-code file-drop seam
+
+You can run kuna under Ghidra without this extension at all: copy the kuna binary
+**named `decompile`** to
+
+```
+<GHIDRA_INSTALL_DIR>/Ghidra/Features/Decompiler/build/os/<platform>/decompile
+```
+
+`Application.getModuleOSFile` searches a module's `build/os/<platform>/` *before*
+`os/<platform>/`, so this shadows the stock binary without overwriting it (delete the
+`build/os` copy to revert). Tradeoffs versus the extension:
+
+- applies **unconditionally** to that install — every project, every tool, no toggle,
+  no logging of which core is active;
+- invisible: nothing in the GUI indicates the core was swapped (use
+  `KunaCoreStatus.java`'s output path, or the phase-1 message, to tell);
+- survives extension uninstalls but may be wiped by Ghidra upgrades/rebuilds;
+- per-install file surgery rather than a distributable artifact.
+
+The extension is the recommended path; the file drop is handy for quick experiments on
+a release install.

--- a/integrations/ghidra/KunaDecompiler/build.gradle
+++ b/integrations/ghidra/KunaDecompiler/build.gradle
@@ -1,0 +1,49 @@
+// Builds the KunaDecompiler Ghidra extension for a given Ghidra installation.
+// (Modeled on GhidraBuild/Skeleton/buildTemplate.gradle from the Ghidra tree.)
+//
+// An absolute path to the Ghidra installation directory must be supplied either by setting the
+// GHIDRA_INSTALL_DIR environment variable or the Gradle project property:
+//
+//     > export GHIDRA_INSTALL_DIR=<Absolute path to Ghidra>
+//     > gradle
+//
+//         or
+//
+//     > gradle -PGHIDRA_INSTALL_DIR=<Absolute path to Ghidra>
+//
+// Gradle should be invoked from the directory of the project to build.  Please see the
+// application.gradle.min property in <GHIDRA_INSTALL_DIR>/Ghidra/application.properties
+// for the correct version of Gradle to use for the Ghidra installation you specify.
+// The built extension zip lands in dist/.
+
+//----------------------START "DO NOT MODIFY" SECTION------------------------------
+def ghidraInstallDir
+
+if (System.env.GHIDRA_INSTALL_DIR) {
+	ghidraInstallDir = System.env.GHIDRA_INSTALL_DIR
+}
+else if (project.hasProperty("GHIDRA_INSTALL_DIR")) {
+	ghidraInstallDir = project.getProperty("GHIDRA_INSTALL_DIR")
+}
+else {
+	throw new GradleException("GHIDRA_INSTALL_DIR is not defined: " +
+		"export GHIDRA_INSTALL_DIR=<Absolute path to Ghidra> or pass " +
+		"-PGHIDRA_INSTALL_DIR=<Absolute path to Ghidra>")
+}
+
+task distributeExtension {
+	group = "Ghidra"
+
+	apply from: new File(ghidraInstallDir).getCanonicalPath() + "/support/buildExtension.gradle"
+	dependsOn ':buildExtension'
+}
+//----------------------END "DO NOT MODIFY" SECTION-------------------------------
+
+repositories {
+	// No external dependency repositories are needed: buildExtension.gradle puts the
+	// Ghidra installation's jars on the compile classpath.
+}
+
+dependencies {
+	// No external dependencies.
+}

--- a/integrations/ghidra/KunaDecompiler/extension.properties
+++ b/integrations/ghidra/KunaDecompiler/extension.properties
@@ -1,0 +1,5 @@
+name=@extname@
+description=Runs kuna, the Rust port of the Ghidra decompiler, as the native decompiler core behind the stock Ghidra GUI.
+author=kuna project
+createdOn=2026-07-05
+version=@extversion@

--- a/integrations/ghidra/KunaDecompiler/ghidra_scripts/KunaCoreStatus.java
+++ b/integrations/ghidra/KunaDecompiler/ghidra_scripts/KunaCoreStatus.java
@@ -1,0 +1,42 @@
+//Prints which native decompiler executable Ghidra will spawn for the NEXT decompiler
+//process (the kuna core-swap seam). Reads the private static field
+//ghidra.app.decompiler.DecompileProcessFactory.exepath by reflection: null means the
+//stock resolution (Application.getOSFile("decompile")) runs lazily on first use.
+//Already-running decompiler processes may still be an older core; this reports what
+//future spawns will use.
+//@category Kuna
+import java.lang.reflect.Field;
+
+import ghidra.app.decompiler.DecompileProcessFactory;
+import ghidra.app.script.GhidraScript;
+
+public class KunaCoreStatus extends GhidraScript {
+
+	@Override
+	public void run() throws Exception {
+		Field field = DecompileProcessFactory.class.getDeclaredField("exepath");
+		field.setAccessible(true); // flat classpath / unnamed module: no --add-opens needed
+		String path = (String) field.get(null);
+
+		if (path == null) {
+			println("DecompileProcessFactory.exepath = (unset)");
+			println("Next decompiler process: STOCK core, resolved lazily via " +
+				"Application.getOSFile(\"decompile\").");
+			println("(The KunaDecompilerPlugin is not active, or the stock core was " +
+				"restored without an eager re-resolve.)");
+			return;
+		}
+
+		println("DecompileProcessFactory.exepath = " + path);
+		if (path.contains("kuna_ghidra")) {
+			println("Next decompiler process: KUNA core.");
+		}
+		else if (path.endsWith("decompile") || path.endsWith("decompile.exe")) {
+			println("Next decompiler process: STOCK core.");
+		}
+		else {
+			println("Next decompiler process: a custom core (neither kuna_ghidra nor " +
+				"the stock 'decompile' name).");
+		}
+	}
+}

--- a/integrations/ghidra/KunaDecompiler/os/linux_x86_64/README.md
+++ b/integrations/ghidra/KunaDecompiler/os/linux_x86_64/README.md
@@ -1,0 +1,39 @@
+# os/linux_x86_64/ — the kuna native binary goes here
+
+This directory holds the Linux x86-64 `kuna_ghidra` binary that the extension makes
+Ghidra spawn as its decompiler process. It is a **build artifact** (gitignored): copy it
+here before building the extension zip, so `gradle buildExtension` packages it into the
+zip's `KunaDecompiler/os/linux_x86_64/` and `Application.getOSFile("KunaDecompiler",
+"kuna_ghidra")` can resolve it at runtime.
+
+From the kuna repo root:
+
+```bash
+cd decompiler
+cargo build --release -p kuna-ghidra
+cp target/release/kuna_ghidra ../integrations/ghidra/KunaDecompiler/os/linux_x86_64/
+chmod +x ../integrations/ghidra/KunaDecompiler/os/linux_x86_64/kuna_ghidra
+```
+
+If you skip this step the extension still builds and installs, but the plugin will show
+an error dialog (and leave the stock decompiler active) until the binary appears in the
+*installed* extension's `os/linux_x86_64/` directory or you point the
+`-Dkuna.decompiler.exe=/abs/path/to/kuna_ghidra` JVM property at a build.
+
+## Other platforms
+
+Ghidra resolves native binaries per platform from sibling directories named after the
+platform. To ship kuna for another OS/arch, cross-build (or build natively) and drop the
+binary, with the same name, into the matching directory before zipping:
+
+| Platform | Directory | Binary name |
+|---|---|---|
+| Linux x86-64 | `os/linux_x86_64/` | `kuna_ghidra` |
+| Linux AArch64 | `os/linux_arm_64/` | `kuna_ghidra` |
+| macOS x86-64 | `os/mac_x86_64/` | `kuna_ghidra` |
+| macOS AArch64 | `os/mac_arm_64/` | `kuna_ghidra` |
+| Windows x86-64 | `os/win_x86_64/` | `kuna_ghidra.exe` |
+
+Directory names are Ghidra's `Platform` enum names (`Ghidra/Framework/Generic/src/main/java/ghidra/framework/Platform.java`) — note the underscore before `64` on the arm variants (`linux_arm_64`, `mac_arm_64`).
+
+Phase 1 only targets `linux_x86_64`; the other directories may simply not exist.

--- a/integrations/ghidra/KunaDecompiler/src/main/java/kuna/KunaCoreSwap.java
+++ b/integrations/ghidra/KunaDecompiler/src/main/java/kuna/KunaCoreSwap.java
@@ -1,0 +1,281 @@
+/* kuna — Ghidra extension that swaps the native decompiler core for kuna.
+ * Apache-2.0. kuna is derived from Ghidra (https://github.com/NationalSecurityAgency/ghidra).
+ */
+package kuna;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.lang.reflect.Field;
+
+import ghidra.app.decompiler.DecompileProcessFactory;
+import ghidra.framework.Application;
+import ghidra.framework.OSFileNotFoundException;
+import ghidra.framework.OperatingSystem;
+import ghidra.framework.Platform;
+import ghidra.util.Msg;
+
+/**
+ * The mechanism that points Ghidra's decompiler-process factory at the kuna binary,
+ * and back at the stock one.
+ *
+ * <p>Every decompiler consumer in Ghidra (the Decompiler window, the switch/param-id
+ * analyzers, BSim, scripts, ...) funnels process creation through the static
+ * {@code ghidra.app.decompiler.DecompileProcessFactory.get()}, which resolves the
+ * executable once and caches it in the {@code private static String exepath} field
+ * (Ghidra 12.2, DecompileProcessFactory.java:28). {@code getExePath()} early-returns
+ * when the field is non-null, so writing the field wins for every <em>future</em>
+ * process spawn — there is no other seam (no system property, env var, service, or
+ * ExtensionPoint anywhere in {@code ghidra.app.decompiler}).
+ *
+ * <p>The reflective write is legal without {@code --add-opens}: Ghidra runs a flat
+ * {@code URLClassLoader} classpath ({@code ghidra.GhidraClassLoader}), so this class
+ * and {@code DecompileProcessFactory} both live in the unnamed module and
+ * {@code setAccessible(true)} is unrestricted.
+ *
+ * <p>Scope caveats, shared by both directions of the swap:
+ * <ul>
+ * <li>The field is static, i.e. JVM-wide: the swap affects every tool in this Ghidra
+ * session, not just the tool hosting the plugin.</li>
+ * <li>A {@link ghidra.app.decompiler.DecompInterface} that already spawned a process
+ * keeps talking to it (the old binary) until that process is respawned — program
+ * reopen, decompiler reset, or a process error/timeout. Only new spawns see the new
+ * path.</li>
+ * </ul>
+ */
+public final class KunaCoreSwap {
+
+	/**
+	 * The extension's module name — the directory name the extension installs under,
+	 * used to scope the two-arg {@link Application#getOSFile(String, String)} lookup
+	 * to this module's {@code os/<platform>/} directory.
+	 */
+	public static final String MODULE_NAME = "KunaDecompiler";
+
+	/** Dev override: {@code -Dkuna.decompiler.exe=/abs/path/to/kuna_ghidra}. */
+	public static final String EXE_PROPERTY = "kuna.decompiler.exe";
+
+	private static final String KUNA_EXECNAME = "kuna_ghidra";
+	private static final String KUNA_WIN_EXECNAME = "kuna_ghidra.exe";
+
+	// Mirror DecompileProcessFactory.EXECNAME / WIN32_EXECNAME (Ghidra 12.2, :29-30)
+	private static final String STOCK_EXECNAME = "decompile";
+	private static final String STOCK_WIN_EXECNAME = "decompile.exe";
+
+	private static final String EXEPATH_FIELD = "exepath";
+
+	/** The kuna path last installed by {@link #swapToKuna()}, for {@link #isKunaActive()}. */
+	private static String lastKunaPath;
+
+	/**
+	 * Live plugin instances that requested the kuna core. The {@code exepath} field is
+	 * JVM-wide, so if two tools host the plugin, only the LAST one to leave should restore
+	 * the stock core — otherwise closing one tool silently reverts kuna for the other.
+	 * Guarded by the class monitor (all mutators are {@code synchronized}).
+	 */
+	private static final java.util.Set<Object> ACTIVE_PLUGINS =
+		java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+
+	private KunaCoreSwap() {
+		// static-only
+	}
+
+	/**
+	 * Registers a plugin instance as a kuna-core user (call from the plugin's swap).
+	 *
+	 * @return the number of live registrants after adding this one
+	 */
+	public static synchronized int register(Object plugin) {
+		ACTIVE_PLUGINS.add(plugin);
+		return ACTIVE_PLUGINS.size();
+	}
+
+	/**
+	 * Unregisters a plugin instance.
+	 *
+	 * @return the number of live registrants remaining (0 = this was the last one, so the
+	 *         caller should restore the stock core)
+	 */
+	public static synchronized int unregister(Object plugin) {
+		ACTIVE_PLUGINS.remove(plugin);
+		return ACTIVE_PLUGINS.size();
+	}
+
+	private static boolean isWindows() {
+		return Platform.CURRENT_PLATFORM.getOperatingSystem() == OperatingSystem.WINDOWS;
+	}
+
+	/**
+	 * Resolves the kuna decompiler binary: (1) the {@value #EXE_PROPERTY} system
+	 * property, (2) this extension's {@code os/<platform>/kuna_ghidra} via the two-arg
+	 * module-scoped {@link Application#getOSFile(String, String)}.
+	 *
+	 * @return the executable file (exists and is executable)
+	 * @throws FileNotFoundException with user-actionable instructions if not found
+	 */
+	public static File findKunaBinary() throws FileNotFoundException {
+		String override = System.getProperty(EXE_PROPERTY);
+		if (override != null && !override.isBlank()) {
+			File file = new File(override);
+			if (!file.isFile()) {
+				throw new FileNotFoundException(
+					"-D" + EXE_PROPERTY + " points at a missing file: " + file.getAbsolutePath());
+			}
+			return checkExecutable(file);
+		}
+
+		String exeName = isWindows() ? KUNA_WIN_EXECNAME : KUNA_EXECNAME;
+		try {
+			return checkExecutable(Application.getOSFile(MODULE_NAME, exeName));
+		}
+		catch (OSFileNotFoundException e) {
+			throw new FileNotFoundException("The kuna decompiler binary '" + exeName +
+				"' was not found in the " + MODULE_NAME + " extension.\n\n" +
+				"Build it and copy it into the installed extension, then restart Ghidra:\n" +
+				"    cd <kuna-repo>/decompiler && cargo build --release -p kuna-ghidra\n" +
+				"    cp target/release/" + exeName + " <ghidra user settings>/Extensions/" +
+				MODULE_NAME + "/os/" + Platform.CURRENT_PLATFORM.getDirectoryName() + "/\n\n" +
+				"Alternatively point the JVM property -D" + EXE_PROPERTY +
+				"=/abs/path/to/" + exeName + " at a build.");
+		}
+	}
+
+	private static File checkExecutable(File file) throws FileNotFoundException {
+		if (!file.canExecute()) {
+			throw new FileNotFoundException("The kuna decompiler binary exists but is not " +
+				"executable: " + file.getAbsolutePath() + " (chmod +x it).");
+		}
+		return file;
+	}
+
+	/**
+	 * Resolves the stock native decompiler binary. Uses the single-arg
+	 * {@link Application#getOSFile(String)}: it searches the calling class's module
+	 * first — this ({@value #MODULE_NAME}) module, which does not ship a file named
+	 * {@code decompile} — then falls back to scanning every module, where the
+	 * Features/Decompiler module's binary is found ({@code build/os/<platform>/} is
+	 * preferred over {@code os/<platform>/} within a module, so a dev-built or
+	 * file-dropped binary there wins, exactly as it does for the stock factory).
+	 *
+	 * @return the stock executable file
+	 * @throws OSFileNotFoundException if no module provides the binary
+	 */
+	public static File findStockBinary() throws OSFileNotFoundException {
+		String exeName = isWindows() ? STOCK_WIN_EXECNAME : STOCK_EXECNAME;
+		return Application.getOSFile(exeName);
+	}
+
+	private static Field exepathField() throws NoSuchFieldException {
+		Field field = DecompileProcessFactory.class.getDeclaredField(EXEPATH_FIELD);
+		field.setAccessible(true); // flat classpath / unnamed module: no --add-opens needed
+		return field;
+	}
+
+	/**
+	 * Reads the currently installed executable path (reflective read of
+	 * {@code DecompileProcessFactory.exepath}).
+	 *
+	 * @return the cached path, or null if unset (the factory will lazily resolve the
+	 *         stock binary on the next spawn)
+	 * @throws ReflectiveOperationException if the Ghidra version renamed the field
+	 */
+	public static String getInstalledExePath() throws ReflectiveOperationException {
+		return (String) exepathField().get(null);
+	}
+
+	/**
+	 * Writes {@code DecompileProcessFactory.exepath}. {@code getExePath()} early-returns
+	 * when the field is non-null, so a non-null value set here wins for every future
+	 * {@code DecompileProcessFactory.get()}; overwriting an already-cached value is
+	 * equally effective for future spawns (already-open DecompInterfaces keep their
+	 * running process until it respawns). Passing null restores the factory's own lazy
+	 * stock resolution.
+	 */
+	public static void setInstalledExePath(String path) throws ReflectiveOperationException {
+		exepathField().set(null, path);
+	}
+
+	/**
+	 * @return true if the most recent successful {@link #swapToKuna()} path is still the
+	 *         installed one (false on reflection failure)
+	 */
+	public static synchronized boolean isKunaActive() {
+		try {
+			String current = getInstalledExePath();
+			return current != null && current.equals(lastKunaPath);
+		}
+		catch (ReflectiveOperationException | SecurityException e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Points the decompiler-process factory at the kuna binary. Shows an error dialog
+	 * (and leaves the factory untouched) if the binary cannot be resolved or the
+	 * reflective write fails.
+	 *
+	 * @param originator the object requesting the swap (for Msg attribution)
+	 * @return true if kuna is now the core for future decompiler spawns
+	 */
+	public static synchronized boolean swapToKuna(Object originator) {
+		File kunaBinary;
+		try {
+			kunaBinary = findKunaBinary();
+		}
+		catch (FileNotFoundException e) {
+			Msg.showError(originator, null, "Kuna Decompiler Binary Not Found", e.getMessage());
+			return false;
+		}
+		String path = kunaBinary.getAbsolutePath();
+		try {
+			setInstalledExePath(path);
+		}
+		catch (ReflectiveOperationException | SecurityException e) {
+			showReflectionError(originator, e);
+			return false;
+		}
+		lastKunaPath = path;
+		Msg.info(originator, "Decompiler core is now KUNA: " + path +
+			" (already-running decompiler processes keep the previous core until they respawn)");
+		return true;
+	}
+
+	/**
+	 * Points the decompiler-process factory back at the stock {@code decompile} binary.
+	 * If the stock binary cannot be resolved from here, the cache is cleared (null) so
+	 * the factory re-runs its own stock resolution — and shows its own error — on the
+	 * next spawn.
+	 *
+	 * @param originator the object requesting the restore (for Msg attribution)
+	 * @return true if the stock core is restored for future decompiler spawns
+	 */
+	public static synchronized boolean restoreStock(Object originator) {
+		String path = null;
+		try {
+			path = findStockBinary().getAbsolutePath();
+		}
+		catch (OSFileNotFoundException e) {
+			Msg.warn(originator, "Stock decompiler binary not found (" + e.getMessage() +
+				"); clearing the cached path so Ghidra re-resolves it on the next decompile");
+		}
+		try {
+			setInstalledExePath(path);
+		}
+		catch (ReflectiveOperationException | SecurityException e) {
+			showReflectionError(originator, e);
+			return false;
+		}
+		lastKunaPath = null;
+		Msg.info(originator, "Decompiler core is now STOCK: " +
+			(path != null ? path : "(lazily re-resolved on next decompile)") +
+			" (already-running decompiler processes keep the previous core until they respawn)");
+		return true;
+	}
+
+	private static void showReflectionError(Object originator, Exception e) {
+		Msg.showError(originator, null, "Kuna Core Swap Failed",
+			"Could not access ghidra.app.decompiler.DecompileProcessFactory." + EXEPATH_FIELD +
+				" by reflection. This Ghidra version may have changed the factory's " +
+				"field layout; the " + MODULE_NAME + " extension targets Ghidra 12.2.",
+			e);
+	}
+}

--- a/integrations/ghidra/KunaDecompiler/src/main/java/kuna/KunaDecompilerPlugin.java
+++ b/integrations/ghidra/KunaDecompiler/src/main/java/kuna/KunaDecompilerPlugin.java
@@ -1,0 +1,119 @@
+/* kuna — Ghidra extension that swaps the native decompiler core for kuna.
+ * Apache-2.0. kuna is derived from Ghidra (https://github.com/NationalSecurityAgency/ghidra).
+ */
+package kuna;
+
+import docking.action.ToggleDockingAction;
+import docking.action.builder.ToggleActionBuilder;
+import docking.tool.ToolConstants;
+import ghidra.MiscellaneousPluginPackage;
+import ghidra.framework.plugintool.Plugin;
+import ghidra.framework.plugintool.PluginInfo;
+import ghidra.framework.plugintool.PluginTool;
+import ghidra.framework.plugintool.util.PluginStatus;
+
+/**
+ * Swaps Ghidra's native decompiler core for kuna, the Rust port of the Ghidra decompiler.
+ *
+ * <p>On plugin load (File → Configure → Miscellaneous → KunaDecompilerPlugin) the plugin
+ * resolves the {@code kuna_ghidra} binary shipped in this extension's
+ * {@code os/<platform>/} directory (or the {@code -Dkuna.decompiler.exe} dev override)
+ * and installs it as the executable behind
+ * {@code ghidra.app.decompiler.DecompileProcessFactory}, the single choke point through
+ * which every decompiler consumer in Ghidra spawns its native process. The native
+ * process is spawned lazily — only on the first decompile — so when this plugin is part
+ * of the tool at startup, the swap performed at plugin init precedes the first spawn.
+ * When the plugin is instead enabled mid-session (a program is already open and its
+ * decompiler process already spawned), that program keeps the stock core until its
+ * process respawns; new spawns pick up kuna immediately.
+ *
+ * <p>The Tools → Kuna Decompiler → "Use Kuna Core" checkbox toggles between the kuna
+ * core and the stock {@code decompile} binary at any time. Either direction only
+ * affects <em>future</em> process spawns: a program whose decompiler process is already
+ * running keeps it until that process restarts (reopen the program, or the process is
+ * reset after an error/timeout). There is no public API to force-restart the per-program
+ * processes from a plugin (the controllers holding them are private to the Decompiler
+ * plugin's providers), so a program reopen is the reliable way to make a swap take
+ * effect on an already-decompiled program.
+ */
+//@formatter:off
+@PluginInfo(
+	status = PluginStatus.RELEASED,
+	packageName = MiscellaneousPluginPackage.NAME,
+	category = "Decompiler",
+	shortDescription = "Use kuna as the native decompiler core",
+	description = "Swaps the native decompiler core for kuna, the Rust port of the " +
+		"Ghidra decompiler: points ghidra.app.decompiler.DecompileProcessFactory at the " +
+		"kuna_ghidra binary shipped with this extension, so every decompiler consumer in " +
+		"this Ghidra session (the Decompiler window, analyzers, scripts) spawns kuna " +
+		"instead of the stock 'decompile' process. Tools -> Kuna Decompiler -> " +
+		"'Use Kuna Core' toggles between the kuna core and the stock core; " +
+		"already-running decompiler processes keep their current core until they " +
+		"respawn (program reopen, or process error/timeout). Removing the plugin " +
+		"restores the stock core for future spawns."
+)
+//@formatter:on
+public class KunaDecompilerPlugin extends Plugin {
+
+	private ToggleDockingAction useKunaAction;
+
+	public KunaDecompilerPlugin(PluginTool tool) {
+		super(tool);
+	}
+
+	@Override
+	protected void init() {
+		super.init();
+
+		// Perform the swap now, before the user's first decompile can spawn a process.
+		boolean kunaActive = KunaCoreSwap.swapToKuna(this);
+		if (kunaActive) {
+			KunaCoreSwap.register(this);
+		}
+
+		useKunaAction = new ToggleActionBuilder("Use Kuna Core", getName())
+				.menuPath(ToolConstants.MENU_TOOLS, "Kuna Decompiler", "Use Kuna Core")
+				.description("Checked: future decompiler processes spawn the kuna core " +
+					"(kuna_ghidra). Unchecked: the stock 'decompile' binary. Programs " +
+					"with an already-running decompiler process keep it until that " +
+					"process restarts (reopen the program, or the process is reset " +
+					"after an error/timeout).")
+				.selected(kunaActive)
+				.onAction(context -> onToggle())
+				.buildAndInstall(tool);
+	}
+
+	private void onToggle() {
+		// The docking framework flips the toggle state before invoking the callback,
+		// so isSelected() is the state the user just requested.
+		if (useKunaAction.isSelected()) {
+			if (KunaCoreSwap.swapToKuna(this)) {
+				KunaCoreSwap.register(this);
+			}
+			else {
+				useKunaAction.setSelected(false); // swap failed: reflect reality
+			}
+		}
+		else {
+			// This tool no longer wants kuna; restore only once the last tool leaves.
+			if (KunaCoreSwap.unregister(this) == 0) {
+				if (!KunaCoreSwap.restoreStock(this)) {
+					KunaCoreSwap.register(this); // restore failed: kuna still active
+					useKunaAction.setSelected(true);
+				}
+			}
+		}
+	}
+
+	@Override
+	protected void dispose() {
+		// Leaving the tool (or being un-configured) should not silently leave kuna as
+		// the JVM-wide core. The factory field is static, so restore only when this was
+		// the LAST tool holding the kuna core — otherwise closing one tool would revert
+		// kuna for the others still using it.
+		if (KunaCoreSwap.unregister(this) == 0 && KunaCoreSwap.isKunaActive()) {
+			KunaCoreSwap.restoreStock(this);
+		}
+		super.dispose();
+	}
+}


### PR DESCRIPTION
## What this is

**Phase 1** of running kuna as the decompiler core inside the **stock Ghidra GUI**, over Ghidra's existing decompiler-process protocol, with **zero changes to Ghidra's Java side**.

Ghidra's GUI drives its decompiler as a spawned child process (`decompile`) over a burst-framed stdin/stdout protocol. Upstream that process is the C++ `ghidra_opt` build — the same DECCORE engine kuna ported, plus a `GHIDRA` glue group (`ghidra_process.cc`/`ghidra_arch.cc`/`ghidra_translate.cc`/…) kuna deliberately excluded from the port (LOSS-002). This PR reimplements that glue group in Rust. **The wire protocol is complete; the engine bridge is stubbed** (that's Phase 2).

## Contents

**New crate `decompiler/crates/kuna-ghidra`** (binary `kuna_ghidra`):
- `protocol.rs` — the burst framing (port of `ghidra_arch.cc:50-248`): `{0,0,1,code}` markers, string/bool/byte streams, the getBytes/getStringData codecs, the exception channel → `KunaError::Java`.
- `process.rs` — the command loop (port of `ghidra_process.cc`): the exact `doit()` lifecycle (response-open before params, archid bind, catch classification, the always-present 16/17 warnings frame), the archlist session model, and the seven decomp commands. `registerProgram` parses the tspec `<sleigh>` into a real `AddrSpaceManager` (so `decompileAt` decodes real `<addr>` params); `decompileAt` returns the incomplete-function shape (empty payload + a clear warning) so the GUI shows a **clean per-function error, not a hang**. `structureGraph` and the four signature commands are unregistered — the "Bad command" path is exactly the graceful-degradation contract Java expects (BSim / nested-graph-layout only).
- `client.rs` — the 19 typed callback queries, byte-exact request framing.
- `ids.rs` — protocol element ids at their upstream numbers (229, 239–257, 261/262/264/268).
- 24 tests incl. a byte-exact MockJava full-session e2e.

**Ghidra extension `integrations/ghidra/KunaDecompiler/`**: a plugin that reflectively points `DecompileProcessFactory.exepath` at the kuna binary (the only viable substitution seam — flat classpath, no `--add-opens`), a Tools-menu toggle, and a status script. Compiles against a real Ghidra install; refcounts live plugin instances so the JVM-wide restore is multi-tool-safe.

**Docs**: `docs/ghidra-integration.md` (kuna-side design + the Phase 1–4 plan) and `docs/decompiler-core-interface.md` (what Ghidra requires from **any** replacement core — the durable, core-agnostic protocol record).

## Deliberate divergences (for drop-in robustness)
- `setOptions` tolerates unknown option elements (upstream fails the whole program-open on one stale option — the live `baddatacount` skew is the motivating case).
- A malformed archid answers a clean `JavaError` instead of wedging + `exit(1)`ing the process.

Both are documented in `docs/ghidra-integration.md` §8; the setOptions one gets a `docs/divergences.md` DIV entry when `setOptions` stops being a stub (Phase 2).

## Verification
- `make test` — **675/675 PARITY OK**
- `make test-stages` — **PARITY OK**
- `make rust-test` — green
- `cargo test -p kuna-ghidra` — 24/24; extension `javac` clean against a Ghidra 12.1 install
- Adversarially reviewed (3 skeptics vs. the upstream C++/Java sources); findings fixed.

Additive — no existing crate is touched.

## Follow-up
Phase 2 (the engine bridge → first real C in the GUI) is proposed in a stacked draft PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017t3eYSdxwUsPjN2s2oLGof