### PR TITLE
feat(ghidra): run kuna as a drop-in, backwards-compatible decompiler backend for the stock Ghidra GUI (Phase 2 — real C)

### DIFF
--- a/decompiler/Cargo.lock
+++ b/decompiler/Cargo.lock
@@ -184,6 +184,8 @@ name = "kuna-ghidra"
 version = "0.1.0"
 dependencies = [
  "kuna-base",
+ "kuna-decomp",
+ "kuna-num",
  "kuna-sleigh",
 ]
 

--- a/decompiler/crates/kuna-analysis/src/s1_fid/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/s1_fid/mod.rs
@@ -116,7 +116,14 @@ impl AnalysisPass for FidPass {
             return out;
         };
         let code_space = Rc::clone(code_space);
-        let translate = ctx.arch.translate();
+        // FID hashing decodes through the concrete SLEIGH engine
+        // (`Sleigh::instruction_mask`); this re-identification path only ever
+        // runs on the standalone engine, so downcast through the seam.
+        let translate = ctx
+            .arch
+            .translate()
+            .as_sleigh()
+            .expect("FID build: standalone Sleigh engine");
 
         // The relocation oracle: a fully-linked image (the stripped `-static
         // -no-pie` re-identification target) carries no dynamic relocations over its

--- a/decompiler/crates/kuna-cli/src/fid.rs
+++ b/decompiler/crates/kuna-cli/src/fid.rs
@@ -163,7 +163,12 @@ fn records_for_object_path(path: &str, spec_roots: &[String]) -> Result<Vec<FidR
     let image = ObjectLoadImage::from_bytes(path, &bytes)
         .map_err(|e| format!("loadimage failed: {e}"))?;
 
-    Ok(build_records(&bytes, &image, arch, arch.translate()))
+    Ok(build_records(
+        &bytes,
+        &image,
+        arch,
+        arch.translate().as_sleigh().expect("fid build: standalone Sleigh engine"),
+    ))
 }
 
 /// Unpack a `.a` archive and build records from every object member. Each member

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -603,6 +603,8 @@ fn build_engine_and_init(sleigh: &mut SleighArchitecture, db: &LanguageDatabase)
         .base_mut()
         .ok_or_else(|| KunaError::lowlevel("no Architecture base after build_translator"))?
         .translate_mut()
+        .as_sleigh_mut()
+        .expect("install_register_lookup: standalone Sleigh engine")
         .install_register_lookup()?;
 
     // The tail of Architecture::init (buildTypegrp/buildCoreTypes/buildAction/…).

--- a/decompiler/crates/kuna-console/tests/verify_fid_build.rs
+++ b/decompiler/crates/kuna-console/tests/verify_fid_build.rs
@@ -83,7 +83,12 @@ fn records_for_fixture() -> Option<Vec<kuna_analysis::s1_fid::db::FidRecord>> {
 
     let bytes = std::fs::read(&bin).expect("read fixture .o");
     let image = ObjectLoadImage::from_bytes(&bin, &bytes).expect("open loadimage");
-    Some(build_records(&bytes, &image, arch, arch.translate()))
+    Some(build_records(
+        &bytes,
+        &image,
+        arch,
+        arch.translate().as_sleigh().expect("standalone Sleigh engine"),
+    ))
 }
 
 #[test]

--- a/decompiler/crates/kuna-decomp/src/infra/architecture.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/architecture.rs
@@ -54,6 +54,7 @@ use kuna_sleigh::sleigh::Sleigh;
 use kuna_sleigh::translate::{Translate, UniqueLayout};
 
 use crate::action::ActionDatabase;
+use crate::engine_translate::EngineTranslate;
 use crate::database::Database;
 use crate::dtype::{type_metatype, TypeFactory, TypeFactoryImpl};
 use crate::flow::flow_flags;
@@ -828,12 +829,15 @@ pub struct Architecture {
 
     /// The disassembly engine for this binary (C++ `translate`, a `Translate*`).
     ///
-    /// Owned here as a concrete [`Sleigh`] (the C++ `Architecture` is-a
-    /// `AddrSpaceManager` and owns its `Translate`; in the Rust port the
-    /// `AddrSpaceManager` lives inside `Sleigh`'s `SleighBase`, reachable via
-    /// `base().manager()`).  The non-SLEIGH `Translate` backends (`raw_arch`) are
-    /// their own item; until then the engine is concrete so `manage()` works.
-    translate: Sleigh,
+    /// Owned behind the [`EngineTranslate`] trait object (the
+    /// `Architecture`↔translator seam) rather than a concrete [`Sleigh`], so a
+    /// ghidra-mode translator can replace `Sleigh` without `kuna-decomp` naming
+    /// a ghidra-specific type (see `crate::engine_translate` /
+    /// `docs/rust-port/ghidra-phase2-plan.md` §2.2).  The C++ `Architecture`
+    /// is-a `AddrSpaceManager` and owns its `Translate`; here the manager lives
+    /// inside the engine, reached through the trait's `manager*` accessors.
+    /// Only `Sleigh` implements the trait today.
+    translate: Box<dyn EngineTranslate>,
 }
 
 impl Architecture {
@@ -983,7 +987,10 @@ impl Architecture {
             lanerecords: Vec::new(),
             inst: Vec::new(),
             opbehaviors: Vec::new(),
-            translate,
+            // Box the concrete engine into the `EngineTranslate` seam (only
+            // `Sleigh` implements it today; the field type keeps the ghidra
+            // translator installable later).
+            translate: Box::new(translate),
         };
         // C++ ctor calls resetDefaultsInternal(); then sets min_funcsymbol_size=1
         // etc. (those one-offs are folded into resetDefaultsInternal's siblings
@@ -1370,17 +1377,20 @@ impl Architecture {
     /// `AddrSpaceManager`); forwarded to the owned `Sleigh` engine's
     /// `SleighBase`.
     pub fn manage(&self) -> &AddrSpaceManager {
-        self.translate.base().manager()
+        self.translate.manager()
     }
 
-    /// Borrow the disassembly engine (C++ `translate`).
-    pub fn translate(&self) -> &Sleigh {
-        &self.translate
+    /// Borrow the disassembly engine (C++ `translate`) through the
+    /// [`EngineTranslate`] seam.  External callers reach the `Translate` /
+    /// `RegisterLookup` surface directly; those needing the concrete standalone
+    /// engine downcast via [`EngineTranslate::as_sleigh`].
+    pub fn translate(&self) -> &dyn EngineTranslate {
+        &*self.translate
     }
 
     /// Mutably borrow the disassembly engine.
-    pub fn translate_mut(&mut self) -> &mut Sleigh {
-        &mut self.translate
+    pub fn translate_mut(&mut self) -> &mut dyn EngineTranslate {
+        &mut *self.translate
     }
 
     /// Get the minimum size of a laned register in bytes, or -1 if there are no
@@ -1690,7 +1700,7 @@ impl Architecture {
         if self.manage().get_fspec_space().is_some() {
             return Ok(());
         }
-        let manager = self.translate.base_mut().manager_mut();
+        let manager = self.translate.manager_mut();
         let next = manager.num_spaces();
         manager.insert_space(Rc::new(FspecSpace::new(next)))?;
         let next = manager.num_spaces();
@@ -1740,7 +1750,7 @@ impl Architecture {
             .expect("addSpacebase: base register has a null space (C++ UB)")
             .get_delay()
             + 1;
-        let manager = self.translate.base_mut().manager_mut();
+        let manager = self.translate.manager_mut();
         let ind = manager.num_spaces();
         let spc = Rc::new(SpacebaseSpace::new(
             nm,
@@ -2038,7 +2048,7 @@ impl Architecture {
         // is a `Decoder` consumer, identical to C++).  Each `<range>`/`<register>`
         // becomes a `RangeProperties`, then `addToGlobalScope`'s `Range(props,this)`
         // + `symboltab->addRange`.
-        let manager = self.translate.base().manager_rc();
+        let manager = self.translate.manager_rc();
         let registry = IdRegistry::with_base_ids();
         let scope = match self.symboltab.get_global_scope() {
             Some(s) => s,
@@ -2131,7 +2141,7 @@ impl Architecture {
         }
         // The injection element/attribute ids the payload decode reads
         // (callfixup/pcode/body/target/name/...).
-        let manager = self.translate.base().manager_rc();
+        let manager = self.translate.manager_rc();
         let mut registry = IdRegistry::with_base_ids();
         crate::pcodeinject::register_ids(&mut registry);
         for fixup in fixups.iter() {
@@ -2196,7 +2206,7 @@ impl Architecture {
             if fixups.is_empty() {
                 return Ok(());
             }
-            let manager = self.translate.base().manager_rc();
+            let manager = self.translate.manager_rc();
             let mut registry = IdRegistry::with_base_ids();
             crate::pcodeinject::register_ids(&mut registry);
             crate::userop::register_ids(&mut registry);
@@ -2215,8 +2225,12 @@ impl Architecture {
         //    borrow of self.translate does not alias the &mut library.
         let mut lib = std::mem::take(&mut self.pcodeinjectlib);
         // The SnippetLanguage is the loaded `SleighBase`; drive parse_inject over
-        // it (the &SleighBase read does not alias the &mut library).
-        let parse_res = lib.parse_inject_all(self.translate.base());
+        // it (the &SleighBase read does not alias the &mut library).  Injection
+        // compilation is a Sleigh-engine concern, so reach the concrete engine's
+        // `SleighBase` through the downcast (only `Sleigh` implements the seam).
+        let parse_res = lib.parse_inject_all(
+            self.translate.as_sleigh().expect("parse_inject_all: standalone Sleigh engine").base(),
+        );
         self.pcodeinjectlib = lib;
         parse_res
     }
@@ -2361,7 +2375,17 @@ impl Architecture {
         &self,
         f: impl FnOnce(&mut dyn kuna_sleigh::globalcontext::ContextDatabase) -> R,
     ) -> R {
-        self.translate.with_context_db_mut(f)
+        // The engine seam exposes the object-safe `with_context_db_dyn` (a
+        // `&mut dyn FnMut`, so it survives the `Box<dyn EngineTranslate>` trait
+        // object); adapt the generic, value-returning closure over it.  The
+        // protocol is synchronous — the closure runs exactly once — so `f` and
+        // the result move through `Option` slots cleanly.
+        let mut f = Some(f);
+        let mut result: Option<R> = None;
+        self.translate.with_context_db_dyn(&mut |db| {
+            result = Some((f.take().expect("with_context_db_mut: closure runs once"))(db));
+        });
+        result.expect("with_context_db_mut: closure ran")
     }
 
     /// Resolve a register by name to its storage (C++
@@ -2752,12 +2776,11 @@ impl Architecture {
         // manager (so `space="ram"` resolves to the real ram space).  The Rc
         // keeps the manager alive for the decoder while the context database
         // (a sibling RefCell on the engine) is borrowed mutably — no aliasing.
-        let manager = self.translate.base().manager_rc();
+        let manager = self.translate.manager_rc();
         let mut registry = IdRegistry::with_base_ids();
         register_globalcontext_ids(&mut registry);
         let mut decoder = XmlDecode::new_with_root(&manager, &registry, &context_data, 0);
-        self.translate
-            .with_context_db_mut(|db| db.decode_from_spec(&mut decoder))?;
+        self.with_context_db_mut(|db| db.decode_from_spec(&mut decoder))?;
         Ok(())
     }
 
@@ -2782,7 +2805,7 @@ impl Architecture {
         use kuna_base::address::{Range, RangeProperties};
         use kuna_base::marshal::{IdRegistry, XmlDecode};
 
-        let manager = self.translate.base().manager_rc();
+        let manager = self.translate.manager_rc();
         let registry = IdRegistry::with_base_ids();
         // C++ `decodeVolatile`: while peekElement() != 0 { Range r; r.decode(decoder);
         // symboltab->setPropertyRange(Varnode::volatil, r); }.  Each child is a
@@ -3529,7 +3552,7 @@ impl Architecture {
         // the engine's float formats so the table is self-contained (the C++
         // passes the long-lived `Translate *`).
         let provider: Rc<dyn kuna_num::opbehavior::FloatFormatProvider> =
-            Rc::new(OwnedFloatFormats::from_translate(&self.translate));
+            Rc::new(OwnedFloatFormats::from_translate(self.translate.as_ref()));
         let mut behaviors: Vec<Option<Rc<dyn kuna_num::opbehavior::OpBehavior>>> = Vec::new();
         kuna_num::opbehavior::register_instructions(&mut behaviors, &provider);
         self.opbehaviors = behaviors;
@@ -3962,7 +3985,7 @@ impl crate::userop::UseropArchitecture for Architecture {
         // C++ `glb->translate->getUserOpNames(res)`.  The Sleigh translate hands
         // back display strings; convert to the byte-string form the manager keys.
         let mut res: Vec<String> = Vec::new();
-        kuna_sleigh::translate::Translate::get_user_op_names(&self.translate, &mut res);
+        self.translate.get_user_op_names(&mut res);
         res.into_iter().map(String::into_bytes).collect()
     }
 
@@ -4012,8 +4035,7 @@ impl OwnedFloatFormats {
     /// Clone the engine's float formats for the standard p-code encoding sizes
     /// (the C++ candidates: 2/4/8/10/16-byte IEEE formats; the engine returns
     /// only those it actually defines).
-    fn from_translate(translate: &Sleigh) -> Self {
-        use kuna_sleigh::translate::Translate;
+    fn from_translate(translate: &dyn EngineTranslate) -> Self {
         let mut formats = Vec::new();
         for size in [2, 4, 8, 10, 16] {
             if let Some(fmt) = translate.get_float_format(size) {

--- a/decompiler/crates/kuna-decomp/src/infra/architecture.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/architecture.rs
@@ -2809,6 +2809,23 @@ impl Architecture {
             return Ok(());
         };
 
+        // Ghidra-mode: skip the <context_data> paints (C++
+        // `ContextGhidra::decode`/`decodeFromSpec`, ghidra_context.cc, are both a
+        // bare `decoder.skipElement()` — "Ignore details handled by ghidra").  In
+        // ghidra mode the Java host owns disassembly context and returns
+        // already-context-resolved p-code via `getPcode`, so the query-backed
+        // engine's own context database is never consulted for disassembly — and
+        // it has no variables registered (there is no `.sla` parse to
+        // `registerContext` them), so applying `<set name="addrsize" .../>` would
+        // raise "Non-existent context variable: addrsize".  `as_sleigh()` is
+        // `None` iff this is the query-backed `GhidraTranslate`; the standalone
+        // `Sleigh` path returns `Some` and still applies the paints, exactly as
+        // the 675 x86 datatests (which need `addrsize`/`opsize` for 64-bit
+        // disassembly) require.
+        if self.translate.as_sleigh().is_none() {
+            return Ok(());
+        }
+
         // Decode <context_data> against the engine's single address-space
         // manager (so `space="ram"` resolves to the real ram space).  The Rc
         // keeps the manager alive for the decoder while the context database

--- a/decompiler/crates/kuna-decomp/src/infra/architecture.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/architecture.rs
@@ -51,7 +51,7 @@ use kuna_base::space::{AddrSpace, AddrSpaceManager};
 use kuna_base::types::{int4, uint4, uintb};
 
 use kuna_sleigh::sleigh::Sleigh;
-use kuna_sleigh::translate::{Translate, UniqueLayout};
+use kuna_sleigh::translate::UniqueLayout;
 
 use crate::action::ActionDatabase;
 use crate::engine_translate::EngineTranslate;
@@ -851,6 +851,33 @@ impl Architecture {
     /// `.sla`); the architecture borrows its `AddrSpaceManager` and the
     /// `getUniqueStart(INJECT)` tempbase for the injection library.
     pub fn new(archid: &str, translate: Sleigh) -> Architecture {
+        // The standalone (SLEIGH) engine: box the concrete `Sleigh` into the
+        // `EngineTranslate` seam and share the construction with the ghidra-mode
+        // path.  `EngineTranslate::manager()` / the provided
+        // `Translate::get_unique_start` on the boxed `Sleigh` are the very calls
+        // the former direct-`Sleigh` body made (`base().manager()` /
+        // `get_unique_start`), so this delegation is behavior-identical for the
+        // 675-datatest path.
+        Architecture::from_engine_translate(archid, Box::new(translate))
+    }
+
+    /// Construct an `Architecture` over an already-initialized disassembly
+    /// engine behind the [`EngineTranslate`] seam — the shared body of
+    /// [`Architecture::new`] (the standalone `Sleigh`) and the ghidra-mode
+    /// bridge (`kuna-ghidra`'s query-backed `GhidraTranslate`, which
+    /// `kuna-decomp` cannot name as a concrete type here — the whole reason the
+    /// field is a trait object, see `crate::engine_translate`).
+    ///
+    /// The `translate` must already be initialized (spaces decoded,
+    /// endianness/unique-base set); the architecture reads its space manager and
+    /// `getUniqueStart(INJECT)` tempbase for the injection library, then builds
+    /// the subsystems whose dependencies exist (the tail of C++
+    /// `Architecture::init`/`restoreFromSpec` runs later, in
+    /// [`init_post_engine`](Architecture::init_post_engine)).
+    pub fn from_engine_translate(
+        archid: &str,
+        translate: Box<dyn EngineTranslate>,
+    ) -> Architecture {
         // C++ PcodeInjectLibrarySleigh(g): tempbase = g->translate->getUniqueStart(INJECT).
         let inject_tempbase = translate.get_unique_start(UniqueLayout::INJECT);
 
@@ -858,8 +885,8 @@ impl Architecture {
         //   Scope *globscope = new ScopeInternal(0,"",this);
         //   symboltab->attachScope(globscope,(Scope*)0);
         // ScopeInternal sizes its per-space maps to numSpaces(); count before the
-        // translate is moved into the struct (manage() borrows it).
-        let space_count = translate.base().manager().num_spaces();
+        // translate is moved into the struct (the manager accessor borrows it).
+        let space_count = translate.manager().num_spaces();
         let mut symboltab = Database::new(true);
         symboltab
             .find_create_scope(0, "", None, space_count)
@@ -987,10 +1014,10 @@ impl Architecture {
             lanerecords: Vec::new(),
             inst: Vec::new(),
             opbehaviors: Vec::new(),
-            // Box the concrete engine into the `EngineTranslate` seam (only
-            // `Sleigh` implements it today; the field type keeps the ghidra
-            // translator installable later).
-            translate: Box::new(translate),
+            // The engine behind the `EngineTranslate` seam: a boxed `Sleigh` on
+            // the standalone path, a query-backed `GhidraTranslate` on the
+            // ghidra-mode path (already boxed by the caller).
+            translate,
         };
         // C++ ctor calls resetDefaultsInternal(); then sets min_funcsymbol_size=1
         // etc. (those one-offs are folded into resetDefaultsInternal's siblings
@@ -2228,9 +2255,19 @@ impl Architecture {
         // it (the &SleighBase read does not alias the &mut library).  Injection
         // compilation is a Sleigh-engine concern, so reach the concrete engine's
         // `SleighBase` through the downcast (only `Sleigh` implements the seam).
-        let parse_res = lib.parse_inject_all(
-            self.translate.as_sleigh().expect("parse_inject_all: standalone Sleigh engine").base(),
-        );
+        //
+        // In ghidra mode there is no local `.sla` to compile snippets against —
+        // the host supplies inject p-code on demand via a `getPcodeInject` query
+        // (C++ `PcodeInjectLibraryGhidra`).  That query-backed library is Phase 3
+        // (`docs/rust-port/ghidra-phase2-plan.md` §6); for now the non-Sleigh
+        // engine skips local compilation, leaving each registered payload's `tpl`
+        // null (exactly the state a not-yet-fetched ghidra inject is in).  The
+        // guard is a no-op on the standalone path, where `as_sleigh()` is always
+        // `Some` (the 675-datatest behavior is unchanged).
+        let parse_res = match self.translate.as_sleigh() {
+            Some(sleigh) => lib.parse_inject_all(sleigh.base()),
+            None => Ok(()),
+        };
         self.pcodeinjectlib = lib;
         parse_res
     }

--- a/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
@@ -309,7 +309,12 @@ impl FlowEnvironment for ArchFlowEnv {
             let space = vnref.get_space();
             let off = vnref.get_offset();
             let size = vnref.get_size();
-            let raw = arch.translate().base().get_register_name(space, off, size);
+            let raw = arch
+                .translate()
+                .as_sleigh()
+                .expect("v850 indirect-branch predicate: standalone Sleigh engine")
+                .base()
+                .get_register_name(space, off, size);
             if raw.is_empty() {
                 None
             } else {

--- a/decompiler/crates/kuna-decomp/src/infra/engine_translate.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/engine_translate.rs
@@ -1,0 +1,127 @@
+//! The `Architecture`↔translator seam: the [`EngineTranslate`] trait.
+//!
+//! [`Architecture`](crate::architecture::Architecture) owns its disassembly
+//! engine behind a `Box<dyn EngineTranslate>` trait object rather than a
+//! concrete [`Sleigh`], so a future ghidra-mode translator (p-code fetched
+//! from the Java host per instruction, no local `.sla`) can be installed in
+//! its place without `kuna-decomp` naming any ghidra-specific type — the
+//! ghidra translator lives in the downstream `kuna-ghidra` crate, so an enum
+//! variant would be a dependency cycle, but a trait object owned here is not.
+//! See `docs/rust-port/ghidra-phase2-plan.md` §2.2.
+//!
+//! The trait extends [`Translate`] (already `: RegisterLookup`), adding only
+//! the handful of engine-owned surfaces `Architecture` and its external
+//! callers reach beyond the abstract `Translate` API: the address-space
+//! manager handles, the load image, the context database, and the
+//! register-storage lookup.  Everything the callers reach through
+//! `Translate`/`RegisterLookup` (endianness, float formats, `oneInstruction`,
+//! register *names*, …) needs no new method here.
+//!
+//! Only [`Sleigh`] implements it today; the implementation forwards to the
+//! engine's inherent methods, so routing an `Architecture` call through the
+//! trait object is behavior-identical to the former direct `Sleigh` call.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use kuna_base::address::Address;
+use kuna_base::error::KunaResult;
+use kuna_base::space::AddrSpaceManager;
+use kuna_num::pcoderaw::VarnodeData;
+use kuna_sleigh::globalcontext::ContextDatabase;
+use kuna_sleigh::loadimage::LoadImage;
+use kuna_sleigh::sleigh::Sleigh;
+use kuna_sleigh::translate::Translate;
+
+/// The seam between [`Architecture`](crate::architecture::Architecture) and
+/// its disassembly engine (see the module docs).
+pub trait EngineTranslate: Translate {
+    /// Borrow the engine's address-space manager (C++ the `Architecture`
+    /// IS-A `AddrSpaceManager`; in the Rust port it lives inside the engine
+    /// and `Architecture::manage()` forwards here).
+    fn manager(&self) -> &AddrSpaceManager;
+
+    /// Share the engine's single address-space manager (LOSS-132): the `Rc`
+    /// the lift populated, handed to `glb` so every subsystem keys state by
+    /// the same space identities/indices.
+    fn manager_rc(&self) -> Rc<AddrSpaceManager>;
+
+    /// Mutably borrow the engine's address-space manager — used during init
+    /// to insert the analysis-only fspec/iop/join spaces (C++
+    /// `Architecture::restoreFromSpec`).
+    fn manager_mut(&mut self) -> &mut AddrSpaceManager;
+
+    /// Share the program load image (C++ `Architecture::loader`); the `Rc`
+    /// aliases the engine's loader, so a shared handle stays current across
+    /// `set_loader`.
+    fn loader_rc(&self) -> Rc<RefCell<Box<dyn LoadImage>>>;
+
+    /// Replace the load image (C++ `restoreFromSpec` hands the loader to the
+    /// translator once the `.sla` is decoded).
+    fn set_loader(&mut self, loader: Box<dyn LoadImage>);
+
+    /// Read a Varnode's-worth of bytes from the load image at `addr`, masked
+    /// to `sz` (C++ `Emulate*::getLoadImageValue`); drives jump-table LOAD
+    /// emulation.
+    fn read_loadimage_value(&self, addr: &Address, sz: i32) -> KunaResult<u64>;
+
+    /// Resolve a register by name to its [`VarnodeData`] storage (C++
+    /// `Translate::getRegister(name)`).
+    fn get_register_varnode(&self, nm: &[u8]) -> KunaResult<VarnodeData>;
+
+    /// Run a closure with mutable access to the engine's [`ContextDatabase`]
+    /// (C++ `glb->context`).  The object-safe form of
+    /// [`Sleigh::with_context_db_mut`]: it takes `&mut dyn FnMut` (rather than
+    /// a generic closure) so the method stays callable on a trait object;
+    /// [`Architecture::with_context_db_mut`](crate::architecture::Architecture::with_context_db_mut)
+    /// keeps the generic, value-returning wrapper over it.
+    fn with_context_db_dyn(&self, f: &mut dyn FnMut(&mut dyn ContextDatabase));
+
+    /// Downcast to the concrete standalone [`Sleigh`] engine when this
+    /// translator is one (default `None`; the `Sleigh` impl returns `Some`).
+    /// The standalone-only analysis / FID / console paths — which never run
+    /// on a non-Sleigh engine — use this escape hatch to reach the
+    /// Sleigh-specific surface (`SleighBase`, `instruction_mask`,
+    /// `install_register_lookup`, …).
+    fn as_sleigh(&self) -> Option<&Sleigh> {
+        None
+    }
+
+    /// Mutable [`EngineTranslate::as_sleigh`].
+    fn as_sleigh_mut(&mut self) -> Option<&mut Sleigh> {
+        None
+    }
+}
+
+impl EngineTranslate for Sleigh {
+    fn manager(&self) -> &AddrSpaceManager {
+        self.base().manager()
+    }
+    fn manager_rc(&self) -> Rc<AddrSpaceManager> {
+        Sleigh::manager_rc(self)
+    }
+    fn manager_mut(&mut self) -> &mut AddrSpaceManager {
+        self.base_mut().manager_mut()
+    }
+    fn loader_rc(&self) -> Rc<RefCell<Box<dyn LoadImage>>> {
+        Sleigh::loader_rc(self)
+    }
+    fn set_loader(&mut self, loader: Box<dyn LoadImage>) {
+        Sleigh::set_loader(self, loader)
+    }
+    fn read_loadimage_value(&self, addr: &Address, sz: i32) -> KunaResult<u64> {
+        Sleigh::read_loadimage_value(self, addr, sz)
+    }
+    fn get_register_varnode(&self, nm: &[u8]) -> KunaResult<VarnodeData> {
+        Sleigh::get_register_varnode(self, nm)
+    }
+    fn with_context_db_dyn(&self, f: &mut dyn FnMut(&mut dyn ContextDatabase)) {
+        self.with_context_db_mut(|db| f(db));
+    }
+    fn as_sleigh(&self) -> Option<&Sleigh> {
+        Some(self)
+    }
+    fn as_sleigh_mut(&mut self) -> Option<&mut Sleigh> {
+        Some(self)
+    }
+}

--- a/decompiler/crates/kuna-decomp/src/infra/mod.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod action;
 pub mod architecture;
+pub mod engine_translate;
 pub mod decompile_drive;
 pub mod capability;
 pub mod libdecomp;

--- a/decompiler/crates/kuna-decomp/src/s9_emit/prettyprint.rs
+++ b/decompiler/crates/kuna-decomp/src/s9_emit/prettyprint.rs
@@ -119,8 +119,9 @@ pub mod ids {
     // cross-file: defined in funcdata.cc / type.cc / variable.cc (not yet
     // ported).  Mirrored with the *exact* upstream numeric id so the markup
     // encoding is byte-identical; collapses to a re-export once those land.
-    /// Marshaling element `<function>` (funcdata.cc:23, id 116, cross-file).
-    pub const ELEM_FUNCTION: ElementId = ElementId::new("function", 116);
+    /// Marshaling element `<function>` (funcdata.cc:23, id 116), re-exported
+    /// from the `Funcdata::encode` port (same numeric id).
+    pub use crate::funcdata_encode::ELEM_FUNCTION;
     /// Marshaling element `<type>` (type.cc:67, id 60, cross-file).
     pub const ELEM_TYPE: ElementId = ElementId::new("type", 60);
     /// Marshaling element `<field>` (type.cc:56, id 49, cross-file).

--- a/decompiler/crates/kuna-decomp/src/s9_emit/prettyprint.rs
+++ b/decompiler/crates/kuna-decomp/src/s9_emit/prettyprint.rs
@@ -747,6 +747,13 @@ impl EmitMarkup {
     pub fn take_output(&mut self) -> Vec<u8> {
         std::mem::take(&mut self.out)
     }
+    /// Reset the output buffer (C++ `EmitMarkup::setOutputStream`, prettyprint.cc:
+    /// which rebinds the encoder to a fresh stream).  Mirrors
+    /// [`EmitNoMarkup::set_output_stream`]; used by `PrintC::set_output_stream`
+    /// through the [`crate::printc::PrintEmit`] delegator.
+    pub fn set_output_stream(&mut self) {
+        self.out.clear();
+    }
 
     /// Run `f` with a fresh [`PackedEncode`] over the output buffer.
     ///

--- a/decompiler/crates/kuna-decomp/src/s9_emit/printc.rs
+++ b/decompiler/crates/kuna-decomp/src/s9_emit/printc.rs
@@ -1565,7 +1565,6 @@ use crate::cast::{CastContext, CastStrategy, CastStrategyC, OpRef, VnRef};
 use crate::funcdata::Funcdata;
 use crate::seams::{BlockId, OpId, VarnodeId};
 use kuna_num::opcodes::OpCode;
-use kuna_base::space::RegisterLookup;
 
 /// One resolved member token of a partial-symbol access walk (C++
 /// `PartialSymbolEntry`, printc.cc:1985-1994).  A struct/union field becomes a
@@ -6372,7 +6371,6 @@ impl PrintC {
     /// is no `FloatFormat` for the size, the token is `FLOAT_UNKNOWN`.
     fn push_float_ir(&mut self, arch: &Architecture, val: uintb, sz: int4, op: OpId) {
         use kuna_num::float::floatclass;
-        use kuna_sleigh::translate::Translate;
         let force_scinote = self.context.is_set(modifiers::FORCE_SCINOTE);
         let tok = match arch.translate().get_float_format(sz) {
             None => format_float_token(FloatClass::Unknown, false, "", force_scinote),
@@ -6475,7 +6473,6 @@ impl PrintC {
         char_type: &std::rc::Rc<crate::dtype::Datatype>,
     ) -> bool {
         use crate::stringmanage::StringManager;
-        use kuna_sleigh::translate::Translate;
         // Pull UTF-8 string data through the architecture's persistent
         // `stringManager` (C++ `glb->stringManager`).  Using the shared instance
         // (not a transient one) is what lets `getInternalString`-registered

--- a/decompiler/crates/kuna-decomp/src/s9_emit/printc.rs
+++ b/decompiler/crates/kuna-decomp/src/s9_emit/printc.rs
@@ -2365,8 +2365,23 @@ impl PrintC {
         } else {
             None
         };
-        let markup = MarkupRef::none();
         for (high, name) in &decls {
+            // C++ `emitVarDecl(sym)` always writes the declared symbol's id
+            // (prettyprint.cc:154 `writeUnsignedInteger(ATTRIB_SYMREF, sym->getId())`),
+            // and Ghidra's `ClangVariableDecl.decode` does a REQUIRED read of `symref`:
+            // an ABSENT attribute aborts the whole markup decode with "Attribute symref
+            // is not present", so the Decompiler window shows nothing for any function
+            // that declares a local.  Phase 2 does not yet encode `<localdb>`
+            // (funcdata_encode.rs), so no HighSymbol reaches Java to resolve against —
+            // but the attribute must still be PRESENT (Java only *logs* an unresolvable
+            // ref, non-fatally, and still renders the declaration tokens).  Use the
+            // declaration representative Varnode's create index — the same id the
+            // `<ast>` and the token `varref` already carry — as the placeholder symref
+            // until the lazy scope encoding (Phase 3/4) supplies real symbol ids.
+            let mut markup = MarkupRef::none();
+            markup.symref = decl_rep_varnode(fd, *high)
+                .and_then(|vn| fd.vbank().get(vn))
+                .map(|v| v.get_create_index() as uintb);
             // Type: the high's recovered type name (W8-unknown -> `undefined<N>`).
             let (mut type_name, comment) = self.local_decl_type_and_comment(fd, arch, *high);
             let rt = self.rt_ctx; // (kuna) realtypes ctx for the composite/array relabel

--- a/decompiler/crates/kuna-decomp/src/s9_emit/printc.rs
+++ b/decompiler/crates/kuna-decomp/src/s9_emit/printc.rs
@@ -78,7 +78,8 @@ use kuna_base::types::{int4, int8, uint4, uintb};
 use crate::dtype::type_metatype;
 use crate::options::{BraceStyle, NamespaceStrategy};
 use crate::prettyprint::{
-    BraceStyle as EmitBraceStyle, Emit, EmitNoMarkup, MarkupRef, SyntaxHighlight,
+    BraceStyle as EmitBraceStyle, Emit, EmitBase, EmitMarkup, EmitNoMarkup, MarkupRef,
+    SyntaxHighlight,
 };
 use crate::printlanguage::{
     format_binary, modifiers, most_natural_base, parentheses, unicode_needs_escape, Atom, OpToken,
@@ -954,6 +955,147 @@ pub fn op_emit_kind(opcode: kuna_num::opcodes::OpCode) -> OpEmitKind {
 //   - the option toggles (`PrintCOptions`) gate the seam branches.
 
 // ===========================================================================
+// PrintEmit — the emit back-end selector (static, no-vtable delegation)
+// ===========================================================================
+
+/// The low-level [`Emit`] back-end `PrintC` drives, selected between the
+/// byte-exact plain-text sink ([`EmitNoMarkup`], the `print C` datatest path)
+/// and the packed clang token-markup sink ([`EmitMarkup`], the ghidra-mode
+/// `decompileAt` `<function>` document).
+///
+/// C++ swaps a heap `Emit *lowlevel` in `EmitPrettyPrint::setMarkup`
+/// (prettyprint.cc:2531); this port holds the two back-ends in a concrete enum
+/// so every one of the ~260 `self.emit.<method>()` call sites in `PrintC` stays
+/// a **static** call that matches on the active variant — no `Box<dyn Emit>`,
+/// no vtable on the hot path (the standalone datatest path is always
+/// `NoMarkup`).  Mirrors the [`crate::prettyprint::LowLevel`] precedent
+/// (prettyprint.rs:1740) but delegates the FULL `Emit` surface by static match
+/// rather than through a `&mut dyn Emit` re-dispatch.
+///
+/// The delegation MUST cover every `Emit` method — required AND
+/// default-provided — because [`EmitNoMarkup`] overrides `tag_line`
+/// (pending-brace absorption, prettyprint.rs:603) and `clear`: a method left to
+/// fall through to a `PrintEmit` trait default would silently diverge the
+/// byte-exact `print C` output the 675 datatests pin.
+#[derive(Debug)]
+pub enum PrintEmit {
+    /// The plain-text back-end (`print C`, the byte-exact datatest path).
+    NoMarkup(EmitNoMarkup),
+    /// The packed clang token-markup back-end (ghidra-mode `decompileAt`).
+    Markup(EmitMarkup),
+}
+
+/// Forward one [`Emit`] call to whichever [`PrintEmit`] variant is active — the
+/// static match that stands in for C++'s `Emit *` vtable dispatch.
+macro_rules! pe_forward {
+    ($self:ident . $method:ident ( $($arg:expr),* )) => {
+        match $self {
+            PrintEmit::NoMarkup(e) => e.$method($($arg),*),
+            PrintEmit::Markup(e) => e.$method($($arg),*),
+        }
+    };
+}
+
+impl PrintEmit {
+    /// Reset the active back-end's output buffer (C++ `Emit::setOutputStream`),
+    /// dispatched to the concrete leaf (both leaves clear their owned sink).
+    /// Type-divergent (not on the [`Emit`] trait): the leaves' sinks differ.
+    pub fn set_output_stream(&mut self) {
+        match self {
+            PrintEmit::NoMarkup(e) => e.set_output_stream(),
+            PrintEmit::Markup(e) => e.set_output_stream(),
+        }
+    }
+    /// Borrow the accumulated plain text (the `EmitNoMarkup` standalone
+    /// `doc_function_full` return).  The markup leaf holds packed bytes, not
+    /// text, so it yields `""` (mirrors [`crate::prettyprint::LowLevel::output`]).
+    pub fn output_str(&self) -> &str {
+        match self {
+            PrintEmit::NoMarkup(e) => e.output(),
+            PrintEmit::Markup(_) => "",
+        }
+    }
+    /// Take ownership of the accumulated packed markup bytes (the `EmitMarkup`
+    /// `doc_function_markup` return); empty on the plain-text leaf.
+    pub fn take_markup_bytes(&mut self) -> Vec<u8> {
+        match self {
+            PrintEmit::NoMarkup(_) => Vec::new(),
+            PrintEmit::Markup(e) => e.take_output(),
+        }
+    }
+}
+
+// The FULL `Emit` surface (prettyprint.rs:235-492), each method static-delegated
+// to the active leaf.  Required AND default-provided methods are ALL forwarded
+// so no call can fall through to a `PrintEmit` default that would diverge from
+// the leaf (`EmitNoMarkup` overrides `tag_line`/`clear`; see the type doc).
+impl Emit for PrintEmit {
+    fn state(&self) -> &EmitBase { pe_forward!(self.state()) }
+    fn state_mut(&mut self) -> &mut EmitBase { pe_forward!(self.state_mut()) }
+
+    fn begin_document(&mut self) -> int4 { pe_forward!(self.begin_document()) }
+    fn end_document(&mut self, id: int4) { pe_forward!(self.end_document(id)) }
+    fn begin_function(&mut self) -> int4 { pe_forward!(self.begin_function()) }
+    fn end_function(&mut self, id: int4) { pe_forward!(self.end_function(id)) }
+    fn begin_block(&mut self, blockref: int4) -> int4 { pe_forward!(self.begin_block(blockref)) }
+    fn end_block(&mut self, id: int4) { pe_forward!(self.end_block(id)) }
+
+    fn tag_line(&mut self) { pe_forward!(self.tag_line()) }
+    fn tag_line_indent(&mut self, indent: int4) { pe_forward!(self.tag_line_indent(indent)) }
+
+    fn begin_return_type(&mut self, markup: &MarkupRef) -> int4 { pe_forward!(self.begin_return_type(markup)) }
+    fn end_return_type(&mut self, id: int4) { pe_forward!(self.end_return_type(id)) }
+    fn begin_var_decl(&mut self, markup: &MarkupRef) -> int4 { pe_forward!(self.begin_var_decl(markup)) }
+    fn end_var_decl(&mut self, id: int4) { pe_forward!(self.end_var_decl(id)) }
+    fn begin_statement(&mut self, markup: &MarkupRef) -> int4 { pe_forward!(self.begin_statement(markup)) }
+    fn end_statement(&mut self, id: int4) { pe_forward!(self.end_statement(id)) }
+    fn begin_func_proto(&mut self) -> int4 { pe_forward!(self.begin_func_proto()) }
+    fn end_func_proto(&mut self, id: int4) { pe_forward!(self.end_func_proto(id)) }
+
+    fn tag_variable(&mut self, name: &str, hl: SyntaxHighlight, markup: &MarkupRef) { pe_forward!(self.tag_variable(name, hl, markup)) }
+    fn tag_op(&mut self, name: &str, hl: SyntaxHighlight, markup: &MarkupRef) { pe_forward!(self.tag_op(name, hl, markup)) }
+    fn tag_func_name(&mut self, name: &str, hl: SyntaxHighlight, markup: &MarkupRef) { pe_forward!(self.tag_func_name(name, hl, markup)) }
+    fn tag_type(&mut self, name: &str, hl: SyntaxHighlight, markup: &MarkupRef) { pe_forward!(self.tag_type(name, hl, markup)) }
+    fn tag_field(&mut self, name: &str, hl: SyntaxHighlight, off: int4, markup: &MarkupRef) { pe_forward!(self.tag_field(name, hl, off, markup)) }
+    fn tag_bit_field(&mut self, name: &str, hl: SyntaxHighlight, id: int4, markup: &MarkupRef) { pe_forward!(self.tag_bit_field(name, hl, id, markup)) }
+    fn tag_comment(&mut self, name: &str, hl: SyntaxHighlight, spc: &std::rc::Rc<AddrSpace>, off: uintb) { pe_forward!(self.tag_comment(name, hl, spc, off)) }
+    fn tag_label(&mut self, name: &str, hl: SyntaxHighlight, spc: &std::rc::Rc<AddrSpace>, off: uintb) { pe_forward!(self.tag_label(name, hl, spc, off)) }
+    fn tag_case_label(&mut self, name: &str, hl: SyntaxHighlight, markup: &MarkupRef, value: uintb) { pe_forward!(self.tag_case_label(name, hl, markup, value)) }
+    fn print(&mut self, data: &str, hl: SyntaxHighlight) { pe_forward!(self.print(data, hl)) }
+
+    fn open_paren(&mut self, paren: &str, id: int4) -> int4 { pe_forward!(self.open_paren(paren, id)) }
+    fn close_paren(&mut self, paren: &str, id: int4) { pe_forward!(self.close_paren(paren, id)) }
+    fn open_group(&mut self) -> int4 { pe_forward!(self.open_group()) }
+    fn close_group(&mut self, id: int4) { pe_forward!(self.close_group(id)) }
+    fn clear(&mut self) { pe_forward!(self.clear()) }
+    fn set_markup(&mut self, val: bool) { pe_forward!(self.set_markup(val)) }
+    fn set_packed_output(&mut self, val: bool) { pe_forward!(self.set_packed_output(val)) }
+    fn start_indent(&mut self) -> int4 { pe_forward!(self.start_indent()) }
+    fn stop_indent(&mut self, id: int4) { pe_forward!(self.stop_indent(id)) }
+    fn start_comment(&mut self) -> int4 { pe_forward!(self.start_comment()) }
+    fn stop_comment(&mut self, id: int4) { pe_forward!(self.stop_comment(id)) }
+    fn flush(&mut self) -> KunaResult<()> { pe_forward!(self.flush()) }
+    fn set_max_line_size(&mut self, mls: int4) -> KunaResult<()> { pe_forward!(self.set_max_line_size(mls)) }
+    fn get_max_line_size(&self) -> int4 { pe_forward!(self.get_max_line_size()) }
+    fn set_comment_fill(&mut self, fill: &str) { pe_forward!(self.set_comment_fill(fill)) }
+    fn emits_markup(&self) -> bool { pe_forward!(self.emits_markup()) }
+    fn reset_defaults(&mut self) { pe_forward!(self.reset_defaults()) }
+
+    fn get_paren_level(&self) -> int4 { pe_forward!(self.get_paren_level()) }
+    fn get_indent_increment(&self) -> int4 { pe_forward!(self.get_indent_increment()) }
+    fn set_indent_increment(&mut self, val: int4) { pe_forward!(self.set_indent_increment(val)) }
+    fn spaces(&mut self, num: int4, bump: int4) { pe_forward!(self.spaces(num, bump)) }
+    fn open_brace_indent(&mut self, brace: &str, style: EmitBraceStyle) -> int4 { pe_forward!(self.open_brace_indent(brace, style)) }
+    fn open_brace(&mut self, brace: &str, style: EmitBraceStyle) { pe_forward!(self.open_brace(brace, style)) }
+    fn close_brace_indent(&mut self, brace: &str, id: int4) { pe_forward!(self.close_brace_indent(brace, id)) }
+    fn set_pending_brace(&mut self, style: EmitBraceStyle) { pe_forward!(self.set_pending_brace(style)) }
+    fn has_pending_brace(&self) -> bool { pe_forward!(self.has_pending_brace()) }
+    fn cancel_pending_brace(&mut self) { pe_forward!(self.cancel_pending_brace()) }
+    fn pending_brace_indent_id(&self) -> int4 { pe_forward!(self.pending_brace_indent_id()) }
+    fn emit_pending(&mut self) { pe_forward!(self.emit_pending()) }
+}
+
+// ===========================================================================
 // PrintC — the stateful c-language printer object (the `glb->print` the
 // `Architecture` owns).  (w9x-arch-engine-glue)
 // ===========================================================================
@@ -1010,9 +1152,23 @@ pub struct PrintC {
     name: String,
     /// Whether `print C flat` is active (C++ the `flat` mod bit).
     flat: bool,
-    /// The plain-text emit back-end (C++ the bound `Emit *`, an `EmitNoMarkup`
-    /// for the non-pretty `print C` path).
-    emit: EmitNoMarkup,
+    /// The emit back-end (C++ the bound `Emit *`).  Defaults to the plain-text
+    /// [`EmitNoMarkup`] for the byte-exact `print C` path; [`set_markup`](PrintC::set_markup)
+    /// swaps in the packed clang [`EmitMarkup`] for the ghidra-mode `decompileAt`
+    /// `<function>` document.  A concrete enum (not `Box<dyn Emit>`), so the
+    /// ~260 `self.emit.<method>()` sites stay static (see [`PrintEmit`]).
+    emit: PrintEmit,
+    /// (kuna) Scoped raw pointer to the [`Funcdata`] currently being emitted,
+    /// live ONLY for the duration of [`emit_function_document`](PrintC::emit_function_document).
+    /// Lets the fd-free RPN leaf emitters ([`emit_atom`](PrintC::emit_atom) /
+    /// [`emit_op`](PrintC::emit_op)) resolve an [`Atom`]'s carried op/varnode
+    /// arena key back to the `get_time()` / `get_create_index()` the `<ast>`
+    /// stamps — WITHOUT threading `fd` through the pure RPN engine (which the
+    /// synthetic `rpn_*` unit tests drive fd-free).  Dereferenced only when the
+    /// markup back-end is active (`emits_markup()`); the plain-text datatest path
+    /// never touches it, so its byte output is unaffected.  `None` outside body
+    /// emission.
+    emit_fd: Option<*const Funcdata>,
     /// The reverse-polish-notation operator stack (C++ `PrintLanguage::revpol`).
     /// Owned here because `printlanguage.rs` deferred its RPN driver to this
     /// closure (the driver and the `PrintC` op-emitters are one unit).
@@ -1048,7 +1204,8 @@ impl PrintC {
             context: PrintContext::new(),
             name: CAPABILITY_NAME.to_string(),
             flat: false,
-            emit: EmitNoMarkup::new(),
+            emit: PrintEmit::NoMarkup(EmitNoMarkup::new()),
+            emit_fd: None,
             revpol: Vec::new(),
             nodepend: Vec::new(),
             pending: 0,
@@ -1180,7 +1337,7 @@ impl PrintC {
         self.emit.end_function(id1);
 
         // C++ emit->flush() then the bound ostream holds the text.
-        self.emit.output().to_string()
+        self.emit.output_str().to_string()
     }
 
     // --- the options.cc `// SEAM(W8)` print setters (now wired) -----------
@@ -1291,8 +1448,9 @@ impl PrintC {
     // =====================================================================
 
     /// Borrow the emit back-end (so a body driver can interleave `tag_line`
-    /// etc. between RPN expressions).
-    pub fn emit_mut(&mut self) -> &mut EmitNoMarkup {
+    /// etc. between RPN expressions).  A [`PrintEmit`]; use
+    /// [`output_str`](PrintEmit::output_str) for the plain-text buffer.
+    pub fn emit_mut(&mut self) -> &mut PrintEmit {
         &mut self.emit
     }
 
@@ -1431,25 +1589,89 @@ impl PrintC {
         self.push_atom(operand);
     }
 
+    /// (kuna) The [`Funcdata`] published for the duration of
+    /// [`emit_function_document`](PrintC::emit_function_document), else `None`.
+    ///
+    /// SAFETY: see the `emit_fd` field doc — the pointer is live only within that
+    /// call, `fd` outlives it and is never mutated through the pointer, and it
+    /// aliases `fd` (a distinct object from `self`).
+    fn markup_fd(&self) -> Option<&Funcdata> {
+        self.emit_fd.map(|p| unsafe { &*p })
+    }
+
+    /// (kuna) The `MarkupRef` for an RPN operator token from its arena key (C++
+    /// `EmitMarkup::tagOp` derefs the entry's `PcodeOp *` for `opref =
+    /// getTime()`).  The op's `get_time()` is exactly the `<seqnum uniq>`
+    /// `PcodeOp::encode` writes into the `<ast>`, so the token resolves by
+    /// construction.  Returns `none()` (no deref) unless the markup back-end is
+    /// active and `fd` is in scope — a no-op on the byte-exact plain-text path.
+    fn markup_for_op_key(&self, op_key: Option<usize>) -> MarkupRef {
+        if !self.emit.emits_markup() {
+            return MarkupRef::none();
+        }
+        match self.markup_fd() {
+            Some(fd) => MarkupRef::op(resolve_op_ref(fd, op_key)),
+            None => MarkupRef::none(),
+        }
+    }
+
+    /// (kuna) The `MarkupRef` for a leaf [`Atom`] from its carried op/varnode
+    /// arena keys (C++ `EmitMarkup::tagVariable`/`tagOp`/`tagField`/`tagCaseLabel`
+    /// deref the `Varnode *`/`PcodeOp *`).  `varref = vn->getCreateIndex()` and
+    /// `opref = op->getTime()` are the SAME ids `Funcdata::encode` writes into the
+    /// `<ast>` (`<addr ref>` / `<seqnum uniq>`), so a clang token resolves against
+    /// the AST by construction.  `none()` (no deref) on the plain-text path.
+    fn markup_for_atom(&self, atom: &Atom) -> MarkupRef {
+        if !self.emit.emits_markup() {
+            return MarkupRef::none();
+        }
+        let fd = match self.markup_fd() {
+            Some(fd) => fd,
+            None => return MarkupRef::none(),
+        };
+        let mut m = MarkupRef::none();
+        m.opref = resolve_op_ref(fd, atom.op);
+        if let crate::printlanguage::AtomData::Vn(vn_key) = atom.data {
+            m.varref = resolve_var_ref(fd, vn_key);
+        }
+        m
+    }
+
+    /// (kuna) The `MarkupRef` for a DIRECT tag site that already holds an `OpId`
+    /// (C++ passes the `PcodeOp *`): `opref = op->getTime()`, the `<ast>`
+    /// `<seqnum uniq>`.  Gated on the active back-end so the plain-text datatest
+    /// path does no lookup and stays byte-identical.
+    fn op_markup(&self, fd: &Funcdata, op: OpId) -> MarkupRef {
+        if !self.emit.emits_markup() {
+            return MarkupRef::none();
+        }
+        MarkupRef::op(fd.obank().get(op).map(|o| o.get_time() as uintb))
+    }
+
     /// C++ `PrintLanguage::emitOp` (printlanguage.cc:332) — resolve final
     /// spacing / parens for one RPN entry at its current stage.  Mutates the
     /// entry's `id2` for surround tokens (mirrored back by the callers).
     fn emit_op(&mut self, entry_in: &ReversePolish) {
         let mut entry = entry_in.clone();
+        // (kuna) The operator's markup (C++ `EmitMarkup::tagOp` derefs the entry's
+        // `PcodeOp *` for `opref = getTime()`).  Resolved from the entry's arena
+        // key; `none()` (no lookup) on the plain-text path so the datatest bytes
+        // are unchanged.
+        let op_markup = self.markup_for_op_key(entry.op);
         match entry.tok.token_type {
             TokenType::Binary => {
                 if entry.visited != 1 {
                     return;
                 }
                 self.emit.spaces(entry.tok.spacing, entry.tok.bump);
-                self.emit.tag_op(entry.tok.print1, SyntaxHighlight::NoColor, &MarkupRef::none());
+                self.emit.tag_op(entry.tok.print1, SyntaxHighlight::NoColor, &op_markup);
                 self.emit.spaces(entry.tok.spacing, entry.tok.bump);
             }
             TokenType::UnaryPrefix => {
                 if entry.visited != 0 {
                     return;
                 }
-                self.emit.tag_op(entry.tok.print1, SyntaxHighlight::NoColor, &MarkupRef::none());
+                self.emit.tag_op(entry.tok.print1, SyntaxHighlight::NoColor, &op_markup);
                 self.emit.spaces(entry.tok.spacing, entry.tok.bump);
             }
             TokenType::Postsurround => {
@@ -1498,7 +1720,10 @@ impl PrintC {
     /// C++ `PrintLanguage::emitAtom` (printlanguage.cc:379) — send a leaf token
     /// to the low-level emitter according to its tag type.
     fn emit_atom(&mut self, atom: &Atom) {
-        let markup = MarkupRef::none();
+        // (kuna) Resolve the leaf's markup (C++ `EmitMarkup::tag*` derefs the
+        // atom's `Varnode *`/`PcodeOp *` for `varref`/`opref`).  `none()` (no
+        // lookup) on the plain-text path, so the datatest bytes are unchanged.
+        let markup = self.markup_for_atom(atom);
         match atom.tag {
             TagType::Syntax => self.emit.print(&atom.name, to_emit_hl(atom.highlight)),
             TagType::VarToken => {
@@ -1585,12 +1810,69 @@ impl PrintC {
     /// Faithful transcription of C++ `PrintC::docFunction` (printc.cc:2790)
     /// driven over a real [`Funcdata`] + [`Architecture`]: emit the signature
     /// shell (real return type from the recovered proto), then the **structured
-    /// body** (`emitBlockGraph(&fd->getStructure())`) when `sblocks` is present.
+    /// body** (`emitBlockGraph(&fd->getStructure())`) when `sblocks` is present,
+    /// and return the plain-text C.
     ///
-    /// When `sblocks` is empty (structuring declined at a seam) this falls back
-    /// to the brace-matched shell so the output is still a complete function.
+    /// The emission itself is [`emit_function_document`](PrintC::emit_function_document),
+    /// shared verbatim with [`doc_function_markup`](PrintC::doc_function_markup)
+    /// so the plain-text and markup entries can never drift; this entry keeps the
+    /// active back-end (`EmitNoMarkup`, byte-exact) and returns its text.
     pub fn doc_function_full(&mut self, fd: &Funcdata, arch: &Architecture) -> String {
+        self.emit_function_document(fd, arch);
+        self.emit.output_str().to_string()
+    }
+
+    /// Select whether `PrintC` emits token-markup (C++
+    /// `EmitPrettyPrint::setMarkup`, prettyprint.cc:2531, driven from
+    /// `ArchitectureGhidra`'s ctor `print->setMarkup(true)`, ghidra_arch.cc:917).
+    /// Swaps the concrete [`PrintEmit`] variant; a fresh buffer either way (each
+    /// leaf owns its own sink).  The standalone datatest path NEVER calls this, so
+    /// `emit` stays `NoMarkup` and the 675-assertion byte output is untouched.
+    pub fn set_markup(&mut self, val: bool) {
+        self.emit = if val {
+            PrintEmit::Markup(EmitMarkup::new())
+        } else {
+            PrintEmit::NoMarkup(EmitNoMarkup::new())
+        };
+    }
+
+    /// Emit the ghidra-mode `decompileAt` clang token-markup `<function>` document
+    /// (C++ `ArchitectureGhidra::print->docFunction(fd)`, ghidra_process.cc:329):
+    /// run the IDENTICAL [`emit_function_document`](PrintC::emit_function_document)
+    /// sequence that drives `doc_function_full`, but over an [`EmitMarkup`]
+    /// back-end so each token carries its `opref`/`varref` (resolved to the SAME
+    /// `get_time()` / `get_create_index()` that `Funcdata::encode`'s `<ast>` uses,
+    /// so a token resolves against the AST by construction).  Returns the packed
+    /// bytes; the back-end is restored to plain text so the printer stays reusable.
+    pub fn doc_function_markup(&mut self, fd: &Funcdata, arch: &Architecture) -> Vec<u8> {
+        self.set_markup(true);
+        self.emit_function_document(fd, arch);
+        // C++ docFunction ends in emit->flush(); EmitMarkup's flush is a no-op
+        // (packed elements are self-delimiting), so the byte stream is complete.
+        let _ = self.emit.flush();
+        let bytes = self.emit.take_markup_bytes();
+        self.set_markup(false);
+        bytes
+    }
+
+    /// The shared body-emission sequence of C++ `PrintC::docFunction`
+    /// (printc.cc:2790), back-end-agnostic: `beginFunction` → header comment →
+    /// prototype declaration → `openBraceIndent` → local var decls → block graph →
+    /// `closeBraceIndent` → `endFunction`.  Driven by whichever [`PrintEmit`]
+    /// variant is active, so [`doc_function_full`](PrintC::doc_function_full)
+    /// (plain text) and [`doc_function_markup`](PrintC::doc_function_markup)
+    /// (packed markup) share ONE emission path — the token stream (and every
+    /// `MarkupRef` populated below) is identical; only the leaf that serializes it
+    /// differs.
+    fn emit_function_document(&mut self, fd: &Funcdata, arch: &Architecture) {
         self.emit.set_output_stream();
+        // (kuna) Publish the fd for the fd-free RPN leaf emitters (emit_atom /
+        // emit_op) to resolve op/varnode arena keys to the <ast> ids while markup
+        // is active.  SAFETY: `fd` outlives this call; it is only ever read
+        // (get_time/get_create_index), never mutated through the pointer, and
+        // aliases `fd` (a distinct object from `self`), so no `&mut self` here
+        // conflicts.  Cleared before return so the pointer never escapes the call.
+        self.emit_fd = Some(fd as *const Funcdata);
         // (kuna) Resolve the `realtypes` rendering context once per function from
         // the live architecture (the gate + the `long`-is-8 data-model fact); every
         // type-name chokepoint below reads `self.rt_ctx`.
@@ -1667,7 +1949,9 @@ impl PrintC {
         self.emit.close_brace_indent("}", id);
         self.emit.tag_line();
         self.emit.end_function(id1);
-        self.emit.output().to_string()
+        // (kuna) Retire the scoped fd pointer (see the field doc): it is valid
+        // only for this call's dynamic extent.
+        self.emit_fd = None;
     }
 
     /// Emit the function's header warning comments (C++
@@ -2751,8 +3035,9 @@ impl PrintC {
         }
         self.emit.tag_line();
 
-        // dest = ( cond ) ? A : B ;
-        let sid = self.emit.begin_statement(&MarkupRef::none());
+        // dest = ( cond ) ? A : B ;  (opref = the ternary's true-branch assign op)
+        let stmt_markup = self.op_markup(fd, m.true_op);
+        let sid = self.emit.begin_statement(&stmt_markup);
         // LHS assignment target (drains as a leaf on the empty stack).
         self.push_vn_explicit_ir(fd, arch, m.dest, m.true_op);
         // ` = `
@@ -2845,11 +3130,17 @@ impl PrintC {
 
         if case.isdefault {
             // default: (the label value is informational; default emits no value).
+            // C++ `emit->tagCaseLabel(..., op, ...)` with op = the case's first op —
+            // `opref = firstop->getTime()`, the `<ast>` `<seqnum uniq>`.
+            let case_markup = match firstop {
+                Some(o) => self.op_markup(fd, o),
+                None => MarkupRef::none(),
+            };
             self.emit.tag_line();
             self.emit.tag_case_label(
                 keywords::KEYWORD_DEFAULT,
                 SyntaxHighlight::KeywordColor,
-                &MarkupRef::none(),
+                &case_markup,
                 case.label,
             );
             self.emit.print(keywords::COLON, SyntaxHighlight::NoColor);
@@ -3216,7 +3507,10 @@ impl PrintC {
 
     /// C++ `PrintC::emitStatement` (printc.cc:2361).
     fn emit_statement(&mut self, fd: &Funcdata, arch: &Architecture, inst: OpId) {
-        let id = self.emit.begin_statement(&MarkupRef::none());
+        // C++ `emit->beginStatement(inst)`: the statement's root op — `opref =
+        // inst->getTime()`, the `<ast>` `<seqnum uniq>` a client clicks to.
+        let stmt_markup = self.op_markup(fd, inst);
+        let id = self.emit.begin_statement(&stmt_markup);
         self.emit_expression_ir(fd, arch, inst);
         self.emit.end_statement(id);
         if !self.context.is_set(modifiers::COMMA_SEPARATE) {
@@ -3322,7 +3616,8 @@ impl PrintC {
             // The structured switch body (`{ case N: ... }`) is emitted by
             // `emit_block_switch`; here only the `switch(in0)` expression prints.
             OpCode::CPUI_BRANCHIND => {
-                self.emit.tag_op(keywords::KEYWORD_SWITCH, SyntaxHighlight::KeywordColor, &MarkupRef::none());
+                let kw_markup = self.op_markup(fd, op);
+                self.emit.tag_op(keywords::KEYWORD_SWITCH, SyntaxHighlight::KeywordColor, &kw_markup);
                 let id = self.emit.open_paren(crate::printlanguage::OPEN_PAREN, 0);
                 if let Some(vn) = fd.obank().get(op).and_then(|o| o.get_in(0)) {
                     self.push_vn_ir(fd, arch, vn, op);
@@ -3331,7 +3626,8 @@ impl PrintC {
             }
             // RETURN (printc.cc:774 opReturn, the plain-return case).
             OpCode::CPUI_RETURN => {
-                self.emit.tag_op(keywords::KEYWORD_RETURN, SyntaxHighlight::KeywordColor, &MarkupRef::none());
+                let kw_markup = self.op_markup(fd, op);
+                self.emit.tag_op(keywords::KEYWORD_RETURN, SyntaxHighlight::KeywordColor, &kw_markup);
                 let nin = fd.obank().get(op).map(|o| o.num_input()).unwrap_or(0);
                 if nin > 1 {
                     self.emit.spaces(1, 0);
@@ -6862,6 +7158,35 @@ fn op_key(op: OpId) -> usize {
 fn vn_key(vn: VarnodeId) -> usize {
     use slotmap::Key;
     vn.data().as_ffi() as usize
+}
+
+/// (kuna) Invert [`op_key`]: reconstruct the `OpId` from the arena key an
+/// [`Atom`]/[`ReversePolish`] carries and return the op's `get_time()` — the
+/// markup `opref` (C++ `EmitMarkup` derefs the `PcodeOp *` for `getTime()`),
+/// identical to the `<seqnum uniq>` `PcodeOp::encode` writes into the `<ast>`
+/// (op.rs:589; `funcdata_encode.rs`).  `None` when the key is null or the op is
+/// no longer live (defensive — the emitted `opref` set stays a subset of the
+/// AST's op times).
+fn resolve_op_ref(fd: &Funcdata, op_key: Option<usize>) -> Option<uintb> {
+    let key = op_key?;
+    let op = OpId::from(slotmap::KeyData::from_ffi(key as u64));
+    Some(fd.obank().get(op)?.get_time() as uintb)
+}
+
+/// (kuna) Invert [`vn_key`]: reconstruct the `VarnodeId` and return its
+/// `get_create_index()` — the markup `varref` (C++ `EmitMarkup` derefs the
+/// `Varnode *` for `getCreateIndex()`), identical to the `<addr ref>`
+/// `Varnode::encode` writes into the `<ast>` `<varnodes>` (varnode.rs:629;
+/// `funcdata_encode.rs`).  `IPTR_IOP` annotation Varnodes are excluded exactly as
+/// `encode_tree` filters them out of `<varnodes>` — a `varref` to one would
+/// dangle.  `None` when null / not live / iop-space.
+fn resolve_var_ref(fd: &Funcdata, vn_key: usize) -> Option<uintb> {
+    let vn = VarnodeId::from(slotmap::KeyData::from_ffi(vn_key as u64));
+    let v = fd.vbank().get(vn)?;
+    if v.get_space().get_type() == kuna_base::space::spacetype::IPTR_IOP {
+        return None;
+    }
+    Some(v.get_create_index() as uintb)
 }
 
 /// C++ `TypeOpFloatInt2Float::absorbZext` (typeop.cc:1874): if the

--- a/decompiler/crates/kuna-decomp/src/s9_emit/printc/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/s9_emit/printc/tests.rs
@@ -747,7 +747,7 @@ fn emit_expr<F: FnOnce(&mut PrintC)>(f: F) -> String {
     let mut p = PrintC::new();
     p.set_output_stream();
     f(&mut p);
-    p.emit_mut().output().to_string()
+    p.emit_mut().output_str().to_string()
 }
 
 #[test]
@@ -1390,7 +1390,7 @@ mod w10_printc_cast_render {
         p.set_no_cast_printing(nocasts);
         p.set_output_stream();
         p.op_type_cast_ir(fd, &arch, op);
-        p.emit_mut().output().to_string()
+        p.emit_mut().output_str().to_string()
     }
 
     /// FAITHFULNESS (1a): a `CPUI_CAST` whose output is `int8` renders

--- a/decompiler/crates/kuna-decomp/src/substrate/block.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/block.rs
@@ -3542,7 +3542,7 @@ impl BlockGraph {
     /// Encode the \<bhead> list + recursive bodies of a BlockGraph
     /// (C++ `BlockGraph::encodeBody`, `block.cc:1377`).  Leaf blocks have empty
     /// bodies except BlockBasic, which writes its `cover`.
-    fn encode_body(&self, this_id: BlockId, encoder: &mut dyn Encoder) {
+    pub(crate) fn encode_body(&self, this_id: BlockId, encoder: &mut dyn Encoder) {
         let bt = self.arena[this_id].get_type();
         if let BlockKind::Basic(bd) = &self.arena[this_id].kind {
             // BlockBasic::encodeBody: cover.encode(encoder)
@@ -3632,7 +3632,7 @@ impl BlockGraph {
     }
 
     /// Encode edge information (C++ `FlowBlock::encodeEdges`, `block.cc:2489`).
-    fn encode_edges(&self, this_id: BlockId, encoder: &mut dyn Encoder) {
+    pub(crate) fn encode_edges(&self, this_id: BlockId, encoder: &mut dyn Encoder) {
         for i in 0..self.arena[this_id].intothis.len() {
             self.arena[this_id].intothis[i].encode(encoder, &self.arena);
         }

--- a/decompiler/crates/kuna-decomp/src/substrate/funcdata_encode.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/funcdata_encode.rs
@@ -1,0 +1,608 @@
+//! Encode a [`Funcdata`] as the `<function>`/`<ast>` document that answers
+//! Ghidra's `decompileAt` request — a faithful port of `Funcdata::encode`
+//! (`decompiler/cpp/funcdata.cc:734`) and the sub-encoders it drives.
+//!
+//! The consumer of this document is the Java `HighFunction.decode`
+//! (`PcodeSyntaxTree.decode`), which rebuilds the SSA AST and keys every node by
+//! integer ref (`Varnode::getCreateIndex`) / time (`PcodeOp::getTime`).  The
+//! markup C emitted alongside it (`s9_emit/prettyprint.rs`, `EmitMarkup`) then
+//! resolves each token back to those same ids, so the click-to-address contract
+//! holds **by construction**: this encoder emits exactly what
+//! `get_create_index()` / `get_time()` return, unmodified (see the id-consistency
+//! note below).
+//!
+//! ## Scope (v1)
+//!
+//! This is the minimal `<function>` that satisfies `HighFunction.decode` and the
+//! click-to-address contract: `<function id name size [nocode]>` + `<addr>`
+//! (baseaddr) + `<ast>`.  The `<ast>` is `<varnodes>` (every non-`IPTR_IOP`
+//! Varnode, full form) + per basic block a `<block index>` (cover `<rangelist>`
+//! + each `<op>`) + per in-edged block a `<blockedge index>` of `<edge>`s.
+//!
+//! The larger secondary encoders are **deferred** (marked `// v1.1:` at their
+//! skip sites in [`Funcdata::encode`]): `<prototype>` (`FuncProto::encode`,
+//! optional in `HighFunction.decode`), `<localdb>` (`LocalSymbolMap`),
+//! `<highlist>`/`<jumptablelist>` (Phase 4), and `<override>`.
+//!
+//! ## C++ origins
+//!
+//!   * [`Funcdata::encode`]      → `decompiler/cpp/funcdata.cc:734`
+//!   * [`Funcdata::encode_tree`] → `decompiler/cpp/funcdata.cc:686` (`encodeTree`)
+//!   * [`Funcdata::encode_varnode`] → `decompiler/cpp/varnode.cc:1201` (`Varnode::encode`)
+//!   * [`Funcdata::encode_op`]   → `decompiler/cpp/op.cc:412` (`PcodeOp::encode`)
+//!   * `<seqnum>`                → `decompiler/cpp/address.cc:60` (`SeqNum::encode`)
+//!   * cover `<rangelist>`       → `decompiler/cpp/block.cc` (`BlockBasic::encodeBody`)
+//!   * `<blockedge>`/`<edge>`    → `decompiler/cpp/block.cc:2489,35` (`FlowBlock::encodeEdges`/`BlockEdge::encode`)
+
+use kuna_base::address::ELEM_ADDR;
+use kuna_base::error::KunaResult;
+use kuna_base::marshal::{
+    AttributeId, ElementId, Encoder, ATTRIB_ID, ATTRIB_INDEX, ATTRIB_NAME, ATTRIB_REF, ATTRIB_SIZE,
+    ATTRIB_VALUE, ELEM_VOID,
+};
+use kuna_base::space::spacetype;
+use kuna_num::opcodes::OpCode;
+use kuna_num::pcoderaw::{ATTRIB_CODE, ELEM_SPACEID};
+use kuna_sleigh::translate::ELEM_OP;
+
+use crate::block::{ELEM_BLOCK, ELEM_BLOCKEDGE};
+use crate::funcdata::Funcdata;
+use crate::seams::{OpId, VarnodeId};
+
+// ---------------------------------------------------------------------------
+// New marshaling ids (DECOMPILER scope).
+//
+// These live in a separate id namespace from the SLEIGH-compiler attributes
+// that reuse the same numbers (`kuna-sleigh/src/slaformat.rs` etc.) — exactly
+// the coexistence kuna already relies on for ATTRIB_NAME (sleigh=12 vs
+// decomp=14).  Encoding writes `id.get_id()` directly (no registry lookup), so
+// these are never registered on any `IdRegistry`; a duplicate numeric id on the
+// SLEIGH registry would panic, so if any of these are ever registered for a
+// decode round-trip they must go on the decompiler/ghidra registry only.
+// ---------------------------------------------------------------------------
+
+/// Marshaling element `<iop>` (C++ `ELEM_IOP`, `op.cc`, id 113).
+pub const ELEM_IOP: ElementId = ElementId::new("iop", 113);
+/// Marshaling element `<ast>` (C++ `ELEM_AST`, `funcdata.cc`, id 115).
+pub const ELEM_AST: ElementId = ElementId::new("ast", 115);
+/// Marshaling element `<function>` (C++ `ELEM_FUNCTION`, `funcdata.cc`, id 116).
+///
+/// Re-exported by `s9_emit/prettyprint.rs`'s `ids` module (the markup
+/// `<function>` document uses the same numeric id), replacing the placeholder
+/// that anticipated this port.
+pub const ELEM_FUNCTION: ElementId = ElementId::new("function", 116);
+/// Marshaling element `<varnodes>` (C++ `ELEM_VARNODES`, `funcdata.cc`, id 119).
+pub const ELEM_VARNODES: ElementId = ElementId::new("varnodes", 119);
+
+/// Marshaling attribute "addrtied" (C++ `ATTRIB_ADDRTIED`, `funcdata.cc`, id 30).
+pub const ATTRIB_ADDRTIED: AttributeId = AttributeId::new("addrtied", 30);
+/// Marshaling attribute "grp" (C++ `ATTRIB_GRP`, `funcdata.cc`, id 31).
+pub const ATTRIB_GRP: AttributeId = AttributeId::new("grp", 31);
+/// Marshaling attribute "input" (C++ `ATTRIB_INPUT`, `funcdata.cc`, id 32).
+pub const ATTRIB_INPUT: AttributeId = AttributeId::new("input", 32);
+/// Marshaling attribute "persists" (C++ `ATTRIB_PERSISTS`, `funcdata.cc`, id 33).
+pub const ATTRIB_PERSISTS: AttributeId = AttributeId::new("persists", 33);
+/// Marshaling attribute "unaff" (C++ `ATTRIB_UNAFF`, `funcdata.cc`, id 34).
+pub const ATTRIB_UNAFF: AttributeId = AttributeId::new("unaff", 34);
+/// Marshaling attribute "volatile" (C++ `ATTRIB_VOLATILE`, `database.cc`, id 65).
+pub const ATTRIB_VOLATILE: AttributeId = AttributeId::new("volatile", 65);
+/// Marshaling attribute "nocode" (C++ `ATTRIB_NOCODE`, `funcdata.cc`, id 84).
+pub const ATTRIB_NOCODE: AttributeId = AttributeId::new("nocode", 84);
+
+impl Funcdata {
+    /// C++ `Funcdata::encode(Encoder&,uint8 id,bool savetree)` (`funcdata.cc:734`).
+    ///
+    /// Emits the `<function>` document consumed by Ghidra's `HighFunction.decode`.
+    /// v1 covers `<function>` + baseaddr `<addr>` + (when `savetree`) the `<ast>`;
+    /// the secondary encoders are deferred (see the `// v1.1:` skip sites).
+    pub fn encode(&self, enc: &mut dyn Encoder, id: u64, savetree: bool) -> KunaResult<()> {
+        enc.open_element(&ELEM_FUNCTION);
+        if id != 0 {
+            enc.write_unsigned_integer(&ATTRIB_ID, id);
+        }
+        enc.write_string(&ATTRIB_NAME, self.get_name().as_bytes());
+        enc.write_signed_integer(&ATTRIB_SIZE, self.get_size() as i64);
+        if self.has_no_code() {
+            enc.write_bool(&ATTRIB_NOCODE, true);
+        }
+        self.get_address().encode(enc)?;
+        // v1.1: localmap->encodeRecursive(encoder,false)  (<localdb>) — deferred.
+        if savetree {
+            self.encode_tree(enc)?;
+            // v1.1 (Phase 4): encodeHigh(encoder)  (<highlist>) — deferred.
+        }
+        // v1.1 (Phase 4): encodeJumpTable(encoder)  (<jumptablelist>) — deferred.
+        // v1.1: funcp.encode(encoder)  (<prototype>, FuncProto::encode) — deferred.
+        //       A large independent encoder (ProtoStore/ProtoParameter/
+        //       Datatype::encodeRef/effect lists); `HighFunction.decode` treats
+        //       `<prototype>` as optional, so it does not block v1.
+        // v1.1: localoverride.encode(encoder,name)  (<override>) — deferred.
+        enc.close_element(&ELEM_FUNCTION);
+        Ok(())
+    }
+
+    /// C++ `Funcdata::encodeTree(Encoder&)` (`funcdata.cc:686`).
+    ///
+    /// `<ast>` = `<varnodes>` (every non-`IPTR_IOP` Varnode) + per basic block a
+    /// `<block index>` (cover + ops) + per in-edged block a `<blockedge index>`.
+    fn encode_tree(&self, enc: &mut dyn Encoder) -> KunaResult<()> {
+        enc.open_element(&ELEM_AST);
+
+        // <varnodes>: all Varnodes except the iop space (funcdata.cc:695).  The
+        // iop-space annotation Varnode (an INDIRECT's second input) is referenced
+        // instead from inside its <op> as <iop value=time/>, never as an <addr>.
+        enc.open_element(&ELEM_VARNODES);
+        for vn in self.vbank().iter_loc() {
+            let v = self.vbank().get(vn).expect("encode_tree: stale loc Varnode");
+            if v.get_space().get_type() == spacetype::IPTR_IOP {
+                continue;
+            }
+            self.encode_varnode(enc, vn)?;
+        }
+        enc.close_element(&ELEM_VARNODES);
+
+        let n = self.bblocks_get_size();
+        // Per basic block: <block index> = cover <rangelist> + each <op>.
+        for i in 0..n {
+            let bl = self.bblocks_get_block(i);
+            enc.open_element(&ELEM_BLOCK);
+            // The block's OWN index (Java places blocks by it), not the loop
+            // counter `i` — they can differ.
+            enc.write_signed_integer(&ATTRIB_INDEX, self.bblocks_ref().block(bl).get_index() as i64);
+            // BlockBasic::encodeBody: the cover <rangelist> (mandatory — emitted
+            // even when empty).
+            self.bblocks_ref().encode_body(bl, enc);
+            for op in self.bb_ops(bl) {
+                self.encode_op(enc, op)?;
+            }
+            enc.close_element(&ELEM_BLOCK);
+        }
+        // Per block with in-edges: <blockedge index> = each in <edge>.
+        for i in 0..n {
+            let bl = self.bblocks_get_block(i);
+            if self.bblocks_ref().block(bl).size_in() != 0 {
+                enc.open_element(&ELEM_BLOCKEDGE);
+                enc.write_signed_integer(
+                    &ATTRIB_INDEX,
+                    self.bblocks_ref().block(bl).get_index() as i64,
+                );
+                self.bblocks_ref().encode_edges(bl, enc);
+                enc.close_element(&ELEM_BLOCKEDGE);
+            }
+        }
+
+        enc.close_element(&ELEM_AST);
+        Ok(())
+    }
+
+    /// C++ `Varnode::encode(Encoder&)` (`varnode.cc:1201`).
+    ///
+    /// The **full** `<addr>` form under `<varnodes>` carries space, offset, size,
+    /// ref, and the guarded flag attributes.  Do NOT use `Address::encode_sized`
+    /// — it closes the element before ref/flags can be written.
+    fn encode_varnode(&self, enc: &mut dyn Encoder, vn: VarnodeId) -> KunaResult<()> {
+        let v = self.vbank().get(vn).expect("encode_varnode: stale Varnode");
+        enc.open_element(&ELEM_ADDR);
+        v.get_space().encode_attributes_sized(enc, v.get_offset(), v.get_size())?;
+        enc.write_unsigned_integer(&ATTRIB_REF, v.get_create_index() as u64);
+        let mergegroup = v.get_merge_group();
+        if mergegroup != 0 {
+            enc.write_signed_integer(&ATTRIB_GRP, mergegroup as i64);
+        }
+        // Flag order matches varnode.cc exactly.
+        if v.is_persist() {
+            enc.write_bool(&ATTRIB_PERSISTS, true);
+        }
+        if v.is_addr_tied() {
+            enc.write_bool(&ATTRIB_ADDRTIED, true);
+        }
+        if v.is_unaffected() {
+            enc.write_bool(&ATTRIB_UNAFF, true);
+        }
+        if v.is_input() {
+            enc.write_bool(&ATTRIB_INPUT, true);
+        }
+        if v.is_volatile() {
+            enc.write_bool(&ATTRIB_VOLATILE, true);
+        }
+        enc.close_element(&ELEM_ADDR);
+        Ok(())
+    }
+
+    /// C++ `PcodeOp::encode(Encoder&)` (`op.cc:412`).
+    ///
+    /// `<op code>` + `<seqnum>` + the output (`<addr ref>` or `<void>`) + each
+    /// input by the four-way rule (op.cc:426-462).
+    fn encode_op(&self, enc: &mut dyn Encoder, op: OpId) -> KunaResult<()> {
+        let o = self.obank().get(op).expect("encode_op: stale op");
+        let code = o.code();
+        enc.open_element(&ELEM_OP);
+        enc.write_signed_integer(&ATTRIB_CODE, code as i64);
+        o.get_seq_num().encode(enc)?;
+
+        // Output: <addr ref/> (bare back-reference) or <void/>.
+        match o.get_out() {
+            Some(out) => {
+                let create =
+                    self.vbank().get(out).expect("encode_op: stale output").get_create_index();
+                self.encode_bare_ref(enc, create);
+            }
+            None => self.encode_void(enc),
+        }
+
+        // Inputs — the four-way rule.
+        let ninput = o.num_input();
+        for i in 0..ninput {
+            match o.get_in(i) {
+                None => self.encode_void(enc),
+                Some(invn) => {
+                    let iv = self.vbank().get(invn).expect("encode_op: stale input");
+                    let sptype = iv.get_space().get_type();
+                    if sptype == spacetype::IPTR_IOP {
+                        // INDIRECT's iop input: <iop value=indop.getTime()/>.  The
+                        // iop offset encodes the guarded op (op_iop_encode); resolve
+                        // it back and emit its time.  Any other iop input → <void/>.
+                        if i == 1 && code == OpCode::CPUI_INDIRECT {
+                            let indop = crate::funcdata_varnode::op_iop_decode(iv.get_offset());
+                            let time = self
+                                .obank()
+                                .get(indop)
+                                .expect("encode_op: stale INDIRECT iop target")
+                                .get_time();
+                            enc.open_element(&ELEM_IOP);
+                            enc.write_unsigned_integer(&ATTRIB_VALUE, time as u64);
+                            enc.close_element(&ELEM_IOP);
+                        } else {
+                            self.encode_void(enc);
+                        }
+                    } else if sptype == spacetype::IPTR_CONSTANT
+                        && i == 0
+                        && (code == OpCode::CPUI_STORE || code == OpCode::CPUI_LOAD)
+                    {
+                        // LOAD/STORE space operand: <spaceid name=space/>.  The
+                        // constant's offset is the manager index of the space it
+                        // encodes (C++ getSpaceFromConst).
+                        let idx = iv.get_offset() as i32;
+                        let spc = self
+                            .get_arch()
+                            .manage()
+                            .get_space(idx)
+                            .expect("encode_op: LOAD/STORE space operand out of range");
+                        enc.open_element(&ELEM_SPACEID);
+                        enc.write_space(&ATTRIB_NAME, spc);
+                        enc.close_element(&ELEM_SPACEID);
+                    } else {
+                        // Ordinary input (including a non-space constant): a bare
+                        // <addr ref/> back-reference.
+                        self.encode_bare_ref(enc, iv.get_create_index());
+                    }
+                }
+            }
+        }
+
+        enc.close_element(&ELEM_OP);
+        Ok(())
+    }
+
+    /// A bare back-reference `<addr ref=createIndex/>` (op.cc output/input form) —
+    /// only `ATTRIB_REF`, no space/offset.  `Varnode.decode` short-circuits on a
+    /// known ref via `factory.getRef(ref)`, so the full space form appears only
+    /// under `<varnodes>`.
+    fn encode_bare_ref(&self, enc: &mut dyn Encoder, create_index: u32) {
+        enc.open_element(&ELEM_ADDR);
+        enc.write_unsigned_integer(&ATTRIB_REF, create_index as u64);
+        enc.close_element(&ELEM_ADDR);
+    }
+
+    /// An empty `<void/>` element (a null / non-referable op slot).
+    fn encode_void(&self, enc: &mut dyn Encoder) {
+        enc.open_element(&ELEM_VOID);
+        enc.close_element(&ELEM_VOID);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::rc::Rc;
+
+    use kuna_base::address::{Address, ATTRIB_UNIQ, ELEM_RANGELIST, ELEM_SEQNUM};
+    use kuna_base::marshal::{Decoder, PackedDecode, PackedEncode};
+    use kuna_base::space::{
+        addrspace_flags, spacetype, AddrSpace, AddrSpaceManager, ConstantSpace, FspecSpace,
+        IopSpace, UniqueSpace,
+    };
+    use kuna_base::types::int4;
+    use kuna_num::opcodes::OpCode;
+
+    use crate::seams::{Architecture, BlockId, OpId, TypeOp};
+
+    use super::*;
+
+    /// A manager with constant / unique / iop / fspec / ram spaces (the minimal
+    /// set `new_varnode_iop` + LOAD-spaceid need).
+    fn build_manager() -> AddrSpaceManager {
+        let mut m = AddrSpaceManager::new();
+        m.insert_space(Rc::new(ConstantSpace::new())).unwrap();
+        m.insert_space(Rc::new(UniqueSpace::new(1, 0, false))).unwrap();
+        m.insert_space(Rc::new(IopSpace::new(2))).unwrap();
+        m.insert_space(Rc::new(FspecSpace::new(3))).unwrap();
+        m.insert_space(Rc::new(AddrSpace::new(
+            spacetype::IPTR_PROCESSOR,
+            "ram",
+            false,
+            8,
+            1,
+            4,
+            addrspace_flags::hasphysical,
+            1,
+            1,
+        )))
+        .unwrap();
+        m
+    }
+
+    fn build_fd() -> Funcdata {
+        let manage = build_manager();
+        let glb = Rc::new(Architecture::new(manage));
+        let ram = Rc::clone(glb.manage().get_space_by_name("ram").unwrap());
+        let addr = Address::new(ram, 0x1000);
+        Funcdata::new("func", "func", glb, addr, 0x10000000, 0x40).unwrap()
+    }
+
+    fn ram(fd: &Funcdata) -> Rc<AddrSpace> {
+        Rc::clone(fd.get_arch().manage().get_space_by_name("ram").unwrap())
+    }
+
+    fn new_op(fd: &mut Funcdata, inputs: int4, opc: OpCode, off: u64) -> OpId {
+        let r = ram(fd);
+        let op = fd.new_op(inputs, Address::new(r, off));
+        fd.op_set_opcode(op, TypeOp::new(opc, 0, "OP"));
+        op
+    }
+
+    /// What the round-trip decode observed about the `<ast>`.
+    #[derive(Default)]
+    struct Observed {
+        name: Vec<u8>,
+        size: i64,
+        varnode_refs: BTreeSet<u64>,
+        op_uniqs: BTreeSet<u64>,
+        saw_iop: bool,
+        saw_spaceid: bool,
+        saw_void: bool,
+        saw_bare_ref: bool,
+        block_count: usize,
+        op_count: usize,
+    }
+
+    /// Structurally decode a `<function>` document with kuna's PackedDecode and
+    /// collect the structure + the ref/uniq ids for the load-bearing invariant.
+    fn decode_function(manage: &AddrSpaceManager, bytes: &[u8]) -> KunaResult<Observed> {
+        let mut obs = Observed::default();
+        let mut dec = PackedDecode::new(manage);
+        dec.ingest_stream(bytes)?;
+
+        let fid = dec.open_element()?;
+        assert_eq!(fid, ELEM_FUNCTION.get_id(), "root is not <function>");
+        obs.name = dec.read_string_id(&ATTRIB_NAME)?;
+        obs.size = dec.read_signed_integer_id(&ATTRIB_SIZE)?;
+
+        // <function> children: <addr> (baseaddr) then <ast>.
+        loop {
+            let c = dec.peek_element()?;
+            if c == 0 {
+                break;
+            }
+            if c == ELEM_AST.get_id() {
+                let ast = dec.open_element()?;
+                decode_ast(&mut dec, &mut obs)?;
+                dec.close_element(ast)?;
+            } else {
+                dec.skip_element()?; // baseaddr <addr>, or anything unexpected.
+            }
+        }
+        dec.close_element(fid)?;
+        Ok(obs)
+    }
+
+    fn decode_ast(dec: &mut PackedDecode, obs: &mut Observed) -> KunaResult<()> {
+        loop {
+            let c = dec.peek_element()?;
+            if c == 0 {
+                break;
+            }
+            if c == ELEM_VARNODES.get_id() {
+                let vid = dec.open_element()?;
+                loop {
+                    let a = dec.peek_element()?;
+                    if a == 0 {
+                        break;
+                    }
+                    assert_eq!(a, ELEM_ADDR.get_id(), "<varnodes> child is not <addr>");
+                    let aid = dec.open_element()?;
+                    obs.varnode_refs.insert(dec.read_unsigned_integer_id(&ATTRIB_REF)?);
+                    dec.close_element(aid)?;
+                }
+                dec.close_element(vid)?;
+            } else if c == ELEM_BLOCK.get_id() {
+                obs.block_count += 1;
+                let bid = dec.open_element()?;
+                decode_block(dec, obs)?;
+                dec.close_element(bid)?;
+            } else {
+                // <blockedge> (or any later-phase element): skip whole subtree.
+                dec.skip_element()?;
+            }
+        }
+        Ok(())
+    }
+
+    fn decode_block(dec: &mut PackedDecode, obs: &mut Observed) -> KunaResult<()> {
+        // ATTRIB_INDEX is present but not asserted here.
+        loop {
+            let c = dec.peek_element()?;
+            if c == 0 {
+                break;
+            }
+            if c == ELEM_OP.get_id() {
+                obs.op_count += 1;
+                let oid = dec.open_element()?;
+                // Every op carries a code + a <seqnum uniq>.
+                let _code = dec.read_signed_integer_id(&ATTRIB_CODE)?;
+                let mut first = true;
+                loop {
+                    let oc = dec.peek_element()?;
+                    if oc == 0 {
+                        break;
+                    }
+                    if first {
+                        assert_eq!(oc, ELEM_SEQNUM.get_id(), "first <op> child is not <seqnum>");
+                        let sid = dec.open_element()?;
+                        obs.op_uniqs.insert(dec.read_unsigned_integer_id(&ATTRIB_UNIQ)?);
+                        dec.close_element(sid)?;
+                        first = false;
+                    } else {
+                        // output + inputs: classify then skip.
+                        if oc == ELEM_IOP.get_id() {
+                            obs.saw_iop = true;
+                        } else if oc == ELEM_SPACEID.get_id() {
+                            obs.saw_spaceid = true;
+                        } else if oc == ELEM_VOID.get_id() {
+                            obs.saw_void = true;
+                        } else if oc == ELEM_ADDR.get_id() {
+                            obs.saw_bare_ref = true;
+                        }
+                        dec.skip_element()?;
+                    }
+                }
+                dec.close_element(oid)?;
+            } else {
+                // The cover <rangelist> (mandatory, may be empty).
+                assert_eq!(c, ELEM_RANGELIST.get_id(), "unexpected <block> child");
+                dec.skip_element()?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Build a synthetic single-block Funcdata exercising every op-input branch,
+    /// encode it, round-trip through PackedDecode, and assert the structure and
+    /// the load-bearing ref/uniq invariant.
+    #[test]
+    fn encode_roundtrip_covers_all_four_op_input_branches() {
+        let mut fd = build_fd();
+        let r = ram(&fd);
+
+        // One basic block with a real cover range.
+        let root = fd.bblocks_ref().root.unwrap();
+        let bl: BlockId = fd.bblocks_mut().new_block_basic(root);
+        fd.set_basic_block_range(
+            bl,
+            &Address::new(Rc::clone(&r), 0x2000),
+            &Address::new(Rc::clone(&r), 0x2040),
+        );
+
+        // (1) A referenced op with NO output — exercises the void OUTPUT branch,
+        //     and is the target the INDIRECT's iop input points at.
+        let ref_op = new_op(&mut fd, 1, OpCode::CPUI_CALL, 0x2000);
+        let uv = fd.new_unique(4, None);
+        fd.op_set_input(ref_op, uv, 0).unwrap();
+
+        // (2) A binary op with two real refs in + a ref out — normal-ref inputs
+        //     and a ref output.
+        let add_op = new_op(&mut fd, 2, OpCode::CPUI_INT_ADD, 0x2004);
+        let a0 = fd.new_varnode(4, &Address::new(Rc::clone(&r), 0x100), None);
+        let a1 = fd.new_varnode(4, &Address::new(Rc::clone(&r), 0x108), None);
+        let ao = fd.new_varnode(4, &Address::new(Rc::clone(&r), 0x110), None);
+        fd.op_set_input(add_op, a0, 0).unwrap();
+        fd.op_set_input(add_op, a1, 1).unwrap();
+        fd.op_set_output(add_op, ao).unwrap();
+
+        // (3) An op with a null input slot — the void INPUT branch.
+        let void_op = new_op(&mut fd, 2, OpCode::CPUI_INT_ADD, 0x2008);
+        let v0 = fd.new_varnode(4, &Address::new(Rc::clone(&r), 0x118), None);
+        let vo = fd.new_varnode(4, &Address::new(Rc::clone(&r), 0x120), None);
+        fd.op_set_input(void_op, v0, 0).unwrap();
+        // slot 1 left null on purpose.
+        fd.op_set_output(void_op, vo).unwrap();
+
+        // (4) A LOAD whose input(0) is a constant encoding the ram space index —
+        //     the <spaceid> branch.
+        let load_op = new_op(&mut fd, 2, OpCode::CPUI_LOAD, 0x200c);
+        let space_const = fd.new_constant(8, 4); // 4 == ram's manager index
+        let ptr = fd.new_varnode(8, &Address::new(Rc::clone(&r), 0x128), None);
+        let lo = fd.new_varnode(4, &Address::new(Rc::clone(&r), 0x130), None);
+        fd.op_set_input(load_op, space_const, 0).unwrap();
+        fd.op_set_input(load_op, ptr, 1).unwrap();
+        fd.op_set_output(load_op, lo).unwrap();
+
+        // (5) An INDIRECT whose input(1) is an iop annotation — the <iop> branch.
+        //     The iop annotation Varnode is in IPTR_IOP space and must be filtered
+        //     out of <varnodes>.
+        let ind_op = new_op(&mut fd, 2, OpCode::CPUI_INDIRECT, 0x2010);
+        let i0 = fd.new_varnode(4, &Address::new(Rc::clone(&r), 0x138), None);
+        let iop_vn = fd.new_varnode_iop(ref_op);
+        let io = fd.new_varnode(4, &Address::new(Rc::clone(&r), 0x140), None);
+        fd.op_set_input(ind_op, i0, 0).unwrap();
+        fd.op_set_input(ind_op, iop_vn, 1).unwrap();
+        fd.op_set_output(ind_op, io).unwrap();
+
+        for op in [ref_op, add_op, void_op, load_op, ind_op] {
+            fd.bb_insert_op(op, bl, None);
+        }
+
+        // The expected invariant sets: every non-IOP Varnode's create index, and
+        // every op's time.
+        let expected_refs: BTreeSet<u64> = fd
+            .vbank()
+            .iter_loc()
+            .filter(|&vn| {
+                fd.vbank().get(vn).unwrap().get_space().get_type() != spacetype::IPTR_IOP
+            })
+            .map(|vn| fd.vbank().get(vn).unwrap().get_create_index() as u64)
+            .collect();
+        let expected_uniqs: BTreeSet<u64> = fd
+            .bb_ops(bl)
+            .iter()
+            .map(|&op| fd.obank().get(op).unwrap().get_time() as u64)
+            .collect();
+
+        // Encode.
+        let mut bytes: Vec<u8> = Vec::new();
+        {
+            let mut enc = PackedEncode::new(&mut bytes);
+            fd.encode(&mut enc, 0x1234, true).expect("encode");
+        }
+        assert!(!bytes.is_empty(), "encode produced no bytes");
+
+        // Round-trip decode.
+        let obs = decode_function(fd.get_arch().manage(), &bytes).expect("decode");
+
+        // Header.
+        assert_eq!(obs.name, fd.get_name().as_bytes());
+        assert_eq!(obs.size, fd.get_size() as i64);
+
+        // Structure.
+        assert_eq!(obs.block_count, 1, "expected exactly one <block>");
+        assert_eq!(obs.op_count, 5, "expected five <op>s");
+
+        // All four op-input branches + the void output branch fired.
+        assert!(obs.saw_iop, "no <iop> input encoded");
+        assert!(obs.saw_spaceid, "no <spaceid> input encoded");
+        assert!(obs.saw_void, "no <void> slot encoded");
+        assert!(obs.saw_bare_ref, "no bare <addr ref> encoded");
+
+        // The load-bearing invariant: <addr ref> == get_create_index(),
+        // <seqnum uniq> == get_time(), for every Varnode / op.
+        assert_eq!(obs.varnode_refs, expected_refs, "<varnodes> refs != create indices");
+        assert_eq!(obs.op_uniqs, expected_uniqs, "<op> uniqs != op times");
+
+        // The iop annotation Varnode must NOT appear in <varnodes>.
+        let iop_ref = fd.vbank().get(iop_vn).unwrap().get_create_index() as u64;
+        assert!(
+            !obs.varnode_refs.contains(&iop_ref),
+            "iop annotation Varnode leaked into <varnodes>"
+        );
+    }
+}

--- a/decompiler/crates/kuna-decomp/src/substrate/funcdata_printraw.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/funcdata_printraw.rs
@@ -276,11 +276,15 @@ fn render_varnode_no_markup(
         }
     };
     let off = addr.get_offset();
-    let name = arch.translate().base().get_register_name(space, off, size);
+    // Register-name/storage resolution is a Sleigh-engine concern (the C++
+    // `getTrans()` back-pointer); reach the concrete engine's `SleighBase`
+    // through the seam downcast (only `Sleigh` implements it; this print-raw
+    // path only ever runs on the standalone engine).
+    let sleigh = arch.translate().as_sleigh().expect("print_raw: standalone Sleigh engine");
+    let name = sleigh.base().get_register_name(space, off, size);
     if !name.is_empty() {
         // C++ reads the canonical register storage to know the base offset/size.
-        let point = arch
-            .translate()
+        let point = sleigh
             .base()
             .get_register(&name)
             .map_err(|e| e.explain().to_string())?;

--- a/decompiler/crates/kuna-decomp/src/substrate/mod.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/mod.rs
@@ -8,6 +8,7 @@ pub mod op;
 pub mod block;
 pub mod funcdata;
 pub mod funcdata_block;
+pub mod funcdata_encode;
 pub mod funcdata_op;
 pub mod funcdata_printraw;
 pub mod funcdata_varnode;

--- a/decompiler/crates/kuna-decomp/tests/corpus_bootstrap.rs
+++ b/decompiler/crates/kuna-decomp/tests/corpus_bootstrap.rs
@@ -531,7 +531,9 @@ fn ir_boundary_manager(src: &AddrSpaceManager) -> AddrSpaceManager {
 /// "reached the documented seam" check.  Proves the bootstrapped engine is wired
 /// into the flow engine end-to-end.
 fn real_flow_links_ops(bs: &Bootstrap, fd: Funcdata) -> bool {
-    let env = BootstrapEnv { sleigh: bs.arch.sleigh().base().unwrap().translate() };
+    let env = BootstrapEnv {
+        sleigh: bs.arch.sleigh().base().unwrap().translate().as_sleigh().expect("standalone Sleigh"),
+    };
     let mut flow = FlowInfo::new(fd, &env);
     let entry = flow.data.get_address().clone();
     let before = flow.data.obank().iter_dead().count();

--- a/decompiler/crates/kuna-decomp/tests/flow_linkage.rs
+++ b/decompiler/crates/kuna-decomp/tests/flow_linkage.rs
@@ -401,7 +401,9 @@ fn drive_real_flow_and_render(
     start_off: u64,
     max_insn: usize,
 ) -> Vec<String> {
-    let env = BootstrapEnv { sleigh: bs.arch.sleigh().base().unwrap().translate() };
+    let env = BootstrapEnv {
+        sleigh: bs.arch.sleigh().base().unwrap().translate().as_sleigh().expect("standalone Sleigh"),
+    };
     let engine_manager: *const AddrSpaceManager = bs.arch.sleigh().base().unwrap().manage();
     let fd = build_funcdata(bs, "entry", space_name, start_off);
     let mut flow = FlowInfo::new(fd, &env);

--- a/decompiler/crates/kuna-decomp/tests/funcdata_encode_e2e.rs
+++ b/decompiler/crates/kuna-decomp/tests/funcdata_encode_e2e.rs
@@ -39,6 +39,7 @@ use kuna_decomp::decompile_drive::decompile_func;
 use kuna_decomp::funcdata::Funcdata;
 use kuna_decomp::funcdata_encode::{ELEM_AST, ELEM_FUNCTION, ELEM_IOP, ELEM_VARNODES};
 use kuna_decomp::options::{register_option_elements, OptionDatabase};
+use kuna_decomp::prettyprint::ids::{ATTRIB_OPREF, ATTRIB_VARREF};
 use kuna_decomp::sleigh_arch::{register_sleigh_arch_ids, LanguageDatabase};
 use kuna_decomp::xml_arch::{XmlArchitecture, XmlArchitectureCapability};
 
@@ -473,4 +474,228 @@ fn corpus_functions_encode_and_roundtrip() {
     );
     assert!(agg.saw_bare_ref, "no bare <addr ref> observed across real functions");
     assert!(agg.saw_void, "no <void> slot observed across real functions");
+}
+
+// ===========================================================================
+// Step 5 GATE: the click-to-address contract — the clang `<function>` markup's
+// token refs resolve against the `<ast>`.
+//
+// This ties the step-4 encoder (`Funcdata::encode` -> `<ast>`) and the step-5
+// markup emitter (`PrintC::doc_function_markup` -> clang `<function>`) together
+// over the SAME decompiled `Funcdata`: every `opref`/`varref` a marked-up token
+// carries MUST appear as an `<op>`'s `<seqnum uniq>` / a `<varnodes>` `<addr ref>`
+// in the `<ast>` — because both sides read the exact same `get_time()` /
+// `get_create_index()` accessors, the tie holds by construction.
+// ===========================================================================
+
+/// Recursively walk a packed clang `<function>` document, collecting every
+/// `ATTRIB_OPREF` / `ATTRIB_VARREF` value (regardless of the element it hangs
+/// on).  Unmatched attributes are auto-skipped by `get_next_attribute_id`.
+fn walk_markup(
+    dec: &mut PackedDecode,
+    oprefs: &mut BTreeSet<u64>,
+    varrefs: &mut BTreeSet<u64>,
+) -> KunaResult<()> {
+    let id = dec.open_element()?;
+    loop {
+        let a = dec.get_next_attribute_id()?;
+        if a == 0 {
+            break;
+        }
+        if a == ATTRIB_OPREF.get_id() {
+            oprefs.insert(dec.read_unsigned_integer()?);
+        } else if a == ATTRIB_VARREF.get_id() {
+            varrefs.insert(dec.read_unsigned_integer()?);
+        }
+    }
+    loop {
+        let c = dec.peek_element()?;
+        if c == 0 {
+            break;
+        }
+        walk_markup(dec, oprefs, varrefs)?;
+    }
+    dec.close_element(id)?;
+    Ok(())
+}
+
+/// Structurally decode the clang `<function>` markup document and return its
+/// `(oprefs, varrefs)` sets.
+fn decode_markup_refs(
+    manage: &AddrSpaceManager,
+    bytes: &[u8],
+) -> KunaResult<(BTreeSet<u64>, BTreeSet<u64>)> {
+    let mut dec = PackedDecode::new(manage);
+    dec.ingest_stream(bytes)?;
+    // The markup root is the clang <function> (EmitMarkup::begin_function opens
+    // ELEM_FUNCTION, the same numeric id as the encoder's <function>).
+    let root = dec.peek_element()?;
+    assert_eq!(root, ELEM_FUNCTION.get_id(), "markup root is not <function>");
+    let mut oprefs = BTreeSet::new();
+    let mut varrefs = BTreeSet::new();
+    walk_markup(&mut dec, &mut oprefs, &mut varrefs)?;
+    Ok((oprefs, varrefs))
+}
+
+/// Drive `PrintC::doc_function_markup` over `fd` (moving the printer out of the
+/// architecture exactly as `decompile_drive::print_c` does) and decode the
+/// resulting clang `<function>` into its `(oprefs, varrefs)` sets.
+fn markup_refs_for(base: &mut Architecture, fd: &Funcdata) -> (BTreeSet<u64>, BTreeSet<u64>) {
+    let mut printer = base.take_print();
+    let bytes = printer.doc_function_markup(fd, base);
+    base.put_print(printer);
+    assert!(!bytes.is_empty(), "doc_function_markup produced no bytes");
+    decode_markup_refs(fd.get_arch().manage(), &bytes).expect("decode markup <function>")
+}
+
+#[test]
+fn corpus_functions_markup_refs_resolve_against_ast() {
+    let mut verified = 0usize;
+    let mut errors: Vec<String> = Vec::new();
+    let mut total_oprefs = 0usize;
+    let mut total_varrefs = 0usize;
+
+    for stem in FIXTURES {
+        let dt = match parse_datatest(stem) {
+            Ok(dt) => dt,
+            Err(e) => {
+                errors.push(format!("{stem} (parse): {e}"));
+                continue;
+            }
+        };
+        let registry = build_registry();
+        let mut xarch = match bootstrap(&dt) {
+            Ok(x) => x,
+            Err(e) => {
+                errors.push(format!("{stem} (bootstrap): {e}"));
+                continue;
+            }
+        };
+        if let Some(base) = xarch.sleigh_mut().base_mut() {
+            apply_options(base, &dt, &registry);
+        }
+
+        for sym in &dt.symbols {
+            let base = match xarch.sleigh_mut().base_mut() {
+                Some(b) => b,
+                None => continue,
+            };
+            let space = match base.manage().get_space_by_name(&sym.space) {
+                Some(s) => Rc::clone(s),
+                None => continue,
+            };
+            let entry = Address::new(space, sym.offset);
+            let fd = match decompile_func(base, &sym.name, entry, 0) {
+                Ok(fd) => fd,
+                Err(e) => {
+                    errors.push(format!("{stem}:{} decompile: {e}", sym.name));
+                    continue;
+                }
+            };
+
+            // (1)+(2) the <ast> ids (step 4) and the clang markup refs (step 5).
+            let ast_refs = expected_refs(&fd);
+            let ast_uniqs = expected_uniqs(&fd);
+            let (oprefs, varrefs) = markup_refs_for(base, &fd);
+
+            // (3)+(4) the click-to-address contract: every markup opref/varref
+            // resolves to an <ast> op time / varnode create index.  Because the
+            // markup and the <ast> read the SAME get_time()/get_create_index(),
+            // this is a subset relation that must hold exactly.
+            for o in &oprefs {
+                assert!(
+                    ast_uniqs.contains(o),
+                    "{stem}:{} markup opref {o} has no matching <ast> <op> <seqnum uniq>",
+                    sym.name
+                );
+            }
+            for v in &varrefs {
+                assert!(
+                    ast_refs.contains(v),
+                    "{stem}:{} markup varref {v} has no matching <ast> <varnodes> <addr ref>",
+                    sym.name
+                );
+            }
+            total_oprefs += oprefs.len();
+            total_varrefs += varrefs.len();
+            verified += 1;
+        }
+    }
+
+    eprintln!("=== markup-refs-resolve-against-ast report ===");
+    eprintln!(
+        "verified functions: {verified}, distinct oprefs {total_oprefs}, distinct varrefs {total_varrefs}"
+    );
+    for e in &errors {
+        eprintln!("  note: {e}");
+    }
+
+    // The gate's teeth: several real functions verify, and — crucially — the
+    // markup actually CARRIES refs (guards against a MarkupRef-still-none
+    // regression) that ALL resolve against the <ast> (asserted per function above).
+    assert!(
+        verified >= 3,
+        "expected >= 3 corpus functions to markup + resolve, got {verified} (notes: {errors:?})"
+    );
+    assert!(
+        total_oprefs > 0,
+        "no <opref> emitted across the corpus markup — MarkupRef still none()?"
+    );
+    assert!(
+        total_varrefs > 0,
+        "no <varref> emitted across the corpus markup — MarkupRef still none()?"
+    );
+}
+
+#[test]
+fn markup_emits_nonempty_refs() {
+    // A focused tripwire for the MarkupRef-still-none() regression: SOME real
+    // decompiled function's clang markup must carry BOTH a resolvable opref AND a
+    // varref.  (Not every function has named variable leaves — a purely boolean
+    // body may emit only oprefs — so scan the corpus for one fully-marked
+    // function rather than pinning a single fixture.)
+    let mut saw_op = false;
+    let mut saw_var = false;
+    let mut found_both = false;
+
+    'outer: for stem in FIXTURES {
+        let dt = match parse_datatest(stem) {
+            Ok(dt) => dt,
+            Err(_) => continue,
+        };
+        let registry = build_registry();
+        let mut xarch = match bootstrap(&dt) {
+            Ok(x) => x,
+            Err(_) => continue,
+        };
+        if let Some(base) = xarch.sleigh_mut().base_mut() {
+            apply_options(base, &dt, &registry);
+        }
+        for sym in &dt.symbols {
+            let base = match xarch.sleigh_mut().base_mut() {
+                Some(b) => b,
+                None => continue,
+            };
+            let space = match base.manage().get_space_by_name(&sym.space) {
+                Some(s) => Rc::clone(s),
+                None => continue,
+            };
+            let entry = Address::new(space, sym.offset);
+            let fd = match decompile_func(base, &sym.name, entry, 0) {
+                Ok(fd) => fd,
+                Err(_) => continue,
+            };
+            let (oprefs, varrefs) = markup_refs_for(base, &fd);
+            saw_op |= !oprefs.is_empty();
+            saw_var |= !varrefs.is_empty();
+            if !oprefs.is_empty() && !varrefs.is_empty() {
+                found_both = true;
+                break 'outer;
+            }
+        }
+    }
+
+    assert!(saw_op, "doc_function_markup emitted no <opref> — MarkupRef never populated");
+    assert!(saw_var, "doc_function_markup emitted no <varref> — MarkupRef never populated");
+    assert!(found_both, "no single function's markup carried both an opref and a varref");
 }

--- a/decompiler/crates/kuna-decomp/tests/funcdata_encode_e2e.rs
+++ b/decompiler/crates/kuna-decomp/tests/funcdata_encode_e2e.rs
@@ -1,0 +1,476 @@
+//! END-TO-END GATE for the `Funcdata::encode` port
+//! (`crates/kuna-decomp/src/substrate/funcdata_encode.rs`).
+//!
+//! Decompiles real corpus functions (reusing the `decompile_e2e.rs` bootstrap
+//! mechanics), encodes each resulting [`Funcdata`] as the `<function>`/`<ast>`
+//! document, round-trips the bytes back through kuna's `PackedDecode`, and
+//! asserts:
+//!
+//!   * the header (`<function name size>`) round-trips,
+//!   * the `<ast>` has `<varnodes>` + `<block>`(s), each `<op>` a `<seqnum uniq>`
+//!     and a `code`, and
+//!   * the **load-bearing invariant**: every `<addr ref>` under `<varnodes>`
+//!     equals a live Varnode's `get_create_index()`, and every `<op>`'s
+//!     `<seqnum uniq>` equals that op's `get_time()` — the same accessors the
+//!     markup `EmitMarkup` path reads, so the `<ast>` ref-ids match the markup
+//!     ref-ids by construction.
+//!
+//! Like `decompile_e2e.rs`, this needs the built `.sla` artifacts (`make specs`);
+//! a fixture whose bootstrap/decompile fails is reported (not silently skipped),
+//! and the gate requires at least a few functions to validate.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use kuna_base::address::{Address, ELEM_ADDR, ATTRIB_UNIQ, ELEM_RANGELIST, ELEM_SEQNUM};
+use kuna_base::error::{KunaError, KunaResult};
+use kuna_base::marshal::{
+    Decoder, IdRegistry, PackedDecode, PackedEncode, ATTRIB_NAME, ATTRIB_REF, ATTRIB_SIZE,
+    ELEM_VOID,
+};
+use kuna_base::space::{spacetype, AddrSpaceManager};
+use kuna_base::types::int4;
+use kuna_base::xml::{DocumentStorage, Element};
+
+use kuna_decomp::architecture::Architecture;
+use kuna_decomp::block::ELEM_BLOCK;
+use kuna_decomp::decompile_drive::decompile_func;
+use kuna_decomp::funcdata::Funcdata;
+use kuna_decomp::funcdata_encode::{ELEM_AST, ELEM_FUNCTION, ELEM_IOP, ELEM_VARNODES};
+use kuna_decomp::options::{register_option_elements, OptionDatabase};
+use kuna_decomp::sleigh_arch::{register_sleigh_arch_ids, LanguageDatabase};
+use kuna_decomp::xml_arch::{XmlArchitecture, XmlArchitectureCapability};
+
+use kuna_num::pcoderaw::{ATTRIB_CODE, ELEM_SPACEID};
+use kuna_sleigh::loadimage::LoadImage;
+use kuna_sleigh::loadimage_xml::register_loadimage_xml_ids;
+use kuna_sleigh::translate::{register_translate_ids, ELEM_OP};
+
+// ===========================================================================
+// Fixture selection (same as decompile_e2e.rs).
+// ===========================================================================
+
+const FIXTURES: &[&str] = &["boolless", "ccmp", "gp", "lzcount", "condexesub"];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+// ===========================================================================
+// Datatest XML parsing (copied from decompile_e2e.rs).
+// ===========================================================================
+
+struct SymbolFn {
+    name: String,
+    space: String,
+    offset: u64,
+}
+
+struct DataTest {
+    binaryimage: Rc<Element>,
+    arch_id: String,
+    symbols: Vec<SymbolFn>,
+    options: Vec<(String, String, String, String)>,
+}
+
+fn parse_u64(s: &str) -> u64 {
+    let s = s.trim();
+    if let Some(hex) = s.strip_prefix("0x") {
+        u64::from_str_radix(hex, 16).unwrap_or(0)
+    } else {
+        s.parse().unwrap_or(0)
+    }
+}
+
+fn find_named(el: &Rc<Element>, name: &str, out: &mut Vec<Rc<Element>>) {
+    if el.get_name() == name {
+        out.push(Rc::clone(el));
+    }
+    for c in el.get_children() {
+        find_named(c, name, out);
+    }
+}
+
+fn attr(el: &Element, name: &str) -> Option<String> {
+    el.get_attribute_value(name).ok().map(|b| String::from_utf8_lossy(b).into_owned())
+}
+
+fn parse_option_com(text: &str) -> Option<(String, String, String, String)> {
+    let mut it = text.split_whitespace();
+    if it.next()? != "option" {
+        return None;
+    }
+    let name = it.next()?.to_string();
+    let p1 = it.next().unwrap_or("").to_string();
+    let p2 = it.next().unwrap_or("").to_string();
+    let p3 = it.next().unwrap_or("").to_string();
+    Some((name, p1, p2, p3))
+}
+
+fn parse_datatest(stem: &str) -> Result<DataTest, String> {
+    let path = repo_root().join("tests/datatests").join(format!("{stem}.xml"));
+    let xml = std::fs::read(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let mut store = DocumentStorage::new();
+    let root = store
+        .parse_document(&xml)
+        .map_err(|e| format!("parse {stem}: {e}"))?
+        .get_root()
+        .clone();
+
+    let mut bis = Vec::new();
+    find_named(&root, "binaryimage", &mut bis);
+    let binaryimage = bis.into_iter().next().ok_or("no <binaryimage>")?;
+    let arch_id = attr(&binaryimage, "arch").ok_or("<binaryimage> has no arch")?;
+
+    let mut syms = Vec::new();
+    find_named(&binaryimage, "symbol", &mut syms);
+    let symbols: Vec<SymbolFn> = syms
+        .iter()
+        .filter_map(|s| {
+            Some(SymbolFn {
+                name: attr(s, "name")?,
+                space: attr(s, "space")?,
+                offset: parse_u64(&attr(s, "offset")?),
+            })
+        })
+        .collect();
+
+    let mut coms = Vec::new();
+    find_named(&root, "com", &mut coms);
+    let options: Vec<_> = coms
+        .iter()
+        .filter_map(|c| parse_option_com(&String::from_utf8_lossy(c.get_content())))
+        .collect();
+
+    Ok(DataTest { binaryimage, arch_id, symbols, options })
+}
+
+// ===========================================================================
+// Bootstrap a full Architecture (copied from decompile_e2e.rs).
+// ===========================================================================
+
+struct DummyImg;
+impl LoadImage for DummyImg {
+    fn get_file_name(&self) -> &str {
+        "dummy"
+    }
+    fn load_fill(&mut self, _ptr: &mut [u8], _addr: &Address) -> KunaResult<()> {
+        Err(KunaError::data_unavail("dummy"))
+    }
+    fn get_arch_type(&self) -> Vec<u8> {
+        Vec::new()
+    }
+    fn adjust_vma(&mut self, _adjust: i64) {}
+}
+
+fn build_registry() -> IdRegistry {
+    let mut registry = IdRegistry::with_base_ids();
+    register_translate_ids(&mut registry);
+    register_sleigh_arch_ids(&mut registry);
+    register_loadimage_xml_ids(&mut registry);
+    register_option_elements(&mut registry);
+    registry
+}
+
+fn bootstrap(dt: &DataTest) -> Result<XmlArchitecture, String> {
+    let root = repo_root();
+    let registry = build_registry();
+
+    let capability = XmlArchitectureCapability::new();
+    let mut arch = capability.build_architecture("datatest", "");
+
+    arch.build_loader(Rc::clone(&dt.binaryimage)).map_err(|e| format!("build_loader: {e}"))?;
+
+    let mut db = LanguageDatabase::new();
+    db.scan_for_sleigh_directories(root.join("specs").to_str().unwrap());
+    db.get_descriptions(&registry).map_err(|e| format!("collect ldefs: {e}"))?;
+
+    arch.sleigh_mut().set_archid(&dt.arch_id);
+    arch.sleigh_mut()
+        .resolve_architecture(&db, &dt.arch_id)
+        .map_err(|e| format!("resolve_architecture: {e}"))?;
+    if arch.sleigh().language_index() < 0 {
+        return Err("language index unresolved".to_string());
+    }
+
+    let specs = arch.sleigh().build_spec_file(&db).map_err(|e| format!("build_spec_file: {e}"))?;
+    let resolved_sla = specs.slafile.ok_or("build_spec_file resolved no .sla")?;
+    let sla = std::fs::read(&resolved_sla).map_err(|e| format!("read sla: {e}"))?;
+    arch.sleigh_mut()
+        .build_translator(Box::new(DummyImg), &sla)
+        .map_err(|e| format!("build_translator: {e}"))?;
+
+    arch.sleigh_mut()
+        .base_mut()
+        .ok_or("no Architecture base after build_translator")?
+        .init_post_engine()
+        .map_err(|e| format!("init_post_engine: {e}"))?;
+
+    let manager_ptr: *const AddrSpaceManager = arch.sleigh().base().unwrap().manage();
+    // SAFETY: the manager lives inside `arch` and outlives the open() call; the
+    // borrow is released before any &mut use of `arch` (same shape as
+    // decompile_e2e.rs).
+    arch.open_image(unsafe { &*manager_ptr }, &registry)
+        .map_err(|e| format!("open_image: {e}"))?;
+    let img = arch.take_loader().ok_or("loader vanished after open")?;
+    arch.sleigh_mut().base_mut().unwrap().set_loader(Box::new(img));
+
+    Ok(arch)
+}
+
+fn apply_options(arch: &mut Architecture, dt: &DataTest, registry: &IdRegistry) {
+    let options = OptionDatabase::new();
+    for (name, p1, p2, p3) in &dt.options {
+        let id = registry.find_element(name, 0);
+        if id == 0 {
+            continue;
+        }
+        let _ = options.set(arch, id, p1, p2, p3);
+    }
+}
+
+// ===========================================================================
+// Round-trip structural decode of a <function> document.
+// ===========================================================================
+
+#[derive(Default)]
+struct Observed {
+    name: Vec<u8>,
+    size: i64,
+    varnode_refs: BTreeSet<u64>,
+    op_uniqs: BTreeSet<u64>,
+    saw_iop: bool,
+    saw_spaceid: bool,
+    saw_void: bool,
+    saw_bare_ref: bool,
+    block_count: usize,
+    op_count: usize,
+}
+
+fn decode_function(manage: &AddrSpaceManager, bytes: &[u8]) -> KunaResult<Observed> {
+    let mut obs = Observed::default();
+    let mut dec = PackedDecode::new(manage);
+    dec.ingest_stream(bytes)?;
+
+    let fid = dec.open_element()?;
+    assert_eq!(fid, ELEM_FUNCTION.get_id(), "root is not <function>");
+    obs.name = dec.read_string_id(&ATTRIB_NAME)?;
+    obs.size = dec.read_signed_integer_id(&ATTRIB_SIZE)?;
+
+    loop {
+        let c = dec.peek_element()?;
+        if c == 0 {
+            break;
+        }
+        if c == ELEM_AST.get_id() {
+            let ast = dec.open_element()?;
+            decode_ast(&mut dec, &mut obs)?;
+            dec.close_element(ast)?;
+        } else {
+            dec.skip_element()?; // baseaddr <addr>, or anything unexpected.
+        }
+    }
+    dec.close_element(fid)?;
+    Ok(obs)
+}
+
+fn decode_ast(dec: &mut PackedDecode, obs: &mut Observed) -> KunaResult<()> {
+    loop {
+        let c = dec.peek_element()?;
+        if c == 0 {
+            break;
+        }
+        if c == ELEM_VARNODES.get_id() {
+            let vid = dec.open_element()?;
+            loop {
+                let a = dec.peek_element()?;
+                if a == 0 {
+                    break;
+                }
+                assert_eq!(a, ELEM_ADDR.get_id(), "<varnodes> child is not <addr>");
+                let aid = dec.open_element()?;
+                obs.varnode_refs.insert(dec.read_unsigned_integer_id(&ATTRIB_REF)?);
+                dec.close_element(aid)?;
+            }
+            dec.close_element(vid)?;
+        } else if c == ELEM_BLOCK.get_id() {
+            obs.block_count += 1;
+            let bid = dec.open_element()?;
+            decode_block(dec, obs)?;
+            dec.close_element(bid)?;
+        } else {
+            // <blockedge> (or any later-phase element): skip the subtree.
+            dec.skip_element()?;
+        }
+    }
+    Ok(())
+}
+
+fn decode_block(dec: &mut PackedDecode, obs: &mut Observed) -> KunaResult<()> {
+    loop {
+        let c = dec.peek_element()?;
+        if c == 0 {
+            break;
+        }
+        if c == ELEM_OP.get_id() {
+            obs.op_count += 1;
+            let oid = dec.open_element()?;
+            let _code = dec.read_signed_integer_id(&ATTRIB_CODE)?;
+            let mut first = true;
+            loop {
+                let oc = dec.peek_element()?;
+                if oc == 0 {
+                    break;
+                }
+                if first {
+                    assert_eq!(oc, ELEM_SEQNUM.get_id(), "first <op> child is not <seqnum>");
+                    let sid = dec.open_element()?;
+                    obs.op_uniqs.insert(dec.read_unsigned_integer_id(&ATTRIB_UNIQ)?);
+                    dec.close_element(sid)?;
+                    first = false;
+                } else {
+                    if oc == ELEM_IOP.get_id() {
+                        obs.saw_iop = true;
+                    } else if oc == ELEM_SPACEID.get_id() {
+                        obs.saw_spaceid = true;
+                    } else if oc == ELEM_VOID.get_id() {
+                        obs.saw_void = true;
+                    } else if oc == ELEM_ADDR.get_id() {
+                        obs.saw_bare_ref = true;
+                    }
+                    dec.skip_element()?;
+                }
+            }
+            dec.close_element(oid)?;
+        } else {
+            assert_eq!(c, ELEM_RANGELIST.get_id(), "unexpected <block> child");
+            dec.skip_element()?;
+        }
+    }
+    Ok(())
+}
+
+// ===========================================================================
+// The live-Funcdata expectations for the invariant cross-check.
+// ===========================================================================
+
+fn expected_refs(fd: &Funcdata) -> BTreeSet<u64> {
+    fd.vbank()
+        .iter_loc()
+        .filter(|&vn| fd.vbank().get(vn).unwrap().get_space().get_type() != spacetype::IPTR_IOP)
+        .map(|vn| fd.vbank().get(vn).unwrap().get_create_index() as u64)
+        .collect()
+}
+
+fn expected_uniqs(fd: &Funcdata) -> BTreeSet<u64> {
+    let mut out = BTreeSet::new();
+    let n: int4 = fd.bblocks_get_size();
+    for i in 0..n {
+        let bl = fd.bblocks_get_block(i);
+        for op in fd.bb_ops(bl) {
+            out.insert(fd.obank().get(op).unwrap().get_time() as u64);
+        }
+    }
+    out
+}
+
+/// Encode `fd`, round-trip, and assert the structure + the load-bearing
+/// invariant.  Returns the `Observed` for the aggregate coverage report.
+fn encode_and_verify(fd: &Funcdata) -> Observed {
+    let mut bytes: Vec<u8> = Vec::new();
+    {
+        let mut enc = PackedEncode::new(&mut bytes);
+        fd.encode(&mut enc, 1, true).expect("encode");
+    }
+    assert!(!bytes.is_empty(), "encode produced no bytes");
+
+    let obs = decode_function(fd.get_arch().manage(), &bytes).expect("decode round-trip");
+
+    assert_eq!(obs.name, fd.get_name().as_bytes(), "<function name> mismatch");
+    assert_eq!(obs.size, fd.get_size() as i64, "<function size> mismatch");
+    assert!(obs.block_count >= 1, "no <block> encoded");
+    assert!(obs.op_count >= 1, "no <op> encoded");
+
+    // The load-bearing invariant.
+    assert_eq!(obs.varnode_refs, expected_refs(fd), "<varnodes> refs != create indices");
+    assert_eq!(obs.op_uniqs, expected_uniqs(fd), "<op> uniqs != op times");
+
+    obs
+}
+
+// ===========================================================================
+// The gate.
+// ===========================================================================
+
+#[test]
+fn corpus_functions_encode_and_roundtrip() {
+    let mut verified = 0usize;
+    let mut errors: Vec<String> = Vec::new();
+    let mut agg = Observed::default();
+
+    for stem in FIXTURES {
+        let dt = match parse_datatest(stem) {
+            Ok(dt) => dt,
+            Err(e) => {
+                errors.push(format!("{stem} (parse): {e}"));
+                continue;
+            }
+        };
+        let registry = build_registry();
+        let mut xarch = match bootstrap(&dt) {
+            Ok(x) => x,
+            Err(e) => {
+                errors.push(format!("{stem} (bootstrap): {e}"));
+                continue;
+            }
+        };
+        if let Some(base) = xarch.sleigh_mut().base_mut() {
+            apply_options(base, &dt, &registry);
+        }
+
+        for sym in &dt.symbols {
+            let base = match xarch.sleigh_mut().base_mut() {
+                Some(b) => b,
+                None => continue,
+            };
+            let space = match base.manage().get_space_by_name(&sym.space) {
+                Some(s) => Rc::clone(s),
+                None => continue,
+            };
+            let entry = Address::new(space, sym.offset);
+            match decompile_func(base, &sym.name, entry, 0) {
+                Ok(fd) => {
+                    let obs = encode_and_verify(&fd);
+                    verified += 1;
+                    agg.saw_iop |= obs.saw_iop;
+                    agg.saw_spaceid |= obs.saw_spaceid;
+                    agg.saw_void |= obs.saw_void;
+                    agg.saw_bare_ref |= obs.saw_bare_ref;
+                }
+                Err(e) => errors.push(format!("{stem}:{} decompile: {e}", sym.name)),
+            }
+        }
+    }
+
+    eprintln!("=== funcdata_encode_e2e report ===");
+    eprintln!("verified functions: {verified}");
+    eprintln!(
+        "aggregate branch coverage: bare_ref={} void={} spaceid={} iop={}",
+        agg.saw_bare_ref, agg.saw_void, agg.saw_spaceid, agg.saw_iop
+    );
+    for e in &errors {
+        eprintln!("  note: {e}");
+    }
+
+    // The gate's teeth: several real functions must encode + round-trip with the
+    // invariant intact, and the always-present branches (bare ref + void) must
+    // appear across real code.  (The <iop>/<spaceid> branches are guaranteed by
+    // the synthetic unit test; they are only reported here.)
+    assert!(
+        verified >= 3,
+        "expected >= 3 corpus functions to encode + round-trip, got {verified} (notes: {errors:?})"
+    );
+    assert!(agg.saw_bare_ref, "no bare <addr ref> observed across real functions");
+    assert!(agg.saw_void, "no <void> slot observed across real functions");
+}

--- a/decompiler/crates/kuna-decomp/tests/print_b5_boolless.rs
+++ b/decompiler/crates/kuna-decomp/tests/print_b5_boolless.rs
@@ -159,7 +159,7 @@ fn bootstrap(dt: &DataTest) -> Result<XmlArchitecture, String> {
         .base_mut()
         .ok_or("no Architecture base after build_translator")?
         .translate_mut()
-        .install_register_lookup()
+        .as_sleigh_mut().expect("standalone Sleigh engine").install_register_lookup()
         .map_err(|e| format!("install_register_lookup: {e}"))?;
     // Hand the resolved cspec XML to the architecture so build_default_proto
     // decodes the real <default_proto> input/output param lists (proto recovery).

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_baseexplicit_piece_verifier.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_baseexplicit_piece_verifier.rs
@@ -109,7 +109,7 @@ fn bootstrap(dt: &DataTest) -> Result<XmlArchitecture, String> {
     arch.sleigh_mut().build_translator(Box::new(DummyImg), &sla).map_err(|e| format!("build_translator: {e}"))?;
     if !specs.compilerfile.is_empty() { if let Ok(cspec) = std::fs::read(&specs.compilerfile) { arch.sleigh_mut().base_mut().unwrap().set_cspec_xml(cspec); } }
     if !specs.processorfile.is_empty() { if let Ok(pspec) = std::fs::read(&specs.processorfile) { arch.sleigh_mut().base_mut().unwrap().set_pspec_xml(pspec); } }
-    arch.sleigh_mut().base_mut().unwrap().translate_mut().install_register_lookup().map_err(|e| format!("install_register_lookup: {e}"))?;
+    arch.sleigh_mut().base_mut().unwrap().translate_mut().as_sleigh_mut().expect("standalone Sleigh engine").install_register_lookup().map_err(|e| format!("install_register_lookup: {e}"))?;
     arch.sleigh_mut().base_mut().ok_or("no Architecture base after build_translator")?.init_post_engine().map_err(|e| format!("init_post_engine: {e}"))?;
     let manager_ptr: *const AddrSpaceManager = arch.sleigh().base().unwrap().manage();
     // SAFETY: the manager outlives the open() call; borrow released before &mut use.

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_callsite_args_adversarial.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_callsite_args_adversarial.rs
@@ -229,7 +229,7 @@ fn bootstrap(dt: &DataTest) -> Result<XmlArchitecture, String> {
         .base_mut()
         .unwrap()
         .translate_mut()
-        .install_register_lookup()
+        .as_sleigh_mut().expect("standalone Sleigh engine").install_register_lookup()
         .map_err(|e| format!("install_register_lookup: {e}"))?;
 
     arch.sleigh_mut()

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_divmod_corpus.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_divmod_corpus.rs
@@ -187,7 +187,7 @@ fn bootstrap(dt: &DataTest) -> Result<XmlArchitecture, String> {
         .base_mut()
         .unwrap()
         .translate_mut()
-        .install_register_lookup()
+        .as_sleigh_mut().expect("standalone Sleigh engine").install_register_lookup()
         .map_err(|e| format!("install_register_lookup: {e}"))?;
 
     arch.sleigh_mut()

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_implied_vars_adversarial.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_implied_vars_adversarial.rs
@@ -191,7 +191,7 @@ fn bootstrap(dt: &DataTest) -> Result<XmlArchitecture, String> {
         .base_mut()
         .unwrap()
         .translate_mut()
-        .install_register_lookup()
+        .as_sleigh_mut().expect("standalone Sleigh engine").install_register_lookup()
         .map_err(|e| format!("install_register_lookup: {e}"))?;
     arch.sleigh_mut()
         .base_mut()

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_jts_chain.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_jts_chain.rs
@@ -194,7 +194,7 @@ fn bootstrap(dt: &DataTest) -> Result<XmlArchitecture, String> {
         .base_mut()
         .unwrap()
         .translate_mut()
-        .install_register_lookup()
+        .as_sleigh_mut().expect("standalone Sleigh engine").install_register_lookup()
         .map_err(|e| format!("install_register_lookup: {e}"))?;
 
     arch.sleigh_mut()

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_merge_casts.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_merge_casts.rs
@@ -344,7 +344,7 @@ mod harness {
             .base_mut()
             .ok_or("no Architecture base after build_translator")?
             .translate_mut()
-            .install_register_lookup()
+            .as_sleigh_mut().expect("standalone Sleigh engine").install_register_lookup()
             .map_err(|e| format!("install_register_lookup: {e}"))?;
         if !specs.compilerfile.is_empty() {
             if let Ok(cspec) = std::fs::read(&specs.compilerfile) {

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_merge_facing.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_merge_facing.rs
@@ -183,7 +183,7 @@ fn bootstrap(dt: &DataTest) -> Result<XmlArchitecture, String> {
         .base_mut()
         .unwrap()
         .translate_mut()
-        .install_register_lookup()
+        .as_sleigh_mut().expect("standalone Sleigh engine").install_register_lookup()
         .map_err(|e| format!("install_register_lookup: {e}"))?;
 
     arch.sleigh_mut()

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_mips_callother.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_mips_callother.rs
@@ -164,7 +164,7 @@ fn bootstrap(dt: &DataTest) -> Result<XmlArchitecture, String> {
         .base_mut()
         .ok_or("no Architecture base after build_translator")?
         .translate_mut()
-        .install_register_lookup()
+        .as_sleigh_mut().expect("standalone Sleigh engine").install_register_lookup()
         .map_err(|e| format!("install_register_lookup: {e}"))?;
     if !specs.compilerfile.is_empty() {
         if let Ok(cspec) = std::fs::read(&specs.compilerfile) {

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_struct_corpus.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_struct_corpus.rs
@@ -229,7 +229,7 @@ fn bootstrap(dt: &DataTest) -> Result<XmlArchitecture, String> {
         .base_mut()
         .unwrap()
         .translate_mut()
-        .install_register_lookup()
+        .as_sleigh_mut().expect("standalone Sleigh engine").install_register_lookup()
         .map_err(|e| format!("install_register_lookup: {e}"))?;
 
     arch.sleigh_mut()

--- a/decompiler/crates/kuna-ghidra/Cargo.toml
+++ b/decompiler/crates/kuna-ghidra/Cargo.toml
@@ -17,10 +17,18 @@ publish.workspace = true
 
 [dependencies]
 kuna-base.workspace = true
+# VarnodeData / opcodes (the packed <op> decode + the register-storage triple
+# GhidraTranslate hands back through EngineTranslate::get_register_varnode).
+kuna-num.workspace = true
 # The tspec <sleigh> element decode (ELEM_SLEIGH / ATTRIB_UNIQBASE /
-# TruncationTag / register_translate_ids) — the GhidraTranslate::initialize
-# subset of translate.cc lives in kuna-sleigh.
+# TruncationTag / register_translate_ids), the Translate / RegisterLookup /
+# PcodeEmit traits and TranslateBase, the ContextDatabase, and LoadImage — the
+# GhidraTranslate live-translator surface lives in kuna-sleigh.
 kuna-sleigh.workspace = true
+# The Architecture<->translator seam (the EngineTranslate trait GhidraTranslate
+# implements).  kuna-decomp does NOT depend on kuna-ghidra, so this is not a
+# cycle: the ghidra translator is the downstream implementor of the trait.
+kuna-decomp.workspace = true
 
 [lints]
 workspace = true

--- a/decompiler/crates/kuna-ghidra/src/client.rs
+++ b/decompiler/crates/kuna-ghidra/src/client.rs
@@ -105,6 +105,28 @@ impl<R: Read, W: Write> GhidraClient<R, W> {
         (self.sin, self.sout)
     }
 
+    /// Mutably borrow the input stream (C++ `sin`) for the command loop's own
+    /// framing reads.
+    ///
+    /// The loop and the engine's providers share one `GhidraClient` (a
+    /// [`SharedClient`](crate::provider::SharedClient)): the loop frames command
+    /// responses through these accessors, and mid-decompile the engine's
+    /// providers issue callback queries through the typed query methods — on the
+    /// *same* streams.  The borrow handed out here must be short-lived (framing
+    /// one read/write, then dropped) so it never overlaps a provider's query
+    /// borrow; the protocol is synchronous, so those borrows never actually
+    /// overlap.  See [`crate::process`] for the no-borrow-across-`raw_action`
+    /// invariant that makes this sound.
+    pub fn sin_mut(&mut self) -> &mut R {
+        &mut self.sin
+    }
+
+    /// Mutably borrow the output stream (C++ `sout`) for the command loop's own
+    /// framing writes.  See [`sin_mut`](GhidraClient::sin_mut).
+    pub fn sout_mut(&mut self) -> &mut W {
+        &mut self.sout
+    }
+
     /// The shared request framing: query open, string stream holding the
     /// packed command document, string close, query close, flush.
     fn send_query_document(&mut self, packed: &[u8]) -> WireResult<()> {

--- a/decompiler/crates/kuna-ghidra/src/ids.rs
+++ b/decompiler/crates/kuna-ghidra/src/ids.rs
@@ -29,6 +29,20 @@ use kuna_base::marshal::{AttributeId, ElementId, IdRegistry};
 pub const ELEM_DOC: ElementId = ElementId::new("doc", 229);
 
 // ---------------------------------------------------------------------------
+// op.cc — the p-code emit vocabulary GhidraTranslate::oneInstruction needs
+// ---------------------------------------------------------------------------
+
+/// Marshaling element \<unimpl> — the getPcode response for an instruction
+/// the host cannot translate (C++ `ELEM_UNIMPL`, `decompiler/cpp/op.cc:22`).
+///
+/// kuna's `ELEM_INST` (id 98) / `ELEM_OP` (id 27) live in kuna-decomp /
+/// kuna-sleigh; only `ELEM_UNIMPL` is missing, and `GhidraTranslate` compares
+/// it by numeric id alone (the packed decoder returns raw ids from
+/// `open_element`), so it is defined here rather than pulled from another
+/// crate.  Numeric id must match upstream for wire compatibility.
+pub const ELEM_UNIMPL: ElementId = ElementId::new("unimpl", 114);
+
+// ---------------------------------------------------------------------------
 // ghidra_arch.cc:30-48 — the query command elements (239-257)
 // ---------------------------------------------------------------------------
 
@@ -157,6 +171,7 @@ mod tests {
     #[test]
     fn test_protocol_id_numbers_match_upstream() {
         assert_eq!(ELEM_DOC.get_id(), 229);
+        assert_eq!(ELEM_UNIMPL.get_id(), 114);
         assert_eq!(ELEM_COMMAND_ISNAMEUSED.get_id(), 239);
         assert_eq!(ELEM_COMMAND_GETBYTES.get_id(), 240);
         assert_eq!(ELEM_COMMAND_GETCALLFIXUP.get_id(), 241);

--- a/decompiler/crates/kuna-ghidra/src/lib.rs
+++ b/decompiler/crates/kuna-ghidra/src/lib.rs
@@ -49,4 +49,5 @@ pub mod client;
 pub mod ids;
 pub mod process;
 pub mod protocol;
+pub mod provider;
 pub mod translate;

--- a/decompiler/crates/kuna-ghidra/src/process.rs
+++ b/decompiler/crates/kuna-ghidra/src/process.rs
@@ -51,7 +51,7 @@ use crate::protocol::{
     BURST_COMMAND_OPEN, BURST_MESSAGE_CLOSE, BURST_MESSAGE_OPEN, BURST_RESPONSE_CLOSE,
     BURST_RESPONSE_OPEN, BURST_STRING_CLOSE, BURST_STRING_OPEN,
 };
-use crate::translate::{build_registry, GhidraTranslate};
+use crate::translate::{build_registry, TspecModel};
 
 /// One registered program: the kuna analog of an `ArchitectureGhidra` slot
 /// in the global `archlist` (ghidra_process.cc:76,176-201).
@@ -78,7 +78,11 @@ struct Session {
     /// tspec failed to parse (recorded as a warning; \<addr> params are
     /// then consumed without decoding — TODO(phase-2): a parse failure
     /// should fail registerProgram once the engine init is real).
-    translate: Option<GhidraTranslate>,
+    ///
+    /// The command loop needs only the client-free tspec model
+    /// ([`TspecModel`]); the live query-backed `GhidraTranslate<R,W>` is
+    /// built later (phase 3, when the engine bridge shares the streams).
+    translate: Option<TspecModel>,
     /// Accumulated warnings, shipped on the 16/17 channel by sendResult
     /// (C++ `ArchitectureGhidra::warnings`; `printMessage` appends
     /// `'\n' + message`, ghidra_arch.cc:898-902).
@@ -103,7 +107,7 @@ impl Session {
     fn new(pspec: Vec<u8>, cspec: Vec<u8>, tspec: Vec<u8>, corespec: Vec<u8>) -> Session {
         let registry = build_registry();
         let mut warnings = String::new();
-        let translate = match GhidraTranslate::decode(&tspec, &registry) {
+        let translate = match TspecModel::decode(&tspec, &registry) {
             Ok(t) => Some(t),
             Err(e) => {
                 // printMessage semantics: '\n' + message

--- a/decompiler/crates/kuna-ghidra/src/process.rs
+++ b/decompiler/crates/kuna-ghidra/src/process.rs
@@ -28,61 +28,55 @@
 //! issues are nested inside the open command response (the phase-2 engine
 //! bridge relies on this).
 //!
-//! Phase-1 scope (see `docs/ghidra-integration.md`): the protocol side of
-//! all seven decomp commands is complete; `decompileAt` answers with the
-//! incomplete-function shape (an EMPTY 14/15 payload,
-//! ghidra_process.cc:313-334) plus a not-implemented warning, and
-//! `flushNative` has no engine caches to clear yet.  `structureGraph` and
-//! the four signature commands are deliberately NOT registered: the
-//! unknown-command response `{6}{16}"Bad command: <name>"{17}{7}`
-//! (ghidra_process.cc:476-484) is the exact graceful-degradation shape the
-//! Java side expects (DecompInterface.java:341-347).
+//! Phase-2 step 3 (see `docs/rust-port/ghidra-phase2-plan.md`): registerProgram
+//! now builds a *live* [`Architecture`] over the query-backed
+//! [`GhidraTranslate`] — its `init_post_engine` issues the getUserOpName probe
+//! loop as a real query nested in the registerProgram response.  `decompileAt`
+//! still answers the incomplete-function shape (an EMPTY 14/15 payload,
+//! ghidra_process.cc:313-334) plus a not-implemented warning — driving the
+//! engine from `decompileAt` is the next step.  `flushNative` has no engine
+//! caches to clear yet.  `structureGraph` and the four signature commands are
+//! deliberately NOT registered: the unknown-command response
+//! `{6}{16}"Bad command: <name>"{17}{7}` (ghidra_process.cc:476-484) is the
+//! exact graceful-degradation shape the Java side expects
+//! (DecompInterface.java:341-347).
 
+use std::cell::RefCell;
 use std::io::{Read, Write};
+use std::rc::Rc;
 
 use kuna_base::address::Address;
-use kuna_base::error::KunaError;
-use kuna_base::marshal::{Decoder, IdRegistry, PackedDecode};
+use kuna_base::error::{KunaError, KunaResult};
+use kuna_base::marshal::{Decoder, PackedDecode};
 use kuna_base::space::AddrSpaceManager;
 
+use kuna_decomp::architecture::Architecture;
+
+use crate::client::GhidraClient;
 use crate::protocol::{
     pass_java_exception, read_string_stream, read_string_stream_optional, read_to_any_burst,
     write_burst, write_string_stream, WireError, WireResult, BURST_COMMAND_CLOSE,
     BURST_COMMAND_OPEN, BURST_MESSAGE_CLOSE, BURST_MESSAGE_OPEN, BURST_RESPONSE_CLOSE,
     BURST_RESPONSE_OPEN, BURST_STRING_CLOSE, BURST_STRING_OPEN,
 };
-use crate::translate::{build_registry, TspecModel};
+use crate::provider::SharedClient;
+use crate::translate::{build_registry, GhidraTranslate};
 
 /// One registered program: the kuna analog of an `ArchitectureGhidra` slot
 /// in the global `archlist` (ghidra_process.cc:76,176-201).
 ///
-/// Phase 1 holds the wire-session state only; the engine (`Architecture`
-/// init over the four specs, the query-backed providers) is phase 2.
+/// Phase-2 step 3 makes this a *live engine*: registerProgram builds a real
+/// [`Architecture`] over the query-backed [`GhidraTranslate`] (the four wire
+/// specs → `from_engine_translate` + the console frontend's cspec/pspec →
+/// `init_post_engine` tail).  Its space manager decodes wire \<addr> elements
+/// and its subsystems are exercised by `decompileAt` (the next step).
 struct Session {
-    /// The four registerProgram XML documents, held verbatim for the
-    /// phase-2 engine bridge (C++ parses them in buildSpecFile and clears
-    /// them; kuna keeps them so phase 2 can replay them into the engine).
-    #[allow(dead_code)]
-    pspec: Vec<u8>,
-    #[allow(dead_code)]
-    cspec: Vec<u8>,
-    #[allow(dead_code)]
-    tspec: Vec<u8>,
-    #[allow(dead_code)]
-    corespec: Vec<u8>,
-    /// The session's marshaling id tables (the C++ static registration).
-    #[allow(dead_code)]
-    registry: IdRegistry,
-    /// The parsed tspec — endianness, unique base, and the address-space
-    /// manager whose indices decode wire \<addr> elements.  `None` when the
-    /// tspec failed to parse (recorded as a warning; \<addr> params are
-    /// then consumed without decoding — TODO(phase-2): a parse failure
-    /// should fail registerProgram once the engine init is real).
-    ///
-    /// The command loop needs only the client-free tspec model
-    /// ([`TspecModel`]); the live query-backed `GhidraTranslate<R,W>` is
-    /// built later (phase 3, when the engine bridge shares the streams).
-    translate: Option<TspecModel>,
+    /// The live decompiler engine built from the four registerProgram specs
+    /// (C++ `ArchitectureGhidra`, the `archlist` slot's `Architecture`).
+    /// `None` when engine construction failed — the failure is recorded on
+    /// `warnings` (shipped on the 16/17 frame) so Java detects the
+    /// registration failure (DecompInterface.java:291-294).
+    architecture: Option<Architecture>,
     /// Accumulated warnings, shipped on the 16/17 channel by sendResult
     /// (C++ `ArchitectureGhidra::warnings`; `printMessage` appends
     /// `'\n' + message`, ghidra_arch.cc:898-902).
@@ -102,32 +96,12 @@ struct Session {
 }
 
 impl Session {
-    /// Build a session from the four registerProgram documents, parsing the
-    /// tspec leniently (a failure becomes a warning, not a command error).
-    fn new(pspec: Vec<u8>, cspec: Vec<u8>, tspec: Vec<u8>, corespec: Vec<u8>) -> Session {
-        let registry = build_registry();
-        let mut warnings = String::new();
-        let translate = match TspecModel::decode(&tspec, &registry) {
-            Ok(t) => Some(t),
-            Err(e) => {
-                // printMessage semantics: '\n' + message
-                warnings.push('\n');
-                warnings.push_str(&format!(
-                    "kuna ghidra-mode: could not parse tspec <sleigh> element ({}); \
-                     <addr> parameters will not be decoded",
-                    e.explain()
-                ));
-                None
-            }
-        };
+    /// A fresh session shell (defaults only); the live [`Architecture`] is
+    /// installed after construction by [`GhidraProcess::build_architecture`].
+    fn new() -> Session {
         Session {
-            pspec,
-            cspec,
-            tspec,
-            corespec,
-            registry,
-            translate,
-            warnings,
+            architecture: None,
+            warnings: String::new(),
             // ArchitectureGhidra constructor defaults (ghidra_arch.cc:912-926)
             send_syntax_tree: true,
             send_c_code: true,
@@ -135,6 +109,12 @@ impl Session {
             record_jumploads: false,
             current_action: "decompile".to_string(),
         }
+    }
+
+    /// The engine's space manager (for decoding wire \<addr> elements), or
+    /// `None` when construction failed.
+    fn manager(&self) -> Option<&AddrSpaceManager> {
+        self.architecture.as_ref().map(|a| a.manage())
     }
 
     /// C++ `ArchitectureGhidra::printMessage` (ghidra_arch.cc:898-902).
@@ -176,7 +156,7 @@ struct CommandState {
     /// setAction params.
     actionstring: Vec<u8>,
     printstring: Vec<u8>,
-    /// decompileAt param: the decoded address (None if the tspec is
+    /// decompileAt param: the decoded address (None if the engine is
     /// unavailable) plus its rendered form for messages.
     addr_text: Option<String>,
     /// setOptions param: the raw packed \<optionslist> bytes.
@@ -204,27 +184,56 @@ impl CommandState {
 /// The ghidra-mode process: the command loop over the two protocol streams
 /// plus the architecture list (C++ `archlist` + `GhidraCapability::
 /// readCommand`, ghidra_process.cc:76,464-486).
-pub struct GhidraProcess<R: Read, W: Write> {
-    sin: R,
-    sout: W,
+///
+/// The process no longer owns `sin`/`sout` directly: it owns the
+/// [`SharedClient`] (`Rc<RefCell<GhidraClient>>`) that every session's engine
+/// providers (`GhidraTranslate`/`GhidraLoadImage`) hold `Rc::clone`s of.  The
+/// command loop frames each response through a *short-lived*
+/// `self.client.borrow_mut()` (via [`GhidraClient::sin_mut`]/
+/// [`GhidraClient::sout_mut`]); mid-decompile the engine re-entrantly issues
+/// callback queries through the same client on the same streams.
+///
+/// **The soundness invariant** (matching the C++ single-owner `glb` model): the
+/// loop must NEVER hold a `client` borrow across [`raw_action`](GhidraProcess::raw_action),
+/// where the engine re-entrantly calls providers that `borrow_mut()` the same
+/// client.  Each framing read/write here borrows, acts, and drops before the
+/// next statement, and the protocol is strictly synchronous (exactly one query
+/// is ever in flight, completing before the engine regains control), so no two
+/// borrows ever overlap.
+pub struct GhidraProcess<R: Read + 'static, W: Write + 'static> {
+    client: SharedClient<R, W>,
     archlist: Vec<Option<Session>>,
 }
 
-impl<R: Read, W: Write> GhidraProcess<R, W> {
+impl<R: Read + 'static, W: Write + 'static> GhidraProcess<R, W> {
     /// Construct over the two protocol streams (stdin/stdout in the real
-    /// binary; in-memory buffers in tests).
+    /// binary; in-memory buffers in tests), wrapping them in the
+    /// [`SharedClient`] the loop and the engine providers share.
     pub fn new(sin: R, sout: W) -> Self {
         GhidraProcess {
-            sin,
-            sout,
+            client: Rc::new(RefCell::new(GhidraClient::new(sin, sout))),
             archlist: Vec::new(),
         }
     }
 
     /// Tear down into the underlying streams (test access to the written
     /// response bytes).
+    ///
+    /// Drops every session first: each holds an [`Architecture`] whose ghidra
+    /// translator carries an `Rc::clone` of the shared client, so the client is
+    /// uniquely owned (and unwrappable) only once the archlist is gone.  In the
+    /// real binary this is never called (the process runs to a terminating
+    /// status); tests call it after deregistering / dropping all sessions.
     pub fn into_inner(self) -> (R, W) {
-        (self.sin, self.sout)
+        let GhidraProcess { client, archlist } = self;
+        drop(archlist);
+        match Rc::try_unwrap(client) {
+            Ok(cell) => cell.into_inner().into_inner(),
+            Err(_) => panic!(
+                "GhidraProcess::into_inner: the shared client is still referenced by a \
+                 live session engine (deregister or drop all sessions first)"
+            ),
+        }
     }
 
     /// Run the process loop until a command terminates it (C++ `main`'s
@@ -247,11 +256,11 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
         // anything else (including the dangling params + close burst of a
         // rejected command).
         loop {
-            if read_to_any_burst(&mut self.sin)? == BURST_COMMAND_OPEN {
+            if read_to_any_burst(self.client.borrow_mut().sin_mut())? == BURST_COMMAND_OPEN {
                 break;
             }
         }
-        let name_bytes = read_string_stream(&mut self.sin)?;
+        let name_bytes = read_string_stream(self.client.borrow_mut().sin_mut())?;
         let name = String::from_utf8_lossy(&name_bytes).into_owned();
         let kind = match name.as_str() {
             "registerProgram" => CommandKind::RegisterProgram,
@@ -267,14 +276,20 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
             // graceful-degradation contract the Java side expects
             // (ghidra_process.cc:476-484; DecompInterface.java:341-347).
             _ => {
-                write_burst(&mut self.sout, BURST_RESPONSE_OPEN)?;
-                write_burst(&mut self.sout, BURST_MESSAGE_OPEN)?;
-                self.sout
+                write_burst(self.client.borrow_mut().sout_mut(), BURST_RESPONSE_OPEN)?;
+                write_burst(self.client.borrow_mut().sout_mut(), BURST_MESSAGE_OPEN)?;
+                self.client
+                    .borrow_mut()
+                    .sout_mut()
                     .write_all(format!("Bad command: {name}").as_bytes())
                     .map_err(WireError::Io)?;
-                write_burst(&mut self.sout, BURST_MESSAGE_CLOSE)?;
-                write_burst(&mut self.sout, BURST_RESPONSE_CLOSE)?;
-                self.sout.flush().map_err(WireError::Io)?;
+                write_burst(self.client.borrow_mut().sout_mut(), BURST_MESSAGE_CLOSE)?;
+                write_burst(self.client.borrow_mut().sout_mut(), BURST_RESPONSE_CLOSE)?;
+                self.client
+                    .borrow_mut()
+                    .sout_mut()
+                    .flush()
+                    .map_err(WireError::Io)?;
                 return Ok(0);
             }
         };
@@ -285,8 +300,11 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
     /// ghidra_process.cc:125-160).
     fn doit(&mut self, kind: CommandKind) -> WireResult<i32> {
         let mut cmd = CommandState::new(kind);
-        // Command response header — BEFORE any work, so queries nest inside
-        write_burst(&mut self.sout, BURST_RESPONSE_OPEN)?;
+        // Command response header — BEFORE any work, so queries nest inside.
+        // Borrow the client only for this framing write, then drop it: the
+        // rawAction inside run_command re-borrows it per callback query, and the
+        // loop must never hold a borrow across that re-entry (see the struct doc).
+        write_burst(self.client.borrow_mut().sout_mut(), BURST_RESPONSE_OPEN)?;
         let result = self.run_command(&mut cmd);
         match result {
             Ok(()) => {}
@@ -294,10 +312,14 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
             Err(e @ (WireError::PipeClosed | WireError::Io(_))) => return Err(e),
             // catch(JavaError): pass the exception, abort sending results
             Err(WireError::Kuna(KunaError::Java { type_name, explain })) => {
-                pass_java_exception(&mut self.sout, &type_name, &explain)?;
+                pass_java_exception(self.client.borrow_mut().sout_mut(), &type_name, &explain)?;
                 // C++ relies on cin.tie(&cout) flushing before the next
                 // blocking read; Rust must flush explicitly.
-                self.sout.flush().map_err(WireError::Io)?;
+                self.client
+                    .borrow_mut()
+                    .sout_mut()
+                    .flush()
+                    .map_err(WireError::Io)?;
                 return Ok(cmd.status);
             }
             // catch(DecoderError) / catch(RecovError) / catch(LowlevelError):
@@ -314,8 +336,12 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
             }
         }
         self.send_result(&cmd)?;
-        write_burst(&mut self.sout, BURST_RESPONSE_CLOSE)?;
-        self.sout.flush().map_err(WireError::Io)?;
+        write_burst(self.client.borrow_mut().sout_mut(), BURST_RESPONSE_CLOSE)?;
+        self.client
+            .borrow_mut()
+            .sout_mut()
+            .flush()
+            .map_err(WireError::Io)?;
         Ok(cmd.status)
     }
 
@@ -323,7 +349,7 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
     /// body of doit).
     fn run_command(&mut self, cmd: &mut CommandState) -> WireResult<()> {
         self.load_parameters(cmd)?;
-        let t = read_to_any_burst(&mut self.sin)?;
+        let t = read_to_any_burst(self.client.borrow_mut().sin_mut())?;
         if t != BURST_COMMAND_CLOSE {
             return Err(WireError::Kuna(KunaError::java(
                 "alignment",
@@ -339,11 +365,11 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
     /// the architecture id as ASCII decimal in a string stream, validated
     /// against the archlist, then `clearWarnings`.
     fn bind_session(&mut self, start_msg: &str, end_msg: &str) -> WireResult<usize> {
-        let t = read_to_any_burst(&mut self.sin)?;
+        let t = read_to_any_burst(self.client.borrow_mut().sin_mut())?;
         if t != BURST_STRING_OPEN {
             return Err(WireError::Kuna(KunaError::java("alignment", start_msg)));
         }
-        let (payload, code) = crate::protocol::read_id_payload(&mut self.sin)?;
+        let (payload, code) = crate::protocol::read_id_payload(self.client.borrow_mut().sin_mut())?;
         if code != BURST_STRING_CLOSE {
             return Err(WireError::Kuna(KunaError::java("alignment", end_msg)));
         }
@@ -367,10 +393,10 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
             // RegisterProgram::loadParameters (ghidra_process.cc:162-173):
             // four consecutive string streams, no arch id
             CommandKind::RegisterProgram => {
-                let pspec = read_string_stream(&mut self.sin)?;
-                let cspec = read_string_stream(&mut self.sin)?;
-                let tspec = read_string_stream(&mut self.sin)?;
-                let corespec = read_string_stream(&mut self.sin)?;
+                let pspec = read_string_stream(self.client.borrow_mut().sin_mut())?;
+                let cspec = read_string_stream(self.client.borrow_mut().sin_mut())?;
+                let tspec = read_string_stream(self.client.borrow_mut().sin_mut())?;
+                let corespec = read_string_stream(self.client.borrow_mut().sin_mut())?;
                 cmd.specs = Some([pspec, cspec, tspec, corespec]);
                 Ok(())
             }
@@ -393,20 +419,19 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
             CommandKind::DecompileAt => {
                 let slot = self.bind_session("Expecting arch id start", "Expecting arch id end")?;
                 cmd.slot = Some(slot);
-                let raw = read_string_stream_optional(&mut self.sin)?;
+                let raw = read_string_stream_optional(self.client.borrow_mut().sin_mut())?;
                 let session = self.archlist[slot].as_ref().expect("bound session");
-                match (&session.translate, raw) {
-                    (Some(tr), Some(bytes)) => {
-                        let mut decoder = PackedDecode::new(&tr.manager);
+                match (session.manager(), raw) {
+                    (Some(manager), Some(bytes)) => {
+                        let mut decoder = PackedDecode::new(manager);
                         decoder.ingest_stream(&bytes).map_err(WireError::Kuna)?;
                         let addr = Address::decode(&mut decoder).map_err(WireError::Kuna)?;
                         cmd.addr_text = Some(render_address(&addr));
                     }
                     (None, Some(_bytes)) => {
-                        // tspec unavailable: the <addr> was consumed but
-                        // cannot be decoded (lenient skip; the session
-                        // already carries the tspec warning).
-                        // TODO(phase-2): hard-fail once engine init is real.
+                        // Engine construction failed: the <addr> was consumed
+                        // but cannot be decoded (the session already carries the
+                        // construction-failure warning on its 16/17 frame).
                         cmd.addr_text = None;
                     }
                     (_, None) => {
@@ -423,8 +448,8 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
             CommandKind::SetAction => {
                 let slot = self.bind_session("Expecting arch id start", "Expecting arch id end")?;
                 cmd.slot = Some(slot);
-                cmd.actionstring = read_string_stream(&mut self.sin)?;
-                cmd.printstring = read_string_stream(&mut self.sin)?;
+                cmd.actionstring = read_string_stream(self.client.borrow_mut().sin_mut())?;
+                cmd.printstring = read_string_stream(self.client.borrow_mut().sin_mut())?;
                 Ok(())
             }
             // SetOptions::loadParameters (ghidra_process.cc:418-426): base,
@@ -432,7 +457,7 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
             CommandKind::SetOptions => {
                 let slot = self.bind_session("Expecting arch id start", "Expecting arch id end")?;
                 cmd.slot = Some(slot);
-                cmd.options_raw = read_string_stream_optional(&mut self.sin)?;
+                cmd.options_raw = read_string_stream_optional(self.client.borrow_mut().sin_mut())?;
                 Ok(())
             }
         }
@@ -443,12 +468,11 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
     fn raw_action(&mut self, cmd: &mut CommandState) -> WireResult<()> {
         match cmd.kind {
             // RegisterProgram::rawAction (ghidra_process.cc:176-201): find a
-            // free slot (the C++ loop keeps the LAST open slot), build the
-            // session, archid = slot index
+            // free slot (the C++ loop keeps the LAST open slot), install a
+            // session shell, build the live engine, archid = slot index.
             CommandKind::RegisterProgram => {
                 let [pspec, cspec, tspec, corespec] =
                     cmd.specs.take().expect("registerProgram params");
-                let session = Session::new(pspec, cspec, tspec, corespec);
                 let mut open: Option<usize> = None;
                 for (i, s) in self.archlist.iter().enumerate() {
                     if s.is_none() {
@@ -457,16 +481,44 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
                 }
                 let slot = match open {
                     Some(i) => {
-                        self.archlist[i] = Some(session);
+                        self.archlist[i] = Some(Session::new());
                         i
                     }
                     None => {
-                        self.archlist.push(Some(session));
+                        self.archlist.push(Some(Session::new()));
                         self.archlist.len() - 1
                     }
                 };
                 cmd.slot = Some(slot);
                 cmd.archid = slot as i32;
+                // Build the live engine over the four wire specs.  This issues
+                // the init-time queries (the getUserOpName probe loop, C++
+                // `userops.initialize`) on the shared client — nested inside the
+                // still-open registerProgram command response.  The slot (and so
+                // the warning sink) is bound BEFORE this fallible build, so a
+                // construction failure ships its error on the 16/17 warnings
+                // frame and Java treats the non-empty nativeMessage as a
+                // registration failure (DecompInterface.java:291-294; the C++
+                // `RegisterProgram::rawAction` assigns `ghidra` before `init` for
+                // exactly this reason, ghidra_process.cc:176-201).
+                match self.build_architecture(cmd.archid, &pspec, &cspec, &tspec, &corespec) {
+                    Ok(arch) => {
+                        self.archlist[slot]
+                            .as_mut()
+                            .expect("bound session")
+                            .architecture = Some(arch);
+                    }
+                    Err(e) => {
+                        self.print_message(
+                            cmd.slot,
+                            &format!(
+                                "kuna ghidra-mode: could not build the decompiler engine from \
+                                 the registerProgram specs ({}); this program will not decompile",
+                                e.explain()
+                            ),
+                        );
+                    }
+                }
                 Ok(())
             }
             // DeregisterProgram::rawAction (ghidra_process.cc:231-251):
@@ -483,22 +535,23 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
                 }
                 Ok(())
             }
-            // FlushNative::rawAction (ghidra_process.cc:262-273): phase 1
-            // has no engine caches (global scope / non-core types /
-            // comments / strings / cpool are all phase 2) — nothing to
-            // flush.  TODO(phase-2): clear the provider caches here.
+            // FlushNative::rawAction (ghidra_process.cc:262-273): phase 2
+            // step 3 has no per-function engine caches to clear yet (the
+            // ScopeGhidra lazy symbol cache is phase 3).
+            // TODO(phase-3): clear the provider caches here.
             CommandKind::FlushNative => {
                 cmd.res = 0;
                 Ok(())
             }
-            // DecompileAt::rawAction (ghidra_process.cc:293-335): phase 1
+            // DecompileAt::rawAction (ghidra_process.cc:293-335): step 3 still
             // emits the incomplete-function shape — an EMPTY 14/15 payload
-            // (exactly what upstream sends when !fd->isProcComplete()) —
-            // plus a warning on the 16/17 channel, which renders as a clean
-            // error in the Ghidra GUI instead of a hang/desync.
+            // (exactly what upstream sends when !fd->isProcComplete()) — plus a
+            // warning on the 16/17 channel, which renders as a clean error in
+            // the Ghidra GUI instead of a hang/desync.  Driving the (now-built)
+            // engine from decompileAt is the next step.
             CommandKind::DecompileAt => {
-                write_burst(&mut self.sout, BURST_STRING_OPEN)?;
-                write_burst(&mut self.sout, BURST_STRING_CLOSE)?;
+                write_burst(self.client.borrow_mut().sout_mut(), BURST_STRING_OPEN)?;
+                write_burst(self.client.borrow_mut().sout_mut(), BURST_STRING_CLOSE)?;
                 let at = match &cmd.addr_text {
                     Some(t) => t.clone(),
                     None => "(address not decoded)".to_string(),
@@ -563,15 +616,15 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
             // decodes the <optionslist> and throws on any unknown option
             // (OptionDatabase::set -> ParseError -> response 'f' -> Java
             // IOException "Did not accept decompiler options", killing the
-            // program open).  Phase-1 kuna has no option database yet, and
-            // for drop-in robustness across Ghidra versions it TOLERATES
-            // the whole list: the packed stream is consumed (and counted
-            // when decodable) and the answer is always 't'.
+            // program open).  kuna step-3 has no option database wired to the
+            // engine yet, and for drop-in robustness across Ghidra versions it
+            // TOLERATES the whole list: the packed stream is consumed (and
+            // counted when decodable) and the answer is always 't'.
             CommandKind::SetOptions => {
                 let slot = cmd.slot.expect("bound session");
                 let counted = cmd.options_raw.as_ref().and_then(|raw| {
                     let session = self.archlist[slot].as_ref().expect("bound session");
-                    count_option_elements(raw, session.translate.as_ref().map(|t| &t.manager))
+                    count_option_elements(raw, session.manager())
                 });
                 let msg = match counted {
                     Some(n) => format!(
@@ -588,6 +641,45 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
         }
     }
 
+    /// Build the live ghidra-mode [`Architecture`] from the four registerProgram
+    /// wire documents (C++ `ArchitectureGhidra::buildSpecFile` +
+    /// `Architecture::init`/`restoreFromSpec`).
+    ///
+    /// - `buildTranslator` → a [`GhidraTranslate`] over a *clone* of the shared
+    ///   client (the kuna analog of the C++ `glb` back-pointer every ghidra-mode
+    ///   component holds).  The engine, mid-init and mid-decompile, issues
+    ///   queries through this clone on the same streams the command loop frames.
+    /// - `Architecture::from_engine_translate` builds the subsystems over the
+    ///   query-backed engine, and the wire cspec/pspec feed the same setters the
+    ///   console frontend uses (`build_engine_and_init`).
+    /// - `init_post_engine` runs the shared restoreFromSpec tail
+    ///   (typegrp / core types / default proto / actions / …) and — via
+    ///   `userops.initialize` — issues the getUserOpName probe loop, a real
+    ///   query nested inside the open registerProgram response.
+    ///
+    /// The wire corespec is the `<coretypes>` document; decoding it needs the
+    /// (unported) TypeFactory type decoder, which arrives with TypeFactoryGhidra
+    /// in Phase 3 (`docs/rust-port/ghidra-phase2-plan.md` §6).  For now
+    /// `init_post_engine` builds the default core types — the same set the
+    /// standalone engine uses, which the 675-datatest parity proves sufficient.
+    fn build_architecture(
+        &self,
+        archid: i32,
+        pspec: &[u8],
+        cspec: &[u8],
+        tspec: &[u8],
+        _corespec: &[u8],
+    ) -> KunaResult<Architecture> {
+        let registry = build_registry();
+        let translate = GhidraTranslate::new(tspec, &registry, Rc::clone(&self.client))?;
+        let mut arch =
+            Architecture::from_engine_translate(&archid.to_string(), Box::new(translate));
+        arch.set_cspec_xml(cspec.to_vec());
+        arch.set_pspec_xml(pspec.to_vec());
+        arch.init_post_engine()?;
+        Ok(arch)
+    }
+
     // -- sendResult -----------------------------------------------------------
 
     /// The per-command payload plus the base `GhidraCommand::sendResult`
@@ -597,13 +689,22 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
     fn send_result(&mut self, cmd: &CommandState) -> WireResult<()> {
         match cmd.kind {
             CommandKind::RegisterProgram => {
-                write_string_stream(&mut self.sout, cmd.archid.to_string().as_bytes())?;
+                write_string_stream(
+                    self.client.borrow_mut().sout_mut(),
+                    cmd.archid.to_string().as_bytes(),
+                )?;
             }
             CommandKind::DeregisterProgram | CommandKind::FlushNative => {
-                write_string_stream(&mut self.sout, cmd.res.to_string().as_bytes())?;
+                write_string_stream(
+                    self.client.borrow_mut().sout_mut(),
+                    cmd.res.to_string().as_bytes(),
+                )?;
             }
             CommandKind::SetAction | CommandKind::SetOptions => {
-                write_string_stream(&mut self.sout, if cmd.ok { b"t" } else { b"f" })?;
+                write_string_stream(
+                    self.client.borrow_mut().sout_mut(),
+                    if cmd.ok { b"t" } else { b"f" },
+                )?;
             }
             // DecompileAt writes its payload inside rawAction (or none at
             // all when rawAction was aborted) — nothing here
@@ -611,11 +712,13 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
         }
         if let Some(slot) = cmd.slot {
             if let Some(session) = self.archlist[slot].as_ref() {
-                write_burst(&mut self.sout, BURST_MESSAGE_OPEN)?;
-                self.sout
+                write_burst(self.client.borrow_mut().sout_mut(), BURST_MESSAGE_OPEN)?;
+                self.client
+                    .borrow_mut()
+                    .sout_mut()
                     .write_all(session.warnings.as_bytes())
                     .map_err(WireError::Io)?;
-                write_burst(&mut self.sout, BURST_MESSAGE_CLOSE)?;
+                write_burst(self.client.borrow_mut().sout_mut(), BURST_MESSAGE_CLOSE)?;
             }
         }
         Ok(())
@@ -625,17 +728,13 @@ impl<R: Read, W: Write> GhidraProcess<R, W> {
     /// a bound session the message is dropped (the C++ base sendResult
     /// skips the 16/17 frame entirely when `ghidra` is null).
     ///
-    /// TODO(phase-2): C++ `RegisterProgram::rawAction` assigns `ghidra` to
-    /// the freshly-`new`'d `ArchitectureGhidra` *before* `init`, so an
-    /// `init` that throws on bad specs still ships its error on the 16/17
-    /// channel — and Java's registerProgram treats a non-empty
-    /// nativeMessage as registration failure (`DecompInterface.java:291-294`).
-    /// Phase 1 never hits this (`Session::new` is infallible; every pre-bind
-    /// error is a `JavaError`), but once phase 2 makes registerProgram's
-    /// engine init fallible, the in-flight session needs a warning sink here
-    /// (bind the slot first, or buffer warnings on `CommandState`) or a
-    /// failed registration would answer with a bare archid and no warning,
-    /// and Java would think it succeeded.
+    /// C++ `RegisterProgram::rawAction` assigns `ghidra` to the freshly-`new`'d
+    /// `ArchitectureGhidra` *before* `init`, so an `init` that throws on bad
+    /// specs still ships its error on the 16/17 channel — and Java's
+    /// registerProgram treats a non-empty nativeMessage as registration failure
+    /// (`DecompInterface.java:291-294`).  kuna mirrors this: the slot is bound
+    /// before the fallible `build_architecture`, so a construction failure
+    /// routes here and ships on the 16/17 frame.
     fn print_message(&mut self, slot: Option<usize>, message: &str) {
         if let Some(slot) = slot {
             if let Some(session) = self.archlist[slot].as_mut() {

--- a/decompiler/crates/kuna-ghidra/src/process.rs
+++ b/decompiler/crates/kuna-ghidra/src/process.rs
@@ -168,8 +168,6 @@ struct CommandState {
     addr: Option<Address>,
     /// decompileAt param: the rendered form of `addr` for warning messages.
     addr_text: Option<String>,
-    /// setOptions param: the raw packed \<optionslist> bytes.
-    options_raw: Option<Vec<u8>>,
 }
 
 impl CommandState {
@@ -186,7 +184,6 @@ impl CommandState {
             printstring: Vec::new(),
             addr: None,
             addr_text: None,
-            options_raw: None,
         }
     }
 }
@@ -469,7 +466,10 @@ impl<R: Read + 'static, W: Write + 'static> GhidraProcess<R, W> {
             CommandKind::SetOptions => {
                 let slot = self.bind_session("Expecting arch id start", "Expecting arch id end")?;
                 cmd.slot = Some(slot);
-                cmd.options_raw = read_string_stream_optional(self.client.borrow_mut().sin_mut())?;
+                // Consume the packed <optionslist> for protocol alignment; the
+                // engine has no option database yet, so the list is accepted but
+                // not applied (see SetOptions::rawAction).
+                let _ = read_string_stream_optional(self.client.borrow_mut().sin_mut())?;
                 Ok(())
             }
         }
@@ -721,25 +721,19 @@ impl<R: Read + 'static, W: Write + 'static> GhidraProcess<R, W> {
             // decodes the <optionslist> and throws on any unknown option
             // (OptionDatabase::set -> ParseError -> response 'f' -> Java
             // IOException "Did not accept decompiler options", killing the
-            // program open).  kuna step-3 has no option database wired to the
-            // engine yet, and for drop-in robustness across Ghidra versions it
-            // TOLERATES the whole list: the packed stream is consumed (and
-            // counted when decodable) and the answer is always 't'.
+            // program open).  kuna's phase-2 engine has no option database wired
+            // yet, so for drop-in robustness it TOLERATES the whole list (the
+            // packed stream is consumed in loadParameters) and answers 't' —
+            // SILENTLY, with an empty 16/17 frame, exactly as upstream does on
+            // success.  It must emit NO message here: DecompInterface init stores
+            // the native message returned by setOptions, and
+            // openProgram/isErrorMessage (DecompInterface.java) flags any
+            // non-empty text lacking the word "warning" as a FATAL error — so a
+            // stray "recorded but not applied" note made the GUI report
+            // "Unable to initialize the DecompilerInterface" even though the
+            // options were accepted and the function would decompile.
             CommandKind::SetOptions => {
-                let slot = cmd.slot.expect("bound session");
-                let counted = cmd.options_raw.as_ref().and_then(|raw| {
-                    let session = self.archlist[slot].as_ref().expect("bound session");
-                    count_option_elements(raw, session.manager())
-                });
-                let msg = match counted {
-                    Some(n) => format!(
-                        "kuna ghidra-mode: setOptions: {n} option element(s) recorded \
-                         but not applied (phase 1)"
-                    ),
-                    None => "kuna ghidra-mode: setOptions accepted but not applied (phase 1)"
-                        .to_string(),
-                };
-                self.print_message(cmd.slot, &msg);
+                let _ = cmd.slot.expect("bound session");
                 cmd.ok = true;
                 Ok(())
             }
@@ -948,33 +942,6 @@ fn render_address(addr: &Address) -> String {
         s.push_str("invalid_addr");
     }
     s
-}
-
-/// Best-effort count of the child elements of the packed \<optionslist>
-/// (option elements hold only strings/ints, so an empty manager decodes
-/// them fine).  `None` when the stream doesn't decode.
-fn count_option_elements(raw: &[u8], manager: Option<&AddrSpaceManager>) -> Option<usize> {
-    let empty;
-    let mgr = match manager {
-        Some(m) => m,
-        None => {
-            empty = AddrSpaceManager::new();
-            &empty
-        }
-    };
-    let mut decoder = PackedDecode::new(mgr);
-    decoder.ingest_stream(raw).ok()?;
-    let root = decoder.open_element().ok()?;
-    if root == 0 {
-        return None;
-    }
-    let mut n = 0usize;
-    while decoder.peek_element().ok()? != 0 {
-        decoder.skip_element().ok()?;
-        n += 1;
-    }
-    decoder.close_element(root).ok()?;
-    Some(n)
 }
 
 #[cfg(test)]

--- a/decompiler/crates/kuna-ghidra/src/process.rs
+++ b/decompiler/crates/kuna-ghidra/src/process.rs
@@ -28,13 +28,17 @@
 //! issues are nested inside the open command response (the phase-2 engine
 //! bridge relies on this).
 //!
-//! Phase-2 step 3 (see `docs/rust-port/ghidra-phase2-plan.md`): registerProgram
-//! now builds a *live* [`Architecture`] over the query-backed
-//! [`GhidraTranslate`] — its `init_post_engine` issues the getUserOpName probe
-//! loop as a real query nested in the registerProgram response.  `decompileAt`
-//! still answers the incomplete-function shape (an EMPTY 14/15 payload,
-//! ghidra_process.cc:313-334) plus a not-implemented warning — driving the
-//! engine from `decompileAt` is the next step.  `flushNative` has no engine
+//! Phase-2 step 6 (see `docs/rust-port/ghidra-phase2-plan.md`): registerProgram
+//! builds a *live* [`Architecture`] over the query-backed [`GhidraTranslate`] —
+//! its `init_post_engine` issues the getUserOpName probe loop as a real query
+//! nested in the registerProgram response — and `decompileAt` now DRIVES that
+//! engine: it names the function (getCodeLabel), runs [`decompile_func`] (whose
+//! providers issue the getPcode/getBytes/… queries nested in the still-open
+//! decompileAt response), and emits the `<doc>` response — `Funcdata::encode`'s
+//! `<function>`/`<ast>` plus the Clang-markup `<function>` — the first real C
+//! from kuna in ghidra mode.  A decompile failure degrades to the C++
+//! `!fd->isProcComplete()` incomplete-function shape (empty 14/15 payload +
+//! warning) so it never desyncs the GUI.  `flushNative` has no engine
 //! caches to clear yet.  `structureGraph` and the four signature commands are
 //! deliberately NOT registered: the unknown-command response
 //! `{6}{16}"Bad command: <name>"{17}{7}` (ghidra_process.cc:476-484) is the
@@ -47,12 +51,15 @@ use std::rc::Rc;
 
 use kuna_base::address::Address;
 use kuna_base::error::{KunaError, KunaResult};
-use kuna_base::marshal::{Decoder, PackedDecode};
+use kuna_base::marshal::{Decoder, Encoder, PackedDecode, PackedEncode};
 use kuna_base::space::AddrSpaceManager;
 
 use kuna_decomp::architecture::Architecture;
+use kuna_decomp::decompile_drive::decompile_func;
+use kuna_decomp::funcdata::Funcdata;
 
 use crate::client::GhidraClient;
+use crate::ids::ELEM_DOC;
 use crate::protocol::{
     pass_java_exception, read_string_stream, read_string_stream_optional, read_to_any_burst,
     write_burst, write_string_stream, WireError, WireResult, BURST_COMMAND_CLOSE,
@@ -156,8 +163,10 @@ struct CommandState {
     /// setAction params.
     actionstring: Vec<u8>,
     printstring: Vec<u8>,
-    /// decompileAt param: the decoded address (None if the engine is
-    /// unavailable) plus its rendered form for messages.
+    /// decompileAt param: the decoded entry address (None if the engine is
+    /// unavailable), driving the [`decompile_func`] build.
+    addr: Option<Address>,
+    /// decompileAt param: the rendered form of `addr` for warning messages.
     addr_text: Option<String>,
     /// setOptions param: the raw packed \<optionslist> bytes.
     options_raw: Option<Vec<u8>>,
@@ -175,6 +184,7 @@ impl CommandState {
             specs: None,
             actionstring: Vec::new(),
             printstring: Vec::new(),
+            addr: None,
             addr_text: None,
             options_raw: None,
         }
@@ -427,11 +437,13 @@ impl<R: Read + 'static, W: Write + 'static> GhidraProcess<R, W> {
                         decoder.ingest_stream(&bytes).map_err(WireError::Kuna)?;
                         let addr = Address::decode(&mut decoder).map_err(WireError::Kuna)?;
                         cmd.addr_text = Some(render_address(&addr));
+                        cmd.addr = Some(addr);
                     }
                     (None, Some(_bytes)) => {
                         // Engine construction failed: the <addr> was consumed
                         // but cannot be decoded (the session already carries the
                         // construction-failure warning on its 16/17 frame).
+                        cmd.addr = None;
                         cmd.addr_text = None;
                     }
                     (_, None) => {
@@ -543,26 +555,119 @@ impl<R: Read + 'static, W: Write + 'static> GhidraProcess<R, W> {
                 cmd.res = 0;
                 Ok(())
             }
-            // DecompileAt::rawAction (ghidra_process.cc:293-335): step 3 still
-            // emits the incomplete-function shape — an EMPTY 14/15 payload
-            // (exactly what upstream sends when !fd->isProcComplete()) — plus a
-            // warning on the 16/17 channel, which renders as a clean error in
-            // the Ghidra GUI instead of a hang/desync.  Driving the (now-built)
-            // engine from decompileAt is the next step.
+            // DecompileAt::rawAction (ghidra_process.cc:293-335): the live
+            // engine bridge.  Establish the function name (getCodeLabel), drive
+            // `decompile_func` to a ready-to-print `Funcdata` (its providers
+            // issue the getPcode/getBytes/… queries nested inside this still-open
+            // command response), then emit the `<doc>` between the 14/15 burst —
+            // `fd.encode` (the `<function>`/`<ast>` syntax tree) plus, when C is
+            // requested for the `decompile` action, the Clang-markup `<function>`
+            // spliced into the SAME `<doc>` stream.  Any decompile failure
+            // degrades to the C++ `!fd->isProcComplete()` incomplete-function
+            // shape (empty 14/15 payload + a 16/17 warning) so a failure never
+            // desyncs the GUI.
             CommandKind::DecompileAt => {
-                write_burst(self.client.borrow_mut().sout_mut(), BURST_STRING_OPEN)?;
-                write_burst(self.client.borrow_mut().sout_mut(), BURST_STRING_CLOSE)?;
-                let at = match &cmd.addr_text {
-                    Some(t) => t.clone(),
-                    None => "(address not decoded)".to_string(),
+                let slot = cmd.slot.expect("bound session");
+                // The entry address decoded in loadParameters.  `None` ⇒ engine
+                // construction failed (no manager) — degrade to the
+                // incomplete-function shape (the construction-failure warning is
+                // already on the session's 16/17 frame).
+                let addr = match cmd.addr.clone() {
+                    Some(a) => a,
+                    None => {
+                        write_burst(self.client.borrow_mut().sout_mut(), BURST_STRING_OPEN)?;
+                        write_burst(self.client.borrow_mut().sout_mut(), BURST_STRING_CLOSE)?;
+                        self.print_message(
+                            cmd.slot,
+                            "kuna ghidra-mode: engine unavailable; \
+                             function at (address not decoded) not decompiled",
+                        );
+                        return Ok(());
+                    }
                 };
-                self.print_message(
-                    cmd.slot,
-                    &format!(
-                        "kuna ghidra-mode: engine bridge not yet implemented (phase 1); \
-                         function at {at} not decompiled"
-                    ),
-                );
+
+                // (2) Establish the display name.  C++ `queryFunction` resolves
+                // it from the mapped symbol; the v1 milestone (no `<mapsym>`
+                // decoder yet — Phase 3) uses the plain-string `getCodeLabel`,
+                // falling back to a synthesized `FUN_<addr>` on an empty label or
+                // a query failure.  Short-lived client borrow, dropped before the
+                // decompile re-borrows the client through the engine providers
+                // (the no-borrow-across-decompile invariant).
+                let name = match self.client.borrow_mut().get_code_label(&addr) {
+                    Ok(label) if !label.is_empty() => {
+                        String::from_utf8_lossy(&label).into_owned()
+                    }
+                    _ => format!("FUN_{:08x}", addr.get_offset()),
+                };
+
+                // Snapshot the render flags before taking `&mut Architecture`.
+                let (send_syntax_tree, send_c_code, current_action) = {
+                    let session = self.archlist[slot].as_ref().expect("bound session");
+                    (
+                        session.send_syntax_tree,
+                        session.send_c_code,
+                        session.current_action.clone(),
+                    )
+                };
+
+                // (3) Drive the decompile FULLY — releasing every provider query
+                // borrow — BEFORE re-borrowing the client to write the `<doc>`.
+                // `size = 0` = the flow-discovered natural extent (the console
+                // decompile-all path's shape: build a `Funcdata` for the raw
+                // entry, let flow-following via the getPcode/getBytes providers
+                // discover the body).  Assemble the response document while the
+                // `&mut Architecture` is in hand (the markup needs `&Architecture`).
+                let doc: KunaResult<Vec<u8>> = {
+                    let session = self.archlist[slot].as_mut().expect("bound session");
+                    let arch = session
+                        .architecture
+                        .as_mut()
+                        .expect("addr decoded ⇒ engine present");
+                    match decompile_func(arch, &name, addr.clone(), 0) {
+                        Ok(fd) => build_decompile_at_doc(
+                            arch,
+                            &fd,
+                            send_syntax_tree,
+                            send_c_code,
+                            &current_action,
+                        ),
+                        Err(e) => Err(e),
+                    }
+                };
+
+                match doc {
+                    // C++ `isProcComplete` branch: the `<doc>` inside the 14/15
+                    // burst.
+                    Ok(bytes) => {
+                        write_burst(self.client.borrow_mut().sout_mut(), BURST_STRING_OPEN)?;
+                        self.client
+                            .borrow_mut()
+                            .sout_mut()
+                            .write_all(&bytes)
+                            .map_err(WireError::Io)?;
+                        write_burst(self.client.borrow_mut().sout_mut(), BURST_STRING_CLOSE)?;
+                    }
+                    // A decompile failure (a decode error, an un-ported seam that
+                    // `decompile_func` caught, or a Java exception a provider
+                    // surfaced) degrades to the SAME clean incomplete-function
+                    // shape — empty 14/15 payload + a 16/17 warning naming the
+                    // address.  DELIBERATE DIVERGENCE from the C++
+                    // passJavaException abort: a failure never desyncs the GUI
+                    // (the phase-1 stub's clean-error contract).
+                    Err(e) => {
+                        write_burst(self.client.borrow_mut().sout_mut(), BURST_STRING_OPEN)?;
+                        write_burst(self.client.borrow_mut().sout_mut(), BURST_STRING_CLOSE)?;
+                        let at = cmd.addr_text.clone().unwrap_or_else(|| "?".to_string());
+                        self.print_message(
+                            cmd.slot,
+                            &format!(
+                                "kuna ghidra-mode: could not decompile the function at {at} \
+                                 ({}); returning an incomplete function",
+                                e.explain()
+                            ),
+                        );
+                    }
+                }
                 Ok(())
             }
             // SetAction::rawAction (ghidra_process.cc:378-406)
@@ -779,6 +884,57 @@ fn parse_arch_id(payload: &[u8]) -> i32 {
         val = -val;
     }
     val.clamp(i32::MIN as i64, i32::MAX as i64) as i32
+}
+
+/// Assemble the decompileAt response document (C++ `DecompileAt::rawAction`
+/// isProcComplete branch, `decompiler/cpp/ghidra_process.cc:317-333`):
+///
+/// ```text
+///   XmlEncode encoder(sout);        // kuna: PackedEncode over a buffer
+///   encoder.openElement(ELEM_DOC);
+///   fd->encode(encoder,0,ghidra->getSendSyntaxTree());   // <function>/<ast>
+///   if (ghidra->getSendCCode() && (actionname == "decompile")) {
+///     ghidra->print->setOutputStream(&sout);
+///     ghidra->print->docFunction(fd);   // the Clang-markup <function>
+///   }
+///   encoder.closeElement(ELEM_DOC);
+/// ```
+///
+/// The dual `<function>` (the markup) is spliced AFTER the syntax tree and
+/// BEFORE `</doc>`.  Its `opref`/`varref` tokens resolve to the SAME
+/// `get_time()`/`get_create_index()` the `<ast>` emitted, so the
+/// click-to-address contract holds by construction.  [`PackedEncode`] writes
+/// its 0x00-free bytes straight to the buffer with no open-element stack, so
+/// appending the markup bytes then writing `</doc>` from a fresh encoder is
+/// byte-identical to C++ writing both to one `sout` — exactly the same splice.
+fn build_decompile_at_doc(
+    arch: &mut Architecture,
+    fd: &Funcdata,
+    send_syntax_tree: bool,
+    send_c_code: bool,
+    current_action: &str,
+) -> KunaResult<Vec<u8>> {
+    let mut buf: Vec<u8> = Vec::new();
+    // <doc> open + fd.encode (the <function>/<ast> syntax tree).
+    {
+        let mut enc = PackedEncode::new(&mut buf);
+        enc.open_element(&ELEM_DOC);
+        fd.encode(&mut enc, 0, send_syntax_tree)?;
+    }
+    // The dual <function>: the Clang token-markup document.  `doc_function_markup`
+    // needs `&mut PrintC` + `&Architecture`; move the printer out (the
+    // `print_c` split-borrow precedent), render, put it back, splice the bytes.
+    if send_c_code && current_action == "decompile" {
+        let mut printer = arch.take_print();
+        let markup = printer.doc_function_markup(fd, arch);
+        arch.put_print(printer);
+        buf.extend_from_slice(&markup);
+    }
+    {
+        let mut enc = PackedEncode::new(&mut buf);
+        enc.close_element(&ELEM_DOC);
+    }
+    Ok(buf)
 }
 
 /// Render an address for warning messages: the space shortcut plus the C++

--- a/decompiler/crates/kuna-ghidra/src/provider.rs
+++ b/decompiler/crates/kuna-ghidra/src/provider.rs
@@ -104,7 +104,7 @@ impl<R: Read, W: Write> LoadImage for GhidraLoadImage<R, W> {
 /// "host pipe dead → terminate" so a mid-decompile pipe death still exits
 /// the process with status 1 (the `SharedClient` should carry a fatal flag
 /// the loop checks after each command).
-fn wire_to_kuna(err: WireError) -> KunaError {
+pub(crate) fn wire_to_kuna(err: WireError) -> KunaError {
     match err {
         WireError::Kuna(e) => e,
         WireError::PipeClosed => KunaError::lowlevel("ghidra host pipe closed during query"),
@@ -119,7 +119,7 @@ mod tests {
 
     use kuna_base::marshal::{Encoder, PackedEncode};
 
-    use crate::translate::{build_registry, GhidraTranslate};
+    use crate::translate::{build_registry, TspecModel};
 
     const TSPEC: &[u8] = b"<sleigh bigendian=\"false\" uniqbase=\"0x10000000\">\
 <spaces defaultspace=\"ram\">\
@@ -128,8 +128,8 @@ mod tests {
 <space name=\"ram\" index=\"3\" size=\"8\" bigendian=\"false\" delay=\"1\" physical=\"true\"/>\
 </spaces></sleigh>";
 
-    fn test_translate() -> GhidraTranslate {
-        GhidraTranslate::decode(TSPEC, &build_registry()).expect("test tspec parses")
+    fn test_translate() -> TspecModel {
+        TspecModel::decode(TSPEC, &build_registry()).expect("test tspec parses")
     }
 
     fn burst(v: &mut Vec<u8>, code: u8) {

--- a/decompiler/crates/kuna-ghidra/src/provider.rs
+++ b/decompiler/crates/kuna-ghidra/src/provider.rs
@@ -1,0 +1,239 @@
+//! Ghidra-backed engine providers — the Phase-2 scaffolding.
+//!
+//! Upstream, `ArchitectureGhidra::init` installs a family of component
+//! subclasses that back the engine's loader / translator / symbol table /
+//! type factory / … with queries to the Java host instead of a local file
+//! (`decompiler/cpp/loadimage_ghidra.cc`, `ghidra_translate.cc`,
+//! `database_ghidra.cc`, `typegrp_ghidra.cc`, `comment_ghidra.cc`,
+//! `string_ghidra.cc`, `ghidra_context.cc`, `cpool_ghidra.cc`,
+//! `inject_ghidra.cc`).  This module ports them into kuna as query-backed
+//! implementations of kuna's existing engine traits.
+//!
+//! **Phase-2 status.** [`GhidraLoadImage`] is implemented and tested here as
+//! the demonstrator for the pattern the whole phase turns on: the engine,
+//! mid-decompile, re-entrantly calls a provider (here `load_fill`), which
+//! issues a callback query on the *same* streams the command response is
+//! being written to (`SharedClient`, below).  Proving that seam plugs into a
+//! real kuna trait (`kuna_sleigh::loadimage::LoadImage`) with no change to
+//! the standalone engine is what de-risks the rest.  The remaining providers
+//! (`ContextGhidra`, the `ScopeGhidra` lazy symbol cache, `TypeFactoryGhidra`,
+//! …) and the wiring into an `Architecture` are the gated work — see
+//! `docs/rust-port/ghidra-phase2-plan.md`.
+
+use std::cell::RefCell;
+use std::io::{Read, Write};
+use std::rc::Rc;
+
+use kuna_base::address::Address;
+use kuna_base::error::{KunaError, KunaResult};
+use kuna_sleigh::loadimage::LoadImage;
+
+use crate::client::GhidraClient;
+use crate::protocol::WireError;
+
+/// A [`GhidraClient`] shared between the command loop and the engine's
+/// providers.
+///
+/// This is the kuna analog of the C++ `glb` back-pointer every ghidra-mode
+/// component holds to its `ArchitectureGhidra` (e.g. `LoadImageGhidra::glb`,
+/// `loadimage_ghidra.hh`).  During a `decompileAt` the engine re-entrantly
+/// calls a provider, which issues a query on the same `sin`/`sout` the
+/// command response is mid-flight on — so the client must be *shared*, not
+/// owned, by both the process loop and every provider.  `Rc<RefCell<…>>` is
+/// the single-threaded shared-mutable analog of the raw C++ pointer (the
+/// protocol is strictly synchronous — at most one borrow is ever live,
+/// because a query fully completes before the engine regains control).
+pub type SharedClient<R, W> = Rc<RefCell<GhidraClient<R, W>>>;
+
+/// C++ `LoadImageGhidra` (`loadimage_ghidra.cc`): every engine read of
+/// program bytes — constant-pointer dereference, read-only propagation,
+/// string probing — becomes a `getBytes` query to the host.  There is no
+/// local cache (the Java side caches; `loadimage_ghidra.cc` comment).
+pub struct GhidraLoadImage<R: Read, W: Write> {
+    client: SharedClient<R, W>,
+}
+
+impl<R: Read, W: Write> GhidraLoadImage<R, W> {
+    /// Construct over the shared query client (C++ `new LoadImageGhidra(this)`,
+    /// `ghidra_arch.cc:283-287`).
+    pub fn new(client: SharedClient<R, W>) -> Self {
+        GhidraLoadImage { client }
+    }
+}
+
+impl<R: Read, W: Write> LoadImage for GhidraLoadImage<R, W> {
+    /// C++ constructs it with the pseudo-filename `"ghidra_progam"` [sic]
+    /// (`loadimage_ghidra.cc:20-25`).
+    fn get_file_name(&self) -> &str {
+        "ghidra_progam"
+    }
+
+    /// C++ `LoadImageGhidra::loadFill` → `glb->getBytes`
+    /// (`loadimage_ghidra.cc:37-41`).  An unmapped range comes back as the
+    /// empty-response `DataUnavailError` from `getBytes`.
+    fn load_fill(&mut self, ptr: &mut [u8], addr: &Address) -> KunaResult<()> {
+        self.client
+            .borrow_mut()
+            .get_bytes(ptr, addr)
+            .map_err(wire_to_kuna)
+    }
+
+    /// C++ `getArchType` → `"ghidra"` (`loadimage_ghidra.cc:43-47`).
+    fn get_arch_type(&self) -> Vec<u8> {
+        b"ghidra".to_vec()
+    }
+
+    /// C++ `adjustVma` throws `LowlevelError` (`loadimage_ghidra.cc:49-53`) —
+    /// it is a raw-binary concern never reached in ghidra mode.  kuna's trait
+    /// method cannot return an error, so this is a no-op.
+    /// TODO(phase-2): if a caller ever reaches it, surface a fatal error
+    /// through the process loop rather than silently doing nothing.
+    fn adjust_vma(&mut self, _adjust: i64) {}
+}
+
+/// Map a query [`WireError`] onto the [`KunaError`] a [`LoadImage`] method
+/// must return.
+///
+/// A `DataUnavail` passes through unchanged (the `getBytes` empty-response
+/// case — an unmapped address).  A pipe/IO failure means the host connection
+/// died mid-query; upstream `exit(1)`s from inside `readToAnyBurst`
+/// (`ghidra_arch.cc:95-96`), but the trait method can only return a
+/// `KunaError`, so it is mapped to a `LowlevelError` here.
+///
+/// TODO(phase-2): the process loop needs a way for a provider to signal
+/// "host pipe dead → terminate" so a mid-decompile pipe death still exits
+/// the process with status 1 (the `SharedClient` should carry a fatal flag
+/// the loop checks after each command).
+fn wire_to_kuna(err: WireError) -> KunaError {
+    match err {
+        WireError::Kuna(e) => e,
+        WireError::PipeClosed => KunaError::lowlevel("ghidra host pipe closed during query"),
+        WireError::Io(e) => KunaError::lowlevel(format!("i/o error during query: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    use kuna_base::marshal::{Encoder, PackedEncode};
+
+    use crate::translate::{build_registry, GhidraTranslate};
+
+    const TSPEC: &[u8] = b"<sleigh bigendian=\"false\" uniqbase=\"0x10000000\">\
+<spaces defaultspace=\"ram\">\
+<space_other name=\"OTHER\" index=\"1\" size=\"8\" bigendian=\"false\" delay=\"0\" physical=\"true\"/>\
+<space_unique name=\"unique\" index=\"2\" size=\"4\" bigendian=\"false\" delay=\"0\" physical=\"true\"/>\
+<space name=\"ram\" index=\"3\" size=\"8\" bigendian=\"false\" delay=\"1\" physical=\"true\"/>\
+</spaces></sleigh>";
+
+    fn test_translate() -> GhidraTranslate {
+        GhidraTranslate::decode(TSPEC, &build_registry()).expect("test tspec parses")
+    }
+
+    fn burst(v: &mut Vec<u8>, code: u8) {
+        v.extend_from_slice(&[0, 0, 1, code]);
+    }
+
+    /// Nibble-double each byte as `'A'+hi, 'A'+lo` — DecompileProcess.java's
+    /// getBytes byte-stream encoding (:867-885).
+    fn nibble_expand(bytes: &[u8]) -> Vec<u8> {
+        let mut v = Vec::with_capacity(bytes.len() * 2);
+        for &b in bytes {
+            v.push(b'A' + (b >> 4));
+            v.push(b'A' + (b & 0x0f));
+        }
+        v
+    }
+
+    /// A getBytes query response carrying `data` (burst 8, byte-stream
+    /// 12/13, burst 9).
+    fn get_bytes_response(data: &[u8]) -> Vec<u8> {
+        let mut r = Vec::new();
+        burst(&mut r, 8);
+        burst(&mut r, 12);
+        r.extend_from_slice(&nibble_expand(data));
+        burst(&mut r, 13);
+        burst(&mut r, 9);
+        r
+    }
+
+    /// The unmapped-address case: an empty query response (burst 8 then a
+    /// close burst) that getBytes turns into DataUnavailError.
+    fn empty_response() -> Vec<u8> {
+        let mut r = Vec::new();
+        burst(&mut r, 8);
+        burst(&mut r, 9);
+        r
+    }
+
+    fn shared(reader: Vec<u8>) -> SharedClient<Cursor<Vec<u8>>, Vec<u8>> {
+        Rc::new(RefCell::new(GhidraClient::new(
+            Cursor::new(reader),
+            Vec::new(),
+        )))
+    }
+
+    #[test]
+    fn load_fill_pulls_bytes_from_host() {
+        let tr = test_translate();
+        let ram = Rc::clone(tr.manager.get_space_by_name("ram").expect("ram"));
+        let want = [0xde, 0xad, 0xbe, 0xef];
+
+        let client = shared(get_bytes_response(&want));
+        // Exercise it through the trait object, proving the seam plugs in.
+        let mut loader: Box<dyn LoadImage> = Box::new(GhidraLoadImage::new(Rc::clone(&client)));
+
+        assert_eq!(loader.get_arch_type(), b"ghidra");
+        assert_eq!(loader.get_file_name(), "ghidra_progam");
+
+        let mut buf = [0u8; 4];
+        loader
+            .load_fill(&mut buf, &Address::new(ram, 0x401000))
+            .expect("load_fill");
+        assert_eq!(buf, want);
+
+        // The query it issued is byte-exact getBytes framing. Drop the loader
+        // first so `client` is the sole owner of the shared handle.
+        drop(loader);
+        let (_r, w) = Rc::try_unwrap(client).unwrap().into_inner().into_inner();
+
+        // Encode the expected <command_getbytes> document once, then wrap it
+        // in the query/string bursts.
+        let mut cmd = Vec::new();
+        {
+            let ram2 = Rc::clone(test_translate().manager.get_space_by_name("ram").unwrap());
+            let mut e = PackedEncode::new(&mut cmd);
+            e.open_element(&crate::ids::ELEM_COMMAND_GETBYTES);
+            Address::new(ram2, 0x401000)
+                .encode_sized(&mut e, 4)
+                .unwrap();
+            e.close_element(&crate::ids::ELEM_COMMAND_GETBYTES);
+        }
+        let mut expected = Vec::new();
+        burst(&mut expected, 4); // query open
+        burst(&mut expected, 14); // string open
+        expected.extend_from_slice(&cmd);
+        burst(&mut expected, 15); // string close
+        burst(&mut expected, 5); // query close
+        assert_eq!(w, expected, "getBytes request framing");
+    }
+
+    #[test]
+    fn load_fill_unmapped_is_data_unavail() {
+        let tr = test_translate();
+        let ram = Rc::clone(tr.manager.get_space_by_name("ram").expect("ram"));
+        let client = shared(empty_response());
+        let mut loader = GhidraLoadImage::new(client);
+
+        let mut buf = [0u8; 4];
+        let err = loader
+            .load_fill(&mut buf, &Address::new(ram, 0x0))
+            .expect_err("unmapped address must fail");
+        assert!(
+            matches!(err, KunaError::DataUnavail { .. }),
+            "expected DataUnavail, got {err:?}"
+        );
+    }
+}

--- a/decompiler/crates/kuna-ghidra/src/translate.rs
+++ b/decompiler/crates/kuna-ghidra/src/translate.rs
@@ -351,6 +351,7 @@ impl<R: Read, W: Write> RegisterLookup for GhidraTranslate<R, W> {
     /// C++ `GhidraTranslate::getExactRegisterName`
     /// (ghidra_translate.cc:89-106): the register name only if it matches the
     /// location AND size exactly, else "".
+    #[allow(clippy::mutable_key_type)] // see cache_register
     fn get_exact_register_name(&self, base: &Rc<AddrSpace>, off: u64, size: i32) -> String {
         if base.get_type() != spacetype::IPTR_PROCESSOR {
             return String::new();
@@ -360,6 +361,17 @@ impl<R: Read, W: Write> RegisterLookup for GhidraTranslate<R, W> {
             offset: off,
             size: size as u32,
         };
+        // C++ getExactRegisterName opens with `addr2nm.find(vndata)` and returns
+        // the cached name before any query (ghidra_translate.cc:96-98).  A hit is
+        // keyed by a cached FULL register's exact vndata, so it already satisfies
+        // the exact-size requirement — no size re-check needed.  Mirrors the same
+        // short-circuit in `get_register_name`.
+        {
+            let cache = self.addr2nm.borrow();
+            if let Some(nm) = cache.get(&vndata) {
+                return nm.clone();
+            }
+        }
         let bytes = match self.client.borrow_mut().get_register_name(&vndata) {
             Ok(b) => b,
             Err(_) => return String::new(),

--- a/decompiler/crates/kuna-ghidra/src/translate.rs
+++ b/decompiler/crates/kuna-ghidra/src/translate.rs
@@ -1,38 +1,64 @@
-//! The tspec \<sleigh> element decode — the address-space subset of
-//! `decompiler/cpp/ghidra_translate.cc` (`GhidraTranslate::initialize` /
-//! `decode`, ghidra_translate.cc:35-43,161-176).
+//! The ghidra-mode translator — a port of
+//! `decompiler/cpp/ghidra_translate.cc` (`GhidraTranslate`): a [`Translate`]
+//! whose disassembly/p-code and register lookups are answered by queries to
+//! the Java host instead of a local `.sla`.
 //!
-//! In ghidra mode no `.sla` file exists: the entire "language" the native
-//! side knows is the stripped-down `<sleigh>` document the Java client
-//! sends at registerProgram (produced by `SleighLanguage.encodeTranslator`,
-//! SleighLanguage.java) — endianness, the unique base, and the address
-//! space list whose per-space `index` attributes are the Java
-//! `AddressSpace.getUnique()` values.  Those indices are the deepest
-//! interop invariant of the packed protocol: `PackedDecode::read_space` /
+//! In ghidra mode no `.sla` file exists.  The entire "language" the native
+//! side knows is the stripped-down `<sleigh>` document the Java client sends
+//! at registerProgram (produced by `SleighLanguage.encodeTranslator`,
+//! SleighLanguage.java) — endianness, the unique base, and the address-space
+//! list whose per-space `index` attributes are the Java
+//! `AddressSpace.getUnique()` values.  Those indices are the deepest interop
+//! invariant of the packed protocol: `PackedDecode::read_space` /
 //! `PackedEncode::write_space` exchange spaces by exactly these numbers, so
-//! parsing the tspec into a real [`AddrSpaceManager`] (sparse
-//! `insert_space`, kuna-base/src/space.rs) is what gives decompileAt a
-//! working \<addr> decoder.
+//! parsing the tspec into a real [`AddrSpaceManager`] (sparse `insert_space`,
+//! kuna-base/src/space.rs) is what gives `decompileAt` a working `<addr>`
+//! decoder.
 //!
-//! The C++ `decodeSpaces` loop cannot be called directly in Rust (the
-//! decoder borrows the manager the loop mutates); the sanctioned stepwise
-//! pattern — a fresh decoder per child element around each
-//! `decode_space`/`insert_space` pair — comes from the kuna-sleigh space
-//! manager test (kuna-sleigh/src/translate.rs:1086-1124).
+//! The C++ `decodeSpaces` loop cannot be called directly in Rust (the decoder
+//! borrows the manager the loop mutates); the sanctioned stepwise pattern — a
+//! fresh decoder per child element around each `decode_space`/`insert_space`
+//! pair — comes from the kuna-sleigh space manager test
+//! (kuna-sleigh/src/translate.rs).
 //!
-//! Phase-1 scope: the query-side register/user-op caches and
-//! `oneInstruction` (the getPcode path) of C++ GhidraTranslate are the
-//! phase-2 engine bridge; see `docs/ghidra-integration.md`.
+//! Two shapes live here.  [`TspecModel`] is the pure, client-free tspec decode
+//! (`AddrSpaceManager` + endianness + unique base); the phase-1 command loop
+//! ([`crate::process`]) needs exactly this and nothing more, so the parse stays
+//! free of the query client.  [`GhidraTranslate`] is the phase-2 live
+//! translator: a `TspecModel` folded into a [`TranslateBase`], plus the shared
+//! query `GhidraClient`, the register caches, a query-backed [`GhidraLoadImage`],
+//! and a context database.  It implements [`RegisterLookup`], [`Translate`] and
+//! [`EngineTranslate`] by issuing queries (`getPcode`, `getRegister`,
+//! `getRegisterName`, `getUserOpName`) on the host.
 
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::{Read, Write};
 use std::rc::Rc;
 
+use kuna_base::address::Address;
 use kuna_base::error::{KunaError, KunaResult};
-use kuna_base::marshal::{Decoder, IdRegistry, XmlDecode, ATTRIB_BIGENDIAN};
-use kuna_base::space::{AddrSpaceManager, ConstantSpace, ATTRIB_DEFAULTSPACE};
-use kuna_base::xml::xml_tree;
-use kuna_sleigh::translate::{register_translate_ids, TruncationTag, ATTRIB_UNIQBASE, ELEM_SLEIGH};
+use kuna_base::marshal::{
+    Decoder, IdRegistry, PackedDecode, XmlDecode, ATTRIB_BIGENDIAN, ATTRIB_OFFSET,
+};
+use kuna_base::space::{
+    spacetype, AddrSpace, AddrSpaceManager, ConstantSpace, RegisterLookup, VarnodeStorage,
+    ATTRIB_DEFAULTSPACE,
+};
+use kuna_base::xml::{xml_tree, DocumentStorage};
+use kuna_num::pcoderaw::VarnodeData;
+use kuna_sleigh::globalcontext::{ContextDatabase, ContextInternal};
+use kuna_sleigh::loadimage::LoadImage;
+use kuna_sleigh::translate::{
+    register_translate_ids, varnode_data_from_storage, AssemblyEmit, PcodeEmit, Translate,
+    TranslateBase, TruncationTag, ATTRIB_UNIQBASE, ELEM_SLEIGH,
+};
 
-use crate::ids::register_ghidra_ids;
+use kuna_decomp::engine_translate::EngineTranslate;
+
+use crate::ids::{register_ghidra_ids, ELEM_UNIMPL};
+use crate::protocol::WireError;
+use crate::provider::{wire_to_kuna, GhidraLoadImage, SharedClient};
 
 /// Build the marshaling [`IdRegistry`] a ghidra-mode session needs: the
 /// kuna-base tables, the translate.cc ids (the tspec vocabulary), and the
@@ -45,11 +71,15 @@ pub fn build_registry() -> IdRegistry {
     registry
 }
 
-/// The decoded tspec: what C++ `GhidraTranslate` caches after `initialize`
-/// (ghidra_translate.hh:36-57) — minus the query-backed register/user-op
-/// caches (phase 2).
+/// The client-free tspec decode: the address-space model plus endianness /
+/// unique base that C++ `GhidraTranslate::decode` (ghidra_translate.cc:161-176)
+/// extracts from the `<sleigh>` document.
+///
+/// This is the seed [`GhidraTranslate::new`] folds into a [`TranslateBase`] +
+/// [`AddrSpaceManager`]; it also stands alone as the only piece the phase-1
+/// command loop needs (it decodes `<addr>` parameters but issues no queries).
 #[derive(Debug)]
-pub struct GhidraTranslate {
+pub struct TspecModel {
     /// The address-space model, indices bound to the Java
     /// `AddressSpace.getUnique()` numbering.
     pub manager: AddrSpaceManager,
@@ -61,8 +91,8 @@ pub struct GhidraTranslate {
     pub unique_base: u64,
 }
 
-impl GhidraTranslate {
-    /// Parse the \<sleigh> tspec document (C++ `GhidraTranslate::decode`,
+impl TspecModel {
+    /// Parse the `<sleigh>` tspec document (C++ `GhidraTranslate::decode`,
     /// ghidra_translate.cc:161-176):
     ///
     /// ```text
@@ -73,7 +103,7 @@ impl GhidraTranslate {
     ///     <truncate_space space=... size=.../> ...
     ///   </sleigh>
     /// ```
-    pub fn decode(tspec: &[u8], registry: &IdRegistry) -> KunaResult<GhidraTranslate> {
+    pub fn decode(tspec: &[u8], registry: &IdRegistry) -> KunaResult<TspecModel> {
         let document = xml_tree(tspec)?;
         let root = Rc::clone(document.get_root());
         if root.get_name() != "sleigh" {
@@ -142,7 +172,7 @@ impl GhidraTranslate {
             manager.truncate_space(tag.get_name(), tag.get_size())?;
         }
 
-        Ok(GhidraTranslate {
+        Ok(TspecModel {
             manager,
             big_endian,
             unique_base,
@@ -150,9 +180,368 @@ impl GhidraTranslate {
     }
 }
 
+/// C++ `GhidraTranslate` (ghidra_translate.hh:36-57): the live ghidra-mode
+/// translator.  Its disassembly/p-code (`oneInstruction`) and register
+/// lookups (`getRegister`/`getRegisterName`) are served by queries on the
+/// shared [`GhidraClient`] (the kuna analog of the C++ `glb` back-pointer).
+///
+/// All the query I/O and cache fills run through `&self` (the trait methods
+/// are `&self`, matching C++ `const`/`mutable`), so mutation goes through the
+/// `RefCell` caches and the `RefCell` inside [`SharedClient`] — the sanctioned
+/// kuna interior-mutability pattern.
+pub struct GhidraTranslate<R: Read, W: Write> {
+    /// The concrete C++ `Translate` base-class state — endianness, unique
+    /// base, float formats (reached through [`Translate::translate_base`]).
+    base: TranslateBase,
+    /// The address-space model; indices bound to the Java
+    /// `AddressSpace.getUnique()` numbering.  Held as `Rc` so
+    /// [`EngineTranslate::manager_rc`] shares the same space set (identities
+    /// and indices) the tspec decode built.
+    manager: Rc<AddrSpaceManager>,
+    /// The shared query client (C++ `ArchitectureGhidra *glb`).
+    client: SharedClient<R, W>,
+    /// C++ `mutable map<string,VarnodeData> nm2addr` — the name→storage
+    /// register cache (`RefCell` ports `mutable`).
+    nm2addr: RefCell<BTreeMap<String, VarnodeStorage>>,
+    /// C++ `mutable map<VarnodeData,string> addr2nm` — the storage→name
+    /// register cache.
+    addr2nm: RefCell<BTreeMap<VarnodeStorage, String>>,
+    /// The program load image (C++ `LoadImageGhidra`): every read of program
+    /// bytes becomes a `getBytes` query.  Boxed behind `Rc<RefCell<…>>` to
+    /// mirror `Sleigh::loader`, so [`EngineTranslate::loader_rc`] can hand out
+    /// a shared handle and `set_loader` can replace it in place.
+    loader: Rc<RefCell<Box<dyn LoadImage>>>,
+    /// The context database (C++ `ContextGhidra`).
+    ///
+    /// STEP-2 STUB: a real [`ContextInternal`] with empty tracked sets.  In
+    /// ghidra mode the host disassembles, so local disassembly context is
+    /// essentially never consulted; an empty context is correct for step 2.
+    /// TODO(phase-3): back `get_tracked_set` with the `getTrackedRegisters`
+    /// query (`GhidraClient::get_tracked_registers` + `decode_tracked`), which
+    /// needs a fetch-and-cache design resolving the
+    /// `&TrackedSet`-from-`&self` borrow (spec §5 risks).
+    context: RefCell<ContextInternal>,
+}
+
+// `'static` on the stream types: the loader coerces `GhidraLoadImage<R,W>`
+// into a `Box<dyn LoadImage>` (a `dyn … + 'static` trait object), so the
+// erased stream types must outlive it.  The real binary uses stdin/stdout and
+// the tests use owned `Cursor`/`Vec`, all `'static`.
+impl<R: Read + 'static, W: Write + 'static> GhidraTranslate<R, W> {
+    /// Build the live translator from the tspec document and the shared query
+    /// client (the kuna analog of the C++ `ArchitectureGhidra` installing
+    /// `buildTranslator`→GhidraTranslate + `buildLoader`→LoadImageGhidra,
+    /// ghidra_arch.cc:283-299).
+    ///
+    /// The `<sleigh>` parse ([`TspecModel::decode`]) yields the address-space
+    /// manager and endianness/unique base, which are folded into the
+    /// [`TranslateBase`]; the loader is a [`GhidraLoadImage`] over the same
+    /// shared client.
+    pub fn new(
+        tspec: &[u8],
+        registry: &IdRegistry,
+        client: SharedClient<R, W>,
+    ) -> KunaResult<GhidraTranslate<R, W>> {
+        let TspecModel {
+            manager,
+            big_endian,
+            unique_base,
+        } = TspecModel::decode(tspec, registry)?;
+        let mut base = TranslateBase::new();
+        // C++ Translate::setBigEndian / setUniqueBase (via decode).
+        base.set_big_endian(big_endian);
+        base.set_unique_base(unique_base as u32); // uintb -> uintm (uint4), as C++ setUniqueBase
+                                                  // Downstream stages (float-op typing) expect IEEE formats present.
+        base.set_default_float_formats();
+
+        let loader: Box<dyn LoadImage> = Box::new(GhidraLoadImage::new(Rc::clone(&client)));
+
+        Ok(GhidraTranslate {
+            base,
+            manager: Rc::new(manager),
+            client,
+            nm2addr: RefCell::new(BTreeMap::new()),
+            addr2nm: RefCell::new(BTreeMap::new()),
+            loader: Rc::new(RefCell::new(loader)),
+            context: RefCell::new(ContextInternal::new()),
+        })
+    }
+}
+
+impl<R: Read, W: Write> GhidraTranslate<R, W> {
+    /// C++ `GhidraTranslate::cacheRegister` (ghidra_translate.cc): record a
+    /// resolved register in both directions.
+    #[allow(clippy::mutable_key_type)] // AddrSpace interior-mutable fields do not affect VarnodeStorage's Ord
+    fn cache_register(&self, nm: &str, vndata: &VarnodeStorage) {
+        self.nm2addr
+            .borrow_mut()
+            .insert(nm.to_string(), vndata.clone());
+        self.addr2nm
+            .borrow_mut()
+            .insert(vndata.clone(), nm.to_string());
+    }
+}
+
+impl<R: Read, W: Write> RegisterLookup for GhidraTranslate<R, W> {
+    /// C++ `GhidraTranslate::getRegister` (ghidra_translate.cc:45-70): the
+    /// `nm2addr` cache, else a `getRegister` query decoded into a storage
+    /// triple and cached both ways.
+    fn get_register(&self, nm: &str) -> KunaResult<VarnodeStorage> {
+        {
+            let cache = self.nm2addr.borrow();
+            if let Some(vndata) = cache.get(nm) {
+                return Ok(vndata.clone());
+            }
+        }
+        let mut decoder = PackedDecode::new(&self.manager);
+        let found = self
+            .client
+            .borrow_mut()
+            .get_register(nm, &mut decoder)
+            .map_err(wire_to_kuna)?;
+        if !found {
+            // C++ throws SleighError (a LowlevelError).
+            return Err(KunaError::lowlevel(format!("No register named {nm}")));
+        }
+        // C++ Address::decode(decoder, regsize) -> (addr, size).
+        let (regaddr, regsize) = Address::decode_sized(&mut decoder)?;
+        let vndata = VarnodeStorage {
+            space: regaddr.get_space().cloned(),
+            offset: regaddr.get_offset(),
+            size: regsize as u32, // int4 -> uint4, as the VarnodeData member
+        };
+        self.cache_register(nm, &vndata);
+        Ok(vndata)
+    }
+
+    /// C++ `GhidraTranslate::getRegisterName` (ghidra_translate.cc:72-87): the
+    /// name of the register overlapping a processor-space location, else "".
+    /// The infallible signature swallows a query failure to "" (spec risks).
+    #[allow(clippy::mutable_key_type)] // see cache_register
+    fn get_register_name(&self, base: &Rc<AddrSpace>, off: u64, size: i32) -> String {
+        if base.get_type() != spacetype::IPTR_PROCESSOR {
+            return String::new();
+        }
+        let vndata = VarnodeStorage {
+            space: Some(Rc::clone(base)),
+            offset: off,
+            size: size as u32,
+        };
+        {
+            let cache = self.addr2nm.borrow();
+            if let Some(nm) = cache.get(&vndata) {
+                return nm.clone();
+            }
+        }
+        let bytes = match self.client.borrow_mut().get_register_name(&vndata) {
+            Ok(b) => b,
+            Err(_) => return String::new(),
+        };
+        if bytes.is_empty() {
+            return String::new();
+        }
+        let name = String::from_utf8_lossy(&bytes).into_owned();
+        // The queried vndata may be a truncated piece; cache the FULL
+        // register (C++ comment).  Any failure is swallowed — the name is
+        // still valid.
+        let _ = self.get_register(&name);
+        name
+    }
+
+    /// C++ `GhidraTranslate::getExactRegisterName`
+    /// (ghidra_translate.cc:89-106): the register name only if it matches the
+    /// location AND size exactly, else "".
+    fn get_exact_register_name(&self, base: &Rc<AddrSpace>, off: u64, size: i32) -> String {
+        if base.get_type() != spacetype::IPTR_PROCESSOR {
+            return String::new();
+        }
+        let vndata = VarnodeStorage {
+            space: Some(Rc::clone(base)),
+            offset: off,
+            size: size as u32,
+        };
+        let bytes = match self.client.borrow_mut().get_register_name(&vndata) {
+            Ok(b) => b,
+            Err(_) => return String::new(),
+        };
+        if bytes.is_empty() {
+            return String::new();
+        }
+        let name = String::from_utf8_lossy(&bytes).into_owned();
+        // Exact match required: the resolved register's size must equal the
+        // requested size (C++ checks `reg.size == size`).
+        match self.get_register(&name) {
+            Ok(full) if full.size == size as u32 => name,
+            _ => String::new(),
+        }
+    }
+}
+
+impl<R: Read, W: Write> Translate for GhidraTranslate<R, W> {
+    fn translate_base(&self) -> &TranslateBase {
+        &self.base
+    }
+    fn translate_base_mut(&mut self) -> &mut TranslateBase {
+        &mut self.base
+    }
+    /// The tspec is parsed at construction ([`GhidraTranslate::new`]), so the
+    /// `DocumentStorage` initialize path is vestigial (C++
+    /// `GhidraTranslate::initialize` pulls the `<sleigh>` tag from the store;
+    /// kuna already has it).
+    fn initialize(&mut self, _store: &mut DocumentStorage) -> KunaResult<()> {
+        Ok(())
+    }
+    /// C++ `GhidraTranslate::getAllRegisters` throws `LowlevelError`
+    /// (ghidra_translate.hh:49-50); kuna's infallible signature can only
+    /// no-op.  The Java host owns the register table; this is never reached in
+    /// ghidra mode.
+    #[allow(clippy::mutable_key_type)] // VarnodeData interior mutability does not affect its Ord (see the trait)
+    fn get_all_registers(&self, _reglist: &mut BTreeMap<VarnodeData, String>) {}
+    /// C++ `GhidraTranslate::getUserOpNames` (ghidra_translate.cc:108-118):
+    /// the init-time index probe — query `getUserOpName(i)` for `i=0,1,…`
+    /// until the host answers an empty name.  Infallible: a query error also
+    /// ends the loop (spec risks).
+    fn get_user_op_names(&self, res: &mut Vec<String>) {
+        let mut i = 0i32;
+        loop {
+            let bytes = match self.client.borrow_mut().get_user_op_name(i) {
+                Ok(b) => b,
+                Err(_) => break,
+            };
+            if bytes.is_empty() {
+                break;
+            }
+            res.push(String::from_utf8_lossy(&bytes).into_owned());
+            i += 1;
+        }
+    }
+    /// C++ throws (ghidra_translate.hh:53-54) — the length is only knowable by
+    /// disassembling, which is the host's job.
+    fn instruction_length(&self, _baseaddr: &Address) -> KunaResult<i32> {
+        Err(KunaError::lowlevel(
+            "Cannot get instruction length through this interface",
+        ))
+    }
+    /// C++ `GhidraTranslate::oneInstruction` (ghidra_translate.cc:120-156): a
+    /// `getPcode` query whose response is either `<unimpl offset=.../>` or
+    /// `<inst offset=..><addr/> <op ...>* </inst>`.  The load-bearing method.
+    fn one_instruction(&self, emit: &mut dyn PcodeEmit, baseaddr: &Address) -> KunaResult<i32> {
+        // The decoder's space indices come from the tspec manager, which is
+        // what makes the packed <addr>/<spaceid> elements decode correctly.
+        let mut decoder = PackedDecode::new(&self.manager);
+        let success = match self.client.borrow_mut().get_pcode(baseaddr, &mut decoder) {
+            Ok(s) => s,
+            // C++ catch(JavaError&): rethrow LowlevelError with the address.
+            Err(WireError::Kuna(KunaError::Java { .. })) => {
+                let mut msg = String::from("Error generating pcode at address: ");
+                let _ = baseaddr.print_raw(&mut msg);
+                return Err(KunaError::lowlevel(msg));
+            }
+            Err(other) => return Err(wire_to_kuna(other)),
+        };
+        if !success {
+            // C++ BadDataError — the flow decode-error ladder's BadData branch.
+            let mut msg = String::from("No pcode could be generated at address: ");
+            let _ = baseaddr.print_raw(&mut msg);
+            return Err(KunaError::bad_data(msg));
+        }
+        let el = decoder.open_element()?;
+        let offset = decoder.read_signed_integer_id(&ATTRIB_OFFSET)? as i32; // intb -> int4
+        if el == ELEM_UNIMPL.get_id() {
+            // C++ UnimplError(msg, offset) — the Unimpl variant must carry the
+            // instruction length the flow ladder reads.
+            let mut msg = String::from("Instruction not implemented in pcode:\n ");
+            let _ = baseaddr.print_raw(&mut msg);
+            return Err(KunaError::unimpl(msg, offset));
+        }
+        let pc = Address::decode(&mut decoder)?;
+        // The <inst> element is never closed; peek returns 0 at </inst>.
+        while decoder.peek_element()? != 0 {
+            emit.decode_op(&pc, &mut decoder)?;
+        }
+        Ok(offset)
+    }
+    /// C++ throws (ghidra_translate.hh:55-56) — disassembly is the host's job.
+    fn print_assembly(&self, _emit: &mut dyn AssemblyEmit, _baseaddr: &Address) -> KunaResult<i32> {
+        Err(KunaError::lowlevel(
+            "Cannot disassemble through this interface",
+        ))
+    }
+}
+
+impl<R: Read, W: Write> EngineTranslate for GhidraTranslate<R, W> {
+    fn manager(&self) -> &AddrSpaceManager {
+        &self.manager
+    }
+    fn manager_rc(&self) -> Rc<AddrSpaceManager> {
+        Rc::clone(&self.manager)
+    }
+    fn manager_mut(&mut self) -> &mut AddrSpaceManager {
+        // Mirrors Sleigh: mutable access is only taken during init, while the
+        // engine is still the sole `Rc` owner (before any `glb` clones it).
+        Rc::get_mut(&mut self.manager)
+            .expect("ghidra engine address-space manager already shared (Rc not unique)")
+    }
+    fn loader_rc(&self) -> Rc<RefCell<Box<dyn LoadImage>>> {
+        Rc::clone(&self.loader)
+    }
+    fn set_loader(&mut self, loader: Box<dyn LoadImage>) {
+        *self.loader.borrow_mut() = loader;
+    }
+    /// Read `sz` (<=8) bytes of a Varnode's value from the load image (mirrors
+    /// `Sleigh::read_loadimage_value` / C++ `Emulate*::getLoadImageValue`):
+    /// `loadFill` a full `uintb`, byte-swap to host order if the space
+    /// endianness differs, then mask/shift down to `sz`.
+    fn read_loadimage_value(&self, addr: &Address, sz: i32) -> KunaResult<u64> {
+        use kuna_base::address::{byte_swap, calc_mask};
+        use kuna_base::types::HOST_ENDIAN;
+        let mut buf = [0u8; 8]; // sizeof(uintb)
+        self.loader.borrow_mut().load_fill(&mut buf, addr)?;
+        let big = addr.is_big_endian();
+        let mut res = if HOST_ENDIAN == 1 {
+            u64::from_be_bytes(buf)
+        } else {
+            u64::from_le_bytes(buf)
+        };
+        if (HOST_ENDIAN == 1) != big {
+            res = byte_swap(res, 8);
+        }
+        if big && (sz as usize) < 8 {
+            res >>= (8 - sz as u32) * 8;
+        } else {
+            res &= calc_mask(sz);
+        }
+        Ok(res)
+    }
+    /// C++ `Translate::getRegister(name)` returning the canonical
+    /// [`VarnodeData`] — adapts [`RegisterLookup::get_register`] (which yields
+    /// the kuna-base [`VarnodeStorage`] triple).
+    fn get_register_varnode(&self, nm: &[u8]) -> KunaResult<VarnodeData> {
+        let name = String::from_utf8_lossy(nm);
+        let vndata = RegisterLookup::get_register(self, &name)?;
+        Ok(varnode_data_from_storage(&vndata))
+    }
+    /// Run a closure with mutable access to the context database (C++
+    /// `glb->context`).  STEP-2 STUB: the [`ContextInternal`] field (see the
+    /// struct doc); TODO(phase-3) query-backed tracked registers.
+    fn with_context_db_dyn(&self, f: &mut dyn FnMut(&mut dyn ContextDatabase)) {
+        let mut db = self.context.borrow_mut();
+        f(&mut *db);
+    }
+    // as_sleigh / as_sleigh_mut: take the trait defaults (None) — this is not
+    // the standalone Sleigh engine.
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
+
+    use kuna_base::marshal::{Encoder, PackedEncode};
+    use kuna_num::opcodes::{OpCode, OpcodeEncoder};
+    use kuna_sleigh::translate::{ATTRIB_CODE, ELEM_OP};
+
+    use crate::client::GhidraClient;
 
     /// A realistic tspec, shaped exactly like SleighLanguage.encodeTranslator
     /// output (single line, XmlEncode(false)): OTHER at unique index 1
@@ -165,10 +554,12 @@ mod tests {
 <space name=\"register\" index=\"4\" size=\"4\" bigendian=\"false\" delay=\"0\" physical=\"true\"/>\
 </spaces></sleigh>";
 
+    // -- TspecModel decode (the former GhidraTranslate::decode tests) --------
+
     #[test]
     fn test_decode_tspec() {
         let registry = build_registry();
-        let tr = GhidraTranslate::decode(TEST_TSPEC, &registry).unwrap();
+        let tr = TspecModel::decode(TEST_TSPEC, &registry).unwrap();
         assert!(!tr.big_endian);
         assert_eq!(tr.unique_base, 0x10000000);
         let ram = tr.manager.get_space_by_name("ram").expect("ram space");
@@ -184,10 +575,8 @@ mod tests {
             .get_space_by_name("unique")
             .expect("unique space");
         assert_eq!(unique.get_index(), 2);
-        // defaultspace resolution
         let def = tr.manager.get_default_code_space().expect("default space");
         assert_eq!(def.get_name(), "ram");
-        // constant space auto-inserted at index 0
         let cspace = tr.manager.get_constant_space().expect("constant space");
         assert_eq!(cspace.get_index(), 0);
     }
@@ -199,7 +588,7 @@ mod tests {
 <spaces defaultspace=\"ram\">\
 <space name=\"ram\" index=\"1\" size=\"8\" bigendian=\"true\" delay=\"1\" physical=\"true\"/>\
 </spaces><truncate_space space=\"ram\" size=\"4\"/></sleigh>";
-        let tr = GhidraTranslate::decode(tspec, &registry).unwrap();
+        let tr = TspecModel::decode(tspec, &registry).unwrap();
         assert!(tr.big_endian);
         let ram = tr.manager.get_space_by_name("ram").unwrap();
         assert_eq!(ram.get_addr_size(), 4);
@@ -208,6 +597,272 @@ mod tests {
     #[test]
     fn test_decode_tspec_rejects_non_sleigh_root() {
         let registry = build_registry();
-        assert!(GhidraTranslate::decode(b"<x/>", &registry).is_err());
+        assert!(TspecModel::decode(b"<x/>", &registry).is_err());
+    }
+
+    // -- GhidraTranslate live-translator tests (canned-stream MockJava) ------
+
+    type TestClient = SharedClient<Cursor<Vec<u8>>, Vec<u8>>;
+
+    fn shared(reader: Vec<u8>) -> TestClient {
+        Rc::new(RefCell::new(GhidraClient::new(
+            Cursor::new(reader),
+            Vec::new(),
+        )))
+    }
+
+    fn translate(client: TestClient) -> GhidraTranslate<Cursor<Vec<u8>>, Vec<u8>> {
+        GhidraTranslate::new(TEST_TSPEC, &build_registry(), client).expect("tspec parses")
+    }
+
+    fn burst(v: &mut Vec<u8>, code: u8) {
+        v.extend_from_slice(&[0, 0, 1, code]);
+    }
+
+    /// Wrap a packed document as a query response: response open (8), string
+    /// open (14), the packed bytes, string close (15), response close (9).
+    fn packed_response(packed: &[u8]) -> Vec<u8> {
+        let mut r = Vec::new();
+        burst(&mut r, 8);
+        burst(&mut r, 14);
+        r.extend_from_slice(packed);
+        burst(&mut r, 15);
+        burst(&mut r, 9);
+        r
+    }
+
+    /// A plain-string query response (getRegisterName / getUserOpName):
+    /// response open (8), string open (14), bytes, string close (15),
+    /// response close (9).
+    fn string_response(s: &[u8]) -> Vec<u8> {
+        let mut r = Vec::new();
+        burst(&mut r, 8);
+        burst(&mut r, 14);
+        r.extend_from_slice(s);
+        burst(&mut r, 15);
+        burst(&mut r, 9);
+        r
+    }
+
+    /// An empty query response: response open (8) then response close (9),
+    /// with no string stream — `read_all` returns `false`.
+    fn empty_response() -> Vec<u8> {
+        let mut r = Vec::new();
+        burst(&mut r, 8);
+        burst(&mut r, 9);
+        r
+    }
+
+    fn ram_space(tr: &GhidraTranslate<Cursor<Vec<u8>>, Vec<u8>>) -> Rc<AddrSpace> {
+        Rc::clone(tr.manager.get_space_by_name("ram").expect("ram"))
+    }
+
+    /// A recording `PcodeEmit` that captures each decoded op.
+    #[derive(Default)]
+    struct RecordEmit {
+        ops: Vec<(OpCode, Option<VarnodeData>, Vec<VarnodeData>)>,
+    }
+    impl PcodeEmit for RecordEmit {
+        fn dump(
+            &mut self,
+            _addr: &Address,
+            opc: OpCode,
+            outvar: Option<&VarnodeData>,
+            vars: &[VarnodeData],
+        ) {
+            self.ops.push((opc, outvar.cloned(), vars.to_vec()));
+        }
+    }
+
+    /// (a) `one_instruction` against a canned `<inst><addr/><op ...></inst>`
+    /// getPcode response: assert the byte-exact request framing AND the
+    /// decoded ops handed to the emit.
+    #[test]
+    fn one_instruction_decodes_inst_ops() {
+        // Build the getPcode response document over the tspec manager.
+        let model = TspecModel::decode(TEST_TSPEC, &build_registry()).unwrap();
+        let ram = Rc::clone(model.manager.get_space_by_name("ram").unwrap());
+        // ELEM_INST id 98 (kuna-decomp/pcodeinject.rs) — any non-unimpl id.
+        let elem_inst = kuna_base::marshal::ElementId::new("inst", 98);
+        let mut doc = Vec::new();
+        {
+            let mut e = PackedEncode::new(&mut doc);
+            e.open_element(&elem_inst);
+            e.write_signed_integer(&ATTRIB_OFFSET, 4); // instruction length
+                                                       // the pc <addr>
+            Address::new(Rc::clone(&ram), 0x401000)
+                .encode(&mut e)
+                .unwrap();
+            // one <op>: INT_ADD out=ram:0x20:4  in=ram:0x30:4, ram:0x34:4
+            e.open_element(&ELEM_OP);
+            e.write_signed_integer(&kuna_base::marshal::ATTRIB_SIZE, 2); // isize
+            e.write_opcode(&ATTRIB_CODE, OpCode::CPUI_INT_ADD);
+            Address::new(Rc::clone(&ram), 0x20)
+                .encode_sized(&mut e, 4)
+                .unwrap();
+            Address::new(Rc::clone(&ram), 0x30)
+                .encode_sized(&mut e, 4)
+                .unwrap();
+            Address::new(Rc::clone(&ram), 0x34)
+                .encode_sized(&mut e, 4)
+                .unwrap();
+            e.close_element(&ELEM_OP);
+            e.close_element(&elem_inst);
+        }
+
+        let client = shared(packed_response(&doc));
+        let tr = translate(Rc::clone(&client));
+        let ram = ram_space(&tr);
+        let baseaddr = Address::new(Rc::clone(&ram), 0x401000);
+
+        let mut emit = RecordEmit::default();
+        let len = tr
+            .one_instruction(&mut emit, &baseaddr)
+            .expect("one_instruction");
+        assert_eq!(len, 4, "returned instruction length is the <inst> offset");
+
+        assert_eq!(emit.ops.len(), 1);
+        let (opc, out, ins) = &emit.ops[0];
+        assert_eq!(*opc, OpCode::CPUI_INT_ADD);
+        let out = out.as_ref().expect("output varnode");
+        assert_eq!((out.offset, out.size), (0x20, 4));
+        assert_eq!(ins.len(), 2);
+        assert_eq!((ins[0].offset, ins[0].size), (0x30, 4));
+        assert_eq!((ins[1].offset, ins[1].size), (0x34, 4));
+
+        // Byte-exact getPcode request framing (query open, string, packed
+        // command doc, string close, query close).
+        drop(tr);
+        let (_r, w) = Rc::try_unwrap(client).unwrap().into_inner().into_inner();
+        let mut cmd = Vec::new();
+        {
+            let ram2 = Rc::clone(
+                TspecModel::decode(TEST_TSPEC, &build_registry())
+                    .unwrap()
+                    .manager
+                    .get_space_by_name("ram")
+                    .unwrap(),
+            );
+            let mut e = PackedEncode::new(&mut cmd);
+            e.open_element(&crate::ids::ELEM_COMMAND_GETPCODE);
+            Address::new(ram2, 0x401000).encode(&mut e).unwrap();
+            e.close_element(&crate::ids::ELEM_COMMAND_GETPCODE);
+        }
+        let mut expected = Vec::new();
+        burst(&mut expected, 4);
+        burst(&mut expected, 14);
+        expected.extend_from_slice(&cmd);
+        burst(&mut expected, 15);
+        burst(&mut expected, 5);
+        assert_eq!(w, expected, "getPcode request framing");
+    }
+
+    /// (b) `<unimpl offset=N/>` → `KunaError::Unimpl` carrying the offset.
+    #[test]
+    fn one_instruction_unimpl_carries_length() {
+        let mut doc = Vec::new();
+        {
+            let mut e = PackedEncode::new(&mut doc);
+            e.open_element(&ELEM_UNIMPL);
+            e.write_signed_integer(&ATTRIB_OFFSET, 2);
+            e.close_element(&ELEM_UNIMPL);
+        }
+        let client = shared(packed_response(&doc));
+        let tr = translate(client);
+        let ram = ram_space(&tr);
+        let err = tr
+            .one_instruction(&mut RecordEmit::default(), &Address::new(ram, 0x1000))
+            .expect_err("unimpl must error");
+        match err {
+            KunaError::Unimpl {
+                instruction_length, ..
+            } => assert_eq!(instruction_length, 2),
+            other => panic!("expected Unimpl, got {other:?}"),
+        }
+    }
+
+    /// (c) An empty getPcode response → `KunaError::BadData`.
+    #[test]
+    fn one_instruction_empty_is_bad_data() {
+        let client = shared(empty_response());
+        let tr = translate(client);
+        let ram = ram_space(&tr);
+        let err = tr
+            .one_instruction(&mut RecordEmit::default(), &Address::new(ram, 0x1000))
+            .expect_err("empty response must error");
+        assert!(
+            matches!(err, KunaError::BadData { .. }),
+            "expected BadData, got {err:?}"
+        );
+    }
+
+    /// (d) `get_register` cache miss (canned `<addr>` response) then cache hit
+    /// (no second query issued).
+    #[test]
+    fn get_register_caches() {
+        let model = TspecModel::decode(TEST_TSPEC, &build_registry()).unwrap();
+        let reg = Rc::clone(model.manager.get_space_by_name("register").unwrap());
+        let mut doc = Vec::new();
+        {
+            let mut e = PackedEncode::new(&mut doc);
+            // A bare <addr> for the register (register:0x10 size 4) — the
+            // shape AddressXML.encode sends as the getRegister response.
+            Address::new(Rc::clone(&reg), 0x10)
+                .encode_sized(&mut e, 4)
+                .unwrap();
+        }
+        // Only ONE response is canned: a second query would run off the end
+        // of the reader and error, so a cache hit is proven by success.
+        let client = shared(packed_response(&doc));
+        let tr = translate(Rc::clone(&client));
+
+        let first = RegisterLookup::get_register(&tr, "myreg").expect("first lookup");
+        assert_eq!(first.offset, 0x10);
+        assert_eq!(first.size, 4);
+        assert_eq!(
+            first.space.as_ref().unwrap().get_name(),
+            "register",
+            "decoded against the tspec register space"
+        );
+
+        // Cache hit: no bytes left in the reader, yet this must succeed.
+        let second = RegisterLookup::get_register(&tr, "myreg").expect("cache hit");
+        assert_eq!(second, first);
+
+        // Exactly one query was written (one request framing).
+        drop(tr);
+        let (_r, w) = Rc::try_unwrap(client).unwrap().into_inner().into_inner();
+        let mut expected_one = Vec::new();
+        {
+            let mut cmd = Vec::new();
+            {
+                let mut e = PackedEncode::new(&mut cmd);
+                e.open_element(&crate::ids::ELEM_COMMAND_GETREGISTER);
+                e.write_string(&kuna_base::marshal::ATTRIB_NAME, b"myreg");
+                e.close_element(&crate::ids::ELEM_COMMAND_GETREGISTER);
+            }
+            burst(&mut expected_one, 4);
+            burst(&mut expected_one, 14);
+            expected_one.extend_from_slice(&cmd);
+            burst(&mut expected_one, 15);
+            burst(&mut expected_one, 5);
+        }
+        assert_eq!(w, expected_one, "exactly one getRegister query issued");
+    }
+
+    /// (e) `get_user_op_names` probe loop terminates on the empty answer.
+    #[test]
+    fn get_user_op_names_probe_loop() {
+        // Two named ops then an empty answer ends the loop.
+        let mut reader = Vec::new();
+        reader.extend_from_slice(&string_response(b"COUNTLEADINGZEROS"));
+        reader.extend_from_slice(&string_response(b"COUNTLEADINGONES"));
+        reader.extend_from_slice(&empty_response());
+        let client = shared(reader);
+        let tr = translate(client);
+
+        let mut names = Vec::new();
+        tr.get_user_op_names(&mut names);
+        assert_eq!(names, vec!["COUNTLEADINGZEROS", "COUNTLEADINGONES"]);
     }
 }

--- a/decompiler/crates/kuna-ghidra/tests/decompile_at_e2e.rs
+++ b/decompiler/crates/kuna-ghidra/tests/decompile_at_e2e.rs
@@ -1,0 +1,555 @@
+//! The decompileAt end-to-end proof (phase-2 step 6): drive a FULL ghidra-mode
+//! session — registerProgram → setAction("decompile","c") → decompileAt(entry)
+//! — for a TINY real function and prove C comes out.
+//!
+//! Unlike the pre-canned byte streams of `protocol_e2e.rs`, this drives the LIVE
+//! decompiler: `decompileAt` runs `decompile_func`, whose flow-follow + pipeline
+//! issue getPcode/getCodeLabel/getRegister/... queries whose exact sequence
+//! depends on engine internals.  Pre-canning that sequence would be brittle, so
+//! the MockJava here is an **interactive single-threaded loopback**: the process
+//! writes queries into a shared buffer; the mock decodes each query's command
+//! element id and generates a response on demand (empty getUserOpName to end the
+//! probe, a name for getCodeLabel, a canned `<inst>` RETURN for getPcode at the
+//! entry, safe minimal answers for everything else).  This is sound because
+//! packed protocol payloads are 0x00-free (protocol.rs:21), so the 4-byte
+//! query-open marker `[0,0,1,4]` never occurs inside a payload and query frames
+//! are unambiguously delimited.
+//!
+//! ## What this covers
+//!   * The whole wire lifecycle end to end over the real command loop.
+//!   * `decompileAt` names the function from `getCodeLabel`, builds+decompiles a
+//!     `Funcdata` for the raw entry (flow-discovered extent), and emits a
+//!     well-formed `<doc>` containing the `Funcdata::encode` `<function>`/`<ast>`.
+//!   * The dual `<function>` (the Clang markup) is present when C is requested,
+//!     decodes, and its `opref`/`varref` tokens are a subset of the `<ast>`'s op
+//!     times / varnode create-indices — the click-to-address contract, end to end.
+//!
+//! ## What this stubs / canned
+//!   * The decompiled function is a synthetic single-instruction `RETURN #0x0`
+//!     (the mock's getPcode answer for the entry; BadData elsewhere) — enough to
+//!     produce a non-empty AST without needing a real processor `.sla`.
+//!   * getRegister returns a fixed register storage, getRegisterName/getComments
+//!     return empty, getBytes returns DataUnavail — defensive minimal answers so
+//!     the decompile of this register-free function completes; the specs are the
+//!     same four tiny valid documents `protocol_e2e.rs` proves build a live arch.
+//!   * There is NO symbol scope (Phase 3): unresolved refs degrade to
+//!     placeholders, which is the accepted phase-2 quality.
+
+use std::cell::RefCell;
+use std::cmp::min;
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::{Read, Write};
+use std::rc::Rc;
+
+use kuna_base::address::Address;
+use kuna_base::marshal::{
+    Decoder, ElementId, Encoder, PackedDecode, PackedEncode, ATTRIB_NAME, ATTRIB_SIZE,
+};
+use kuna_base::space::AddrSpaceManager;
+use kuna_num::opcodes::{OpCode, OpcodeEncoder};
+use kuna_sleigh::translate::{ATTRIB_CODE, ELEM_OP};
+
+use kuna_ghidra::ids::{
+    ELEM_COMMAND_GETBYTES, ELEM_COMMAND_GETCODELABEL, ELEM_COMMAND_GETPCODE,
+    ELEM_COMMAND_GETREGISTER, ELEM_COMMAND_GETREGISTERNAME, ELEM_COMMAND_GETUSEROPNAME, ELEM_DOC,
+};
+use kuna_ghidra::process::GhidraProcess;
+use kuna_ghidra::translate::{build_registry, TspecModel};
+
+// The four registerProgram documents — the same tiny valid specs
+// `protocol_e2e.rs` proves build a live `Architecture` (single init query, empty
+// warnings).  `<default_proto/>` is empty (no register storage in the model), so
+// the register-free RETURN function needs no register recovery.
+const TSPEC: &[u8] = b"<sleigh bigendian=\"false\" uniqbase=\"0x10000000\">\
+<spaces defaultspace=\"ram\">\
+<space_other name=\"OTHER\" index=\"1\" size=\"8\" bigendian=\"false\" delay=\"0\" physical=\"true\"/>\
+<space_unique name=\"unique\" index=\"2\" size=\"4\" bigendian=\"false\" delay=\"0\" physical=\"true\"/>\
+<space name=\"ram\" index=\"3\" size=\"8\" bigendian=\"false\" delay=\"1\" physical=\"true\"/>\
+<space name=\"register\" index=\"4\" size=\"4\" bigendian=\"false\" delay=\"0\" physical=\"true\"/>\
+</spaces></sleigh>";
+const PSPEC: &[u8] = b"<processor_spec><programcounter register=\"PC\"/></processor_spec>";
+const CSPEC: &[u8] = b"<compiler_spec><default_proto/></compiler_spec>";
+const CORETYPES: &[u8] =
+    b"<coretypes><type name=\"int\" size=\"4\" metatype=\"int\" id=\"-1\"/></coretypes>";
+
+const ENTRY: u64 = 0x1000;
+const FUNC_NAME: &[u8] = b"myfunc";
+
+// Marshaling attribute ids used only for decoding the response (raw numeric ids;
+// PackedDecode returns them straight from open_element / get_next_attribute_id).
+const ATTRIB_REF_ID: u32 = 18; // Varnode::getCreateIndex back-ref (marshal.rs)
+const ATTRIB_UNIQ_ID: u32 = 29; // <seqnum uniq> == PcodeOp::getTime (address.rs)
+const ATTRIB_OPREF_ID: u32 = 41; // EmitMarkup opref (prettyprint.rs)
+const ATTRIB_VARREF_ID: u32 = 42; // EmitMarkup varref (prettyprint.rs)
+const ELEM_FUNCTION_ID: u32 = 116; // <function> (funcdata_encode.rs)
+
+// ---------------------------------------------------------------------------
+// Interactive loopback MockJava
+// ---------------------------------------------------------------------------
+
+/// State shared between the process's `sin` ([`MockReader`]) and `sout`
+/// ([`MockWriter`]): the proactive command stream, the process's output buffer
+/// (scanned for query frames), and the response queue fed back to the process.
+struct MockState {
+    /// The proactive command frames (registerProgram/setAction/decompileAt).
+    commands: Vec<u8>,
+    /// Cursor into `commands`.
+    cmd_cursor: usize,
+    /// Everything the process has written (queries + command-response framing).
+    from_process: Vec<u8>,
+    /// How far `from_process` has been scanned for query frames.
+    parsed: usize,
+    /// Bytes queued to feed the process back (query responses).
+    to_process: Vec<u8>,
+    /// The tspec address-space manager (decodes the getPcode `<addr>`, encodes
+    /// the canned `<inst>` / register responses).
+    manager: Rc<AddrSpaceManager>,
+}
+
+impl MockState {
+    /// Scan `from_process` for complete query frames `{4}{14}<doc>{15}{5}`,
+    /// generating a response for each into `to_process`.  Safe because packed
+    /// payloads are 0x00-free, so `[0,0,1,4]` marks only a query open.
+    fn pump(&mut self) {
+        loop {
+            let rest = &self.from_process[self.parsed..];
+            let start = match find_subseq(rest, &[0, 0, 1, 4]) {
+                Some(i) => self.parsed + i,
+                None => {
+                    // No query pending; keep the last 3 bytes in case a marker
+                    // straddles the next write.
+                    self.parsed = self.from_process.len().saturating_sub(3);
+                    return;
+                }
+            };
+            let after_qopen = start + 4;
+            // Expect the string-open marker {14}.
+            if self.from_process.len() < after_qopen + 4 {
+                self.parsed = start;
+                return; // incomplete — wait for more bytes
+            }
+            if self.from_process[after_qopen..after_qopen + 4] != [0, 0, 1, 14] {
+                // Not a well-formed query open; skip this marker.
+                self.parsed = start + 1;
+                continue;
+            }
+            let doc_start = after_qopen + 4;
+            // The packed doc is 0x00-free, so {15} delimits it unambiguously.
+            let close = match find_subseq(&self.from_process[doc_start..], &[0, 0, 1, 15]) {
+                Some(i) => doc_start + i,
+                None => {
+                    self.parsed = start;
+                    return; // incomplete — wait for the string close
+                }
+            };
+            let doc = self.from_process[doc_start..close].to_vec();
+            let after_sclose = close + 4; // past {15}
+            if self.from_process.len() < after_sclose + 4 {
+                self.parsed = start;
+                return; // the {5} query close has not arrived yet
+            }
+            let resp = self.generate_response(&doc);
+            self.to_process.extend_from_slice(&resp);
+            self.parsed = after_sclose + 4; // past the {5} query close
+        }
+    }
+
+    /// Decode a query's command element id and produce its response bytes.
+    fn generate_response(&self, doc: &[u8]) -> Vec<u8> {
+        let mut dec = PackedDecode::new(&self.manager);
+        dec.ingest_stream(doc).expect("query doc ingests");
+        let el = dec.open_element().expect("query has a command element");
+        if el == ELEM_COMMAND_GETUSEROPNAME.get_id() {
+            // Empty name at index 0 terminates the init-time user-op probe.
+            resp_string(b"")
+        } else if el == ELEM_COMMAND_GETCODELABEL.get_id() {
+            // The primary symbol name -> <function name>.
+            resp_string(FUNC_NAME)
+        } else if el == ELEM_COMMAND_GETPCODE.get_id() {
+            let addr = Address::decode(&mut dec).expect("getPcode carries an <addr>");
+            if addr.get_offset() == ENTRY {
+                resp_string(&self.return_inst_doc())
+            } else {
+                resp_empty() // BadData: flow should not ask past the RETURN
+            }
+        } else if el == ELEM_COMMAND_GETREGISTER.get_id() {
+            // A fixed valid register storage so a register lookup never errors
+            // (the register-free RETURN function should not reach here).
+            resp_string(&self.register_addr_doc())
+        } else if el == ELEM_COMMAND_GETREGISTERNAME.get_id() {
+            resp_string(b"") // no named register -> render by raw location
+        } else if el == ELEM_COMMAND_GETBYTES.get_id() {
+            resp_empty() // DataUnavail (no loadimage for a register/const-only fn)
+        } else {
+            // getComments / getMappedSymbols / getTrackedRegisters / getDataType
+            // / ... : an empty response (the decompile of this function issues
+            // none of them, but answer defensively so nothing desyncs).
+            resp_empty()
+        }
+    }
+
+    /// The canned getPcode answer for the entry: `<inst offset=1>` + the pc
+    /// `<addr>` + one `<op>` `RETURN #0x0:8` (output `<void/>`, one constant
+    /// input).  A RETURN terminates flow, so this single instruction is the whole
+    /// function body.
+    fn return_inst_doc(&self) -> Vec<u8> {
+        let ram = Rc::clone(self.manager.get_space_by_name("ram").expect("ram"));
+        let cst = Rc::clone(self.manager.get_constant_space().expect("constant"));
+        let elem_inst = ElementId::new("inst", 98); // ELEM_INST (kuna-decomp)
+        let mut doc = Vec::new();
+        {
+            let mut e = PackedEncode::new(&mut doc);
+            e.open_element(&elem_inst);
+            e.write_signed_integer(&kuna_base::marshal::ATTRIB_OFFSET, 1); // instr length
+            Address::new(Rc::clone(&ram), ENTRY).encode(&mut e).expect("pc addr");
+            // <op>: RETURN, isize=1, void output, one constant input.
+            e.open_element(&ELEM_OP);
+            e.write_signed_integer(&ATTRIB_SIZE, 1); // isize = one input
+            e.write_opcode(&ATTRIB_CODE, OpCode::CPUI_RETURN);
+            e.open_element(&kuna_base::marshal::ELEM_VOID);
+            e.close_element(&kuna_base::marshal::ELEM_VOID);
+            Address::new(cst, 0).encode_sized(&mut e, 8).expect("const input");
+            e.close_element(&ELEM_OP);
+            e.close_element(&elem_inst);
+        }
+        doc
+    }
+
+    /// A fixed register storage `<addr space=register offset=0 size=8>` (the
+    /// getRegister answer shape AddressXML.encode sends).
+    fn register_addr_doc(&self) -> Vec<u8> {
+        let reg = Rc::clone(self.manager.get_space_by_name("register").expect("register"));
+        let mut doc = Vec::new();
+        {
+            let mut e = PackedEncode::new(&mut doc);
+            Address::new(reg, 0).encode_sized(&mut e, 8).expect("register addr");
+        }
+        doc
+    }
+}
+
+/// The process's `sin`: serves query responses (from `to_process`) first, then
+/// the proactive command stream.
+struct MockReader {
+    shared: Rc<RefCell<MockState>>,
+}
+impl Read for MockReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let mut st = self.shared.borrow_mut();
+        st.pump(); // answer any pending query before serving
+        if !st.to_process.is_empty() {
+            let n = min(buf.len(), st.to_process.len());
+            buf[..n].copy_from_slice(&st.to_process[..n]);
+            st.to_process.drain(..n);
+            return Ok(n);
+        }
+        if st.cmd_cursor >= st.commands.len() {
+            return Ok(0); // EOF: the test stops driving before this is hit
+        }
+        let n = min(buf.len(), st.commands.len() - st.cmd_cursor);
+        let start = st.cmd_cursor;
+        buf[..n].copy_from_slice(&st.commands[start..start + n]);
+        st.cmd_cursor += n;
+        Ok(n)
+    }
+}
+
+/// The process's `sout`: accumulates output; flush triggers the query pump.
+struct MockWriter {
+    shared: Rc<RefCell<MockState>>,
+}
+impl Write for MockWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.shared.borrow_mut().from_process.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.shared.borrow_mut().pump();
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire builders (mirroring DecompileProcess.java's writer)
+// ---------------------------------------------------------------------------
+
+fn burst(v: &mut Vec<u8>, code: u8) {
+    v.extend_from_slice(&[0, 0, 1, code]);
+}
+
+/// `writeString`: {14} bytes {15}.
+fn wire_string(v: &mut Vec<u8>, s: &[u8]) {
+    burst(v, 14);
+    v.extend_from_slice(s);
+    burst(v, 15);
+}
+
+/// A query response wrapping a string stream: {8}{14}s{15}{9}.
+fn resp_string(s: &[u8]) -> Vec<u8> {
+    let mut r = Vec::new();
+    burst(&mut r, 8);
+    wire_string(&mut r, s);
+    burst(&mut r, 9);
+    r
+}
+
+/// An empty query response: {8}{9} (read_all -> false: BadData / DataUnavail /
+/// "not found", per the caller).
+fn resp_empty() -> Vec<u8> {
+    let mut r = Vec::new();
+    burst(&mut r, 8);
+    burst(&mut r, 9);
+    r
+}
+
+/// Build the proactive command stream: registerProgram + setAction + decompileAt.
+fn build_commands(addr_packed: &[u8]) -> Vec<u8> {
+    let mut v = Vec::new();
+    // registerProgram: {2}"registerProgram" + 4 string streams + {3}
+    burst(&mut v, 2);
+    wire_string(&mut v, b"registerProgram");
+    wire_string(&mut v, PSPEC);
+    wire_string(&mut v, CSPEC);
+    wire_string(&mut v, TSPEC);
+    wire_string(&mut v, CORETYPES);
+    burst(&mut v, 3);
+    // setAction: archid + "decompile" + "c"
+    burst(&mut v, 2);
+    wire_string(&mut v, b"setAction");
+    wire_string(&mut v, b"0");
+    wire_string(&mut v, b"decompile");
+    wire_string(&mut v, b"c");
+    burst(&mut v, 3);
+    // decompileAt: archid + packed <addr>
+    burst(&mut v, 2);
+    wire_string(&mut v, b"decompileAt");
+    wire_string(&mut v, b"0");
+    wire_string(&mut v, addr_packed);
+    burst(&mut v, 3);
+    v
+}
+
+// ---------------------------------------------------------------------------
+// Response-stream tokenizer + <doc> extractor
+// ---------------------------------------------------------------------------
+
+/// Find the first occurrence of `needle` in `hay`.
+fn find_subseq(hay: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || hay.len() < needle.len() {
+        return None;
+    }
+    (0..=hay.len() - needle.len()).find(|&i| &hay[i..i + needle.len()] == needle)
+}
+
+/// Split the process output into `(burst_code, payload)` tokens.  Payloads are
+/// 0x00-free, so each is exactly the bytes between one marker and the next.
+fn tokenize(stream: &[u8]) -> Vec<(u8, Vec<u8>)> {
+    let mut toks = Vec::new();
+    let mut i = 0usize;
+    while i < stream.len() {
+        // Skip any non-zero garbage, then the (1+) zero run, then 0x01.
+        while i < stream.len() && stream[i] != 0 {
+            i += 1;
+        }
+        while i < stream.len() && stream[i] == 0 {
+            i += 1;
+        }
+        if i >= stream.len() || stream[i] != 1 {
+            break;
+        }
+        i += 1;
+        if i >= stream.len() {
+            break;
+        }
+        let code = stream[i];
+        i += 1;
+        let start = i;
+        while i < stream.len() && stream[i] != 0 {
+            i += 1;
+        }
+        toks.push((code, stream[start..i].to_vec()));
+    }
+    toks
+}
+
+/// Extract the payload string-stream of the LAST command response (the
+/// decompileAt `<doc>`): within the last `{6}..{7}`, the `{14}` token that is NOT
+/// nested inside a `{4}..{5}` query.
+fn extract_last_response_payload(stream: &[u8]) -> Vec<u8> {
+    let toks = tokenize(stream);
+    let last6 = toks
+        .iter()
+        .rposition(|(c, _)| *c == 6)
+        .expect("a command-response open in the output");
+    let mut in_query = false;
+    for (code, payload) in &toks[last6..] {
+        match code {
+            4 => in_query = true,
+            5 => in_query = false,
+            14 if !in_query => return payload.clone(),
+            7 => break,
+            _ => {}
+        }
+    }
+    Vec::new()
+}
+
+// ---------------------------------------------------------------------------
+// <doc> decoder
+// ---------------------------------------------------------------------------
+
+/// Recursively walk the current (already-opened) element, collecting the values
+/// of the `target` attribute ids into `out`, then recursing into children.
+fn walk(
+    dec: &mut PackedDecode,
+    targets: &[u32],
+    out: &mut BTreeMap<u32, BTreeSet<u64>>,
+) -> Result<(), kuna_base::error::KunaError> {
+    loop {
+        let aid = dec.get_next_attribute_id()?;
+        if aid == 0 {
+            break;
+        }
+        if targets.contains(&aid) {
+            let v = dec.read_unsigned_integer()?;
+            out.entry(aid).or_default().insert(v);
+        }
+        // Un-targeted attributes are left un-read; the next get_next_attribute_id
+        // auto-skips them (PackedDecode contract).
+    }
+    loop {
+        let c = dec.peek_element()?;
+        if c == 0 {
+            break;
+        }
+        let id = dec.open_element()?;
+        walk(dec, targets, out)?;
+        dec.close_element(id)?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// The test
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_decompile_at_emits_c() {
+    // The tspec manager the mock uses to decode/encode <addr> elements.
+    let registry = build_registry();
+    let model = TspecModel::decode(TSPEC, &registry).expect("tspec parses");
+    let manager = Rc::new(model.manager);
+
+    // The packed <addr> for the decompileAt entry (ram:ENTRY).
+    let addr_packed = {
+        let ram = Rc::clone(manager.get_space_by_name("ram").expect("ram"));
+        let mut v = Vec::new();
+        {
+            let mut e = PackedEncode::new(&mut v);
+            Address::new(ram, ENTRY).encode(&mut e).expect("entry addr");
+        }
+        v
+    };
+
+    let shared = Rc::new(RefCell::new(MockState {
+        commands: build_commands(&addr_packed),
+        cmd_cursor: 0,
+        from_process: Vec::new(),
+        parsed: 0,
+        to_process: Vec::new(),
+        manager: Rc::clone(&manager),
+    }));
+
+    let reader = MockReader { shared: Rc::clone(&shared) };
+    let writer = MockWriter { shared: Rc::clone(&shared) };
+
+    let mut process = GhidraProcess::new(reader, writer);
+    // Drive the three commands (registerProgram, setAction, decompileAt).
+    for cmd in ["registerProgram", "setAction", "decompileAt"] {
+        assert_eq!(
+            process.read_command().unwrap_or_else(|e| panic!("{cmd}: {e:?}")),
+            0,
+            "{cmd} should complete without terminating the loop"
+        );
+    }
+
+    let out = shared.borrow().from_process.clone();
+    // Drop the process (releases the session engine's client Rc clones) so the
+    // shared state has no live borrower for the assertions below.
+    let _ = process.into_inner();
+
+    // Sanity: no engine-construction failure warning leaked into the stream.
+    let text = String::from_utf8_lossy(&out);
+    assert!(
+        !text.contains("could not build the decompiler engine"),
+        "engine construction failed: {text}"
+    );
+    assert!(
+        !text.contains("could not decompile the function"),
+        "decompileAt degraded to the incomplete-function shape: {text}"
+    );
+
+    // Extract the decompileAt <doc> payload and decode it.
+    let doc = extract_last_response_payload(&out);
+    assert!(!doc.is_empty(), "decompileAt emitted an EMPTY payload (no <doc>)");
+
+    let mut dec = PackedDecode::new(&manager);
+    dec.ingest_stream(&doc).expect("<doc> ingests");
+    let did = dec.open_element().expect("open <doc>");
+    assert_eq!(did, ELEM_DOC.get_id(), "root is not <doc>");
+
+    // --- the first <function>: the Funcdata::encode <function>/<ast> ---
+    let fid = dec.open_element().expect("open <function>");
+    assert_eq!(fid, ELEM_FUNCTION_ID, "first child of <doc> is not <function>");
+    let name = dec.read_string_id(&ATTRIB_NAME).expect("<function name>");
+    assert_eq!(
+        name, FUNC_NAME,
+        "<function name> must be the getCodeLabel name"
+    );
+    // Collect the AST's op times (<seqnum uniq>) and varnode create-indices
+    // (<addr ref>).
+    let mut ast = BTreeMap::new();
+    walk(&mut dec, &[ATTRIB_REF_ID, ATTRIB_UNIQ_ID], &mut ast).expect("walk <function>");
+    dec.close_element(fid).expect("close <function>");
+
+    let op_times = ast.get(&ATTRIB_UNIQ_ID).cloned().unwrap_or_default();
+    let var_refs = ast.get(&ATTRIB_REF_ID).cloned().unwrap_or_default();
+    assert!(
+        !op_times.is_empty(),
+        "the <ast> has no ops (empty function body) — expected the RETURN op"
+    );
+
+    // --- the second <function>: the Clang token markup ---
+    let next = dec.peek_element().expect("peek after <function>");
+    assert_eq!(
+        next, ELEM_FUNCTION_ID,
+        "the C-code markup <function> is missing (send_c_code + decompile action)"
+    );
+    let mid = dec.open_element().expect("open markup <function>");
+    let mut markup = BTreeMap::new();
+    walk(&mut dec, &[ATTRIB_OPREF_ID, ATTRIB_VARREF_ID], &mut markup)
+        .expect("walk markup <function>");
+    dec.close_element(mid).expect("close markup <function>");
+    dec.close_element(did).expect("close <doc>");
+
+    let oprefs = markup.get(&ATTRIB_OPREF_ID).cloned().unwrap_or_default();
+    let varrefs = markup.get(&ATTRIB_VARREF_ID).cloned().unwrap_or_default();
+
+    // The click-to-address contract: every markup token ref resolves against the
+    // AST it was emitted alongside.
+    assert!(
+        oprefs.is_subset(&op_times),
+        "markup oprefs {oprefs:?} are not a subset of the AST op times {op_times:?}"
+    );
+    assert!(
+        varrefs.is_subset(&var_refs),
+        "markup varrefs {varrefs:?} are not a subset of the AST varnode refs {var_refs:?}"
+    );
+    // The markup must actually reference the syntax tree (a bare `return;` still
+    // tags its statement/op), proving the two documents are cross-linked rather
+    // than trivially both empty.
+    assert!(
+        !oprefs.is_empty() || !varrefs.is_empty(),
+        "the markup carried NO opref/varref — the dual <function> is not cross-linked to the <ast>"
+    );
+}

--- a/decompiler/crates/kuna-ghidra/tests/protocol_e2e.rs
+++ b/decompiler/crates/kuna-ghidra/tests/protocol_e2e.rs
@@ -197,15 +197,13 @@ fn test_full_session_byte_exact() {
         .burst(16)
         .burst(17)
         .burst(7)
-        // setOptions: "t" + phase-1 warning
+        // setOptions: "t", empty warnings — accepted SILENTLY.  A non-empty
+        // 16/17 message here fails DecompInterface init (openProgram stores it
+        // and isErrorMessage flags any non-"warning" text as fatal), so the GUI
+        // reports "Unable to initialize the DecompilerInterface" (see process.rs).
         .burst(6)
         .string(b"t")
         .burst(16)
-        .raw(
-            b"\nkuna ghidra-mode: setOptions: 2 option element(s) recorded \
-              but not applied (phase 1)"
-                .as_slice(),
-        )
         .burst(17)
         .burst(7)
         // setAction: "t", empty warnings
@@ -235,22 +233,6 @@ fn test_full_session_byte_exact() {
         out, expected.0,
         "response stream mismatch\n got: {:02x?}\nwant: {:02x?}",
         out, expected.0
-    );
-}
-
-/// The warning-string literals above must not drift: `\` line continuations
-/// inside the source would silently change the bytes.  (This guards the
-/// test itself, comparing against the same strings built without
-/// continuation.)
-#[test]
-fn test_expected_warning_literals() {
-    assert_eq!(
-        b"\nkuna ghidra-mode: setOptions: 2 option element(s) recorded \
-          but not applied (phase 1)"
-            .as_slice()
-            .len(),
-        "\nkuna ghidra-mode: setOptions: 2 option element(s) recorded but not applied (phase 1)"
-            .len()
     );
 }
 

--- a/decompiler/crates/kuna-ghidra/tests/protocol_e2e.rs
+++ b/decompiler/crates/kuna-ghidra/tests/protocol_e2e.rs
@@ -14,12 +14,12 @@ use std::rc::Rc;
 use kuna_base::address::Address;
 use kuna_base::error::KunaError;
 use kuna_base::marshal::{
-    ElementId, Encoder, PackedDecode, PackedEncode, ATTRIB_CONTENT, ATTRIB_NAME,
+    ElementId, Encoder, PackedDecode, PackedEncode, ATTRIB_CONTENT, ATTRIB_INDEX, ATTRIB_NAME,
 };
 use kuna_base::space::VarnodeStorage;
 
 use kuna_ghidra::client::GhidraClient;
-use kuna_ghidra::ids::ELEM_COMMAND_GETREGISTER;
+use kuna_ghidra::ids::{ELEM_COMMAND_GETREGISTER, ELEM_COMMAND_GETUSEROPNAME};
 use kuna_ghidra::process::GhidraProcess;
 use kuna_ghidra::protocol::{nibble_expand, string_data_size_header, WireError};
 use kuna_ghidra::translate::{build_registry, TspecModel};
@@ -117,6 +117,22 @@ fn packed_optionslist() -> Vec<u8> {
     packed
 }
 
+/// The packed `<command_getuseropname index=N>` document the client emits for
+/// the init-time user-op probe (client.rs `get_user_op_name`).  Phase-2
+/// registerProgram issues exactly one of these (index 0) during
+/// `init_post_engine` → `userops.initialize`, and terminates the probe on the
+/// host's empty answer.
+fn get_user_op_name_doc(index: i32) -> Vec<u8> {
+    let mut doc = Vec::new();
+    {
+        let mut e = PackedEncode::new(&mut doc);
+        e.open_element(&ELEM_COMMAND_GETUSEROPNAME);
+        e.write_signed_integer(&ATTRIB_INDEX, index as i64);
+        e.close_element(&ELEM_COMMAND_GETUSEROPNAME);
+    }
+    doc
+}
+
 // ---------------------------------------------------------------------------
 // (a) full session over the command loop
 // ---------------------------------------------------------------------------
@@ -135,6 +151,12 @@ fn test_full_session_byte_exact() {
         .string(TSPEC)
         .string(CORETYPES)
         .end_command()
+        // ...then the getUserOpName probe answer the engine's init reads back:
+        // an empty name terminates the probe (client.rs `get_user_op_name`).
+        // This query is nested inside the still-open registerProgram response.
+        .burst(8)
+        .string(b"")
+        .burst(9)
         // setOptions: archid + packed <optionslist>
         .command("setOptions")
         .string(b"0")
@@ -183,8 +205,14 @@ fn test_full_session_byte_exact() {
         .unwrap();
 
     let expected = Wire::new()
-        // registerProgram: {6}{14}"0"{15}{16}{17}{7}
+        // registerProgram: {6} then the nested getUserOpName probe query
+        // {4}{14}<doc>{15}{5}, then the archid {14}"0"{15}, then the (empty)
+        // warnings frame {16}{17}, then {7}.  The empty warnings prove the
+        // live Architecture was built with no construction error.
         .burst(6)
+        .burst(4)
+        .string(&get_user_op_name_doc(0))
+        .burst(5)
         .string(b"0")
         .burst(16)
         .burst(17)
@@ -281,9 +309,12 @@ fn test_unregistered_archid_passes_java_exception() {
     assert_eq!(out, expected.0);
 }
 
-/// registerProgram with an unparseable tspec still succeeds (lenient phase-1
-/// parse), records a warning, and decompileAt then reports the undecoded
-/// address.
+/// registerProgram with an unparseable tspec still succeeds at the protocol
+/// level (returns an archid, does not JavaError), but engine construction fails
+/// (the tspec drives `GhidraTranslate::new` / the `<sleigh>` decode, C++
+/// `buildTranslator`).  The failure is recorded as a warning on the 16/17
+/// frame — Java treats the non-empty nativeMessage as a registration failure —
+/// and decompileAt then reports the undecoded address (no engine manager).
 #[test]
 fn test_bad_tspec_is_lenient() {
     let input = Wire::new()
@@ -303,12 +334,85 @@ fn test_bad_tspec_is_lenient() {
     let (_, out) = process.into_inner();
     let text = String::from_utf8_lossy(&out);
     assert!(
-        text.contains("could not parse tspec <sleigh> element"),
-        "missing tspec warning in: {text}"
+        text.contains("could not build the decompiler engine from the registerProgram specs"),
+        "missing engine-construction-failure warning in: {text}"
     );
     assert!(
         text.contains("function at (address not decoded) not decompiled"),
         "missing decompileAt warning in: {text}"
+    );
+}
+
+/// Phase-2 step 3: registerProgram over four tiny valid specs (plus the
+/// init-time query answers) builds a live [`Architecture`], and a follow-up
+/// command drives that live engine's space manager.
+///
+/// Proof the engine was built: registerProgram issues exactly one nested query
+/// (the getUserOpName probe, from `init_post_engine` → `userops.initialize`),
+/// its warnings frame is empty (no construction error), and the follow-up
+/// decompileAt decodes its wire `<addr>` through the live manager (the warning
+/// names the actual address, not "(address not decoded)").
+#[test]
+fn test_register_program_builds_live_architecture() {
+    let tr = test_translate();
+    let addr_packed = packed_ram_addr(&tr, 0x401000);
+
+    let input = Wire::new()
+        .command("registerProgram")
+        .string(PSPEC)
+        .string(CSPEC)
+        .string(TSPEC)
+        .string(CORETYPES)
+        .end_command()
+        // getUserOpName probe answer: empty name terminates the probe.
+        .burst(8)
+        .string(b"")
+        .burst(9)
+        // decompileAt: archid + packed <addr> — exercises the LIVE engine's
+        // space manager (the whole point: the addr decodes only because
+        // registerProgram built a real Architecture whose manager the tspec
+        // spaces populated).
+        .command("decompileAt")
+        .string(b"0")
+        .string(&addr_packed)
+        .end_command();
+
+    let mut process = GhidraProcess::new(Cursor::new(input.0), Vec::new());
+    assert_eq!(process.read_command().expect("registerProgram completes"), 0);
+    assert_eq!(process.read_command().expect("decompileAt completes"), 0);
+    let (_, out) = process.into_inner();
+
+    // registerProgram issued exactly one init query (the getUserOpName probe) —
+    // it ran `init_post_engine`, so the Architecture is present.
+    let mut query_opens = 0usize;
+    let mut i = 0usize;
+    while i + 4 <= out.len() {
+        if out[i..i + 4] == [0, 0, 1, 4] {
+            query_opens += 1;
+        }
+        i += 1;
+    }
+    assert_eq!(
+        query_opens, 1,
+        "registerProgram should issue exactly one init query (getUserOpName probe)"
+    );
+
+    let text = String::from_utf8_lossy(&out);
+    assert!(
+        !text.contains("could not build the decompiler engine"),
+        "engine construction unexpectedly failed: {text}"
+    );
+
+    // The follow-up decompileAt decoded ram:0x401000 through the live manager.
+    let ram = tr.manager.get_space_by_name("ram").unwrap();
+    let mut addr_text = String::new();
+    addr_text.push(ram.get_shortcut());
+    Address::new(Rc::clone(ram), 0x401000)
+        .print_raw(&mut addr_text)
+        .unwrap();
+    assert!(
+        text.contains(&format!("function at {addr_text} not decompiled")),
+        "decompileAt did not decode the wire <addr> through the live engine manager: {text}"
     );
 }
 

--- a/decompiler/crates/kuna-ghidra/tests/protocol_e2e.rs
+++ b/decompiler/crates/kuna-ghidra/tests/protocol_e2e.rs
@@ -22,7 +22,7 @@ use kuna_ghidra::client::GhidraClient;
 use kuna_ghidra::ids::ELEM_COMMAND_GETREGISTER;
 use kuna_ghidra::process::GhidraProcess;
 use kuna_ghidra::protocol::{nibble_expand, string_data_size_header, WireError};
-use kuna_ghidra::translate::{build_registry, GhidraTranslate};
+use kuna_ghidra::translate::{build_registry, TspecModel};
 
 // ---------------------------------------------------------------------------
 // MockJava wire builder
@@ -78,14 +78,14 @@ const CORETYPES: &[u8] = b"<coretypes><type name=\"int\" size=\"4\" metatype=\"i
 </coretypes>";
 
 /// The tspec-derived translate the mock shares with the process under test.
-fn test_translate() -> GhidraTranslate {
+fn test_translate() -> TspecModel {
     let registry = build_registry();
-    GhidraTranslate::decode(TSPEC, &registry).expect("test tspec parses")
+    TspecModel::decode(TSPEC, &registry).expect("test tspec parses")
 }
 
 /// Encode an `<addr>` for ram:offset the way Java's AddressXML.encode does
 /// (space + offset attributes in a packed document).
-fn packed_ram_addr(tr: &GhidraTranslate, offset: u64) -> Vec<u8> {
+fn packed_ram_addr(tr: &TspecModel, offset: u64) -> Vec<u8> {
     let ram = Rc::clone(tr.manager.get_space_by_name("ram").expect("ram"));
     let mut packed = Vec::new();
     {

--- a/decompiler/crates/kuna-ghidra/tests/protocol_e2e.rs
+++ b/decompiler/crates/kuna-ghidra/tests/protocol_e2e.rs
@@ -83,18 +83,6 @@ fn test_translate() -> TspecModel {
     TspecModel::decode(TSPEC, &registry).expect("test tspec parses")
 }
 
-/// Encode an `<addr>` for ram:offset the way Java's AddressXML.encode does
-/// (space + offset attributes in a packed document).
-fn packed_ram_addr(tr: &TspecModel, offset: u64) -> Vec<u8> {
-    let ram = Rc::clone(tr.manager.get_space_by_name("ram").expect("ram"));
-    let mut packed = Vec::new();
-    {
-        let mut enc = PackedEncode::new(&mut packed);
-        Address::new(ram, offset).encode(&mut enc).unwrap();
-    }
-    packed
-}
-
 /// A packed `<optionslist>` with two single-param option children
 /// (DecompileOptions.encode / appendOption shape; the ids only need to be
 /// self-consistent for the count).
@@ -137,10 +125,15 @@ fn get_user_op_name_doc(index: i32) -> Vec<u8> {
 // (a) full session over the command loop
 // ---------------------------------------------------------------------------
 
+// NOTE: decompileAt is deliberately absent from this byte-exact test.  Since
+// phase-2 step 6 wired `decompileAt` to the live engine, its response bytes are
+// a real `<doc>` whose contents (the `Funcdata::encode` `<ast>` + the Clang
+// markup) depend on the whole decompile pipeline's internal Varnode/op
+// numbering — not hand-assertable byte-exact.  `decompileAt` is proven
+// end-to-end in `test_decompile_at_emits_c` (the interactive MockJava e2e);
+// this test keeps the byte-exact framing coverage of every OTHER command.
 #[test]
 fn test_full_session_byte_exact() {
-    let tr = test_translate();
-    let addr_packed = packed_ram_addr(&tr, 0x401000);
     let options_packed = packed_optionslist();
 
     let input = Wire::new()
@@ -168,11 +161,6 @@ fn test_full_session_byte_exact() {
         .string(b"decompile")
         .string(b"c")
         .end_command()
-        // decompileAt: archid + packed <addr>
-        .command("decompileAt")
-        .string(b"0")
-        .string(&addr_packed)
-        .end_command()
         // flushNative: archid only
         .command("flushNative")
         .string(b"0")
@@ -190,19 +178,11 @@ fn test_full_session_byte_exact() {
 
     let mut process = GhidraProcess::new(Cursor::new(input.0), Vec::new());
     let mut statuses = Vec::new();
-    for _ in 0..7 {
+    for _ in 0..6 {
         statuses.push(process.read_command().expect("command completes"));
     }
-    assert_eq!(statuses, vec![0, 0, 0, 0, 0, 0, 1]);
+    assert_eq!(statuses, vec![0, 0, 0, 0, 0, 1]);
     let (_, out) = process.into_inner();
-
-    // The rendered form of ram:0x401000 in the decompileAt warning
-    let ram = tr.manager.get_space_by_name("ram").unwrap();
-    let mut addr_text = String::new();
-    addr_text.push(ram.get_shortcut());
-    Address::new(Rc::clone(ram), 0x401000)
-        .print_raw(&mut addr_text)
-        .unwrap();
 
     let expected = Wire::new()
         // registerProgram: {6} then the nested getUserOpName probe query
@@ -232,20 +212,6 @@ fn test_full_session_byte_exact() {
         .burst(6)
         .string(b"t")
         .burst(16)
-        .burst(17)
-        .burst(7)
-        // decompileAt: EMPTY payload (incomplete-function shape) + warning
-        .burst(6)
-        .burst(14)
-        .burst(15)
-        .burst(16)
-        .raw(
-            format!(
-                "\nkuna ghidra-mode: engine bridge not yet implemented (phase 1); \
-                 function at {addr_text} not decompiled"
-            )
-            .as_bytes(),
-        )
         .burst(17)
         .burst(7)
         // flushNative: "0"
@@ -343,20 +309,16 @@ fn test_bad_tspec_is_lenient() {
     );
 }
 
-/// Phase-2 step 3: registerProgram over four tiny valid specs (plus the
-/// init-time query answers) builds a live [`Architecture`], and a follow-up
-/// command drives that live engine's space manager.
+/// Phase-2: registerProgram over four tiny valid specs (plus the init-time
+/// query answer) builds a live [`Architecture`].
 ///
 /// Proof the engine was built: registerProgram issues exactly one nested query
 /// (the getUserOpName probe, from `init_post_engine` → `userops.initialize`),
-/// its warnings frame is empty (no construction error), and the follow-up
-/// decompileAt decodes its wire `<addr>` through the live manager (the warning
-/// names the actual address, not "(address not decoded)").
+/// its warnings frame is empty (no construction error), and it returns archid
+/// "0".  (The live manager's `<addr>` decode + the whole decompile drive are
+/// proven end-to-end in `test_decompile_at_emits_c`.)
 #[test]
 fn test_register_program_builds_live_architecture() {
-    let tr = test_translate();
-    let addr_packed = packed_ram_addr(&tr, 0x401000);
-
     let input = Wire::new()
         .command("registerProgram")
         .string(PSPEC)
@@ -367,19 +329,10 @@ fn test_register_program_builds_live_architecture() {
         // getUserOpName probe answer: empty name terminates the probe.
         .burst(8)
         .string(b"")
-        .burst(9)
-        // decompileAt: archid + packed <addr> — exercises the LIVE engine's
-        // space manager (the whole point: the addr decodes only because
-        // registerProgram built a real Architecture whose manager the tspec
-        // spaces populated).
-        .command("decompileAt")
-        .string(b"0")
-        .string(&addr_packed)
-        .end_command();
+        .burst(9);
 
     let mut process = GhidraProcess::new(Cursor::new(input.0), Vec::new());
     assert_eq!(process.read_command().expect("registerProgram completes"), 0);
-    assert_eq!(process.read_command().expect("decompileAt completes"), 0);
     let (_, out) = process.into_inner();
 
     // registerProgram issued exactly one init query (the getUserOpName probe) —
@@ -403,16 +356,12 @@ fn test_register_program_builds_live_architecture() {
         "engine construction unexpectedly failed: {text}"
     );
 
-    // The follow-up decompileAt decoded ram:0x401000 through the live manager.
-    let ram = tr.manager.get_space_by_name("ram").unwrap();
-    let mut addr_text = String::new();
-    addr_text.push(ram.get_shortcut());
-    Address::new(Rc::clone(ram), 0x401000)
-        .print_raw(&mut addr_text)
-        .unwrap();
+    // The response is archid "0" with an EMPTY 16/17 warnings frame (no
+    // construction error): {6} {4}<query>{5} {14}"0"{15} {16}{17} {7}.
+    let expected_tail = Wire::new().string(b"0").burst(16).burst(17).burst(7);
     assert!(
-        text.contains(&format!("function at {addr_text} not decompiled")),
-        "decompileAt did not decode the wire <addr> through the live engine manager: {text}"
+        out.ends_with(&expected_tail.0),
+        "registerProgram must end with archid \"0\" + empty warnings frame; got {out:02x?}"
     );
 }
 

--- a/decompiler/crates/kuna-harness/src/corpus.rs
+++ b/decompiler/crates/kuna-harness/src/corpus.rs
@@ -547,7 +547,9 @@ pub fn extract_rust_model(bs: &Bootstrap, c: &Case) -> Result<StructModel, Strin
     let fd = Funcdata::new(c.stem, c.stem, ir_arch, entry, uniq_start, 0x40)
         .map_err(|e| format!("Funcdata::new: {e}"))?;
 
-    let env = DiffEnv { sleigh: base.translate() };
+    let env = DiffEnv {
+        sleigh: base.translate().as_sleigh().expect("diff harness: standalone Sleigh engine"),
+    };
     let mut flow = FlowInfo::new(fd, &env);
     flow.generate_ops().map_err(|e| format!("EXCLUDED: generate_ops {}", seam_reason(&e)))?;
     flow.generate_blocks()

--- a/decompiler/crates/kuna-num/src/float.rs
+++ b/decompiler/crates/kuna-num/src/float.rs
@@ -11,9 +11,16 @@
 //!
 //! - Exactly where the C++ computes on host `double`, this port computes on
 //!   host `f64` (same IEEE 754 binary64 arithmetic, same hardware ops on the
-//!   oracle's x86 host).  The sign of a NaN *result* therefore follows host
-//!   semantics (x86 NaN-producing arithmetic yields the negative default
-//!   QNaN; the payload is canonicalized by `get_nan_encoding`).
+//!   oracle's x86 host).  IEEE-754 leaves the *sign* of a NaN produced by an
+//!   invalid operation (`sqrt(-1)`, `0/0`, `inf-inf`, `0*inf`, …) host-defined:
+//!   the x86 FPU yields the negative "real indefinite" QNaN (`0xffc00000`),
+//!   Apple-Silicon/ARM the positive default NaN (`0x7fc00000`); Ghidra's C++
+//!   inherits whichever the build host produces (float.cc `signbit(host)`).
+//!   To stay deterministic across build hosts *and* byte-identical to the
+//!   Linux/x86 golden oracle everywhere, the arithmetic ops pin the x86 sign
+//!   for a *generated* NaN (see [`FloatFormat::encode_generated`]); a
+//!   *propagated* NaN (an input was already NaN) keeps its host-deterministic
+//!   sign.  The payload is canonicalized by `get_nan_encoding`.
 //! - `opTrunc`'s `(intb)double` cast is the host x86 `cvttsd2si` cast, NOT
 //!   Rust's saturating `as`; see [`host_double_to_int64`].
 //! - C++ `ldexp`/`frexp` have no Rust std equivalent; [`ldexp`] / [`frexp`]
@@ -713,32 +720,50 @@ impl FloatFormat {
         u64::from(tp == floatclass::nan)
     }
 
+    /// Encode a host FP result, pinning the sign of an *invalid-operation-
+    /// generated* NaN to the x86 "real indefinite" (`0xffc00000` / sign set),
+    /// so the engine is deterministic across build hosts and byte-identical to
+    /// the Linux/x86 golden oracle everywhere (see the module header).
+    ///
+    /// `input_was_nan` is true when any operand already decoded to a NaN — then
+    /// the result is a *propagated* NaN whose sign is host-deterministic (it
+    /// follows the operand: the `0x7fc00000` propagation rows of the golden
+    /// vectors), so it is left untouched.  On the x86 oracle host the fixup is a
+    /// no-op (the host already yields `0xffc00000`), so x86 output is unchanged.
+    fn encode_generated(&self, host: f64, input_was_nan: bool) -> u64 {
+        let enc = self.get_encoding(host);
+        if !input_was_nan && self.get_class(enc) == floatclass::nan {
+            return self.get_nan_encoding(true);
+        }
+        enc
+    }
+
     /// Addition (+).
     pub fn op_add(&self, a: u64, b: u64) -> u64 {
-        let (val1, _type) = self.get_host_float(a);
-        let (val2, _type) = self.get_host_float(b);
-        self.get_encoding(val1 + val2)
+        let (val1, t1) = self.get_host_float(a);
+        let (val2, t2) = self.get_host_float(b);
+        self.encode_generated(val1 + val2, t1 == floatclass::nan || t2 == floatclass::nan)
     }
 
     /// Division (/).
     pub fn op_div(&self, a: u64, b: u64) -> u64 {
-        let (val1, _type) = self.get_host_float(a);
-        let (val2, _type) = self.get_host_float(b);
-        self.get_encoding(val1 / val2)
+        let (val1, t1) = self.get_host_float(a);
+        let (val2, t2) = self.get_host_float(b);
+        self.encode_generated(val1 / val2, t1 == floatclass::nan || t2 == floatclass::nan)
     }
 
     /// Multiplication (*).
     pub fn op_mult(&self, a: u64, b: u64) -> u64 {
-        let (val1, _type) = self.get_host_float(a);
-        let (val2, _type) = self.get_host_float(b);
-        self.get_encoding(val1 * val2)
+        let (val1, t1) = self.get_host_float(a);
+        let (val2, t2) = self.get_host_float(b);
+        self.encode_generated(val1 * val2, t1 == floatclass::nan || t2 == floatclass::nan)
     }
 
     /// Subtraction (-).
     pub fn op_sub(&self, a: u64, b: u64) -> u64 {
-        let (val1, _type) = self.get_host_float(a);
-        let (val2, _type) = self.get_host_float(b);
-        self.get_encoding(val1 - val2)
+        let (val1, t1) = self.get_host_float(a);
+        let (val2, t2) = self.get_host_float(b);
+        self.encode_generated(val1 - val2, t1 == floatclass::nan || t2 == floatclass::nan)
     }
 
     /// Unary negate.
@@ -755,8 +780,8 @@ impl FloatFormat {
 
     /// Square root (sqrt).
     pub fn op_sqrt(&self, a: u64) -> u64 {
-        let (val, _type) = self.get_host_float(a);
-        self.get_encoding(val.sqrt())
+        let (val, tp) = self.get_host_float(a);
+        self.encode_generated(val.sqrt(), tp == floatclass::nan)
     }
 
     /// Convert integer to floating-point: `a` is a signed integer value,

--- a/decompiler/crates/kuna-num/tests/testfloatemu.rs
+++ b/decompiler/crates/kuna-num/tests/testfloatemu.rs
@@ -55,6 +55,25 @@ fn double_to_raw_bits(f: f64) -> u64 {
     f.to_bits()
 }
 
+/// Pin a NaN *generated* from non-NaN inputs to the x86 "real indefinite"
+/// (`0xffc00000`), mirroring [`FloatFormat::encode_generated`] (see the float.rs
+/// module header).  These are host-parity tests: they compare `FloatFormat`
+/// against the build host's native FP, which agree everywhere EXCEPT the sign of
+/// an invalid-operation-generated NaN — the x86 FPU sets it, Apple-Silicon/ARM
+/// clears it.  The engine canonicalizes generated NaNs to the x86 sign for
+/// cross-host determinism, so the host reference is canonicalized the same way
+/// to keep the test meaningful off-x86.  On the x86 oracle host this is a no-op
+/// (the host already yields `0xffc00000`).  `inputs_nan` marks a *propagated*
+/// NaN (host-deterministic sign), which is left untouched.
+fn canon_generated_nan4(raw: u64, inputs_nan: bool) -> u64 {
+    let is_nan = (raw & 0x7f80_0000) == 0x7f80_0000 && (raw & 0x007f_ffff) != 0;
+    if !inputs_nan && is_nan {
+        0xffc0_0000
+    } else {
+        raw
+    }
+}
+
 // macros to preserve call site (testfloatemu.cc:64-82); Rust panics carry the
 // fixture-fn location, but the assert message still shows both values.
 
@@ -331,7 +350,7 @@ fn float_opSqrt() {
     let format = FloatFormat::new(4);
 
     for f in float_test_values() {
-        let true_result = float_to_raw_bits(f.sqrt());
+        let true_result = canon_generated_nan4(float_to_raw_bits(f.sqrt()), f.is_nan());
         let encoding = format.get_encoding(f64::from(f));
         let result = format.op_sqrt(encoding);
 
@@ -528,7 +547,8 @@ fn float_opAdd() {
     for f1 in float_test_values() {
         let encoding1 = format.get_encoding(f64::from(f1));
         for f2 in float_test_values() {
-            let true_result = float_to_raw_bits(f1 + f2);
+            let true_result =
+                canon_generated_nan4(float_to_raw_bits(f1 + f2), f1.is_nan() || f2.is_nan());
             let encoding2 = format.get_encoding(f64::from(f2));
             let result = format.op_add(encoding1, encoding2);
 
@@ -544,7 +564,8 @@ fn float_opDiv() {
     for f1 in float_test_values() {
         let encoding1 = format.get_encoding(f64::from(f1));
         for f2 in float_test_values() {
-            let true_result = float_to_raw_bits(f1 / f2);
+            let true_result =
+                canon_generated_nan4(float_to_raw_bits(f1 / f2), f1.is_nan() || f2.is_nan());
             let encoding2 = format.get_encoding(f64::from(f2));
             let result = format.op_div(encoding1, encoding2);
 
@@ -560,7 +581,8 @@ fn float_opMult() {
     for f1 in float_test_values() {
         let encoding1 = format.get_encoding(f64::from(f1));
         for f2 in float_test_values() {
-            let true_result = float_to_raw_bits(f1 * f2);
+            let true_result =
+                canon_generated_nan4(float_to_raw_bits(f1 * f2), f1.is_nan() || f2.is_nan());
             let encoding2 = format.get_encoding(f64::from(f2));
             let result = format.op_mult(encoding1, encoding2);
 
@@ -576,7 +598,8 @@ fn float_opSub() {
     for f1 in float_test_values() {
         let encoding1 = format.get_encoding(f64::from(f1));
         for f2 in float_test_values() {
-            let true_result = float_to_raw_bits(f1 - f2);
+            let true_result =
+                canon_generated_nan4(float_to_raw_bits(f1 - f2), f1.is_nan() || f2.is_nan());
             let encoding2 = format.get_encoding(f64::from(f2));
             let result = format.op_sub(encoding1, encoding2);
 

--- a/docs/ghidra-integration.md
+++ b/docs/ghidra-integration.md
@@ -410,14 +410,19 @@ What breaks when a partial core omits pieces — all failure modes are clean:
       exepath swap, binary shipped as `os/<platform>/kuna_ghidra`.
 - [x] These two documents.
 
-**Phase 2 — engine bridge (first real C in the GUI).**
-- [ ] `ArchitectureGhidra`-equivalent construction path: Architecture from the four
+**Phase 2 — engine bridge (first real C in the GUI).** Full plan + risk
+assessment + sequencing: **`docs/rust-port/ghidra-phase2-plan.md`** (a [PROPOSAL]
+awaiting go/no-go, since this is the first phase that touches kuna-decomp's core).
+- [x] `SharedClient` design (the re-entrant provider→query pattern) +
+      `GhidraLoadImage` (`load_fill` = `getBytes`) — `kuna-ghidra/src/provider.rs`,
+      implemented and tested as the phase's demonstrator.
+- [ ] `Architecture`-equivalent construction path: Architecture from the four
       wire spec documents (wire the Phase-1 tspec space manager into the engine;
       cspec/pspec via the existing `set_cspec_xml`/`set_pspec_xml` + `init_post_engine`).
 - [ ] `Translate` enum seam on `Architecture` (`{Sleigh, GhidraTranslate}`);
       `GhidraTranslate` port (getPcode per instruction, register caches, user-op probe
-      loop).
-- [ ] `GhidraLoadImage` (`load_fill` = `getBytes`); `ContextGhidra::getTrackedSet`.
+      loop). *The go/no-go linchpin — must land as a behavior-preserving refactor.*
+- [ ] `ContextGhidra::getTrackedSet` (the trait-borrow friction is resolved in the plan).
 - [ ] `Funcdata::encode` — minimal `<function>` (name/addr + `<ast>` + prototype).
 - [ ] PrintC → `EmitMarkup` wiring; `doc_function` markup path; dual-`<function>`
       `decompileAt` response.

--- a/docs/ghidra-integration.md
+++ b/docs/ghidra-integration.md
@@ -410,22 +410,38 @@ What breaks when a partial core omits pieces — all failure modes are clean:
       exepath swap, binary shipped as `os/<platform>/kuna_ghidra`.
 - [x] These two documents.
 
-**Phase 2 — engine bridge (first real C in the GUI).** Full plan + risk
-assessment + sequencing: **`docs/rust-port/ghidra-phase2-plan.md`** (a [PROPOSAL]
-awaiting go/no-go, since this is the first phase that touches kuna-decomp's core).
+**Phase 2 — engine bridge (first real C in the GUI). DONE** (PR #135, branch
+`feat/ghidra-mode-phase2`). Full plan + risk assessment + sequencing:
+**`docs/rust-port/ghidra-phase2-plan.md`**. Each step landed as its own commit
+keeping `make test` at 675/675 PARITY OK. One design refinement vs the plan: the
+translator seam is a `Box<dyn EngineTranslate>` **trait**, not an enum — an enum
+variant naming `kuna-ghidra`'s `GhidraTranslate` would be a `kuna-decomp`↔`kuna-ghidra`
+dependency cycle; a trait object owned in `kuna-decomp` is not.
 - [x] `SharedClient` design (the re-entrant provider→query pattern) +
-      `GhidraLoadImage` (`load_fill` = `getBytes`) — `kuna-ghidra/src/provider.rs`,
-      implemented and tested as the phase's demonstrator.
-- [ ] `Architecture`-equivalent construction path: Architecture from the four
-      wire spec documents (wire the Phase-1 tspec space manager into the engine;
-      cspec/pspec via the existing `set_cspec_xml`/`set_pspec_xml` + `init_post_engine`).
-- [ ] `Translate` enum seam on `Architecture` (`{Sleigh, GhidraTranslate}`);
-      `GhidraTranslate` port (getPcode per instruction, register caches, user-op probe
-      loop). *The go/no-go linchpin — must land as a behavior-preserving refactor.*
-- [ ] `ContextGhidra::getTrackedSet` (the trait-borrow friction is resolved in the plan).
-- [ ] `Funcdata::encode` — minimal `<function>` (name/addr + `<ast>` + prototype).
-- [ ] PrintC → `EmitMarkup` wiring; `doc_function` markup path; dual-`<function>`
-      `decompileAt` response.
+      `GhidraLoadImage` (`load_fill` = `getBytes`) — `kuna-ghidra/src/provider.rs`.
+- [x] `EngineTranslate` trait seam on `Architecture` (`translate: Box<dyn EngineTranslate>`,
+      `infra/engine_translate.rs`) — behavior-preserving; only `Sleigh` implements it today.
+- [x] `GhidraTranslate` port (getPcode per instruction, register caches, user-op probe
+      loop) — `kuna-ghidra/src/translate.rs`. `ContextGhidra` is a `ContextInternal`
+      stub (empty tracked sets; the query-backed `getTrackedRegisters` is Phase 3).
+- [x] `Architecture::from_engine_translate` construction path: `registerProgram` builds
+      a live engine from the wire specs (tspec→manager, cspec/pspec via
+      `set_cspec_xml`/`set_pspec_xml`, `init_post_engine`; wire `<coretypes>` decode
+      deferred — uses the default `build_core_types`, Phase 3).
+- [x] `Funcdata::encode` — minimal `<function>`/`<ast>` (name/addr + ast;
+      `<prototype>`/`<localdb>`/`<highlist>`/`<jumptablelist>` deferred).
+- [x] PrintC → `EmitMarkup` wiring (`PrintEmit` enum, `doc_function_markup`, `MarkupRef`
+      population); the dual-`<function>` `decompileAt` response, driven by `decompile_func`
+      (name from `getCodeLabel`, flow-discovered extent). Proven end to end
+      (`kuna-ghidra/tests/decompile_at_e2e.rs`: the response decodes to a `<function>`
+      + a markup `<function>` whose refs resolve against the `<ast>`).
+
+**Phase-2 scope boundary (important):** `decompileAt` runs against an *empty*
+`ScopeInternal` global scope, so unresolved symbol/type references degrade to
+placeholders (`sub_ADDR`/`DAT_ADDR`/default types) and no `getMappedSymbols` query
+fires. Simple, self-contained functions decompile cleanly; correct names/types on
+global-heavy functions is exactly what Phase 3 (the lazy `ScopeGhidra`/
+`TypeFactoryGhidra`) adds. This is the intended Phase-2/Phase-3 line.
 
 **Phase 3 — lazy providers (correct symbols/types at scale).**
 - [ ] `ScopeGhidra`-equivalent lazy symbol cache: query-through + `<hole>` negatives +

--- a/docs/rust-port/ghidra-phase2-plan.md
+++ b/docs/rust-port/ghidra-phase2-plan.md
@@ -1,0 +1,260 @@
+# Ghidra mode — Phase 2 plan: the engine bridge
+
+**Status: [PROPOSAL] — awaiting go/no-go.** Phase 2 is the first phase that
+touches `kuna-decomp`'s core types and can perturb the standalone engine's
+output, so per the repo's standing requirement (large/output-changing features
+go through a proposal for human sign-off) it is scoped here before the risky
+work lands.
+
+Phase 1 (PR #134, branch `feat/ghidra-mode`) shipped the wire protocol complete
+and the engine stubbed: `decompileAt` answers the incomplete-function shape so
+the Ghidra GUI degrades cleanly. **Phase 2 makes `decompileAt` return real,
+marked-up C** — the first end-to-end decompilation of a live Ghidra program by
+kuna, rendered in the stock GUI.
+
+Citations: Ghidra 12.2-DEV (`f9e13846`); C++ under
+`Ghidra/Features/Decompiler/src/decompile/cpp/`, Java under
+`.../src/main/java/ghidra/app/decompiler/`. kuna paths are relative to
+`decompiler/crates/`. The seam inventory this plan implements is
+`docs/ghidra-integration.md` §9; the response contracts it must satisfy are
+§6 there.
+
+---
+
+## 0. What "done" means for Phase 2
+
+Open a small stripped x86-64 ELF in the stock Ghidra GUI with the kuna core
+active (PR #134's extension), double-click a function, and see kuna's C in the
+Decompiler window — with working click-to-address and variable highlighting.
+Concretely, `decompileAt` must return a packed `<doc>` carrying, in order, the
+`HighFunction` `<function>` (prototype + `<localdb>` + `<ast>`) and the Clang
+markup `<function>`, with the two cross-referenced consistently
+(`DecompileResults.java:215-264`, `HighFunction.java:245-293`). Rename/retype,
+the switch analyzer's `<jumptablelist>`, `<parammeasures>`, and `structureGraph`
+are explicitly **out of scope** — Phase 4.
+
+## 1. The central design decision: how a provider calls back into Java
+
+This is the crux of the whole phase and the one thing worth settling first.
+
+Upstream, every ghidra-mode component (`LoadImageGhidra`, `GhidraTranslate`,
+`ScopeGhidra`, …) holds a raw back-pointer `glb` to its `ArchitectureGhidra`,
+and issues queries through it *mid-decompile*: the engine, deep inside
+`decompileAt`'s action loop, calls e.g. `loadimage->loadFill`, which writes a
+`getBytes` query onto the same `sout` the command response is being built on,
+then blocks reading `sin` for the answer. The protocol is strictly
+synchronous — exactly one query is ever in flight, and it completes before the
+engine regains control (`ghidra_arch.cc:63-76`).
+
+**Proposed kuna shape (demonstrated in Phase 1's `kuna-ghidra/src/provider.rs`):**
+a `SharedClient<R,W> = Rc<RefCell<GhidraClient<R,W>>>` cloned into every
+provider and into the process loop. `GhidraLoadImage::load_fill` already does
+`self.client.borrow_mut().get_bytes(...)` and is unit-tested end to end. The
+`RefCell` never double-borrows because the protocol is synchronous; the `Rc`
+mirrors the C++ shared `glb` pointer. This keeps everything single-threaded and
+allocation-cheap, and — critically — is entirely additive: it lives in
+`kuna-ghidra` and touches no existing crate.
+
+Open sub-question for review: the process loop currently (Phase 1) owns
+`sin`/`sout` directly in `GhidraProcess` and writes command responses inline.
+Phase 2 must move stream ownership into the `SharedClient` so the loop and the
+providers share it. Two options:
+
+- **(a) `GhidraProcess` holds the `SharedClient`** and writes responses through
+  it (borrow for the duration of a response-frame write, drop before handing
+  control to the engine, which re-borrows per query). Simple; one owner.
+- **(b) split reader/writer** so response-writing and query-writing hold
+  independent handles to the same `W`. More plumbing, no clear benefit given the
+  protocol is half-duplex within a command.
+
+**Recommendation: (a).** It matches the C++ single-owner model and the Phase-1
+`SharedClient` type already expresses it.
+
+A second concern the scaffolding flags with a `TODO(phase-2)`: a pipe death
+*during* a query. Upstream `exit(1)`s from inside `readToAnyBurst`
+(`ghidra_arch.cc:95-96`); kuna's trait methods can only return a `KunaError`, so
+the fatal signal must ride out through the engine and be re-checked by the loop.
+Proposed: a `Cell<bool> fatal` on the `SharedClient`; `wire_to_kuna` sets it on
+`PipeClosed`/`Io`, the query returns a `KunaError`, and `run_command` checks it
+after the action returns and propagates `WireError::PipeClosed` so `main` exits
+1. This preserves the "one bad pipe ends the process" contract without unwinding
+across the FFI-like boundary.
+
+## 2. Work breakdown
+
+Ordered by dependency. Each item notes the kuna type it touches and the risk to
+the standalone engine (the thing the three gates protect).
+
+### 2.1 The `Architecture` construction path (`registerProgram` → engine)
+
+Today Phase 1's `Session` holds the four spec strings and a parsed
+`GhidraTranslate` (space manager only). Phase 2 turns a `Session` into a live
+`Architecture` (`infra/architecture.rs:218`).
+
+- **Reuse the existing frontend recipe** (`docs/ghidra-integration.md` §3 of the
+  kuna-console path): the console's `build_engine_and_init` already sets cspec/
+  pspec XML (`set_cspec_xml` :2665, `set_pspec_xml` :2675) and runs
+  `init_post_engine` (:3584). The wire cspec/pspec are the *same XML* those
+  setters expect — so most of registerProgram is feeding the four wire documents
+  into the path that already exists. `build_engine_and_init` is file-private
+  (`kuna-console/src/engine.rs:542`); **promote it to `pub` or replicate the
+  ~70-line tail in `kuna-ghidra`** (replication avoids a `kuna-console`
+  dependency and keeps the crate lean — recommended).
+- **coretypes**: decode the wire `<coretypes>` into the `TypeFactoryImpl`
+  (`buildCoreTypes`, `ghidra_arch.cc:316-349`); the decode machinery is ported.
+- **Risk: LOW-MEDIUM.** This constructs a *new* `Architecture` on the ghidra
+  path; it does not change how the standalone path constructs one. The shared
+  code (`init_post_engine`) is exercised identically by both, so a regression
+  would show in `make test`. The one real risk is promoting `build_engine_and_init`
+  to `pub` — mitigated by replicating instead.
+
+### 2.2 The `Translate` enum seam (the concrete-`Sleigh` field)
+
+`Architecture.translate` is a concrete `Sleigh` (`architecture.rs:836`), chosen
+so `manage()` (the space-manager accessor) is concrete. A `GhidraTranslate`
+(p-code per instruction from `getPcode`) cannot be installed without generalizing
+that field.
+
+- **Proposed: `enum EngineTranslate { Sleigh(Sleigh), Ghidra(GhidraTranslate) }`**
+  with `manage()`/`base()` etc. delegating. NOT `Box<dyn Translate>` — an enum
+  keeps `manage()` returning a concrete `&AddrSpaceManager` (the Sleigh-only call
+  surface — `manager_rc`, `get_register_varnode`, `get_unique_start`,
+  `with_context_db_mut` — audited and delegated per variant).
+- The lift consumer is already trait-typed
+  (`FlowEnvironment::translate() -> &dyn Translate`, `s2_lift/flow.rs:1321`), so
+  the pipeline below `Architecture` is untouched — only the owner changes.
+- `GhidraTranslate` itself: port `ghidra_translate.cc:45-156` — `getRegister`/
+  `getRegisterName` caches (`nm2addr`/`addr2nm`), `getUserOpNames` (the probe
+  loop at init), and `oneInstruction` (one `getPcode` query per instruction, the
+  `<inst>`/`<op>` decode, `ELEM_UNIMPL` → `UnimplError`, empty → `BadDataError`).
+  The space manager it needs already exists (Phase 1's `GhidraTranslate::decode`).
+- **Risk: MEDIUM-HIGH — this is the highest-risk item.** Making
+  `Architecture.translate` an enum touches ~30 call sites in `architecture.rs`
+  and anything reaching `translate()`. Every one must delegate to the `Sleigh`
+  variant with byte-identical behavior on the standalone path. **Mitigation: land
+  it as a mechanical, behavior-preserving refactor in its own commit, gated by
+  all three test suites BEFORE any `Ghidra` variant logic is added** — the enum
+  with only the `Sleigh` variant wired must be a no-op for the 675 datatests.
+
+### 2.3 `GhidraLoadImage` + `ContextGhidra` (the two "trivial" providers)
+
+- **`GhidraLoadImage`**: **done in Phase 1's `provider.rs`** (implements the real
+  `kuna_sleigh::loadimage::LoadImage`, backed by `getBytes`, tested). Phase 2 only
+  hands it to the engine as the loader (`set_loader`, `architecture.rs:2336`).
+- **`ContextGhidra`**: implements `kuna_sleigh::globalcontext::ContextDatabase`,
+  overriding only `getTrackedSet` via a `getTrackedRegisters` query
+  (`ghidra_context.cc:20-31`; everything else throws — it is Java's job).
+  **Friction to resolve in review:** the trait signature is
+  `get_tracked_set(&self, addr) -> &TrackedSet` (`globalcontext.rs:453`) —
+  returning a borrow from `&self` while querying on demand needs interior
+  mutability that can hand out a `&TrackedSet`. Options: (i) a `RefCell` cache +
+  an `unsafe`-free `Ref::leak`-style pattern (rejected — fragile); (ii) query
+  eagerly at function-start into an owned field the trait then borrows (the C++
+  `cache` member is cleared each call, so a single-entry owned cache matches
+  semantics); (iii) widen the trait to `&mut self` (touches the standalone impl).
+  **Recommendation: (ii)** — a single-slot owned cache populated by an explicit
+  `prime(addr)` the loop calls before the action, mirroring C++'s clear-then-fill.
+- **Risk: LOW** for `GhidraLoadImage` (additive, done); **LOW-MEDIUM** for
+  `ContextGhidra` (the trait-borrow friction is real but self-contained; option
+  (ii) touches no standalone code).
+
+### 2.4 `Funcdata::encode` — the `<function>` response document
+
+kuna has **no** `Funcdata::encode` (no encode on `substrate/funcdata*.rs`). This
+is the biggest *new* code in the phase: port `funcdata.cc Funcdata::encode` — the
+`<function>` element with `<addr>`, `<prototype>`, `<localdb>` (the local symbol
+map), and `<ast>` (the SSA varnodes + p-code ops). Minimal first cut: name/entry
++ `<ast>` + prototype; `<highlist>`/`<jumptablelist>` are Phase 4.
+
+- The Java decoder is the normative contract (`HighFunction.java:245-293`,
+  `PcodeSyntaxTree.decode`, `LocalSymbolMap.decodeScope`); the C++ encoder at
+  `GHIDRA_REV` is the porting source. The `<ast>` varnode/op ids emitted here must
+  be the same ids `EmitMarkup` references (see 2.5) — that consistency is the
+  click-to-address contract.
+- **Risk: LOW to the standalone engine (purely additive — a new method), HIGH in
+  effort/correctness.** Getting the `<ast>` id scheme to match `EmitMarkup`'s
+  `MarkupRef` (op `getTime()` / varnode `getCreateIndex()`) is the subtle part; a
+  mismatch silently breaks click-to-address without breaking rendering.
+
+### 2.5 PrintC → `EmitMarkup` — the marked-up C
+
+The token-markup emitter is ported (`s9_emit/prettyprint.rs:719`, packed clang
+doc) but **unreachable**: `PrintC` hardwires `EmitNoMarkup`
+(`s9_emit/printc.rs:1015`, ctor). Phase 2 generalizes `PrintC`'s `emit` field and
+wires `doc_function` (`printc.rs:1102`) to emit the markup document into the
+`decompileAt` response after the `<function>`.
+
+- **Proposed: an `enum` or `Box<dyn Emit>` for `PrintC.emit`**, defaulting to
+  `EmitNoMarkup` (the standalone/console path, unchanged) and switched to the
+  markup emitter only on the ghidra path. Also flips the console's stubbed
+  `print C xml` (`kuna-console/src/ifacedecomp.rs:2095`) into a real command as a
+  free side benefit.
+- **Risk: MEDIUM.** `PrintC` is on the standalone hot path; generalizing its emit
+  field must be zero-cost and zero-change for `EmitNoMarkup`. The 675 datatests
+  render C through this exact path, so a regression is caught immediately. Keep
+  the default variant a direct `EmitNoMarkup` (no dynamic dispatch) to avoid any
+  standalone perf/behavior delta.
+
+### 2.6 Wire `decompileAt` to the engine
+
+Replace Phase 1's stub `rawAction` for `decompileAt`: `queryFunction(addr)` (which
+lazily triggers `getMappedSymbols` — but Phase 2 can pre-query the one function at
+`addr` and defer the general lazy scope to Phase 3), run the action, then emit the
+`<doc>`: optional `<parammeasures>` (Phase 4), `Funcdata::encode` (2.4), and — when
+`sendCcode` && action=="decompile" — the `docFunction` markup (2.5). The
+incomplete-function empty-payload path stays as the failure shape.
+
+- **Symbols in Phase 2:** to keep scope bounded, Phase 2 does the *minimum*
+  symbol work to decompile one function: query the function's own mapped symbol
+  and its immediate references eagerly. The full `ScopeGhidra` lazy cache/holes
+  model (`database_ghidra.cc`) — required for correctness and speed on a real
+  program — is **Phase 3**. Phase 2 output on a function that references many
+  globals will be imperfect (missing names/types); that is expected and gated.
+
+## 3. Sequencing (each step gated by `make test` + `test-stages` + `rust-test`)
+
+1. **Translate enum seam, Sleigh-only** (2.2 refactor) — must be a no-op; full
+   gates green before proceeding. *This is the go/no-go linchpin: if the enum
+   refactor cannot be made behavior-preserving cleanly, the whole approach needs
+   rethinking.*
+2. `Architecture` construction from wire specs (2.1) + hand it `GhidraLoadImage`
+   (2.3) — a registerProgram that builds a real (if symbol-starved) engine.
+3. `GhidraTranslate` + `ContextGhidra` (2.2/2.3) — p-code flows from the host.
+4. `Funcdata::encode` minimal `<function>` (2.4).
+5. `PrintC` markup wiring (2.5) + `decompileAt` emit (2.6) — first C in the GUI.
+
+Steps 1 and 5 are the ones that touch the standalone hot path; 2–4 are additive.
+
+## 4. Testing
+
+- **Unit** (in `kuna-ghidra`, MockJava-driven, as Phase 1): each provider against
+  canned host answers; `GhidraTranslate::oneInstruction` against a canned
+  `getPcode` document; the full `registerProgram → decompileAt → <doc>` shape.
+- **Fixtures**: Ghidra's "Debug Function Decompilation" writes an `<xml_savefile>`
+  capturing every callback answer (`DecompInterface.enableDebug`,
+  `DebugDecompilerAction.java:38-73`) — the same document kuna's datatest corpus
+  consumes. A capture gives us recorded host answers to replay `decompileAt`
+  against without a live Ghidra, and a golden `<doc>` to diff. **Building a small
+  capture corpus is the recommended Phase-2 regression backbone.**
+- **Live smoke**: the extension + a real 12.2 release; decompile a function, eyeball
+  the C, click a token, confirm it navigates.
+- **The three standing gates stay green throughout** — every standalone-touching
+  step (1, 5) lands behind them.
+
+## 5. Divergences to record when they ship
+
+- `setOptions` unknown-option tolerance (deferred from Phase 1) gets its
+  `docs/divergences.md` DIV entry once `setOptions` actually decodes options.
+- Any place `Funcdata::encode` or the markup emitter must filter varnodes the
+  Java `PackedDecode.readSpace` rejects (fspec/iop/spacebase — it accepts only
+  stack/join) is a wire constraint to honor, not a divergence, but note it.
+
+## 6. Explicitly out of scope (Phase 3 / Phase 4)
+
+- Lazy `ScopeGhidra` symbol cache with `<hole>` negatives + namespace resolution
+  + the per-function `ArchSeam` snapshot rework (Phase 3).
+- `TypeFactoryGhidra` lazy `findById`, `CommentDatabaseGhidra`, injects via the
+  wire-fed cspec, `getStringData` charset fidelity (Phase 3).
+- `<highlist>`/`<jumptablelist>` + DB symbol-id echo for rename/retype;
+  `structureGraph`; `<parammeasures>`; the four signature commands; overlay
+  spaces (Phase 4).

--- a/integrations/ghidra/KunaDecompiler/README.md
+++ b/integrations/ghidra/KunaDecompiler/README.md
@@ -1,14 +1,17 @@
 # KunaDecompiler — the kuna core inside the stock Ghidra GUI
 
-A standard Ghidra extension that makes Ghidra spawn **kuna** (the Rust port of the
-Ghidra decompiler, this repository) as its native decompiler process, in place of the
-stock C++ `decompile` binary — the full Ghidra GUI (Decompiler window, analyzers,
-scripts) on top of the kuna engine.
+A standard Ghidra extension that makes the **stock Ghidra GUI** spawn **kuna** (the Rust
+port of the Ghidra decompiler, this repository) as its native decompiler backend, in
+place of the stock C++ `decompile` binary — the *unchanged* Ghidra GUI (Decompiler
+window, analyzers, scripts) running on the kuna engine. It is a drop-in, backwards-
+compatible backend: Ghidra's Java side is untouched; only the spawned process changes.
 
-**Status: Phase 1 — protocol skeleton.** The `kuna_ghidra` binary speaks the complete
-Ghidra⇄decompiler wire protocol (burst framing, packed documents, query upcalls), but
-the engine bridge is not yet connected: Ghidra will show a clean per-function error
-message in the Decompiler window instead of decompiled C until Phase 2 lands. See
+**Status: Phase 2 — kuna decompiles.** The `kuna_ghidra` binary speaks the complete
+Ghidra⇄decompiler wire protocol *and* drives kuna's engine, so the Decompiler window
+shows **real C produced by kuna**, with working click-to-address. Current scope: simple,
+self-contained functions decompile cleanly; a function that references globals/types the
+engine can't yet resolve shows placeholder names (`sub_…`/`DAT_…`) and default types —
+correct names/types at scale is Phase 3 (the lazy symbol scope). See
 [`docs/ghidra-integration.md`](../../../docs/ghidra-integration.md) for the design and
 phase plan. Target Ghidra version: **12.2** (the swap relies on the exact shape of
 `DecompileProcessFactory`; see *How it works* below).
@@ -24,9 +27,37 @@ env var, or ExtensionPoint to substitute it — so at plugin load,
 field by reflection, before the lazily-spawned first decompiler process exists. A
 Tools-menu checkbox toggles between the kuna core and the stock one at runtime.
 
-## Build the kuna binary
+## Run the kuna backend in a real Ghidra instance
 
-From the kuna repo root:
+The whole flow, against a **Ghidra release install** — build the backend, package the
+extension, install it, enable the plugin, decompile:
+
+```bash
+# 1. Build the kuna_ghidra backend and package the extension in one step.
+#    build.sh compiles the release binary, stages it into os/<platform>/, and
+#    (because GHIDRA_INSTALL_DIR is set) builds the installable zip.
+cd integrations/ghidra/KunaDecompiler
+GHIDRA_INSTALL_DIR=/abs/path/to/ghidra_12.2 ./build.sh
+#    -> dist/ghidra_12.2_..._KunaDecompiler.zip
+```
+
+2. **Install the extension:** in Ghidra's project window, **File → Install Extensions… →
+   `+` → select `dist/…_KunaDecompiler.zip`**, then restart Ghidra when prompted.
+3. **Enable the plugin:** open a program in the CodeBrowser, then **File → Configure →
+   Miscellaneous** and check **KunaDecompilerPlugin**. On load it swaps the decompiler
+   core and logs `Decompiler core is now KUNA: <path>`.
+4. **Decompile:** open any function — the Decompiler window now shows kuna's C. (Try a
+   small, self-contained function first; see the status note above for what Phase 2 does
+   and doesn't yet resolve.)
+5. **Toggle / revert** at runtime with **Tools → Kuna Decompiler → Use Kuna Core** (see
+   *Revert* below).
+
+Manual equivalents and the dev-checkout path are in the sections below.
+
+### Just the binary (manual)
+
+`build.sh` with no `GHIDRA_INSTALL_DIR` builds + stages the binary only; the equivalent
+by hand, from the repo root:
 
 ```bash
 cd decompiler
@@ -35,8 +66,9 @@ cp target/release/kuna_ghidra ../integrations/ghidra/KunaDecompiler/os/linux_x86
 ```
 
 The binary is a gitignored build artifact; it must be present under
-`os/linux_x86_64/` **before** building the extension zip so it gets packaged (other
-platforms: see `os/linux_x86_64/README.md`).
+`os/<platform>/` **before** building the extension zip so it gets packaged (`build.sh`
+picks the right `os/<platform>/` dir for your host; for other platforms see
+`os/linux_x86_64/README.md`).
 
 ## Build & install the extension
 
@@ -82,9 +114,12 @@ leaves the stock core active.
 - Run the bundled script `KunaCoreStatus.java` (Script Manager, category *Kuna*): it
   prints the executable path currently installed in `DecompileProcessFactory` and
   whether the next decompiler process is the kuna or stock core.
-- Decompile any function: in Phase 1 the Decompiler window shows the kuna phase-1
-  per-function message instead of C — that message coming from the Decompiler window
-  *is* the proof that Ghidra spawned kuna.
+- Decompile a small, self-contained function: the Decompiler window shows kuna's C, and
+  clicking a token navigates to its address — proof that the stock GUI is running on the
+  kuna engine. If a function can't be decompiled yet (an un-supported engine path), the
+  window shows a clean per-function message instead of hanging.
+- Sanity check that it's really kuna and not the stock core: the two decompilers produce
+  cosmetically different C, and `KunaCoreStatus.java` reports the `kuna_ghidra` path.
 
 ## Revert
 

--- a/integrations/ghidra/KunaDecompiler/README.md
+++ b/integrations/ghidra/KunaDecompiler/README.md
@@ -153,3 +153,41 @@ You can run kuna under Ghidra without this extension at all: copy the kuna binar
 
 The extension is the recommended path; the file drop is handy for quick experiments on
 a release install.
+
+## Use with PyGhidra (headless / scripting)
+
+The GUI plugin can't load in a headless PyGhidra session, so preload the kuna core with
+the **file-drop seam** above — then the *unchanged* Ghidra (GUI, `analyzeHeadless`, or
+PyGhidra) runs on kuna with no code changes:
+
+```bash
+# 1. Build the backend and shadow the stock `decompile` (non-destructive: delete the
+#    copy to revert). Pick your host's os dir — see build.sh's platform map.
+cd decompiler && cargo build --release -p kuna-ghidra && cd ..
+PLAT=mac_arm_64   # or linux_x86_64 | mac_x86_64 | linux_arm_64
+DROP="$GHIDRA_INSTALL_DIR/Ghidra/Features/Decompiler/build/os/$PLAT"
+mkdir -p "$DROP" && cp decompiler/target/release/kuna_ghidra "$DROP/decompile"
+
+# 2. Install pyghidra (bundled with Ghidra) and point it at your install.
+export GHIDRA_INSTALL_DIR=/abs/path/to/ghidra
+pip install "$GHIDRA_INSTALL_DIR"/Ghidra/Features/PyGhidra/pypkg/dist/pyghidra-*.whl  # or: pip install pyghidra
+```
+
+```python
+import pyghidra
+pyghidra.start()
+from ghidra.app.decompiler import DecompInterface
+from ghidra.util.task import ConsoleTaskMonitor
+
+with pyghidra.open_program("a.out") as flat:      # analyze=True by default
+    program = flat.getCurrentProgram()
+    ifc = DecompInterface(); ifc.openProgram(program)
+    for func in program.getFunctionManager().getFunctions(True):
+        res = ifc.decompileFunction(func, 60, ConsoleTaskMonitor())
+        print(res.getDecompiledFunction().getC())   # kuna's C
+```
+
+Confirm kuna is the active core: `ghidra.framework.Application.getOSFile("Decompiler",
+"decompile")` resolves to the `build/os/<platform>/decompile` you dropped. Remove that
+file to restore the stock decompiler. (Ghidra searches `build/os/<platform>/` before
+`os/<platform>/`, so the drop shadows the stock binary without overwriting it.)

--- a/integrations/ghidra/KunaDecompiler/README.md
+++ b/integrations/ghidra/KunaDecompiler/README.md
@@ -156,38 +156,56 @@ a release install.
 
 ## Use with PyGhidra (headless / scripting)
 
-The GUI plugin can't load in a headless PyGhidra session, so preload the kuna core with
-the **file-drop seam** above — then the *unchanged* Ghidra (GUI, `analyzeHeadless`, or
-PyGhidra) runs on kuna with no code changes:
+Build the backend once (`cd decompiler && cargo build --release -p kuna-ghidra`), install
+pyghidra (`pip install "$GHIDRA_INSTALL_DIR"/Ghidra/Features/PyGhidra/pypkg/dist/pyghidra-*.whl`,
+or `pip install pyghidra`), and set `GHIDRA_INSTALL_DIR`. Then pick one of two ways to make
+Ghidra use kuna.
 
-```bash
-# 1. Build the backend and shadow the stock `decompile` (non-destructive: delete the
-#    copy to revert). Pick your host's os dir — see build.sh's platform map.
-cd decompiler && cargo build --release -p kuna-ghidra && cd ..
-PLAT=mac_arm_64   # or linux_x86_64 | mac_x86_64 | linux_arm_64
-DROP="$GHIDRA_INSTALL_DIR/Ghidra/Features/Decompiler/build/os/$PLAT"
-mkdir -p "$DROP" && cp decompiler/target/release/kuna_ghidra "$DROP/decompile"
+### In-script toggle — recommended (no file changes)
 
-# 2. Install pyghidra (bundled with Ghidra) and point it at your install.
-export GHIDRA_INSTALL_DIR=/abs/path/to/ghidra
-pip install "$GHIDRA_INSTALL_DIR"/Ghidra/Features/PyGhidra/pypkg/dist/pyghidra-*.whl  # or: pip install pyghidra
-```
+The GUI plugin can't load headless, but you can do exactly what it does — set
+`DecompileProcessFactory`'s cached `exepath` by reflection — straight from Python. This
+flips the core on and off at runtime with **no file surgery**; it takes effect on the next
+decompiler-process spawn (a freshly constructed `DecompInterface`):
 
 ```python
-import pyghidra
+import os, pyghidra
 pyghidra.start()
-from ghidra.app.decompiler import DecompInterface
+from ghidra.app.decompiler import DecompileProcessFactory, DecompInterface
 from ghidra.util.task import ConsoleTaskMonitor
 
-with pyghidra.open_program("a.out") as flat:      # analyze=True by default
+def _exepath():
+    f = DecompileProcessFactory.class_.getDeclaredField("exepath")
+    f.setAccessible(True)
+    return f
+def enable_kuna(exe):  _exepath().set(None, exe)    # kuna ON  (abs path to kuna_ghidra)
+def disable_kuna():    _exepath().set(None, None)   # back to the stock decompiler
+def active_core():     return _exepath().get(None)  # what Ghidra will spawn next
+
+with pyghidra.open_program("a.out") as flat:        # analyze=True by default
     program = flat.getCurrentProgram()
+    enable_kuna(os.environ["KUNA_GHIDRA_EXE"])       # target/release/kuna_ghidra
     ifc = DecompInterface(); ifc.openProgram(program)
     for func in program.getFunctionManager().getFunctions(True):
-        res = ifc.decompileFunction(func, 60, ConsoleTaskMonitor())
-        print(res.getDecompiledFunction().getC())   # kuna's C
+        print(ifc.decompileFunction(func, 60, ConsoleTaskMonitor()).getDecompiledFunction().getC())
+    ifc.dispose()
+    disable_kuna()                                   # later DecompInterfaces use stock again
 ```
 
-Confirm kuna is the active core: `ghidra.framework.Application.getOSFile("Decompiler",
-"decompile")` resolves to the `build/os/<platform>/decompile` you dropped. Remove that
-file to restore the stock decompiler. (Ghidra searches `build/os/<platform>/` before
-`os/<platform>/`, so the drop shadows the stock binary without overwriting it.)
+`enable_kuna`/`disable_kuna` are the headless equivalent of the extension's
+**Tools → Kuna Decompiler → Use Kuna Core** checkbox (which already toggles the GUI at
+runtime). An already-open `DecompInterface` keeps its current core until it respawns, so
+toggle *before* constructing the one you want to run.
+
+### Persistent swap — the file-drop seam
+
+When you can't inject Python (e.g. `analyzeHeadless`) or want *every* Ghidra invocation to
+use kuna, drop the binary named `decompile` into the module's `build/os/<platform>/` (Ghidra
+searches it before `os/<platform>/`, so it shadows the stock binary without overwriting it —
+delete the copy to revert):
+
+```bash
+PLAT=mac_arm_64   # or linux_x86_64 | mac_x86_64 | linux_arm_64 (see build.sh)
+DROP="$GHIDRA_INSTALL_DIR/Ghidra/Features/Decompiler/build/os/$PLAT"
+mkdir -p "$DROP" && cp decompiler/target/release/kuna_ghidra "$DROP/decompile"
+```

--- a/integrations/ghidra/KunaDecompiler/build.sh
+++ b/integrations/ghidra/KunaDecompiler/build.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# One-command build + deploy for the KunaDecompiler Ghidra extension: compiles the
+# `kuna_ghidra` backend binary, stages it into this extension's `os/<platform>/`
+# directory (a gitignored build artifact), and — if GHIDRA_INSTALL_DIR is set —
+# packages the installable extension zip.
+#
+#   ./build.sh                              # build + stage the binary only
+#   GHIDRA_INSTALL_DIR=/path ./build.sh     # also build the installable zip
+#
+# See README.md ("Run the kuna backend in a real Ghidra instance") for the full
+# runbook, including the dev-checkout (`-Dghidra.external.modules`) path.
+set -euo pipefail
+
+# Resolve paths relative to this script (integrations/ghidra/KunaDecompiler/).
+EXT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$EXT_DIR/../../.." && pwd)"
+
+# Map the host to Ghidra's `Platform` enum directory name
+# (Ghidra/Framework/Generic/.../Platform.java — note the underscore before 64 on arm).
+os="$(uname -s)"; arch="$(uname -m)"
+case "$os/$arch" in
+	Linux/x86_64)         PLATFORM=linux_x86_64; EXE=kuna_ghidra ;;
+	Linux/aarch64)        PLATFORM=linux_arm_64; EXE=kuna_ghidra ;;
+	Darwin/x86_64)        PLATFORM=mac_x86_64;   EXE=kuna_ghidra ;;
+	Darwin/arm64)         PLATFORM=mac_arm_64;   EXE=kuna_ghidra ;;
+	*)
+		echo "error: unsupported host '$os/$arch'. Build kuna_ghidra manually" >&2
+		echo "       (cd decompiler && cargo build --release -p kuna-ghidra) and copy it" >&2
+		echo "       into os/<ghidra-platform-dir>/ yourself." >&2
+		exit 1 ;;
+esac
+
+echo ">> building the kuna_ghidra backend (release)"
+( cd "$REPO_ROOT/decompiler" && cargo build --release -p kuna-ghidra )
+
+echo ">> staging $EXE into os/$PLATFORM/"
+mkdir -p "$EXT_DIR/os/$PLATFORM"
+cp "$REPO_ROOT/decompiler/target/release/$EXE" "$EXT_DIR/os/$PLATFORM/$EXE"
+chmod +x "$EXT_DIR/os/$PLATFORM/$EXE"
+
+if [ -n "${GHIDRA_INSTALL_DIR:-}" ]; then
+	echo ">> packaging the extension against $GHIDRA_INSTALL_DIR"
+	( cd "$EXT_DIR" && gradle -PGHIDRA_INSTALL_DIR="$GHIDRA_INSTALL_DIR" buildExtension )
+	echo ">> done. Install the zip in $EXT_DIR/dist/ via Ghidra: File -> Install Extensions..."
+else
+	echo ">> binary staged at os/$PLATFORM/$EXE."
+	echo "   - release install: set GHIDRA_INSTALL_DIR and re-run to build the installable zip; or"
+	echo "   - dev checkout: launch Ghidra with -Dghidra.external.modules=$EXT_DIR"
+	echo "     (skip staging entirely with -Dkuna.decompiler.exe=$REPO_ROOT/decompiler/target/release/$EXE)."
+fi


### PR DESCRIPTION
## Phase 2 — the engine bridge: kuna emits real C as Ghidra's decompiler core

Stacked on Phase 1 (#134, merged). This makes kuna's engine actually decompile a live Ghidra program over the wire protocol — **first real C from kuna in ghidra mode, proven end to end.** Each step landed as its own commit keeping `make test` at **675/675 datatest parity**, `make test-stages` at 254/254, and `make rust-test` green — the change is additive to `kuna-ghidra` plus a new `Architecture` constructor; the standalone engine is untouched.

### What landed (8 commits)
1. **`EngineTranslate` trait seam** — `Architecture.translate` is now `Box<dyn EngineTranslate>` so a query-backed translator can replace `Sleigh`. Behavior-preserving; only `Sleigh` implements it today. *(Design refinement vs the proposal: a trait object, not an enum — an enum variant naming `kuna-ghidra`'s type would be a `kuna-decomp`↔`kuna-ghidra` cycle.)*
2. **`GhidraTranslate`** — p-code (`getPcode` per instruction) and registers from host queries; `ContextGhidra` is an empty-tracked-set stub (query-backed tracking is Phase 3).
3. **`Architecture::from_engine_translate` + `SharedClient` restructure** — `registerProgram` builds a live engine from the wire specs; the process loop shares its query client with the engine's providers so they call back into Java mid-decompile (borrow discipline: never a client borrow across the decompile).
4. **`Funcdata::encode`** — the `<function>`/`<ast>` response document (`ref`=`get_create_index`, `uniq`=`get_time`).
5. **`PrintC` token-markup** — `PrintEmit` enum (no vtable on the hot path) + `MarkupRef` population + `doc_function_markup`; the plain-text datatest path stays byte-identical.
6. **`decompileAt` drives the engine** — decode `<addr>` → name via `getCodeLabel` → `decompile_func` (flow-discovered extent) → emit the dual-`<function>` `<doc>` (fd.encode + spliced markup). Errors degrade to the clean incomplete-function shape.

### Proof
`kuna-ghidra/tests/decompile_at_e2e.rs::test_decompile_at_emits_c` drives a full session (registerProgram → setAction → decompileAt) through a loopback MockJava that answers the callback queries, and asserts the response is a `<doc>` with a `<function name>` + non-empty `<ast>` **and** a second markup `<function>` whose `opref`/`varref` tokens resolve against that ast (the click-to-address contract).

### Scope boundary (Phase 2 → Phase 3)
`decompileAt` runs against an empty scope, so **simple, self-contained functions decompile now**; unresolved global/type references degrade to placeholders (`sub_ADDR`/`DAT_ADDR`/default types) and no `getMappedSymbols` query fires. Correct names/types on global-heavy functions is exactly what **Phase 3** adds (the lazy `ScopeGhidra`/`TypeFactoryGhidra`, wire `<coretypes>` decode, the query-backed inject library). See `docs/ghidra-integration.md` §12 and `docs/rust-port/ghidra-phase2-plan.md`.

### Gates
`make test` 675/675 PARITY OK · `make test-stages` 254/254 PARITY OK · `make rust-test` green · `cargo test -p kuna-ghidra` all pass — every commit independently re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017t3eYSdxwUsPjN2s2oLGof

### Running kuna in a real Ghidra instance

kuna is a **drop-in, backwards-compatible backend**: Ghidra's Java side is untouched — only the spawned decompiler process changes. The `KunaDecompiler` Ghidra extension (`integrations/ghidra/KunaDecompiler/`, plugin from Phase 1, refreshed here for the working Phase-2 backend) does the swap by reflectively pointing `DecompileProcessFactory` at the `kuna_ghidra` binary. One-command build + deploy:

```bash
cd integrations/ghidra/KunaDecompiler
GHIDRA_INSTALL_DIR=/abs/path/to/ghidra_12.2 ./build.sh   # build backend -> stage -> package zip
```

Then **File → Install Extensions…** (the zip) → restart → **File → Configure** (enable `KunaDecompilerPlugin`) → decompile. The Decompiler window shows kuna's C with working click-to-address. Full runbook + the dev-checkout (`-Dghidra.external.modules`) and no-code file-drop paths: `integrations/ghidra/KunaDecompiler/README.md`.

---

### Next steps (real-Ghidra / GUI hardening — for the next iteration)

Follow-up work driving the **stock Ghidra 12.x GUI** end to end, validated on macOS/arm64 via the stock GUI plus a PyGhidra "decompile every function through the C markup" harness (the same document the Decompiler window renders).

**Landed in this iteration** (GUI now works on simple/self-contained functions):
- `678aaf62` ghidra-mode **context skip** — registerProgram was failing on real pspecs (`Non-existent context variable: addrsize`); skip `<context_data>` like C++ `ContextGhidra::decodeFromSpec`.
- `b46936d6` **setOptions accepts silently** — a phase-1 warning on the success frame made `DecompInterface` init fail ("Unable to initialize the DecompilerInterface").
- `0cf365ec` **vardecl `symref`** — a function declaring a local aborted the markup decode ("Attribute symref is not present"); always write the symref.
- Extension **packaging without gradle** (javac/jar/zip reproduction of `buildExtension`) + a **headless PyGhidra** runbook and an in-script enable/disable **toggle** in the extension README.

**Open follow-ups** (surfaced by the GUI-faithful sweep over `/usr/bin/{fmt,head,wc,nl,uniq,od}` + an x86-64 ELF):
1. **Graceful failure degradation.** When a function hits an un-ported pass, `decompile_func` catches the panic and takes the incomplete-function branch, but the response still reaches Java as a *decode* error — `Pcode: Decoding error: Expecting <doc> but did not scan an element` — instead of a clean incomplete function. C++ writes an **empty** 14/15 payload and `DecompileResults.decodeStream` early-returns on `isEmpty()`; make the caught-panic degradation emit exactly that clean empty shape so failures render as a tidy "incomplete" message and never surface a decode error. (~27/1040 functions in a large static ELF.)
2. **Un-ported passes (LOSS-131).** Those panics are the real M3-grind seams — porting them is what makes those functions actually decompilable; tracked separately from (1).
3. **External-stub name mismatch.** One `/usr/bin/head` function fails with `Function name mismatch: ____chkstk_darwin + <EXTERNAL>_____chkstk_darwin` — reconcile the name kuna returns for an external/thunk against what the Java side expects.
4. **Real `symref` / `<localdb>`.** The vardecl symref is currently a placeholder (the decl varnode's create index); Java logs an unresolvable ref. Encoding `<localdb>` (deferred in `funcdata_encode.rs`) supplies real `HighSymbol` ids so decl↔symbol linking (rename/nav) works — pairs with the Phase-3 lazy `ScopeGhidra`.
5. **setOptions applied.** Options are accepted but not applied (no option database wired to the engine yet) — Phase 3.
6. **Land the GUI-faithful harness** under `integrations/ghidra/` as a regression driver (full analysis + decompile every function via the C markup).

Cross-host note: the standalone float suite is now deterministic across build hosts (`5fa6c6ff` canonicalizes generated-NaN sign to the x86 convention), so `make rust-test`/`make test` are green on macOS/arm64 as well as Linux/x86-64.
