### PR TITLE
analysis: prune error(nonzero) call fall-through — stop the boundary overrun (closes ~50% of the Ghidra GED gap)

### DIFF
--- a/decompiler/crates/kuna-analysis/src/pass.rs
+++ b/decompiler/crates/kuna-analysis/src/pass.rs
@@ -276,6 +276,14 @@ pub struct AnalysisOutput {
     /// The commit resolves each by ADDRESS (stable across demangling), falling
     /// back to the name path. See [`NoReturnFact`].
     pub noreturn: Vec<NoReturnFact>,
+    /// (kuna, Ghidra-gap) Addresses of `call error(nonzero,…)` / `error_at_line`
+    /// sites whose fall-through must be PRUNED — glibc `error()` with a nonzero
+    /// constant status calls `exit()` and never returns, so the CALL must not fall
+    /// through (Ghidra flags it "Subroutine does not return"). Committed as
+    /// `CALL_RETURN` flow overrides at the decompile seam; without this the
+    /// flow-follower walks past the call into the NEXT function and absorbs it
+    /// (the boundary-overrun class, ~50% of kuna's Ghidra GED gap).
+    pub no_fallthru_calls: Vec<u64>,
     /// Extra read-only address ranges (e.g. `.got` after relocation).
     pub readonly: Vec<(u64, u64)>,
     /// Detected NUL-terminated string literals (a typed `char[N]` per address).
@@ -338,6 +346,7 @@ impl AnalysisOutput {
         self.entries.extend(other.entries);
         self.entry_names.extend(other.entry_names);
         self.noreturn.extend(other.noreturn);
+        self.no_fallthru_calls.extend(other.no_fallthru_calls);
         self.readonly.extend(other.readonly);
         self.strings.extend(other.strings);
         self.prototypes.extend(other.prototypes);

--- a/decompiler/crates/kuna-analysis/src/s1_noreturn_propagate/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/s1_noreturn_propagate/mod.rs
@@ -137,8 +137,50 @@ impl AnalysisPass for NoReturnPropagatePass {
         for fact in propagate_noreturn(listing, &error_recog, reach) {
             out.noreturn.push(fact);
         }
+        // (kuna, Ghidra-gap) Emit every `call error(nonzero,…)` site so the decompile
+        // seam prunes its fall-through (CALL_RETURN override). Gated by the same
+        // `noreturn_error` flag as the recognizer; the recognizer is `disabled()` (no
+        // addresses) when the flag is off, so this yields an empty set then.
+        out.no_fallthru_calls = collect_error_noreturn_callsites(listing, &error_recog);
         out
     }
+}
+
+/// (kuna, Ghidra-gap) Every `call error(nonzero,…)` / `error_at_line(nonzero,…)`
+/// call-site address in the program. glibc `error()` with a nonzero constant status
+/// calls `exit(status)` and never returns, so the CALL's fall-through must be pruned
+/// exactly as Ghidra does ("Subroutine does not return"). Unlike [`function_is_no_return`]
+/// (which only inspects a *tail* call to conclude a wrapper no-return, entry-keyed),
+/// this collects EVERY such call site — the fall-through prune is what stops the
+/// flow-follower from walking past the call into the next function (the docolon→eval6
+/// boundary-overrun class). Reuses the recognizer's per-call-site value check.
+fn collect_error_noreturn_callsites(
+    listing: &Listing,
+    error_recog: &ErrorRecognizer,
+) -> Vec<u64> {
+    let mut sites = Vec::new();
+    if error_recog.error_addrs.is_empty() {
+        return sites;
+    }
+    for (&entry, _) in listing.functions() {
+        let next = listing.next_function_after(entry).map(|f| f.entry);
+        let body: Vec<(u64, &Insn)> = listing
+            .instructions()
+            .filter(|(&vma, _)| vma >= entry && next.map_or(true, |n| vma < n))
+            .map(|(&vma, insn)| (vma, insn))
+            .collect();
+        for i in 0..body.len() {
+            // `call_is_terminal_error` = is_call && target is error && arg0 nonzero const
+            // (its name is "terminal" because such a call never returns; it is valid at
+            // any body position, not only the last).
+            if error_recog.call_is_terminal_error(&body, i) {
+                sites.push(body[i].0);
+            }
+        }
+    }
+    sites.sort_unstable();
+    sites.dedup();
+    sites
 }
 
 /// The `error(status,…)`-conditional no-return recognizer (decbench F2).

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -182,6 +182,28 @@ fn decompile_all(args: &Args) -> Result<Vec<FuncResult>, String> {
         // catches un-ported-seam panics and returns Err, so a single bad function
         // degrades to an `error` record instead of aborting the binary.
         let mapped = prog.dwarf_locals_for(address);
+        // (kuna, Ghidra-gap) `CALL_RETURN` flow overrides for the binary's
+        // `call error(nonzero,…)` sites — prune the fall-through so the flow-follower
+        // stops at the no-return call (Ghidra "Subroutine does not return") instead of
+        // walking into the next function and absorbing it. The whole binary's list is
+        // passed; only sites this function's flow actually visits are applied. Empty
+        // unless the Listing + `noreturn_error` are on (so `kuna functions`/console are
+        // unaffected).
+        let flow_ovr: Vec<(kuna_base::address::Address, kuna_base::types::uint4)> =
+            match entry.get_space() {
+                Some(space) if !prog.arch().error_noreturn_callsites.is_empty() => prog
+                    .arch()
+                    .error_noreturn_callsites
+                    .iter()
+                    .map(|&off| {
+                        (
+                            kuna_base::address::Address::new(std::rc::Rc::clone(space), off),
+                            kuna_decomp::overrides::flow_type::CALL_RETURN,
+                        )
+                    })
+                    .collect(),
+                _ => Vec::new(),
+            };
         match decompile_func_full_with_override_dyn(
             prog.arch_mut(),
             &name,
@@ -191,7 +213,7 @@ fn decompile_all(args: &Args) -> Result<Vec<FuncResult>, String> {
             &[],
             &[],
             None,
-            &[],
+            &flow_ovr,
             &[],
             &[],
         ) {

--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -53,6 +53,17 @@ fn json_count(stdout: &str) -> Option<usize> {
     stdout[i..].trim_start().split(|c: char| !c.is_ascii_digit()).next()?.parse().ok()
 }
 
+/// The `error(nonzero,…)` boundary-overrun fixture (`noreturn_error_x86_64`):
+/// `err_fatal.constprop.0` @ 0x4011c0 ends in `call error(2,…)` and is immediately
+/// followed by `compute` @ 0x4011f0.
+fn noreturn_error_fixture() -> String {
+    repo_root()
+        .join("decompiler/crates/kuna-analysis/tests/fixtures/noreturn_error_x86_64")
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
 /// Run the built `kuna` binary, returning `(stdout, stderr, success)`.
 fn run_kuna(args: &[&str]) -> (String, String, bool) {
     let out = Command::new(env!("CARGO_BIN_EXE_kuna"))
@@ -394,4 +405,53 @@ fn functions_lists_main() {
     }
     assert!(stdout.contains("\"name\": \"main\""), "enumeration missing `main`:\n{stdout}");
     assert!(stdout.contains("\"address\""), "enumeration missing addresses:\n{stdout}");
+}
+
+/// (kuna, Ghidra-gap) The `error(nonzero,…)` boundary-overrun fix. `err_fatal`
+/// (0x4011c0) ends in `call error(2,…)` — glibc `error()` with a nonzero status
+/// never returns — so the decompile-all seam must prune its fall-through (a
+/// `CALL_RETURN` flow override) exactly as Ghidra does ("Subroutine does not
+/// return"). Without the prune the flow-follower walks past the call into the
+/// following function `compute` (0x4011f0) and absorbs it, inflating the CFG —
+/// the single biggest cause of kuna losing to Ghidra proper on the benchmark
+/// (~50% of the ghidra-beats-kuna GED cases were this boundary overrun).
+///
+/// The test isolates exactly the fix: `--option noreturn_error off` (no error
+/// recognizer ⇒ no prune ⇒ err_fatal absorbs `compute`) must yield a LARGER
+/// function byte-extent than the default (`noreturn_error on`, the prune fires).
+#[test]
+fn decompile_all_error_nonzero_does_not_absorb_next_function() {
+    let bin = noreturn_error_fixture();
+    let sp = specs();
+    let code = |extra: &[&str]| -> Option<String> {
+        let mut a: Vec<&str> =
+            vec!["decompile-all", &bin, "--addr", "0x4011c0", "--json", "--sleighpath", &sp];
+        a.extend_from_slice(extra);
+        let (stdout, stderr, ok) = run_kuna(&a);
+        if !ok {
+            eprintln!("decompile-all failed (likely a specs-less environment): {stderr}");
+            return None;
+        }
+        Some(stdout)
+    };
+    // OFF: err_fatal's flow walks past `call error(2)` into the following functions.
+    let Some(off) = code(&["--option", "noreturn_error", "off"]) else {
+        return; // specs-less skip
+    };
+    // ON (default): the CALL_RETURN prune stops err_fatal at the no-return call.
+    let on = code(&[]).expect("second run succeeds if the first did");
+    // `err_warn` belongs to `compute_warn` — a DIFFERENT function two hops after
+    // err_fatal. It can only appear in err_fatal's decompilation if the flow-follower
+    // overran `call error(2)` and absorbed the following functions. OFF must show the
+    // overrun; ON (the prune) must not.
+    assert!(
+        off.contains("err_warn"),
+        "with noreturn_error off, err_fatal should overrun and absorb the following \
+         functions (the pre-fix behaviour):\n{off}"
+    );
+    assert!(
+        !on.contains("err_warn"),
+        "noreturn_error must prune the `call error(2)` fall-through so err_fatal does \
+         NOT absorb `compute`/`compute_warn`:\n{on}"
+    );
 }

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -1067,6 +1067,17 @@ fn commit_analysis_output(
         }
     }
 
+    // 3a'. (kuna, Ghidra-gap) Stash the `call error(nonzero,…)` prune list on the arch
+    //      so `decompile-all` applies CALL_RETURN flow overrides per function (prunes the
+    //      fall-through Ghidra also prunes). Empty unless the Listing + `noreturn_error`
+    //      are on, so the datatest/console parity paths (no Listing) are unaffected.
+    if !out.no_fallthru_calls.is_empty() {
+        let mut sites = out.no_fallthru_calls.clone();
+        sites.sort_unstable();
+        sites.dedup();
+        prog.arch_mut().error_noreturn_callsites = sites;
+    }
+
     // 3b. FID re-identification (the kuna analog of Ghidra's FID identification
     //     analyzer): RENAME a function whose instruction-stream fingerprint matched
     //     a known-library record. Unlike the SymFact arm (step 1) — an idempotent

--- a/decompiler/crates/kuna-decomp/src/infra/architecture.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/architecture.rs
@@ -635,6 +635,13 @@ pub struct Architecture {
     /// Listing AND `noreturn_propagate` on; a no-op otherwise, so every parity gate is
     /// byte-identical (real-ELF path only). Default **on** (DIV-19).
     pub analysis_noreturn_reach: bool,
+    /// (kuna, Ghidra-gap) `call error(nonzero,…)` call-site addresses whose fall-through
+    /// the decompile seam must prune (as `CALL_RETURN` flow overrides). Populated at the
+    /// analysis commit from `AnalysisOutput::no_fallthru_calls` (empty unless `listing` +
+    /// `noreturn_error` are on); read by `decompile-all` per function. glibc `error()`
+    /// with a nonzero status never returns, so without the prune the flow-follower walks
+    /// past the call into the next function and absorbs it. Sorted/deduped.
+    pub error_noreturn_callsites: Vec<u64>,
     /// (kuna) Gate the FID fingerprint matcher (`fid`), a Listing/xref consumer;
     /// default **off**. The kuna analog of Ghidra's FID identification analyzer:
     /// over the built Listing it fingerprints each function with the byte-exact
@@ -952,6 +959,7 @@ impl Architecture {
             analysis_noreturn_propagate: false,
             analysis_noreturn_error: false,
             analysis_noreturn_reach: false,
+            error_noreturn_callsites: Vec::new(),
             analysis_fid: false,
             analysis_rtti: false,
             analysis_aif: false,


### PR DESCRIPTION
A 22-agent investigation of *why kuna loses to Ghidra proper* found **~50% (11/22, all the biggest margins) are one bug**: glibc `error(status,…)` is conditionally no-return (calls `exit()` when `status != 0`), and kuna didn't prune the post-call fall-through. So the flow-follower walked **past `call error(nonzero)`, over the NOP pad, into the next function's prologue** and decompiled both as one blob — `expr/docolon` absorbed all of `eval6` (561 LOC vs Ghidra's 140); `split/bytes_chunk_extract` swallowed **five** functions. Absorbing a foreign CFG maximally inflates node/edge counts → the catastrophic GED margins.

## The wiring gap

kuna already *recognised* `error(nonzero)` (the `ErrorRecognizer`/`noreturn_error`, DIV-16) but only committed it **function-entry-keyed** (concludes a *wrapper* no-return — helps callers). This adds the missing **per-call-site prune**, exactly as Ghidra's discovered-no-return analyzer does:
- `s1_noreturn_propagate` collects every `call error(nonzero,…)` site (`AnalysisOutput::no_fallthru_calls`),
- the commit stashes them on `Architecture::error_noreturn_callsites`,
- `decompile-all` applies them as `CALL_RETURN` flow overrides — the mechanism was fully ported but nothing fed it.

## Effect (decompile-all)

| function | before | after | Ghidra |
|---|---|---|---|
| expr/docolon | 561 | **133** | 140 |
| tr/read_and_delete | 374 | **41** | ~40 |
| split/bytes_chunk_extract | 446 | **62** | — |
| nl/build_type_arg | 351 | **35** | — |
| cat/simple_cat | 286 | **23** | — |

Pure **port-fidelity** (kuna now does exactly what Ghidra does — no readability trade-off).

## Safety

Gated by the existing `noreturn_error` + `listing`, so the datatest/console parity paths (no Listing) are **byte-identical**. `make test` **675/675 PARITY OK**, `make test-stages` **254/254 PARITY OK**, `make rust-test` green. New regression test `decompile_all_error_nonzero_does_not_absorb_next_function`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J