### PR TITLE
analysis: add err/errx family + quick_exit/__chk_fail/__libc_fatal to the no-return list (DIV-21)

### DIFF
--- a/decompiler/crates/kuna-analysis/data/ElfFunctionsThatDoNotReturn
+++ b/decompiler/crates/kuna-analysis/data/ElfFunctionsThatDoNotReturn
@@ -25,3 +25,21 @@ fortify_fail
 ZSt9terminatev
 ZN10__cxxabiv111__terminateEPFvvE
 pthread_exit
+#
+# (kuna divergence, DIV-21) Genuinely-UNCONDITIONAL no-return libc/BSD functions that
+# upstream Ghidra's ELF list omits (it catches them only via its default-on discovered
+# >=3-evidence analyzer). Each ALWAYS exits/aborts — safe to mark unconditionally
+# (unlike error()/error_at_line(), which RETURN for status 0 and are handled per-call-
+# site by noreturn_error). Adding them stops the function-boundary overrun where an
+# internal die()/fatal() wrapper ends in one of these (the same class as the error()
+# overrun fixed in #138). NB: warn/warnx/vwarn/vwarnx RETURN and are deliberately absent.
+err
+errx
+verr
+verrx
+errc
+verrc
+quick_exit
+assert_perror_fail
+chk_fail
+libc_fatal

--- a/decompiler/crates/kuna-analysis/src/s1_loader/noreturn.rs
+++ b/decompiler/crates/kuna-analysis/src/s1_loader/noreturn.rs
@@ -284,6 +284,27 @@ mod tests {
         assert!(!exact.iter().any(|e| e.starts_with('_')));
     }
 
+    /// (kuna DIV-21) The genuinely-unconditional no-return libc/BSD names added beyond
+    /// upstream's ELF list — the `err`/`errx` family + `quick_exit`/`__assert_perror_fail`/
+    /// `__chk_fail`/`__libc_fatal`. Each ALWAYS exits, so a `die()`/`fatal()` wrapper ending
+    /// in one is no-return; without them its callers overrun into the next function (the
+    /// same class as the `error()` boundary overrun). `warn`/`warnx` RETURN and must stay OUT.
+    #[test]
+    fn div21_unconditional_noreturn_family_present_warn_absent() {
+        let (exact, wildcard) = sets();
+        for want in ["err", "errx", "verr", "verrx", "errc", "verrc", "quick_exit"] {
+            assert!(name_matches(want, &exact, &wildcard), "DIV-21: {want} must be no-return");
+        }
+        // underscore-stripped glibc internals
+        assert!(name_matches("__assert_perror_fail", &exact, &wildcard));
+        assert!(name_matches("__chk_fail", &exact, &wildcard));
+        assert!(name_matches("__libc_fatal", &exact, &wildcard));
+        // the warn family RETURNS — a false positive here would drop live caller code.
+        for nope in ["warn", "warnx", "vwarn", "vwarnx"] {
+            assert!(!name_matches(nope, &exact, &wildcard), "{nope} RETURNS; must NOT be no-return");
+        }
+    }
+
     #[test]
     fn strips_all_leading_underscores() {
         let (exact, wildcard) = sets();

--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -781,3 +781,25 @@ gh558-experiment protocol: run the 204+675 upstream assertions, list every chang
 - **Testcase**: `kuna-cli/tests/decompile_all_cli.rs` (the non-x86-64 default-on injection) +
   the real ARM Cortex-M behavior on the decbench `cps` corpus.
 - **Date**: 2026-07-05.
+
+## DIV-21: extra genuinely-unconditional no-return libc/BSD names (`err`/`errx` family, …)
+
+- **Flip**: kuna's `decompiler/crates/kuna-analysis/data/ElfFunctionsThatDoNotReturn` (the
+  data behind the default-on `noreturn_known` pass) adds names beyond the verbatim upstream
+  Ghidra list: the BSD `err`/`errx`/`verr`/`verrx`/`errc`/`verrc` family plus `quick_exit`,
+  `__assert_perror_fail`, `__chk_fail`, `__libc_fatal`.
+- **Why**: each of these ALWAYS `exit()`s/aborts (genuinely unconditional no-return), yet
+  upstream Ghidra's *ELF* list omits them — Ghidra catches them only via its default-on
+  discovered ≥3-evidence analyzer (`FindNoReturnFunctionsAnalyzer`), which kuna keeps
+  default-off. Without a no-return mark, kuna's flow-follower walks past a tail
+  `call errx(1,…)` (in an internal `die()`/`fatal()` wrapper) into the following function and
+  **absorbs** it — the exact function-boundary overrun class fixed for glibc `error()` in the
+  per-call-site prune (#138). Unlike `error()`/`error_at_line()` (which RETURN for status 0 and
+  are handled per-call-site by `noreturn_error`), the `err` family is unconditional, so a
+  whole-function mark is sound. `warn`/`warnx`/`vwarn`/`vwarnx` RETURN and are deliberately
+  excluded (a false positive would drop live caller code).
+- **Parity**: byte-identical on the datatest corpus (no datatest names any of these) and the
+  stage corpus — `make test` 675/675 PARITY OK. It only changes output on a real binary that
+  actually calls one of these as a no-returning tail.
+- **Testcase**: `s1_loader/noreturn.rs::div21_unconditional_noreturn_family_present_warn_absent`.
+- **Date**: 2026-07-06.


### PR DESCRIPTION
Follow-up to #138. A deep Ghidra-vs-kuna comparison of the no-return / function-boundary machinery found the general prune wiring is **faithful** — `query_call_no_return` prunes the fall-through for any callee marked no-return (known-list, discovered via `noreturn_reach`, or name-matched). The deficit is **marking coverage**: kuna's `ElfFunctionsThatDoNotReturn` is byte-identical to Ghidra's, and **both omit the BSD `err`/`errx` family** — upstream catches them only via its default-on discovered ≥3-evidence analyzer (which kuna keeps default-off).

## Fix

Add the genuinely-**unconditional** no-return names (each always `exit()`s/aborts): `err errx verr verrx errc verrc quick_exit __assert_perror_fail __chk_fail __libc_fatal`. A `die()`/`fatal()` wrapper ending in a tail `call errx(1,…)` otherwise reproduces the exact boundary overrun fixed for `error()` in #138. Unlike `error()`/`error_at_line()` (conditional — return for status 0, handled per-call-site by `noreturn_error`), the `err` family is unconditional so a whole-function mark is sound. `warn`/`warnx`/`vwarn`/`vwarnx` **return** and are deliberately excluded.

## Safety

Byte-identical on the datatest corpus (**675/675 PARITY OK**) + stages (**254/254**) — no test names any of these. `make rust-test` green. New unit test `div21_unconditional_noreturn_family_present_warn_absent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J