### PR TITLE
s6 merge: don't abort VariablePiece grouping on a conflicting addr-tied slot (kill the SUBPIECE/CONCAT soup)

### DIFF
--- a/decompiler/crates/kuna-decomp/src/s6_variables/merge.rs
+++ b/decompiler/crates/kuna-decomp/src/s6_variables/merge.rs
@@ -1640,7 +1640,22 @@ impl Merge {
             }
             self.unify_address(ctx, &range.all_varnodes)?;
             for sub in &range.must_merge_ranges {
-                self.merge_range_must(ctx, sub)?;
+                // (kuna divergence) A forced merge that intersects — a heavily-reused
+                // stack slot (compiler stack-coloring, hundreds of SSA versions) the
+                // port's `eliminate_intersect` cannot fully snip — is SKIPPED, not fatal.
+                // Upstream Ghidra's `mergeAddrTied` is INFALLIBLE (its `eliminateIntersect`
+                // always resolves, `merge.cc:489`), so `mergeRangeMust` never throws there.
+                // When kuna's does, `?`-propagating it aborts the WHOLE loop, which skips
+                // the `bank_group_with` VariablePiece grouping below for every OTHER slot
+                // too — so `mark_internal_copies` can hide no partial-preserve SUBPIECE and
+                // the function renders `SUB84(x,4)`/`CONCAT44(…)` reconstruction soup
+                // instead of Ghidra's inline `x._4_4_` member access. Swallowing just the
+                // conflicting sub-range (leaving it exactly as un-unified as the total
+                // abort did — strictly no worse there) and STILL forming the groups below
+                // lets every other slot's pieces coalesce and print correctly. The residual
+                // conflicting slot is the follow-up (match Ghidra's `eliminateIntersect`
+                // on the INPUT-vs-INDIRECT reused-slot intersection).
+                let _ = self.merge_range_must(ctx, sub);
             }
             for &(vn2_high, off, vn1_high) in &range.group_with {
                 ctx.bank_group_with(vn2_high, off, vn1_high)?;

--- a/docs/baseline-stages.json
+++ b/docs/baseline-stages.json
@@ -171,7 +171,7 @@
     "data:angr-StackGuard #3: bug -- label (goto target + definition) emitted only with option off",
     "data:angr-StackGuard #4: fix -- only the option-on pass inlines the deep match path as a direct return 1",
     "data:angr-dedupvardecls #1: slot 0x58 declared 4x (off, the bug) + 1x (on, the fix) = 5 total",
-    "data:angr-dedupvardecls #2: slot 0x3c declared 2x (off) + 1x (on) = 3 total",
+    "data:angr-dedupvardecls #2: slot 0x3c declared 1x (off, now merge-coalesced) + 1x (on) = 2 total",
     "data:angr-gotoreduce #1 (bug, off): one residual goto to the shared return tail",
     "data:angr-gotoreduce #2 (bug, off): goto label reference + label definition present, none on",
     "data:angr-gotoreduce #3 (fix, on): return tail duplicated (1 return off + 2 returns on)",

--- a/tests/stages/ghangr-x8664-cvs-863633.xml
+++ b/tests/stages/ghangr-x8664-cvs-863633.xml
@@ -31,11 +31,14 @@
 
     Assertions are on the name-independent storage comment '; // stack - 0xNN'
     (one per declaration of that slot), summed over both passes:
-      Pass 1 (option dedupvardecls off): slot 0x58 declared 4x, slot 0x3c 2x
-        - the bug (duplicate scalar declarations).
+      Pass 1 (option dedupvardecls off): slot 0x58 declared 4x, slot 0x3c 1x
+        - the bug (duplicate scalar declarations); 0x58 still shows it.
       Pass 2 (option dedupvardecls on): each slot declared exactly 1x - the fix.
-    So slot 0x58 totals 4 + 1 = 5 and slot 0x3c totals 2 + 1 = 3.  A broken fix
-    (no collapse: 8 / 4) or an over-eager collapse (under 5 / under 3) fails.
+    So slot 0x58 totals 4 + 1 = 5 and slot 0x3c totals 1 + 1 = 2.  A broken fix
+    (no collapse: 8 / >=3) or an over-eager collapse (under 5 / under 2) fails.
+    (kuna: since the addr-tied merge coalescing fix (VariablePiece grouping no longer
+    aborts on a reused stack slot), the OFF pass already coalesces 0x3c to 1x, so its
+    total dropped from 3 to 2; dedupvardecls is still exercised by the 0x58 case.)
 
     Chunks: cvs main's .text bytes from 0x404df0 (plus slack so the jump-table
     over-read decodes), and the getopt-dispatch table in .rodata at 0x49b8f0.
@@ -63,5 +66,5 @@ f30f1efa41564155415455534883ec30897c240c488d3dfc6709004889342464488b042528000000
   <com>quit</com>
 </script>
 <stringmatch name="angr-dedupvardecls #1: slot 0x58 declared 4x (off, the bug) + 1x (on, the fix) = 5 total" min="5" max="5">; // stack - 0x58</stringmatch>
-<stringmatch name="angr-dedupvardecls #2: slot 0x3c declared 2x (off) + 1x (on) = 3 total" min="3" max="3">; // stack - 0x3c</stringmatch>
+<stringmatch name="angr-dedupvardecls #2: slot 0x3c declared 1x (off, now merge-coalesced) + 1x (on) = 2 total" min="2" max="2">; // stack - 0x3c</stringmatch>
 </decompilertest>


### PR DESCRIPTION
The last big structural gap vs Ghidra. On optimized functions, kuna emitted `SUB84(x,4)`/`CONCAT44(…)` "reconstruction soup" (a 64-bit stack slot's low half written from a 32-bit value, high half rebuilt via a temp) where Ghidra renders the same p-code as an **inline `x._4_4_` member access**.

## Root cause (a cascading abort, not a missing rule)
A deep investigation (agent, with an instrumented build) found kuna has faithfully ported every mechanism — heritage refinement, `VariablePiece`/`VariableGroup`, `mark_internal_copies`, the partial-symbol renderer. The soup is a **whole-function abort**: on a heavily-reused stack slot (compiler stack-coloring, hundreds of SSA versions), `Merge::merge_addr_tied` → `merge_range_must` throws `"Forced merge caused intersection"` (kuna's `eliminate_intersect` can't snip an INPUT-vs-INDIRECT cover intersection that Ghidra's **infallible** `eliminateIntersect` does). The caller `?`-propagated it, aborting the loop → **skips `bank_group_with` (VariablePiece grouping) for every OTHER slot too** → `mark_internal_copies` can hide no partial-preserve SUBPIECE → soup.

## Fix
Ghidra's `mergeAddrTied` never throws, so degrade gracefully: swallow the per-range forced-merge error and **still form the groups**. The conflicting slot is left exactly as un-unified as the total abort already left it (strictly no worse there); every other slot now coalesces.

## Effect

| | before | after | Ghidra |
|---|---|---|---|
| cp/copy_internal SUB84 | 27 | **0** | 0 |
| cp partials (`._N_N_`) | 0 | **72** | (inline) |
| split/main soup ops | 51 | **0** | 0 |
| **split/main GED** | 249 | **93** | **149** |

**split/main GED went 669 → 249 (no-return fixes) → 93 — now *below* Ghidra's 149.** kuna's structure is closer to source than Ghidra's on this function.

## Gates
`make test` **675/675 PARITY OK**, `make rust-test` green, `make test-stages` **254/254** after re-pinning `angr-dedupvardecls #2` (slot 0x3c is now merge-coalesced to 1× in the OFF pass, so its cross-pass total dropped 3→2 — a genuine improvement; the flag stays exercised by the 0x58 case). Follow-up: make `eliminate_intersect` match Ghidra to also clear the residual (cp SUB87 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J