### PR TITLE
s9 emit: frame-local pending-brace close (fix branchflip extra-`}` invalid C + cross-function indent leak)

### DIFF
--- a/decompiler/crates/kuna-decomp/src/s9_emit/prettyprint.rs
+++ b/decompiler/crates/kuna-decomp/src/s9_emit/prettyprint.rs
@@ -456,6 +456,41 @@ pub trait Emit {
         let st = self.state_mut();
         st.pend_print = Some(style);
         st.pend_brace_indent = -1;
+        // Stamp this registration with a fresh generation (its C++ pointer
+        // identity).  A later registration shadows this one; the shadowed brace
+        // then never fires and its owning frame must not close a brace it never
+        // opened.
+        st.pend_gen_ctr += 1;
+        st.pend_reg_gen = st.pend_gen_ctr;
+    }
+
+    /// The generation stamp of the pending-brace registration this call just
+    /// made — the caller keeps it and later asks [`Emit::pending_fired_indent`]
+    /// whether *its own* brace fired.  Read immediately after
+    /// [`Emit::set_pending_brace`].
+    fn pending_reg_gen(&self) -> u64 {
+        self.state().pend_reg_gen
+    }
+
+    /// The indent id the pending brace registered under `gen` opened when it
+    /// fired, or `-1` if that generation never fired (it was shadowed by a later
+    /// registration, or canceled).  This is C++'s frame-local
+    /// `PendingBrace::getIndentId()`: it answers "did *my* brace fire", immune to
+    /// sibling/descendant fires that share the emitter's pending slot.
+    fn pending_fired_indent(&self, gen: u64) -> int4 {
+        self.state()
+            .pend_fired
+            .iter()
+            .rev()
+            .find(|(g, _)| *g == gen)
+            .map(|(_, id)| *id)
+            .unwrap_or(-1)
+    }
+
+    /// Drop recorded pending-brace fire results (call at the start of a fresh
+    /// function body so the `pend_fired` log cannot accumulate across functions).
+    fn reset_pending_fired(&mut self) {
+        self.state_mut().pend_fired.clear();
     }
 
     /// Is a brace still pending (C++ `Emit::hasPendingPrint`)?  True only while
@@ -484,9 +519,14 @@ pub trait Emit {
         if let Some(style) = self.state().pend_print {
             // Clear pending before the callback (C++ emitPending order).
             self.state_mut().pend_print = None;
+            // The brace being fired is the *currently active* registration; stamp
+            // its generation so its owning frame (and only that frame) can later
+            // recognise its own fire.
+            let gen = self.state().pend_reg_gen;
             let id = self.open_brace_indent(OPEN_CURLY_FOR_PENDING, style);
             // Record the fired brace's indent id (C++ PendingBrace::indentId).
             self.state_mut().pend_brace_indent = id;
+            self.state_mut().pend_fired.push((gen, id));
         }
     }
 }
@@ -514,6 +554,20 @@ pub struct EmitBase {
     /// `PendingBrace::indentId`, which lives on the caller's stack frame).  Read
     /// by `emit_block_if` to decide whether a brace needs closing.
     pub pend_brace_indent: int4,
+    /// Monotonic id source for pending-brace registrations.  Each
+    /// [`Emit::set_pending_brace`] bumps this and stamps the new registration.
+    pub pend_gen_ctr: u64,
+    /// Generation stamp of the *currently active* pending-brace registration
+    /// (the C++ `pendPrint` pointer identity).  A later `set_pending_brace`
+    /// shadows an earlier one; the earlier registration then never fires.
+    pub pend_reg_gen: u64,
+    /// `(generation, fired indent id)` for every pending brace that actually
+    /// *fired*.  This is the per-frame `PendingBrace::indentId` of C++: an
+    /// `emit_block_if` frame stamps its own generation at registration and later
+    /// asks [`Emit::pending_fired_indent`] whether *that* generation fired — so a
+    /// frame closes its `else { … }` brace only when its own brace opened, never
+    /// on a stale sibling/descendant fire (the shared-slot bug).
+    pub pend_fired: Vec<(u64, int4)>,
 }
 
 impl Default for EmitBase {
@@ -531,6 +585,9 @@ impl EmitBase {
             indentincrement: 2,
             pend_print: None,
             pend_brace_indent: -1,
+            pend_gen_ctr: 0,
+            pend_reg_gen: 0,
+            pend_fired: Vec::new(),
         }
     }
     /// C++ `Emit::resetDefaultsInternal()`.

--- a/decompiler/crates/kuna-decomp/src/s9_emit/printc.rs
+++ b/decompiler/crates/kuna-decomp/src/s9_emit/printc.rs
@@ -2253,6 +2253,11 @@ impl PrintC {
             Some(r) => r,
             None => return,
         };
+        // Drop any pending-brace fire log from a previous function so the
+        // per-registration `pend_fired` record cannot accumulate across a
+        // load-once/decompile-many run (generations are globally unique, so this
+        // is purely to bound memory, not for correctness).
+        self.emit.reset_pending_fired();
         self.emit_block_graph(fd, arch, sroot);
     }
 
@@ -2582,8 +2587,13 @@ impl PrintC {
         //   else-clause of a parent if, the parent set the pending_brace mod; we
         //   register a brace that opens lazily so a real `else if` collapses.
         let mut registered_pending = false;
+        let mut my_pending_gen = 0u64;
         if self.context.is_set(modifiers::PENDING_BRACE) {
             self.emit.set_pending_brace(to_emit_brace(self.options.brace_ifelse));
+            // Remember *our* registration's generation so the close decision below
+            // asks whether OUR brace fired, not whether the shared slot holds any
+            // fired id (which could be a nested/sibling BlockIf's brace).
+            my_pending_gen = self.emit.pending_reg_gen();
             registered_pending = true;
         }
 
@@ -2614,7 +2624,12 @@ impl PrintC {
             self.emit.spaces(1, 0);
         } else {
             if registered_pending {
-                my_pending_indent = self.emit.pending_brace_indent_id();
+                // C++ `pendingBrace.getIndentId()`: close a lazy `else { … }`
+                // brace only if OUR OWN registration fired.  Reading the shared
+                // `pending_brace_indent_id()` here would pick up a stale id left by
+                // a nested BlockIf's fire and emit an unmatched `}` (dumping code to
+                // file scope) whenever our brace was shadowed but never opened.
+                my_pending_indent = self.emit.pending_fired_indent(my_pending_gen);
             }
             self.emit.tag_line();
         }
@@ -2725,8 +2740,10 @@ impl PrintC {
         // parent if's else-clause, register the lazy brace so the ternary statement
         // renders `else { ... }` (a statement can never be `else if`).
         let mut registered_pending = false;
+        let mut my_pending_gen = 0u64;
         if self.context.is_set(modifiers::PENDING_BRACE) {
             self.emit.set_pending_brace(to_emit_brace(self.options.brace_ifelse));
+            my_pending_gen = self.emit.pending_reg_gen();
             registered_pending = true;
         }
         self.context.push_mod();
@@ -2746,11 +2763,14 @@ impl PrintC {
 
         // Start the ternary statement on a fresh line; the tag_line fires any
         // pending brace (so an else-clause diamond renders `else { v = ...; }`).
+        // Read whether OUR registration fired only *after* the tag_line that fires
+        // it, and key it to our own generation (per-frame, like emit_block_if) so a
+        // nested/sibling fire can never leave us closing a brace we never opened.
+        self.emit.tag_line();
         let mut my_pending_indent = -1;
         if registered_pending {
-            my_pending_indent = self.emit.pending_brace_indent_id();
+            my_pending_indent = self.emit.pending_fired_indent(my_pending_gen);
         }
-        self.emit.tag_line();
 
         // dest = ( cond ) ? A : B ;
         let sid = self.emit.begin_statement(&MarkupRef::none());


### PR DESCRIPTION
A ghidra-beats-kuna case (`sort/keycompare`, O2-noinline) where kuna lost purely to **invalid C**: it emitted one unmatched `}` (57 open / 58 close), dumping the rest of the function to file scope. Structurally kuna already matched Ghidra (both 31 gotos).

## Root cause (a C++ port-fidelity gap)
`emit_block_if` / `emit_block_if_ite` (s9_emit/printc.rs) decided whether to close a lazy `else { … }` brace by reading the emitter's **single shared** `pend_brace_indent` slot. Upstream C++ `pendingBrace.getIndentId()` is **frame-local** — set only when *that* frame's own brace fires. When an else-clause `BlockIf`'s pending brace was **shadowed** by a nested `BlockIf`'s fire (so its own brace never opened), the port read the nested frame's stale id and emitted one extra `}`. Confirmed via a brace trace: keycompare had 6 frames closing a pending brace but only 5 fires.

**Bonus:** the same shared slot **leaked across functions** in the in-process `decompile-all` (load-once/decompile-many) path, emitting later functions' bodies at column 0. Fixed by the same change (+ a per-function reset).

## Fix
Made the fired-indent **per-registration** (frame-local), mirroring C++'s `PendingBrace`: each `set_pending_brace` stamps a monotonic generation; each `emit_block_if` frame closes only if *its own* generation actually fired (`pending_fired_indent(my_gen) >= 0`). It can no longer close on a stale sibling/descendant fire.

## Verification
- Gates: `make test` **675/675 PARITY OK**, `make test-stages` **254/254**, `make rust-test` **0 failures** (independently re-confirmed 675/675 + keycompare balance).
- Whole-binary safety (coreutils `sort`, 489 fns, branchflip default-on), true pre/post baseline: keycompare **57/58 invalid → 57/57 valid** (branchflip still fires, 31 gotos = Ghidra's target); **unbalanced 1→0, newly-unbalanced 0, total gotos 231→231, column-0-body functions 29→0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J