### PR TITLE
s8 structure: set overflow syntax for complex-head while-do (fix regionstructure invalid C)

### DIFF
--- a/decompiler/crates/kuna-decomp/src/s8_structure/region_structurer.rs
+++ b/decompiler/crates/kuna-decomp/src/s8_structure/region_structurer.rs
@@ -1592,13 +1592,28 @@ impl<'a> RegionStructurer<'a> {
             if cb.get_out(0) != head {
                 continue; // clause must loop back to head
             }
-            if i == 0 {
+            // Overflow syntax (`CollapseStructure::ruleBlockWhileDo`,
+            // `blockaction.cc:1518`): a top-tested while-do whose condition block
+            // (`head`) is *complex* (a BlockList/BlockIf sequence — anything but a
+            // single BlockCopy/BlockCondition, per `FlowBlock::isComplex`) cannot be
+            // rendered inline as a comma-separated `while (<expr>)` — the emitter
+            // would print the region's nested `if`/statements *inside* the loop's
+            // condition parentheses (malformed C).  Ghidra flags such a loop with
+            // overflow syntax so it renders as `while (true) { <cond-body>;
+            // if (<cond>) break; <clause-body> }`, and flips the loop-continue edge
+            // accordingly: the clause must be the FALSE out under overflow syntax
+            // (the break fires on the TRUE cond), the TRUE out without it.  Mirrors
+            // `ruleBlockWhileDo` exactly, so a non-complex head (`overflow == false`)
+            // keeps the existing `negate-when-i==0` behavior byte-for-byte.
+            let overflow = self.is_complex(head);
+            if (i == 0) != overflow {
                 self.negate_condition_rec(head, true);
             }
             let graph_id = self.graph_id;
-            // After a possible flip the clause is now the TRUE out; re-read it.
-            let clause_now = self.graph.block(head).get_true_out();
-            self.graph.new_block_while_do(graph_id, head, clause_now);
+            let newbl = self.graph.new_block_while_do(graph_id, head, clause);
+            if overflow {
+                self.graph.block_mut(newbl).set_overflow_syntax();
+            }
             return Ok(true);
         }
 


### PR DESCRIPTION
A ghidra-beats-kuna case (`sort/compare_random`, O0) where kuna lost to **invalid C**: `regionstructure` folded a loop whose condition block is a *complex* region (a `BlockList` with nested if/else) into a top-tested `while(...)` and the s9 emitter flattened the region's statements inline into the condition parentheses — an unterminated `while (v1 = …` head with `if v18 < v1 {` (missing parens). Confirmed culprit: `--option regionstructure off` is the only one of the seven default-on passes that restores valid, Ghidra-like C.

## Root cause (C++ port gap)
`RegionStructurer::try_fold_loop`'s while-do branch (s8_structure/region_structurer.rs:1580) folded the loop into a `BlockWhileDo` **without setting overflow syntax**. Upstream `CollapseStructure::ruleBlockWhileDo` (blockaction.cc:1518; kuna mirror blockaction.rs:2351) guards exactly this: `overflow = isComplex(head)` → `setOverflowSyntax()`, which renders `while(true){ …; if(cond) break; … }` instead of inlining the region into `while(cond)`.

## Fix
19-line port of `ruleBlockWhileDo`'s overflow logic into `try_fold_loop`: compute `is_complex(head)`, negate on `(i==0) != overflow`, pass the pre-negation clause block, and `set_overflow_syntax()` when complex. **Non-complex heads are byte-for-byte unchanged.**

## Verification
- Gates: `make test` **675/675 PARITY OK**, `make test-stages` **254/254**, `make rust-test` **0 failures** (independently re-confirmed 675/675 + compare_random balanced 25/25).
- Whole-binary safety (coreutils `sort`, 504 fns, true pre/post baseline): **malformed-C conditions 12→0** (compare_random 11→0, sub_10057 1→0); **total gotos 91→91**; **0** newly-unbalanced; **0** new indent corruption. The other 7 changed functions improved from valid-but-ugly `while(a,cond){}` comma-expr to Ghidra-like `while(true){…; if(cond) break;}`. Zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J