### PR TITLE
s9 emit: restore emitBlockLs size==1 early-return (fix taildup/gotoreduce double-emit)

### DIFF
--- a/decompiler/crates/kuna-decomp/src/s9_emit/printc.rs
+++ b/decompiler/crates/kuna-decomp/src/s9_emit/printc.rs
@@ -2544,8 +2544,21 @@ impl PrintC {
             return;
         }
         let n = list.len();
-        // First block: no_branch (unless flat).
         let id1 = self.emit.begin_block(0);
+        // C++ `PrintC::emitBlockLs` (printc.cc:2929-2933): a single-element list
+        // emits its one block **once**, in the caller's branch state (before the
+        // `no_branch` push), and returns.  Without this early-return the block is
+        // emitted a second time below as the "Final block" (`list[0] == list[n-1]`),
+        // duplicating it — e.g. the single-block `abort(); return;` tail that
+        // `taildup`/`gotoreduce` wrap in a 1-element `BlockList`, which otherwise
+        // renders `abort(); abort();`.  The datatest corpus never produces a
+        // size-1 `Ls`, so this only surfaced under the kuna structuring passes.
+        if n == 1 {
+            self.emit_block(fd, arch, list[0]);
+            self.emit.end_block(id1);
+            return;
+        }
+        // First block: no_branch (unless flat).
         self.context.push_mod();
         if !self.is_flat() {
             self.context.set_mod(modifiers::NO_BRANCH);


### PR DESCRIPTION
A ghidra-beats-kuna case (`chgrp/describe_change`, O0) where kuna emitted a **redundant** `if (a1 != 3) { abort(); abort(); }` (3 aborts vs Ghidra's single shared-goto abort). Not invalid C — duplicated statements. `--option taildup off` surfaced it, but the defect is in the **printer**, not taildup.

## Root cause (C++ port gap)
`PrintC::emitBlockLs` (decompiler/cpp/printc.cc:2929-2933) has an explicit `if (i==bl->getSize())` **size==1 early-return**: emit the one block once and return. The Rust port (`emit_block_ls`, s9_emit/printc.rs) dropped it, so for a 1-element `BlockList` it emits `list[0]` as the "first block" then falls through and emits `list[n-1]` as the "Final block" — the **same node, emitted twice**. `taildup`/`gotoreduce` wrap a single-block return tail (`abort(); return;`, `return fcntl(...);`) in a 1-element `BlockList` (`kuna_inline_return_tail`), so every such duplicated tail printed its statement twice. The 675 datatests never produce a size-1 `Ls`, so the port stayed byte-identical and this only manifests under kuna's structuring passes.

## Fix
14-line, mirrors the C++ early-return exactly (n==1 → emit once with caller's branch state, return).

## Verification
- Gates: `make test` **675/675 PARITY OK**, `make test-stages` **254/254**, `make rust-test` **0 failures** (independently re-confirmed 675/675 + describe_change 3→2 aborts).
- Whole-binary safety (coreutils `chgrp`, 305 fns, true pre/post baseline): describe_change aborts **3→2**; 4 functions changed, **all shrank by removing verified-duplicate tail statements** (sub_3c25 aborts 5→3; sub_5190 dropped a duplicate `free`/`return`; sub_d16e dropped 3 duplicate `return fcntl(...)`); **0 newly-unbalanced**, **total gotos 74→74**, no new indent corruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J