### PR TITLE
s8 structure: reject compound-head while-do fold under regionlooprefine (fix invalid C)

### DIFF
--- a/decompiler/crates/kuna-decomp/src/s8_structure/region_structurer.rs
+++ b/decompiler/crates/kuna-decomp/src/s8_structure/region_structurer.rs
@@ -1577,6 +1577,29 @@ impl<'a> RegionStructurer<'a> {
         if self.graph.block(head).is_interior_goto_target() {
             return Ok(false);
         }
+        // (kuna) Companion malformed-while-head guard for the `regionlooprefine`
+        // path.  A refined multi-latch loop can present a head that has absorbed an
+        // inner loop / if / switch — i.e. the head is a `BlockList` (or another
+        // non-condition graph subtype) rather than a bare condition block.  Folding
+        // such a head as a *top-tested* while-do would render those control-flow
+        // statements INSIDE the `while (...)` controlling expression — malformed C
+        // (a full `while (...) {...}` loop nested in another loop's condition, as
+        // seen on libedit `vi_history_word`).  A valid while-do head is always a
+        // single condition block: a `BlockCopy` (comma-expression basic block, e.g.
+        // `while (v = *p, iswspace(v) != 0)`) or a folded `BlockCondition` (`&&`/`||`
+        // of such).  Reject anything else so the loop falls through to the
+        // `BlockInfLoop` form (`while(true){ …; if(!cond) break; … }`) — the OFF /
+        // Ghidra rendering.  Gated on `loop_refine`: the base structurer (which
+        // produces the 675 byte-identical datatests, and to which `regionlooprefine`
+        // ON is byte-identical on reducible code) is left completely untouched.
+        if self.loop_refine
+            && !matches!(
+                self.graph.block(head).get_type(),
+                crate::block::BlockType::Copy | crate::block::BlockType::Condition
+            )
+        {
+            return Ok(false);
+        }
         for i in 0..2 {
             let clause = self.graph.block(head).get_out(i);
             if clause == head {


### PR DESCRIPTION
A **fresh** ghidra-beats-kuna case (from the post-#6 fair re-run's current gap pool): libedit `vi_history_word` (O0), kuna GED 60 vs Ghidra 9. kuna emits **INVALID C** — a full nested loop *with its body* inside the outer loop's controlling expression:
```c
while ( while (v3=*v7, iswspace(v3)!=0) {v7=&v7[1]} *v7 != 0 ) { ... }   // statement-in-condition
```
It is **brace-balanced**, so neither naive nor literal-aware brace counting flags it — only structural inspection does (FINDING 3 in reverse: not every invalid-C bug is a brace imbalance). Ghidra renders the clean `while(true){ inner-while; if(*p==0) break; …; if(cond) break; }`.

## Root cause
`regionlooprefine` (S8, `region_structurer.rs`, default-on DIV-12 port of angr `RegionIdentifier._refine_loop_successors_to_guarded_successors`) refines the outer loop into a top-tested while-do candidate whose **head has absorbed the inner skip-whitespace loop** (head type `BlockList`). `try_fold_loop`'s while-do branch guarded against interior goto targets but **not against a compound (loop/if-containing) head**, so the emitter renders that compound head inside the outer `while(...)` condition. Confirmed culprit: `--option regionlooprefine off` restores valid, Ghidra-matching C.

## Fix (23 lines, gated on `loop_refine`)
A valid while-do head is always a single condition block — `BlockCopy` (comma-expr basic block) or a folded `BlockCondition` (`&&`/`||`). Reject anything else so the loop folds as `BlockInfLoop` → `while(true){…break}`. Gated on `loop_refine`, so the base structurer (which produces the 675 byte-identical datatests, and to which `regionlooprefine` ON is byte-identical on reducible code) is completely untouched.

## Verification
- Gates: `make test` **675/675 PARITY OK**, `make test-stages` **254/254**, `make rust-test` **0 failures**.
- Whole-binary safety (libedit.so, 777 fns, true #142 baseline): **SURGICAL** — vi_history_word's bad loop → valid `while(true)` (while(true) 38→39), **total gotos unchanged (105), 0 newly-unbalanced, 0 indent corruption**; bzip2 completely unchanged.

## Note
A *separate* `regionstructure` compound-head case (bzip2 `generateMTFValues`) is **not** covered by this `loop_refine` guard and remains for follow-up. Related to (but distinct from) #143 (regionstructure complex-head overflow syntax) — both are while-do invalid-C fixes in the same branch; may need a trivial rebase if merged together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J