### PR TITLE
s9 emit: port Ghidra markLabelBumpUp — hoist loop-head labels out of loop conditions (fix invalid C)

### DIFF
--- a/decompiler/crates/kuna-decomp/src/s8_structure/blockaction.rs
+++ b/decompiler/crates/kuna-decomp/src/s8_structure/blockaction.rs
@@ -3621,9 +3621,9 @@ impl Action for ActionFinalStructure {
         // and for the whiledo case: finalize the for-loop iterator/initializer
         // (BlockWhileDo::finalizePrinting) so the printer can emit
         // `for (init; cond; iter)`.
-        // SEAM(W7/W8): `orderBlocks`/`scopeBreak`/`markLabelBumpUp` (the rest of
-        // the goto/break/label-bump print-prep) remain unported in `block.rs`.
-        // Recorded as losses.
+        // SEAM(W7/W8): `orderBlocks`/`scopeBreak` (the rest of the goto/break
+        // print-prep) remain unported in `block.rs`.  Recorded as losses.
+        // (`markLabelBumpUp` is now ported — see the call below.)
         data.finalize_switch_printing();
         data.finalize_forloop_printing();
         // graph.scopeBreak(-1,-1): lower loop-exit `goto <successor>` edges to
@@ -3642,6 +3642,12 @@ impl Action for ActionFinalStructure {
         // it enables is the BlockCopy label statement.
         let sroot = data.sblocks_root();
         data.sblocks_mut().mark_unstructured(sroot);
+        // graph.markLabelBumpUp(false): let loop blocks steal the label of their
+        // (first) component so a loop-head label is hoisted to its own line above
+        // the loop rather than emitted inside the loop condition (invalid C).
+        // Must run AFTER markUnstructured (it reads the f_unstructured_targ marks
+        // via the printer's emitAnyLabelStatement).  (port of blockaction.cc:2196)
+        data.sblocks_mut().mark_label_bump_up(sroot, false);
         0
     }
 }

--- a/decompiler/crates/kuna-decomp/src/s9_emit/printc.rs
+++ b/decompiler/crates/kuna-decomp/src/s9_emit/printc.rs
@@ -2652,11 +2652,13 @@ impl PrintC {
     /// C++ `PrintC::emitBlockCopy` (printc.cc:2908): emit the underlying basic
     /// block (the `BlockCopy.copy` points back into `bblocks`).
     fn emit_block_copy(&mut self, fd: &Funcdata, arch: &Architecture, blk: BlockId) {
-        // emitBlockBasic -> emitLabelStatement(bb) (printc.cc:2834): a label line
+        // emitBlockCopy -> emitAnyLabelStatement(bl) (printc.cc:2894): a label line
         // for an unstructured-goto target.  Its `tag_line(0)` fires any pending
         // `else if` brace, forcing `else { label: if ... }` (the `else if`
-        // collapse is suppressed when the clause carries a goto label).
-        self.emit_label_statement(fd, blk);
+        // collapse is suppressed when the clause carries a goto label).  Routing
+        // through `emit_any_label_statement` skips the label when it was hoisted up
+        // to an enclosing loop head (`isLabelBumpUp`).
+        self.emit_any_label_statement(fd, blk);
         if let Some(under) = fd.sblocks_ref().block(blk).get_copy() {
             // The copy's `copy` field is a *bblocks* BlockId.
             self.emit_basic_block_ops(fd, arch, under, true);
@@ -2701,6 +2703,24 @@ impl PrintC {
         self.emit.tag_line_indent(0);
         self.emit.print(&self.block_label_name(fd, bl), SyntaxHighlight::NoColor);
         self.emit.print(keywords::COLON, SyntaxHighlight::NoColor);
+    }
+
+    /// C++ `PrintC::emitAnyLabelStatement` (printc.cc:3354): find the entry basic
+    /// block of `bl` and emit any required label statement for it — unless the
+    /// label was hoisted up the hierarchy (`isLabelBumpUp`), in which case the
+    /// enclosing loop emitter prints it above the loop head instead (so a
+    /// loop-head label never lands inside the loop condition).  The block does not
+    /// have to be a basic block; `get_front_leaf` finds the entry `t_copy` leaf.
+    fn emit_any_label_statement(&mut self, fd: &Funcdata, bl: BlockId) {
+        // if (bl->isLabelBumpUp()) return;  // Label printed by someone else
+        if fd.sblocks_ref().block(bl).is_label_bump_up() {
+            return;
+        }
+        // bl = bl->getFrontLeaf(); if (bl == 0) return;
+        let Some(front) = fd.sblocks_ref().get_front_leaf(bl) else {
+            return;
+        };
+        self.emit_label_statement(fd, front);
     }
 
     /// Seed [`commsorter`](PrintC::commsorter) with this function's comments (C++
@@ -3298,8 +3318,11 @@ impl PrintC {
     fn emit_for_loop(&mut self, fd: &Funcdata, arch: &Architecture, blk: BlockId) {
         self.context.push_mod();
         self.context.unset_mod(modifiers::NO_BRANCH | modifiers::ONLY_BRANCH);
-        // emitCommentBlockTree(condBlock) (printc.cc:3116).  (emitAnyLabelStatement
-        // is a no-op here unless the for-loop head is an unstructured-goto target.)
+        // emitAnyLabelStatement(bl) (printc.cc:3097): hoist the loop-head label to
+        // its own line above the `for` (it was marked f_label_bumpup, so the inline
+        // emit_block_copy suppresses it).
+        self.emit_any_label_statement(fd, blk);
+        // emitCommentBlockTree(condBlock) (printc.cc:3099).
         let cond_block = fd.sblocks_ref().block(blk).get_block(0);
         self.emit_comment_block_tree(fd, cond_block);
         self.emit.tag_line();
@@ -3350,6 +3373,9 @@ impl PrintC {
         // whiledo block NEVER prints the final branch.
         self.context.push_mod();
         self.context.unset_mod(modifiers::NO_BRANCH | modifiers::ONLY_BRANCH);
+        // emitAnyLabelStatement(bl) (printc.cc:3146): hoist the loop-head label
+        // above the `while` (suppressed inline via f_label_bumpup).
+        self.emit_any_label_statement(fd, blk);
         let cond_block = fd.sblocks_ref().block(blk).get_block(0);
         let indent;
         if fd.sblocks_ref().block(blk).has_overflow_syntax() {
@@ -3404,6 +3430,9 @@ impl PrintC {
         // dowhile block NEVER prints the final branch.
         self.context.push_mod();
         self.context.unset_mod(modifiers::NO_BRANCH | modifiers::ONLY_BRANCH);
+        // emitAnyLabelStatement(bl) (printc.cc:3208): hoist the loop-head label
+        // above the `do` (suppressed inline via f_label_bumpup).
+        self.emit_any_label_statement(fd, blk);
         self.emit.tag_line();
         self.emit.print(keywords::KEYWORD_DO, SyntaxHighlight::KeywordColor);
         let id = self.emit.open_brace_indent(keywords::OPEN_CURLY, to_emit_brace(self.options.brace_loop));
@@ -3429,6 +3458,9 @@ impl PrintC {
     fn emit_block_inf_loop(&mut self, fd: &Funcdata, arch: &Architecture, blk: BlockId) {
         self.context.push_mod();
         self.context.unset_mod(modifiers::NO_BRANCH | modifiers::ONLY_BRANCH);
+        // emitAnyLabelStatement(bl) (printc.cc:3236): hoist the loop-head label
+        // above the `do` (suppressed inline via f_label_bumpup).
+        self.emit_any_label_statement(fd, blk);
         self.emit.tag_line();
         self.emit.print(keywords::KEYWORD_DO, SyntaxHighlight::KeywordColor);
         let id = self.emit.open_brace_indent(keywords::OPEN_CURLY, to_emit_brace(self.options.brace_loop));

--- a/decompiler/crates/kuna-decomp/src/substrate/block.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/block.rs
@@ -1917,6 +1917,54 @@ impl BlockGraph {
         }
     }
 
+    /// Let hierarchical blocks steal the label of their (first) component so a
+    /// loop-head label is hoisted to its own line ABOVE the loop rather than
+    /// printed inside the loop condition (C++ `BlockGraph::markLabelBumpUp` and
+    /// the `BlockWhileDo`/`BlockDoWhile`/`BlockInfLoop` overrides, `block.cc:1259`/
+    /// `3364`/`3477`/`3505`; the base `FlowBlock::markLabelBumpUp`, `block.cc:259`).
+    ///
+    /// Virtual dispatch by block type (the C++ `virtual markLabelBumpUp`): the
+    /// three loop blocks steal the label of their front leaf (their `getBlock(0)`
+    /// front-leaf gets `f_label_bumpup`, so the printer's `emitAnyLabelStatement`
+    /// suppresses the inline label and the loop emitter prints it above); every
+    /// other block uses the plain `BlockGraph` recursion (mark self if `bump`,
+    /// pass `bump` only to the first component, `false` to the rest).
+    pub fn mark_label_bump_up(&mut self, this_id: BlockId, bump: bool) {
+        match self.arena[this_id].get_type() {
+            // Block{WhileDo,DoWhile,InfLoop}::markLabelBumpUp: loops steal the
+            // lower block's label.  Always recurse with bump=true, then clear our
+            // own flag back if we were not asked to bump up.
+            BlockType::WhileDo | BlockType::DoWhile | BlockType::InfLoop => {
+                self.block_graph_mark_label_bump_up(this_id, true);
+                if !bump {
+                    self.arena[this_id].clear_flag(block_flags::f_label_bumpup);
+                }
+            }
+            _ => self.block_graph_mark_label_bump_up(this_id, bump),
+        }
+    }
+
+    /// C++ `BlockGraph::markLabelBumpUp` (`block.cc:1259`): mark ourselves if
+    /// `bump`, then pass `bump` down to the first subblock only and `false` to the
+    /// rest.  For a leaf (empty list) this reduces to the base
+    /// `FlowBlock::markLabelBumpUp` (`block.cc:259`).
+    fn block_graph_mark_label_bump_up(&mut self, this_id: BlockId, bump: bool) {
+        // FlowBlock::markLabelBumpUp(bump): mark ourselves if true.
+        if bump {
+            self.arena[this_id].set_flag(block_flags::f_label_bumpup);
+        }
+        let n = self.arena[this_id].get_size();
+        if n == 0 {
+            return;
+        }
+        // Only pass `bump` down to the first subblock; the rest get false.
+        for i in 0..n {
+            if let Some(child) = self.arena[this_id].list.get(i as usize).copied() {
+                self.mark_label_bump_up(child, if i == 0 { bump } else { false });
+            }
+        }
+    }
+
     /// (kuna) Recursively tally the goto-count structure-quality metric over the
     /// structured tree from `this_id` (C++ `IfcKunaQuality kunaCountGotos`).
     ///


### PR DESCRIPTION
Ports Ghidra's unported `markLabelBumpUp` / `emitAnyLabelStatement` label-hoist — fixing an **invalid-C** emission bug (a loop-head label rendered *inside* a `for(...)` condition). Found while disentangling proposal #39 (condfold): this is the separable, low-risk half; the large `condfold` region-structurer work is a follow-up.

## The bug (grep/parse_grep_colors @ 0x9ddf, O0)
Before — label inside the `for` condition (uncompilable):
```c
    for (; (
label_9e38:*v3 == ':' || (*v3 == '\0')); v3 = &v3[1]) {
```
After — hoisted to its own line above the loop; the `goto label_9e38;` still targets it:
```c
label_9e38:
  do {
    for (; (*v3 == ':' || (*v3 == '\0')); v3 = &v3[1]) {
```

## Root cause
kuna had the `f_label_bumpup` flag (`block.rs:175`) but never ported the mechanism that sets it: Ghidra's `markLabelBumpUp` was commented out at the `ActionFinalStructure` seam (`blockaction.rs:3617`), and `emitAnyLabelStatement` didn't exist, so loop emitters never hoisted the head label — `emit_block_copy` emitted it inline (inside the `for`).

## The port (line-faithful, cites C++ origins)
- `substrate/block.rs`: `mark_label_bump_up` + graph walk — port of `FlowBlock::markLabelBumpUp` (block.cc:259), `BlockGraph::markLabelBumpUp` (block.cc:1259) + the WhileDo/DoWhile/InfLoop overrides that steal the front-leaf's label (block.cc:3364/3477/3505).
- `s8_structure/blockaction.rs`: call `mark_label_bump_up(sroot, false)` at the seam (blockaction.cc:2196).
- `s9_emit/printc.rs`: added `emit_any_label_statement` (printc.cc:3354); routed `emit_block_copy` (printc.cc:2894) + the 4 loop emitters (printc.cc:3097/3146/3208/3236) through it. Double-emit avoidance preserved.

## Verification
- Gates: `make test` **675/675 PARITY OK (byte-identical, no baseline edit)**, `make test-stages` **256/256**, `make rust-test` **0 failures** (no golden-fixture updates needed).
- Whole-binary safety (decompile-all, true pre/post baseline): **grep** — label-in-condition **2→0**, total gotos **207→207** (unchanged — this is a label-*position* fix, not a goto fix), 0 brace-unbalanced, 0 new errors; **factor** — clean. All 10 changed functions are pure label-position hoists to the Ghidra-canonical position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J
