### PR TITLE
fix(s3): cover INT_EQUAL/INT_NOTEQUAL in opflags_for seam shim (#150 regression)

### DIFF
--- a/decompiler/crates/kuna-decomp/src/s3_dataflow/ruleaction_3.rs
+++ b/decompiler/crates/kuna-decomp/src/s3_dataflow/ruleaction_3.rs
@@ -113,6 +113,11 @@ fn opflags_for(opc: OpCode) -> u32 {
         OpCode::CPUI_INT_LEFT | OpCode::CPUI_INT_RIGHT => binary,
         // TypeOpIntLess: binary | booloutput (typeop.cc:1069)
         OpCode::CPUI_INT_LESS => binary | booloutput,
+        // TypeOpEqual / TypeOpNotEqual: binary | booloutput | commutative
+        // (typeop.cc:929/993).  Reachable since the `markLabelBumpUp` port (#150)
+        // hoists loop-head labels out of loop *conditions*, which drives a rule to
+        // re-set the opcode of an `==`/`!=` guard through this seam.
+        OpCode::CPUI_INT_EQUAL | OpCode::CPUI_INT_NOTEQUAL => binary | booloutput | commutative,
         other => panic!(
             "ruleaction_3::opflags_for: no W6 opflags entry for {other:?} \
              (a rule produced an opcode not covered by this seam shim)"
@@ -2424,6 +2429,18 @@ pub fn specs() -> Vec<RuleSpec> {
 mod tests {
     use super::*;
     use std::rc::Rc;
+
+    /// Regression: `opflags_for` must cover the equality comparisons (a
+    /// `markLabelBumpUp`-hoisted loop-head `==`/`!=` guard re-set its opcode
+    /// through this seam and panicked — #150 regression).  The flags match
+    /// Ghidra `TypeOpEqual`/`TypeOpNotEqual` (binary | booloutput | commutative).
+    #[test]
+    fn opflags_for_covers_int_equality() {
+        use pcodeop_flags::*;
+        let expect = binary | booloutput | commutative;
+        assert_eq!(opflags_for(OpCode::CPUI_INT_EQUAL), expect);
+        assert_eq!(opflags_for(OpCode::CPUI_INT_NOTEQUAL), expect);
+    }
 
     use kuna_base::address::Address;
     use kuna_base::space::{


### PR DESCRIPTION
## Regression

`decompile-all fmt --json` started erroring functions with a panic:

```
ruleaction_3::opflags_for: no W6 opflags entry for CPUI_INT_EQUAL
(a rule produced an opcode not covered by this seam shim)
```

`opflags_for` (the W6 `TypeOp`-flags seam) enumerated the *ordering* comparisons (`INT_LESS`/`INT_LESSEQUAL`/`INT_SLESS`/`INT_SLESSEQUAL`) but not the *equality* comparisons, and its unlisted arm `panic!`s. The `markLabelBumpUp` port (#150) hoists loop-head labels out of loop **conditions** — typically `==`/`!=` guards — which drives a rule to re-set such a guard's opcode through this seam, so an `INT_EQUAL` now reaches `opflags_for`. Pre-#150 no `fmt` function exercised that path (I ran `decompile-all fmt --json` cleanly on the pre-#150 base).

## Fix

Add `INT_EQUAL | INT_NOTEQUAL => binary | booloutput | commutative`, matching Ghidra `TypeOpEqual`/`TypeOpNotEqual` (`typeop.cc:929/993`, both `opflags = binary | booloutput | commutative`).

After the fix `decompile-all fmt --json` completes with **160/160 functions, 0 errored**.

## Tests / gates

- New direct regression unit test `opflags_for_covers_int_equality`.
- `make test` — **675/675**, PARITY OK
- `make test-stages` — **256/256**, PARITY OK
- `make rust-test` — **4241 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJimTmF4YYsbdAumrkyPoL