### PR TITLE
fix(s1/noreturn): conditional jump to no-return .cold target still returns via fall-through

### DIFF
--- a/decompiler/crates/kuna-analysis/src/s1_noreturn_propagate/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/s1_noreturn_propagate/mod.rs
@@ -543,7 +543,22 @@ fn reaches_only_noreturn_walk(
                 let call_idx = win.len() - 1;
                 error_recog.call_is_terminal_error(&win, call_idx)
             };
-        if transfers_to_noreturn || transfers_to_error {
+        // A CONDITIONAL jump (`ja`/`jne`/… — a jump that also FALLS THROUGH) to a
+        // no-return target ends only its TAKEN arm; the fall-through (the normal,
+        // non-taken path) must still be walked. This is the GCC -O2 hot/cold-split
+        // shape: an assertion / stack-canary check `jcc <.cold fragment>` where the
+        // `.cold` fragment is `call abort`/`__stack_chk_fail` (no-return), while the
+        // function returns on the fall-through. Short-circuiting here (as an
+        // unconditional transfer does) skips that returning path and wrongly
+        // concludes the whole function no-return — which then propagates up every
+        // caller (the coreutils `quotearg_*` family → `fmt`/main's dropped file-open
+        // `error()` path). IDA Pro / Ghidra both treat such a function as returning.
+        // So only short-circuit an UNCONDITIONAL transfer (a call whose no-return
+        // callee makes its fall-through dead, or a jump with no fall-through); a
+        // conditional jump falls into the `is_jump` handler below, which walks BOTH
+        // its taken (→ terminal) and fall-through arms.
+        let conditional_jump = insn.flow.is_jump && insn.flow.has_fallthrough;
+        if (transfers_to_noreturn || transfers_to_error) && !conditional_jump {
             hit_noreturn = true;
             continue;
         }
@@ -718,6 +733,64 @@ mod tests {
         let p = NoReturnPropagatePass;
         assert_eq!(p.id(), "noreturn_propagate");
         assert_eq!(p.stage(), Stage::S1);
+    }
+
+    // --- reach walk: a conditional jump to a no-return target still returns via its
+    //     fall-through (the GCC hot/cold-split regression) --------------------------
+
+    fn mk_insn(addr: u64, ft: Option<u64>, flow: crate::listing::model::FlowType, flows: Vec<u64>) -> crate::listing::model::Insn {
+        crate::listing::model::Insn {
+            addr,
+            len: 2,
+            fall_through: ft,
+            flow,
+            flows,
+            mnemonic: String::new(),
+            operands: String::new(),
+            pcode: None,
+        }
+    }
+
+    /// A function guarded by an assertion / stack-canary branch to a no-return
+    /// `.cold` fragment — `jcc <terminal>; …; RET` — RETURNS on the fall-through.
+    /// The reach walk must follow that fall-through and conclude it returns. Before
+    /// the fix the `transfers_to_noreturn` fast-path `continue`d past the conditional
+    /// jump, skipping the returning arm, and wrongly marked the whole coreutils
+    /// `quotearg_*` family no-return (dropping `fmt`/main's file-open `error()` path).
+    #[test]
+    fn reach_walk_follows_conditional_jump_fallthrough_to_ret() {
+        use std::collections::{BTreeMap, BTreeSet};
+        let straight = crate::listing::model::FlowType { has_fallthrough: true, ..Default::default() };
+        let cjump = crate::listing::model::FlowType {
+            is_jump: true,
+            is_conditional: true,
+            has_fallthrough: true,
+            ..Default::default()
+        };
+        let ret = crate::listing::model::FlowType { is_terminal: true, ..Default::default() };
+        // entry → cjump[→ 0x100 terminal] (fall-through) → RET
+        let insns = vec![
+            mk_insn(0x0, Some(0x2), straight, vec![]),
+            mk_insn(0x2, Some(0x4), cjump, vec![0x100]),
+            mk_insn(0x4, Some(0x6), straight, vec![]),
+            mk_insn(0x6, None, ret, vec![]),
+        ];
+        let body: BTreeMap<u64, &crate::listing::model::Insn> = insns.iter().map(|i| (i.addr, i)).collect();
+        let terminal: BTreeSet<u64> = [0x100].into_iter().collect();
+        let recog = super::ErrorRecognizer::disabled();
+        assert!(
+            !super::reaches_only_noreturn_walk(&body, 0x0, Some(0x100), &terminal, &recog),
+            "a function that returns on the conditional-jump fall-through must NOT be no-return"
+        );
+
+        // Control: an UNCONDITIONAL jump to the terminal (no fall-through) IS no-return.
+        let ujump = crate::listing::model::FlowType { is_jump: true, ..Default::default() };
+        let only = vec![mk_insn(0x0, None, ujump, vec![0x100])];
+        let body2: BTreeMap<u64, &crate::listing::model::Insn> = only.iter().map(|i| (i.addr, i)).collect();
+        assert!(
+            super::reaches_only_noreturn_walk(&body2, 0x0, Some(0x100), &terminal, &recog),
+            "an unconditional jump whose only target is no-return IS no-return"
+        );
     }
 
     // --- error(nonzero,…) recognizer predicates (decbench F2) ------------------

--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -746,6 +746,22 @@ gh558-experiment protocol: run the 204+675 upstream assertions, list every chang
   e2e gates (which stay green with the rule on). Real-binary behavior verified on the decbench
   openssh corpus (ssh_tun_confirm, sshd_hostkey_sign).
 - **Date**: 2026-07-05.
+- **Fix (2026-07-08, conditional-jump fall-through)**: the reachability walk over-concluded on
+  the **GCC `-O2` hot/cold-split** shape — an assertion / stack-canary check
+  `jcc <.cold fragment>` where the outlined `.cold` fragment is `call abort`/`__stack_chk_fail`
+  (correctly no-return via the strict rule), while the function **returns** on the fall-through.
+  The `transfers_to_noreturn` fast-path treated the conditional jump like an *unconditional*
+  transfer and `continue`d past it, skipping the returning fall-through arm — so the whole
+  function was wrongly concluded no-return, then propagated up **every** caller. On coreutils
+  `fmt`/main this marked the entire `quotearg_*` family no-return and dropped the file-open
+  `error()` path (`quotearg_style(4,file)` rendered `/* Subroutine does not return */`).
+  **IDA Pro and Ghidra both treat such a function as returning.** Fix: only short-circuit an
+  *unconditional* transfer (a call whose no-return callee makes its fall-through dead, or a
+  jump with no fall-through); a conditional jump now falls into the `is_jump` handler, which
+  walks BOTH its taken (→ terminal) and fall-through arms. Regression test
+  `reach_walk_follows_conditional_jump_fallthrough_to_ret`; the `my_die`/mv/tee legit
+  no-return cases (`verify_noreturn_propagate`) stay green (`abort` remains no-return via the
+  strict rule). `source_decompiler = ida` (parity target for the returning-function shape).
 
 ## DIV-20: `decompile-all` defaults `funcstart_patterns` ON for non-x86-64 (ARM discovery)
 


### PR DESCRIPTION
## Problem (IDA/Ghidra parity — matches Feature #4 in the fmt comparison)

On coreutils `fmt`/main, kuna dropped the file-open error path:

```c
if (f == 0) { /* WARNING: Subroutine does not return */ quotearg_style(4,file); }
v20 = fmt(f,file);   // error() + ok=0 LOST
```

IDA/Ghidra keep it — `quotearg_style` **returns**.

## Root cause — `noreturn_reach` (DIV-19) over-conclusion on GCC hot/cold-split

`quotearg_style` is a thunk into the `quotearg_*` family. GCC `-O2` outlines each function's assertion / stack-canary error path into a `.cold` fragment that is `call abort` / `call __stack_chk_fail` — correctly no-return via the strict rule. The main functions branch to those `.cold` fragments with a **conditional** jump (`jcc <.cold>`), returning normally on the fall-through.

`function_reaches_only_noreturn`'s `transfers_to_noreturn` fast-path treated that conditional jump like an **unconditional** transfer and `continue`d past it, **skipping the returning fall-through arm**. So the reach walk concluded the whole function no-return, and the call-graph fixpoint propagated it up the entire `quotearg_*` family → every caller's `call quotearg_*; ret` had its `ret` treated as dead.

I traced it end-to-end: the walk for `quotearg_buffer_restyled` visited only 30 instructions, stopping dead at the `ja <.cold abort>` conditional jump and never exploring the fall-through that reaches the `RET`.

## Fix

Only short-circuit an **unconditional** transfer (a call whose no-return callee makes its fall-through dead, or a jump with no fall-through). A conditional jump now falls into the `is_jump` handler, which already walks **both** the taken (→ terminal) and fall-through arms.

`fmt/main` now renders, matching IDA/Ghidra:

```c
else {
  v6 = quotearg_style(4,file);
  v7 = dcgettext(0,"cannot open %s for reading",5);
  v16 = 0;
  error(0,*__errno_location(),v7,v6);
}
```

Only the real `.cold` abort fragments stay no-return (strict rule).

## Not regressing the legitimate no-return cases

- New unit test `reach_walk_follows_conditional_jump_fallthrough_to_ret` (+ an unconditional-jump control that stays no-return).
- `verify_noreturn_propagate` (the `my_die`/mv/tee custom-wrapper cases) stays green — `abort` is still no-return via the strict rule; only a *conditional* jump to a no-return target flips to returning.

## Timing / gates

- `fmt` `decompile-all` unchanged (~1.5s).
- `make test` **675/675** PARITY OK · `make test-stages` **256/256** PARITY OK · `make rust-test` **4241 / 0**.

Docs: `docs/divergences.md` DIV-19 fix note (`source_decompiler = ida`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJimTmF4YYsbdAumrkyPoL