### PR TITLE
[PROPOSAL] kuna→IDA parity roadmap — 6 remaining feature proposals

### DIFF
--- a/docs/features/README-ida-parity.md
+++ b/docs/features/README-ida-parity.md
@@ -1,0 +1,48 @@
+# kuna → IDA Pro parity roadmap
+
+Tracks kuna's decompiled-output gaps against **IDA Pro 9.2** (reference oracle:
+`tests/x86_64/decompiler/fmt`, function `main`; captured via the `decompiler`/idalib CLI).
+Started from a `fmt/main` diff after the register↔global render fix.
+
+## Landed (merged to `main`)
+
+| PR | What | IDA gap closed |
+|---|---|---|
+| #149 | Render register/`unique` members of a global-merged high as the global (no stray `EAX`/`Unique<hex>`) | raw-register variables |
+| #151 | Name the program's DWARF data globals (`dat_215120` → `max_width`, `goal_width`, `prefix*`) | unnamed globals (DWARF) |
+| #152 | `opflags_for` `INT_EQUAL` regression (from #150) — was erroring functions in `decompile-all` | (regression) |
+| #153 | No-return: a conditional jump to a `.cold abort` still returns via fall-through (`quotearg_style` error path restored) | over-aggressive no-return |
+| #154 | Reconcile the #149 regmerge test witness with #151's naming | (test) |
+
+## Proposed (this directory — go/no-go)
+
+Ranked by value × tractability. Default policy for all: **default-on, no flag** (clearly-correct
+matches to IDA), except where a bring-up `--option` gate is flagged.
+
+| Proposal | Gap | Effort | Value | Notes |
+|---|---|---|---|---|
+| [`ida-libc-extern-globals`](ida-libc-extern-globals/proposal.md) | `dat_20a098` → `optind`/`stdin`/`stdout`/`optarg` | **Small–Med** | High | `.dynsym`/`.symtab` `STT_OBJECT` reader; reuses #151's install path |
+| [`ida-dwarf-prototypes`](ida-dwarf-prototypes/proposal.md) | `undefined16 main(uint4,void*)` → `int main(int argc, char **argv)` | **Med** | High | applies DWARF `DW_TAG_subprogram` return+params; also fixes #2 for DWARF binaries |
+| [`ida-string-ref-recovery`](ida-string-ref-recovery/proposal.md) | `bindtextdomain(0x68d8,…)` → `"coreutils"` | **Med** | Med | `char*` typing for **mid-string** readonly-char pointers |
+| [`ida-dwarf-enums`](ida-dwarf-enums/proposal.md) | `quotearg_style(4,…)` → `quoting_style::…` | **Med** | Low–Med | DWARF enum types → existing `push_enum_constant` render; best after prototypes |
+| [`ida-return-storage-inference`](ida-return-storage-inference/proposal.md) | `undefined16` return + `char[16]` phantom → `int` | **Large** | High | general/stripped return-storage recovery (core dataflow); high blast radius |
+| [`ida-inlined-libc-idioms`](ida-inlined-libc-idioms/proposal.md) | inlined `cmpsb`/`df` loop → `strcmp(v19,"-")` | **Large (multi-week)** | Med–High | idiom-recognition pass + `df` folding; staged, per-recognizer gate |
+
+### Suggested order
+
+1. `ida-libc-extern-globals` (finishes the naming story from #151)
+2. `ida-dwarf-prototypes` (biggest signature win; subsumes #2 for DWARF)
+3. `ida-string-ref-recovery`
+4. `ida-dwarf-enums`
+5. `ida-return-storage-inference` — approve step-1 investigation first
+6. `ida-inlined-libc-idioms` — approve Phase 0 (`df` folding) first
+
+## Where kuna already beats IDA
+
+Char literals: kuna renders `'-'`/`' '`/`'0'` where IDA emits decimal `45`/`32`/`48`.
+
+## Tooling note
+
+IDA reference capture: see the `kuna-ida-declib-setup` steps — corrected `IDA_PATH`
+(`/home/mahaloz/ctf/tools/idapro_9.2/idat`), `idalib` activation + `PYTHONPATH`, then
+`decompiler decompile main --backend ida`.

--- a/docs/features/ida-dwarf-enums/proposal.md
+++ b/docs/features/ida-dwarf-enums/proposal.md
@@ -1,0 +1,71 @@
+# [PROPOSAL] DWARF enum-constant naming (`quotearg_style(4,…)` → `quoting_style::shell_escape_always_quoting_style`)
+
+Part of the **kuna → IDA Pro parity** program. Gap #7.
+
+## The problem
+
+`fmt/main`:
+
+```c
+// kuna
+quotearg_style(4,(char *)file);
+// IDA Pro
+quotearg_style(quoting_style::shell_escape_always_quoting_style, (char *)file);
+```
+
+kuna renders the enum argument as the raw integer `4`; IDA names it from the `quoting_style`
+enum. (Lower-priority than naming/prototypes — a single call site here — but a clean DWARF win
+that generalizes to every enum-typed argument/variable.)
+
+## Root cause
+
+The binary's `.debug_info` carries `DW_TAG_enumeration_type quoting_style` with its
+`DW_TAG_enumerator` members (`literal_quoting_style=0`, …, `shell_escape_always_quoting_style=4`,
+…). kuna's DWARF pass (`s1_dwarf/mod.rs`) does not build enum `Datatype`s, and even when a
+constant's type resolves to an integer, kuna has no enum member table to decompose it against.
+The decompiler already has an **enum render path** (`s9_emit/printc.rs:5699`
+`push_enum_constant_ir`, gated on `Datatype::is_enum_type()`), so the missing piece is the
+DWARF→enum-type construction + binding the callee arg / variable to that enum type.
+
+## The IDA / Ghidra reference
+
+Both import DWARF `DW_TAG_enumeration_type` as a first-class enum type and, when a constant's
+type is that enum, render the member name (decomposing an OR of flags for flag-enums —
+`pushEnumConstant`, which kuna already ports).
+
+## Proposed implementation
+
+1. **DWARF pass:** resolve `DW_TAG_enumeration_type` → a kuna enum `Datatype` (name + `{value →
+   member}` map + base metatype), registered in the type factory. `build_datatype` already
+   walks DWARF type DIEs; add the enum arm.
+2. **Binding:** the enum shows up (a) as a `DW_TAG_formal_parameter`/variable type — covered by
+   the `ida-dwarf-prototypes` proposal (apply the param's enum type) — or (b) via a callee
+   prototype whose arg is the enum. The `quotearg_style` case needs the *callee* prototype
+   (also from DWARF if `quotearg_style` is described, else a libc/coreutils type). Once the arg
+   varnode carries the enum type, the existing `push_enum_constant_ir` renders the member.
+
+## Dependency
+
+Best landed **after** `ida-dwarf-prototypes` (that proposal supplies the param-type application
+this render hangs off). Standalone value is the enum-type construction (reusable everywhere an
+enum-typed variable appears), even before full callee-arg binding.
+
+## Default policy
+
+Default-on, no flag. Re-pin only if a DWARF enum datatest changes render.
+
+## Speed / risk
+
+- **Speed:** load-time (enum DIE walk). Negligible decompile impact.
+- **Risk:** LOW–MEDIUM. Enum construction is additive; the render path already exists and is
+  tested. Risk is limited to mis-decomposing a flag-enum (the ported `pushEnumConstant` already
+  handles the OR-of-flags case).
+
+## Testing
+
+`verify_*.rs` with a DWARF enum fixture asserting the member name renders. Gates: all three.
+
+## Effort
+
+**Medium**, and largely reuses the enum render path + the DWARF prototype work. Lower priority
+than naming/prototypes/strings.

--- a/docs/features/ida-dwarf-prototypes/proposal.md
+++ b/docs/features/ida-dwarf-prototypes/proposal.md
@@ -1,0 +1,81 @@
+# [PROPOSAL] Apply DWARF function prototypes (`undefined16 main(uint4,void*)` → `int main(int argc, char **argv)`)
+
+Part of the **kuna → IDA Pro parity** program. Addresses gaps #6 (argument types/names) and the
+DWARF-having case of #2 (return type) in one feature.
+
+## The problem
+
+`fmt/main`:
+
+```c
+// kuna
+undefined16 main(uint4 a0,void *a1)
+// IDA Pro
+int __fastcall main(int argc, const char **argv, const char **envp)
+```
+
+kuna recovers neither the return type (`undefined16` — a 16-byte value, see the sibling
+`ida-return-storage-inference` proposal), nor the parameter types (`uint4`/`void*` instead of
+`int`/`char**`), nor the parameter names (`a0`/`a1` instead of `argc`/`argv`).
+
+**Root cause.** The binary's `.debug_info` fully describes `main` — verified:
+
+```
+<1a17> DW_AT_name : main
+<1a1f> DW_AT_type : <0x5f>                     # return type (int)
+<2><1a39> DW_TAG_formal_parameter
+<1a3a>   DW_AT_name : argc                      # + DW_AT_type
+         DW_TAG_formal_parameter  DW_AT_name : argv  ...
+```
+
+kuna's DWARF pass (`s1_dwarf/mod.rs`) already resolves `DW_TAG_variable` (globals — PR #151)
+and stack locals (`dwarf_locals`), but it does **not** consume the `DW_TAG_subprogram`
+return type or its `DW_TAG_formal_parameter` children. So the recovered prototype is never
+applied to the function symbol / `Funcdata` proto.
+
+## The IDA / Ghidra reference
+
+Both apply the DWARF (or PDB) subprogram prototype: return type, parameter types + names,
+`typelock` so propagation preserves them. Ghidra's `DWARFFunctionImporter`; IDA's DWARF plugin.
+
+## Proposed implementation
+
+1. **DWARF pass** (`s1_dwarf/mod.rs`): for each `DW_TAG_subprogram` with a low-pc, resolve
+   `DW_AT_type` → return `Datatype` (via the existing `build_datatype`), and each
+   `DW_TAG_formal_parameter`'s `DW_AT_type`+`DW_AT_name`. Emit a `FuncProtoFact { addr,
+   ret_type, params: Vec<(name, type)> }`.
+2. **Engine commit**: apply the recovered prototype to the function's symbol / stored proto
+   with `typelock|namelock` (the same lock discipline `dwarf_locals` uses for stack symbols).
+   The prototype must be installed **before** decompile so the `Funcdata` proto seeds from it
+   (mirror how `dwarf_locals_for` threads into the decompile drive).
+3. **Calling-convention interplay**: the ABI (`__fastcall`/SysV) already maps params to storage;
+   applying the DWARF *types/names* to those slots is the delta. Return type narrows the
+   return storage (fixing `undefined16 main` → `int main` for DWARF binaries — the fmt case of
+   #2).
+
+## Default policy
+
+Default-on, no flag. Re-pin baselines only if a DWARF datatest binary changes prototype render
+(the corpus is largely DWARF-less bytechunk/`.o`; expect none).
+
+## Speed / risk
+
+- **Speed:** load-time DWARF walk (already performed for globals/locals) + a per-function proto
+  install. Negligible decompile impact.
+- **Risk:** MEDIUM. Prototype application interacts with the ABI/param-storage recovery and
+  type propagation; a wrong `typelock` could fight the recovered type. Mitigate by matching the
+  existing `dwarf_locals` lock convention and gating on a successfully-sized `build_datatype`
+  (fall through to today's behavior otherwise). Struct-by-value / varargs params are edge cases
+  to handle or skip conservatively.
+
+## Testing
+
+`verify_*.rs`: a DWARF fixture (extend #151's `dwarf_globals_x86_64.c`, or the vendored
+`regglobal_fmt_x86_64`) asserting `main` renders `int main(int argc, char **argv)` (return type
++ arg types + names). Gates: all three.
+
+## Effort
+
+**Medium.** Builds directly on the existing DWARF pass + the #151/`dwarf_locals` install
+machinery. ~1–2 PRs (return type + params can split). High readability payoff (every
+DWARF-built function gets its real signature).

--- a/docs/features/ida-inlined-libc-idioms/proposal.md
+++ b/docs/features/ida-inlined-libc-idioms/proposal.md
@@ -1,0 +1,90 @@
+# [PROPOSAL] Re-roll inlined libc idioms (`cmpsb`/`df` loop → `strcmp(v19,"-")`)
+
+Part of the **kuna → IDA Pro parity** program. Gap #5. **Large (multi-week) — needs human
+go/no-go.**
+
+## The problem
+
+In `fmt/main`, gcc `-O2` inlines the `strcmp(file, "-")` used to detect the `-` (stdin)
+argument as a 2-byte `repe cmpsb`. kuna emits the raw lowered loop; IDA re-rolls it:
+
+```c
+// kuna
+v21 = 0;                       // df (direction flag)
+...
+v11 = 2;
+v14 = file; v16 = (uint1 *)0x6f52;    // 0x6f52 = "-"
+do {
+  if (v11 == 0) break;
+  v11 = v11 + -1;
+  v15 = &v16[(uint8)v21 * -2 + 1];    // df-driven pointer step
+  v13 = &v14[(uint8)v21 * -2 + 1];
+  v19 = *v14 < *v16;
+  v20 = *v14 == *v16;
+  v14 = v13; v16 = v15;
+} while (v20);
+if ((!v19 && !v20) != v19) { ... }    // the mangled comparison result
+// IDA Pro
+if ( !strcmp(v19, "-") ) { ... }
+```
+
+kuna surfaces the whole `cmpsb` machinery: the `df` direction flag (`v21`), the count-down
+(`v11`), the `df`-scaled pointer increments (`* -2 + 1`), and the flag-arithmetic comparison
+result (`(!v19 && !v20) != v19`). This is correct but deeply unreadable, and the `df`/flag
+plumbing leaks into many string-heavy functions.
+
+## The IDA / Ghidra reference
+
+IDA's decompiler has a library of **inlined-libc-idiom recognizers** (its microcode pattern
+matchers / "idioms") that re-roll recognized `rep movs`/`rep stos`/`rep cmps`/inlined
+`strcmp`/`memcpy`/`memset`/`strlen` sequences back into the library call. Ghidra recognizes some
+via its `rep`-prefix + string-op modeling and structuring; coverage varies.
+
+## Why this is large (needs go/no-go)
+
+1. **A new recognition pass, not a tweak.** Detecting the lowered idiom requires matching a
+   multi-op, loop-shaped pattern (the `cmpsb`/`movs` body + the `df`-scaled stride + the count),
+   proving it computes `strcmp`/`memcpy` semantics, and rewriting it to a synthesized call —
+   an S6/S7-class transform with its own pattern library. This is architecturally comparable to
+   the SAILR structuring ports, not a single-op rule.
+2. **`df` modeling.** kuna currently exposes the direction flag as a live variable (`v21`).
+   Correct re-rolling needs to prove `df == 0` (the standard forward case) and fold the
+   `* -2 + 1` stride to `+1`, then eliminate `df` — a prerequisite sub-analysis.
+3. **Correctness surface.** Each recognized idiom must be provably equivalent (count, direction,
+   NUL/length semantics) or it silently changes behavior. A conservative matcher covers the
+   common gcc/clang shapes; a general one is open-ended.
+4. **Scope of payoff vs cost.** High readability win on string-heavy code, but the matcher set is
+   large (strcmp/strncmp/strlen/memcmp/memcpy/memset/strcpy, each with size/direction variants)
+   and compiler-version-sensitive.
+
+## Proposed staging (for an approved worker)
+
+- **Phase 0 (prerequisite):** `df`-forward proof + stride folding (`(uint8)df * -2 + 1` → `1`
+  when `df==0` is provable), eliminating the direction-flag variable. Independently valuable
+  (removes `v21`-style noise) and smaller.
+- **Phase 1:** the single highest-value recognizer — inlined `strcmp`/`memcmp` (the `rep cmpsb`
+  shape above) → synthesized `strcmp`/`memcmp` call, behind strict pattern guards.
+- **Phase 2+:** `memcpy`/`memset`/`strlen`/`strcpy` recognizers, one per PR.
+
+## Default policy
+
+Given the correctness surface, this is the one area where an `--option` ablation gate is
+recommended during bring-up (per-recognizer), even under the program's default "no flag" policy,
+until each recognizer is corpus-proven — then flip default-on.
+
+## Speed / risk
+
+- **Speed:** a pattern-scan over loop bodies; bounded, but adds an analysis pass. Measure per
+  phase.
+- **Risk:** HIGH (correctness). Strict provable-equivalence guards; conservative bail-out on any
+  unmatched variant (fall through to today's raw loop).
+
+## Testing
+
+Per recognizer: a compiled fixture (`gcc -O2` inlined `strcmp`/`memcpy`) asserting the re-rolled
+call, plus a near-miss fixture that must NOT be re-rolled. Full corpus gates.
+
+## Effort
+
+**Large (multi-week), multi-PR.** Recommend approving **Phase 0** (`df` folding) first as a
+standalone readability win, then go/no-go on Phase 1.

--- a/docs/features/ida-libc-extern-globals/proposal.md
+++ b/docs/features/ida-libc-extern-globals/proposal.md
@@ -1,0 +1,72 @@
+# [PROPOSAL] Name libc-extern data globals from `.dynsym` / `.symtab` (`dat_20a098` → `optind`)
+
+Part of the **kuna → IDA Pro parity** program (reference oracle: IDA 9.2 on
+`tests/x86_64/decompiler/fmt`). Follow-up to the merged data-global naming feature
+(PR #151), which named the program's *own* DWARF globals.
+
+## The problem
+
+`fmt/main` still renders the four libc-extern data objects as raw addresses:
+
+| kuna | IDA Pro | ELF symbol |
+|---|---|---|
+| `dat_20a098` | `optind` | `optind@@GLIBC_2.2.5` (`.dynsym` `STT_OBJECT`) |
+| `dat_20a090` | `stdin` | `stdin@@GLIBC_2.2.5` |
+| `dat_20a088` | `stdout` | `stdout@@GLIBC_2.2.5` |
+| `dat_20a0a0` | `optarg` | `optarg@@GLIBC_2.2.5` |
+
+PR #151 recovers globals declared in the *program's* DWARF (`max_width`, `goal_width`,
+`prefix*`). These four are **imported libc objects** — they appear only as `STT_OBJECT`
+entries in `.dynsym` (and `.symtab`), never in the program's `.debug_info`, so #151 does not
+reach them.
+
+**Root cause.** The loader (`decompiler/crates/kuna-analysis/src/loadimage_object.rs:293,327`)
+keeps only `SymbolKind::Text` from `file.symbols()` / `file.dynamic_symbols()` — it drops
+every `SymbolKind::Data`. (`lib.rs:29` already flags "`.symtab`/`.dynsym` symbol reader" as a
+future item.) A copy-relocated libc global like `optind` has a defined address in the main
+binary (a `.bss` `R_X86_64_COPY` slot), so its name+address are available; kuna just never
+surfaces them.
+
+## The IDA / Ghidra reference
+
+Both name data globals from the symbol table (`.symtab`/`.dynsym` `STT_OBJECT`), independent
+of DWARF. IDA additionally types them from its libc type library; this proposal covers **naming
+only** (typing is out of scope — the `undefined<size>` default from #151 applies).
+
+## Proposed implementation
+
+1. **Loader** (`loadimage_object.rs`): in the two symbol loops, additionally collect
+   `SymbolKind::Data` defined symbols with a non-empty name and a size into a
+   `datasyms: Vec<DataSym{addr,name,size}>` (parallel to `funcsyms`); expose a
+   `data_symbols() -> Vec<(u64,String,u64)>` accessor (mirror `func_symbols()`). For a copy-reloc
+   extern the `object` symbol address is the `.bss` slot; use it directly.
+2. **Engine** (`engine.rs`): reuse the exact `commit_analysis_output` data-object install path
+   PR #151 added — `add_symbol_mapped(global_scope, name, get_base(size, TYPE_UNKNOWN), addr, …)`
+   with `namelock`, skip-if-occupied. (A `DataObjectFact` already exists; feed the loader
+   datasyms through the same field, or add a sibling loader-symbol commit.)
+3. **De-dup vs #151**: the skip-if-occupied guard already prevents shadowing a DWARF-named
+   global; DWARF wins where both exist.
+
+## Default policy
+
+Default-on, no flag (per the parity program's decision — a clearly-correct naming improvement).
+Re-pin `docs/baseline.json` / `docs/baseline-stages.json` only if a datatest binary carries a
+named `.dynsym`/`.symtab` data global (none is expected; the corpus is bytechunk/`.o`).
+
+## Speed / risk
+
+- **Speed:** load-time only (a handful of `add_symbol_mapped` calls). No decompile impact.
+- **Risk:** LOW. Naming-only; typed `undefined<size>` so type propagation is unchanged. The
+  only correctness concern is a wrong address for a copy-reloc extern — mitigated by using the
+  `object` crate's resolved defined address and the skip-if-occupied guard.
+
+## Testing
+
+End-to-end `verify_*.rs` on the vendored `regglobal_fmt_x86_64` fixture asserting `main`
+renders `optind`/`stdin`/`stdout`/`optarg` (not `dat_20a0??`). Gates: `make test`,
+`make test-stages`, `make rust-test`.
+
+## Effort
+
+**Small–Medium.** Reuses #151's install path; the new work is the loader `SymbolKind::Data`
+collection + accessor + threading. ~1 focused PR.

--- a/docs/features/ida-return-storage-inference/proposal.md
+++ b/docs/features/ida-return-storage-inference/proposal.md
@@ -1,0 +1,94 @@
+# [PROPOSAL] Return-storage inference (`undefined16 main` + `char[16]` return → `int` / `return v16 ^ 1`)
+
+Part of the **kuna → IDA Pro parity** program. Gap #2 — the general/stripped case (the
+DWARF-having case is handled by `ida-dwarf-prototypes`). **Large — needs human go/no-go.**
+
+## The problem
+
+`fmt/main` returns a bogus 16-byte struct:
+
+```c
+// kuna
+undefined16 main(uint4 a0,void *a1) { ...
+  char v4 [16];
+  ...
+  v4[0] = v16 ^ 1;    // the real int result
+  v4[8] = v22;        // a GARBAGE uninitialized stack value
+  return v4;          // returns a 16-byte value
+}
+// IDA Pro
+int __fastcall main(...) { ...
+  return (unsigned __int8)v16 ^ 1;
+}
+```
+
+kuna models `main`'s return as a **16-byte value** (`undefined16`) and materializes it by
+writing the genuine result to byte 0 and an uninitialized stack slot (`v22`) to byte 8 — an
+`RAX:RDX` (or XMM) pair treated as a struct return. IDA recovers the true return: the low int in
+`EAX`. This is pervasive (it recurs at every `return` in the function) and produces *invalid*
+output — the phantom `v4[8] = v22` reads uninitialized memory.
+
+## Root cause (hypothesis — step 1 of the work is to confirm)
+
+kuna's return-value / output-storage recovery defaults `main`'s return to a wide register pair
+(SysV `RAX:RDX` = 16 bytes, the struct-return storage) rather than inferring the **narrow**
+storage the function actually defines and callers actually read (`EAX`, 4 bytes). Because the
+high half (`RDX`) is never meaningfully written, it picks up an uninitialized stack spill
+(`v22`). The likely seam is the prototype's `ProtoModel` output/return-storage selection +
+the "which bytes of the return register are live at every RETURN" analysis (Ghidra's
+`ActionReturnRecovery` / `RuleReturnSplit` territory). A focused trace (which pass installs the
+16-byte return varnode; where the `RAX:RDX` join is formed) is **step 1**.
+
+## The IDA / Ghidra reference
+
+Ghidra's return-value recovery (`ActionReturnRecovery`, the `ParamMeasure`/`ScoreProtoModel`
+return-storage scoring) determines the actual return register+width from the def/use at each
+RETURN and the callers' reads, narrowing `RAX:RDX` to `EAX` when only the low bytes carry a
+value. IDA's Hex-Rays does the equivalent (microcode return-value analysis).
+
+## Why this is large (needs go/no-go)
+
+1. **It is core return-value dataflow, not a naming/markup pass.** It touches how the return
+   storage varnode is chosen and how the RETURN's input is typed/sized across the whole
+   function — an S4 (call/proto) + S5 (type) interaction, not an isolated Action.
+2. **High blast radius.** Changing return-storage inference perturbs *every* function's return
+   rendering and can shift many datatest baselines; it must be validated against the full 675
+   corpus with careful re-pinning, and cross-checked against the ported Ghidra
+   `ActionReturnRecovery` semantics to avoid regressing the many small functions that already
+   return correctly.
+3. **Interacts with the ABI/`ProtoModel`.** The 16-byte-vs-4-byte choice is a proto-model/output
+   decision; getting it right without breaking genuine struct-by-value returns (which *are*
+   `RAX:RDX`) requires the liveness/scoring discrimination Ghidra uses, not a blanket narrowing.
+
+## Relationship to other proposals
+
+For DWARF binaries, `ida-dwarf-prototypes` fixes the *fmt* case directly (applies the `int`
+return type → narrows the storage). This proposal is the **general** fix (stripped / no-DWARF),
+and the correct end state where both apply.
+
+## Proposed plan (for an approved worker)
+
+1. Trace the 16-byte-return origin on `fmt/main` (instrument the proto output-storage +
+   RETURN-input formation; identify the pass that installs `undefined16`).
+2. Compare to the ported `ActionReturnRecovery`/return-scoring; find where kuna diverges
+   (missing liveness-based narrowing, or a default-wide output storage).
+3. Implement the narrowing (return storage = the covered bytes actually defined-and-read),
+   guarding genuine struct-by-value returns.
+4. Full-corpus baseline validation + re-pin with per-assertion justification.
+
+## Speed / risk
+
+- **Speed:** an added liveness/scoring step at return recovery; likely negligible, confirm.
+- **Risk:** HIGH (blast radius above). Mitigation: stage behind careful corpus diffing; this is
+  the one item where an `--option` ablation gate may be warranted despite the program's default
+  "no flag" policy, at least during bring-up.
+
+## Testing
+
+Real-ELF `verify_*.rs` (`regglobal_fmt_x86_64`: `main` returns `int`, no `[8] = v22` phantom) +
+a struct-by-value-return fixture that must STAY 16-byte. Full `make test` re-pin.
+
+## Effort
+
+**Large (multi-week).** Recommend approving as a scoped investigation first (step 1), then a
+go/no-go on the implementation once the exact divergence is known.

--- a/docs/features/ida-string-ref-recovery/proposal.md
+++ b/docs/features/ida-string-ref-recovery/proposal.md
@@ -1,0 +1,77 @@
+# [PROPOSAL] String-reference recovery for readonly-char pointers (`bindtextdomain(0x68d8,…)` → `"coreutils"`)
+
+Part of the **kuna → IDA Pro parity** program. Gap #3.
+
+## The problem
+
+`fmt/main`:
+
+```c
+// kuna
+bindtextdomain(0x68d8,"/usr/local/share/locale");   // arg1 raw, arg2 fine
+textdomain(0x68d8);
+error(1,*__errno_location(),0x6f0c,v8);               // 0x6f0c should be "%s"
+// IDA Pro
+bindtextdomain("coreutils","/usr/local/share/locale");
+textdomain("coreutils");
+error(1, *v30, "%s", v29);
+```
+
+Within the *same* `bindtextdomain` call, `arg2` resolves to a string but `arg1` (`0x68d8`)
+renders as a raw integer — so this is **not** a callee-prototype / arg-type problem.
+
+**Root cause (confirmed).** `0x68d8` points at the bytes `63 6f 72 65 75 74 69 6c 73 00` =
+`"coreutils"`, which is a **substring** of `"GNU coreutils"` starting at `0x68d4`. kuna types
+(and string-marks) a constant pointer only when it targets the **start** of a detected string;
+a pointer into the *middle* of a larger readonly string never gets a `TYPE_PTR`-to-char, so
+`PrintC::pushConstant` renders it as an integer instead of taking the
+`push_ptr_char_constant_ir` string arm (`s9_emit/printc.rs:5760`). `"/usr/local/share/locale"`
+is a standalone string start, so it resolves. `0x6f0c` (`"%s"`) is the same class.
+
+## The IDA / Ghidra reference
+
+Both resolve a constant that points **anywhere** into readonly character data by reading from
+that offset to the terminating NUL — no requirement that the offset be a pre-detected string
+start. Ghidra: `TypeFactory`/`StringManager` readonly-char reference on any pointer into a
+`readonly` char range. IDA: any offset into a string segment renders as the tail string.
+
+## Proposed implementation
+
+Two layers, either/both:
+
+1. **Type layer (preferred, general):** when a constant's value falls inside a readonly
+   (`Varnode::readonly` / section-flag) range whose bytes at that offset are printable char
+   data ending in NUL, give the constant a `char *` (`TYPE_PTR`→`TYPE_INT1` char-print) type —
+   regardless of whether the offset is a marked string start. This is the point where
+   `dcgettext`'s already-typed arg gets its string; extend the same typing to any
+   readonly-char pointer constant.
+2. **Print layer (fallback):** in `push_ptr_char_constant_ir`, if the pointer is untyped but
+   lands in a readonly-char range, read to NUL and emit the literal (the C++ `pushPtrCharConstant`
+   already does the readonly-string read; the gap is the *entry* condition being gated on the
+   char-ptr type, which layer 1 supplies).
+
+## Default policy
+
+Default-on, no flag. Any baseline that renders a mid-string pointer as an int would flip to the
+string literal — re-pin with justification (matches IDA).
+
+## Speed / risk
+
+- **Speed:** negligible (one readonly-range membership test + NUL scan per constant, only for
+  constants in a readonly data range).
+- **Risk:** MEDIUM. Must not over-eagerly stringify a numeric constant that merely *happens* to
+  land in a readonly range but isn't a genuine char pointer (e.g. a jump-table base, a packed
+  bitmask). Gate strictly: the target bytes must be printable-char + NUL-terminated within a
+  bounded length, AND (ideally) the constant must be used in a pointer context. Ghidra's own
+  heuristic is a good reference for the guard.
+
+## Testing
+
+`verify_*.rs` on `regglobal_fmt_x86_64`: assert `main` renders `bindtextdomain("coreutils",…)`
+and `error(…,"%s",…)`. Add a negative fixture (a numeric constant in `.rodata` that must NOT
+stringify). Gates: all three.
+
+## Effort
+
+**Medium.** The print machinery exists; the work is the readonly-char pointer typing + a
+careful guard against false positives.


### PR DESCRIPTION
Draft/proposal PR (per the pipeline's `[PROPOSAL]` go/no-go convention) documenting the remaining `fmt/main` gaps against **IDA Pro 9.2**, after the landed parity work.

## Landed (already merged to `main`)
| PR | What |
|---|---|
| #149 | render fix — no stray `EAX`/`Unique` (register↔global merged highs render as the global) |
| #151 | name DWARF data globals (`dat_215120` → `max_width`, `goal_width`, `prefix*`) |
| #152 | `opflags_for` `INT_EQUAL` regression (from #150) |
| #153 | no-return: conditional jump to `.cold abort` still returns (`quotearg_style` error path restored) |
| #154 | reconcile #149 test witness with #151 naming |

## Proposals (this PR — `docs/features/<slug>/proposal.md` + a roadmap index)
| Proposal | Gap | Effort | Value |
|---|---|---|---|
| `ida-libc-extern-globals` | `dat_20a098` → `optind`/`stdin`/`stdout`/`optarg` (`.dynsym` `STT_OBJECT`) | Small–Med | High |
| `ida-dwarf-prototypes` | `undefined16 main(uint4,void*)` → `int main(int argc, char **argv)` | Med | High |
| `ida-string-ref-recovery` | `bindtextdomain(0x68d8,…)` → `"coreutils"` (mid-string char* ptr) | Med | Med |
| `ida-dwarf-enums` | `quotearg_style(4,…)` → `quoting_style::…` | Med | Low–Med |
| `ida-return-storage-inference` | `undefined16` return + `char[16]` phantom → `int` | **Large** | High |
| `ida-inlined-libc-idioms` | inlined `cmpsb`/`df` loop → `strcmp(v19,"-")` | **Large (multi-week)** | Med–High |

Each proposal carries the **confirmed root cause** (traced this session), the IDA/Ghidra reference, default-on policy, speed/risk, a testing plan, and an effort estimate. Suggested order + "where kuna already beats IDA" (char literals) are in `docs/features/README-ida-parity.md`.

The two `Large` items are flagged for explicit go/no-go and recommend approving a scoped first step (return-storage: a step-1 investigation; inlined-idioms: Phase 0 `df` folding) before committing to the full implementation.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJimTmF4YYsbdAumrkyPoL