### PR TITLE
feat(cli): --mode aggressive|reliable decompiler presets

### DIFF
--- a/decompiler/crates/kuna-base/src/xml.rs
+++ b/decompiler/crates/kuna-base/src/xml.rs
@@ -1658,8 +1658,10 @@ mod tests {
         // and ghangr-iteregion / iteregion, angr ITERegionConverter assignment-diamond
         // -> `?:` ternary, decbench F5 O0-iproute2-ip-print_link_flags,
         // and ghangr-switchreturn / switchreturn, the continuation of earlyreturn to the
-        // WIDE multi-way switch-phi return, O0-libedit-tty__getcharindex)
-        assert_eq!(count, 162, "corpus file count drifted");
+        // WIDE multi-way switch-phi return, O0-libedit-tty__getcharindex,
+        // and modes-aggressive / the `mode reliable|aggressive` preset axis
+        // (Architecture::apply_mode; returndup-only warning as the discriminator))
+        assert_eq!(count, 163, "corpus file count drifted");
     }
 
     /// ~20 representative SLEIGH spec files across varied processors

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -587,6 +587,20 @@ fn render_c(funcs: &[FuncResult]) -> String {
 
 // --- argument parsing --------------------------------------------------------
 
+/// Expand a decompiler *mode* name (`reliable` | `aggressive`) into its owned
+/// `(option, value)` overrides. Callers PREPEND these before the user's
+/// `--option` pairs so an explicit `--option` still wins (last-write, matching
+/// the console's `mode` then `option` ordering). Errors on an unknown mode.
+pub fn mode_override_pairs(mode: &str) -> Result<Vec<(String, String)>, String> {
+    match kuna_decomp::modes::mode_overrides(mode) {
+        Some(ovr) => Ok(ovr.iter().map(|(o, v)| ((*o).to_string(), (*v).to_string())).collect()),
+        None => {
+            let known: Vec<&str> = kuna_decomp::modes::mode_names().collect();
+            Err(format!("unknown mode {mode:?} (known: {})", known.join(", ")))
+        }
+    }
+}
+
 fn parse_args(argv: &[String], cmd: &str) -> Result<Args, String> {
     let mut binary: Option<String> = None;
     let mut json = false;
@@ -595,6 +609,7 @@ fn parse_args(argv: &[String], cmd: &str) -> Result<Args, String> {
     let mut no_vars = false;
     let mut max_fn_seconds: u64 = 120;
     let mut options: Vec<(String, String)> = Vec::new();
+    let mut mode: Option<String> = None;
     let mut slice: Option<String> = None;
     let mut target: Option<String> = None;
     let mut sleighpath: Option<String> = None;
@@ -627,6 +642,7 @@ fn parse_args(argv: &[String], cmd: &str) -> Result<Args, String> {
                 options.push((argv[i + 1].clone(), argv[i + 2].clone()));
                 i += 2;
             }
+            "--mode" => mode = Some(take(argv, &mut i, "--mode")?),
             "--slice" => slice = Some(take(argv, &mut i, "--slice")?),
             "--target" => target = Some(take(argv, &mut i, "--target")?),
             "--sleighpath" => sleighpath = Some(take(argv, &mut i, "--sleighpath")?),
@@ -651,6 +667,18 @@ fn parse_args(argv: &[String], cmd: &str) -> Result<Args, String> {
     }
 
     let binary = binary.ok_or_else(|| format!("{cmd} requires <binary>"))?;
+
+    // Expand a selected `--mode` into its option overrides, PREPENDED so an
+    // explicit `--option` still wins (last-write). Every downstream consumer
+    // (`apply_loadtime_env`, the listing/funcstart auto-inject skips,
+    // `apply_runtime_options`) reads `args.options`, so this is the single wire
+    // point for both `decompile-all` and `functions`.
+    if let Some(m) = mode {
+        let mut merged = mode_override_pairs(&m)?;
+        merged.extend(options);
+        options = merged;
+    }
+
     Ok(Args { binary, json, names, addrs, no_vars, max_fn_seconds, options, slice, target, sleighpath })
 }
 
@@ -672,8 +700,8 @@ fn parse_hex(s: &str) -> Result<u64, String> {
 fn usage_decompile_all() {
     eprintln!(
         "usage: kuna decompile-all <binary> [--json] [--functions a,b,..] [--addr 0xVMA].. \\\n\
-         \x20                   [--no-vars] [--max-fn-seconds N] [--option N V].. \\\n\
-         \x20                   [--slice ARCH] [--target T] [--sleighpath D]\n\
+         \x20                   [--no-vars] [--max-fn-seconds N] [--mode reliable|aggressive] \\\n\
+         \x20                   [--option N V].. [--slice ARCH] [--target T] [--sleighpath D]\n\
          \n\
          Decompile every function of a binary in one in-process load (load-once,\n\
          decompile-many).  --json emits {{binary,count,functions:[{{name,address,code,variables,..}}]}};\n\
@@ -689,7 +717,7 @@ fn usage_decompile_all() {
 
 fn usage_functions() {
     eprintln!(
-        "usage: kuna functions <binary> [--json] [--slice ARCH] [--target T] [--sleighpath D]\n\
+        "usage: kuna functions <binary> [--json] [--mode reliable|aggressive] [--slice ARCH] [--target T] [--sleighpath D]\n\
          \n\
          List every function kuna discovers in a binary as `<addr>\\t<name>` (or\n\
          --json: {{binary,count,functions:[{{name,address}}]}})."

--- a/decompiler/crates/kuna-cli/src/main.rs
+++ b/decompiler/crates/kuna-cli/src/main.rs
@@ -44,6 +44,7 @@ fn main() -> ExitCode {
         "functions" => decompile_all::run_functions(rest),
         "test" => cmd_test(rest),
         "catalog" => cmd_catalog(rest),
+        "modes" => cmd_modes(rest),
         "specs" => specs::run(rest),
         "fid" => fid::run(rest),
         "-V" | "--version" | "version" => {
@@ -67,11 +68,12 @@ fn usage() {
     eprintln!(
         "usage: kuna <decompile|decompile-all|functions|test|catalog|specs|fid> ...\n\
          \n\
-         kuna decompile <binary> <func> [--addr] [--slice ARCH] [--option NAME VALUE]... [--kassert ARGS]...\n\
-         kuna decompile-all <binary> [--json] [--functions a,b,..] [--addr 0xVMA]... [--no-vars] [--max-fn-seconds N] [--option N V]...\n\
-         kuna functions <binary> [--json]\n\
+         kuna decompile <binary> <func> [--addr] [--slice ARCH] [--mode reliable|aggressive] [--option NAME VALUE]... [--kassert ARGS]...\n\
+         kuna decompile-all <binary> [--json] [--functions a,b,..] [--addr 0xVMA]... [--no-vars] [--max-fn-seconds N] [--mode reliable|aggressive] [--option N V]...\n\
+         kuna functions <binary> [--json] [--mode reliable|aggressive]\n\
          kuna test [--all|--unittests|--datatests] [--name N]... [--baseline F] [--save-baseline F] [--json]\n\
          kuna catalog [--json|--markdown|--check] [--option NAME] [--tier transform|analysis|core]\n\
+         kuna modes [--json]\n\
          kuna specs [-a <dir>] [<slaspec>...] [--diff]\n\
          kuna fid build <lib.a|*.o ...> -o <out.fid> --lang <id> --cspec <id>\n\
          kuna --version"
@@ -98,6 +100,7 @@ fn cmd_decompile(argv: &[String]) -> i32 {
     let mut raw = false;
     let mut regions = false;
     let mut options: Vec<(String, String)> = Vec::new();
+    let mut mode: Option<String> = None;
     let mut kasserts: Vec<String> = Vec::new();
     let mut decomp_dbg: Option<String> = None;
     let mut engine: Option<String> = None;
@@ -124,6 +127,7 @@ fn cmd_decompile(argv: &[String]) -> i32 {
                 options.push((argv[i + 1].clone(), argv[i + 2].clone()));
                 i += 2;
             }
+            "--mode" => mode = take_value(argv, &mut i, "--mode"),
             "--kassert" => {
                 if let Some(v) = take_value(argv, &mut i, "--kassert") {
                     kasserts.push(v);
@@ -164,6 +168,23 @@ fn cmd_decompile(argv: &[String]) -> i32 {
         }
     };
     apply_engine(engine.as_deref());
+
+    // Expand a selected `--mode` into its option overrides, PREPENDED so an
+    // explicit `--option` still wins (later `option NAME VALUE` console lines
+    // overwrite in `build_script`; the load-time env gates + `listing`
+    // auto-inject already key off the merged `options` list).
+    if let Some(m) = mode.as_deref() {
+        match decompile_all::mode_override_pairs(m) {
+            Ok(mut pairs) => {
+                pairs.extend(options);
+                options = pairs;
+            }
+            Err(e) => {
+                eprintln!("error: {e}");
+                return 2;
+            }
+        }
+    }
 
     let dargs = DecompileArgs {
         binary,
@@ -313,6 +334,72 @@ fn cmd_catalog(argv: &[String]) -> i32 {
     } else {
         catalog::cmd_text(option.as_deref(), tier.as_deref())
     }
+}
+
+// --- modes -------------------------------------------------------------------
+
+/// `kuna modes [--json]` — list the decompiler mode presets (`reliable`,
+/// `aggressive`) and the `(option → value)` overrides each applies.  Modes are
+/// *not* settable catalog rows (`kuna catalog` covers those); they are presets
+/// over the option surface, applied via `--mode` / the console `mode` command.
+fn cmd_modes(argv: &[String]) -> i32 {
+    let mut json = false;
+    for a in argv {
+        match a.as_str() {
+            "--json" => json = true,
+            "-h" | "--help" => {
+                eprintln!("usage: kuna modes [--json]");
+                return 0;
+            }
+            s if s.starts_with("--") => {
+                eprintln!("error: unknown option {s}");
+                return 2;
+            }
+            other => {
+                eprintln!("error: unexpected argument {other:?}");
+                return 2;
+            }
+        }
+    }
+
+    use jsonfmt::Json;
+    if json {
+        let modes: Vec<Json> = kuna_decomp::modes::MODE_TABLE
+            .iter()
+            .map(|m| {
+                let overrides: Vec<Json> = m
+                    .overrides
+                    .iter()
+                    .map(|(opt, val)| {
+                        Json::Object(vec![
+                            ("option".into(), Json::Str((*opt).into())),
+                            ("value".into(), Json::Str((*val).into())),
+                        ])
+                    })
+                    .collect();
+                Json::Object(vec![
+                    ("name".into(), Json::Str(m.name.into())),
+                    ("summary".into(), Json::Str(m.summary.into())),
+                    ("overrides".into(), Json::Array(overrides)),
+                ])
+            })
+            .collect();
+        let root = Json::Object(vec![("modes".into(), Json::Array(modes))]);
+        println!("{}", jsonfmt::dumps_indent2(&root));
+    } else {
+        for m in kuna_decomp::modes::MODE_TABLE {
+            println!("{}", m.name);
+            println!("  {}", m.summary);
+            if m.overrides.is_empty() {
+                println!("  (no overrides — the shipped defaults)");
+            } else {
+                let joined: Vec<String> =
+                    m.overrides.iter().map(|(o, v)| format!("{o}={v}")).collect();
+                println!("  overrides: {}", joined.join(", "));
+            }
+        }
+    }
+    0
 }
 
 // --- helpers -----------------------------------------------------------------

--- a/decompiler/crates/kuna-console/src/kuna_console.rs
+++ b/decompiler/crates/kuna-console/src/kuna_console.rs
@@ -918,6 +918,45 @@ impl IfaceCommandAction for IfcKunaPipeline {
 }
 
 // ---------------------------------------------------------------------------
+// `mode <name>` — IfcKunaMode
+// ---------------------------------------------------------------------------
+
+/// (kuna) `mode <reliable|aggressive>`: apply a decompiler mode preset — a batch
+/// of option overrides fanned out through `Architecture::apply_mode` (see
+/// `kuna_decomp::modes`).  Mirrors `IfcOption`'s dcp/conf access; issue it
+/// before `read symbols` so an analysis-tier override (`listing`/`aif`/…) is
+/// committed, exactly like an `option` command.  A later `option NAME VALUE`
+/// overrides the mode (last-write).
+pub struct IfcKunaMode;
+
+impl IfaceCommandAction for IfcKunaMode {
+    fn execute(&self, status: &mut IfaceStatus, s: &mut CommandStream) -> IfaceResult<()> {
+        s.skip_ws();
+        let name = s.read_token();
+        s.skip_ws();
+        if name.is_empty() {
+            return Err(IfaceError::parse(
+                "Missing mode name (try `mode reliable` or `mode aggressive`)",
+            ));
+        }
+        let dcp = dcp_mut(status)?;
+        if dcp.conf.is_none() {
+            return Err(IfaceError::execution("No load image present"));
+        }
+        let prog = dcp.conf.as_mut().expect("conf checked non-None above");
+        let res = prog
+            .arch_mut()
+            .apply_mode(&name)
+            .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
+        status.out(&format!("{res}\n"));
+        Ok(())
+    }
+    fn module(&self) -> String {
+        DECOMPILE_MODULE.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // `quality` — IfcKunaQuality
 // ---------------------------------------------------------------------------
 
@@ -1130,6 +1169,7 @@ pub fn register_kuna_commands(status: &mut IfaceStatus) {
     status.register_com(Box::new(IfcKunaAssert::new()), &["kassert"]);
     status.register_com(Box::new(IfcKunaRestarts), &["restarts"]);
     status.register_com(Box::new(IfcKunaPipeline), &["pipeline"]);
+    status.register_com(Box::new(IfcKunaMode), &["mode"]);
     status.register_com(Box::new(IfcKunaQuality), &["quality"]);
     status.register_com(Box::new(IfcKunaRegionTree), &["region", "tree"]);
     status.register_com(Box::new(IfcKunaRegionBlocks), &["region", "blocks"]);

--- a/decompiler/crates/kuna-console/src/kuna_console/tests.rs
+++ b/decompiler/crates/kuna-console/src/kuna_console/tests.rs
@@ -60,18 +60,18 @@ fn run_one(line: &str) -> String {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn registers_all_fifteen_kuna_commands() {
+fn registers_all_sixteen_kuna_commands() {
     // register_decomp_commands registers 105 (see ifacedecomp/tests.rs); the
-    // kuna capability adds 15: phase list/map/status/catalog (plus the four
+    // kuna capability adds 16: phase list/map/status/catalog (plus the four
     // deprecated `stage ...` alias registrations), kassert, restarts,
-    // pipeline, quality, region tree/blocks/walk.
+    // pipeline, mode, quality, region tree/blocks/walk.
     let only_kuna = {
         let mut st = ConsoleCommands::into_status(vec![]);
         register_kuna_commands(&mut st);
         st.num_commands()
     };
-    assert_eq!(only_kuna, 15);
-    assert_eq!(console(&[]).num_commands(), 105 + 15);
+    assert_eq!(only_kuna, 16);
+    assert_eq!(console(&[]).num_commands(), 105 + 16);
 }
 
 #[test]

--- a/decompiler/crates/kuna-decomp/src/infra/architecture.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/architecture.rs
@@ -1419,6 +1419,31 @@ impl Architecture {
         }
     }
 
+    /// Apply a named decompiler *mode* preset (`reliable` | `aggressive`): a
+    /// batch of `(option, value)` overrides fanned out through
+    /// [`Self::set_kuna_option`]. Overrides apply in table order; any later
+    /// `set_kuna_option` -- another override or a user `option`/`--option` --
+    /// wins (last-write). `reliable` is the shipped defaults (empty override
+    /// list, a no-op alias); `aggressive` turns on every off-by-default pass.
+    /// See [`crate::modes`]. Errors on an unknown mode name.
+    pub fn apply_mode(&mut self, name: &str) -> KunaResult<String> {
+        let overrides = crate::modes::mode_overrides(name).ok_or_else(|| {
+            let known: Vec<&str> = crate::modes::mode_names().collect();
+            KunaError::parse(format!(
+                "Unknown decompiler mode: {name} (known: {})",
+                known.join(", ")
+            ))
+        })?;
+        for (opt, val) in overrides {
+            self.set_kuna_option(opt, val)?;
+        }
+        Ok(format!(
+            "mode {name} applied ({} option override{})",
+            overrides.len(),
+            if overrides.len() == 1 { "" } else { "s" }
+        ))
+    }
+
     /// Reset options modifiable by the OptionDatabase, including the action
     /// database (C++ `Architecture::resetDefaults`, `architecture.cc:1463`).
     ///

--- a/decompiler/crates/kuna-decomp/src/infra/architecture/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/architecture/tests.rs
@@ -137,6 +137,46 @@ fn reset_defaults_is_idempotent_after_mutation() {
 }
 
 #[test]
+fn apply_mode_aggressive_flips_offdefault_flags_but_not_v850() {
+    let mut arch = Architecture::new("test:LE:32", bare_sleigh());
+    // Off-by-default under the shipped defaults.
+    assert!(!arch.analysis_listing);
+    assert!(!arch.analysis_aif);
+    assert!(!arch.switch_guard_bound);
+    assert!(!arch.duplicate_shared_returns);
+    assert!(!arch.sparc_struct_return);
+    assert!(!arch.v850_indirect_branch);
+
+    arch.apply_mode("aggressive").expect("aggressive mode applies");
+
+    // Representative aggressive members turned on.
+    assert!(arch.analysis_listing);
+    assert!(arch.analysis_aif);
+    assert!(arch.switch_guard_bound);
+    assert!(arch.duplicate_shared_returns);
+    assert!(arch.sparc_struct_return); // SPARC-idiom-gated, safe to enable
+    // The one intentional exclusion: aggressive must NOT enable this (it
+    // reclassifies register-indirect calls on non-V850 targets).
+    assert!(!arch.v850_indirect_branch);
+}
+
+#[test]
+fn apply_mode_reliable_is_a_no_op() {
+    let mut arch = Architecture::new("test:LE:32", bare_sleigh());
+    arch.apply_mode("reliable").expect("reliable mode applies");
+    // reliable == shipped defaults: nothing off-default gets flipped.
+    assert!(!arch.analysis_listing);
+    assert!(!arch.analysis_aif);
+    assert!(!arch.duplicate_shared_returns);
+}
+
+#[test]
+fn apply_mode_unknown_errors() {
+    let mut arch = Architecture::new("test:LE:32", bare_sleigh());
+    assert!(arch.apply_mode("turbo").is_err());
+}
+
+#[test]
 fn name_function_angr_vs_upstream() {
     let mut arch = Architecture::new("t", bare_sleigh());
     // Need a space to make an address; use a constant-space address (any space

--- a/decompiler/crates/kuna-decomp/src/p0_knowledge/mod.rs
+++ b/decompiler/crates/kuna-decomp/src/p0_knowledge/mod.rs
@@ -4,6 +4,7 @@
 //! `lib.rs` so public paths (`kuna_decomp::<module>`) are unchanged.
 
 pub mod options;
+pub mod modes;
 pub mod database;
 pub mod overrides;
 pub mod kuna_phases;

--- a/decompiler/crates/kuna-decomp/src/p0_knowledge/modes.rs
+++ b/decompiler/crates/kuna-decomp/src/p0_knowledge/modes.rs
@@ -1,0 +1,159 @@
+//! P0 -- decompiler MODES: named presets over the runtime option surface.
+//!
+//! A *mode* is a named, ordered list of `(option, value)` overrides layered on
+//! top of the shipped defaults, applied *before* any explicit user `--option`
+//! (last-write-wins, so a user `--option` always overrides the mode). A mode is
+//! **not** a `[[settable]]` row -- it references existing option names and lives
+//! entirely in this table, so it never touches `phases.toml` / `SETTABLE_TABLE`
+//! / the catalog count+tier gates. With no mode selected, behaviour is
+//! byte-identical to the shipped defaults.
+//!
+//! Two modes ship:
+//!   - **`reliable`** -- the shipped, well-tested defaults (a stable, named
+//!     alias with an empty override list). Anchors the "give me the safe output"
+//!     product surface and future-proofs the preset if defaults later drift.
+//!   - **`aggressive`** -- turn on every off-by-default quality/recovery/analysis
+//!     pass for the most-recovered (and slowest, most speculative) output.
+//!
+//! The mode is applied through `Architecture::apply_mode` (which fans out to
+//! `set_kuna_option`), reachable from `kuna decompile`, `kuna decompile-all`,
+//! and the interactive console `mode <name>` command.
+
+/// A named preset over the option surface.
+pub struct Mode {
+    /// The mode token (`reliable`, `aggressive`).
+    pub name: &'static str,
+    /// One-line human/LLM description.
+    pub summary: &'static str,
+    /// Ordered `(option, value)` overrides. Applied in order; a later
+    /// `set_kuna_option` (another override, or a user `--option`) wins. An empty
+    /// slice = the shipped defaults (a no-op alias).
+    pub overrides: &'static [(&'static str, &'static str)],
+}
+
+/// The two shipped modes.
+pub const MODE_TABLE: &[Mode] = &[
+    Mode {
+        name: "reliable",
+        summary: "The shipped, well-tested defaults -- the safe, stable baseline \
+                  (no extra transforms). Byte-identical to running with no mode.",
+        overrides: RELIABLE_OVERRIDES,
+    },
+    Mode {
+        name: "aggressive",
+        summary: "Maximum recovery: turn on every off-by-default quality, \
+                  structuring, and analysis pass. Slower and more speculative \
+                  (may over-recover); best for readability and the benchmark \
+                  ceiling, not for guaranteed faithfulness.",
+        overrides: AGGRESSIVE_OVERRIDES,
+    },
+];
+
+/// `reliable` = the shipped defaults. Deliberately empty: pinning any option
+/// here (e.g. `listing off`) would *change* behaviour vs the defaults -- in
+/// particular `decompile-all` auto-enables the Listing (DIV-15), so an explicit
+/// `listing off` would regress it. An empty list leaves every default untouched.
+const RELIABLE_OVERRIDES: &[(&str, &str)] = &[];
+
+/// `aggressive` = every off-by-default option flipped ON, **except**
+/// `v850indirectbranch`.
+///
+/// All 21 default-off options are safe to blanket-enable except that one: unlike
+/// the format-gated no-ops (`rtti`/`pdb`=PE, `objc`/`macho-arm64e`=Mach-O,
+/// `sparcstructret`=SPARC `unimp`-trap idiom -- all inert off their target),
+/// `v850indirectbranch`'s predicate matches *any* register-indirect `CALLIND`
+/// (`kuna_is_v850_indirect_jmp`, `p2_lift/kuna_v850indbranch.rs`), so on x86-64 /
+/// ARM it would reclassify every `call reg` into an indirect branch -- corruption,
+/// not recovery. It stays a manual per-target opt-in (`--option
+/// v850indirectbranch on`) even under `--mode aggressive`.
+const AGGRESSIVE_OVERRIDES: &[(&str, &str)] = &[
+    // transform-tier default-off recovery/structuring passes.
+    ("switchmodbound", "on"),
+    ("switchguardbound", "on"), // speed-expensive
+    ("unrolledguard", "on"),    // speed-expensive
+    ("stackalias", "on"),
+    ("sparcstructret", "on"), // SPARC-idiom-gated; no-op off-SPARC
+    ("regionedgeorder", "on"),
+    ("returndup", "on"),
+    // analysis-tier default-off discovery/markup passes. `listing` is the master
+    // gate that enables the Listing-consuming passes (fid/aif/discovered-noreturn).
+    ("listing", "on"),
+    ("eh_frame_full", "on"),
+    ("funcstart_patterns", "on"),
+    ("dwarf_lines", "on"),
+    ("addrtable", "on"),
+    ("operand_refs", "on"),
+    ("formatstring", "on"),
+    ("fid", "on"),
+    ("rtti", "on"),          // PE-only; no-op off-PE
+    ("aif", "on"),           // speculative gap-walk ("may create bad code")
+    ("objc", "on"),          // Mach-O-only; no-op off-Mach-O
+    ("pdb", "on"),           // PE-only; no-op off-PE
+    ("macho-arm64e", "on"),  // Mach-O arm64e-only; no-op elsewhere
+];
+
+/// The override list for `name`, or `None` if `name` is not a known mode.
+pub fn mode_overrides(name: &str) -> Option<&'static [(&'static str, &'static str)]> {
+    MODE_TABLE.iter().find(|m| m.name == name).map(|m| m.overrides)
+}
+
+/// The shipped mode names, in table order.
+pub fn mode_names() -> impl Iterator<Item = &'static str> {
+    MODE_TABLE.iter().map(|m| m.name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::options::KUNA_OPTION_NAMES;
+
+    #[test]
+    fn every_override_names_a_real_option() {
+        for m in MODE_TABLE {
+            for (opt, _val) in m.overrides {
+                assert!(
+                    KUNA_OPTION_NAMES.contains(opt),
+                    "mode `{}` references unknown option `{}`",
+                    m.name,
+                    opt
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn reliable_is_a_no_op_alias() {
+        assert!(mode_overrides("reliable").unwrap().is_empty());
+    }
+
+    #[test]
+    fn aggressive_excludes_v850_but_includes_the_rest() {
+        let agg = mode_overrides("aggressive").unwrap();
+        // The one intentional exclusion: it corrupts non-V850 targets.
+        assert!(
+            !agg.iter().any(|(o, _)| *o == "v850indirectbranch"),
+            "aggressive must NOT enable v850indirectbranch (reclassifies x86-64 call reg)"
+        );
+        // Representative members that MUST be on.
+        for want in ["listing", "aif", "switchguardbound", "returndup", "sparcstructret"] {
+            assert!(
+                agg.iter().any(|(o, v)| *o == want && *v == "on"),
+                "aggressive must enable `{want}`"
+            );
+        }
+        // Every aggressive override turns its option on.
+        assert!(agg.iter().all(|(_, v)| *v == "on"));
+    }
+
+    #[test]
+    fn unknown_mode_is_none() {
+        assert!(mode_overrides("turbo").is_none());
+        assert!(mode_overrides("").is_none());
+    }
+
+    #[test]
+    fn mode_names_lists_both() {
+        let names: Vec<_> = mode_names().collect();
+        assert_eq!(names, vec!["reliable", "aggressive"]);
+    }
+}

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,5 +1,28 @@
 # kuna Progress Log
 
+## Session (2026-07-10) — Decompiler modes: `--mode aggressive | reliable`
+
+A new **mode** axis over the option surface: a *mode* is a named, ordered list of `(option,
+value)` overrides layered on the shipped defaults, applied *before* the user's `--option`
+(last-write, so `--option` still wins). Two ship — **`reliable`** (the shipped defaults, an
+empty-override alias; byte-identical to no `--mode`) and **`aggressive`** (every off-by-default
+recovery/analysis pass on, **except** `v850indirectbranch`, whose predicate matches any
+register-indirect `CALLIND` and would corrupt x86-64/ARM). Modes are **not** `[[settable]]` rows
+(they reference existing option names), so the catalog and its count/tier gates are untouched.
+
+- Single source of truth: `kuna-decomp/src/p0_knowledge/modes.rs` (`MODE_TABLE`, `mode_overrides`);
+  batch helper `Architecture::apply_mode`. Reachable from `kuna decompile` / `decompile-all` /
+  `functions` (`--mode`) and the interactive/datatest console (`mode <name>`); discovery via
+  `kuna modes [--json]`.
+- No default changes ⇒ **no DIV entry**; corpus byte-identical. `make test` 675/675, `make
+  test-stages` 259→**260** (one additive case `tests/stages/modes-aggressive.xml`, a two-pass
+  `mode reliable` vs `mode aggressive` on the returndup witness), `make rust-test` (+8 unit tests
+  in `modes.rs` / `architecture/tests.rs`), `make check-spec` green.
+- Speed (b2sum, whole-binary O0): default 6.05 s vs `--mode aggressive` 6.43 s (+6%); `reliable`
+  is byte-identical to default. Docs: `docs/modes.md`, spec §0.4.
+- Purpose: the aggressive preset is the recovery-ceiling / decbench measurement lever (A/B which
+  off-by-default options net-help GED → candidate default-on flips).
+
 ## Session (2026-07-08) — Grand consolidation: compiler vocabulary, tiered catalog, the live spec, and a comment strip
 
 A large, cross-cutting cleanup landed on one branch (`refactor/consolidation`, ~31 commits, each

--- a/docs/baseline-stages.json
+++ b/docs/baseline-stages.json
@@ -1,7 +1,7 @@
 {
   "data_footer": [
-    259,
-    259
+    260,
+    260
   ],
   "passing": [
     "data:BRANCHFLIP #1: default pipeline keeps the negated `== 0` guard (opt-in is default-off)",
@@ -206,6 +206,7 @@
     "data:iteregion #3: fix (on) -- the diamond collapses to a single ?: ternary (on pass only)",
     "data:iteregion #4: fix (on) -- the rewrite is logged",
     "data:iteregion #5: p-code untouched -- the merged variable still feeds the call in BOTH passes",
+    "data:mode aggressive enables returndup (warning appears once); mode reliable does not",
     "data:namestyle #1 default: argument renders as aN",
     "data:namestyle #2 default: local renders as vN with a register source-location comment",
     "data:namestyle #3 default: unnamed call target renders as sub_<addr>",

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -1,0 +1,77 @@
+# Decompiler modes (`reliable` | `aggressive`)
+
+A **mode** is a named preset over kuna's runtime option surface: an ordered list
+of `(option, value)` overrides layered on top of the shipped defaults. Modes are
+**not** catalog options (`kuna catalog` covers the per-option settable surface);
+they reference existing option names and live in one table,
+`decompiler/crates/kuna-decomp/src/p0_knowledge/modes.rs` (`MODE_TABLE`), applied
+by `Architecture::apply_mode` (a fan-out over `set_kuna_option`).
+
+Select a mode with `--mode <name>` on `kuna decompile`, `kuna decompile-all`, or
+`kuna functions`, or with the console `mode <name>` command. A mode's overrides
+are applied **before** the user's `--option`/`option` lines, so an explicit
+`--option` always wins (last-write). Discover them with `kuna modes` (or
+`kuna modes --json`).
+
+| Mode | What it does |
+|---|---|
+| `reliable` | The shipped, well-tested defaults — the safe, stable baseline. An **empty** override list, so it is byte-identical to running with no `--mode` at all. |
+| `aggressive` | Maximum recovery: turns **on** every off-by-default quality, structuring, and analysis pass. Slower and more speculative (may over-recover); best for readability and for measuring the recovery ceiling on the benchmark, not for guaranteed faithfulness. |
+
+Running with **no** `--mode` is exactly `reliable` (the current defaults) — the
+default path is untouched, so every corpus/test gate is unaffected.
+
+## `reliable`
+
+The current defaults are already a well-tuned, net-positive-on-benchmark set
+(many angr structuring flags are default-on; see `docs/divergences.md`).
+`reliable` is a stable, named alias for that set — its override list is
+deliberately empty. Pinning options here (e.g. `listing off`) would *change*
+behaviour versus the defaults (`decompile-all` auto-enables the Listing, DIV-15),
+so the empty list is the faithful implementation. It future-proofs the preset: if
+the defaults later drift more aggressive, `reliable` can pin them back.
+
+## `aggressive`
+
+`aggressive` flips **every** off-by-default option on, with **one** exclusion.
+The options it enables:
+
+- **transform tier**: `switchmodbound`, `switchguardbound` (speed-costly),
+  `unrolledguard` (speed-costly), `stackalias`, `sparcstructret`,
+  `regionedgeorder`, `returndup`
+- **analysis tier**: `listing` (the master gate that enables the
+  Listing-consuming passes — `fid`, `aif`, the discovered-no-return family),
+  `eh_frame_full`, `funcstart_patterns`, `dwarf_lines`, `addrtable`,
+  `operand_refs`, `formatstring`, `fid`, `rtti`, `aif`, `objc`, `pdb`,
+  `macho-arm64e`
+
+### The one exclusion: `v850indirectbranch`
+
+Every other off-by-default option is safe to blanket-enable: the format-specific
+ones are inert off their target (`rtti`/`pdb` = PE, `objc`/`macho-arm64e` =
+Mach-O, `sparcstructret` = the SPARC `unimp`-trap idiom, which cannot occur off
+SPARC). `v850indirectbranch` is the exception — its predicate
+(`kuna_is_v850_indirect_jmp`, `p2_lift/kuna_v850indbranch.rs`) matches **any**
+register-indirect `CALLIND`, so on x86-64/ARM it would reclassify every
+`call reg` into an indirect branch — corruption, not recovery. It therefore stays
+a manual per-target opt-in (`--option v850indirectbranch on`) even under
+`--mode aggressive`.
+
+### Caveats
+
+`aggressive` is slower (the Listing build, `funcstart_patterns` discovery, and
+`formatstring`'s re-decompile loop) and can over-recover: `aif` is a speculative
+gap-walk ("may create bad code"), `addrtable` over-accepts pointer tables, and
+`returndup` is known to regress aggregate GED on the benchmark (DIV-18, reverted
+as a default) even though it recovers early returns some functions need. That is
+by design — `aggressive` is the recovery-ceiling / measurement envelope, not the
+faithful default. Use it to read maximally-recovered output or to A/B which
+options net-help; promote an option to a default only when its own ablation shows
+net-positive-zero-regression (the DIV process).
+
+## Measuring with modes
+
+`aggressive` is a first-class measurement lever: run the decbench GED benchmark
+with a `kuna-aggressive` backend (or `kuna decompile-all --mode aggressive`) and
+compare against the default `kuna` (== `reliable`) to find options that net-help,
+which then become candidate default-on flips (a new `docs/divergences.md` DIV).

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -255,6 +255,19 @@ and an agent writes:
   (SETTABLE_TABLE, emit_catalog_json)` from `decompiler/crates/kuna-decomp/phases.toml`
   by `decompiler/crates/kuna-decomp/build.rs`; the rendered catalog is
   [docs/options.md](../options.md) and this spec never duplicates its metadata.
+- **Modes (option presets)** (kuna)
+  (`decompiler/crates/kuna-decomp/src/p0_knowledge/modes.rs (MODE_TABLE, mode_overrides)`,
+  applied by `decompiler/crates/kuna-decomp/src/infra/architecture.rs (apply_mode)`):
+  a *mode* is a named, ordered list of `(option, value)` overrides layered over the
+  shipped defaults — a P0 pipeline-variant preset over the option surface, **not** a
+  `[[settable]]` row (it references existing option names, so it never touches the
+  catalog or its count/tier gates). Two ship: **`reliable`** (the shipped defaults, an
+  empty-override alias) and **`aggressive`** (every off-by-default recovery/analysis
+  pass on, except `v850indirectbranch` which would mis-decode register-indirect calls
+  off-V850). Selected with `--mode` on `kuna decompile`/`decompile-all`/`functions` or
+  the console `mode <name>` command; overrides are applied *before* the user's
+  `--option` (last-write, so an explicit `--option` still wins). Discover with
+  `kuna modes`; full membership in [docs/modes.md](../modes.md).
 - **The restart log** (kuna)
   (`decompiler/crates/kuna-decomp/src/p0_knowledge/kuna_restartlog.rs (RestartLog)`):
   owned by the engine `Architecture` so it survives function clears; every
@@ -273,8 +286,10 @@ loader adjustments made at bootstrap (e.g. `readonlypropagate` forced on for
 MIPS so GOT-slot loads fold to import names,
 `decompiler/crates/kuna-console/src/engine.rs (bootstrap_from_object)`);
 (3) driver surface injections (`listing`, non-x86-64 `funcstart_patterns`, §0.2);
-(4) the user's `--option`/`kassert` lines; and finally (5) the per-function
-snapshot copy (§0.5), after which the value is frozen for that function's drive.
+(4) a selected `--mode`/`mode` preset (`modes.rs`), prepended to the option list;
+(5) the user's `--option`/`kassert` lines (which override the mode); and finally
+(6) the per-function snapshot copy (§0.5), after which the value is frozen for that
+function's drive.
 Which defaults deliberately diverge from upstream, and the measurements behind
 each flip, live in `docs/divergences.md`, not here.
 

--- a/tests/stages/modes-aggressive.xml
+++ b/tests/stages/modes-aggressive.xml
@@ -1,0 +1,51 @@
+<decompilertest>
+<binaryimage arch="x86:LE:64:default:gcc">
+<!--
+    Decompiler MODE presets (kuna_decomp::modes, Architecture::apply_mode): the
+    `mode reliable | aggressive` console command applies a named batch of option
+    overrides through the SAME binary to decompile path a real `kuna decompile`
+    / `decompile-all` uses.  This is the end to end proof that a mode reaches the
+    engine (standing requirement: every output changing feature ships a
+    binary to decompile testcase; here the "flag" is the whole preset).
+
+    `reliable` == the shipped defaults (an empty override list, a no op alias);
+    `aggressive` turns ON every off by default recovery/analysis pass, INCLUDING
+    `returndup` (default OFF, angr ReturnDuplicatorHigh, s8_structure/kuna_returndup.rs).
+    So `returndup`s emit only warning ("returndup: duplicated N shared bare
+    epilogue return(s)") is the clean discriminator between the two modes:
+    it can appear ONLY under `mode aggressive` and NEVER under `mode reliable`.
+
+    The reproducer is the sibling ghangr-returndup.xml witness: an if/else if guard
+    chain over `a0` whose three paths each `mov eax, K; jmp .Lend` into a single
+    shared bare `ret` epilogue (3 in edges, the return value a MULTIEQUAL of
+    {1,2,3}).  returndup duplicates that shared epilogue into 2 of its 3
+    predecessors, logging the warning once.
+
+    Pass 1 (mode reliable): returndup is off, so the warning never appears.
+    Pass 2 (mode aggressive): returndup is on, so the warning appears exactly once.
+
+    The default on siblings earlyreturn (DIV-23) and switchreturn (DIV-25) are on
+    in BOTH passes (they are shipped defaults, part of `reliable`), so they do not
+    affect the returndup only warning count; they are left at their defaults here
+    precisely to show that `aggressive` adds returndup ON TOP of the default set.
+-->
+<bytechunk space="ram" offset="0x100000">
+85ff7507b801000000eb1183ff017507b802000000eb05b803000000c3
+</bytechunk>
+<symbol space="ram" offset="0x100000" name="f"/>
+</binaryimage>
+<script>
+  <!-- Pass 1: reliable == shipped defaults (returndup OFF). -->
+  <com>mode reliable</com>
+  <com>lo fu f</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <!-- Pass 2: aggressive turns returndup (and the rest of the off by default
+       passes) ON.  The only observable that is returndup exclusive is its warning. -->
+  <com>mode aggressive</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="mode aggressive enables returndup (warning appears once); mode reliable does not" min="1" max="1">returndup: duplicated</stringmatch>
+</decompilertest>


### PR DESCRIPTION
## Decompiler modes: `--mode aggressive | reliable`

Adds a **mode** axis over kuna's runtime option surface. A *mode* is a named,
ordered list of `(option, value)` overrides layered on the shipped defaults,
applied **before** the user's `--option`/`option` (last-write, so `--option`
still wins). Two ship:

| Mode | Effect |
|---|---|
| `reliable` | The shipped, well-tested defaults — an **empty** override list, byte-identical to no `--mode`. A stable, named alias for today's tuned set. |
| `aggressive` | Turns **on** every off-by-default recovery/analysis pass (20 options), **except** `v850indirectbranch`. The recovery-ceiling / measurement envelope. |

### Why the one exclusion (`v850indirectbranch`)

All other off-by-default options are safe to blanket-enable: the format-specific
ones are inert off their target (`rtti`/`pdb`=PE, `objc`/`macho-arm64e`=Mach-O,
`sparcstructret`=SPARC `unimp`-trap idiom). `v850indirectbranch` is the exception
— its predicate (`kuna_is_v850_indirect_jmp`) matches **any** register-indirect
`CALLIND`, so on x86-64/ARM it would reclassify every `call reg` into an indirect
branch (corruption, not recovery). It stays a per-target opt-in even under
aggressive. (Confirmed by reading the predicate; `sparcstructret` was verified
narrow enough to include.)

### Design

- Single source of truth: `kuna-decomp/src/p0_knowledge/modes.rs` (`MODE_TABLE`,
  `mode_overrides`) + batch helper `Architecture::apply_mode` (fan-out over
  `set_kuna_option`). Modes are **not** `[[settable]]` rows — they reference
  existing option names, so the catalog and its count/tier gates are untouched.
- Reachable from `kuna decompile` / `decompile-all` / `functions` (`--mode`) and
  the interactive/datatest console (`mode <name>`). Discovery: `kuna modes [--json]`.
- decbench: two thin backend variants `kuna-aggressive` / `kuna-reliable` (append
  `--mode`), so aggressive-vs-default is measurable on the scoreboard out of the box.

### Not a default change

No default changes ⇒ **no `docs/divergences.md` DIV entry**; the corpus is
byte-identical. `reliable`/no-`--mode` is bit-for-bit today's output.

### Gates

- `make test` — **675/675** PARITY OK (datatest corpus byte-identical)
- `make test-stages` — 259 → **260** (one additive case,
  `tests/stages/modes-aggressive.xml`: a two-pass `mode reliable` vs
  `mode aggressive` on the returndup witness)
- `make rust-test` — green (+8 unit tests: `modes.rs` membership/validity +
  `architecture/tests.rs` apply_mode flag-flip)
- `make check-spec` — green (spec §0.4 + `modes.rs` under the already-anchored
  `p0_knowledge/`)

### Speed (standing req #4)

b2sum, whole-binary O0: default **6.05 s** vs `--mode aggressive` **6.43 s**
(+6%; the Listing build + `funcstart_patterns` + `formatstring` loop).
`--mode reliable` is byte-identical to default.

### Verification

`kuna decompile-all b2sum` vs `--mode reliable` → **byte-identical**;
vs `--mode aggressive` → 1320 changed lines (valid output: `returndup` fires,
`funcstart_patterns`/`eh_frame_full` discover extra functions). `kuna modes
--json` lists both; unknown mode errors cleanly.

Docs: `docs/modes.md`, spec `docs/spec/00-overview.md` §0.4, `docs/PROGRESS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
