### PR TITLE
ci(web): deploy the in-browser demo to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,88 @@
+name: Deploy web demo to GitHub Pages
+
+# Builds the in-browser (WebAssembly) decompiler demo — integrations/web —
+# and publishes it to GitHub Pages. The engine runs entirely client-side; the
+# deployed site is a static bundle (page + glue + WASI shim + wasm + x86-64
+# SLEIGH specs), so nothing talks to a backend. See docs/web-integration.md.
+
+on:
+  # Redeploy when the demo, the engine, or the vendored specs change.
+  push:
+    branches: [main]
+    paths:
+      - 'integrations/web/**'
+      - 'decompiler/**'
+      - 'specs/**'
+      - '.github/workflows/pages.yml'
+  # Allow a manual redeploy from the Actions tab.
+  workflow_dispatch:
+
+# Least-privilege token for the Pages deployment.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One in-flight deploy at a time; let a running deploy finish rather than cancel.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (stable) + wasm32-wasip1 target
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup target add wasm32-wasip1
+
+      # The one third-party action here — the de-facto standard cargo cache.
+      # Drop it (or swap for actions/cache) if you prefer zero third-party actions.
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: decompiler
+
+      # Optional but worth it: wasm-opt -Oz shrinks the wasm ~7 MB -> ~1.7 MB.
+      # build.sh applies it only if present; the demo works without it.
+      - name: Install wasm-opt (binaryen)
+        run: sudo apt-get update && sudo apt-get install -y binaryen
+
+      # build.sh needs x86-64.sla (a gitignored build artifact). Compiling just
+      # this one slaspec (~0.2s) is far cheaper than `make specs` (the whole tree).
+      - name: Build the SLEIGH compiler and the x86-64 spec
+        run: |
+          cargo build --release -p kuna-slacomp --manifest-path decompiler/Cargo.toml
+          ./decompiler/target/release/slacomp \
+            specs/Ghidra/Processors/x86/data/languages/x86-64.slaspec
+
+      # Builds kuna_wasm for wasm32-wasip1 and assembles integrations/web/dist/.
+      - name: Assemble the static demo (dist/)
+        run: bash integrations/web/build.sh
+
+      # Serve every file verbatim (belt-and-suspenders; the artifact path skips Jekyll).
+      - name: Disable Jekyll
+        run: touch integrations/web/dist/.nojekyll
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: integrations/web/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/web-integration.md
+++ b/docs/web-integration.md
@@ -107,6 +107,13 @@ a one-language tree is sufficient and fast. Adding an architecture = add its fil
 `wasm-opt -Oz` if available, and assembles a self-contained `integrations/web/dist/`
 (page + glue + vendored shim + wasm + specs). Serve `dist/` with any static file server.
 
+**Hosting on GitHub Pages.** `.github/workflows/pages.yml` runs this same build in CI
+(stable Rust + `wasm32-wasip1`, `binaryen` for `wasm-opt`, a targeted `x86-64.slaspec`
+compile instead of the full `make specs`) and deploys `dist/` via `actions/deploy-pages`.
+All asset references are relative, so it serves correctly from a project subpath
+(`https://<owner>.github.io/<repo>/`); no COOP/COEP headers are needed (no threads /
+SharedArrayBuffer). Enable once under *Settings → Pages → Source = GitHub Actions*.
+
 Payload for a full x86-64 decompiler in the tab: **~1.7 MB** wasm + **~0.46 MB** specs,
 gzipped ≈ **2.2 MB**. Cold decompile of a small binary is sub-second (≈0.45 s measured in
 Node `node:wasi` and in headless Chrome on the committed fixture).

--- a/integrations/web/README.md
+++ b/integrations/web/README.md
@@ -25,6 +25,17 @@ integrations/web/build.sh --serve       # -> http://localhost:8000
 Open the page, click **Load binary**, and pick an **x86-64 ELF**. The decompiler runs in
 the tab and lists every function; click one to see its C.
 
+## Hosted on GitHub Pages
+
+`.github/workflows/pages.yml` builds this bundle and publishes it to GitHub Pages on every
+push to `main` that touches `integrations/web/`, `decompiler/`, or `specs/` (and on manual
+dispatch). The workflow builds `slacomp`, compiles the one `x86-64.slaspec`, runs `build.sh`,
+and deploys `dist/` — nothing is committed. The site is served at
+`https://<owner>.github.io/<repo>/` (relative asset paths, so a project subpath just works).
+
+**One-time enablement** (repo admin): *Settings → Pages → Build and deployment → Source =
+**GitHub Actions***. The next push to `main` (or a manual run from the Actions tab) deploys.
+
 ## What's here
 
 | Path | Role |


### PR DESCRIPTION
## What

Adds `.github/workflows/pages.yml` — a GitHub Actions workflow that builds the in-browser (WebAssembly) decompiler demo (`integrations/web/`) and publishes it to **GitHub Pages**.

- **Triggers:** push to `main` touching `integrations/web/`, `decompiler/`, or `specs/`, plus manual `workflow_dispatch`.
- **Build:** installs stable Rust + `wasm32-wasip1`, installs `binaryen` (so `build.sh`'s `wasm-opt -Oz` fires, ~7 MB → ~1.7 MB), compiles just the one `x86-64.slaspec` (~0.2s, vs the full `make specs` tree), runs `integrations/web/build.sh`, and uploads `integrations/web/dist/` via `actions/upload-pages-artifact` → `actions/deploy-pages`.
- **Subpath-safe:** every asset reference in the demo is relative (`./kuna-web.js`, `./kuna_wasm.wasm`, `./specs`, `./vendor/…`), so it serves correctly from a project subpath. No COOP/COEP headers needed (no threads / SharedArrayBuffer).

Site URL once live: `https://noelo-lab.github.io/kuna/`.

## Enablement (one-time, repo admin)

**Settings → Pages → Build and deployment → Source = "GitHub Actions"**. After this PR merges to `main` (or via a manual run from the Actions tab), the demo deploys.

## Validation

- Confirmed locally: `slacomp x86-64.slaspec` produces `x86-64.sla` in 0.2s; `build.sh` builds `kuna_wasm.wasm` and assembles a complete `dist/` (page + glue + vendored WASI shim + wasm + x86-64 specs).
- Workflow YAML parses (two jobs: `build`, `deploy`).

## Scope

CI + docs only — no engine, phase-model, or `docs/spec/` behavior change, so `make test` / `test-stages` / `rust-test` / `check-spec` are unaffected. Docs updated: `integrations/web/README.md` and `docs/web-integration.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
