### PR TITLE
fix(ci): build the AArch64 spec in the Pages workflow (multi-arch demo)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -52,13 +52,17 @@ jobs:
       - name: Install wasm-opt (binaryen)
         run: sudo apt-get update && sudo apt-get install -y binaryen
 
-      # build.sh needs x86-64.sla (a gitignored build artifact). Compiling just
-      # this one slaspec (~0.2s) is far cheaper than `make specs` (the whole tree).
-      - name: Build the SLEIGH compiler and the x86-64 spec
+      # build.sh copies each shipped arch's .sla (gitignored build artifacts).
+      # Compiling just the demo's slaspecs (~0.7s each) is far cheaper than
+      # `make specs` (the whole tree). Keep this list in sync with the arches
+      # integrations/web/build.sh copies (x86-64 + AArch64).
+      - name: Build the SLEIGH compiler and the demo specs (x86-64 + AArch64)
         run: |
           cargo build --release -p kuna-slacomp --manifest-path decompiler/Cargo.toml
           ./decompiler/target/release/slacomp \
             specs/Ghidra/Processors/x86/data/languages/x86-64.slaspec
+          ./decompiler/target/release/slacomp \
+            specs/Ghidra/Processors/AARCH64/data/languages/AARCH64.slaspec
 
       # Builds kuna_wasm for wasm32-wasip1 and assembles integrations/web/dist/.
       - name: Assemble the static demo (dist/)


### PR DESCRIPTION
## What

The Pages deploy workflow has been failing since the demo went multi-arch (#170):

```
>> copying SLEIGH specs (x86-64)
error: missing spec .../AARCH64/data/languages/AARCH64.sla
       run 'make specs' at the repo root first (the .sla are built artifacts).
```

`integrations/web/build.sh` copies **both** x86-64 and AArch64 `.sla` (they're gitignored build artifacts), but the workflow's spec-build step compiled only `x86-64.slaspec`. This compiles `AARCH64.slaspec` too (~0.7s, same as x86-64).

## Verification

Ran `integrations/web/build.sh` locally after compiling both specs: the "copying SLEIGH specs" step passes and `dist/` assembles (exit 0, specs 1.1M for both arches). Left a note to keep the CI spec list in sync with `build.sh`.

Workflow-only change; no engine code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)