### PR TITLE
sleigh: rebase live walker cursor on ParserContext::expandState — fix ARM NEON deep-operand panic (whole-binary 0-output)

### DIFF
--- a/decompiler/crates/kuna-sleigh/src/sleigh.rs
+++ b/decompiler/crates/kuna-sleigh/src/sleigh.rs
@@ -806,7 +806,22 @@ impl<'a> ParserWalkerChange<'a> {
             return Err(KunaError::lowlevel("SLEIGH parser out of state space"));
         }
         if self.ctx.alloc < 0 {
+            // C++ `ParserContext::expandState` does `state.insert(state.begin(),
+            // amount, ...)`, front-inserting `amount` nodes. In C++ the walker's
+            // `point`/`parent`/`resolve`/`base_state` are raw pointers into the
+            // heap `ConstructState` objects, so this vector reshuffle never
+            // invalidates them. kuna models those references as Vec indices, so
+            // `expand_state` already rebases the ones it owns (parent/resolve/
+            // base_state/alloc) by `amount`. The live walker cursor `self.cur.
+            // point` is the one index it can't reach — rebase it here so the
+            // in-progress parse (deep operand trees, e.g. ARM NEON `{d16-d31}`
+            // reg lists) keeps pointing at the same node after the growth.
+            let before = self.ctx.state.len();
             self.ctx.expand_state(STATE_GROWTH);
+            let amount = self.ctx.state.len() - before;
+            if let Some(p) = self.cur.point {
+                self.cur.point = Some(p + amount);
+            }
         }
         let opstate = self.ctx.alloc as usize;
         self.ctx.alloc -= 1;

--- a/decompiler/crates/kuna-sleigh/tests/arm_neon_vldm_regression.rs
+++ b/decompiler/crates/kuna-sleigh/tests/arm_neon_vldm_regression.rs
@@ -1,0 +1,135 @@
+//! Regression gate for the `ParserContext::expandState` walker-cursor rebase
+//! (kuna port bug in `sleigh.rs::allocate_operand`).
+//!
+//! Decoding the ARM Thumb-2 instruction `vldmia r0, {d16-d31}`
+//! (bytes `d0 ec 20 0b`, little-endian) resolves an operand tree deep enough to
+//! exhaust the `INITIAL_STATE_NUM` (64) node pool, forcing
+//! `ParserContext::expandState`.  In upstream C++ (`context.cc`/`context.hh`)
+//! `expandState` front-inserts nodes (`state.insert(state.begin(), amount, ...)`)
+//! and the walker's `point` is a raw pointer, so the reshuffle never invalidates
+//! it.  kuna models `point` as a `Vec` index; the front-insertion shifts every
+//! stored index by `amount`, and the *live* walker cursor must be rebased too.
+//! Before the fix the stale cursor corrupted the walk and drove `depth` to `-1`,
+//! panicking in `ParserWalker::getOperand` (`breadcrumb[depth as usize]`, index
+//! `usize::MAX`).  Observed in the wild on stripped ARM Cortex-M firmware
+//! (libopencm3 `usart_irq_console.elf` @ 0x8001d1c): the whole-binary load
+//! panicked, producing zero output.
+//!
+//! This test lifts exactly that instruction against the built `ARM8_le.sla`
+//! (`ARM:LE:32:v8`) in Thumb mode and asserts it decodes cleanly (no panic,
+//! 4-byte instruction).  It is skipped when the `.sla` is absent (`make specs`).
+
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use kuna_base::address::Address;
+use kuna_base::error::{KunaError, KunaResult};
+use kuna_num::opcodes::OpCode;
+use kuna_num::pcoderaw::VarnodeData;
+use kuna_sleigh::globalcontext::ContextInternal;
+use kuna_sleigh::loadimage::LoadImage;
+use kuna_sleigh::sleigh::Sleigh;
+use kuna_sleigh::translate::{PcodeEmit, Translate};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+/// In-memory image: the instruction bytes at `base`, zero-filled elsewhere so
+/// the decoder's read-ahead never errors.
+struct MemImg {
+    base: u64,
+    bytes: Vec<u8>,
+}
+
+impl LoadImage for MemImg {
+    fn get_file_name(&self) -> &str {
+        "mem"
+    }
+    fn load_fill(&mut self, ptr: &mut [u8], addr: &Address) -> KunaResult<()> {
+        let start = addr.get_offset();
+        for (i, b) in ptr.iter_mut().enumerate() {
+            let a = start.wrapping_add(i as u64);
+            *b = a
+                .checked_sub(self.base)
+                .and_then(|off| self.bytes.get(off as usize).copied())
+                .unwrap_or(0);
+        }
+        Ok(())
+    }
+    fn get_arch_type(&self) -> Vec<u8> {
+        Vec::new()
+    }
+    fn adjust_vma(&mut self, _adjust: i64) {}
+}
+
+/// A p-code sink that only needs to prove the lift ran (counts emitted ops).
+struct CountEmit {
+    ops: usize,
+}
+impl PcodeEmit for CountEmit {
+    fn dump(
+        &mut self,
+        _addr: &Address,
+        _opc: OpCode,
+        _outvar: Option<&VarnodeData>,
+        _vars: &[VarnodeData],
+    ) {
+        self.ops += 1;
+    }
+}
+
+/// A stub loader used only until the real image is installed.
+struct DummyImg;
+impl LoadImage for DummyImg {
+    fn get_file_name(&self) -> &str {
+        "dummy"
+    }
+    fn load_fill(&mut self, _ptr: &mut [u8], _addr: &Address) -> KunaResult<()> {
+        Err(KunaError::data_unavail("dummy"))
+    }
+    fn get_arch_type(&self) -> Vec<u8> {
+        Vec::new()
+    }
+    fn adjust_vma(&mut self, _adjust: i64) {}
+}
+
+#[test]
+fn arm_thumb_vldmia_upper_neon_regs_does_not_panic() {
+    let sla_path = repo_root()
+        .join("specs/Ghidra/Processors/ARM/data/languages/ARM8_le.sla");
+    let Ok(sla) = std::fs::read(&sla_path) else {
+        eprintln!(
+            "arm_neon_vldm_regression: skipping (no `{}`; run `make specs`)",
+            sla_path.display()
+        );
+        return;
+    };
+
+    let base: u64 = 0x1000;
+    // `vldmia r0, {d16-d31}` (d0 ec 20 0b) then `bx lr` / nop padding, matching
+    // the shape seen on the firmware; the trailing bytes cover any read-ahead.
+    let bytes = vec![0xd0, 0xec, 0x20, 0x0b, 0x70, 0x47, 0x00, 0xbf, 0, 0, 0, 0, 0, 0, 0, 0];
+
+    let ctx = Box::new(ContextInternal::new());
+    let mut sleigh = Sleigh::new(Box::new(DummyImg), ctx);
+    sleigh.initialize_from_sla(&sla).expect("initialize ARM8_le.sla");
+    // Thumb decode mode (ARM.sinc: `TMode = (0,0)`, 1 => Thumb).
+    sleigh.set_context_default("TMode", 1);
+
+    sleigh.set_loader(Box::new(MemImg { base, bytes }));
+
+    let ram = Rc::clone(
+        sleigh.base().manager().get_space_by_name("ram").expect("ram space"),
+    );
+    let addr = Address::new(ram, base);
+
+    let mut emit = CountEmit { ops: 0 };
+    // Before the fix this panicked in ParserWalker::getOperand (depth == -1)
+    // while resolving the operand tree after expandState front-inserted nodes.
+    let len = sleigh
+        .one_instruction(&mut emit, &addr)
+        .expect("vldmia {d16-d31} must lift without error");
+    assert_eq!(len, 4, "Thumb-2 vldmia is a 4-byte instruction (got len {len})");
+    assert!(emit.ops > 0, "the lift must emit at least one p-code op");
+}


### PR DESCRIPTION
Fixes a **load-time panic** that produced ZERO output for a whole stripped ARM Cortex-M binary (libopencm3 `usart_irq_console.elf` scored 0% discovery — kuna crashed during the listing walk).

## Triggering instruction
`vldmia r0, {d16-d31}` (Thumb-2 VFP/NEON load of the *upper* double-register bank, bytes `d0 ec 20 0b`) @ 0x8001d1c. Its `{d0-d15}` sibling decoded fine; only the deep register-list constructor for the upper bank crashed:
```
sleigh.rs:734 index out of bounds: len 33, index 18446744073709551615 (= i32 -1 as usize)
  ParserWalker::getOperand  (breadcrumb[depth], depth == -1)
```

## Root cause (C++ pointer vs Rust index divergence)
`ParserContext::expandState` (`context.cc`) grows the node pool with a **front** insertion. In C++ the walker cursor and every node reference are raw `ConstructState *` pointers, so front-inserting never invalidates them. kuna models those references as `Vec` **indices**: `expand_state` already rebases the indices it owns (`parent`/`resolve`/`base_state`/`alloc`) by `amount`, but the **live walker cursor `cur.point` was left stale** — after the shift it pointed at the wrong node, corrupting the in-progress `resolve` walk so a later `popOperand` underflowed `depth` to −1. This only fires when one instruction's operand tree exhausts the 64-node `INITIAL_STATE_NUM` pool (the sole site in the whole binary), which is why no x86 datatest ever exposed it.

## Fix
`allocate_operand`: after `expand_state` front-inserts `amount` nodes, rebase `self.cur.point` by `amount` — the natural completion of the same index reconciliation `expand_state` already performs. Provably inert on any decode that never grows the pool.

## Verification
- usart_irq_console.elf: **panic/0 output → 89 functions**, no panic, 0 per-fn errors.
- crazyflie cf2.elf: 2785 → 2786 (**purely additive** — recovers the one function with the deep NEON insn; no other function changed).
- betaflight STM32F405: **byte-identical JSON**.
- Gates: `make test` **675/675 byte-identical** (the walker fix alters no x86 decode — the critical guard), `make test-stages` **261/261**, `make rust-test` **0 failures**.
- Regression test: `kuna-sleigh/tests/arm_neon_vldm_regression.rs` reproduces the exact panic without the fix, passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J
