### PR TITLE
feat(cli): kuna decompile-project — whole-binary .c/.h/.asm/README export

### DIFF
--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -44,35 +44,36 @@ use kuna_base::address::Address;
 use kuna_console::engine::{bootstrap_from_object, ConsoleProgram};
 use object::Object; // `File::architecture()` (ARM-discovery default, decbench)
 use kuna_decomp::decompile_drive::{
-    decompile_func_full_with_override_dyn, extract_variables, print_c, VarInfo,
+    decompile_func_full_with_override_dyn, extract_variables, print_c, print_c_prototype, VarInfo,
 };
 use kuna_decomp::options::{OptionDatabase, KUNA_OPTION_NAMES, RELOC_OBJECTS_ENV};
 
 use crate::jsonfmt::{dumps_indent2, Json};
 use crate::paths;
 
-/// Parsed `decompile-all` / `functions` arguments (the two share a loader).
-struct Args {
-    binary: String,
-    json: bool,
+/// Parsed `decompile-all` / `functions` arguments (the two share a loader;
+/// `decompile-project` reuses the same parse via its own wrapper).
+pub(crate) struct Args {
+    pub(crate) binary: String,
+    pub(crate) json: bool,
     /// `--functions a,b,c`: restrict to these names (None ⇒ every function).
-    names: Option<Vec<String>>,
+    pub(crate) names: Option<Vec<String>>,
     /// `--addr 0xVMA` (repeatable): decompile specific entry addresses, even if
     /// unnamed (stripped / LLM use).  Combined with `--functions` if both given.
-    addrs: Vec<u64>,
+    pub(crate) addrs: Vec<u64>,
     /// `--no-vars`: skip the per-function variable extraction (faster; drops the
     /// `variables` array used by decbench's `type_match`).
-    no_vars: bool,
-    /// `--max-fn-seconds N` (decompile-all only): per-function decompile
-    /// watchdog budget in seconds; `0` disables.  A function that exceeds it is
-    /// recorded as that function's `error` (the batch continues) instead of
-    /// hanging the whole run — the defensive cap for the known stripped-ELF
-    /// non-convergence hang (`tests/hang-repro/`).  Default 120.
-    max_fn_seconds: u64,
-    options: Vec<(String, String)>,
-    slice: Option<String>,
-    target: Option<String>,
-    sleighpath: Option<String>,
+    pub(crate) no_vars: bool,
+    /// `--max-fn-seconds N` (decompile-all / decompile-project): per-function
+    /// decompile watchdog budget in seconds; `0` disables.  A function that
+    /// exceeds it is recorded as that function's `error` (the batch continues)
+    /// instead of hanging the whole run — the defensive cap for the known
+    /// stripped-ELF non-convergence hang (`tests/hang-repro/`).  Default 120.
+    pub(crate) max_fn_seconds: u64,
+    pub(crate) options: Vec<(String, String)>,
+    pub(crate) slice: Option<String>,
+    pub(crate) target: Option<String>,
+    pub(crate) sleighpath: Option<String>,
 }
 
 /// `kuna decompile-all` entry point.
@@ -150,13 +151,18 @@ pub fn run_functions(argv: &[String]) -> i32 {
 
 /// One decompiled function's result (success carries `code`; failure carries
 /// `error`).
-struct FuncResult {
-    name: String,
-    address: u64,
-    size: i64,
-    code: Option<String>,
-    error: Option<String>,
-    variables: Vec<VarInfo>,
+pub(crate) struct FuncResult {
+    pub(crate) name: String,
+    pub(crate) address: u64,
+    pub(crate) size: i64,
+    pub(crate) code: Option<String>,
+    pub(crate) error: Option<String>,
+    /// The `.h` prototype line (`<ret> <name>(<params>);`), captured only when
+    /// the caller asked for it (`decompile_targets(want_proto=true)` — the
+    /// `decompile-project` surface).  Always `None` on the `decompile-all`
+    /// path, whose JSON must stay byte-identical.
+    pub(crate) proto: Option<String>,
+    pub(crate) variables: Vec<VarInfo>,
 }
 
 /// Load + analyze the binary once, then decompile every selected function.
@@ -174,6 +180,22 @@ fn decompile_all(args: &Args) -> Result<Vec<FuncResult>, String> {
             Some(std::time::Duration::from_secs(args.max_fn_seconds));
     }
 
+    Ok(decompile_targets(&mut prog, targets, args.no_vars, /* want_proto= */ false))
+}
+
+/// Decompile each `(name, entry)` target in turn against the already-loaded
+/// program, returning one [`FuncResult`] per target (success or per-function
+/// `error` — a bad function never aborts the batch).  `want_proto`
+/// additionally captures the function's prototype line
+/// ([`print_c_prototype`]) inside the same panic guard as the C render — the
+/// `decompile-project` `.h` surface; `decompile-all` passes `false`, keeping
+/// its JSON byte-identical.
+pub(crate) fn decompile_targets(
+    prog: &mut ConsoleProgram,
+    targets: Vec<(String, Address)>,
+    no_vars: bool,
+    want_proto: bool,
+) -> Vec<FuncResult> {
     let mut out = Vec::with_capacity(targets.len());
     for (name, entry) in targets {
         let address = entry.get_offset();
@@ -225,7 +247,6 @@ fn decompile_all(args: &Args) -> Result<Vec<FuncResult>, String> {
                 // would otherwise abort the WHOLE binary and discard every function
                 // already decompiled. Containing it here honors the per-function
                 // isolation contract (one bad function → one `error` record).
-                let no_vars = args.no_vars;
                 let rendered = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     // Trim the surrounding newlines the same way `kuna decompile`
                     // does (`decompile.rs::trim_newlines`), so the per-function
@@ -233,15 +254,24 @@ fn decompile_all(args: &Args) -> Result<Vec<FuncResult>, String> {
                     let code = print_c(prog.arch_mut(), &fd).trim_matches('\n').to_string();
                     let variables =
                         if no_vars { Vec::new() } else { extract_variables(prog.arch(), &fd) };
-                    (code, variables)
+                    // The prototype must be captured HERE (fd is dropped at the
+                    // end of the iteration) and inside the same guard (the
+                    // declarator walk shares the printer's fail-fast invariants).
+                    let proto = if want_proto {
+                        Some(print_c_prototype(prog.arch_mut(), &fd))
+                    } else {
+                        None
+                    };
+                    (code, variables, proto)
                 }));
                 match rendered {
-                    Ok((code, variables)) => out.push(FuncResult {
+                    Ok((code, variables, proto)) => out.push(FuncResult {
                         name,
                         address,
                         size,
                         code: Some(code),
                         error: None,
+                        proto,
                         variables,
                     }),
                     Err(_) => out.push(FuncResult {
@@ -250,6 +280,7 @@ fn decompile_all(args: &Args) -> Result<Vec<FuncResult>, String> {
                         size: 0,
                         code: None,
                         error: Some("panic while rendering C / extracting variables".into()),
+                        proto: None,
                         variables: Vec::new(),
                     }),
                 }
@@ -260,11 +291,12 @@ fn decompile_all(args: &Args) -> Result<Vec<FuncResult>, String> {
                 size: 0,
                 code: None,
                 error: Some(e.explain().to_string()),
+                proto: None,
                 variables: Vec::new(),
             }),
         }
     }
-    Ok(out)
+    out
 }
 
 /// Enumerate the program's functions as `(name, address)` (the `functions`
@@ -287,7 +319,7 @@ fn list_functions(args: &Args) -> Result<Vec<(String, u64)>, String> {
 /// `--option`s in the correct order.  `default_listing` injects the Listing
 /// default of the `decompile-all` surface (decbench F1, DIV-15) — `true` from
 /// [`decompile_all`], `false` from [`list_functions`] (enumeration stays cheap).
-fn load_program(args: &Args, default_listing: bool) -> Result<ConsoleProgram, String> {
+pub(crate) fn load_program(args: &Args, default_listing: bool) -> Result<ConsoleProgram, String> {
     let binary = std::fs::canonicalize(&args.binary)
         .map_err(|_| format!("binary not found: {}", args.binary))?
         .to_string_lossy()
@@ -396,7 +428,10 @@ fn load_program(args: &Args, default_listing: bool) -> Result<ConsoleProgram, St
 /// Build the target `(name, Address)` list from the filters: `--addr` entries
 /// (named via the symbol table, else `name_function`), `--functions` names, or —
 /// with no filter — every enumerated function.
-fn resolve_targets(prog: &ConsoleProgram, args: &Args) -> Result<Vec<(String, Address)>, String> {
+pub(crate) fn resolve_targets(
+    prog: &ConsoleProgram,
+    args: &Args,
+) -> Result<Vec<(String, Address)>, String> {
     let code_space = prog
         .arch()
         .manage()
@@ -596,7 +631,7 @@ fn var_json(v: &VarInfo) -> Json {
 
 /// Render the functions as concatenated C with `// Function:` headers (the human
 /// output, mirroring `DecompilationResult.to_c_file`).
-fn render_c(funcs: &[FuncResult]) -> String {
+pub(crate) fn render_c(funcs: &[FuncResult]) -> String {
     let mut out = String::new();
     for f in funcs {
         match (&f.code, &f.error) {
@@ -633,7 +668,7 @@ pub fn mode_override_pairs(mode: &str) -> Result<Vec<(String, String)>, String> 
     }
 }
 
-fn parse_args(argv: &[String], cmd: &str) -> Result<Args, String> {
+pub(crate) fn parse_args(argv: &[String], cmd: &str) -> Result<Args, String> {
     let mut binary: Option<String> = None;
     let mut json = false;
     let mut names: Option<Vec<String>> = None;
@@ -660,7 +695,7 @@ fn parse_args(argv: &[String], cmd: &str) -> Result<Args, String> {
                 let v = take(argv, &mut i, "--addr")?;
                 addrs.push(parse_hex(&v)?);
             }
-            "--max-fn-seconds" if cmd == "decompile-all" => {
+            "--max-fn-seconds" if cmd == "decompile-all" || cmd == "decompile-project" => {
                 let v = take(argv, &mut i, "--max-fn-seconds")?;
                 max_fn_seconds = v
                     .trim()

--- a/decompiler/crates/kuna-cli/src/decompile_project.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_project.rs
@@ -1,0 +1,589 @@
+//! `kuna decompile-project` — whole-binary **project export**.
+//!
+//! ```text
+//!   kuna decompile-project <binary> [-o|--output DIR] [--functions a,b,..]
+//!                          [--addr 0xVMA].. [--max-fn-seconds N]
+//!                          [--mode reliable|aggressive] [--option N V]..
+//!                          [--slice ARCH] [--target T] [--sleighpath D]
+//! ```
+//!
+//! Loads + analyzes the binary once (the `decompile-all` in-process path,
+//! Listing on by default) and writes a **project folder** — default
+//! `<binary-filename>.kuna/` next to the binary, `-o DIR` overrides — designed
+//! so a human or LLM can study the binary and attempt recompilation:
+//!
+//! * `<name>.c`   — every decompiled function (`// Function: <name> @ <addr>`
+//!   headers, exactly the `decompile-all` rendering), `#include "<name>.h"`.
+//! * `<name>.h`   — include-guarded recompile prelude (core scalar +
+//!   `undefined` typedefs), the user-defined type definitions
+//!   (`print_c_types`), and one prototype per decompiled function
+//!   (`print_c_prototype` — token-identical to the `.c` definition line).
+//! * `<name>.asm` — full labeled linear disassembly of every CODE section:
+//!   `<name>:` labels matching the `.c` function names, per-function
+//!   `; arg:` / `; stack:` comments mapping decompiled variables to stack
+//!   offsets, undecodable bytes as `db` lines, and a `; --- data ---` tail
+//!   listing the named globals plus every `dat_<hex>` address the `.c`
+//!   references, with raw bytes.
+//! * `README.md`  — binary metadata (size, arch, entry point, sections,
+//!   function counts) and the artifact/labeling conventions.
+//!
+//! Exit code 0 on success **even if individual functions failed** (matching
+//! `decompile-all` — failures are recorded in the artifacts); nonzero on load
+//! errors, an empty target set, or I/O errors.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use kuna_console::engine::ConsoleProgram;
+use kuna_decomp::decompile_drive::{print_c_recompile_prelude, print_c_types};
+use object::{Object, ObjectSection};
+
+use crate::decompile_all::{
+    decompile_targets, load_program, parse_args, render_c, resolve_targets, Args, FuncResult,
+};
+
+/// `kuna_sleigh::loadimage::section_flags::CODE` — kuna-cli deliberately does
+/// not depend on kuna-sleigh, so the (stable, upstream-fixed) bit value is
+/// mirrored here; `ConsoleProgram::sections` documents its `flags` word as
+/// exactly that constant set (UNALLOC=1, NOLOAD=2, CODE=4, DATA=8,
+/// READONLY=16).
+const SECTION_FLAG_CODE: u32 = 4;
+
+/// `dat_` blocks larger than this are truncated in the `.asm` data tail (the
+/// printer's `dat_<hex>` names carry no size; the label only marks the start).
+const DAT_SIZE_CAP: u64 = 32;
+
+/// `kuna decompile-project` entry point.
+pub fn run(argv: &[String]) -> i32 {
+    // Wrapper parse: extract `-o/--output`, intercept help, reject the
+    // decompile-all-only flags, and hand the remainder to the shared parser.
+    let mut output: Option<String> = None;
+    let mut rest: Vec<String> = Vec::new();
+    let mut i = 0;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "-o" | "--output" => {
+                if i + 1 >= argv.len() {
+                    eprintln!("error: {} requires a value", argv[i]);
+                    usage();
+                    return 2;
+                }
+                output = Some(argv[i + 1].clone());
+                i += 1;
+            }
+            "-h" | "--help" => {
+                usage();
+                return 0;
+            }
+            "--json" | "--no-vars" => {
+                eprintln!("error: {} is not a decompile-project option", argv[i]);
+                usage();
+                return 2;
+            }
+            other => rest.push(other.to_string()),
+        }
+        i += 1;
+    }
+    let args = match parse_args(&rest, "decompile-project") {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("error: {e}");
+            usage();
+            return 2;
+        }
+    };
+    match decompile_project(&args, output.as_deref()) {
+        Ok(()) => 0,
+        Err(e) => {
+            eprintln!("error: {e}");
+            1
+        }
+    }
+}
+
+fn usage() {
+    eprintln!(
+        "usage: kuna decompile-project <binary> [-o|--output DIR] [--functions a,b,..] \\\n\
+         \x20                   [--addr 0xVMA].. [--max-fn-seconds N] [--mode reliable|aggressive] \\\n\
+         \x20                   [--option N V].. [--slice ARCH] [--target T] [--sleighpath D]\n\
+         \n\
+         Decompile a whole binary in one in-process load and write a project folder\n\
+         (default `<binary-filename>.kuna/` next to the binary; -o DIR overrides):\n\
+         \x20 <name>.c    every decompiled function (#include \"<name>.h\")\n\
+         \x20 <name>.h    recompile prelude + type definitions + prototypes\n\
+         \x20 <name>.asm  labeled disassembly (function labels, stack-var comments,\n\
+         \x20             dat_<hex> data labels with raw bytes)\n\
+         \x20 README.md   binary metadata (size, arch, entry, sections, counts)\n\
+         Individual function failures are recorded in the artifacts; the run still\n\
+         exits 0 (load errors / an empty target set / I/O errors exit nonzero)."
+    );
+}
+
+/// The whole flow: load once → decompile every target (with prototypes) →
+/// build the four artifacts → write them all at the end.
+fn decompile_project(args: &Args, output: Option<&str>) -> Result<(), String> {
+    let binary_path = std::fs::canonicalize(&args.binary)
+        .map_err(|_| format!("binary not found: {}", args.binary))?;
+    let file_name = binary_path
+        .file_name()
+        .ok_or_else(|| format!("binary has no file name: {}", binary_path.display()))?
+        .to_string_lossy()
+        .into_owned();
+    let out_dir: PathBuf = match output {
+        Some(dir) => PathBuf::from(dir),
+        None => binary_path
+            .parent()
+            .ok_or_else(|| format!("binary has no parent directory: {}", binary_path.display()))?
+            .join(format!("{file_name}.kuna")),
+    };
+
+    let mut prog = load_program(args, /* default_listing= */ true)?;
+    // Per-function watchdog — same driver policy as `decompile-all` (default
+    // 120 s, 0 disables): a non-converging function becomes its own error
+    // record in the artifacts instead of hanging the export.
+    if args.max_fn_seconds > 0 {
+        prog.arch_mut().kuna_fn_budget =
+            Some(std::time::Duration::from_secs(args.max_fn_seconds));
+    }
+    let targets = resolve_targets(&prog, args)?;
+    if targets.is_empty() {
+        return Err(format!("no functions selected/discovered in {}", args.binary));
+    }
+
+    let mut results =
+        decompile_targets(&mut prog, targets, /* no_vars= */ false, /* want_proto= */ true);
+    // Every artifact is address-ordered (resolve_targets only guarantees that
+    // for the no-filter default; --addr/--functions arrive in user order).
+    results.sort_by(|a, b| a.address.cmp(&b.address).then_with(|| a.name.cmp(&b.name)));
+
+    // `print_c_types` AFTER the decompile loop: user-defined types are interned
+    // into the factory as functions decompile.
+    let prelude = print_c_recompile_prelude(prog.arch());
+    let types = print_c_types(prog.arch_mut());
+
+    let header = build_header(&file_name, &prelude, &types, &results);
+    let c_file = build_c(&file_name, &results);
+    let dat_addrs = collect_dat_addrs(&results);
+    let asm = build_asm(&prog, &results, &dat_addrs, &file_name);
+    let readme = build_readme(&binary_path, &file_name, &prog, &results);
+
+    std::fs::create_dir_all(&out_dir)
+        .map_err(|e| format!("cannot create {}: {e}", out_dir.display()))?;
+    let mut sizes: Vec<(String, usize)> = Vec::new();
+    for (base, text) in [
+        (format!("{file_name}.c"), &c_file),
+        (format!("{file_name}.h"), &header),
+        (format!("{file_name}.asm"), &asm),
+        ("README.md".to_string(), &readme),
+    ] {
+        let path = out_dir.join(&base);
+        std::fs::write(&path, text).map_err(|e| format!("cannot write {}: {e}", path.display()))?;
+        sizes.push((base, text.len()));
+    }
+
+    let ok = results.iter().filter(|r| r.error.is_none()).count();
+    let failed = results.len() - ok;
+    let files = sizes
+        .iter()
+        .map(|(n, s)| format!("{n} ({s} bytes)"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!("wrote {}: {files}; functions: {ok} ok, {failed} failed", out_dir.display());
+    Ok(())
+}
+
+// --- .h ------------------------------------------------------------------
+
+/// The include-guard macro: the file name sanitized to `[A-Z0-9_]` + `_H`
+/// (a leading digit gets a `_` prefix — a macro name can't start with one).
+fn sanitize_guard(file_name: &str) -> String {
+    let mut s: String = file_name
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c.to_ascii_uppercase() } else { '_' })
+        .collect();
+    if s.chars().next().is_none_or(|c| c.is_ascii_digit()) {
+        s.insert(0, '_');
+    }
+    s.push_str("_H");
+    s
+}
+
+/// `<name>.h`: include guard + recompile prelude + user type definitions +
+/// the prototype section (successes in address order; failures as comments).
+fn build_header(file_name: &str, prelude: &str, types: &str, results: &[FuncResult]) -> String {
+    let guard = sanitize_guard(file_name);
+    let mut out = String::new();
+    out.push_str(&format!("#ifndef {guard}\n#define {guard}\n\n"));
+    out.push_str(prelude);
+    if !types.is_empty() {
+        out.push_str("\n/* user-defined types */\n");
+        out.push_str(types);
+    }
+    out.push_str("\n/* function prototypes */\n");
+    for r in results {
+        match (&r.proto, &r.error) {
+            (Some(proto), None) => {
+                out.push_str(proto);
+                if !proto.ends_with('\n') {
+                    out.push('\n');
+                }
+            }
+            _ => {
+                out.push_str(&format!(
+                    "/* {} @ 0x{:x}: decompile failed */\n",
+                    r.name, r.address
+                ));
+            }
+        }
+    }
+    out.push_str(&format!("\n#endif /* {guard} */\n"));
+    out
+}
+
+// --- .c ------------------------------------------------------------------
+
+/// `<name>.c`: the header include + the exact `decompile-all` concatenated-C
+/// rendering (`render_c` — `// Function: <name> @ <addr>` blocks, failures as
+/// `(error: …)` comments).
+fn build_c(file_name: &str, results: &[FuncResult]) -> String {
+    format!("#include \"{file_name}.h\"\n\n{}", render_c(results))
+}
+
+// --- dat_ collection ------------------------------------------------------
+
+/// Scan every decompiled function's C for `dat_<hex>` tokens — the names the
+/// printer generates on the fly (`kuna_global_data_name`, `dat_{off:x}`,
+/// lowercase hex) for data addresses no symbol covers.  Hand-rolled (no regex
+/// dep): the char before `dat_` must not be an identifier char, the token is
+/// `dat_` + 1+ lowercase-hex chars, and the char after the hex run must not
+/// be an identifier char either (so a user symbol like `dat_foo` or
+/// `dat_12x3` never false-positives — the printer's tokens are exact by
+/// construction).  Returns the parsed VMAs.
+fn collect_dat_addrs(results: &[FuncResult]) -> BTreeSet<u64> {
+    fn is_ident(b: u8) -> bool {
+        b.is_ascii_alphanumeric() || b == b'_'
+    }
+    let mut out = BTreeSet::new();
+    for r in results {
+        let Some(code) = &r.code else { continue };
+        let b = code.as_bytes();
+        let mut i = 0;
+        while let Some(pos) = code[i..].find("dat_") {
+            let start = i + pos;
+            let hex_start = start + 4;
+            let mut hex_end = hex_start;
+            while hex_end < b.len() && matches!(b[hex_end], b'0'..=b'9' | b'a'..=b'f') {
+                hex_end += 1;
+            }
+            let prev_ok = start == 0 || !is_ident(b[start - 1]);
+            let next_ok = hex_end == b.len() || !is_ident(b[hex_end]);
+            if prev_ok && next_ok && hex_end > hex_start {
+                if let Ok(vma) = u64::from_str_radix(&code[hex_start..hex_end], 16) {
+                    out.insert(vma);
+                }
+            }
+            i = hex_end.max(hex_start);
+        }
+    }
+    out
+}
+
+// --- .asm ------------------------------------------------------------------
+
+/// A function label in the sweep: the (possibly several — alias names at one
+/// address survive `resolve_targets`) results anchored at a normalized VMA.
+type LabelMap<'a> = BTreeMap<u64, Vec<&'a FuncResult>>;
+
+/// `<name>.asm`: linear sweep of every CODE section with function labels +
+/// stack-var comment blocks, then the `; --- data ---` tail (named globals ∪
+/// the `dat_<hex>` set, with raw bytes).
+fn build_asm(
+    prog: &ConsoleProgram,
+    results: &[FuncResult],
+    dat_addrs: &BTreeSet<u64>,
+    file_name: &str,
+) -> String {
+    // On ARM-family specs a Thumb function's entry VMA carries the mode bit;
+    // the sweep walks even byte addresses, so labels are keyed on `vma & !1`.
+    let arm = prog.description().starts_with("ARM");
+    let normalize = |vma: u64| if arm { vma & !1 } else { vma };
+
+    let mut labels: LabelMap = BTreeMap::new();
+    for r in results {
+        labels.entry(normalize(r.address)).or_default().push(r);
+    }
+
+    let sections = prog.sections();
+    let mut out = String::new();
+    out.push_str(&format!("; kuna decompile-project — {file_name}\n"));
+    out.push_str(&format!("; arch: {}\n", prog.description()));
+
+    let mut code_secs: Vec<(u64, u64)> = sections
+        .iter()
+        .filter(|(_, _, flags)| flags & SECTION_FLAG_CODE != 0)
+        .map(|&(vma, size, _)| (vma, size))
+        .collect();
+    code_secs.sort_unstable();
+    for (vma, size) in code_secs {
+        let end = vma.saturating_add(size);
+        out.push_str(&format!("\n; --- code section 0x{vma:x}..0x{end:x} ---\n"));
+        sweep_code(prog, &labels, vma, end, &mut out);
+    }
+
+    emit_data_tail(prog, &sections, dat_addrs, &mut out);
+    out
+}
+
+/// Disassemble `[start, end)` linearly: labels + stack-var headers at function
+/// entries, one instruction line per decode, `db` byte lines (coalesced up to
+/// 8, clamped at the next label) where decoding fails.
+fn sweep_code(prog: &ConsoleProgram, labels: &LabelMap, start: u64, end: u64, out: &mut String) {
+    // Pending `db` bytes not yet flushed: (start VMA, bytes).
+    let mut db: Option<(u64, Vec<u8>)> = None;
+    let flush_db = |db: &mut Option<(u64, Vec<u8>)>, out: &mut String| {
+        if let Some((at, bytes)) = db.take() {
+            let hex = bytes.iter().map(|b| format!("0x{b:02x}")).collect::<Vec<_>>().join(", ");
+            out.push_str(&format!("  {at:08x}: db {hex}\n"));
+        }
+    };
+
+    let mut addr = start;
+    while addr < end {
+        if let Some(rs) = labels.get(&addr) {
+            flush_db(&mut db, out);
+            for r in rs {
+                out.push('\n');
+                out.push_str(&format!("{}:  ; 0x{:x}\n", r.name, r.address));
+                emit_var_header(r, out);
+            }
+        }
+        // Never decode across the next label (a mis-sync would otherwise
+        // swallow a function label into an instruction's byte extent) or the
+        // section end.
+        let next_stop =
+            labels.range(addr + 1..).next().map(|(&a, _)| a.min(end)).unwrap_or(end);
+        match prog.disassemble_at(addr) {
+            Ok((len, mnem, body)) if len > 0 && addr + len as u64 <= next_stop => {
+                flush_db(&mut db, out);
+                let bytes = prog.read_bytes(addr, len as usize).unwrap_or_default();
+                let hex = bytes.iter().map(|b| format!("{b:02x}")).collect::<Vec<_>>().join(" ");
+                let line = format!("  {addr:08x}: {hex:<24}  {mnem:<10} {body}");
+                out.push_str(line.trim_end());
+                out.push('\n');
+                addr += len as u64;
+            }
+            _ => {
+                // Decode failure (or a decode that would cross the next label):
+                // one raw byte, coalesced into up-to-8-byte `db` lines.
+                match prog.read_bytes(addr, 1) {
+                    Some(bytes) => {
+                        let (_, pending) = db.get_or_insert_with(|| (addr, Vec::new()));
+                        pending.push(bytes[0]);
+                        if pending.len() >= 8 {
+                            flush_db(&mut db, out);
+                        }
+                    }
+                    None => {
+                        flush_db(&mut db, out);
+                        out.push_str(&format!("  {addr:08x}: db ?? (unreadable)\n"));
+                    }
+                }
+                addr += 1;
+            }
+        }
+    }
+    flush_db(&mut db, out);
+}
+
+/// The per-function variable comment block: `; arg:` lines (ABI order), then
+/// `; stack:` lines with the signed frame offset the decompiled name lives at.
+fn emit_var_header(r: &FuncResult, out: &mut String) {
+    for v in r.variables.iter().filter(|v| v.is_param) {
+        out.push_str(&format!("; arg:   {} ({})\n", v.name, v.type_name));
+    }
+    for v in r.variables.iter().filter(|v| !v.is_param) {
+        match v.stack_offset {
+            Some(off) => {
+                let sign = if off < 0 { '-' } else { '+' };
+                out.push_str(&format!(
+                    "; stack: {} @ [stack{}0x{:x}] ({})\n",
+                    v.name,
+                    sign,
+                    off.unsigned_abs(),
+                    v.type_name
+                ));
+            }
+            None => out.push_str(&format!("; stack: {} ({})\n", v.name, v.type_name)),
+        }
+    }
+}
+
+/// One data-tail label: display name, byte size if a typed symbol supplied
+/// one, and whether a `dat_<hex>` token also resolves here (the alias case:
+/// the named symbol stays the label, the `dat_` spelling is appended so the
+/// `.c` token remains greppable — `<name>:  ; 0x<addr> = dat_<hex>`).
+struct DataLabel {
+    name: String,
+    type_size: Option<i64>,
+    dat_alias: bool,
+}
+
+/// `; --- data ---`: address-sorted deduped labels (named globals ∪ `dat_`
+/// tokens), each with a raw-byte dump (16/line + printable-ASCII column) or an
+/// `?? (uninitialized/unmapped)` line for image-backed-less ranges (.bss).
+fn emit_data_tail(
+    prog: &ConsoleProgram,
+    sections: &[(u64, u64, u32)],
+    dat_addrs: &BTreeSet<u64>,
+    out: &mut String,
+) {
+    let mut data: BTreeMap<u64, DataLabel> = BTreeMap::new();
+    for (name, vma, type_size) in prog.global_data_symbols() {
+        // First named symbol at a VMA wins (global_data_symbols is
+        // (vma, name)-sorted; duplicates at one address are aliases).
+        data.entry(vma).or_insert(DataLabel { name, type_size: Some(type_size), dat_alias: false });
+    }
+    for &vma in dat_addrs {
+        data.entry(vma)
+            .and_modify(|l| l.dat_alias = true)
+            .or_insert_with(|| DataLabel {
+                name: format!("dat_{vma:x}"),
+                type_size: None,
+                dat_alias: false,
+            });
+    }
+    if data.is_empty() {
+        return;
+    }
+
+    out.push_str("\n; --- data ---\n");
+    let addrs: Vec<u64> = data.keys().copied().collect();
+    for (idx, (&vma, label)) in data.iter().enumerate() {
+        // Size: a typed symbol's datatype size; a bare `dat_` gets
+        // min(gap to the next label / containing-section end, 32), floor 1.
+        let size = match label.type_size {
+            Some(s) if s > 0 => s as u64,
+            _ => {
+                let next_label = addrs.get(idx + 1).copied();
+                let sec_end = sections
+                    .iter()
+                    .find(|&&(sv, ss, _)| vma >= sv && vma < sv.saturating_add(ss))
+                    .map(|&(sv, ss, _)| sv + ss);
+                let bound = [next_label, sec_end]
+                    .into_iter()
+                    .flatten()
+                    .filter(|&b| b > vma)
+                    .map(|b| b - vma)
+                    .min()
+                    .unwrap_or(DAT_SIZE_CAP);
+                bound.clamp(1, DAT_SIZE_CAP)
+            }
+        };
+        out.push('\n');
+        if label.dat_alias {
+            out.push_str(&format!("{}:  ; 0x{vma:x} = dat_{vma:x}\n", label.name));
+        } else {
+            out.push_str(&format!("{}:  ; 0x{vma:x}\n", label.name));
+        }
+        match prog.read_bytes(vma, size as usize) {
+            Some(bytes) => {
+                for (row, chunk) in bytes.chunks(16).enumerate() {
+                    let hex =
+                        chunk.iter().map(|b| format!("{b:02x}")).collect::<Vec<_>>().join(" ");
+                    let ascii: String = chunk
+                        .iter()
+                        .map(|&b| if (0x20..0x7f).contains(&b) { b as char } else { '.' })
+                        .collect();
+                    out.push_str(&format!(
+                        "  {:08x}: {hex:<47}  |{ascii}|\n",
+                        vma + row as u64 * 16
+                    ));
+                }
+            }
+            None => {
+                out.push_str(&format!(
+                    "  {vma:08x}: ?? (uninitialized/unmapped, {size} bytes)\n"
+                ));
+            }
+        }
+    }
+}
+
+// --- README.md ---------------------------------------------------------------
+
+/// `README.md`: binary metadata (file size, arch id, entry point + sections
+/// re-parsed via the `object` crate — the engine's LoadImage sections carry no
+/// names), function counts, and the artifact inventory / labeling conventions.
+fn build_readme(
+    binary_path: &Path,
+    file_name: &str,
+    prog: &ConsoleProgram,
+    results: &[FuncResult],
+) -> String {
+    let file_size =
+        std::fs::metadata(binary_path).map(|m| m.len().to_string()).unwrap_or_else(|_| "?".into());
+    let ok = results.iter().filter(|r| r.error.is_none()).count();
+    let failed = results.len() - ok;
+
+    let mut out = String::new();
+    out.push_str(&format!("# {file_name} — kuna project export\n\n"));
+    out.push_str("Generated by `kuna decompile-project`.\n\n");
+    out.push_str("## Binary\n\n");
+    out.push_str("| Field | Value |\n|---|---|\n");
+    out.push_str(&format!("| Path | `{}` |\n", binary_path.display()));
+    out.push_str(&format!("| File size | {file_size} bytes |\n"));
+    out.push_str(&format!("| Architecture | `{}` |\n", prog.description()));
+
+    // Entry point + named sections come from an `object` re-parse (the engine's
+    // section iterator has no name field).
+    let parsed = std::fs::read(binary_path).ok();
+    let parsed = parsed.as_deref().and_then(|b| object::File::parse(b).ok());
+    match &parsed {
+        Some(f) => out.push_str(&format!("| Entry point | `0x{:x}` |\n", f.entry())),
+        None => out.push_str("| Entry point | unavailable |\n"),
+    }
+    out.push_str(&format!("| Functions | {} total, {ok} decompiled, {failed} failed |\n", results.len()));
+
+    if let Some(f) = &parsed {
+        out.push_str("\n## Sections\n\n");
+        out.push_str("| Name | Address | Size | Kind |\n|---|---|---|---|\n");
+        for s in f.sections() {
+            out.push_str(&format!(
+                "| `{}` | `0x{:x}` | `0x{:x}` | {:?} |\n",
+                s.name().unwrap_or("?"),
+                s.address(),
+                s.size(),
+                s.kind()
+            ));
+        }
+    }
+
+    out.push_str(&format!(
+        "\n## Files\n\n\
+         - `{file_name}.c` — every decompiled function, address-ordered, each under a\n\
+         \x20 `// Function: <name> @ <addr>` header (failures appear as\n\
+         \x20 `// Function: <name> @ <addr>  (error: ...)` comments). Includes `{file_name}.h`.\n\
+         - `{file_name}.h` — recompilation aid: the generated core-typedef prelude (the\n\
+         \x20 Ghidra/kuna `undefined` family included), the user-defined type definitions\n\
+         \x20 recovered during decompilation, and one prototype per decompiled function\n\
+         \x20 (token-identical to its `.c` definition line).\n\
+         - `{file_name}.asm` — labeled linear disassembly of every code section. Function\n\
+         \x20 labels match the `.c` names exactly (`main:`, `sub_<addr>:`); under each label\n\
+         \x20 a comment block maps the decompiled variables to their storage\n\
+         \x20 (`; arg: <name> (<type>)`, `; stack: <name> @ [stack-0x18] (<type>)`).\n\
+         \x20 Undecodable bytes appear as `db` lines. The `; --- data ---` tail labels the\n\
+         \x20 named globals and every `dat_<hex>` address the `.c` references, with raw\n\
+         \x20 bytes (`??` for unmapped/.bss ranges).\n\
+         - `README.md` — this file.\n\
+         \n\
+         ## Labeling conventions\n\n\
+         - Functions without a symbol name keep the generated `sub_<addr>` /\n\
+         \x20 `FUN_<addr>` name in both `{file_name}.c` and `{file_name}.asm` — the label in the\n\
+         \x20 `.asm` is the anchor for the same function in the `.c`.\n\
+         - Unnamed data referenced by the C appears as `dat_<hex>` (the hex is the VMA);\n\
+         \x20 the same spelling labels the bytes in the `.asm` data tail. When a named\n\
+         \x20 global covers that address the symbol name stays the label and the `dat_`\n\
+         \x20 spelling is appended: `<name>:  ; 0x<addr> = dat_<hex>`.\n"
+    ));
+    out
+}

--- a/decompiler/crates/kuna-cli/src/main.rs
+++ b/decompiler/crates/kuna-cli/src/main.rs
@@ -19,6 +19,7 @@
 mod catalog;
 mod decompile;
 mod decompile_all;
+mod decompile_project;
 mod fid;
 mod jsonfmt;
 mod paths;
@@ -41,6 +42,7 @@ fn main() -> ExitCode {
     let code = match sub {
         "decompile" => cmd_decompile(rest),
         "decompile-all" => decompile_all::run(rest),
+        "decompile-project" => decompile_project::run(rest),
         "functions" => decompile_all::run_functions(rest),
         "test" => cmd_test(rest),
         "catalog" => cmd_catalog(rest),
@@ -66,10 +68,11 @@ fn main() -> ExitCode {
 
 fn usage() {
     eprintln!(
-        "usage: kuna <decompile|decompile-all|functions|test|catalog|specs|fid> ...\n\
+        "usage: kuna <decompile|decompile-all|decompile-project|functions|test|catalog|specs|fid> ...\n\
          \n\
          kuna decompile <binary> <func> [--addr] [--slice ARCH] [--mode reliable|aggressive] [--option NAME VALUE]... [--kassert ARGS]...\n\
          kuna decompile-all <binary> [--json] [--functions a,b,..] [--addr 0xVMA]... [--no-vars] [--max-fn-seconds N] [--mode reliable|aggressive] [--option N V]...\n\
+         kuna decompile-project <binary> [-o DIR] [--functions a,b,..] [--addr 0xVMA]... [--max-fn-seconds N] [--mode reliable|aggressive] [--option N V]...\n\
          kuna functions <binary> [--json] [--mode reliable|aggressive]\n\
          kuna test [--all|--unittests|--datatests] [--name N]... [--baseline F] [--save-baseline F] [--json]\n\
          kuna catalog [--json|--markdown|--check] [--option NAME] [--tier transform|analysis|core]\n\

--- a/decompiler/crates/kuna-cli/tests/decompile_project_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_project_cli.rs
@@ -1,0 +1,250 @@
+//! CLI end-to-end gate for `kuna decompile-project` — drives the built `kuna`
+//! binary over the vendored `fauxware` (x86-64) and `arm_thumb_linked_le32`
+//! (ARM Thumb) ELF fixtures and asserts the four project artifacts
+//! (`.c` / `.h` / `.asm` / `README.md`) are written, cross-referenced, and
+//! (for the `.h`) syntactically valid C.
+//!
+//! ## `.sla` precondition
+//!
+//! Bootstrapping needs the built `x86` / `ARM` `.sla` under `specs/` (gitignored;
+//! `make specs`).  When it is absent the command fails to build an architecture;
+//! the affected test prints that and returns early (a specs-less CI is a visible
+//! skip, never a false green).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+fn fixture(name: &str) -> String {
+    repo_root()
+        .join("decompiler/crates/kuna-analysis/tests/fixtures")
+        .join(name)
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+fn specs() -> String {
+    repo_root().join("specs").to_str().unwrap().to_string()
+}
+
+/// A unique per-test output directory under the system temp dir.
+fn out_dir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "kuna_decompile_project_{tag}_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    dir
+}
+
+fn run_kuna(args: &[&str]) -> (String, String, bool) {
+    let out = Command::new(env!("CARGO_BIN_EXE_kuna"))
+        .args(args)
+        .output()
+        .expect("failed to spawn the kuna binary");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.success(),
+    )
+}
+
+/// `true` when the failure is a missing-`.sla` bootstrap failure (a legitimate
+/// skip), not a real bug.
+fn is_specs_skip(stderr: &str) -> bool {
+    stderr.contains("could not build an architecture")
+        || stderr.contains("SLEIGH")
+        || stderr.contains("Could not discover")
+}
+
+/// Run `decompile-project` on `fixture_name` into a fresh temp dir; returns
+/// `Some(out_dir)` on success or `None` on a specs-less skip (panics on any
+/// other failure).
+fn project(fixture_name: &str, tag: &str) -> Option<PathBuf> {
+    let bin = fixture(fixture_name);
+    let dir = out_dir(tag);
+    let (_stdout, stderr, ok) = run_kuna(&[
+        "decompile-project",
+        &bin,
+        "-o",
+        dir.to_str().unwrap(),
+        "--sleighpath",
+        &specs(),
+    ]);
+    if !ok {
+        if is_specs_skip(&stderr) {
+            eprintln!("decompile_project_cli: skipping (no `.sla`; run `make specs`): {stderr}");
+            return None;
+        }
+        panic!("kuna decompile-project failed on {fixture_name}: {stderr}");
+    }
+    Some(dir)
+}
+
+/// The four artifact paths for a `<file_name>` project export.
+fn artifacts(dir: &std::path::Path, file_name: &str) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+    (
+        dir.join(format!("{file_name}.c")),
+        dir.join(format!("{file_name}.h")),
+        dir.join(format!("{file_name}.asm")),
+        dir.join("README.md"),
+    )
+}
+
+#[test]
+fn project_folder_written_for_fauxware() {
+    let Some(dir) = project("fauxware", "written") else { return };
+    let (c, h, asm, readme) = artifacts(&dir, "fauxware");
+    for f in [&c, &h, &asm, &readme] {
+        assert!(f.exists(), "missing artifact {}", f.display());
+    }
+    let c_text = std::fs::read_to_string(&c).unwrap();
+    assert!(c_text.contains("#include \"fauxware.h\""), ".c missing header include:\n{c_text}");
+    assert!(c_text.contains("// Function: main"), ".c missing main function header:\n{c_text}");
+
+    let h_text = std::fs::read_to_string(&h).unwrap();
+    assert!(
+        h_text.contains("typedef unsigned int undefined4;"),
+        ".h missing the undefined4 typedef:\n{h_text}"
+    );
+    // The `main` prototype line ends in `;` (token-identical to the .c
+    // definition's signature line).
+    let main_proto = h_text
+        .lines()
+        .find(|l| l.contains("main(") && !l.contains("//"))
+        .unwrap_or_else(|| panic!(".h missing a main( prototype:\n{h_text}"));
+    assert!(main_proto.trim_end().ends_with(';'), "main prototype must end in `;`: {main_proto:?}");
+
+    let readme_text = std::fs::read_to_string(&readme).unwrap();
+    assert!(readme_text.contains("x86:LE:64"), "README missing arch id:\n{readme_text}");
+    assert!(readme_text.contains("Entry point"), "README missing entry point:\n{readme_text}");
+    assert!(readme_text.contains("## Sections"), "README missing sections table:\n{readme_text}");
+}
+
+#[test]
+fn asm_labels_match_c_function_names() {
+    let Some(dir) = project("fauxware", "labels") else { return };
+    let (c, _h, asm, _r) = artifacts(&dir, "fauxware");
+    let c_text = std::fs::read_to_string(&c).unwrap();
+    let asm_text = std::fs::read_to_string(&asm).unwrap();
+    // Every `// Function: <name>` in the .c must have a `<name>:` label in the .asm.
+    let mut checked = 0;
+    for line in c_text.lines() {
+        if let Some(rest) = line.strip_prefix("// Function: ") {
+            let name = rest.split_whitespace().next().unwrap();
+            assert!(
+                asm_text.lines().any(|l| l.starts_with(&format!("{name}:"))),
+                "asm has no `{name}:` label for the .c function {name:?}"
+            );
+            checked += 1;
+        }
+    }
+    assert!(checked > 1, "expected several functions cross-checked, got {checked}");
+}
+
+#[test]
+fn asm_has_stack_comment_for_main() {
+    let Some(dir) = project("fauxware", "stack") else { return };
+    let (_c, _h, asm, _r) = artifacts(&dir, "fauxware");
+    let asm_text = std::fs::read_to_string(&asm).unwrap();
+    // Find `main:` and assert a `; stack:` or `; arg:` line appears in its
+    // header block (before the first instruction / blank separator).
+    let mut lines = asm_text.lines();
+    let found = lines.by_ref().any(|l| l.starts_with("main:"));
+    assert!(found, "no main: label in asm:\n{asm_text}");
+    let header: Vec<&str> = lines.take_while(|l| l.starts_with(';')).collect();
+    assert!(
+        header.iter().any(|l| l.starts_with("; stack:") || l.starts_with("; arg:")),
+        "main: has no stack/arg comment block:\n{}",
+        header.join("\n")
+    );
+}
+
+#[test]
+fn dat_labels_cross_referenced() {
+    let Some(dir) = project("fauxware", "dat") else { return };
+    let (c, _h, asm, _r) = artifacts(&dir, "fauxware");
+    let c_text = std::fs::read_to_string(&c).unwrap();
+    let asm_text = std::fs::read_to_string(&asm).unwrap();
+
+    // Collect every `dat_<hex>` token in the .c (same policy as the emitter:
+    // preceding char must not be an identifier char).
+    let bytes = c_text.as_bytes();
+    let is_ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    let mut tokens = std::collections::BTreeSet::new();
+    let mut i = 0;
+    while let Some(pos) = c_text[i..].find("dat_") {
+        let start = i + pos;
+        let hs = start + 4;
+        let mut he = hs;
+        while he < bytes.len() && matches!(bytes[he], b'0'..=b'9' | b'a'..=b'f') {
+            he += 1;
+        }
+        let prev_ok = start == 0 || !is_ident(bytes[start - 1]);
+        let next_ok = he == bytes.len() || !is_ident(bytes[he]);
+        if prev_ok && next_ok && he > hs {
+            tokens.insert(c_text[start..he].to_string());
+        }
+        i = he.max(hs);
+    }
+    assert!(!tokens.is_empty(), "fauxware .c should reference some dat_<hex> data:\n{c_text}");
+
+    // Label policy (documented in decompile_project.rs): a bare `dat_<hex>`
+    // gets its own `dat_<hex>:` label line; when a NAMED global covers the
+    // address the symbol name is the label and the `dat_` spelling is appended
+    // as `= dat_<hex>`.  Either form satisfies the cross-reference.
+    for t in &tokens {
+        let has_label = asm_text.lines().any(|l| l.starts_with(&format!("{t}:")))
+            || asm_text.contains(&format!("= {t}"));
+        assert!(has_label, "dat token {t:?} from the .c has no label/alias in the .asm");
+    }
+}
+
+#[test]
+fn header_syntax_checks_with_cc() {
+    // Gated: only run when a C compiler is available.
+    if Command::new("cc").arg("--version").output().map(|o| !o.status.success()).unwrap_or(true) {
+        eprintln!("header_syntax_checks_with_cc: skipping (no working `cc`)");
+        return;
+    }
+    let Some(dir) = project("fauxware", "cc") else { return };
+    let (_c, h, _asm, _r) = artifacts(&dir, "fauxware");
+    // A stub that includes the .h; it must NOT define `main` (the recovered
+    // header declares `void main(void)`, so an `int main` would legitimately
+    // conflict — we are asserting the .h itself is valid, not the decompiled C).
+    let stub = dir.join("hcheck.c");
+    std::fs::write(&stub, format!("#include \"{}\"\nint stub_entry(void){{return 0;}}\n", h.display()))
+        .unwrap();
+    let out = Command::new("cc")
+        .args(["-std=c99", "-fsyntax-only", stub.to_str().unwrap()])
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "generated .h failed cc -fsyntax-only:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn arm_thumb_project_smoke() {
+    let Some(dir) = project("arm_thumb_linked_le32", "arm") else { return };
+    let (_c, _h, asm, _r) = artifacts(&dir, "arm_thumb_linked_le32");
+    assert!(asm.exists(), "arm project missing .asm");
+    let asm_text = std::fs::read_to_string(&asm).unwrap();
+    assert!(!asm_text.trim().is_empty(), "arm .asm is empty");
+    // The non-x86 sweep + ARM Thumb odd-address normalization must still label
+    // functions (at least one `<name>:  ; 0x` line).
+    assert!(
+        asm_text.lines().any(|l| l.contains(":  ; 0x")),
+        "arm .asm has no function labels:\n{asm_text}"
+    );
+}

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -47,7 +47,7 @@ use kuna_decomp::options::register_option_elements;
 use kuna_decomp::sleigh_arch::{register_sleigh_arch_ids, LanguageDatabase, SleighArchitecture};
 use kuna_decomp::xml_arch::XmlArchitectureCapability;
 
-use kuna_sleigh::loadimage::{LoadImage, LoadImageFunc};
+use kuna_sleigh::loadimage::{LoadImage, LoadImageFunc, LoadImageSection};
 use kuna_analysis::loadimage_object::ObjectLoadImage;
 use kuna_sleigh::loadimage_xml::LoadImageXml;
 use kuna_sleigh::loadimage_xml::register_loadimage_xml_ids;
@@ -58,6 +58,23 @@ use kuna_sleigh::translate::register_translate_ids;
 struct ProgramSymbol {
     name: String,
     addr: Address,
+}
+
+/// (kuna) A one-shot [`AssemblyEmit`](kuna_sleigh::translate::AssemblyEmit)
+/// sink: `Translate::print_assembly` dumps exactly one instruction, whose
+/// mnemonic/body strings are captured here (the single-instruction form of the
+/// `IfcPrintdisasm` listing emitter in `ifacedecomp.rs`).
+#[derive(Default)]
+struct OneShotAssemblyEmit {
+    mnem: String,
+    body: String,
+}
+
+impl kuna_sleigh::translate::AssemblyEmit for OneShotAssemblyEmit {
+    fn dump(&mut self, _addr: &Address, mnem: &str, body: &str) {
+        self.mnem = mnem.to_string();
+        self.body = body.to_string();
+    }
 }
 
 /// The console's loaded program: the engine assembly (C++ `dcp->conf`, an
@@ -173,6 +190,122 @@ impl ConsoleProgram {
     /// raw-backend convention — the engine reports every function it found.
     pub fn function_entries(&self) -> impl Iterator<Item = (&str, &Address)> {
         self.symbols.iter().map(|s| (s.name.as_str(), &s.addr))
+    }
+
+    /// (kuna) Every section of bytes the load image maps, as `(vma, size, flags)`
+    /// triples — `flags` bits per [`kuna_sleigh::loadimage::section_flags`]
+    /// (CODE/DATA/READONLY/UNALLOC/NOLOAD).
+    ///
+    /// Consumes the LoadImage section-iteration API
+    /// (`openSectionInfo`/`getNextSection`/`closeSectionInfo`) in one shot, the
+    /// same loop shape as `CodeDataAnalysis::runModel` (`codedata.rs`), reached
+    /// through the engine's shared loader handle (`translate().loader_rc()`) —
+    /// the loader the bootstrap handed to the engine via `set_loader`.
+    /// Zero-size records are skipped (the `runModel` convention). Empty when the
+    /// loader publishes no section info (e.g. the XML `<binaryimage>` corpus
+    /// loader, which keeps the trait's default no-op iteration).
+    pub fn sections(&self) -> Vec<(u64, u64, u32)> {
+        let loader_rc = self.arch().translate().loader_rc();
+        // The iteration methods are `&self` (C++ `const` with a `mutable`
+        // cursor; interior mutability here), so a shared borrow suffices.
+        let loader = loader_rc.borrow();
+        let mut out = Vec::new();
+        let mut secinfo = LoadImageSection::default();
+        loader.open_section_info();
+        loop {
+            // getNextSection fills `secinfo` and returns whether ANOTHER record
+            // follows — so the record is consumed BEFORE the loop-exit check
+            // (the runModel shape). An empty section list leaves the default
+            // record (size 0), which the skip below drops.
+            let moresections = loader.get_next_section(&mut secinfo);
+            if secinfo.size != 0 {
+                out.push((secinfo.address.get_offset(), secinfo.size, secinfo.flags));
+            }
+            if !moresections {
+                break;
+            }
+        }
+        loader.close_section_info();
+        out
+    }
+
+    /// (kuna) Disassemble the single machine instruction at code-space VMA
+    /// `vma`, returning `(length, mnemonic, body)` — the one-instruction form
+    /// of the `disassemble` console command (`IfcPrintdisasm`), for a caller
+    /// that walks a range itself (advance by `length` per step).
+    ///
+    /// Builds the `Address` in the engine's default code space (the
+    /// `function_named_at` idiom) and drives `Translate::print_assembly`
+    /// through a one-shot [`AssemblyEmit`](kuna_sleigh::translate::AssemblyEmit)
+    /// sink. An undecodable/unmapped address surfaces as the translator's
+    /// `Err` (C++ `BadDataError`/`DataUnavailError`).
+    pub fn disassemble_at(&self, vma: u64) -> KunaResult<(int4, String, String)> {
+        let code_space = Rc::clone(
+            self.arch()
+                .manage()
+                .get_default_code_space()
+                .ok_or_else(|| KunaError::lowlevel("no default code space"))?,
+        );
+        let addr = Address::new(code_space, vma);
+        let mut emit = OneShotAssemblyEmit::default();
+        let length = self.arch().translate().print_assembly(&mut emit, &addr)?;
+        Ok((length, emit.mnem, emit.body))
+    }
+
+    /// (kuna) Read `size` raw image bytes at code-space VMA `vma` through the
+    /// engine's load image (`LoadImage::load`, the `loader_rc()` handle) —
+    /// `None` when the range is not backed by the image (e.g. `.bss`, an
+    /// unmapped address, or a `size` beyond the C++ `int4` read contract).
+    pub fn read_bytes(&self, vma: u64, size: usize) -> Option<Vec<u8>> {
+        if size > i32::MAX as usize {
+            return None; // LoadImage::load reads at most int4 bytes (C++ contract).
+        }
+        let code_space = Rc::clone(self.arch().manage().get_default_code_space()?);
+        let addr = Address::new(code_space, vma);
+        let loader_rc = self.arch().translate().loader_rc();
+        // `load` is `&mut self` (it seeks/caches); the RefCell covers it.
+        let bytes = loader_rc.borrow_mut().load(size as i32, &addr);
+        bytes.ok()
+    }
+
+    /// (kuna) Every **named global data symbol** mapped into the engine's
+    /// default data space, as `(name, vma, type_size)` — the label set a
+    /// whole-binary exporter cross-references against the `dat_<addr>` tokens
+    /// the C printer generates for unnamed data.
+    ///
+    /// Enumerates the global scope (`Database::get_global_scope`) via
+    /// `scope_space_symbol_specs` over the default data space (`ram` on every
+    /// vendored processor; Harvard-style splits follow the data space).
+    /// FunctionSymbols live in the SAME per-space rangemap (`add_function` maps
+    /// them at their entry address) and the specs tuple's `uint4` is the
+    /// varnode `flags` word — which does NOT distinguish them (functions carry
+    /// `namelock|typelock`, but so can data) — so functions are excluded by
+    /// their datatype instead: a FunctionSymbol's type is exactly the
+    /// TYPE_CODE base, and every `metatype == TYPE_CODE` spec is dropped.
+    /// This also drops the deliberately code-typed untyped Data placeholders
+    /// some gated analysis passes install (size-1, no real extent — useless as
+    /// data labels); typed data (DWARF `undefined<N>` globals, `char[N]`
+    /// string symbols) is kept. `type_size` is the mapped datatype's byte size.
+    /// Sorted by VMA.
+    pub fn global_data_symbols(&self) -> Vec<(String, u64, i64)> {
+        use kuna_decomp::dtype::type_metatype;
+        let arch = self.arch();
+        let Some(scope) = arch.symboltab.get_global_scope() else {
+            return Vec::new();
+        };
+        let Some(data_space) = arch.manage().get_default_data_space() else {
+            return Vec::new();
+        };
+        let space_index = data_space.get_index() as usize;
+        let mut out: Vec<(String, u64, i64)> = arch
+            .symboltab
+            .scope_space_symbol_specs(scope, space_index)
+            .into_iter()
+            .filter(|(_, ct, _, _)| ct.get_metatype() != type_metatype::TYPE_CODE)
+            .map(|(name, ct, addr, _)| (name, addr.get_offset(), i64::from(ct.get_size())))
+            .collect();
+        out.sort_by(|a, b| (a.1, &a.0).cmp(&(b.1, &b.0)));
+        out
     }
 
     /// (kuna) Is a (possibly `::`-scoped) symbol of full name `full_name` present in

--- a/decompiler/crates/kuna-console/src/ifacedecomp.rs
+++ b/decompiler/crates/kuna-console/src/ifacedecomp.rs
@@ -78,7 +78,7 @@ use crate::interface::{
 };
 use kuna_base::types::{int4, uintb, uintm};
 use kuna_decomp::decompile_drive::{
-    build_and_follow_flow, build_and_follow_flow_with_override, print_c,
+    build_and_follow_flow, build_and_follow_flow_with_override, print_c, print_c_types,
 };
 use kuna_decomp::funcdata::Funcdata;
 use kuna_decomp::options::OptionDatabase;
@@ -2089,14 +2089,24 @@ decomp_command!(
 );
 
 decomp_command!(
-    /// C++ `IfcPrintCTypes`: `print C types`.
+    /// C++ `IfcPrintCTypes`: `print C types` — render every user-defined
+    /// data-type as C definitions (`PrintLanguage::docTypeDefinitions`,
+    /// `ifacedecomp.cc:960`).  Output goes to the bulk stream (`fileoptr`),
+    /// mirroring `print C` (`IfcPrintCStruct` below): render with `dcp`
+    /// borrowed, then write to the status.  Returns nothing (an empty string)
+    /// when no user types are interned — empty is not an error.
     IfcPrintCTypes,
     fn execute(&self, status: &mut IfaceStatus, _s: &mut CommandStream) -> IfaceResult<()> {
-        let dcp = dcp_mut(status)?;
-        if dcp.conf.is_none() {
-            return Err(IfaceError::execution("No load image present"));
-        }
-        Err(engine_unavailable("PrintLanguage::docTypeDefinitions (Architecture::print/types)"))
+        let text = {
+            let dcp = dcp_mut(status)?;
+            if dcp.conf.is_none() {
+                return Err(IfaceError::execution("No load image present"));
+            }
+            let prog = dcp.conf.as_mut().expect("conf checked non-None above");
+            print_c_types(prog.arch_mut())
+        };
+        status.file_out(&text);
+        Ok(())
     }
 );
 

--- a/decompiler/crates/kuna-console/tests/verify_decompile_project_helpers.rs
+++ b/decompiler/crates/kuna-console/tests/verify_decompile_project_helpers.rs
@@ -1,0 +1,124 @@
+//! End-to-end gate for the **whole-binary export helpers** on [`ConsoleProgram`]
+//! that back `kuna decompile-project` (the `.asm`/README surface):
+//!
+//! ```text
+//!   sections()             (vma, size, flags) — the loader's section map
+//!   disassemble_at(vma)    (length, mnemonic, body) — one instruction
+//!   read_bytes(vma, size)  raw image bytes (None when unmapped)
+//!   global_data_symbols()  (name, vma, type_size) — named global data
+//! ```
+//!
+//! Drives them against the real vendored `fauxware` ELF (x86-64, non-PIE,
+//! dynamically linked, non-stripped) after the exact `decompile-all` load shape
+//! (`bootstrap_from_object` + `commit_pending_analysis`).
+//!
+//! ## `.sla` precondition
+//!
+//! Like the sibling loader gates, bootstrapping needs the built `x86` `.sla`
+//! under `specs/` (gitignored; `make specs`).  When it is absent the bootstrap
+//! fails; the test prints that and returns early (a specs-less CI is a visible
+//! skip, never a false green).
+
+use std::path::PathBuf;
+
+use kuna_console::engine::bootstrap_from_object;
+use kuna_sleigh::loadimage::section_flags;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+/// The vendored fauxware fixture (shared with the kuna-analysis loader gate).
+fn fauxware() -> PathBuf {
+    repo_root().join("decompiler/crates/kuna-analysis/tests/fixtures/fauxware")
+}
+
+/// fauxware's text `PT_LOAD` maps file offset 0 at vaddr 0x400000 (non-PIE
+/// ET_EXEC), so a text VMA's file offset is `vma - LOAD_BASE` — the round-trip
+/// oracle for `read_bytes`.
+const LOAD_BASE: u64 = 0x400000;
+
+#[test]
+fn export_helpers_report_sections_disasm_bytes_and_globals() {
+    let root = repo_root();
+    let spec_roots = vec![root.join("specs").to_str().unwrap().to_string()];
+    let bin = match fauxware().to_str() {
+        Some(s) => s.to_string(),
+        None => return,
+    };
+
+    let mut prog = match bootstrap_from_object(&bin, "", &spec_roots) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "verify_decompile_project_helpers: skipping (bootstrap failed, build `.sla` \
+                 with `make specs`): {}",
+                e.explain()
+            );
+            return;
+        }
+    };
+    prog.commit_pending_analysis().expect("read symbols (analysis commit) must succeed");
+
+    // (1) sections(): the loader's section map must be non-empty and contain at
+    // least one CODE-flagged range (the `.text` sweep range the `.asm` emitter
+    // walks), and `main`'s entry must fall inside a CODE range.
+    let sections = prog.sections();
+    assert!(!sections.is_empty(), "sections() returned no sections");
+    let code_ranges: Vec<&(u64, u64, u32)> =
+        sections.iter().filter(|(_, _, f)| f & section_flags::CODE != 0).collect();
+    assert!(!code_ranges.is_empty(), "no CODE-flagged section in {sections:?}");
+    let main_vma = prog
+        .function_entries()
+        .find(|(n, _)| *n == "main")
+        .map(|(_, a)| a.get_offset())
+        .expect("main present in enumeration");
+    assert!(
+        code_ranges.iter().any(|(vma, size, _)| main_vma >= *vma && main_vma < vma + size),
+        "main @ {main_vma:#x} not inside any CODE section: {code_ranges:?}"
+    );
+
+    // (2) disassemble_at(main entry): one decoded instruction with a positive
+    // length and a non-empty mnemonic.
+    let (len, mnem, _body) = prog.disassemble_at(main_vma).expect("disassemble_at(main) failed");
+    assert!(len > 0, "instruction length must be positive, got {len}");
+    assert!(!mnem.is_empty(), "empty mnemonic at main entry");
+
+    // (3) read_bytes: correct length, stable across two calls, and a byte-exact
+    // round-trip against the fixture file at the corresponding file offset
+    // (fauxware's text LOAD maps file offset 0 at LOAD_BASE).
+    let n = len as usize + 8; // one instruction plus a tail
+    let got = prog.read_bytes(main_vma, n).expect("read_bytes(main) returned None");
+    assert_eq!(got.len(), n, "read_bytes returned the wrong number of bytes");
+    let again = prog.read_bytes(main_vma, n).expect("second read_bytes(main) returned None");
+    assert_eq!(got, again, "read_bytes not stable across two calls");
+    let file = std::fs::read(fauxware()).expect("read fixture file");
+    let off = (main_vma - LOAD_BASE) as usize;
+    assert_eq!(
+        &got[..],
+        &file[off..off + n],
+        "read_bytes({main_vma:#x}) != file bytes at offset {off:#x}"
+    );
+    // An address far below the image is unmapped: Err maps to None (the `.bss` /
+    // hole contract the `.asm` data tail relies on).
+    assert!(prog.read_bytes(0x10, 4).is_none(), "read of unmapped address must be None");
+
+    // (4) global_data_symbols(): returns without error; every tuple is sane
+    // (non-empty name, positive type size) and no function symbol leaks through
+    // (fauxware's `main`/`authenticate` are FunctionSymbols in the same scope).
+    let globals = prog.global_data_symbols();
+    for (name, vma, size) in &globals {
+        assert!(!name.is_empty(), "global data symbol with an empty name @ {vma:#x}");
+        assert!(*size >= 1, "global data symbol {name} has non-positive size {size}");
+    }
+    assert!(
+        globals.iter().all(|(n, _, _)| n != "main" && n != "authenticate"),
+        "function symbols leaked into global_data_symbols(): {globals:?}"
+    );
+    // Non-stripped fauxware carries string literals; the default-on strings
+    // analysis maps each as a typed `s_<addr>` char[N] data symbol, so the set
+    // is non-empty (verified empirically; keeps the exporter's data-label merge
+    // honest).
+    assert!(!globals.is_empty(), "expected named global data on non-stripped fauxware");
+    eprintln!("global_data_symbols on fauxware ({}): {:?}", globals.len(), globals);
+}

--- a/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
@@ -953,6 +953,110 @@ pub fn print_c(arch: &mut Architecture, fd: &Funcdata) -> String {
     out
 }
 
+/// (kuna) Render every user-defined data-type in the architecture's type
+/// factory as C definitions (the `PrintC::docTypeDefinitions` port,
+/// [`crate::printc::PrintC::doc_type_definitions`]) — the type-definition
+/// block of the `kuna decompile-project` `.h` artifact.  Same
+/// take/put split-borrow dance as [`print_c`] (the printer is owned by `arch`).
+pub fn print_c_types(arch: &mut Architecture) -> String {
+    let mut printer = arch.take_print();
+    let out = printer.doc_type_definitions(arch);
+    arch.put_print(printer);
+    out
+}
+
+/// (kuna) Render ONLY the decompiled function's prototype declaration —
+/// `<ret> <name>(<params>);` — via
+/// [`crate::printc::PrintC::doc_prototype`]: the `.h`-prototype half of the
+/// `kuna decompile-project` prototype == definition-line contract (the emitted
+/// text minus the trailing `;` appears char-for-char inside [`print_c`]'s
+/// render of the same `Funcdata`).  A function whose prototype was never
+/// recovered (no proto store) renders as `void <name>(void);`.
+pub fn print_c_prototype(arch: &mut Architecture, fd: &Funcdata) -> String {
+    let mut printer = arch.take_print();
+    let out = printer.doc_prototype(fd, arch);
+    arch.put_print(printer);
+    out
+}
+
+/// (kuna) The generated recompile prelude for a `kuna decompile-project` `.h`:
+/// C typedefs for the architecture's interned **core** scalar types (`uint4`,
+/// `int8`, `float8`, …, spelled per standard C — 8-byte integers always use
+/// `long long` so the text is data-model independent) plus the fixed Ghidra
+/// `undefined` family block (`undefined`, `undefined1..8` — 3/5/6/7 mapped to
+/// the next larger unsigned integer with a sizeof note — and `undefined16/32`
+/// as byte-array structs).  `bool` is covered by `#include <stdbool.h>`;
+/// `char`/`void` are real C and emit nothing.
+pub fn print_c_recompile_prelude(arch: &Architecture) -> String {
+    use crate::dtype::type_metatype::*;
+    let mut out = String::new();
+    out.push_str("/* kuna recompile prelude (generated): core scalar typedefs */\n");
+    out.push_str("#include <stdbool.h>\n\n");
+
+    // Generated typedefs for the interned core types (dependent_order filtered
+    // on is_core_type; sorted by name for a stable, readable block).
+    let mut lines: Vec<String> = Vec::new();
+    for ct in arch.types_impl().dependent_order() {
+        if !ct.is_core_type() {
+            continue;
+        }
+        let name = ct.get_name();
+        // `void`/`char` are real C; `bool` comes from <stdbool.h> above.
+        if name.is_empty() || matches!(name, "void" | "char" | "bool") {
+            continue;
+        }
+        let size = ct.get_size();
+        let (spelling, note): (&str, &str) = match ct.get_metatype() {
+            TYPE_INT => match size {
+                1 => ("signed char", ""),
+                2 => ("short", ""),
+                4 => ("int", ""),
+                8 => ("long long", ""),
+                _ => continue,
+            },
+            TYPE_UINT | TYPE_UNKNOWN => match size {
+                1 => ("unsigned char", ""),
+                2 => ("unsigned short", ""),
+                4 => ("unsigned int", ""),
+                8 => ("unsigned long long", ""),
+                _ => continue,
+            },
+            TYPE_FLOAT => match size {
+                4 => ("float", ""),
+                8 => ("double", ""),
+                10 | 16 => ("long double", " /* sizeof may differ */"),
+                _ => continue,
+            },
+            // The pseudo "function body" type: only ever used as `code *`;
+            // a 1-byte scalar keeps `sizeof(code)` meaningful too.
+            TYPE_CODE => ("unsigned char", " /* pseudo (function body) type */"),
+            _ => continue,
+        };
+        lines.push(format!("typedef {spelling} {name};{note}\n"));
+    }
+    lines.sort();
+    lines.dedup();
+    for l in &lines {
+        out.push_str(l);
+    }
+
+    // The fixed Ghidra/kuna `undefined` family (the anonymous-unknown
+    // rendering `undefined<N>`, printc.rs `declarator_parts`).
+    out.push_str("\n/* the Ghidra/kuna `undefined` family */\n");
+    out.push_str("typedef unsigned char undefined;\n");
+    out.push_str("typedef unsigned char undefined1;\n");
+    out.push_str("typedef unsigned short undefined2;\n");
+    out.push_str("typedef unsigned int undefined3; /* 3 bytes in the decompiler; sizeof differs */\n");
+    out.push_str("typedef unsigned int undefined4;\n");
+    out.push_str("typedef unsigned long long undefined5; /* 5 bytes in the decompiler; sizeof differs */\n");
+    out.push_str("typedef unsigned long long undefined6; /* 6 bytes in the decompiler; sizeof differs */\n");
+    out.push_str("typedef unsigned long long undefined7; /* 7 bytes in the decompiler; sizeof differs */\n");
+    out.push_str("typedef unsigned long long undefined8;\n");
+    out.push_str("typedef struct { unsigned char b[16]; } undefined16;\n");
+    out.push_str("typedef struct { unsigned char b[32]; } undefined32;\n");
+    out
+}
+
 /// A recovered variable surfaced for the machine-readable batch output
 /// (`kuna decompile-all --json`) — the fields decbench's `type_match` metric
 /// consumes from a decompiler's per-function variable list.

--- a/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
@@ -1850,6 +1850,62 @@ impl PrintC {
         bytes
     }
 
+    /// (kuna) Render ONLY the function's prototype declaration —
+    /// `<ret> <name>(<params>);` — as plain text, for the `kuna
+    /// decompile-project` `.h` artifact.
+    ///
+    /// Mirrors [`doc_function_full`](PrintC::doc_function_full)'s capture
+    /// harness (`set_output_stream()` reset → emit → `output_str()`), driving
+    /// the IDENTICAL [`emit_prototype_declaration`](PrintC::emit_prototype_declaration)
+    /// token sequence the full function document emits, so the `.h` prototype
+    /// (minus the trailing `;` added here) matches the `.c` definition line
+    /// char-for-char.  Deliberately does NOT emit the header warning comments
+    /// (`emit_comment_func_header`) — prototype only.
+    pub fn doc_prototype(&mut self, fd: &Funcdata, arch: &Architecture) -> String {
+        self.emit.set_output_stream();
+        // Same per-function realtypes context resolution as
+        // `emit_function_document` — the type-name chokepoints read `rt_ctx`.
+        self.rt_ctx = RealTypeCtx::from_arch(arch);
+        let markup = MarkupRef::none();
+        self.emit_prototype_declaration(fd, arch, &markup);
+        self.emit.print(";", SyntaxHighlight::NoColor);
+        // C++ docFunction ends in emit->flush(); EmitNoMarkup writes straight
+        // to its sink so this is a formality (kept for harness parity).
+        let _ = self.emit.flush();
+        self.emit.output_str().to_string()
+    }
+
+    /// (kuna) C++ `PrintC::docTypeDefinitions` (decompiler/cpp/printc.cc:2779):
+    /// emit a C definition for every user-defined data-type in the factory, in
+    /// [`TypeFactoryImpl::dependent_order`](crate::dtype::TypeFactoryImpl::dependent_order)
+    /// (definition-before-use), skipping core types — the `.h` artifact of
+    /// `kuna decompile-project`.
+    ///
+    /// Documented `(kuna)` divergences from the upstream emission (which prints
+    /// one `typedef struct {…} name;` per type through the emitter):
+    ///
+    ///   * **forward-declaration block first**: every struct/union gets a
+    ///     `typedef struct <n> <n>;` up front, then bodies follow as plain
+    ///     `struct <n> { … };` in dependency order.  Upstream's anonymous
+    ///     `typedef struct {…} n;` form cannot express a self-referential or
+    ///     mutually-recursive pointer field; the tag+typedef split always can.
+    ///     An incomplete (fieldless) struct emits ONLY the forward declaration,
+    ///     annotated `/* opaque */`.
+    ///   * **padding fields**: struct field-offset gaps and trailing padding
+    ///     render as explicit `undefined1 _pad<hexoff>[N];` members so
+    ///     `sizeof(struct <n>)` matches the decompiler's layout when recompiled.
+    ///   * **name sanitisation + dedup**: a non-C identifier is rewritten
+    ///     (annotated `/* renamed from "…" */`); a later duplicate name emits
+    ///     `/* duplicate type name skipped: <n> */` instead of a redefinition.
+    ///
+    /// Emission is direct string building (no emitter markup exists for type
+    /// definitions); the per-type body renderers are pure functions
+    /// ([`compose_type_body`] etc.) for unit-testability.
+    pub fn doc_type_definitions(&mut self, arch: &Architecture) -> String {
+        let deporder = arch.types_impl().dependent_order();
+        render_type_definitions(&deporder, RealTypeCtx::from_arch(arch))
+    }
+
     /// The shared body-emission sequence of C++ `PrintC::docFunction`
     /// (printc.cc:2790), back-end-agnostic: `beginFunction` → header comment →
     /// prototype declaration → `openBraceIndent` → local var decls → block graph →
@@ -1877,23 +1933,6 @@ impl PrintC {
         // pick them up in order.
         self.setup_comments(fd, arch);
         let markup = MarkupRef::none();
-        let display = fd.get_display_name().to_string();
-        // Return type from the recovered proto output (C++ `getFuncProto().
-        // getOutputType()`), defaulting to "void".  The output storage/type is
-        // recovered by `ActionOutputPrototype` (the stand-alone `ProtoStoreInternal`
-        // path).  The TYPE NAME is the W8 `ActionInferTypes` surface: until it
-        // lands the recovered output type is the size-correct but un-inferred
-        // base (metatype UNKNOWN), rendered as `undefined<N>` — the documented
-        // residual vs. the oracle's inferred `uint1`.
-        let rt = self.rt_ctx;
-        let ret_type = if fd.get_func_proto().has_store() {
-            fd.get_func_proto()
-                .get_output_type()
-                .map(|t| type_name_for_decl(t, rt))
-                .unwrap_or_else(|| "void".to_string())
-        } else {
-            "void".to_string()
-        };
 
         let id1 = self.emit.begin_function();
         // emitCommentFuncHeader(fd): the header warning comments (C++
@@ -1904,24 +1943,9 @@ impl PrintC {
         self.emit_comment_func_header(fd, arch);
         self.emit.tag_line(); // emitCommentFuncHeader trailing tagLine
 
-        // emitFunctionDeclaration shell.
-        let idp = self.emit.begin_func_proto();
-        let idret = self.emit.begin_return_type(&markup);
-        self.emit.tag_type(&ret_type, SyntaxHighlight::TypeColor, &markup);
-        self.emit.end_return_type(idret);
-        self.emit.spaces(1, 0);
-        let id1g = self.emit.open_group();
-        self.emit.tag_func_name(&display, SyntaxHighlight::FuncnameColor, &markup);
-        let id2 = self.emit.open_paren("(", 0);
-        // emitPrototypeInputs (printc.cc:2298): the recovered proto's parameter
-        // list, or `void` when there are none.  Each `ProtoParameter` renders its
-        // declared type + name (`twostruct *ptr`, `int8 a`) via the C-declarator
-        // builder; the backing-`Symbol` path (`emitVarDecl`) is the W4 scope
-        // surface, so the param's own stored name + type are used directly.
-        self.emit_prototype_inputs(fd, arch, &markup);
-        self.emit.close_paren(")", id2);
-        self.emit.close_group(id1g);
-        self.emit.end_func_proto(idp);
+        // emitFunctionDeclaration shell (the prototype segment, shared with
+        // `doc_prototype`).
+        self.emit_prototype_declaration(fd, arch, &markup);
 
         let id = self.emit.open_brace_indent("{", to_emit_brace(self.options.brace_func));
         // emitLocalVarDecls(fd) (printc.cc:2805 / emitGlobalVarDeclsRecursive +
@@ -1947,6 +1971,61 @@ impl PrintC {
         // (kuna) Retire the scoped fd pointer (see the field doc): it is valid
         // only for this call's dynamic extent.
         self.emit_fd = None;
+    }
+
+    /// Emit the function prototype declaration (the `emitFunctionDeclaration`
+    /// shell of C++ `PrintC::docFunction`, printc.cc:2790 →
+    /// `emitFunctionDeclaration`, printc.cc:2380): the recovered return type,
+    /// the function name, and the parenthesised
+    /// [`emit_prototype_inputs`](PrintC::emit_prototype_inputs) parameter list —
+    /// `<ret> <name>(<params>)`, no trailing `;` or body.
+    ///
+    /// Pure code motion out of
+    /// [`emit_function_document`](PrintC::emit_function_document) (byte-identical
+    /// there) so [`doc_prototype`](PrintC::doc_prototype) can emit the IDENTICAL
+    /// token sequence standalone — the `.h`-prototype == `.c`-definition-line
+    /// contract of `kuna decompile-project`.
+    fn emit_prototype_declaration(
+        &mut self,
+        fd: &Funcdata,
+        arch: &Architecture,
+        markup: &MarkupRef,
+    ) {
+        let display = fd.get_display_name().to_string();
+        // Return type from the recovered proto output (C++ `getFuncProto().
+        // getOutputType()`), defaulting to "void".  The output storage/type is
+        // recovered by `ActionOutputPrototype` (the stand-alone `ProtoStoreInternal`
+        // path).  The TYPE NAME is the W8 `ActionInferTypes` surface: until it
+        // lands the recovered output type is the size-correct but un-inferred
+        // base (metatype UNKNOWN), rendered as `undefined<N>` — the documented
+        // residual vs. the oracle's inferred `uint1`.
+        let rt = self.rt_ctx;
+        let ret_type = if fd.get_func_proto().has_store() {
+            fd.get_func_proto()
+                .get_output_type()
+                .map(|t| type_name_for_decl(t, rt))
+                .unwrap_or_else(|| "void".to_string())
+        } else {
+            "void".to_string()
+        };
+
+        let idp = self.emit.begin_func_proto();
+        let idret = self.emit.begin_return_type(markup);
+        self.emit.tag_type(&ret_type, SyntaxHighlight::TypeColor, markup);
+        self.emit.end_return_type(idret);
+        self.emit.spaces(1, 0);
+        let id1g = self.emit.open_group();
+        self.emit.tag_func_name(&display, SyntaxHighlight::FuncnameColor, markup);
+        let id2 = self.emit.open_paren("(", 0);
+        // emitPrototypeInputs (printc.cc:2298): the recovered proto's parameter
+        // list, or `void` when there are none.  Each `ProtoParameter` renders its
+        // declared type + name (`twostruct *ptr`, `int8 a`) via the C-declarator
+        // builder; the backing-`Symbol` path (`emitVarDecl`) is the W4 scope
+        // surface, so the param's own stored name + type are used directly.
+        self.emit_prototype_inputs(fd, arch, markup);
+        self.emit.close_paren(")", id2);
+        self.emit.close_group(id1g);
+        self.emit.end_func_proto(idp);
     }
 
     /// Emit the function's header warning comments (C++
@@ -6968,6 +7047,291 @@ pub fn type_to_c_string(
 ) -> String {
     let (front, back) = declarator_parts(ct, RealTypeCtx::from_arch(arch));
     format!("{front}{back}")
+}
+
+// ===========================================================================
+// (kuna) `doc_type_definitions` rendering helpers — the pure per-type body
+// renderers behind the `docTypeDefinitions` port (see
+// `PrintC::doc_type_definitions` for the emission shape + divergences).  All
+// take an explicit `RealTypeCtx` and hand-built `Datatype`s so they unit-test
+// without an `Architecture`.
+// ===========================================================================
+
+/// (kuna) Rewrite `name` into a valid C identifier: every character outside
+/// `[A-Za-z0-9_]` becomes `_`, and a leading digit gains a `_` prefix.
+/// Borrowed unchanged when already valid (the caller emits a
+/// `/* renamed from "…" */` comment when it changed).
+fn sanitize_type_name(name: &str) -> std::borrow::Cow<'_, str> {
+    let ok_char = |c: char| c.is_ascii_alphanumeric() || c == '_';
+    let clean = !name.is_empty()
+        && name.chars().all(ok_char)
+        && !name.starts_with(|c: char| c.is_ascii_digit());
+    if clean {
+        return std::borrow::Cow::Borrowed(name);
+    }
+    let mut s = String::with_capacity(name.len() + 1);
+    if name.starts_with(|c: char| c.is_ascii_digit()) {
+        s.push('_');
+    }
+    for c in name.chars() {
+        s.push(if ok_char(c) { c } else { '_' });
+    }
+    std::borrow::Cow::Owned(s)
+}
+
+/// (kuna) One member declaration `<front><name><back>` via the C-declarator
+/// builder [`declarator_parts`] — the same front/name spacing rule the emit
+/// loop uses (`a `*` front glues to the identifier with no space).
+fn field_decl_text(
+    ct: &std::rc::Rc<crate::dtype::Datatype>,
+    name: &str,
+    rt: RealTypeCtx,
+) -> String {
+    let (front, back) = declarator_parts(ct, rt);
+    let sep = if front.ends_with('*') || name.is_empty() { "" } else { " " };
+    format!("{front}{sep}{name}{back}")
+}
+
+/// (kuna) The unsigned C integer spelling for a byte size (the empty-enum /
+/// fallback scalar spelling; 8 covers any larger size best-effort).
+fn unsigned_c_int_of_size(size: int4) -> &'static str {
+    match size {
+        1 => "unsigned char",
+        2 => "unsigned short",
+        4 => "unsigned int",
+        _ => "unsigned long long",
+    }
+}
+
+/// (kuna) Render ONE complete composite (struct/union) body definition —
+/// `struct <name> { … };` — as a pure function of the data-type.
+///
+/// Struct field-offset gaps and trailing padding (vs `get_size()`) become
+/// explicit `undefined1 _pad<hexoff>[N];` members.  Bitfields render
+/// best-effort as `<type> <name> : <bits>;` with padding suppressed (their
+/// byte coverage overlaps the gap computation).  Unions carry no padding.
+/// Returns `""` for a non-composite kind.
+fn compose_type_body(
+    ct: &std::rc::Rc<crate::dtype::Datatype>,
+    name: &str,
+    rt: RealTypeCtx,
+) -> String {
+    use crate::dtype::DatatypeKind;
+    let mut out = String::new();
+    match &ct.kind {
+        DatatypeKind::Struct { field, bitfield } => {
+            out.push_str(&format!("struct {name} {{\n"));
+            let have_bits = !bitfield.is_empty();
+            let mut cur: int4 = 0;
+            for f in field {
+                if !have_bits && f.offset > cur {
+                    out.push_str(&format!(
+                        "    undefined1 _pad{:x}[{}];\n",
+                        cur,
+                        f.offset - cur
+                    ));
+                }
+                let fname = sanitize_type_name(&f.name);
+                out.push_str(&format!(
+                    "    {};\n",
+                    field_decl_text(&f.field_type, &fname, rt)
+                ));
+                cur = cur.max(f.offset + f.field_type.get_size());
+            }
+            if have_bits {
+                out.push_str(
+                    "    /* bitfields (byte layout approximate; padding omitted) */\n",
+                );
+                for bf in bitfield {
+                    let bname = sanitize_type_name(&bf.name);
+                    out.push_str(&format!(
+                        "    {} : {};\n",
+                        field_decl_text(&bf.field_type, &bname, rt),
+                        bf.num_bits
+                    ));
+                }
+            } else if ct.get_size() > cur {
+                out.push_str(&format!(
+                    "    undefined1 _pad{:x}[{}];\n",
+                    cur,
+                    ct.get_size() - cur
+                ));
+            }
+            out.push_str("};\n");
+        }
+        DatatypeKind::Union { field } => {
+            out.push_str(&format!("union {name} {{\n"));
+            for f in field {
+                let fname = sanitize_type_name(&f.name);
+                out.push_str(&format!(
+                    "    {};\n",
+                    field_decl_text(&f.field_type, &fname, rt)
+                ));
+            }
+            out.push_str("};\n");
+        }
+        _ => {}
+    }
+    out
+}
+
+/// (kuna) Render ONE enum definition — `typedef enum <name> { A = <v>, … }
+/// <name>;` — from the `TypeEnum` namemap.  A `TYPE_INT`-facing enum (the
+/// decode-time `TYPE_ENUM_INT` form) prints signed decimal values
+/// (sign-extended by the enum's byte size); the `TYPE_UINT` form prints hex.
+/// An empty namemap falls back to a plain integer typedef (an empty `enum {}`
+/// is not valid C).
+fn compose_enum_body(ct: &std::rc::Rc<crate::dtype::Datatype>, name: &str) -> String {
+    use crate::dtype::type_metatype;
+    let Some(nmap) = ct.as_enum_namemap() else {
+        return String::new();
+    };
+    let size = ct.get_size();
+    if nmap.is_empty() {
+        return format!(
+            "typedef {} {name}; /* empty enum */\n",
+            unsigned_c_int_of_size(size)
+        );
+    }
+    let signed = ct.get_metatype() == type_metatype::TYPE_INT;
+    let mut out = format!("typedef enum {name} {{\n");
+    let n = nmap.len();
+    for (i, (val, ename)) in nmap.iter().enumerate() {
+        let ename = sanitize_type_name(ename);
+        let vtxt = if signed && size > 0 && size <= 8 {
+            format!("{}", kuna_base::address::sign_extend(*val as i64, size * 8 - 1))
+        } else {
+            format!("0x{val:x}")
+        };
+        let comma = if i + 1 < n { "," } else { "" };
+        out.push_str(&format!("    {ename} = {vtxt}{comma}\n"));
+    }
+    out.push_str(&format!("}} {name};\n"));
+    out
+}
+
+/// (kuna) Render ONE typedef — `typedef <declarator around name>;` — of the
+/// typedef's immediate base type (`get_typedef()`), via the C-declarator
+/// builder (so `typedef char *mystr;` and array typedefs lay out correctly).
+fn compose_typedef_line(
+    base: &std::rc::Rc<crate::dtype::Datatype>,
+    name: &str,
+    rt: RealTypeCtx,
+) -> String {
+    format!("typedef {};\n", field_decl_text(base, name, rt))
+}
+
+/// (kuna) The full `docTypeDefinitions` walk over an already
+/// dependency-ordered type list (see
+/// [`PrintC::doc_type_definitions`](PrintC::doc_type_definitions) for the
+/// shape + divergence notes): pass 1 emits the struct/union forward-declaration
+/// block, pass 2 the bodies (struct/union/enum/typedef) in dependency order.
+/// Pure over the input slice for unit-testability.
+fn render_type_definitions(
+    deporder: &[std::rc::Rc<crate::dtype::Datatype>],
+    rt: RealTypeCtx,
+) -> String {
+    use crate::dtype::{Datatype, DatatypeKind};
+    use std::collections::HashSet;
+    use std::rc::Rc;
+
+    let is_composite = |ct: &Rc<Datatype>| {
+        matches!(&ct.kind, DatatypeKind::Struct { .. } | DatatypeKind::Union { .. })
+    };
+    // A type this emitter renders: user-defined (non-core), named, not an
+    // internal partial (`has_stripped`), and a typedef / struct / union / enum.
+    let relevant = |ct: &Rc<Datatype>| {
+        !ct.is_core_type()
+            && !ct.get_name().is_empty()
+            && !ct.has_stripped()
+            && (ct.get_typedef().is_some() || is_composite(ct) || ct.is_enum_type())
+    };
+
+    // Which sanitized composite tag names have a COMPLETE definition somewhere
+    // (drives the `/* opaque */` annotation on forward-only names).
+    let mut complete_names: HashSet<String> = HashSet::new();
+    for ct in deporder {
+        if relevant(ct) && is_composite(ct) && ct.get_typedef().is_none() && !ct.is_incomplete()
+        {
+            complete_names.insert(sanitize_type_name(ct.get_name()).into_owned());
+        }
+    }
+
+    let mut out = String::new();
+
+    // -- Pass 1: the forward-declaration block (every struct/union tag). -----
+    let mut fwd: HashSet<String> = HashSet::new();
+    for ct in deporder {
+        if !relevant(ct) || !is_composite(ct) || ct.get_typedef().is_some() {
+            continue;
+        }
+        let raw = ct.get_name();
+        let name = sanitize_type_name(raw);
+        if !fwd.insert(name.to_string()) {
+            continue; // one forward declaration per tag name
+        }
+        let kw = if matches!(&ct.kind, DatatypeKind::Union { .. }) { "union" } else { "struct" };
+        out.push_str(&format!("typedef {kw} {name} {name};"));
+        if name != raw {
+            out.push_str(&format!(" /* renamed from \"{raw}\" */"));
+        }
+        if !complete_names.contains(name.as_ref()) {
+            out.push_str(" /* opaque */");
+        }
+        out.push('\n');
+    }
+    if !fwd.is_empty() {
+        out.push('\n');
+    }
+
+    // -- Pass 2: bodies in dependency order. ---------------------------------
+    let mut defined: HashSet<String> = HashSet::new();
+    for ct in deporder {
+        if !relevant(ct) {
+            continue;
+        }
+        let raw = ct.get_name();
+        let name = sanitize_type_name(raw);
+        if let Some(base) = ct.get_typedef() {
+            // A typedef (of anything, including a composite clone — checked
+            // FIRST since the clone carries the base's kind).  The struct-tag
+            // forward typedef already claims its own name, so a same-named
+            // typedef-of-struct is exactly that declaration — skip as a dup.
+            if fwd.contains(name.as_ref()) || !defined.insert(name.to_string()) {
+                out.push_str(&format!("/* duplicate type name skipped: {name} */\n"));
+                continue;
+            }
+            if name != raw {
+                out.push_str(&format!("/* renamed from \"{raw}\" */\n"));
+            }
+            out.push_str(&compose_typedef_line(base, &name, rt));
+            out.push('\n');
+        } else if is_composite(ct) {
+            if ct.is_incomplete() {
+                continue; // forward-declared only (`/* opaque */`)
+            }
+            if !defined.insert(name.to_string()) {
+                out.push_str(&format!("/* duplicate type name skipped: {name} */\n"));
+                continue;
+            }
+            if name != raw {
+                out.push_str(&format!("/* renamed from \"{raw}\" */\n"));
+            }
+            out.push_str(&compose_type_body(ct, &name, rt));
+            out.push('\n');
+        } else if ct.is_enum_type() {
+            if fwd.contains(name.as_ref()) || !defined.insert(name.to_string()) {
+                out.push_str(&format!("/* duplicate type name skipped: {name} */\n"));
+                continue;
+            }
+            if name != raw {
+                out.push_str(&format!("/* renamed from \"{raw}\" */\n"));
+            }
+            out.push_str(&compose_enum_body(ct, &name));
+            out.push('\n');
+        }
+    }
+    out
 }
 
 /// The type-token text for a local declaration.  Mirrors C++ `pushTypeStart`

--- a/decompiler/crates/kuna-decomp/src/p9_emit/printc/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/printc/tests.rs
@@ -188,6 +188,327 @@ mod w10_input_prototype_declarator {
     }
 }
 
+// ===========================================================================
+// (kuna decompile-project) `doc_type_definitions` pure renderers —
+// `compose_type_body` / `compose_enum_body` / `render_type_definitions` /
+// `sanitize_type_name` over hand-built Datatypes + `RealTypeCtx::OFF` (the
+// same pattern as `w10_input_prototype_declarator` above).
+// ===========================================================================
+mod decompile_project_type_render {
+    use crate::dtype::{flags, type_metatype, Datatype, DatatypeKind, TypeField};
+    use crate::printc::{
+        compose_enum_body, compose_type_body, render_type_definitions, sanitize_type_name,
+        RealTypeCtx,
+    };
+    use std::rc::Rc;
+
+    fn named(size: i32, m: type_metatype, nm: &str) -> Rc<Datatype> {
+        let mut t = Datatype::new_with_align(size, -1, m);
+        t.name = nm.to_string();
+        t.display_name = nm.to_string();
+        t.id = Datatype::hash_name(nm);
+        Rc::new(t)
+    }
+
+    fn ptr_to(ptrto: Rc<Datatype>) -> Rc<Datatype> {
+        let mut p = Datatype::new_with_align(8, -1, type_metatype::TYPE_PTR);
+        p.kind = DatatypeKind::Pointer { ptrto, spaceid: None, truncate: None, wordsize: 1 };
+        Rc::new(p)
+    }
+
+    fn array_of(arrayof: Rc<Datatype>, n: i32) -> Rc<Datatype> {
+        let elt = arrayof.get_size().max(1);
+        let mut a = Datatype::new_with_align(elt * n, -1, type_metatype::TYPE_ARRAY);
+        a.kind = DatatypeKind::Array { arrayof, arraysize: n };
+        Rc::new(a)
+    }
+
+    /// A complete named struct with the given (offset, name, type) fields and
+    /// total size.
+    fn struct_of(nm: &str, size: i32, fields: &[(i32, &str, Rc<Datatype>)]) -> Rc<Datatype> {
+        let mut s = Datatype::new_with_align(size, -1, type_metatype::TYPE_STRUCT);
+        s.name = nm.to_string();
+        s.display_name = nm.to_string();
+        s.id = Datatype::hash_name(nm);
+        s.kind = DatatypeKind::Struct {
+            field: fields
+                .iter()
+                .enumerate()
+                .map(|(i, (off, fnm, ft))| TypeField::new(i as i32, *off, *fnm, Rc::clone(ft)))
+                .collect(),
+            bitfield: vec![],
+        };
+        Rc::new(s)
+    }
+
+    fn make_enum(nm: &str, size: i32, m: type_metatype, entries: &[(u64, &str)]) -> Rc<Datatype> {
+        let mut dt = Datatype::new_with_align(size, size, m);
+        dt.name = nm.to_string();
+        dt.display_name = nm.to_string();
+        dt.id = Datatype::hash_name(nm);
+        dt.flags |= flags::enumtype;
+        let mut namemap = std::collections::BTreeMap::new();
+        for (v, n) in entries {
+            namemap.insert(*v, (*n).to_string());
+        }
+        dt.kind = DatatypeKind::Enum { namemap };
+        Rc::new(dt)
+    }
+
+    /// Struct body with a scalar, a pointer, an array, an interior padding gap
+    /// AND trailing padding: every member/padding shape at once.
+    #[test]
+    fn struct_body_scalar_pointer_array_gap_trailing_pad() {
+        let i4 = named(4, type_metatype::TYPE_INT, "int4");
+        let ch = named(1, type_metatype::TYPE_INT, "char");
+        // struct mystruct { int4 a@0; <gap 4>; char *p@8; int4 arr[4]@16;
+        //                   <trailing pad 8> } size 40.
+        let s = struct_of(
+            "mystruct",
+            40,
+            &[
+                (0, "a", Rc::clone(&i4)),
+                (8, "p", ptr_to(ch)),
+                (16, "arr", array_of(i4, 4)),
+            ],
+        );
+        let body = compose_type_body(&s, "mystruct", RealTypeCtx::OFF);
+        assert_eq!(
+            body,
+            "struct mystruct {\n\
+             \x20   int4 a;\n\
+             \x20   undefined1 _pad4[4];\n\
+             \x20   char *p;\n\
+             \x20   int4 arr[4];\n\
+             \x20   undefined1 _pad20[8];\n\
+             };\n",
+            "struct body: scalar + gap pad + glued pointer + array tail + trailing pad"
+        );
+    }
+
+    /// Union body: every field at offset 0, NO padding members.
+    #[test]
+    fn union_body_no_padding() {
+        let i4 = named(4, type_metatype::TYPE_INT, "int4");
+        let f8 = named(8, type_metatype::TYPE_FLOAT, "float8");
+        let mut u = Datatype::new_with_align(8, -1, type_metatype::TYPE_UNION);
+        u.name = "myunion".to_string();
+        u.display_name = "myunion".to_string();
+        u.id = Datatype::hash_name("myunion");
+        u.kind = DatatypeKind::Union {
+            field: vec![
+                TypeField::new(0, 0, "as_int", i4),
+                TypeField::new(1, 0, "as_float", f8),
+            ],
+        };
+        let u = Rc::new(u);
+        let body = compose_type_body(&u, "myunion", RealTypeCtx::OFF);
+        assert_eq!(
+            body,
+            "union myunion {\n\
+             \x20   int4 as_int;\n\
+             \x20   float8 as_float;\n\
+             };\n"
+        );
+        assert!(!body.contains("_pad"), "unions carry no padding members");
+    }
+
+    /// Enum values: the TYPE_INT (decode-time TYPE_ENUM_INT) form prints
+    /// SIGNED decimal sign-extended by the enum size; the TYPE_UINT form hex.
+    #[test]
+    fn enum_signed_and_unsigned_value_forms() {
+        // Signed 4-byte enum: 0xffffffff sign-extends to -1.
+        let se = make_enum(
+            "serrs",
+            4,
+            type_metatype::TYPE_INT,
+            &[(0, "OK"), (0xffff_ffff, "FAIL")],
+        );
+        let body = compose_enum_body(&se, "serrs");
+        assert_eq!(
+            body,
+            "typedef enum serrs {\n\
+             \x20   OK = 0,\n\
+             \x20   FAIL = -1\n\
+             } serrs;\n"
+        );
+        // Unsigned 4-byte enum: hex values.
+        let ue = make_enum(
+            "uflags",
+            4,
+            type_metatype::TYPE_UINT,
+            &[(0x1, "LO"), (0x80, "HI")],
+        );
+        let body = compose_enum_body(&ue, "uflags");
+        assert_eq!(
+            body,
+            "typedef enum uflags {\n\
+             \x20   LO = 0x1,\n\
+             \x20   HI = 0x80\n\
+             } uflags;\n"
+        );
+    }
+
+    /// A typedef renders through the declarator builder; a plain scalar
+    /// typedef and a pointer typedef both lay out correctly.
+    #[test]
+    fn typedef_renders_via_declarator() {
+        let i4 = named(4, type_metatype::TYPE_INT, "int4");
+        let td = {
+            let mut t = (*i4).clone();
+            t.name = "myint".to_string();
+            t.display_name = "myint".to_string();
+            t.id = Datatype::hash_name("myint");
+            t.typedef_imm = Some(Rc::clone(&i4));
+            Rc::new(t)
+        };
+        let out = render_type_definitions(&[Rc::clone(&i4), Rc::clone(&td)], RealTypeCtx::OFF);
+        assert!(
+            out.contains("typedef int4 myint;\n"),
+            "scalar typedef line missing:\n{out}"
+        );
+        // Pointer typedef: `typedef char *mystr;` (the `*` glues to the name).
+        let ch = named(1, type_metatype::TYPE_INT, "char");
+        let pstr = ptr_to(ch);
+        let tdp = {
+            let mut t = (*pstr).clone();
+            t.name = "mystr".to_string();
+            t.display_name = "mystr".to_string();
+            t.id = Datatype::hash_name("mystr");
+            t.typedef_imm = Some(Rc::clone(&pstr));
+            Rc::new(t)
+        };
+        let out = render_type_definitions(&[tdp], RealTypeCtx::OFF);
+        assert!(
+            out.contains("typedef char *mystr;\n"),
+            "pointer typedef line missing:\n{out}"
+        );
+    }
+
+    /// An INCOMPLETE struct emits ONLY the forward declaration, annotated
+    /// `/* opaque */` — never a body.  A complete struct gets forward decl
+    /// (un-annotated) FIRST, then its body.
+    #[test]
+    fn incomplete_struct_forward_decl_only() {
+        let i4 = named(4, type_metatype::TYPE_INT, "int4");
+        let complete = struct_of("solid", 4, &[(0, "a", i4)]);
+        let opaque = {
+            let mut s = Datatype::new_with_align(1, -1, type_metatype::TYPE_STRUCT);
+            s.name = "mystery".to_string();
+            s.display_name = "mystery".to_string();
+            s.id = Datatype::hash_name("mystery");
+            s.flags |= flags::type_incomplete;
+            s.kind = DatatypeKind::Struct { field: vec![], bitfield: vec![] };
+            Rc::new(s)
+        };
+        let out =
+            render_type_definitions(&[Rc::clone(&opaque), Rc::clone(&complete)], RealTypeCtx::OFF);
+        assert!(
+            out.contains("typedef struct mystery mystery; /* opaque */\n"),
+            "opaque forward decl missing:\n{out}"
+        );
+        assert!(!out.contains("struct mystery {"), "opaque struct must have NO body:\n{out}");
+        assert!(
+            out.contains("typedef struct solid solid;\n"),
+            "complete struct forward decl missing (and must not be /* opaque */):\n{out}"
+        );
+        assert!(out.contains("struct solid {"), "complete struct body missing:\n{out}");
+        // Forward-decl block precedes ALL bodies (the self-reference guarantee).
+        let fwd_pos = out.find("typedef struct solid").unwrap();
+        let body_pos = out.find("struct solid {").unwrap();
+        assert!(fwd_pos < body_pos, "forward declarations must precede bodies:\n{out}");
+    }
+
+    /// Name sanitisation: non-identifier characters become `_` (with the
+    /// `/* renamed from … */` note); a digit-first name gains a `_` prefix.
+    #[test]
+    fn sanitize_type_names() {
+        assert_eq!(sanitize_type_name("good_Name2"), "good_Name2");
+        assert!(matches!(
+            sanitize_type_name("good_Name2"),
+            std::borrow::Cow::Borrowed(_)
+        ));
+        assert_eq!(sanitize_type_name("bad-name$1"), "bad_name_1");
+        assert_eq!(sanitize_type_name("9lives"), "_9lives");
+        assert_eq!(sanitize_type_name("std::vector<int>"), "std__vector_int_");
+
+        let i4 = named(4, type_metatype::TYPE_INT, "int4");
+        let s = struct_of("bad-name$1", 4, &[(0, "a", i4)]);
+        let out = render_type_definitions(&[s], RealTypeCtx::OFF);
+        assert!(
+            out.contains(
+                "typedef struct bad_name_1 bad_name_1; /* renamed from \"bad-name$1\" */"
+            ),
+            "renamed forward decl missing:\n{out}"
+        );
+        assert!(out.contains("struct bad_name_1 {"), "renamed body missing:\n{out}");
+    }
+
+    /// Duplicate type names: the FIRST definition wins; a later same-named
+    /// complete type emits only the `/* duplicate type name skipped */` note.
+    #[test]
+    fn duplicate_type_name_first_wins() {
+        let i4 = named(4, type_metatype::TYPE_INT, "int4");
+        let i8t = named(8, type_metatype::TYPE_INT, "int8");
+        let first = struct_of("dup", 4, &[(0, "a", i4)]);
+        let second = struct_of("dup", 8, &[(0, "b", i8t)]);
+        let out = render_type_definitions(&[first, second], RealTypeCtx::OFF);
+        assert_eq!(
+            out.matches("typedef struct dup dup;").count(),
+            1,
+            "exactly one forward decl for the shared tag:\n{out}"
+        );
+        assert_eq!(
+            out.matches("struct dup {").count(),
+            1,
+            "exactly one body for the shared tag:\n{out}"
+        );
+        assert!(out.contains("int4 a;"), "the FIRST definition's body wins:\n{out}");
+        assert!(!out.contains("int8 b;"), "the second definition must be skipped:\n{out}");
+        assert!(
+            out.contains("/* duplicate type name skipped: dup */"),
+            "duplicate note missing:\n{out}"
+        );
+    }
+
+    /// Core types and unnamed types never render; an enum name colliding with
+    /// a struct tag is skipped as a duplicate (the tag's forward typedef
+    /// already claims the identifier).
+    #[test]
+    fn core_unnamed_and_cross_kind_collisions_skipped() {
+        // A core type (flagged) is skipped even though it is a composite.
+        let i4 = named(4, type_metatype::TYPE_INT, "int4");
+        let core_struct = {
+            let s = struct_of("sys", 4, &[(0, "a", Rc::clone(&i4))]);
+            let mut c = (*s).clone();
+            c.flags |= flags::coretype;
+            Rc::new(c)
+        };
+        // An unnamed struct is skipped.
+        let anon = {
+            let mut s = Datatype::new_with_align(4, -1, type_metatype::TYPE_STRUCT);
+            s.kind = DatatypeKind::Struct {
+                field: vec![TypeField::new(0, 0, "a", Rc::clone(&i4))],
+                bitfield: vec![],
+            };
+            Rc::new(s)
+        };
+        let named_struct = struct_of("tagged", 4, &[(0, "a", Rc::clone(&i4))]);
+        let colliding_enum = make_enum("tagged", 4, type_metatype::TYPE_UINT, &[(1, "ONE")]);
+        let out = render_type_definitions(
+            &[core_struct, anon, Rc::clone(&named_struct), colliding_enum],
+            RealTypeCtx::OFF,
+        );
+        assert!(!out.contains("sys"), "core types must be skipped:\n{out}");
+        assert!(out.contains("struct tagged {"), "named struct body missing:\n{out}");
+        assert!(
+            out.contains("/* duplicate type name skipped: tagged */"),
+            "enum colliding with a struct tag must be skipped as a duplicate:\n{out}"
+        );
+        assert!(!out.contains("typedef enum tagged"), "colliding enum must not define:\n{out}");
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Operator token table (printc.cc:24-78)
 // ---------------------------------------------------------------------------

--- a/decompiler/crates/kuna-decomp/src/substrate/dtype.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/dtype.rs
@@ -1898,8 +1898,9 @@ impl Datatype {
     }
 
     /// Borrow a `TypeEnum`'s `namemap`, used where the C++ casts `&op` to
-    /// `TypeEnum *`.  `None` if not an enum.
-    fn as_enum_namemap(&self) -> Option<&std::collections::BTreeMap<u64, String>> {
+    /// `TypeEnum *`.  `None` if not an enum.  `pub(crate)` for the enum body
+    /// rendering in [`crate::printc`] (`doc_type_definitions`).
+    pub(crate) fn as_enum_namemap(&self) -> Option<&std::collections::BTreeMap<u64, String>> {
         match &self.kind {
             DatatypeKind::Enum { namemap } => Some(namemap),
             _ => None,
@@ -4826,6 +4827,62 @@ impl TypeFactoryImpl {
         Ok(())
     }
 
+    // -- Dependency ordering (type.cc:3745-3773) ------------------------------
+
+    /// Place all interned data-types in dependency order (C++
+    /// `TypeFactory::dependentOrder`, decompiler/cpp/type.cc): every data-type
+    /// is preceded by the types it depends on (its typedef base and its
+    /// component sub-types), so a definition-before-use walk (e.g. emitting C
+    /// type definitions, `PrintC::docTypeDefinitions`) can consume the list
+    /// front to back.
+    ///
+    /// The interning `tree` itself is ordered by `compareDependency` — submeta,
+    /// then *descending* size ([`Datatype::compare_dependency_base`]) — which is
+    /// NOT definition-before-use (a struct containing another struct by value
+    /// sorts *before* its component); hence this explicit postorder DFS.
+    pub fn dependent_order(&self) -> Vec<Rc<Datatype>> {
+        // Snapshot the tree contents so the recursion never holds the store
+        // borrow (the same pattern as `cache_core_types`).
+        let entries: Vec<Rc<Datatype>> = {
+            let store = self.store.borrow();
+            store.tree.iter().map(|k| Rc::clone(&k.0)).collect()
+        };
+        let mut deporder: Vec<Rc<Datatype>> = Vec::with_capacity(entries.len());
+        let mut mark: std::collections::HashSet<*const Datatype> =
+            std::collections::HashSet::new();
+        for ct in &entries {
+            Self::order_recurse(&mut deporder, &mut mark, ct);
+        }
+        deporder
+    }
+
+    /// Make sure the dependents of `ct` are in the order list, then add `ct`
+    /// (C++ `TypeFactory::orderRecurse`, decompiler/cpp/type.cc).  The mark set
+    /// keys on `Rc::as_ptr` object identity — the same identity
+    /// [`Datatype::compare_dependency_ptr`] orders by — so a pointer cycle
+    /// (`struct A { struct B *b; }; struct B { struct A *a; };`) terminates
+    /// with each data-type appearing exactly once.
+    fn order_recurse(
+        deporder: &mut Vec<Rc<Datatype>>,
+        mark: &mut std::collections::HashSet<*const Datatype>,
+        ct: &Rc<Datatype>,
+    ) {
+        if !mark.insert(Rc::as_ptr(ct)) {
+            return; // Already inserted before
+        }
+        if let Some(td) = ct.get_typedef() {
+            let td = Rc::clone(td);
+            Self::order_recurse(deporder, mark, &td);
+        }
+        let size = ct.num_depend();
+        for i in 0..size {
+            if let Some(dep) = ct.get_depend(i) {
+                Self::order_recurse(deporder, mark, &dep);
+            }
+        }
+        deporder.push(Rc::clone(ct));
+    }
+
     // -- Atomic / core getters (type.cc:4056-4198) ---------------------------
 
     /// Get the unique "void" data-type (C++ `TypeFactory::getTypeVoid`,
@@ -6920,6 +6977,150 @@ mod tests {
             Some(4),
             "high slice records its byte offset into the parent enum"
         );
+    }
+
+    /// `TypeFactory::dependentOrder` (type.cc) puts a component BEFORE its
+    /// container: for `struct outer { struct inner in_; ... }` the postorder
+    /// DFS yields `inner` before `outer`, while the raw interning `tree`
+    /// (ordered by `compareDependency`: submeta, then DESCENDING size) has
+    /// `outer` (size 16) before `inner` (size 8) — emitting C definitions in
+    /// raw tree order would use `inner` before defining it.  This pins WHY the
+    /// explicit DFS exists.
+    #[test]
+    fn dependent_order_nested_struct() {
+        use type_metatype::*;
+        let f = factory();
+        let i4 = f.get_base(4, TYPE_INT).unwrap();
+        // struct inner { int4 a@0; int4 b@4; } (size 8).
+        let inner = {
+            let mut s = Datatype::new_with_align(8, 4, TYPE_STRUCT);
+            s.name = "inner".to_string();
+            s.display_name = "inner".to_string();
+            s.id = Datatype::hash_name("inner");
+            s.kind = DatatypeKind::Struct {
+                field: vec![
+                    TypeField::new(0, 0, "a", Rc::clone(&i4)),
+                    TypeField::new(1, 4, "b", Rc::clone(&i4)),
+                ],
+                bitfield: vec![],
+            };
+            f.find_add(s).unwrap()
+        };
+        // struct outer { inner in_@0; int4 c@8; int4 d@12; } (size 16) —
+        // contains inner BY VALUE.
+        let outer = {
+            let mut s = Datatype::new_with_align(16, 4, TYPE_STRUCT);
+            s.name = "outer".to_string();
+            s.display_name = "outer".to_string();
+            s.id = Datatype::hash_name("outer");
+            s.kind = DatatypeKind::Struct {
+                field: vec![
+                    TypeField::new(0, 0, "in_", Rc::clone(&inner)),
+                    TypeField::new(1, 8, "c", Rc::clone(&i4)),
+                    TypeField::new(2, 12, "d", Rc::clone(&i4)),
+                ],
+                bitfield: vec![],
+            };
+            f.find_add(s).unwrap()
+        };
+
+        // The raw tree order is BROKEN for definition-before-use: same submeta,
+        // descending size puts the bigger `outer` first.
+        let tree_pos = |t: &Rc<Datatype>| {
+            f.store
+                .borrow()
+                .tree
+                .iter()
+                .position(|k| Rc::ptr_eq(&k.0, t))
+                .expect("struct is interned in the tree")
+        };
+        assert!(
+            tree_pos(&outer) < tree_pos(&inner),
+            "precondition: raw compareDependency tree order has outer (size 16) \
+             before inner (size 8) — the order the DFS must correct"
+        );
+
+        // dependentOrder: the component precedes its container.
+        let order = f.dependent_order();
+        let pos = |t: &Rc<Datatype>| {
+            order.iter().position(|c| Rc::ptr_eq(c, t)).expect("type is in dependentOrder")
+        };
+        assert!(
+            pos(&inner) < pos(&outer),
+            "dependentOrder must place inner before the outer struct containing it"
+        );
+        assert!(pos(&i4) < pos(&inner), "the int4 component precedes inner");
+        // Every interned tree entry appears in the order (the C++ walk seeds
+        // from every tree node).
+        let store = f.store.borrow();
+        for k in store.tree.iter() {
+            assert!(
+                order.iter().any(|c| Rc::ptr_eq(c, &k.0)),
+                "tree entry `{}` missing from dependentOrder",
+                k.0.get_name()
+            );
+        }
+    }
+
+    /// `dependentOrder` on a POINTER CYCLE (`struct A { B *pb; }; struct B
+    /// { A *pa; };`, built through the real incomplete-struct + assignRawFields
+    /// flow) terminates — the `Rc::as_ptr` mark set breaks the cycle — and each
+    /// data-type object appears exactly once.
+    #[test]
+    fn dependent_order_pointer_cycle() {
+        use type_metatype::*;
+        let f = factory();
+        // The real construction flow: two incomplete structs, mutual pointers,
+        // then complete each with a field pointing at the other.
+        let a0 = f.get_type_struct("cycA").unwrap();
+        let b0 = f.get_type_struct("cycB").unwrap();
+        let pb = f.get_type_pointer(8, Rc::clone(&b0), 1).unwrap();
+        let pa = f.get_type_pointer(8, Rc::clone(&a0), 1).unwrap();
+        let a1 = f
+            .assign_raw_fields_struct(
+                &a0,
+                vec![TypeField::new(0, -1, "next_b", Rc::clone(&pb))],
+                vec![],
+            )
+            .unwrap();
+        let b1 = f
+            .assign_raw_fields_struct(
+                &b0,
+                vec![TypeField::new(0, -1, "next_a", Rc::clone(&pa))],
+                vec![],
+            )
+            .unwrap();
+
+        // Terminates (would loop forever without the mark set) and each object
+        // appears EXACTLY once.
+        let order = f.dependent_order();
+        let mut seen: std::collections::HashSet<*const Datatype> =
+            std::collections::HashSet::new();
+        for ct in &order {
+            assert!(
+                seen.insert(Rc::as_ptr(ct)),
+                "data-type `{}` appears twice in dependentOrder",
+                ct.get_name()
+            );
+        }
+        // The completed structs and both pointers are all present.
+        for (what, t) in
+            [("cycA", &a1), ("cycB", &b1), ("cycA *", &pa), ("cycB *", &pb)]
+        {
+            assert!(
+                order.iter().any(|c| Rc::ptr_eq(c, t)),
+                "`{what}` missing from dependentOrder"
+            );
+        }
+        // Every interned tree entry made it into the order.
+        let store = f.store.borrow();
+        for k in store.tree.iter() {
+            assert!(
+                order.iter().any(|c| Rc::ptr_eq(c, &k.0)),
+                "tree entry `{}` missing from dependentOrder",
+                k.0.get_name()
+            );
+        }
     }
 
     /// `getPtrToFromParent` (type.cc:3157-3171) walks `getSubType` down a container

--- a/decompiler/crates/kuna-decomp/tests/verify_decompile_project_emit.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_decompile_project_emit.rs
@@ -1,0 +1,347 @@
+//! END-TO-END verification for the `kuna decompile-project` engine emitters
+//! (`doc_prototype` / `doc_type_definitions` / the recompile prelude):
+//!
+//!   1. **The `.h`/`.c` identity contract**: for real decompiled corpus
+//!      functions, [`print_c_prototype`]'s output minus its trailing `;`
+//!      appears CHAR-FOR-CHAR as the prototype segment inside the full
+//!      [`print_c`] render of the same `Funcdata` — `doc_prototype` drives the
+//!      IDENTICAL `emit_prototype_declaration` token sequence
+//!      `emit_function_document` does (pure code motion), so the two can never
+//!      drift.
+//!   2. **The `.h` type block**: [`print_c_recompile_prelude`] emits the core
+//!      scalar + `undefined`-family typedefs, and [`print_c_types`] renders
+//!      user types interned in the LIVE architecture's factory (forward-decl
+//!      block first, bodies in `dependent_order`, incomplete structs
+//!      `/* opaque */`).
+//!
+//! Bootstrap mechanics are the `decompile_e2e.rs` harness (datatest XML →
+//! `XmlArchitecture` → `build_translator` → `init_post_engine`).  Like the
+//! `verify_w10_*` files, a fixture whose `.sla` is not built SKIPs cleanly.
+
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use kuna_base::address::Address;
+use kuna_base::error::{KunaError, KunaResult};
+use kuna_base::marshal::IdRegistry;
+use kuna_base::space::AddrSpaceManager;
+use kuna_base::xml::{DocumentStorage, Element};
+
+use kuna_decomp::decompile_drive::{
+    decompile_func, print_c, print_c_prototype, print_c_recompile_prelude, print_c_types,
+};
+use kuna_decomp::dtype::{type_metatype, TypeField};
+use kuna_decomp::options::register_option_elements;
+use kuna_decomp::sleigh_arch::{register_sleigh_arch_ids, LanguageDatabase};
+use kuna_decomp::xml_arch::{XmlArchitecture, XmlArchitectureCapability};
+
+use kuna_sleigh::loadimage::LoadImage;
+use kuna_sleigh::loadimage_xml::register_loadimage_xml_ids;
+use kuna_sleigh::translate::register_translate_ids;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+// ===========================================================================
+// Datatest XML parsing + bootstrap (the decompile_e2e.rs mechanics).
+// ===========================================================================
+
+struct SymbolFn {
+    name: String,
+    space: String,
+    offset: u64,
+}
+
+struct DataTest {
+    binaryimage: Rc<Element>,
+    arch_id: String,
+    symbols: Vec<SymbolFn>,
+}
+
+fn parse_u64(s: &str) -> u64 {
+    let s = s.trim();
+    if let Some(hex) = s.strip_prefix("0x") {
+        u64::from_str_radix(hex, 16).unwrap_or(0)
+    } else {
+        s.parse().unwrap_or(0)
+    }
+}
+
+fn find_named(el: &Rc<Element>, name: &str, out: &mut Vec<Rc<Element>>) {
+    if el.get_name() == name {
+        out.push(Rc::clone(el));
+    }
+    for c in el.get_children() {
+        find_named(c, name, out);
+    }
+}
+
+fn attr(el: &Element, name: &str) -> Option<String> {
+    el.get_attribute_value(name).ok().map(|b| String::from_utf8_lossy(b).into_owned())
+}
+
+fn parse_datatest(stem: &str) -> Result<DataTest, String> {
+    let path = repo_root().join("tests/datatests").join(format!("{stem}.xml"));
+    let xml = std::fs::read(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let mut store = DocumentStorage::new();
+    let root = store
+        .parse_document(&xml)
+        .map_err(|e| format!("parse {stem}: {e}"))?
+        .get_root()
+        .clone();
+
+    let mut bis = Vec::new();
+    find_named(&root, "binaryimage", &mut bis);
+    let binaryimage = bis.into_iter().next().ok_or("no <binaryimage>")?;
+    let arch_id = attr(&binaryimage, "arch").ok_or("<binaryimage> has no arch")?;
+
+    let mut syms = Vec::new();
+    find_named(&binaryimage, "symbol", &mut syms);
+    let symbols: Vec<SymbolFn> = syms
+        .iter()
+        .filter_map(|s| {
+            Some(SymbolFn {
+                name: attr(s, "name")?,
+                space: attr(s, "space")?,
+                offset: parse_u64(&attr(s, "offset")?),
+            })
+        })
+        .collect();
+
+    Ok(DataTest { binaryimage, arch_id, symbols })
+}
+
+struct DummyImg;
+impl LoadImage for DummyImg {
+    fn get_file_name(&self) -> &str {
+        "dummy"
+    }
+    fn load_fill(&mut self, _ptr: &mut [u8], _addr: &Address) -> KunaResult<()> {
+        Err(KunaError::data_unavail("dummy"))
+    }
+    fn get_arch_type(&self) -> Vec<u8> {
+        Vec::new()
+    }
+    fn adjust_vma(&mut self, _adjust: i64) {}
+}
+
+fn build_registry() -> IdRegistry {
+    let mut registry = IdRegistry::with_base_ids();
+    register_translate_ids(&mut registry);
+    register_sleigh_arch_ids(&mut registry);
+    register_loadimage_xml_ids(&mut registry);
+    register_option_elements(&mut registry);
+    registry
+}
+
+fn bootstrap(dt: &DataTest) -> Result<XmlArchitecture, String> {
+    let root = repo_root();
+    let registry = build_registry();
+
+    let capability = XmlArchitectureCapability::new();
+    let mut arch = capability.build_architecture("datatest", "");
+
+    arch.build_loader(Rc::clone(&dt.binaryimage)).map_err(|e| format!("build_loader: {e}"))?;
+
+    let mut db = LanguageDatabase::new();
+    db.scan_for_sleigh_directories(root.join("specs").to_str().unwrap());
+    db.get_descriptions(&registry).map_err(|e| format!("collect ldefs: {e}"))?;
+
+    arch.sleigh_mut().set_archid(&dt.arch_id);
+    arch.sleigh_mut()
+        .resolve_architecture(&db, &dt.arch_id)
+        .map_err(|e| format!("resolve_architecture: {e}"))?;
+    if arch.sleigh().language_index() < 0 {
+        return Err("language index unresolved".to_string());
+    }
+
+    let specs = arch.sleigh().build_spec_file(&db).map_err(|e| format!("build_spec_file: {e}"))?;
+    let resolved_sla = specs.slafile.ok_or("build_spec_file resolved no .sla")?;
+    let sla = std::fs::read(&resolved_sla).map_err(|e| format!("read sla: {e}"))?;
+    arch.sleigh_mut()
+        .build_translator(Box::new(DummyImg), &sla)
+        .map_err(|e| format!("build_translator: {e}"))?;
+
+    arch.sleigh_mut()
+        .base_mut()
+        .ok_or("no Architecture base after build_translator")?
+        .init_post_engine()
+        .map_err(|e| format!("init_post_engine: {e}"))?;
+
+    let manager_ptr: *const AddrSpaceManager = arch.sleigh().base().unwrap().manage();
+    // SAFETY: the manager lives inside `arch` and outlives the open() call; the
+    // borrow is released before any &mut use of `arch` (same shape as
+    // decompile_e2e.rs / corpus_bootstrap.rs).
+    arch.open_image(unsafe { &*manager_ptr }, &registry)
+        .map_err(|e| format!("open_image: {e}"))?;
+    let img = arch.take_loader().ok_or("loader vanished after open")?;
+    arch.sleigh_mut().base_mut().unwrap().set_loader(Box::new(img));
+
+    Ok(arch)
+}
+
+/// Bootstrap a fixture, SKIPping (None) when the `.sla` artifacts are not
+/// built in this checkout (`make specs`).
+fn bootstrap_or_skip(stem: &str) -> Option<(DataTest, XmlArchitecture)> {
+    let dt = match parse_datatest(stem) {
+        Ok(dt) => dt,
+        Err(e) => {
+            eprintln!("SKIP: {stem}: {e}");
+            return None;
+        }
+    };
+    match bootstrap(&dt) {
+        Ok(xarch) => Some((dt, xarch)),
+        Err(e) => {
+            eprintln!("SKIP: {stem} bootstrap failed (specs built?): {e}");
+            None
+        }
+    }
+}
+
+// ===========================================================================
+// (T1) The `.h`/`.c` identity contract: doc_prototype minus the trailing `;`
+//      is char-for-char the prototype segment of the full print_c render.
+// ===========================================================================
+#[test]
+fn doc_prototype_matches_print_c_prototype_segment() {
+    let mut checked = 0usize;
+    for stem in ["boolless", "gp", "ccmp"] {
+        let Some((dt, mut xarch)) = bootstrap_or_skip(stem) else { continue };
+        let base = xarch.sleigh_mut().base_mut().expect("Architecture base");
+        for sym in &dt.symbols {
+            let Some(space) = base.manage().get_space_by_name(&sym.space).map(Rc::clone) else {
+                continue;
+            };
+            let entry = Address::new(space, sym.offset);
+            // Call targets without loaded bytes legitimately fail to
+            // decompile; the contract is asserted on every function that DOES.
+            let Ok(fd) = decompile_func(base, &sym.name, entry, 0) else { continue };
+
+            let proto = print_c_prototype(base, &fd);
+            assert!(
+                proto.ends_with(';'),
+                "{stem}:{}: doc_prototype must end with `;`: {proto:?}",
+                sym.name
+            );
+            let stripped = &proto[..proto.len() - 1];
+            assert!(
+                stripped.contains(&format!("{}(", fd.get_display_name())),
+                "{stem}:{}: prototype lacks the function name + paren: {proto:?}",
+                sym.name
+            );
+            assert!(
+                !stripped.contains('\n') && !stripped.contains('{'),
+                "{stem}:{}: prototype must be a single declaration line: {proto:?}",
+                sym.name
+            );
+
+            let full = print_c(base, &fd);
+            assert!(
+                full.contains(stripped),
+                "{stem}:{}: the `.h` prototype segment is NOT char-for-char inside \
+                 the full render.\nprototype: {stripped:?}\nfull:\n{full}",
+                sym.name
+            );
+            checked += 1;
+        }
+    }
+    // The gate's teeth: at least 2 real corpus functions must have exercised
+    // the identity contract (0 means every fixture SKIPped — specs not built).
+    if checked == 0 {
+        eprintln!("SKIP: no fixture decompiled (specs not built?)");
+        return;
+    }
+    assert!(
+        checked >= 2,
+        "expected >= 2 corpus functions to pin the prototype identity, got {checked}"
+    );
+    eprintln!("prototype identity checked on {checked} functions");
+}
+
+// ===========================================================================
+// (T2) The `.h` type block: the recompile prelude + doc_type_definitions over
+//      the LIVE architecture factory.
+// ===========================================================================
+#[test]
+fn recompile_prelude_and_type_definitions_render() {
+    let Some((_dt, mut xarch)) = bootstrap_or_skip("boolless") else { return };
+    let base = xarch.sleigh_mut().base_mut().expect("Architecture base");
+
+    // -- The prelude: core scalar typedefs + the fixed undefined family. -----
+    let prelude = print_c_recompile_prelude(base);
+    assert!(!prelude.is_empty());
+    for needle in [
+        "#include <stdbool.h>",
+        "typedef unsigned int uint4;",
+        "typedef int int4;",
+        "typedef long long int8;",
+        "typedef unsigned char undefined;\n",
+        "typedef unsigned long long undefined8;\n",
+        "typedef unsigned int undefined3; /* 3 bytes in the decompiler; sizeof differs */",
+        "typedef struct { unsigned char b[16]; } undefined16;",
+        "typedef struct { unsigned char b[32]; } undefined32;",
+        "typedef double float8;",
+    ] {
+        assert!(prelude.contains(needle), "prelude is missing {needle:?}:\n{prelude}");
+    }
+    // `void`/`char` are real C and must NOT be typedef'd; `bool` only via the
+    // include.
+    assert!(!prelude.contains(" void;"), "prelude must not typedef void:\n{prelude}");
+    assert!(!prelude.contains(" char;"), "prelude must not typedef char:\n{prelude}");
+    assert!(!prelude.contains(" bool;"), "prelude must not typedef bool:\n{prelude}");
+
+    // -- doc_type_definitions over the live factory. --------------------------
+    // A fresh factory carries only core types: the block is empty (no
+    // spurious output).
+    let empty = print_c_types(base);
+    assert!(
+        empty.trim().is_empty(),
+        "no user types are interned, so the type block must be empty:\n{empty}"
+    );
+
+    // Intern a complete struct + an opaque struct through the REAL factory
+    // trait flow (getTypeStruct + assignRawFields), then re-render.
+    {
+        let tf = base.types();
+        let s0 = tf.get_type_struct("kunaproj_t").expect("getTypeStruct");
+        let i4 = tf.get_base(4, type_metatype::TYPE_INT).expect("getBase int4");
+        let p = tf
+            .get_type_pointer(8, Rc::clone(&s0), 1)
+            .expect("getTypePointer (self-referential)");
+        tf.assign_raw_fields_struct(
+            &s0,
+            vec![
+                TypeField::new(0, -1, "value", i4),
+                TypeField::new(1, -1, "next", p),
+            ],
+            vec![],
+        )
+        .expect("assignRawFields");
+        tf.get_type_struct("kunaproj_opaque").expect("getTypeStruct opaque");
+    }
+    let types = print_c_types(base);
+    assert!(
+        types.contains("typedef struct kunaproj_t kunaproj_t;"),
+        "forward declaration missing:\n{types}"
+    );
+    assert!(types.contains("struct kunaproj_t {"), "struct body missing:\n{types}");
+    assert!(types.contains("value;"), "scalar field missing:\n{types}");
+    assert!(
+        types.contains("kunaproj_t *next;"),
+        "self-referential pointer field missing (needs the forward decl):\n{types}"
+    );
+    assert!(
+        types.contains("typedef struct kunaproj_opaque kunaproj_opaque; /* opaque */"),
+        "incomplete struct must forward-declare as opaque:\n{types}"
+    );
+    assert!(
+        !types.contains("struct kunaproj_opaque {"),
+        "incomplete struct must have NO body:\n{types}"
+    );
+    // The forward-decl block precedes the body (the self-reference guarantee).
+    let fwd = types.find("typedef struct kunaproj_t").unwrap();
+    let body = types.find("struct kunaproj_t {").unwrap();
+    assert!(fwd < body, "forward declarations must precede bodies:\n{types}");
+}

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,5 +1,48 @@
 # kuna Progress Log
 
+## Session (2026-07-16) — `kuna decompile-project`: whole-binary project export (.c/.h/.asm/README.md)
+
+New CLI subcommand **`kuna decompile-project <binary>`**
+(`decompiler/crates/kuna-cli/src/decompile_project.rs`): loads + analyzes the binary once
+(the `decompile-all` in-process load-once/decompile-many core — same
+`--functions`/`--addr`/`--max-fn-seconds`/`--mode`/`--option`/`--slice`/`--target`/
+`--sleighpath` flags, Listing on by default; no `--json`/`--no-vars`) and writes a project
+folder — default `<binary-filename>.kuna/` next to the binary, `-o/--output DIR` overrides —
+designed so a human or LLM can study the binary and attempt recompilation:
+
+- `<name>.c` — every decompiled function, address-ordered, under `// Function: <name> @ <addr>`
+  headers (failures as `(error: ...)` comments); starts with `#include "<name>.h"`.
+- `<name>.h` — include guard + a generated **recompile prelude** (core scalar typedefs, the
+  Ghidra/kuna `undefined` family, `<stdbool.h>`), the recovered user-defined type
+  definitions, and one prototype per decompiled function — **token-identical** to the `.c`
+  definition line (both drive the same extracted `emit_prototype_declaration`).
+- `<name>.asm` — labeled linear disassembly of every CODE section: labels match the `.c`
+  names (`main:`, `sub_<addr>:`), per-function `; arg:` / `; stack:` comments map decompiled
+  variables to storage, undecodable bytes as `db` lines, and a `; --- data ---` tail
+  labeling named globals + every `dat_<hex>` the `.c` references, with raw bytes + ASCII
+  (`??` for unmapped/.bss).
+- `README.md` — binary size, arch id, entry point, function counts
+  (total/decompiled/failed), sections table, file inventory.
+
+Engine additions (f7a9346b), all additive: `TypeFactoryImpl::dependent_order`
+(`substrate/dtype.rs`) — the C++ `TypeFactory::dependentOrder`/`orderRecurse` port
+(postorder DFS, definition-before-use; the interning tree's `compareDependency` order sorts
+composites by descending size, so a by-value inner struct sorts AFTER its container — the
+reason the DFS exists, pinned by unit tests); `PrintC::doc_type_definitions`
+(`p9_emit/printc.rs`) — the previously-unported `docTypeDefinitions` surface (the console
+`print C types` stub is now wired), with two documented `(kuna)` divergences:
+forward-declaration block first (`typedef struct <n> <n>;`, `/* opaque */` for field-less
+structs) and explicit `undefined1 _pad<off>[N];` padding members; `PrintC::doc_prototype`
+via the pure-code-motion `emit_prototype_declaration` extraction; drivers
+`print_c_types`/`print_c_prototype`/`print_c_recompile_prelude` (`infra/decompile_drive.rs`);
+export surface `ConsoleProgram::sections`/`disassemble_at`/`read_bytes`/`global_data_symbols`
+(kuna-console `engine.rs`).
+
+Zero change to existing decompiler output — no `phases.toml` row, no DIV entry, no
+`docs/options.md` regen, no baseline re-pin. Gates: `make test` 675/675 PARITY OK,
+`make test-stages` 261/261 PARITY OK, `kuna decompile-all --json` byte-identical,
+`make check-spec` green (spec §5.1 updated + new §9.7; CLI docs in `docs/agents.md`).
+
 ## Session (2026-07-12) — Stripped ARM Cortex-M Thumb function discovery
 
 On a stripped bare-metal Cortex-M image kuna decoded everything in A32 (default

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -75,6 +75,10 @@ kuna decompile-all ./a.out --json                              # machine-readabl
 kuna decompile-all ./a.out --functions main,parse --json       # a subset
 kuna functions ./a.out --json                                  # just enumerate (name + address)
 
+# Export a whole binary as a recompile-oriented project folder (.c/.h/.asm/README.md)
+kuna decompile-project ./a.out                                 # writes ./a.out.kuna/
+kuna decompile-project ./a.out -o proj --functions main,parse  # subset, custom dir
+
 # Flip a stage-model assertion per decompilation (the LLM control surface)
 kuna catalog --json                                            # discover settable assertions
 kuna decompile ./a.out main --option compareform canonical
@@ -106,6 +110,22 @@ at the action/rule-pool/heritage loop boundaries) and recorded as that function'
 stage-model settable (zero output change for any function that converges; the console /
 `decomp_dbg` parity path never arms it). The decbench backend
 (`decbench/decompilers/raw/kuna_raw.py`) shells out to `kuna decompile-all --json`.
+`kuna decompile-project` is the **project-export** face of the same in-process core
+(`decompiler/crates/kuna-cli/src/decompile_project.rs`; identical load-once/decompile-many
+path and flags — `--functions`/`--addr`/`--max-fn-seconds`/`--mode`/`--option`/`--slice`/
+`--target`/`--sleighpath`, listing on by default; no `--json`): it writes a project folder —
+default `<binary-filename>.kuna/` next to the binary, `-o/--output DIR` overrides — of four
+artifacts designed so a human or LLM can study the binary and attempt recompilation:
+`<name>.c` (every decompiled function, address-ordered, under `// Function: <name> @ <addr>`
+headers, failures as comments, `#include "<name>.h"`), `<name>.h` (include guard + a
+generated recompile prelude — core scalar and `undefined`-family typedefs — the recovered
+user-defined type definitions, and one prototype per decompiled function, token-identical
+to the `.c` definition line), `<name>.asm` (labeled linear disassembly of every CODE
+section — labels match the `.c` function names, per-function `; arg:`/`; stack:` comments
+map decompiled variables to storage, undecodable bytes as `db` lines, and a `; --- data ---`
+tail labeling named globals plus every `dat_<hex>` the `.c` references, with raw bytes), and
+`README.md` (size, arch id, entry point, function counts, sections table, file inventory).
+Purely additive — no new settable, no change to any existing output path (spec §9.7).
 `kuna catalog` is the **discovery half of the LLM control API**: it parses the decompiler's
 `phase catalog` JSON (single source of truth: `settableTable`, generated from
 `decompiler/crates/kuna-decomp/phases.toml`) into the documented, flippable assertion list —

--- a/docs/spec/05-types.md
+++ b/docs/spec/05-types.md
@@ -99,6 +99,22 @@ known. `get_exact_piece` answers "what type is the size-N slice at offset K of
 this type" (the symbol-piece seed of §5.2); `concretize` maps residual
 `TYPE_UNKNOWN` onto concrete integer types where a formal type is forced.
 
+The interning tree's order is a dependency *comparison*, not a dependency
+*ordering*: `compare_dependency` ranks by sub-metatype then **descending**
+size, so a struct contained by value sorts *after* the struct that contains
+it — walking the tree front to back is not definition-before-use. The
+explicit fix is `decompiler/crates/kuna-decomp/src/substrate/dtype.rs
+(TypeFactoryImpl::dependent_order)`, the C++
+`TypeFactory::dependentOrder`/`orderRecurse` port: a postorder DFS over each
+type's typedef base (`get_typedef`) then its component sub-types
+(`get_depend`), marked on `Rc` identity so a pointer cycle
+(`struct A { struct B *b; }` / `struct B { struct A *a; }`) terminates with
+each type listed exactly once. Its consumer is emission — chapter
+[09](09-emission.md) §9.7's `doc_type_definitions` walks the list front to
+back — and the two inline unit tests (`dependent_order_nested_struct`,
+`dependent_order_pointer_cycle`) pin both facts: the raw tree order really is
+container-first, and the DFS reorders it.
+
 ## 5.2 Inference
 
 Type recovery is **off** for the entire first `fullloop` iteration — early

--- a/docs/spec/09-emission.md
+++ b/docs/spec/09-emission.md
@@ -398,3 +398,78 @@ the cast strategy, `cast.rs (CastStrategyJava)` — Java's pointer-encoded
 object references change which extensions and pointer conversions are
 representable as casts — kept current alongside `CastStrategyC` so a future
 `PrintJava` port is emitter wiring only.
+
+## 9.7 Whole-program document renders (`kuna decompile-project`)
+
+**(kuna) Three additive render surfaces** back the `kuna decompile-project`
+project export (the CLI driver is
+`decompiler/crates/kuna-cli/src/decompile_project.rs`; usage in
+`docs/agents.md`). All three are pure *readers* of finished state — they run
+after analysis, insert no ops, flip no options, and change no byte of any
+existing render path (the datatest / stages / `decompile-all --json` outputs
+are untouched), which is why none carries a `phases.toml` row or a DIV entry.
+
+**Type definitions — the `docTypeDefinitions` port.** `printc.rs
+(PrintC::doc_type_definitions)` is the previously-unported C++
+`PrintC::docTypeDefinitions` surface — the console `print C types` command
+(`decompiler/crates/kuna-console/src/ifacedecomp.rs (IfcPrintCTypes)`) was a
+stub and now wires through it, via the driver
+`decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs (print_c_types)`.
+It emits a C definition for every user-defined data-type in the factory,
+consuming `decompiler/crates/kuna-decomp/src/substrate/dtype.rs
+(TypeFactoryImpl::dependent_order)` (chapter [05](05-types.md) §5.1) so every
+definition precedes its uses. Core types, unnamed types, and the internal
+`Partial*` slices are skipped; what renders is typedefs, structs, unions, and
+enums (`printc.rs (render_type_definitions)`; the per-type body renderers —
+`compose_type_body`, `compose_enum_body`, `compose_typedef_line` — are pure
+functions for unit-testability, and emission is direct string building, since
+no emitter markup exists for type definitions). Two documented `(kuna)`
+divergences from the upstream emission, both in service of "the `.h` always
+compiles":
+
+- **Forward-declaration block first.** Upstream prints one anonymous
+  `typedef struct {…} name;` per type — a form that cannot express a
+  self-referential or mutually recursive pointer field. kuna instead emits a
+  `typedef struct <n> <n>;` tag+typedef forward declaration for every
+  struct/union up front, then the bodies as plain `struct <n> { … };` in
+  dependency order; an incomplete (field-less) struct emits *only* the
+  forward declaration, annotated `/* opaque */`.
+- **Explicit padding fields.** Struct field-offset gaps and trailing padding
+  (the field extents vs `get_size()`) render as `undefined1 _pad<hexoff>[N];`
+  members, so `sizeof(struct <n>)` under a recompile matches the decompiler's
+  layout. Bitfields render best-effort (`<type> <name> : <bits>;`, padding
+  suppressed since their byte coverage overlaps the gap computation); unions
+  carry no padding.
+
+A non-C identifier is rewritten by `printc.rs (sanitize_type_name)` (annotated
+`/* renamed from "…" */`), and a later duplicate name emits a
+`/* duplicate type name skipped */` comment instead of a redefinition — the
+first definition wins.
+
+**The prototype — one token stream, two documents.** The prototype segment of
+§9.2's document walk was extracted verbatim into `printc.rs
+(PrintC::emit_prototype_declaration)` — pure code motion, byte-identical
+inside `emit_function_document` — so `printc.rs (PrintC::doc_prototype)` can
+drive the IDENTICAL token sequence standalone: the same
+`set_output_stream()` → emit → `output_str()` capture harness as
+`doc_function_full`, plus a trailing `;`, minus the header warning comments.
+The contract this buys the export: the `.h` prototype minus its `;` matches
+the `.c` definition line **token-for-token** — there is no second prototype
+printer to drift. The public driver is `decompile_drive.rs
+(print_c_prototype)` (a function with no recovered proto store renders
+`void <name>(void);`).
+
+**The recompile prelude.** `decompile_drive.rs (print_c_recompile_prelude)`
+generates the typedef block that makes the other two renders compile: one
+standard-C typedef per interned *core* scalar type (`typedef unsigned int
+uint4;`, …; 8-byte integers always spell `long long` so the text is
+data-model independent; `bool` is covered by `#include <stdbool.h>`;
+`char`/`void` are real C and emit nothing), then the fixed Ghidra/kuna
+`undefined` family — `undefined`, `undefined1..8` (3/5/6/7 mapped to the next
+larger unsigned integer, each carrying a sizeof-divergence note) and
+`undefined16`/`undefined32` as byte-array structs. The non-printer half of
+the export (section enumeration, one-instruction disassembly, raw image
+bytes, named data symbols for the `.asm`/`README.md` artifacts) lives on the
+console engine, `decompiler/crates/kuna-console/src/engine.rs
+(ConsoleProgram::sections, disassemble_at, read_bytes, global_data_symbols)`,
+not in this folder.


### PR DESCRIPTION
## What

A new CLI subcommand, **`kuna decompile-project <binary>`**, that loads and analyzes a
binary once and writes a **project folder** (default `<binary-filename>.kuna/` next to the
binary; `-o/--output DIR` overrides) designed so a human or LLM can study the binary and
attempt recompilation:

| File | Contents |
|---|---|
| `<name>.c` | Every decompiled function, address-ordered, under `// Function: <name> @ <addr>` headers (failures as comments); `#include`s the `.h`. |
| `<name>.h` | `#ifndef` guard + a generated **recompile prelude** (core-scalar typedefs + the Ghidra/kuna `undefined`/`undefinedN` family + `#include <stdbool.h>`), the recovered user-defined type definitions, and one **function prototype per decompiled function** — token-identical to the `.c` definition line. |
| `<name>.asm` | Labeled linear disassembly of every CODE section. Function labels match the `.c` names (`main:`, `sub_<addr>:`); a per-function comment block maps decompiled variables to storage (`; arg: p (int)`, `; stack: v @ [stack-0x18] (char[8])`); undecodable bytes as `db` lines; a `; --- data ---` tail labels named globals **and every `dat_<hex>` the `.c` references**, with raw bytes + ASCII (`??` for `.bss`/unmapped). |
| `README.md` | Size, arch id, entry point, function counts, sections table, file inventory. |

Flags mirror `decompile-all`: `--functions`, `--addr`, `--max-fn-seconds`, `--mode`,
`--option`, `--slice/--target/--sleighpath` (no `--json`/`--no-vars`).

## How

- **Shares** `decompile-all`'s load-once/decompile-many core: `load_program` /
  `resolve_targets` are now `pub(crate)` and the per-function loop is extracted into
  `decompile_targets(…, want_proto)`. `decompile-all` passes `want_proto=false` and its
  JSON output is **byte-identical** to before.
- **Engine additions (commit `f7a9346b`):**
  - `TypeFactoryImpl::dependent_order` — a port of C++ `TypeFactory::dependentOrder`
    (postorder DFS producing types in definition-before-use order). The interning tree's
    `compareDependency` order is *not* definition-before-use (it sorts composites by
    descending size, so a by-value inner struct can sort after its container); this is the
    explicit fix.
  - `PrintC::doc_type_definitions` — the previously-**unported** `docTypeDefinitions`
    surface (the console `print C types` stub is now wired to it). `(kuna)` divergences:
    forward-declaration block first (`typedef struct <n> <n>;`, `/* opaque */` for
    incomplete structs — upstream's anonymous `typedef struct {…} name;` can't express
    self-reference) and explicit `undefined1 _pad<off>[N];` padding fields.
  - `PrintC::doc_prototype` — built from the same `emit_prototype_declaration` helper that
    `emit_function_document` uses (a pure code-motion extraction), so the `.h` prototype
    matches the `.c` definition line token-for-token.
  - `ConsoleProgram::sections / disassemble_at / read_bytes / global_data_symbols` — the
    `.asm`/README export surface.

## Additive — zero change to existing output

No `phases.toml` row, no DIV entry, no `options.md` regen, no baseline re-pin. Proven:
`decompile-all --json` byte-identical; **datatests 675/675 PARITY OK**, **stages 261/261
PARITY OK**, **check-spec OK (strict)**, **`make rust-test` green** (adds 6 CLI tests + a
console helper test + 12 kuna-decomp unit/integration tests). Spec updated in the same PR:
`docs/spec/09-emission.md` §9.7 and `docs/spec/05-types.md` §5.1.

## Speed (standing requirement)

`ssh-sk-helper` (461 KB, 843 functions): `decompile-all` 26.3 s → `decompile-project`
33.4 s (~27% / +7 s for the whole-`.text` disassembly sweep producing a 4.85 MB `.asm`);
memory comparable (~103 MB RSS).

## Known limitation (v1)

kuna names PLT stubs after the imported symbol (`puts`, `printf`, …) with `void (void)`
prototypes, so the `.h` draws `-Wbuiltin-declaration-mismatch` **warnings** against those
libc names (the header still passes `cc -std=c99 -fsyntax-only`). This is a
decompiler-naming artifact, not a project-export one.

## Deferred (agreed follow-up)

DWARF struct-field import (`dwarf_struct_fields`, option-gated, default-off) so `-g`
binaries get real `struct { … }` bodies instead of opaque `typedef struct foo foo;`
forward decls. The `.h` emitter picks it up unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
