### PR TITLE
feat(p1/loader): name data globals from the ELF symbol table (dat_20a098 → optind)

### DIFF
--- a/decompiler/crates/kuna-analysis/src/loadimage_object.rs
+++ b/decompiler/crates/kuna-analysis/src/loadimage_object.rs
@@ -132,6 +132,32 @@ struct FuncSym {
     name: Vec<u8>,
 }
 
+/// One **data** symbol: a defined `.symtab`/`.dynsym` `STT_OBJECT` entry (the BFD
+/// `BSF_OBJECT` twin of [`FuncSym`]).
+///
+/// The function half of the symbol table has always been read (the `funcsyms`
+/// stream that names `main`/`fmt`); the data half was dropped, so an imported
+/// libc global — `optind`, `stdin`, `stdout`, `optarg` — rendered `dat_20a098`
+/// where IDA Pro and Ghidra show its name. Both of those name data objects from
+/// the symbol table independently of any debug info, which is what reaches a
+/// copy-relocated (`R_X86_64_COPY`) extern: it has a real defined address in the
+/// importing binary's `.bss` and a `STT_OBJECT` `.dynsym` entry, but never
+/// appears in the program's own `.debug_info`.
+///
+/// `size` is the symbol's `st_size`, carried so the commit can map a covering
+/// `SymbolEntry` of the right extent — a size-1 entry does not contain a 4-/8-byte
+/// access, which is exactly the bug the DWARF data globals hit (see
+/// [`crate::pass::DataObjectFact`]).
+#[derive(Debug, Clone)]
+struct DataSym {
+    /// Symbol vma.
+    addr: u64,
+    /// Symbol name, `@VERSION` suffix already stripped.
+    name: Vec<u8>,
+    /// `st_size` (bytes); `0` when the object declares no size.
+    size: u64,
+}
+
 /// \brief A [`LoadImage`] over a real ELF executable, backed by the [`object`]
 /// crate (the kuna substitution for C++ `LoadImageBfd`).
 ///
@@ -159,6 +185,9 @@ pub struct ObjectLoadImage {
     sections: Vec<SectionInfo>,
     /// Function symbols, in symbol-table order.
     funcsyms: Vec<FuncSym>,
+    /// Defined data symbols (`STT_OBJECT`), in symbol-table order. See
+    /// [`DataSym`]; surfaced through [`ObjectLoadImage::data_symbols`].
+    datasyms: Vec<DataSym>,
     /// (kuna) Extra `[start, stop]` (inclusive) byte ranges to treat as *constant*
     /// (read-only) beyond the section-flag scan — the MIPS GOT external slots,
     /// whose static contents (the `.MIPS.stubs` stub addresses) the engine folds
@@ -177,6 +206,43 @@ pub struct ObjectLoadImage {
     cursymbol: RefCell<usize>,
     /// `openSectionInfo`/`getNextSection` cursor (C++ `mutable secinfoptr`).
     cursection: RefCell<usize>,
+}
+
+/// Admit one defined `STT_OBJECT` symbol into the data-symbol stream, deduped by
+/// address (first table wins, so `.symtab` beats `.dynsym` exactly as the funcsym
+/// walk orders them).
+///
+/// The filters mirror the funcsym walk: an *undefined* entry is an import
+/// placeholder with no address of its own, an empty name carries no information,
+/// and an `@VERSION` suffix is stripped so a versioned glibc export
+/// (`optind@@GLIBC_2.2.5`) installs as `optind`.  A **zero `st_size`** entry is
+/// dropped as well — with no extent there is nothing to size a covering
+/// `SymbolEntry` against, and the linker's section-boundary markers
+/// (`__bss_start`, `_edata`, `_end`) are exactly the zero-size entries that would
+/// otherwise plant a spurious name on the first byte of an unrelated object.
+fn collect_data_sym<'a>(
+    sym: &impl object::ObjectSymbol<'a>,
+    out: &mut Vec<DataSym>,
+    seen: &mut HashSet<u64>,
+) {
+    if sym.is_undefined() {
+        return;
+    }
+    let size = sym.size();
+    if size == 0 {
+        return;
+    }
+    let name = match sym.name_bytes() {
+        Ok(n) if !n.is_empty() => crate::loader::elf_plt::strip_version(n),
+        _ => return,
+    };
+    if name.is_empty() {
+        return;
+    }
+    let addr = sym.address();
+    if seen.insert(addr) {
+        out.push(DataSym { addr, name, size });
+    }
 }
 
 impl ObjectLoadImage {
@@ -275,6 +341,10 @@ impl ObjectLoadImage {
         //      whose `.symtab` is gone.
         let mut funcsyms: Vec<FuncSym> = Vec::new();
         let mut seen: HashSet<u64> = HashSet::new();
+        // The data half of the same two symbol tables (`STT_OBJECT`), collected in
+        // the same walks and deduped on its own address set.  See [`DataSym`].
+        let mut datasyms: Vec<DataSym> = Vec::new();
+        let mut seen_data: HashSet<u64> = HashSet::new();
 
         // 1. `.symtab` defined functions.  Skip *undefined* (import-placeholder)
         //    entries — e.g. the ELF UND `puts@@GLIBC_2.2.5` (`st_value == 0`),
@@ -290,6 +360,10 @@ impl ObjectLoadImage {
         //    this is behavior-identical on the ELF arm and additionally admits a
         //    COFF object's defined-at-0 function (design §3.6 object-vs-image).
         for sym in file.symbols() {
+            if sym.kind() == SymbolKind::Data {
+                collect_data_sym(&sym, &mut datasyms, &mut seen_data);
+                continue;
+            }
             if sym.kind() != SymbolKind::Text {
                 continue;
             }
@@ -324,6 +398,10 @@ impl ObjectLoadImage {
         //    dynamic binary stripped of `.symtab` still exports its defined
         //    functions in `.dynsym`.
         for sym in file.dynamic_symbols() {
+            if sym.kind() == SymbolKind::Data {
+                collect_data_sym(&sym, &mut datasyms, &mut seen_data);
+                continue;
+            }
             if sym.kind() != SymbolKind::Text {
                 continue;
             }
@@ -358,6 +436,7 @@ impl ObjectLoadImage {
             segments,
             sections,
             funcsyms,
+            datasyms,
             const_ranges,
             spaceid: None,
             buffer: RefCell::new(vec![0u8; BUFSIZE]),
@@ -429,6 +508,11 @@ impl ObjectLoadImage {
             segments,
             sections,
             funcsyms,
+            // A relocatable object's symbol addresses are section-relative and are
+            // rebased by [`elf_reloc::layout_relocatable`], which resolves the
+            // function half only (`RelocLayout::funcsyms`).  Data-symbol naming is
+            // therefore linked-image-only; an `ET_REL` load keeps today's behavior.
+            datasyms: Vec::new(),
             const_ranges: Vec::new(),
             spaceid: None,
             buffer: RefCell::new(vec![0u8; BUFSIZE]),
@@ -481,6 +565,20 @@ impl ObjectLoadImage {
         self.funcsyms
             .iter()
             .map(|s| (s.addr, String::from_utf8_lossy(&s.name).into_owned()))
+            .collect()
+    }
+
+    /// The loader's **data** symbols as `(vma, name, size)` triples — the
+    /// `STT_OBJECT` half of the same `.symtab`/`.dynsym` walks [`Self::func_symbols`]
+    /// reads, filtered to defined, named, non-zero-size entries (see [`DataSym`]).
+    ///
+    /// The engine installs each as a named, `undefined<size>`-typed global so a
+    /// memory access of the object renders the symbol name (`optind`) rather than
+    /// `dat_<addr>`, matching IDA Pro and Ghidra. Empty for a relocatable object.
+    pub fn data_symbols(&self) -> Vec<(u64, String, u64)> {
+        self.datasyms
+            .iter()
+            .map(|s| (s.addr, String::from_utf8_lossy(&s.name).into_owned(), s.size))
             .collect()
     }
 

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -162,6 +162,21 @@ pub struct ConsoleProgram {
     /// datatest path (no Listing tier), so the gated build is a structural no-op
     /// there. Empty/`None` when the listing flag is off ⇒ zero cost.
     analysis_image: Option<(String, Vec<u8>)>,
+    /// (kuna) The loader's defined `STT_OBJECT` data symbols as `(addr, name,
+    /// size)`, read from `.symtab`/`.dynsym` at load
+    /// ([`ObjectLoadImage::data_symbols`]) and installed as named globals by
+    /// [`commit_analysis_output`].
+    ///
+    /// This is **loader markup**, not an analysis pass: it is the data twin of the
+    /// funcsym stream `read_loader_symbols` already installs, so it carries no
+    /// `--option` gate — kuna has never made "name what the symbol table names"
+    /// optional. It is installed at the analysis commit rather than eagerly at
+    /// bootstrap purely for *precedence*: a DWARF-described global and a detected
+    /// string literal both claim their address first, and this arm only fills the
+    /// addresses neither covered (which is where the imported libc objects —
+    /// `optind`, `stdin`, `stdout`, `optarg` — live). Empty on the XML datatest
+    /// path and for a relocatable object.
+    loader_data_objects: Vec<(u64, String, u64)>,
 }
 
 impl ConsoleProgram {
@@ -540,7 +555,7 @@ impl ConsoleProgram {
     /// gated) facts merge into the same `merged` output committed below. Default
     /// (listing off) ⇒ this whole block is skipped ⇒ byte-identical to today.
     pub fn commit_pending_analysis(&mut self) -> KunaResult<()> {
-        if self.pending_analysis.is_empty() {
+        if self.pending_analysis.is_empty() && self.loader_data_objects.is_empty() {
             // Drop the deferred-Listing stash too: nothing to commit against, and
             // a session with no analysis tier (XML path) must not build a Listing.
             self.analysis_image = None;
@@ -952,6 +967,7 @@ pub fn bootstrap_program(
         analysis_code_space: None,
         dwarf_locals: Vec::new(),
         analysis_image: None,
+        loader_data_objects: Vec::new(),
     };
     // C++ `conf->readLoaderSymbols("::")` (testfunction.cc:160 / consolemain.cc:104):
     // install the binaryimage symbols as FunctionSymbols so a CALL to one resolves
@@ -1104,6 +1120,11 @@ pub fn bootstrap_from_object(
 
     // readLoaderSymbols (the ELF FUNC symbols) BEFORE handing the loader off.
     let symbols = read_loader_symbols_generic(&loader);
+    // The data half of the same symbol tables (`STT_OBJECT`), read here for the
+    // same reason — the loader is about to be moved into the engine. Installed at
+    // the analysis commit, after DWARF and the detected strings have claimed their
+    // addresses. See `ConsoleProgram::loader_data_objects`.
+    let loader_data_objects = loader.data_symbols();
 
     // Hand the loader to the engine (the C++ `loader` back-pointer the decode
     // reads on load_fill).
@@ -1127,6 +1148,7 @@ pub fn bootstrap_from_object(
         // (`read symbols`) when the flag is known — not at load. `bytes` is moved
         // here (it is unused below this point).
         analysis_image: Some((path.to_string(), bytes)),
+        loader_data_objects,
     };
     // conf->readLoaderSymbols("::"): install the ELF symbols as FunctionSymbols.
     // The deferred analysis commit at `read symbols` REQUIRES this to have run
@@ -1428,6 +1450,50 @@ fn commit_analysis_output(
         let (sid, _) =
             arch.symboltab.add_symbol_mapped(scope, &base, arr, &addr, &Address::new_invalid())?;
         arch.symboltab.set_attribute(sid, kuna_decomp::varnode::varnode_flags::typelock);
+    }
+
+    // 4a. Loader data symbols: the defined `STT_OBJECT` entries of `.symtab` /
+    //     `.dynsym` (`ConsoleProgram::loader_data_objects`). Installed exactly like
+    //     the DWARF data globals of arm 1a — an `undefined<size>` global with
+    //     `namelock` only, so the container query matches at the real access width
+    //     and type propagation still infers the object's real type — but committed
+    //     HERE, last, so the two richer sources win every address they claim: a
+    //     DWARF-described global keeps its DWARF extent (arm 1a) and a detected
+    //     string literal keeps its `char[N]` typelock (arm 4). What is left is the
+    //     set neither reaches, and that is precisely the interesting one: a
+    //     copy-relocated libc extern (`optind`, `stdin`, `stdout`, `optarg`) has a
+    //     `.bss` address and a `.dynsym` entry but no `.debug_info` DIE, so before
+    //     this arm it rendered `dat_20a098`. IDA Pro and Ghidra both name data
+    //     objects from the symbol table independently of debug info.
+    let loader_data_objects = std::mem::take(&mut prog.loader_data_objects);
+    for (sym_addr, name, size) in &loader_data_objects {
+        let addr = Address::new(Rc::clone(code_space), *sym_addr);
+        let occupied = {
+            let arch = prog.arch();
+            match arch.symboltab.get_global_scope() {
+                Some(global) => {
+                    arch.symboltab.find_function(global, &addr).is_some()
+                        || arch
+                            .symboltab
+                            .find_container(global, &addr, 1, &Address::new_invalid())
+                            .is_some()
+                }
+                None => false,
+            }
+        };
+        if occupied {
+            continue;
+        }
+        let ct = prog
+            .arch()
+            .types()
+            .get_base((*size).max(1) as int4, kuna_decomp::dtype::type_metatype::TYPE_UNKNOWN)?;
+        let arch = prog.arch_mut();
+        let (scope, base) =
+            arch.symboltab.find_create_scope_from_symbol_name(name, "::", None, num_spaces)?;
+        let (sid, _) =
+            arch.symboltab.add_symbol_mapped(scope, &base, ct, &addr, &Address::new_invalid())?;
+        arch.symboltab.set_attribute(sid, kuna_decomp::varnode::varnode_flags::namelock);
     }
 
     // 5. Library prototypes (the kuna analog of ApplyDataArchiveAnalyzer): park each

--- a/decompiler/crates/kuna-console/tests/verify_loader_data_symbols.rs
+++ b/decompiler/crates/kuna-console/tests/verify_loader_data_symbols.rs
@@ -1,0 +1,113 @@
+//! End-to-end gate for **data-global naming from the ELF symbol table**: an
+//! imported libc object renders by its name (`optind`, `stdin`, `stdout`,
+//! `optarg`) instead of `dat_<addr>`, matching IDA Pro and Ghidra.
+//!
+//! Fixture: `regglobal_fmt_x86_64` — GNU coreutils `fmt`, whose `main` reads all
+//! four through copy relocations (`R_X86_64_COPY` slots in `.bss`).
+//!
+//! The gap: the loader kept only `SymbolKind::Text` entries from `.symtab` /
+//! `.dynsym`, so every `STT_OBJECT` symbol was dropped. A copy-relocated libc
+//! global has a real defined address in the importing binary but never appears in
+//! the program's own `.debug_info`, so the DWARF data-global naming could not
+//! reach it either — `main` rendered `dat_20a098` where both reference
+//! decompilers show `optind`. The loader now collects the data half of the same
+//! two symbol tables and the engine installs each as a named `undefined<size>`
+//! global.
+//!
+//! ## `.sla` precondition
+//!
+//! Bootstrapping needs the built x86 `.sla` under `specs/` (gitignored; `make
+//! specs`). When it is absent the bootstrap fails; the test prints that and
+//! returns early (a specs-less CI is a visible skip, never a false green).
+
+use std::path::PathBuf;
+
+use kuna_console::engine::bootstrap_from_object;
+use kuna_console::ifacedecomp::{execute, register_decomp_commands, IfaceDecompData, DECOMPILE_MODULE};
+use kuna_console::ifaceterm::ConsoleCommands;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+fn fixture() -> PathBuf {
+    repo_root().join("decompiler/crates/kuna-analysis/tests/fixtures/regglobal_fmt_x86_64")
+}
+
+/// Bootstrap the fixture, commit the analysis facts, decompile `func`, and
+/// return the captured C (`None` ⇒ specs-less skip).
+fn decompile(func: &str) -> Option<String> {
+    let root = repo_root();
+    let specs = root.join("specs");
+    let spec_roots = vec![specs.to_str().unwrap().to_string()];
+
+    let bin = fixture().to_str()?.to_string();
+    let mut prog = match bootstrap_from_object(&bin, "", &spec_roots) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "verify_loader_data_symbols: skipping (bootstrap failed, build `.sla` with \
+                 `make specs`): {}",
+                e.explain()
+            );
+            return None;
+        }
+    };
+    // `read symbols`: commit the analysis facts, including the loader's data
+    // symbols (loader markup — no flag).
+    prog.commit_pending_analysis().expect("analysis commit succeeds");
+
+    let cmds: Vec<String> =
+        [format!("load function {func}"), "decompile".into(), "print C".into()].to_vec();
+    let count = cmds.len();
+    let mut status = ConsoleCommands::into_status(cmds);
+    register_decomp_commands(&mut status);
+    {
+        let data = status.get_data_mut(DECOMPILE_MODULE).unwrap();
+        let dcp = data.as_any_mut().downcast_mut::<IfaceDecompData>().unwrap();
+        dcp.conf = Some(prog);
+    }
+    for _ in 0..count {
+        execute(&mut status);
+    }
+    Some(status.optr.clone())
+}
+
+/// `fmt/main` reads `optind` (4 bytes, `.dynsym`+`.symtab` `STT_OBJECT` at
+/// `0x20a098`), `stdin`/`stdout` (8 bytes), and `optarg` (8 bytes). All four are
+/// imported libc objects — absent from the program's DWARF — so before the loader
+/// read the data half of the symbol table each rendered `dat_<addr>`.
+#[test]
+fn libc_extern_globals_render_by_symbol_name() {
+    let Some(code) = decompile("main") else { return }; // specs-less skip
+
+    for name in ["optind", "stdin", "stdout", "optarg"] {
+        assert!(
+            code.contains(name),
+            "expected the libc extern global `{name}` to render by name; got:\n{code}",
+        );
+    }
+    // The four addresses those symbols cover must no longer appear raw.
+    for raw in ["dat_20a098", "dat_20a090", "dat_20a088", "dat_20a0a0"] {
+        assert!(
+            !code.contains(raw),
+            "`{raw}` should have been named from the ELF symbol table; got:\n{code}",
+        );
+    }
+}
+
+/// The program's own DWARF-described globals keep their DWARF-recovered extent:
+/// the loader arm commits LAST and skips any address a richer source already
+/// claimed, so this is a precedence regression guard, not a duplicate of
+/// `verify_data_global_symbols`.
+#[test]
+fn dwarf_named_globals_survive_the_loader_arm() {
+    let Some(code) = decompile("main") else { return }; // specs-less skip
+
+    for name in ["max_width", "goal_width", "prefix_length"] {
+        assert!(
+            code.contains(name),
+            "expected the DWARF-named global `{name}` to still render by name; got:\n{code}",
+        );
+    }
+}

--- a/docs/history.md
+++ b/docs/history.md
@@ -136,6 +136,7 @@ new default flips add a row here (full original entries with evidence: git histo
 | DIV-23 | `earlyreturn` | per-edge const-guard early-return peeling | decbench +47 perfect / −576 GED; 1 opt-out |
 | DIV-24 | DWARF global naming (bug fix) | globals mapped at real byte size so wide accesses get their name | 0/675 |
 | DIV-25 | `switchreturn` | per-case const returns for wide switches (≤256 cases) | +2 perfect / −107 GED; 1 opt-out |
+| DIV-26 | ELF data-symbol naming (no flag) | `.symtab`/`.dynsym` `STT_OBJECT` entries named as globals (`dat_20a098` → `optind`) | 0/675; commits last, DWARF+strings keep precedence |
 
 ## Upstream provenance & sync
 

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -101,6 +101,31 @@ symbol-table property map eagerly at bootstrap (loader markup, not a gated pass)
 they are what lets the printer prove a constant points into read-only memory and
 render a string literal.
 
+The **data** half of those same two symbol tables is read alongside the function
+half (`loadimage_object.rs (data_symbols)`): every defined, named `STT_OBJECT`
+entry with a non-zero `st_size`, deduplicated by address, `.symtab` before
+`.dynsym`. Zero-size entries are dropped because the linker's section-boundary
+markers (`__bss_start`, `_edata`, `_end`) are exactly the sizeless ones, and a
+sizeless symbol would plant a name on the first byte of whatever object follows
+it. Each surviving entry becomes a named `undefined<size>` global — the same
+shape §1.4's DWARF data globals use, and for the same reason: a size-1 entry does
+not contain a 4- or 8-byte access, so the printer's covering-symbol query would
+miss and fall back to `dat_<addr>`. Naming what the symbol table names is not
+optional and carries no flag, matching IDA Pro and Ghidra, which both name data
+objects from the symbol table independently of any debug info.
+
+Precedence is what makes this safe to add underneath the existing sources. The
+loader's data symbols commit **last** (`engine.rs (commit_analysis_output)`),
+after the DWARF globals and after the detected string literals, and each is
+skipped where a function or a covering data symbol already sits. So a
+DWARF-described global keeps its DWARF-recovered extent and a detected string
+keeps its `char[N]` typelock; the loader arm only fills addresses neither source
+reaches. That residue is the interesting one: a copy-relocated libc extern
+(`optind`, `stdin`, `stdout`, `optarg`) has a real `.bss` address and a `.dynsym`
+entry but no DIE in the program's own `.debug_info`, so nothing else could name
+it. Relocatable objects are excluded — `elf_reloc` rebases only the function half
+of the symbol table, so a `.o` keeps its previous behavior.
+
 Format dispatch is by magic (`engine.rs (is_object_binary)`): ELF, thin or fat
 Mach-O, PE (`MZ`, validated downstream by the typed PE parser), and bare COFF
 objects recognized by a whitelisted leading `IMAGE_FILE_MACHINE_*` u16 — anything


### PR DESCRIPTION
Implements the `ida-libc-extern-globals` proposal from #155 (closing that proposal PR; the roadmap docs are not being merged).

## The gap

`fmt/main` rendered its four libc externs as raw addresses where IDA Pro and Ghidra both show names:

| kuna (before) | IDA Pro / Ghidra | ELF symbol |
|---|---|---|
| `dat_20a098` | `optind` | `optind@@GLIBC_2.2.5` (`.dynsym` `STT_OBJECT`, `.bss`) |
| `dat_20a090` | `stdin` | `stdin@@GLIBC_2.2.5` |
| `dat_20a088` | `stdout` | `stdout@@GLIBC_2.2.5` |
| `dat_20a0a0` | `optarg` | `optarg@@GLIBC_2.2.5` |

**Root cause:** every symbol loop in `loadimage_object.rs` filtered `SymbolKind::Text`, so the `STT_OBJECT` half of `.symtab`/`.dynsym` was dropped entirely. The DWARF data-global naming from #151 cannot reach these — a copy-relocated libc extern has a real `.bss` address in the importing binary but no DIE in the program's own `.debug_info`.

## What this does

The loader collects the data half of the same two walks (`ObjectLoadImage::data_symbols`): defined, named, non-zero-`st_size` entries, `@VERSION` stripped, deduped by address. Sizeless entries are dropped — the linker's section-boundary markers (`__bss_start`, `_edata`, `_end`) are exactly the zero-size ones and would plant a name on the first byte of an unrelated object.

Each becomes a named `undefined<size>` global with `namelock` only, reusing the install path #151 built: the covering-symbol query then matches at the real access width, and type propagation still infers the object's real type.

**Precedence** is what makes this safe to slide underneath the existing sources. The arm commits *last* in `commit_analysis_output` — after the DWARF globals and after the detected string literals — and skips any address already covered. A DWARF-described global keeps its DWARF extent; a detected string keeps its `char[N]` typelock; the loader only fills what neither reaches, which is precisely the imported-libc set. Relocatable objects are excluded (`elf_reloc` rebases only the function half).

## Policy

No `--option`. This is loader markup — the data twin of the funcsym stream — and kuna has never made "name what the symbol table names" optional. Recorded as DIV-26.

## Verification

- `make test` — 675/675, **PARITY OK**
- `make test-stages` — 261/261, **PARITY OK**
- `make rust-test` — green (+2 new)
- `make check-spec` — OK
- Speed: 0.54s vs 0.50–0.57s on `fmt/main` (load-time only; 49 extra `add_symbol_mapped` calls) — within noise
- Testcase: `verify_loader_data_symbols.rs` over the vendored `regglobal_fmt_x86_64`, asserting all four render by name and that the DWARF-named globals still win their addresses
- Spec: `docs/spec/01-program-prep.md` §1.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H71mWNphPiqPEesDuknSqW