### PR TITLE
feat(p4/protos): apply a function's own DWARF prototype to its own decompile

### DIFF
--- a/decompiler/crates/kuna-console/tests/verify_dwarf_prototypes.rs
+++ b/decompiler/crates/kuna-console/tests/verify_dwarf_prototypes.rs
@@ -1,0 +1,129 @@
+//! End-to-end gate for **applying a function's own DWARF prototype**: a `-g`
+//! binary's function renders its source signature — real return type, real
+//! parameter types, real parameter names — instead of a data-flow-derived
+//! approximation.
+//!
+//! The gap: the DWARF pass already built a full `PrototypePieces` for every
+//! defined `DW_TAG_subprogram` and parked it on the global `FunctionSymbol`, but
+//! that snapshot was read only by a *caller* (`ActionDefaultParams` copies a
+//! callee's prototype into the call site). A function's own decompile ignored it
+//! and re-derived everything from data flow, so `main` — described by
+//! `.debug_info` as `int main(int argc, char **argv)` — rendered
+//! `undefined16 main(uint4 a0, void *a1)`.
+//!
+//! The wide bogus return is the same bug's second symptom. With no locked output,
+//! return recovery registers a trial per output register the model characterizes
+//! (x86-64 gcc: RAX *and* RDX) and the cspec's `join_dual_class` output rule
+//! accepts the pair as one 16-byte return — emitted as a `char[16]` whose high
+//! half is an uninitialized stack slot. A known `int` return skips that entirely.
+//!
+//! Fixtures: `dwarf_globals_x86_64` (a small purpose-built `-g` binary) and
+//! `regglobal_fmt_x86_64` (GNU coreutils `fmt`, the IDA-parity reference).
+//!
+//! ## `.sla` precondition
+//!
+//! Bootstrapping needs the built x86 `.sla` under `specs/` (gitignored; `make
+//! specs`). When it is absent the bootstrap fails; the test prints that and
+//! returns early (a specs-less CI is a visible skip, never a false green).
+
+use std::path::PathBuf;
+
+use kuna_console::engine::bootstrap_from_object;
+use kuna_console::ifacedecomp::{execute, register_decomp_commands, IfaceDecompData, DECOMPILE_MODULE};
+use kuna_console::ifaceterm::ConsoleCommands;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+fn fixture(name: &str) -> PathBuf {
+    repo_root().join("decompiler/crates/kuna-analysis/tests/fixtures").join(name)
+}
+
+/// Bootstrap `bin`, commit the (default-on) DWARF facts, decompile `func`, and
+/// return the captured C (`None` ⇒ specs-less skip).
+fn decompile(bin: &str, func: &str) -> Option<String> {
+    let root = repo_root();
+    let specs = root.join("specs");
+    let spec_roots = vec![specs.to_str().unwrap().to_string()];
+
+    let path = fixture(bin).to_str()?.to_string();
+    let mut prog = match bootstrap_from_object(&path, "", &spec_roots) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "verify_dwarf_prototypes: skipping (bootstrap failed, build `.sla` with \
+                 `make specs`): {}",
+                e.explain()
+            );
+            return None;
+        }
+    };
+    prog.commit_pending_analysis().expect("analysis commit succeeds");
+
+    let cmds: Vec<String> =
+        [format!("load function {func}"), "decompile".into(), "print C".into()].to_vec();
+    let count = cmds.len();
+    let mut status = ConsoleCommands::into_status(cmds);
+    register_decomp_commands(&mut status);
+    {
+        let data = status.get_data_mut(DECOMPILE_MODULE).unwrap();
+        let dcp = data.as_any_mut().downcast_mut::<IfaceDecompData>().unwrap();
+        dcp.conf = Some(prog);
+    }
+    for _ in 0..count {
+        execute(&mut status);
+    }
+    Some(status.optr.clone())
+}
+
+/// `int bump(int n)` — the DWARF parameter NAME (`n`) is the visible delta from
+/// the recovered-storage default (`a0`).
+#[test]
+fn parameter_names_and_types_come_from_dwarf() {
+    let Some(code) = decompile("dwarf_globals_x86_64", "bump") else { return };
+
+    assert!(
+        code.contains("bump(int4 n)"),
+        "expected the DWARF signature `bump(int4 n)` (typed + named); got:\n{code}",
+    );
+}
+
+/// `int main(int argc, char **argv)` — return type, both parameter types, and
+/// both parameter names.
+#[test]
+fn main_renders_its_source_signature() {
+    let Some(code) = decompile("dwarf_globals_x86_64", "main") else { return };
+
+    assert!(
+        code.contains("main(int4 argc,char **argv)"),
+        "expected `main(int4 argc,char **argv)` from DWARF; got:\n{code}",
+    );
+}
+
+/// The IDA-parity reference. `fmt/main` returned a bogus 16-byte `RAX:RDX` join
+/// (`undefined16` + a `char[16]` local whose high half was an uninitialized stack
+/// slot) because nothing locked its `int` return. With the DWARF prototype
+/// applied the return narrows to the real `int` result, matching IDA Pro's
+/// `return (unsigned __int8)v16 ^ 1;`.
+#[test]
+fn fmt_main_return_narrows_from_the_bogus_register_pair() {
+    let Some(code) = decompile("regglobal_fmt_x86_64", "main") else { return };
+
+    assert!(
+        code.contains("main(int4 argc,char **argv)"),
+        "expected fmt's DWARF signature for main; got:\n{code}",
+    );
+    assert!(
+        !code.contains("undefined16"),
+        "the 16-byte RAX:RDX return join must be gone; got:\n{code}",
+    );
+    assert!(
+        code.contains("return v13 ^ 1;"),
+        "expected the narrowed int return (`return v13 ^ 1;`); got:\n{code}",
+    );
+    assert!(
+        !code.contains("[16]"),
+        "the phantom `char[16]` return buffer must be gone; got:\n{code}",
+    );
+}

--- a/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
@@ -788,6 +788,9 @@ pub fn decompile_func_full_with_override_dyn(
     // rule-pool / heritage loop boundaries.
     arch.kuna_fn_deadline = arch.kuna_fn_budget.map(|b| std::time::Instant::now() + b);
     let result = (|| {
+        // Kept for the parked-prototype lookup below (the flow build consumes the
+        // address).
+        let entry_addr = funcaddr.clone();
         let mut fd = build_and_follow_flow_with_override_and_protos(
             arch,
             name,
@@ -796,10 +799,45 @@ pub fn decompile_func_full_with_override_dyn(
             flow_overrides,
             proto_overrides,
         )?;
-        // Apply any parsed-and-locked prototype to the fresh funcp (the input-param
+        // The prototype the function is decompiled *against*. Two sources, in
+        // precedence order:
+        //
+        //  1. `pending_proto` — a prototype the operator declared for this run
+        //     (`parse line extern ...`). An explicit declaration always wins.
+        //  2. The prototype parked on this function's own global FunctionSymbol.
+        //     That is where the DWARF pass's recovered `DW_TAG_subprogram`
+        //     signature lands (`set_function_prototype_pieces`), and where the
+        //     library-prototype table lands for a named libc function.
+        //
+        // Source 2 used to be read *only* by a CALLER — `ActionDefaultParams`
+        // copies a callee's parked prototype into the call site, so `fmt(FILE*,
+        // char const*)` typed its arguments correctly at every call — while the
+        // function's own decompile ignored it and re-derived everything from data
+        // flow. So `main`, fully described by `.debug_info` as
+        // `int main(int argc, char **argv)`, rendered `undefined16 main(uint4
+        // a0, void *a1)`: the recovered signature existed and was thrown away.
+        //
+        // Applying it locks the inputs and the output, which is also what
+        // collapses the bogus wide return. With no locked output,
+        // `ActionPrototypeTypes` turns on return recovery, `Heritage::guard_returns`
+        // registers a trial per output register the model characterizes (x86-64
+        // gcc: RAX *and* RDX), and the cspec's `join_dual_class` output rule
+        // accepts the consecutive pair as one 16-byte return — materialized as
+        // `PIECE(RDX,RAX)` and typed `undefined16`, with the never-written RDX half
+        // picking up an uninitialized stack slot. A known `int` return skips that
+        // machinery entirely.
+        let recovered_proto = if pending_proto.is_none() {
+            arch.symboltab
+                .get_global_scope()
+                .and_then(|g| arch.symboltab.function_proto_pieces(g, &entry_addr))
+                .cloned()
+        } else {
+            None
+        };
+        // Apply the resolved prototype to the fresh funcp (the input-param
         // recovery SEED): after this the inputs/output are type-locked, so
         // ActionPrototypeTypes forces the typed Varnodes.
-        if let Some(pieces) = pending_proto {
+        if let Some(pieces) = pending_proto.or(recovered_proto.as_ref()) {
             fd.apply_locked_prototype(pieces)?;
         }
         // Re-seed any console `map param <i> <addr> <typedecl>` storage locks (lost

--- a/docs/history.md
+++ b/docs/history.md
@@ -137,6 +137,7 @@ new default flips add a row here (full original entries with evidence: git histo
 | DIV-24 | DWARF global naming (bug fix) | globals mapped at real byte size so wide accesses get their name | 0/675 |
 | DIV-25 | `switchreturn` | per-case const returns for wide switches (≤256 cases) | +2 perfect / −107 GED; 1 opt-out |
 | DIV-26 | ELF data-symbol naming (no flag) | `.symtab`/`.dynsym` `STT_OBJECT` entries named as globals (`dat_20a098` → `optind`) | 0/675; commits last, DWARF+strings keep precedence |
+| DIV-27 | own-prototype seeding (bug fix, no flag) | a function's parked (DWARF/libproto) signature is applied to its OWN decompile, not just to its callers | 0/675; also kills the bogus `undefined16` RAX:RDX return |
 
 ## Upstream provenance & sync
 

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -247,7 +247,10 @@ The always-on core, in pass order (`passes.rs (passes_for)`):
   emits a function symbol, each top-level `DW_TAG_variable` with a `DW_OP_addr`
   location a data symbol; (2) typed signatures — return + formal-parameter DIEs
   mapped to kuna `Datatype`s (structs as named opaques, with a recursion-depth cap
-  against type cycles), registered *after* libproto so real source signatures win;
+  against type cycles), registered *after* libproto so real source signatures win,
+  and read back at *two* points: by a caller's `ActionDefaultParams` for the call
+  site, and by the drive as the function's own locked prototype (04 §4.2 —
+  `int main(int argc, char **argv)`, not `undefined16 main(uint4, void*)`);
   (3) stack locals — direct `DW_OP_fbreg` children become typelock|namelock stack
   symbols at `call_frame_cfa + fbreg`, re-seeded per decompile (§1.1); nested
   lexical-block locals and composite locations are a documented loss. (ida) The

--- a/docs/spec/04-calls-and-prototypes.md
+++ b/docs/spec/04-calls-and-prototypes.md
@@ -197,6 +197,36 @@ in the schedule is `decompiler/crates/kuna-decomp/src/infra/universalaction.rs
 (universal_sched)`: setup before fullloop, the trial passes inside mainloop,
 finalization in the one-shot tail (00 §0.6).
 
+### Seeding: the prototype the function is decompiled against
+
+Everything below is *recovery* — what runs when the function's prototype is
+unknown. Before any of it, the drive
+(`decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs`) asks whether the
+signature is already known, and locks it if so
+(`decompiler/crates/kuna-decomp/src/substrate/funcdata.rs
+(Funcdata::apply_locked_prototype)`). Two sources, in precedence order: a
+prototype the operator declared for this run (`parse line extern …`), then the
+prototype parked on the function's own global `FunctionSymbol` — which is where
+the DWARF pass's recovered `DW_TAG_subprogram` signature lands (01 §1.4) and
+where the library-prototype table lands for a named libc function.
+
+The parked prototype used to be read only by a *caller*: `ActionDefaultParams`
+copies a callee's pieces into the call site, so a DWARF-described callee typed
+its arguments correctly at every call while its own decompile ignored the
+signature and re-derived it from data flow. Applying it to the function itself is
+the difference between `undefined16 main(uint4 a0, void *a1)` and
+`int main(int argc, char **argv)` on any `-g` binary. Storage assignment that
+hits an unported seam degrades gracefully — the prototype is dropped and the
+function decompiles unlocked, exactly as before.
+
+Locking the output is also what collapses the bogus wide return described under
+`ActionReturnRecovery` below: with no locked output, return recovery registers a
+trial for every output register the model characterizes (x86-64 SysV: `RAX` *and*
+`RDX`), the cspec's `join_dual_class` output rule accepts the consecutive pair as
+one 16-byte return, and the result is a `char[16]` whose high half is whatever
+uninitialized value `RDX` happened to hold. A known `int` return never enters
+that machinery.
+
 ### Setup (once, before fullloop)
 
 - **`ActionPrototypeTypes`** (`coreaction_protos.rs (ActionPrototypeTypes)`)


### PR DESCRIPTION
Implements the `ida-dwarf-prototypes` proposal from #155 — and, as a consequence, the `fmt` case of `ida-return-storage-inference`.

> **Stacked on #187** (`feat/elf-data-symbols`). Base is that branch; merge #187 first.

## The gap

```c
// kuna (before)                      // IDA Pro
undefined16 main(uint4 a0,void *a1)   int __fastcall main(int argc, const char **argv, ...)
  char v4 [16];
  v4[0] = v16 ^ 1;   // real result     return (unsigned __int8)v16 ^ 1;
  v4[8] = v22;       // GARBAGE, uninitialized stack slot
  return v4;
```

Both symptoms are **one bug**. The DWARF pass already builds a complete `PrototypePieces` for every defined `DW_TAG_subprogram` — return type, parameter types, parameter names — and `commit_analysis_output` parks it on the function's global `FunctionSymbol`. That snapshot was only ever read by a **caller**: `ActionDefaultParams` copies a callee's pieces into the call site (which is why `fmt(FILE*, char const*)` typed its arguments correctly all along), while the function's own decompile ignored the signature and re-derived everything from data flow. The recovered prototype existed and was thrown away.

## What this does

The drive resolves the prototype from two sources, in precedence order:

1. an operator declaration for this run (`parse line extern …`) — unchanged, still wins;
2. the pieces parked on the function's own entry address (DWARF, or the library-prototype table for a named libc function).

One edit in `decompile_func_full_with_override_dyn` covers every consumer — the console, `decompile-all`, `decompile-project`, the Ghidra front-end, and the WASM build all drive through it.

### Why this also kills the bogus wide return

Locking the output is what collapses it. Unlocked, `ActionPrototypeTypes` starts return recovery, `Heritage::guard_returns` registers a trial for every output register the model characterizes (x86-64 SysV: `RAX` **and** `RDX`), and the cspec's `join_dual_class` output rule accepts the consecutive pair as one 16-byte return — materialized as `PIECE(RDX,RAX)`, typed `undefined16`, with the never-written `RDX` half picking up whatever the stack held. A known `int` return never enters that machinery. `fmt/main` now ends `return v13 ^ 1;`.

This closes the DWARF-having half of the return-storage proposal. The stripped/no-DWARF half is separate work.

## Policy

No `--option`. The prototype was recovered and then dropped on the floor for the function itself; applying it is a strict correction, not a judgment call. `apply_locked_prototype` already degrades gracefully — drops the prototype and decompiles unlocked — if storage assignment hits an unported seam. Recorded as DIV-27.

## Verification

- `make test` — 675/675, **PARITY OK**
- `make test-stages` — 261/261, **PARITY OK**
- `make rust-test` — green (+3 new)
- `make check-spec` — OK
- Speed: 0.54s vs 0.54s on `fmt/main` — unchanged
- Testcase: `verify_dwarf_prototypes.rs` over `dwarf_globals_x86_64` (`bump(int4 n)`, `main(int4 argc,char **argv)`) and `regglobal_fmt_x86_64` (no `undefined16`, no `[16]` phantom, `return v13 ^ 1;`)
- Spec: `docs/spec/04-calls-and-prototypes.md` §4.2 (new "Seeding" subsection), `docs/spec/01-program-prep.md` §1.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H71mWNphPiqPEesDuknSqW