### PR TITLE
fix(cli): report each function entry once on a whole-binary run

### DIFF
--- a/decompiler/crates/kuna-analysis/src/analyzers/entry/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/entry/mod.rs
@@ -308,7 +308,7 @@ fn existing_function_addrs_for_file(file: &object::File) -> Vec<u64> {
         if sym.kind() != SymbolKind::Text {
             continue;
         }
-        let addr = sym.address();
+        let addr = thumb_masked(file, sym.address());
         if addr != 0 {
             out.push(addr);
         }
@@ -500,6 +500,39 @@ pub(crate) fn in_executable_section(execs: &[(u64, u64, Vec<u8>)], vma: u64) -> 
     execs.iter().any(|&(lo, hi, _)| vma >= lo && vma < hi)
 }
 
+/// (kuna, issue #197) Fold the ARM/Thumb mode bit out of a **symbol** address.
+///
+/// On 32-bit ARM a Thumb function's ELF symbol stores the mode bit in bit 0 of
+/// `st_value` (this repo's `arm_thumb_linked_le32` fixture records `compute` at
+/// `0x100b9` and `_start` at `0x100d7`, while `objdump` shows both functions
+/// starting at the even VMA); the odd address is not an instruction boundary at
+/// all.  Oracle 1 already masks `e_entry` this way (`collect_entries`); this is
+/// the same rule for the symbol-table stream, whose consumers were left unmasked:
+///
+/// * the raw odd VMA reached `listing_seeds` and became a `DiscoveredFunction`,
+///   which `funcdisc_recursive` then re-emitted as a "discovered entry" —
+///   the phantom `sub_100b9` that decompiles to an empty `void sub_100b9(void)`;
+/// * and because this same vec is the funcsym-skip set `collect_entries` tests
+///   against, a masked `e_entry` (`0x100d7` → `0x100d6`) failed to match the
+///   *unmasked* `0x100d7` recorded here, so `_start` was re-emitted as a "new"
+///   entry and picked up the generic `sub_100d6` alias.  Masking both sides
+///   restores that comparison.
+///
+/// **Strictly gated to `Architecture::Arm` (32-bit).** x86 instructions are
+/// byte-aligned, so an odd function address there is a genuine address — in-repo
+/// fixtures have real x86-64 functions at `0x40071d` and `0x1357`, and masking
+/// those would corrupt every x86 binary.  AArch64 is a distinct `object`
+/// architecture with no Thumb state, so it is correctly excluded.  MIPS16 /
+/// microMIPS use the same odd-address convention but need an `st_other` test as
+/// well, so they are deliberately not folded in here (`mips_markers`).
+pub(crate) fn thumb_masked(file: &object::File, addr: u64) -> u64 {
+    if file.architecture() == object::Architecture::Arm {
+        addr & !1
+    } else {
+        addr
+    }
+}
+
 /// Sorted VMAs of every already-named function: `.symtab`/`.dynsym` *defined*
 /// FUNC symbols (UND imports have `st_value == 0`) plus PLT import stubs. The
 /// commit seam's `find_function` already no-ops a covered address, but skipping
@@ -510,7 +543,7 @@ pub(crate) fn existing_function_addrs(file: &object::File, bytes: &[u8]) -> Vec<
         if sym.kind() != SymbolKind::Text {
             continue;
         }
-        let addr = sym.address();
+        let addr = thumb_masked(file, sym.address());
         if addr != 0 {
             out.push(addr);
         }

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -41,7 +41,7 @@
 use std::rc::Rc;
 
 use kuna_base::address::Address;
-use kuna_console::engine::{bootstrap_from_object, ConsoleProgram};
+use kuna_console::engine::{bootstrap_from_object, ConsoleProgram, FunctionEntry};
 // The decompile loop + result shape live in the shared decompile-project core
 // (`kuna_console::project` — also reused by the `kuna_wasm` front-end).
 use kuna_console::project::{decompile_targets, render_c, FuncResult};
@@ -119,11 +119,13 @@ pub fn run_functions(argv: &[String]) -> i32 {
                 let arr = Json::Array(
                     entries
                         .iter()
-                        .map(|(n, a)| {
+                        .map(|e| {
+                            let a = e.addr.get_offset();
                             Json::Object(vec![
-                                ("name".into(), Json::Str(n.clone())),
+                                ("name".into(), Json::Str(e.name.clone())),
                                 ("address".into(), Json::Number(a.to_string())),
                                 ("address_hex".into(), Json::Str(format!("0x{a:x}"))),
+                                ("aliases".into(), aliases_json(&e.aliases)),
                             ])
                         })
                         .collect(),
@@ -137,8 +139,15 @@ pub fn run_functions(argv: &[String]) -> i32 {
                     ]))
                 );
             } else {
-                for (name, addr) in &entries {
-                    println!("0x{addr:x}\t{name}");
+                for e in &entries {
+                    // Alias names follow the canonical one on the same line, so
+                    // the plain listing stays one line per function.
+                    let extra = if e.aliases.is_empty() {
+                        String::new()
+                    } else {
+                        format!("\t({})", e.aliases.join(", "))
+                    };
+                    println!("0x{:x}\t{}{extra}", e.addr.get_offset(), e.name);
                 }
             }
             0
@@ -168,19 +177,14 @@ fn decompile_all(args: &Args) -> Result<Vec<FuncResult>, String> {
     Ok(decompile_targets(&mut prog, targets, args.no_vars, /* want_proto= */ false))
 }
 
-/// Enumerate the program's functions as `(name, address)` (the `functions`
-/// command + the default `decompile-all` target set).
-fn list_functions(args: &Args) -> Result<Vec<(String, u64)>, String> {
+/// Enumerate the program's functions, one [`FunctionEntry`] per entry address
+/// (the `functions` command + the default `decompile-all` target set).
+fn list_functions(args: &Args) -> Result<Vec<FunctionEntry>, String> {
     let prog = load_program(args, /* default_listing= */ false)?;
-    let mut entries: Vec<(String, u64)> = prog
-        .function_entries()
-        .map(|(n, a)| (n.to_string(), a.get_offset()))
-        .collect();
-    // Deduplicate by (address, name) — a symbol can appear in both the loader set
-    // and a later register — and sort by address for a stable, readable order.
-    entries.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
-    entries.dedup();
-    Ok(entries)
+    // One record per entry address, address-ordered, alias names carried as data
+    // (issue #197 — this used to dedup by (address, name), so a function the
+    // loader and an analysis pass both named was listed twice).
+    Ok(prog.function_entries_canonical())
 }
 
 /// Bootstrap the architecture from the binary and run the analysis commit (the
@@ -294,46 +298,48 @@ pub(crate) fn load_program(args: &Args, default_listing: bool) -> Result<Console
     Ok(prog)
 }
 
-/// Build the target `(name, Address)` list from the filters: `--addr` entries
-/// (named via the symbol table, else `name_function`), `--functions` names, or —
-/// with no filter — every enumerated function.
+/// Build the target [`FunctionEntry`] list from the filters: `--addr` entries
+/// (the canonical record at that address, else a record named via the symbol
+/// table / `name_function`), `--functions` names or aliases, or — with no filter
+/// — every enumerated function, each exactly once.
 pub(crate) fn resolve_targets(
     prog: &ConsoleProgram,
     args: &Args,
-) -> Result<Vec<(String, Address)>, String> {
+) -> Result<Vec<FunctionEntry>, String> {
     let code_space = prog
         .arch()
         .manage()
         .get_default_code_space()
         .ok_or("no default code space")?;
 
-    // The full enumerated set as (name -> Address), used by the name filter and
-    // the no-filter default.
-    let all: Vec<(String, Address)> = {
-        let mut v: Vec<(String, Address)> =
-            prog.function_entries().map(|(n, a)| (n.to_string(), a.clone())).collect();
-        v.sort_by(|a, b| a.1.get_offset().cmp(&b.1.get_offset()).then_with(|| a.0.cmp(&b.0)));
-        v.dedup_by(|a, b| a.0 == b.0 && a.1.get_offset() == b.1.get_offset());
-        v
-    };
-
-    let mut targets: Vec<(String, Address)> = Vec::new();
+    let mut targets: Vec<FunctionEntry> = Vec::new();
 
     // `--addr 0xVMA`: build the Address directly; name it from the symbol table
     // (or the default `FUN_<addr>` name) so the print/proto path has a name.
+    // Prefer the canonical record when the enumeration knows this entry, so an
+    // explicitly-addressed function reports the same name + aliases it would in
+    // a whole-binary run.
     for &vma in &args.addrs {
-        let addr = Address::new(Rc::clone(code_space), vma);
-        let name = prog
-            .function_named_at(vma)
-            .unwrap_or_else(|| prog.arch().name_function(&addr));
-        targets.push((name, addr));
+        match prog.find_entry_at(vma) {
+            Some(e) => targets.push(e),
+            None => {
+                let addr = Address::new(Rc::clone(code_space), vma);
+                let name = prog
+                    .function_named_at(vma)
+                    .unwrap_or_else(|| prog.arch().name_function(&addr));
+                targets.push(FunctionEntry { name, addr, aliases: Vec::new() });
+            }
+        }
     }
 
-    // `--functions a,b,c`: intersect names with the enumerated set.
+    // `--functions a,b,c`: intersect names with the enumerated set.  An ALIAS
+    // resolves too — collapsing the enumeration must not make a name that used
+    // to select a function stop working (the decbench name-narrowing looks up
+    // generated `sub_<addr>` names).
     if let Some(names) = &args.names {
         for want in names {
-            match all.iter().find(|(n, _)| n == want) {
-                Some((n, a)) => targets.push((n.clone(), a.clone())),
+            match prog.find_entry_by_name(want) {
+                Some(e) => targets.push(e),
                 None => eprintln!("warning: no function named {want:?} in {}", args.binary),
             }
         }
@@ -343,13 +349,13 @@ pub(crate) fn resolve_targets(
     // `--functions f` can resolve to the same function, and decompiling it twice
     // just wastes work + duplicates the JSON entry.
     let mut seen = std::collections::HashSet::new();
-    targets.retain(|(_, a)| seen.insert(a.get_offset()));
+    targets.retain(|e| seen.insert(e.addr.get_offset()));
 
-    // No filter at all ⇒ every function (the `all` set is already deduped by
-    // (name, offset), preserving distinct alias names at one address for the
-    // decbench name-narrowing).
+    // No filter at all ⇒ every function, exactly once (issue #197: `all` used to
+    // be deduped by (name, offset), so one function appeared once per name it
+    // carried — and on ARM once more per Thumb `entry|1` twin).
     if args.addrs.is_empty() && args.names.is_none() {
-        targets = all;
+        targets = prog.function_entries_canonical();
     }
     Ok(targets)
 }
@@ -455,6 +461,7 @@ fn result_json(binary: &str, funcs: &[FuncResult]) -> Json {
                     ("name".into(), Json::Str(f.name.clone())),
                     ("address".into(), Json::Number(f.address.to_string())),
                     ("address_hex".into(), Json::Str(format!("0x{:x}", f.address))),
+                    ("aliases".into(), aliases_json(&f.aliases)),
                     ("size".into(), Json::Number(f.size.to_string())),
                     (
                         "code".into(),
@@ -474,6 +481,15 @@ fn result_json(binary: &str, funcs: &[FuncResult]) -> Json {
         ("count".into(), Json::Number(funcs.len().to_string())),
         ("functions".into(), functions),
     ])
+}
+
+/// (kuna, issue #197) The `aliases` array: every OTHER name the reported entry
+/// carries.  Always present (`[]` when the entry has exactly one name) so a
+/// consumer can read the field unconditionally.  Additive — no existing field
+/// changes shape, and the names that used to appear as extra top-level records
+/// are all still here, one level down.
+fn aliases_json(aliases: &[String]) -> Json {
+    Json::Array(aliases.iter().map(|a| Json::Str(a.clone())).collect())
 }
 
 /// One `VariableInfo`-shaped JSON object (the fields decbench's `type_match`

--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -47,6 +47,23 @@ fn arm_thumb() -> String {
         .to_string()
 }
 
+/// A larger **ARM 32-bit** ELF fixture with functions the prologue-`<patternpairs>`
+/// matcher genuinely finds and the entry oracles do not (`0x3e0`, `0x410`,
+/// `0x3c520`) — the fixture the DIV-20 `funcstart_patterns` assertion needs.
+///
+/// `arm_thumb()` cannot serve that role: it holds exactly two functions, both
+/// already named by `.symtab`, so `funcstart_patterns` adds no real entry there.
+/// Before issue #197 the assertion appeared to pass on it only because the pass's
+/// extra "discoveries" were duplicate records for those same two functions (a
+/// `sub_<addr>` alias plus an odd-address Thumb `entry|1` phantom).
+fn arm_entrymain() -> String {
+    repo_root()
+        .join("decompiler/crates/kuna-analysis/tests/fixtures/entrymain_arm")
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
 /// Parse the `"count": N` field out of the decompile-all `--json` header.
 fn json_count(stdout: &str) -> Option<usize> {
     let i = stdout.find("\"count\":")? + "\"count\":".len();
@@ -166,9 +183,16 @@ fn decompile_all_emits_json_for_main() {
 /// discovers only the ELF entry; with it the prologue `<patternpairs>` matcher finds
 /// more. The default must match an explicit `--option funcstart_patterns on` and beat
 /// `off`.
+///
+/// Runs on `entrymain_arm`, where the pass finds three functions nothing else does
+/// (`0x3e0`, `0x410`, `0x3c520`): 10 entries `off` vs 13 by default. It used to run
+/// on the two-function `arm_thumb()` fixture, where the "extra" entries the
+/// assertion counted were in fact duplicate records for functions already found —
+/// so the fixture swap is what keeps this assertion meaningful once issue #197
+/// stops the enumeration reporting one function more than once.
 #[test]
 fn arm_decompile_all_defaults_funcstart_patterns_on() {
-    let bin = arm_thumb();
+    let bin = arm_entrymain();
     let sp = specs();
     let run = |extra: &[&str]| -> Option<usize> {
         let mut args = vec!["decompile-all", bin.as_str(), "--json", "--sleighpath", sp.as_str()];
@@ -292,6 +316,148 @@ fn arm_decompile_all_raw_thumb_prologue_seed_non_destructive() {
         default_cnt >= off_cnt,
         "raw Thumb-prologue seed must never discover FEWER than funcstart_patterns off \
          (default={default_cnt}, off={off_cnt})"
+    );
+}
+
+/// Issue #197: a whole-binary run reports each function ENTRY exactly once.
+///
+/// `arm_thumb_linked_le32` holds exactly two functions (`compute` @ 0x100b8 and
+/// `_start` @ 0x100d6 — see the fixture's `.c`), but `decompile-all` used to emit
+/// **six** records for them: one per name the entry carried (`compute` +
+/// `sub_100b8`), plus one per ARM Thumb `entry|1` twin (`sub_100b9`, `sub_100d7`)
+/// — the ELF `.symtab` stores these functions at the ODD `st_value` 0x100b9 /
+/// 0x100d7, the mode bit, and the unmasked value was being seeded as a function
+/// start.  The odd twins are not merely redundant: 0x100b9 is not an instruction
+/// boundary, so it decompiled to a bogus empty `void sub_100b9(void)`.
+///
+/// Asserts the canonical shape: two entries, at the two even addresses, named by
+/// their real symbols, with the generated `sub_<addr>` name kept in `aliases` (so
+/// nothing that could be looked up before stops resolving) and no odd address
+/// anywhere in the output.
+#[test]
+fn decompile_all_reports_each_entry_once() {
+    let bin = arm_thumb();
+    let sp = specs();
+    let (stdout, stderr, ok) =
+        run_kuna(&["decompile-all", bin.as_str(), "--json", "--sleighpath", sp.as_str()]);
+    if !ok {
+        if is_specs_skip(&stderr) {
+            eprintln!("entry dedup: skipping (no `.sla`; run `make specs`)");
+            return;
+        }
+        panic!("kuna decompile-all failed on the ARM fixture: {stderr}");
+    }
+    assert_eq!(
+        json_count(&stdout),
+        Some(2),
+        "the 2-function ARM fixture must report 2 entries, not one per name/twin:\n{stdout}"
+    );
+    // The real symbols win the `name` slot ...
+    for want in ["\"name\": \"compute\"", "\"name\": \"_start\""] {
+        assert!(stdout.contains(want), "expected {want} in:\n{stdout}");
+    }
+    // ... the generated placeholders survive as aliases, not as extra records ...
+    for want in ["\"sub_100b8\"", "\"sub_100d6\""] {
+        assert!(stdout.contains(want), "expected the alias {want} in:\n{stdout}");
+    }
+    assert!(
+        !stdout.contains("\"name\": \"sub_100b8\"") && !stdout.contains("\"name\": \"sub_100d6\""),
+        "a generic `sub_<addr>` alias must not be a function's reported name:\n{stdout}"
+    );
+    // ... and the Thumb `entry|1` phantoms are gone entirely (address AND name).
+    for gone in ["0x100b9", "0x100d7", "sub_100b9", "sub_100d7"] {
+        assert!(
+            !stdout.contains(gone),
+            "the ARM Thumb `entry|1` twin {gone} must not be reported at all:\n{stdout}"
+        );
+    }
+}
+
+/// Issue #197, the companion guarantee: collapsing the enumeration must not make a
+/// name that used to select a function stop working.  `--functions <alias>` still
+/// resolves an entry through its alias list — the lookup decbench's name-narrowing
+/// relies on — and reports it under its canonical name.
+#[test]
+fn decompile_all_functions_filter_resolves_an_alias() {
+    let bin = arm_thumb();
+    let sp = specs();
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile-all",
+        bin.as_str(),
+        "--json",
+        "--sleighpath",
+        sp.as_str(),
+        "--functions",
+        "sub_100b8",
+    ]);
+    if !ok {
+        if is_specs_skip(&stderr) {
+            eprintln!("alias lookup: skipping (no `.sla`; run `make specs`)");
+            return;
+        }
+        panic!("kuna decompile-all failed on the ARM fixture: {stderr}");
+    }
+    assert_eq!(
+        json_count(&stdout),
+        Some(1),
+        "`--functions sub_100b8` must still select exactly one function:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("\"name\": \"compute\"") && stdout.contains("\"0x100b8\""),
+        "the alias must resolve to `compute` @ 0x100b8:\n{stdout}"
+    );
+}
+
+/// Issue #197, `--addr` on an ARM/Thumb `entry|1` address.
+///
+/// An ARM caller legitimately holds odd addresses — an ELF `st_value`, a DWARF
+/// entry PC, a benchmark case address all carry the Thumb mode bit. Asking for
+/// `--addr 0x100b9` used to decompile literally there, landing mid-`push {r7}`
+/// and returning an empty `void compute(void) { return; }`. It now resolves to the
+/// real entry, and the odd address must NOT fold on a byte-aligned ISA, where an
+/// odd function address is genuine (`cet_pie_x86_64` really has
+/// `elaborate_debug_symbol` at 0x1357).
+#[test]
+fn decompile_all_addr_tolerates_the_arm_thumb_bit() {
+    let sp = specs();
+    let arm = arm_thumb();
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile-all", arm.as_str(), "--json", "--sleighpath", sp.as_str(), "--addr", "0x100b9",
+    ]);
+    if !ok {
+        if is_specs_skip(&stderr) {
+            eprintln!("thumb --addr: skipping (no `.sla`; run `make specs`)");
+            return;
+        }
+        panic!("kuna decompile-all failed on the ARM fixture: {stderr}");
+    }
+    assert!(
+        stdout.contains("\"address_hex\": \"0x100b8\"") && stdout.contains("\"name\": \"compute\""),
+        "--addr 0x100b9 must resolve to `compute` at its real entry 0x100b8:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("a0 * 3 + 7"),
+        "--addr 0x100b9 must decompile the real body, not an empty phantom:\n{stdout}"
+    );
+
+    // The x86-64 guardrail: an odd address there is a real entry, never folded.
+    let x86 = repo_root()
+        .join("decompiler/crates/kuna-analysis/tests/fixtures/cet_pie_x86_64")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile-all", x86.as_str(), "--json", "--sleighpath", sp.as_str(), "--addr", "0x1357",
+    ]);
+    if !ok {
+        if is_specs_skip(&stderr) {
+            return;
+        }
+        panic!("kuna decompile-all failed on the x86-64 fixture: {stderr}");
+    }
+    assert!(
+        stdout.contains("\"address_hex\": \"0x1357\""),
+        "an odd x86-64 address is a REAL entry and must not be Thumb-masked:\n{stdout}"
     );
 }
 

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -33,6 +33,7 @@
 //! function entry the faithful way (the binaryimage's own symbol records, which
 //! is precisely what `readLoaderSymbols` reads).
 
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use kuna_base::address::Address;
@@ -61,6 +62,26 @@ use kuna_sleigh::translate::register_translate_ids;
 struct ProgramSymbol {
     name: String,
     addr: Address,
+}
+
+/// (kuna, issue #197) One **canonical** function entry — the unit of a
+/// whole-binary run, produced by [`ConsoleProgram::function_entries_canonical`].
+///
+/// Exactly one of these exists per function entry address.  `name` is the most
+/// informative symbol the entry carries ([`entry_name_rank`]); `aliases` holds
+/// every other name for it — a generic `sub_<addr>` placeholder, a debug-info
+/// name alongside the linker one, a decorated/undecorated pair — in the same
+/// preference order, so nothing the raw symbol stream knew is lost and a
+/// name-keyed lookup still resolves.
+#[derive(Debug, Clone)]
+pub struct FunctionEntry {
+    /// The most informative name at this entry (never a placeholder when the
+    /// entry also carries a real symbol).
+    pub name: String,
+    /// The entry address, Thumb-bit normalized on an ARM-family spec.
+    pub addr: Address,
+    /// Every other name this same entry carries, in the same preference order.
+    pub aliases: Vec<String>,
 }
 
 /// (kuna) A one-shot [`AssemblyEmit`](kuna_sleigh::translate::AssemblyEmit)
@@ -231,6 +252,125 @@ impl ConsoleProgram {
     /// raw-backend convention — the engine reports every function it found.
     pub fn function_entries(&self) -> impl Iterator<Item = (&str, &Address)> {
         self.symbols.iter().map(|s| (s.name.as_str(), &s.addr))
+    }
+
+    /// (kuna, issue #197) The **canonical** whole-binary function enumeration:
+    /// exactly one [`FunctionEntry`] per function ENTRY, address-ordered, with
+    /// every other name that entry carries kept as an alias.
+    ///
+    /// [`Self::function_entries`] is the raw symbol stream, in which one function
+    /// can appear several times — [`Self::register_symbol`] retains by NAME, so
+    /// two names at one address are two records.  Three producers feed that:
+    ///
+    /// 1. **A generic alias at the same address.** An analysis pass re-registers a
+    ///    discovered entry under the engine placeholder `sub_<addr>` even though
+    ///    the loader already named it, so `compute` and `sub_100b8` both sit at
+    ///    `0x100b8`.  Likewise every FID/PDB/demangle *rename* leaves the old
+    ///    placeholder behind in the symbol stream.
+    /// 2. **The ARM Thumb `entry|1` twin.** An ARM/Thumb function's ELF symbol
+    ///    stores the mode bit IN `st_value` (this repo's `arm_thumb_linked_le32`
+    ///    fixture has `compute` at `st_value = 0x100b9`), so an unmasked consumer
+    ///    reports a second entry one byte above the real one.  That twin is not
+    ///    merely redundant: `0x100b9` is not an instruction boundary, so it
+    ///    decompiles to a bogus empty `void sub_100b9(void)`.
+    /// 3. **A second, genuinely different name for one function.** A debug-info
+    ///    pass (DWARF/PDB/pclntab/objc) emits a name the linker symbol table does
+    ///    not have, and it is registered beside the loader's: `macho_dwarf.o`
+    ///    carries `_l0`+`first_byte` at `0x0` and `_main`+`main` at `0x40`, and a
+    ///    decorated/undecorated PE pair takes the same path.  (The loader's own
+    ///    funcsym stream cannot do this — it is address-deduped as it is read.)
+    ///
+    /// Producers 1 and 3 collapse by address; producer 2 needs the same Thumb-bit
+    /// normalization [`crate::project::build_asm`] already applies to its labels
+    /// (`vma & !1` on an ARM-family spec), which is also what the loader does when
+    /// it turns an odd `st_value` into an even entry address.
+    ///
+    /// The retained `name` is the most informative one ([`entry_name_rank`]);
+    /// `aliases` keeps the rest so a name-keyed lookup
+    /// ([`Self::find_entry_by_name`], behind `--functions <alias>`) still
+    /// resolves.  Nothing is lost — one function is simply reported, and
+    /// decompiled, once.
+    pub fn function_entries_canonical(&self) -> Vec<FunctionEntry> {
+        let normalize = |vma: u64| self.thumb_normalized(vma);
+
+        // Group every name by normalized entry offset, keeping one Address per
+        // group (rebuilt at the normalized offset, so an ARM twin reports the
+        // real, even entry).
+        let mut groups: BTreeMap<u64, (Address, Vec<String>)> = BTreeMap::new();
+        for s in &self.symbols {
+            // A sentinel (spaceless) address cannot be normalized or rebuilt;
+            // such a record is not a real entry, so skip it rather than guess.
+            let Some(space) = s.addr.get_space() else { continue };
+            let vma = normalize(s.addr.get_offset());
+            let entry = groups
+                .entry(vma)
+                .or_insert_with(|| (Address::new(Rc::clone(space), vma), Vec::new()));
+            if !entry.1.iter().any(|n| n == &s.name) {
+                entry.1.push(s.name.clone());
+            }
+        }
+
+        groups
+            .into_iter()
+            .map(|(_, (addr, mut names))| {
+                // Most informative first — see `entry_name_rank`.
+                names.sort_by(|a, b| {
+                    entry_name_rank(a).cmp(&entry_name_rank(b)).then_with(|| a.cmp(b))
+                });
+                let name = names.remove(0);
+                FunctionEntry { name, addr, aliases: names }
+            })
+            .collect()
+    }
+
+    /// (kuna, issue #197) Resolve a canonical entry by ANY of its names — the
+    /// reported `name` or any of its `aliases`.
+    ///
+    /// The name-keyed lookup behind `kuna decompile-all --functions <name>` (and
+    /// the wasm `decompile <name>` command).  Collapsing the enumeration must not
+    /// make a name that used to select a function stop working, so the filter
+    /// searches the alias set too — this is what preserves the decbench
+    /// name-narrowing the old `(name, offset)` dedup was keeping duplicate records
+    /// for.  Shared by both front-ends so the two `resolve_targets` copies cannot
+    /// drift apart on it.
+    pub fn find_entry_by_name(&self, want: &str) -> Option<FunctionEntry> {
+        self.function_entries_canonical()
+            .into_iter()
+            .find(|e| e.name == want || e.aliases.iter().any(|a| a == want))
+    }
+
+    /// (kuna, issue #197) Resolve the canonical entry AT `vma`, tolerating an
+    /// ARM/Thumb `entry|1` address.
+    ///
+    /// Backs `kuna decompile-all --addr 0xVMA` (and the wasm `decompile 0xADDR`
+    /// command).  An ARM caller legitimately holds odd addresses — an ELF symbol
+    /// value, a DWARF entry PC, or a benchmark case address all carry the Thumb
+    /// mode bit — and decompiling literally there lands mid-instruction and
+    /// yields an empty body.  Folding the bit reaches the real function.
+    ///
+    /// Deliberately conservative: it only ever returns an entry the enumeration
+    /// already knows, so an address that is not a discovered function start is
+    /// still `None` and the caller keeps decompiling exactly where it was asked.
+    pub fn find_entry_at(&self, vma: u64) -> Option<FunctionEntry> {
+        let want = self.thumb_normalized(vma);
+        self.function_entries_canonical()
+            .into_iter()
+            .find(|e| e.addr.get_offset() == want)
+    }
+
+    /// (kuna, issue #197) Fold the ARM/Thumb mode bit out of `vma`.
+    ///
+    /// On an ARM-family spec a Thumb function's recorded address carries the mode
+    /// bit in bit 0 while the instructions live at the even VMA — the same test
+    /// and mask [`crate::project::build_asm`] applies to its labels, and the
+    /// console-tier counterpart of the analysis tier's `thumb_masked`.  A no-op on
+    /// every other architecture, where an odd code address is genuine.
+    fn thumb_normalized(&self, vma: u64) -> u64 {
+        if self.description().starts_with("ARM") {
+            vma & !1
+        } else {
+            vma
+        }
     }
 
     /// (kuna) Every section of bytes the load image maps, as `(vma, size, flags)`
@@ -726,6 +866,48 @@ fn is_generic_placeholder_name(name: &str) -> bool {
         || name.starts_with("func_")
         || name.starts_with("FUN_")
         || name.starts_with("LAB_")
+}
+
+/// (kuna, issue #197) Is `name` a synthesized STRUCTURAL name rather than one the
+/// binary actually carries?
+///
+/// `_INIT_<i>` / `_FINI_<i>` / `_DT_INIT` / `_DT_FINI` are minted by the entry
+/// oracle for the ELF dynamic INIT/FINI tables (Ghidra `ElfProgramBuilder`'s
+/// naming, threaded through `AnalysisOutput::entry_names`).  They say what the
+/// table SLOT is, not what the function is called, so a real symbol at the same
+/// address must outrank them — `fmt_arm`'s `0x4c0` reports
+/// `__do_global_dtors_aux` with `_FINI_0` as an alias, not the reverse.
+fn is_structural_entry_name(name: &str) -> bool {
+    name == "_DT_INIT"
+        || name == "_DT_FINI"
+        || name
+            .strip_prefix("_INIT_")
+            .or_else(|| name.strip_prefix("_FINI_"))
+            .is_some_and(|i| !i.is_empty() && i.bytes().all(|b| b.is_ascii_digit()))
+}
+
+/// (kuna, issue #197) How informative is `name`?  Smaller sorts first when
+/// [`ConsoleProgram::function_entries_canonical`] picks which of an entry's names
+/// to report; the rest become aliases.  Ordered by decreasing importance:
+///
+/// 1. **Not an engine placeholder.**  `sub_`/`func_`/`FUN_`/`LAB_`
+///    ([`is_generic_placeholder_name`]) carry no information beyond the address,
+///    which the record already holds, so they always lose.
+/// 2. **Not a synthesized structural name** ([`is_structural_entry_name`]).
+/// 3. **No leading underscore.**  Where one function carries both a linker symbol
+///    and a debug-info symbol, the underscore-prefixed one is the mangled/ABI
+///    spelling: `macho_dwarf.o` has `_l0`+`first_byte` at `0x0` and `_main`+`main`
+///    at `0x40`, and the reported mingw-PE pair is `_pre_c_init`+`pre_c_init`.
+///    The unprefixed name is the one a reader wants.
+/// 4. **Shorter**, then **lexicographic** — so the choice is total and stable
+///    run to run rather than dependent on symbol-stream order.
+fn entry_name_rank(name: &str) -> (bool, bool, bool, usize) {
+    (
+        is_generic_placeholder_name(name),
+        is_structural_entry_name(name),
+        name.starts_with('_'),
+        name.len(),
+    )
 }
 
 /// Build the marshaling [`IdRegistry`] the console bootstrap needs (the same

--- a/decompiler/crates/kuna-console/src/project.rs
+++ b/decompiler/crates/kuna-console/src/project.rs
@@ -9,12 +9,11 @@
 //! `kuna-cli`'s subprocess machinery.  The callers keep their own argument
 //! parsing / program loading (`load_program` / `resolve_targets` stay in
 //! `kuna-cli`); everything here operates on an already-loaded
-//! [`ConsoleProgram`] and the resolved `(name, Address)` target list.
+//! [`ConsoleProgram`] and the resolved [`FunctionEntry`] target list.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-use kuna_base::address::Address;
 use kuna_decomp::decompile_drive::{
     decompile_func_full_with_override_dyn, extract_variables, print_c, print_c_prototype, VarInfo,
 };
@@ -26,7 +25,7 @@ use kuna_decomp::decompile_drive::{
 use kuna_sleigh::loadimage::section_flags;
 use object::{Object, ObjectSection};
 
-use crate::engine::ConsoleProgram;
+use crate::engine::{ConsoleProgram, FunctionEntry};
 
 /// `dat_` blocks larger than this are truncated in the `.asm` data tail (the
 /// printer's `dat_<hex>` names carry no size; the label only marks the start).
@@ -46,6 +45,13 @@ pub struct FuncResult {
     /// path, whose JSON must stay byte-identical.
     pub proto: Option<String>,
     pub variables: Vec<VarInfo>,
+    /// (kuna, issue #197) Every OTHER name this entry carries — a generic
+    /// `sub_<addr>` placeholder, an ELF weak/strong twin, a PE
+    /// decorated/undecorated pair.  Carried through from
+    /// [`crate::engine::FunctionEntry`] so collapsing the enumeration to one
+    /// record per entry loses no name; empty for a target the caller named
+    /// itself (`--addr` on an address the enumeration does not know).
+    pub aliases: Vec<String>,
 }
 
 /// Decompile each `(name, entry)` target in turn against the already-loaded
@@ -57,12 +63,12 @@ pub struct FuncResult {
 /// its JSON byte-identical.
 pub fn decompile_targets(
     prog: &mut ConsoleProgram,
-    targets: Vec<(String, Address)>,
+    targets: Vec<FunctionEntry>,
     no_vars: bool,
     want_proto: bool,
 ) -> Vec<FuncResult> {
     let mut out = Vec::with_capacity(targets.len());
-    for (name, entry) in targets {
+    for FunctionEntry { name, addr: entry, aliases } in targets {
         let address = entry.get_offset();
         // Mirror IfcDecompile: re-seed this function's DWARF stack locals (so a
         // `-g` binary renders DWARF names/types) and decompile.  The drive itself
@@ -138,6 +144,7 @@ pub fn decompile_targets(
                         error: None,
                         proto,
                         variables,
+                        aliases,
                     }),
                     Err(_) => out.push(FuncResult {
                         name,
@@ -147,6 +154,7 @@ pub fn decompile_targets(
                         error: Some("panic while rendering C / extracting variables".into()),
                         proto: None,
                         variables: Vec::new(),
+                        aliases,
                     }),
                 }
             }
@@ -158,6 +166,7 @@ pub fn decompile_targets(
                 error: Some(e.explain().to_string()),
                 proto: None,
                 variables: Vec::new(),
+                aliases,
             }),
         }
     }

--- a/decompiler/crates/kuna-console/tests/verify_decompile_all.rs
+++ b/decompiler/crates/kuna-console/tests/verify_decompile_all.rs
@@ -125,6 +125,80 @@ fn decompile_all_enumerates_and_decompiles_every_function() {
     assert!(!args[0].type_name.is_empty(), "parameter type string is empty");
 }
 
+/// The vendored ARM/Thumb fixture — two functions (`compute` @ 0x100b8, `_start`
+/// @ 0x100d6) whose ELF `.symtab` records them at the ODD `st_value` 0x100b9 /
+/// 0x100d7 (the Thumb mode bit).
+fn arm_thumb() -> PathBuf {
+    repo_root().join("decompiler/crates/kuna-analysis/tests/fixtures/arm_thumb_linked_le32")
+}
+
+/// Issue #197, at the shared seam: `function_entries_canonical` yields exactly one
+/// record per entry ADDRESS, and every name the raw stream knew is still reachable
+/// (as the record's `name` or one of its `aliases`).
+///
+/// This is the invariant all four whole-binary surfaces inherit — `decompile-all`,
+/// `functions`, `decompile-project`, and the wasm front-end, which has no test
+/// directory of its own and is covered only here.  Checked on both an x86-64 ELF
+/// (`fauxware`) and the ARM/Thumb fixture (whose odd `st_value`s are what made the
+/// duplicates un-collapsible by address alone).
+#[test]
+fn canonical_enumeration_reports_each_entry_address_once() {
+    let root = repo_root();
+    let spec_roots = vec![root.join("specs").to_str().unwrap().to_string()];
+
+    for fixture in [fauxware(), arm_thumb()] {
+        let Some(bin) = fixture.to_str().map(|s| s.to_string()) else { continue };
+        let mut prog = match bootstrap_from_object(&bin, "", &spec_roots) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!(
+                    "canonical enumeration: skipping {bin} (bootstrap failed, build `.sla` \
+                     with `make specs`): {}",
+                    e.explain()
+                );
+                continue;
+            }
+        };
+        prog.commit_pending_analysis().expect("read symbols (analysis commit) must succeed");
+
+        let canonical = prog.function_entries_canonical();
+        assert!(!canonical.is_empty(), "{bin}: canonical enumeration is empty");
+
+        // One record per entry address, strictly ascending (the accessor's order
+        // contract — the surfaces emit it as-is).
+        let mut prev: Option<u64> = None;
+        for e in &canonical {
+            let off = e.addr.get_offset();
+            if let Some(p) = prev {
+                assert!(p < off, "{bin}: entries not strictly address-ordered at 0x{off:x}");
+            }
+            prev = Some(off);
+            // A generated placeholder may only be the reported name when it is the
+            // ONLY name this entry has.
+            if e.name.starts_with("sub_") || e.name.starts_with("FUN_") {
+                assert!(
+                    e.aliases.is_empty(),
+                    "{bin}: 0x{off:x} reports the placeholder {:?} while also carrying {:?}",
+                    e.name,
+                    e.aliases
+                );
+            }
+        }
+
+        // Nothing is lost: every name in the raw stream is still reachable, and
+        // resolves back to the entry that owns it.
+        for (name, _) in prog.function_entries() {
+            let found = prog
+                .find_entry_by_name(name)
+                .unwrap_or_else(|| panic!("{bin}: raw name {name:?} no longer resolves"));
+            assert!(
+                found.name == name || found.aliases.iter().any(|a| a == name),
+                "{bin}: {name:?} resolved to an entry that does not carry it"
+            );
+        }
+    }
+}
+
 /// Assert the cross-cutting `VarInfo` invariants the type_match metric relies on:
 /// non-empty type strings, dense ordered parameter `arg_index`es, and no
 /// `arg_index` on stack locals.

--- a/decompiler/crates/kuna-wasm/src/lib.rs
+++ b/decompiler/crates/kuna-wasm/src/lib.rs
@@ -24,7 +24,7 @@
 use std::rc::Rc;
 
 use kuna_base::address::Address;
-use kuna_console::engine::{bootstrap_from_object, ConsoleProgram};
+use kuna_console::engine::{bootstrap_from_object, ConsoleProgram, FunctionEntry};
 use kuna_console::project::{
     build_asm, build_c, build_header, build_readme, collect_dat_addrs, decompile_targets,
     FuncResult,
@@ -85,16 +85,16 @@ pub fn run(binary: &str, spec_root: &str, cmd: &str, arg: Option<&str>) -> Resul
 
     match command {
         Cmd::List => {
-            let mut entries: Vec<(String, u64)> = prog
-                .function_entries()
-                .map(|(n, a)| (n.to_string(), a.get_offset()))
-                .collect();
-            entries.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
-            entries.dedup();
+            // One record per entry address, alias names carried as data
+            // (issue #197 — this used to dedup by (address, name), so one
+            // function was listed once per name it carried).
+            let entries = prog.function_entries_canonical();
             let classifier =
-                Classifier::new(&prog, binary, entries.iter().map(|&(_, vma)| vma));
-            let kinds: Vec<&'static str> =
-                entries.iter().map(|(n, vma)| classifier.kind(&prog, n, *vma)).collect();
+                Classifier::new(&prog, binary, entries.iter().map(|e| e.addr.get_offset()));
+            let kinds: Vec<&'static str> = entries
+                .iter()
+                .map(|e| classifier.kind(&prog, &e.name, e.addr.get_offset()))
+                .collect();
             Ok(list_json(binary, &entries, &kinds))
         }
         Cmd::Project(display) => project(binary, &mut prog, &display),
@@ -105,7 +105,7 @@ pub fn run(binary: &str, spec_root: &str, cmd: &str, arg: Option<&str>) -> Resul
             let classifier = Classifier::new(
                 &prog,
                 binary,
-                prog.function_entries().map(|(_, a)| a.get_offset()),
+                prog.function_entries_canonical().iter().map(|e| e.addr.get_offset()),
             );
             let out = decompile_targets(&mut prog, targets, /* no_vars= */ false,
                 /* want_proto= */ false);
@@ -203,38 +203,32 @@ fn load_program(
 fn resolve_targets(
     prog: &ConsoleProgram,
     command: &Cmd,
-) -> Result<Vec<(String, Address)>, String> {
+) -> Result<Vec<FunctionEntry>, String> {
     let code_space = prog
         .arch()
         .manage()
         .get_default_code_space()
         .ok_or("no default code space")?;
 
-    let all: Vec<(String, Address)> = {
-        let mut v: Vec<(String, Address)> = prog
-            .function_entries()
-            .map(|(n, a)| (n.to_string(), a.clone()))
-            .collect();
-        v.sort_by(|a, b| {
-            a.1.get_offset().cmp(&b.1.get_offset()).then_with(|| a.0.cmp(&b.0))
-        });
-        v.dedup_by(|a, b| a.0 == b.0 && a.1.get_offset() == b.1.get_offset());
-        v
-    };
-
     match command {
-        Cmd::DecompileAll => Ok(all),
-        Cmd::DecompileName(want) => match all.iter().find(|(n, _)| n == want) {
-            Some((n, a)) => Ok(vec![(n.clone(), a.clone())]),
+        // One record per entry address, alias names carried as data (issue #197).
+        Cmd::DecompileAll => Ok(prog.function_entries_canonical()),
+        // An ALIAS resolves too — collapsing the enumeration must not make a
+        // name that used to select a function stop working.
+        Cmd::DecompileName(want) => match prog.find_entry_by_name(want) {
+            Some(e) => Ok(vec![e]),
             None => Err(format!("no function named {want:?} in the binary")),
         },
-        Cmd::DecompileAddr(vma) => {
-            let addr = Address::new(Rc::clone(&code_space), *vma);
-            let name = prog
-                .function_named_at(*vma)
-                .unwrap_or_else(|| prog.arch().name_function(&addr));
-            Ok(vec![(name, addr)])
-        }
+        Cmd::DecompileAddr(vma) => match prog.find_entry_at(*vma) {
+            Some(e) => Ok(vec![e]),
+            None => {
+                let addr = Address::new(Rc::clone(&code_space), *vma);
+                let name = prog
+                    .function_named_at(*vma)
+                    .unwrap_or_else(|| prog.arch().name_function(&addr));
+                Ok(vec![FunctionEntry { name, addr, aliases: Vec::new() }])
+            }
+        },
         Cmd::List | Cmd::Project(_) => unreachable!("List/Project handled by caller"),
     }
 }
@@ -248,19 +242,21 @@ fn parse_addr(s: &str) -> Option<u64> {
 // --- JSON (self-contained; the `decompile-all --json` fields + `kind`) ------
 
 /// The `list` document:
-/// `{binary, count, functions:[{name, address, address_hex, kind}]}`.
+/// `{binary, count, functions:[{name, address, address_hex, aliases, kind}]}`.
 /// `kinds` is parallel to `entries` (the classifier's verdict per entry).
-fn list_json(binary: &str, entries: &[(String, u64)], kinds: &[&'static str]) -> String {
+fn list_json(binary: &str, entries: &[FunctionEntry], kinds: &[&'static str]) -> String {
     let mut s = String::from("{\n");
     s.push_str(&format!("  \"binary\": {},\n", json_str(binary)));
     s.push_str(&format!("  \"count\": {},\n", entries.len()));
     s.push_str("  \"functions\": [");
-    for (i, (name, addr)) in entries.iter().enumerate() {
+    for (i, e) in entries.iter().enumerate() {
+        let addr = e.addr.get_offset();
         s.push_str(if i == 0 { "\n" } else { ",\n" });
         s.push_str("    {");
-        s.push_str(&format!("\"name\": {}, ", json_str(name)));
+        s.push_str(&format!("\"name\": {}, ", json_str(&e.name)));
         s.push_str(&format!("\"address\": {}, ", addr));
         s.push_str(&format!("\"address_hex\": {}, ", json_str(&format!("0x{addr:x}"))));
+        s.push_str(&format!("\"aliases\": {}, ", json_str_array(&e.aliases)));
         s.push_str(&format!("\"kind\": {}", json_str(kinds[i])));
         s.push('}');
     }
@@ -281,6 +277,7 @@ fn result_json(binary: &str, funcs: &[FuncResult], kinds: &[&'static str]) -> St
         s.push_str(&format!("      \"name\": {},\n", json_str(&f.name)));
         s.push_str(&format!("      \"address\": {},\n", f.address));
         s.push_str(&format!("      \"address_hex\": {},\n", json_str(&format!("0x{:x}", f.address))));
+        s.push_str(&format!("      \"aliases\": {},\n", json_str_array(&f.aliases)));
         s.push_str(&format!("      \"kind\": {},\n", json_str(kinds[i])));
         s.push_str(&format!("      \"size\": {},\n", f.size));
         s.push_str(&format!("      \"code\": {},\n", json_opt_str(f.code.as_deref())));
@@ -342,6 +339,21 @@ fn json_opt_num(v: Option<i64>) -> String {
         Some(n) => n.to_string(),
         None => "null".to_string(),
     }
+}
+
+/// (kuna, issue #197) A JSON array of strings — the `aliases` field: every
+/// OTHER name the reported entry carries.  Always present (`[]` when the entry
+/// has exactly one name).
+fn json_str_array(items: &[String]) -> String {
+    let mut out = String::from("[");
+    for (i, s) in items.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        out.push_str(&json_str(s));
+    }
+    out.push(']');
+    out
 }
 
 /// Encode a Rust string as a JSON string literal (RFC 8259 escaping).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,14 +48,30 @@ The whole-binary surface (the benchmark + LLM path). Runs **in-process**
 `decompile_func` + `print_c`), loading + analyzing the binary **once** instead of
 `kuna decompile`'s subprocess-per-function (≈10×+ faster on a many-function binary).
 
-`--json` emits `{binary,count,functions:[{name,address,address_hex,size,code,error,
+`--json` emits `{binary,count,functions:[{name,address,address_hex,aliases,size,code,error,
 variables:[{name,type,kind,arg_index,stack_offset,size}]}]}` (`kuna functions --json`
-emits `name`/`address`/`address_hex` per function) — per-function `code` matches
+emits `name`/`address`/`address_hex`/`aliases` per function) — per-function `code` matches
 `kuna decompile ... --option listing on` byte-for-byte on x86-64 (elsewhere, see the
 injected defaults below), `error` isolates a single failed function, and `variables`
 (params in ABI order + DWARF/stack locals) feed type-recovery scoring.
 
 Behaviors specific to `decompile-all`:
+
+- **One record per function entry** — a whole-binary run reports (and decompiles) each
+  entry address exactly once. A function can carry several names: a `.symtab` symbol
+  plus a debug-info one (`macho_dwarf.o` has `_l0` and `first_byte` at `0x0`), a
+  decorated/undecorated PE pair, or the generated `sub_<addr>` placeholder an analysis
+  pass registers over an already-named entry. `name` reports the most informative of
+  them — a real symbol beats a synthesized `_INIT_<i>`/`_FINI_<i>`/`_DT_INIT`/`_DT_FINI`
+  table name, which beats a generated `sub_`/`func_`/`FUN_`/`LAB_` placeholder; ties
+  prefer the unprefixed spelling (`main` over `_main`), then the shorter name — and
+  `aliases` carries the rest (`[]` when there is only one). `--functions <name>` matches
+  aliases too, so any name that used to select a function still does. On ARM the Thumb
+  mode bit is folded out of symbol addresses, so a function whose ELF `st_value` is odd
+  (`compute` at `0x100b9`) is reported once, at its real even entry — and `--addr` accepts
+  either spelling, resolving an odd ARM address to the entry it belongs to instead of
+  decompiling mid-instruction. The fold is ARM-only: an odd address on a byte-aligned ISA
+  is a genuine entry and is left alone.
 
 - **Injected default options**: it injects `option listing on` unless the caller names
   `listing` (DIV-15), so the default-on `noreturn_propagate` call-graph fixpoint fires and
@@ -94,6 +110,9 @@ binary and attempt recompilation:
 
 - `<name>.c` — every decompiled function, address-ordered, under
   `// Function: <name> @ <addr>` headers, failures as comments, `#include "<name>.h"`.
+  One definition per entry address: the export shares `decompile-all`'s
+  one-record-per-entry enumeration above, so a function carrying several names cannot
+  produce several (identical, and therefore uncompilable) definitions.
 - `<name>.h` — include guard + a generated recompile prelude (core scalar and
   `undefined`-family typedefs), the recovered user-defined type definitions, and one
   prototype per decompiled function, token-identical to the `.c` definition line.

--- a/docs/history.md
+++ b/docs/history.md
@@ -142,6 +142,7 @@ new default flips add a row here (full original entries with evidence: git histo
 | DIV-29 | DWARF enums (no flag) | `DW_TAG_enumeration_type` builds a real enum type (`quotearg_style(4,…)` → `…(shell_escape_always_quoting_style,…)`) | 0/675; falls back to the underlying int when anonymous/memberless |
 | DIV-30 | uncomputed return half (no flag) | a recovered return PAIR whose half is a callee-saved restore / callee clobber is narrowed to the real half (kills `undefined16 main` + `v[8] = <uninit>`) | 0/675; subsumes `returnpair` on GH-6990 (3 stage assertions re-worded, 261/261) |
 | DIV-31 | x86 `DF` unaffected (no flag) | the ABI's direction-flag guarantee is stated where the cspec is silent, folding `(uint8)df * -2 + 1` strides to `+1` | 0/675; x86-only, spec-silent models only |
+| DIV-32 | whole-binary entry dedup (bug fix, no flag) | `decompile-all`/`functions`/`decompile-project`/wasm report each entry ADDRESS once — extra names move to `aliases[]`, and ARM/Thumb `entry\|1` addresses fold onto the real entry (symbol seeds, the enumeration key, and `--addr`) | 0/675 (analysis tier is parity-isolated); `arm_thumb_linked_le32` 6→2 entries, `fmt_arm` 32→14, x86-64 unchanged; 713/713 surviving functions byte-identical |
 
 ## Upstream provenance & sync
 

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -52,7 +52,15 @@ the order is load-bearing:
    order, and installs them through
    `decompiler/crates/kuna-console/src/engine.rs (commit_analysis_output)`. Every
    commit arm is additive and idempotent against the loader symbols already
-   installed (the `find_function` overlap check no-ops a duplicate).
+   installed *in the symbol table* (the `find_function` overlap check no-ops a
+   duplicate). Idempotence does **not** extend to the flat name→address stream
+   `decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::register_symbol)`
+   maintains: that retains by NAME, so an entry the loader already named
+   accumulates a second record whenever a pass supplies a different name for it —
+   a debug-info name (DWARF/PDB/pclntab/objc), a FID rename, or the generated
+   `sub_<addr>` placeholder for a rediscovered entry. Several names for one entry
+   is therefore the normal state, and §0.2 defines how the whole-binary surfaces
+   collapse it.
 
 Two pass families cannot run at load at all and are deferred *into* the commit:
 the Listing walk and its consumers (the call-graph no-return fixpoint, §1.6–§1.7;
@@ -107,6 +115,38 @@ Four front-ends drive one engine assembly:
   discard the functions already decompiled. `kuna functions` is enumeration only
   and keeps the Listing off (the build would turn a cheap symbol walk into a
   whole-program decode).
+
+  The enumeration these surfaces walk is
+  `decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::function_entries_canonical)`,
+  which yields **exactly one record per function entry address**, address-ordered.
+  It exists because the raw symbol stream
+  (`decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::function_entries)`)
+  holds one record per NAME (§0.1), so without it a whole-binary run reports — and
+  decompiles — the same function once per name it carries. Each record keeps the
+  most informative name and carries the rest as aliases, ranked by
+  `decompiler/crates/kuna-console/src/engine.rs (entry_name_rank)`: a real symbol
+  outranks a synthesized dynamic-table name (`_INIT_<i>` / `_FINI_<i>` /
+  `_DT_INIT` / `_DT_FINI`,
+  `decompiler/crates/kuna-console/src/engine.rs (is_structural_entry_name)`), which
+  outranks a generated placeholder
+  (`decompiler/crates/kuna-console/src/engine.rs (is_generic_placeholder_name)`);
+  ties prefer the unprefixed spelling over the underscore-prefixed one, then the
+  shorter name, then lexicographic order, so the choice is total and independent of
+  symbol-stream order. Name-keyed selection resolves aliases too
+  (`decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::find_entry_by_name)`),
+  so collapsing the records never makes a name stop selecting its function. On an
+  ARM-family spec the grouping key folds away the Thumb mode bit (`vma & !1`, the
+  same normalization
+  `decompiler/crates/kuna-console/src/project.rs (build_asm)` applies to its
+  labels), so an `entry` and its `entry|1` twin are one entry; address-keyed
+  selection folds it too
+  (`decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::find_entry_at)`),
+  so `--addr` on an odd ARM address reaches the function rather than decoding
+  mid-instruction. Both folds are gated to ARM, where an odd symbol address is
+  never an instruction boundary; elsewhere an odd address is genuine and is left
+  alone. All four whole-binary surfaces — `decompile-all`, `functions`,
+  `decompile-project` (`decompiler/crates/kuna-cli/src/decompile_project.rs`), and
+  the wasm front-end (`decompiler/crates/kuna-wasm/src/lib.rs`) — share it.
 - **`kuna_ghidra`** (`decompiler/crates/kuna-ghidra/src/bin/kuna_ghidra.rs`) —
   the ghidra-mode process front-end: the stock Ghidra GUI spawns it as its
   decompiler core and talks the burst-framed stdin/stdout protocol

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -374,7 +374,20 @@ the base of the code section is the only entry source. The table is confirmed wh
 `word[1] == e_entry` (the reset vector); the odd (Thumb) handler pointers are then
 harvested, LSB-masked, up to the start of code. Everything is unioned,
 deduped, restricted to executable sections, and skipped where a real funcsym
-already exists; a discovered ARM `main` whose GOT pointer had the Thumb LSB set
+already exists. That funcsym set
+(`decompiler/crates/kuna-analysis/src/analyzers/entry/mod.rs (existing_function_addrs)`)
+is itself Thumb-masked on 32-bit ARM
+(`decompiler/crates/kuna-analysis/src/analyzers/entry/mod.rs (thumb_masked)`),
+because an ARM/Thumb function's ELF symbol stores the mode bit in bit 0 of
+`st_value` and the odd address is not an instruction boundary. Masking it is what
+makes the skip comparable with the already-masked `e_entry` candidate — otherwise
+a named function is re-emitted as a "new" start and picks up a generated
+`sub_<addr>` name — and it keeps the raw odd address from being seeded as a
+function start in its own right, which would yield a phantom entry that decodes
+mid-instruction to an empty body. The mask is gated to `Architecture::Arm`: on a
+byte-aligned ISA an odd entry address is genuine (x86-64 fixtures have real
+functions at `0x40071d` and `0x1357`), and AArch64 has no Thumb state. A
+discovered ARM `main` whose GOT pointer had the Thumb LSB set
 also emits its own `TMode=1` paint (a stripped binary has no `$t` symbol to paint
 from). On a confirmed Cortex-M image the ELF `e_entry` seed is additionally
 LSB-masked to its even (decode) address, and `cortexm_thumb_paints` region-paints

--- a/docs/web-integration.md
+++ b/docs/web-integration.md
@@ -72,8 +72,10 @@ bootstrap_from_object(binary, "", [spec_root])   // load image + resolve arch + 
 ```
 
 Its `--json` is `kuna decompile-all --json`'s fields (`name`, `address`, `address_hex`,
-`size`, `code`, `error`, `variables[{name,type,kind,arg_index,stack_offset,size}]`) plus
-one kuna-wasm-only per-function field: `"kind"` — `"func"` | `"plt"` | `"thunk"`
+`aliases`, `size`, `code`, `error`, `variables[{name,type,kind,arg_index,stack_offset,size}]`)
+— including the one-record-per-entry contract and the `aliases` array documented in
+`docs/cli.md`, since both front-ends share `ConsoleProgram::function_entries_canonical` —
+plus one kuna-wasm-only per-function field: `"kind"` — `"func"` | `"plt"` | `"thunk"`
 (`kuna-wasm/src/classify.rs`: an `object`-crate re-parse marks entries inside import-stub
 sections — the `.plt` family, Mach-O symbol stubs — or named as imports as `"plt"`, and
 lone-jump entries (`ConsoleProgram::lone_jump_target`, direct-to-another-function or


### PR DESCRIPTION
Fixes the whole-binary duplication reported in #197. Closes #197.

A whole-binary run now reports — and decompiles — each function **entry** exactly once.

## The gap

`arm_thumb_linked_le32` (in-repo fixture) defines exactly two functions. `decompile-all`
reported six:

```
 BEFORE                                        AFTER
 compute    @ 0x100b8                          compute  @ 0x100b8  aliases=["sub_100b8"]
 sub_100b8  @ 0x100b8   <- alias               _start   @ 0x100d6  aliases=["sub_100d6"]
 sub_100b9  @ 0x100b9   <- Thumb entry|1
 _start     @ 0x100d6
 sub_100d6  @ 0x100d6   <- alias
 sub_100d7  @ 0x100d7   <- Thumb entry|1
```

The issue described the duplicates as byte-identical and therefore only wasted work. That
holds for the same-address aliases, but **not** for the ARM twins — those are wrong content.
`decompile-project` exported this `.c`, which has both a duplicate definition and two
functions that do not exist (0x100b9 is mid-`push {r7}`, not an entry):

```c
int4 compute(int4 a0)   { return a0 * 3 + 7; }
int4 sub_100b8(int4 a0) { return a0 * 3 + 7; }   // duplicate definition — will not compile
void sub_100b9(void)    { return; }              // phantom
```

## Root cause

Three producers, all upstream of one enumeration (`ConsoleProgram::function_entries`, a flat
`Vec<ProgramSymbol>`):

1. **A generated alias at the same address.** In `commit_analysis_output` the symbol-table
   insert is guarded (`if find_function(scope,&addr).is_none() { add_function(...) }`) but the
   following `register_symbol(&name, addr)` runs unconditionally, and `register_symbol`
   retains by **name**. An already-named entry therefore gains a second record under the
   generated `sub_<addr>`. Every FID/PDB/objc *rename* leaves its old placeholder behind the
   same way.
2. **The ARM/Thumb `entry|1` twin.** `existing_function_addrs` recorded the raw
   `sym.address()`. On 32-bit ARM the Thumb mode bit lives **in `st_value`** — `readelf` on
   the fixture shows `compute` at `0x100b9` and `_start` at `0x100d7`, while `objdump` shows
   both functions starting at the even VMA. Those odd addresses became Listing seeds and were
   re-emitted by `funcdisc_recursive` as discovered entries. The same defect broke the
   funcsym-skip: PR #168 masks the `e_entry` *candidate*, but compared it against this
   *unmasked* set, so `0x100d6` never matched the recorded `0x100d7` and `_start` was
   re-emitted as "new" — which is why `kuna functions` duplicated even with the Listing off.
3. **A second, genuinely different name for one function** — a debug-info pass emits a name
   the linker symbol table lacks (`macho_dwarf.o` carries `_l0`+`first_byte` at `0x0`,
   `_main`+`main` at `0x40`). This one is information, not noise.

Two corrections to the issue's analysis, both measured:

- **It is not limited to non-x86-64.** The x86-64 PE `pe_dwarf.exe` duplicates through
  producer 1 via the DWARF pass (`first_byte` + `sub_140001550`), which the
  `funcstart_patterns` architecture gate cannot explain. RISC-V also duplicates
  (`fmt_riscv64`: 17 records for 9 functions).
- **Producer 3 is not loader-side.** The loader funcsym stream is address-deduped as it is
  read, so it cannot emit two names at one address; the pair arrives from the analysis tier.

## What this does

- **`ConsoleProgram::function_entries_canonical`** (new, `kuna-console/src/engine.rs`) — one
  record per entry address, address-ordered, keeping the most informative name and carrying
  the rest as `aliases`. Producers 1 and 3 collapse by address; the ARM twin needs the Thumb
  fold in the grouping key, the same `vma & !1` on an ARM-family spec that `build_asm` already
  applies to its labels.
- **`thumb_masked`** (new, `kuna-analysis/.../entry/mod.rs`) — folds the mode bit out of the
  symbol-address stream, killing producer 2 at the source (no phantom is ever seeded, decoded
  or decompiled) and repairing the PR #168 mask/skip asymmetry. Hard-gated to
  `object::Architecture::Arm`.
- **Name preference** (`entry_name_rank`): a real symbol beats a synthesized dynamic-table
  name (`_INIT_<i>`/`_FINI_<i>`/`_DT_INIT`/`_DT_FINI`), which beats a generated
  `sub_`/`func_`/`FUN_`/`LAB_` placeholder; ties prefer the unprefixed spelling (`main` over
  `_main`, `first_byte` over `_l0`), then the shorter name, then lexicographic — total and
  independent of symbol-stream order.
- **Nothing stops resolving.** `find_entry_by_name` searches aliases too, so
  `--functions sub_100b8` still selects `compute` — the lookup the existing "preserving
  distinct alias names ... for the decbench name-narrowing" comment was keeping duplicate
  records for.
- **All four surfaces share it**: `decompile-all`, `functions`, `decompile-project`, and
  `kuna-wasm` (whose hand-copied `resolve_targets` is the drift risk — the grouping rule and
  the alias lookup now both live in `kuna-console`).
- `aliases` is additive in every JSON document, immediately after `address_hex`, always
  present (`[]` when the entry has one name).

**Beyond the issue's stated scope** (flagged for review — drop it if unwanted): `--addr` now
tolerates an odd ARM address. `--addr 0x100b9` used to decompile literally there and return
an empty `void compute(void) { return; }`; it now resolves to the real entry. Deliberately
conservative — it only folds onto an address the enumeration already knows, and it is ARM-only,
so a genuinely odd x86-64 entry (`cet_pie_x86_64` `elaborate_debug_symbol` @ `0x1357`) is
untouched. This matters because decbench drives `--addr` with case addresses.

## Policy

No `--option`. Emitting one function several times — as duplicate definitions in an exported
`.c`, or as an entry that is not a function at all — is wrong output, not a judgment call, so
per `CLAUDE.md` ("a strict bug fix that only corrects wrong output needs no flag") it ships
unflagged; there is also no driver-tier option machinery to hang it on (all 76 `phases.toml`
settables carry an engine phase). Recorded as **DIV-32**. No catalog counts, no
`docs/options.md` regen, no baseline re-pin.

Deliberately *not* done: suppressing the placeholder at the producer. It would delete the
alias data #197 asks to preserve, and with the collapse in place it saves no work.

## Blast radius (measured)

`decompile-all`, before → after (count / distinct addresses):

| fixture | before | after | note |
|---|---|---|---|
| `arm_thumb_linked_le32` | 6 / 4 | **2 / 2** | 2 real functions |
| `fmt_arm` | 32 / 20 | **14 / 14** | 6 odd phantoms + 12 aliases removed |
| `fmt_aarch64` | 28 / 14 | **14 / 14** | pure alias collapse |
| `fmt_riscv64` | 17 / 9 | **9 / 9** | pure alias collapse |
| `fmt_x86_64` | 11 / 11 | 11 / 11 | unchanged |
| `fauxware` | 21 / 21 | 21 / 21 | unchanged |
| `cet_pie_x86_64` | 21 / 21 | 21 / 21 | unchanged |
| `libselinux.so.1` | 621 / 621 | 621 / 621 | unchanged |

Every address that disappeared is an odd ARM Thumb phantom (`0x100b9`, `0x100d7`, `0x409`,
`0x461`, `0x48d`, `0x4c1`, `0x501`, `0x505`); **zero addresses gained**. Across all of the
above, **713/713 surviving functions decompile to byte-identical code, and no reported name is
one that did not already exist at that address.** x86-64 keeps its genuinely-odd entries
(`fauxware` `0x40071d`, `cet_pie` `0x1357`), confirming the ARM gate.

That last check is what caught the one real regression during development: an early "shorter
name wins" tie-break silently renamed `__do_global_dtors_aux` → `_FINI_0` and `frame_dummy` →
`_INIT_0`. No test asserted on either; the code diff did. Hence the structural-name rank.

## Verification

- `make test` — 675/675, **PARITY OK**
- `make test-stages` — 261/261, **PARITY OK**
- `make rust-test` — green, **4308 passed / 0 failed** (4304 before, +4 new)
- `make check-spec` — OK; `kuna catalog --check` — OK
- Testcases: `kuna-cli/tests/decompile_all_cli.rs` — entry-dedup, alias lookup, and the
  ARM-`--addr` fold with an x86-64 negative control; `kuna-console/tests/verify_decompile_all.rs`
  — the shared-seam invariant on both an x86-64 ELF and the ARM fixture (this is also the only
  coverage `kuna-wasm` gets, having no `tests/` dir of its own).
- One existing test changed fixture: `arm_decompile_all_defaults_funcstart_patterns_on`
  asserted `default > funcstart_patterns off` on the two-function ARM fixture, where the
  "extra" entries it counted **were the duplicates**. It now runs on `entrymain_arm`, where the
  pass finds three functions nothing else does (`0x3e0`, `0x410`, `0x3c520`): 10 vs 13. The
  assertion is meaningful again rather than passing on noise.
- Web gates checked by hand against the native `kuna_wasm` (`glue.mjs` assertions `sum_to`,
  ≥3 bodied, `_compute` on `sample_macho.o`, `proj.count > 0` — all hold; those fixtures have
  no alias groups).
- Spec: `docs/spec/00-overview.md` §0.1–§0.2 (the §0.1 idempotence sentence was actively
  false — it claimed every commit arm is idempotent against the loader symbols, which holds
  for the symbol table but not for the name-keyed `register_symbol` stream) and
  `docs/spec/01-program-prep.md` §1.5. Docs: `docs/cli.md`, `docs/web-integration.md`,
  `docs/history.md` (DIV-32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01279bXJ6UBQdhfHE4tUQTKg
