### PR TITLE
ci: run the four gates on every PR and push to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,150 @@
+name: Tests
+
+# Runs the repository's own gates -- the checks AGENTS.md requires green before
+# every commit -- on every pull request and every push to main:
+#
+#   make test              datatest corpus vs docs/baseline.json          (PARITY OK)
+#   make test-stages       stage corpus vs docs/baseline-stages.json      (PARITY OK)
+#   make check-spec        docs/spec/ anchors + phase-folder ownership
+#   kuna catalog --check   docs/options.md documents exactly the registered options
+#   make rust-test         the full cargo workspace suite
+#
+# Until this workflow existed the only automated checks on a PR were GitHub's
+# default CodeQL scan (the "Analyze (...)" jobs). CodeQL never builds the
+# engine and never evaluates a single decompiler assertion, so a change that
+# regressed every datatest still presented an all-green PR.
+#
+# The gates are split across two jobs that run in parallel: the parity gates
+# answer in minutes and catch the common regression, while the workspace suite
+# (a debug build of the whole workspace plus ~4300 tests) is the long pole.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A new push to a PR supersedes that PR's in-flight run; runs on main are never
+# cancelled, so every commit that lands keeps a result of its own.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+defaults:
+  run:
+    # Naming bash explicitly is what enables `-o pipefail`; the implicit default
+    # (`bash -e`) does not set it, which would let a failing command inside a
+    # pipeline report success.
+    shell: bash
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  gates:
+    name: parity gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (stable)
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      # Same cache action and workspace the release/pages workflows use.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: decompiler
+          key: gates
+
+      - name: Build binaries and compile the SLEIGH specs
+        run: make binaries specs
+
+      # `.sla` files are gitignored build artifacts and EVERY datatest decodes
+      # through them. `make test` would bootstrap them on demand, but asserting
+      # the tree is complete here turns a partial spec build into a clear
+      # failure instead of a confusing corpus error.
+      - name: Verify the compiled spec tree is complete
+        run: |
+          want=$(find specs -name '*.slaspec' | wc -l)
+          got=$(find specs -name '*.sla' | wc -l)
+          echo "compiled $got of $want .slaspec"
+          if [ "$got" -ne "$want" ] || [ "$got" -eq 0 ]; then
+            echo "::error::compiled $got .sla for $want .slaspec -- the spec tree is incomplete"
+            exit 1
+          fi
+
+      - name: make test -- datatest corpus vs docs/baseline.json
+        run: make test
+
+      - name: make test-stages -- stage corpus vs docs/baseline-stages.json
+        run: make test-stages
+
+      - name: make check-spec
+        run: make check-spec
+
+      - name: kuna catalog --check
+        run: ./decompiler/target/release/kuna catalog --check
+
+  rust-test:
+    name: cargo workspace suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (stable)
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: decompiler
+          key: rust-test
+
+      # THIS STEP IS LOAD-BEARING, not a convenience. ~55 tests across the
+      # kuna-console/kuna-analysis suites bootstrap a real binary, and when no
+      # `.sla` is present they print "skipping (bootstrap failed, build `.sla`
+      # with `make specs`)" and return early -- by design, so a specs-less
+      # checkout is a visible skip rather than a false failure. But cargo
+      # CAPTURES the output of a passing test, so without `--nocapture` that
+      # notice is invisible: the suite reports "ok" in 0.05 s instead of doing
+      # the work. Compiling the specs first is what makes those tests real.
+      - name: Compile the SLEIGH specs
+        run: make specs
+
+      - name: Verify the compiled spec tree is complete
+        run: |
+          want=$(find specs -name '*.slaspec' | wc -l)
+          got=$(find specs -name '*.sla' | wc -l)
+          echo "compiled $got of $want .slaspec"
+          if [ "$got" -ne "$want" ] || [ "$got" -eq 0 ]; then
+            echo "::error::compiled $got .sla for $want .slaspec -- the spec tree is incomplete"
+            exit 1
+          fi
+
+      # The canary for the trap described above: run one engine-bootstrapping
+      # suite with output shown and fail if it announces a spec-related skip.
+      # The completeness check above should already guarantee this; this catches
+      # the case where the tree is fully built but the engine still cannot
+      # resolve a language id, which would otherwise silently hollow out the
+      # whole run. Cheap -- the binary is built by the suite step regardless.
+      - name: Canary -- engine e2e tests must not skip
+        run: |
+          cd decompiler
+          out=$(cargo test -p kuna-console --test verify_decompile_all -- --nocapture 2>&1)
+          echo "$out"
+          if grep -qE 'skipping \(.*(\.sla|make specs|specs tree)' <<<"$out"; then
+            echo "::error::engine e2e tests skipped for missing/unusable SLEIGH specs -- the suite would be a false green"
+            exit 1
+          fi
+
+      - name: make rust-test -- the full cargo workspace suite
+        run: make rust-test

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -45,6 +45,10 @@ make specs      # compile all .slaspec → .sla with slacomp
 | `make rust-test` | full cargo workspace suite + `docs/options.md` freshness | green |
 | `make check-spec` | `docs/spec/` anchors + inline code paths resolve; each phase folder owned by exactly one chapter (`--strict` adds option-mention coverage) | green |
 
+CI runs all four (plus `kuna catalog --check`) on every pull request and every push to
+main — `.github/workflows/tests.yml`. Run them locally anyway: the workspace suite is the
+long pole in CI, so local failures are found far sooner.
+
 - **Never re-pin `docs/baseline.json` to absorb a regression** — fix the code or make the
   change opt-in. The only sanctioned re-pins are an intentional upstream sync or a
   DIV-recorded default change (`kuna test --save-baseline`; see `docs/history.md`).


### PR DESCRIPTION
Runs the repository's own gates in CI. Until now nothing did.

## The gap

The only automated checks on a pull request were GitHub's **default CodeQL setup** — the `Analyze (actions / c-cpp / java-kotlin / javascript-typescript / python / rust)` jobs. There is no workflow file for them, and CodeQL never builds the engine or evaluates a single decompiler assertion. The repo has exactly two workflows today, `pages.yml` and `release.yml`, and neither runs a test.

`AGENTS.md` requires four gates green before every commit. Nothing enforced them, so a change that regressed all 675 datatest assertions would still show an all-green PR — and `release.yml` publishes binaries on every push to `main` regardless.

## What this adds

`.github/workflows/tests.yml`, on `pull_request` + `push: main` + `workflow_dispatch`, two jobs in parallel on `ubuntu-latest`:

| job | runs | why split |
|---|---|---|
| **gates** | `make binaries specs` → `make test`, `make test-stages`, `make check-spec`, `kuna catalog --check` | answers in minutes; catches the common regression |
| **rust-test** | `make specs` → `make rust-test` (~4300 tests over a debug build of the workspace) | the long pole — shouldn't delay the fast signal |

Both reuse the toolchain install and `Swatinem/rust-cache@v2` (`workspaces: decompiler`) that `release.yml` and `pages.yml` already use, with separate cache keys since the two jobs build different profiles.

## The part that is easy to get wrong

**Compiling the SLEIGH specs in the `rust-test` job is load-bearing, not a convenience.**

About 55 tests across the `kuna-console` / `kuna-analysis` suites bootstrap a real binary. With no `.sla` present they print `skipping (bootstrap failed, build `.sla` with `make specs`)` and return early — deliberate, so a specs-less checkout is a *visible* skip rather than a false failure. But **cargo captures the output of a passing test**, so without `--nocapture` that notice never reaches the log.

Measured on this tree, with the spec tree deleted:

```
$ cargo test -p kuna-console --test verify_decompile_all
test result: ok. 2 passed; 0 failed ... finished in 0.05s     <- decompiled nothing

$ cargo test ... -- --nocapture
verify_decompile_all: skipping (bootstrap failed, build `.sla` with `make specs`): ...
canonical enumeration: skipping .../fauxware (bootstrap failed ...)
canonical enumeration: skipping .../arm_thumb_linked_le32 (bootstrap failed ...)
test result: ok. 2 passed; 0 failed ... finished in 0.05s
```

0.05 s versus 1.26 s for the same "green" result. A CI job that ran `cargo test` without building specs first would be precisely that false green — passing while testing almost nothing.

Two guards make it loud instead of silent:

1. **Spec-completeness check** (both jobs) — asserts one `.sla` per `.slaspec` (148/148), so a partial spec build fails with a clear `::error::` rather than a confusing corpus error downstream.
2. **Canary** (`rust-test`) — runs one engine-bootstrapping suite with `--nocapture` and fails if it announces a spec-related skip. Catches the case the count check can't: a fully built tree the engine still can't resolve a language id against.

Both were verified to fire in **both** directions — each exits 1 with an `::error::` annotation when the spec tree is removed, and both pass with it present.

Also set deliberately: `shell: bash` as a workflow default, because that is what enables `-o pipefail` — the implicit default is `bash -e`, which would let a failing command inside a pipeline report success.

## Verification

- `actionlint` clean on the new file (and on the two existing workflows, so it is consistent with them).
- The **gates job sequence dry-run green end to end** on this branch: `make binaries specs` → 148/148 specs → `make test` **675/675 PARITY OK** → `make test-stages` **278/278 PARITY OK** → `check-spec OK` → `catalog OK`.
- Both failure guards exercised with the spec tree deleted, then restored.
- YAML parsed and job/step structure asserted.

## Scope — deliberately not done

- **Linux only.** `release.yml` already builds on macOS and Windows; running the full suite on three OSes triples cost for little added signal. Easy to add as a matrix later.
- **No `fmt` or `clippy` gate.** `cargo fmt --all --check` does **not** currently pass on `main` (e.g. `kuna-analysis/src/analyzers/addrtable/mod.rs:156`), so adding it would red-flag every branch for unrelated reasons. Worth a separate PR that first reformats.
- **`release.yml` is not gated on this workflow.** It publishes on every push to `main`; making the release depend on tests is a real improvement but changes release semantics, so it is called out as a follow-up rather than slipped in here.
- **The web/wasm gates** (`integrations/web/test/*.mjs`) are not wired up — they need a `wasm32-wasip1` build and their own setup.

Timeouts are 90 min (gates) and 180 min (workspace suite) so a hung job fails rather than burning the 6-hour default. `concurrency` cancels superseded PR runs but never cancels a run on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01279bXJ6UBQdhfHE4tUQTKg
