### PR TITLE
perf(analysis): range-bound Listing consumers

### DIFF
--- a/decompiler/crates/kuna-analysis/src/analyzers/fid/extent.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/fid/extent.rs
@@ -12,7 +12,7 @@
 //! `DiscoveredFunction` model is keyed by entry VMA; there is no per-function
 //! body address set). So this generator reconstructs the body as the
 //! **address-contiguous clip** `[entry, next_function_after(entry))` over the
-//! flat, address-ordered `instructions()` map — the exact idiom
+//! flat, address-ordered instruction map — the exact idiom
 //! [`crate::noreturn_disc`] already uses for its call-site / fall-through
 //! reasoning.
 //!
@@ -38,8 +38,7 @@ use crate::listing::{Insn, Listing};
 /// instructions in `[entry, next_function_after(entry))`, in ascending address
 /// order.
 ///
-/// The flat `instructions()` map is already address-ordered (a `BTreeMap`), so we
-/// scan it once. Returns the instructions in body order — the input to
+/// Returns the instructions in body order — the input to
 /// [`crate::fid::hash::FidHasher`] (PR4 turns each `&Insn` + its SLEIGH mask
 /// into an [`crate::fid::hash::InsnFingerprint`]).
 ///
@@ -51,7 +50,7 @@ pub fn calculate_extent<'a>(listing: &'a Listing, entry: u64) -> Vec<&'a Insn> {
     // (`mod.rs::next_function_after`). `None` ⇒ the clip runs to the end of the
     // instruction map.
     let next = listing.next_function_after(entry).map(|f| f.entry);
-    clip_extent(listing.instructions(), entry, next)
+    clip_extent(listing.instructions_in_range(entry, next), entry, next)
 }
 
 /// The pure clip: given the address-ordered `(vma, insn)` stream, keep the
@@ -59,7 +58,7 @@ pub fn calculate_extent<'a>(listing: &'a Listing, entry: u64) -> Vec<&'a Insn> {
 ///
 /// Split out from [`calculate_extent`] so the clip rule is unit-testable without
 /// constructing a full [`Listing`] (which needs an `object::File` + the SLEIGH
-/// decoder). The production path feeds it `listing.instructions()`.
+/// decoder). The production path supplies the Listing's range-bounded iterator.
 fn clip_extent<'a, I>(instructions: I, entry: u64, next: Option<u64>) -> Vec<&'a Insn>
 where
     I: IntoIterator<Item = (&'a u64, &'a Insn)>,

--- a/decompiler/crates/kuna-analysis/src/analyzers/noreturn_disc/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/noreturn_disc/mod.rs
@@ -183,15 +183,7 @@ fn skip_callee(listing: &Listing, callee: u64, terminal: &BTreeSet<u64>) -> bool
 fn last_act_is_terminal_call(listing: &Listing, entry: u64, terminal: &BTreeSet<u64>) -> bool {
     let next = listing.next_function_after(entry).map(|f| f.entry);
     let mut has_terminal_call = false;
-    for (&vma, insn) in listing.instructions() {
-        if vma < entry {
-            continue;
-        }
-        if let Some(n) = next {
-            if vma >= n {
-                break;
-            }
-        }
+    for (&vma, insn) in listing.instructions_in_range(entry, next) {
         // (b) Any returning path disqualifies the function from this rule.
         if insn.flow.is_terminal {
             return false;

--- a/decompiler/crates/kuna-analysis/src/analyzers/noreturn_propagate/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/noreturn_propagate/mod.rs
@@ -166,8 +166,7 @@ fn collect_error_noreturn_callsites(
     for (&entry, _) in listing.functions() {
         let next = listing.next_function_after(entry).map(|f| f.entry);
         let body: Vec<(u64, &Insn)> = listing
-            .instructions()
-            .filter(|(&vma, _)| vma >= entry && next.map_or(true, |n| vma < n))
+            .instructions_in_range(entry, next)
             .map(|(&vma, insn)| (vma, insn))
             .collect();
         for i in 0..body.len() {
@@ -367,11 +366,9 @@ fn function_is_no_return(
     error_recog: &ErrorRecognizer,
 ) -> bool {
     let next = listing.next_function_after(entry).map(|f| f.entry);
-    // The function body in address order (the Listing's `instructions()` is a
-    // BTreeMap iterator, already sorted).
+    // The function body in address order.
     let body: Vec<(u64, &Insn)> = listing
-        .instructions()
-        .filter(|(&vma, _)| vma >= entry && next.map_or(true, |n| vma < n))
+        .instructions_in_range(entry, next)
         .map(|(&vma, insn)| (vma, insn))
         .collect();
     if body.is_empty() {
@@ -463,8 +460,7 @@ fn function_reaches_only_noreturn(
     let next = listing.next_function_after(entry).map(|f| f.entry);
     // Address-indexed body for O(log n) successor lookup.
     let body: BTreeMap<u64, &Insn> = listing
-        .instructions()
-        .filter(|(&vma, _)| vma >= entry && next.map_or(true, |n| vma < n))
+        .instructions_in_range(entry, next)
         .map(|(&vma, insn)| (vma, insn))
         .collect();
     reaches_only_noreturn_walk(&body, entry, next, terminal, error_recog)

--- a/decompiler/crates/kuna-analysis/src/listing/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/mod.rs
@@ -28,6 +28,7 @@ pub mod model;
 pub mod walk;
 
 use std::collections::BTreeMap;
+use std::ops::Bound;
 use std::rc::Rc;
 
 use kuna_base::address::RangeList;
@@ -206,6 +207,20 @@ impl Listing {
     /// Iterate the decoded instructions in address order.
     pub fn instructions(&self) -> impl Iterator<Item = (&u64, &Insn)> {
         self.insns.iter()
+    }
+
+    /// Iterate decoded instructions in `[start, end)`, or from `start` onward
+    /// when `end` is `None`.
+    pub fn instructions_in_range(
+        &self,
+        start: u64,
+        end: Option<u64>,
+    ) -> impl Iterator<Item = (&u64, &Insn)> {
+        let end = end.map(|end| end.max(start));
+        self.insns.range((
+            Bound::Included(start),
+            end.map_or(Bound::Unbounded, Bound::Excluded),
+        ))
     }
 
     /// The VMA of the first decoded instruction that starts strictly after `vma`
@@ -399,5 +414,51 @@ fn finalize_refs(map: &mut BTreeMap<u64, Vec<Reference>>, by_source: bool) {
             pa.cmp(&pb).then_with(|| ref_kind_ord(a.kind).cmp(&ref_kind_ord(b.kind)))
         });
         refs.dedup_by(|a, b| a.from == b.from && a.to == b.to && a.kind == b.kind);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn insn(addr: u64) -> Insn {
+        Insn {
+            addr,
+            len: 1,
+            fall_through: addr.checked_add(1),
+            flow: Default::default(),
+            flows: Vec::new(),
+            mnemonic: String::new(),
+            operands: String::new(),
+            pcode: None,
+        }
+    }
+
+    #[test]
+    fn instruction_ranges_are_start_inclusive_and_end_exclusive() {
+        let insns = [0x10, 0x20, u64::MAX]
+            .into_iter()
+            .map(|addr| (addr, insn(addr)))
+            .collect();
+        let listing = Listing {
+            insns,
+            refs_to: BTreeMap::new(),
+            refs_from: BTreeMap::new(),
+            funcs: BTreeMap::new(),
+            covered: RangeList::new(),
+            exec_ranges: Vec::new(),
+        };
+        let addrs = |start, end| {
+            listing
+                .instructions_in_range(start, end)
+                .map(|(&addr, _)| addr)
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(addrs(0x10, Some(0x20)), vec![0x10]);
+        assert_eq!(addrs(0x15, Some(u64::MAX)), vec![0x20]);
+        assert_eq!(addrs(0x20, None), vec![0x20, u64::MAX]);
+        assert!(addrs(0x20, Some(0x20)).is_empty());
+        assert!(addrs(0x20, Some(0x10)).is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- add a half-open range iterator over Listing's ordered instruction map
- use it in no-return discovery, no-return propagation, and FID extent calculation
- preserve the existing function-boundary semantics and emitted results

## Why

These consumers previously restarted at the beginning of the complete instruction map for every function, then skipped forward to that function's entry. No-return propagation repeats this over fixpoint sweeps, producing roughly O(functions × instructions × sweeps) traversal on large binaries. BTreeMap range queries start each walk at the function entry instead.

This is a strict implementation optimization, so it is not option-gated.

## Private-binary benchmark

The input is a private PE32/i386 binary with a 2.92 MiB `.text` section, identified only by SHA-256:

`bc4c15d826aaebeace3fec6360eb687e5662cba8745605093254931dcdb3ae1b`

Controlled command (release build):

```sh
kuna functions ./private/binary.exe --json --option listing on | jq -r .count
```

- before: 40.54 s wall
- after: 15.86 s median wall (15.75 s, 15.86 s, 18.01 s)
- improvement: 60.9%
- discovered functions: 693 before and after

The original default `decompile-project` run was stopped after 15m35.91s without completing, which is why the narrower load/discovery benchmark is used for repeatable iteration.

## Validation

- `make test` — PARITY OK, 675/675
- `make test-stages` — PARITY OK, 278/278
- `make rust-test` — passed
- `make check-spec` — passed
