### PR TITLE
[AUTOMATED] feat(p9): no blank line between a function prototype and its { (DIV-33)

### DIFF
--- a/decompiler/crates/kuna-base/src/xml.rs
+++ b/decompiler/crates/kuna-base/src/xml.rs
@@ -1671,8 +1671,10 @@ mod tests {
         // ghangr-condfold-newbury / the guard-cascade shape, goto+label in the
         // off-pass and neither at `wide` (it folds through Rule A), and
         // ghangr-condfold-ruleb / Rule B ISOLATED, a guard whose two
-        // statement-root calls put it outside Rule A's call cap at every level)
-        assert_eq!(count, 167, "corpus file count drifted");
+        // statement-root calls put it outside Rule A's call cap at every level,
+        // and kuna-cnorm-protogap / the DIV-33 brace-placement default flip
+        // (no blank line between a prototype and `{`; braceformat restores)
+        assert_eq!(count, 168, "corpus file count drifted");
     }
 
     /// ~20 representative SLEIGH spec files across varied processors

--- a/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
@@ -414,7 +414,10 @@ impl PrintCOptions {
     /// Construct with the `resetDefaultsPrintC` defaults (printc.cc:1649-1664).
     ///
     /// Note the kuna DIV-2 default-on `array_notation = true` (printc.cc:1658),
-    /// the `&base[index]` form for a standalone PTRADD (GH-558).
+    /// the `&base[index]` form for a standalone PTRADD (GH-558), and the kuna
+    /// DIV-33 `brace_func = NextLine` (upstream `Emit::skip_line` leaves a blank
+    /// line between the prototype and `{`; `option braceformat function skip`
+    /// restores it).
     pub fn new() -> PrintCOptions {
         PrintCOptions {
             convention: true,
@@ -424,7 +427,7 @@ impl PrintCOptions {
             null: false,
             unplaced: false,
             array_notation: true, // (kuna) DIV-2 default-on (GH-558)
-            brace_func: BraceStyle::SkipLine,   // Emit::skip_line
+            brace_func: BraceStyle::NextLine,   // (kuna) DIV-33; upstream Emit::skip_line
             brace_ifelse: BraceStyle::SameLine, // Emit::same_line
             brace_loop: BraceStyle::SameLine,   // Emit::same_line
             brace_switch: BraceStyle::SameLine, // Emit::same_line

--- a/decompiler/crates/kuna-decomp/src/p9_emit/printc/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/printc/tests.rs
@@ -674,7 +674,9 @@ fn option_defaults_match_reset_defaults_printc() {
     assert!(!o.unplaced);
     // (kuna) DIV-2 default-on: &base[index] for standalone PTRADD (GH-558).
     assert!(o.array_notation);
-    assert_eq!(o.brace_func, BraceStyle::SkipLine);
+    // (kuna) DIV-33: no blank line between the prototype and `{` (upstream
+    // skip_line; `option braceformat function skip` restores it).
+    assert_eq!(o.brace_func, BraceStyle::NextLine);
     assert_eq!(o.brace_ifelse, BraceStyle::SameLine);
     assert_eq!(o.brace_loop, BraceStyle::SameLine);
     assert_eq!(o.brace_switch, BraceStyle::SameLine);
@@ -691,8 +693,8 @@ fn option_setters() {
     assert!(o.inplace_ops);
     assert!(o.nocasts);
     assert!(!o.array_notation());
-    o.set_brace_format_function(BraceStyle::NextLine);
-    assert_eq!(o.brace_func, BraceStyle::NextLine);
+    o.set_brace_format_function(BraceStyle::SkipLine);
+    assert_eq!(o.brace_func, BraceStyle::SkipLine);
 }
 
 // ---------------------------------------------------------------------------

--- a/decompiler/crates/kuna-decomp/tests/print_b5_boolless.rs
+++ b/decompiler/crates/kuna-decomp/tests/print_b5_boolless.rs
@@ -306,7 +306,8 @@ fn zz_dump_boolless_cfg() {
 }
 
 /// The committed C++ B5 oracle for boolless (tests/golden/snapshots/cpp/...).
-const CPP_B5_ORACLE: &str = "\nuint1 boolless(void)\n\n{\n  uint1 v1; // acc\n  \n  v1 = dat_52;\n  if (dat_52 <= 10) {\n    v1 = 1;\n  }\n  return v1;\n}\n";
+    // (Header gap adjusted for the kuna DIV-33 brace-placement default.)
+const CPP_B5_ORACLE: &str = "\nuint1 boolless(void)\n{\n  uint1 v1; // acc\n  \n  v1 = dat_52;\n  if (dat_52 <= 10) {\n    v1 = 1;\n  }\n  return v1;\n}\n";
 
 #[test]
 fn boolless_print_c_emits_structured_body() {

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_dominant_copy.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_dominant_copy.rs
@@ -135,7 +135,8 @@ fn w10_dc_boolless_not_over_merged_byte_identical() {
         eprintln!("SKIP: rust decomp_test_dbg / specs unavailable");
         return;
     };
-    const CPP: &str = "\nuint1 boolless(void)\n\n{\n  uint1 v1; // acc\n  \n  v1 = dat_52;\n  if (dat_52 <= 10) {\n    v1 = 1;\n  }\n  return v1;\n}\n";
+    // (Header gap adjusted for the kuna DIV-33 brace-placement default.)
+    const CPP: &str = "\nuint1 boolless(void)\n{\n  uint1 v1; // acc\n  \n  v1 = dat_52;\n  if (dat_52 <= 10) {\n    v1 = 1;\n  }\n  return v1;\n}\n";
     assert_eq!(
         block.trim_end(),
         CPP.trim_end(),

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_emptyblock_orform.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_emptyblock_orform.rs
@@ -144,8 +144,10 @@ fn w10_eob_condconst_conn_forms_andand_byte_identical() {
     };
     let body = slice_function(&block, "condconst_conn")
         .unwrap_or_else(|| panic!("condconst_conn not in dump:\n{block}"));
-    // The C++ oracle B5 for condconst_conn (from `decomp_test_dbg KUNA_DUMP=1`).
-    const CPP: &str = "int4 condconst_conn(int4 x,int4 y)\n\n\
+    // The C++ oracle B5 for condconst_conn (from `decomp_test_dbg KUNA_DUMP=1`);
+    // header gap adjusted for the kuna DIV-33 brace-placement default
+    // (`braceformat function next`; semantic content unchanged).
+    const CPP: &str = "int4 condconst_conn(int4 x,int4 y)\n\
 {\n  int4 v1; // stack - 0xc\n  \n  v1 = x;\n  \
 if ((x == 0) && (y != 10)) {\n    v1 = 0x14;\n  }\n  return v1;\n}";
     assert_eq!(
@@ -171,7 +173,8 @@ fn w10_eob_boolless_not_perturbed_byte_identical() {
         eprintln!("SKIP: rust decomp_test_dbg / specs unavailable");
         return;
     };
-    const CPP: &str = "\nuint1 boolless(void)\n\n{\n  uint1 v1; // acc\n  \n  v1 = dat_52;\n  if (dat_52 <= 10) {\n    v1 = 1;\n  }\n  return v1;\n}\n";
+    // (Header gap adjusted for the kuna DIV-33 brace-placement default.)
+    const CPP: &str = "\nuint1 boolless(void)\n{\n  uint1 v1; // acc\n  \n  v1 = dat_52;\n  if (dat_52 <= 10) {\n    v1 = 1;\n  }\n  return v1;\n}\n";
     assert_eq!(
         block.trim_end(),
         CPP.trim_end(),

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_implied_vars_adversarial.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_implied_vars_adversarial.rs
@@ -420,7 +420,8 @@ fn w10_implied_multiwrite_return_stays_explicit_not_overinlined() {
 fn w10_implied_boolless_acc_unregressed_byte_parity() {
     // The committed C++ B5 oracle (same constant as print_b5_boolless.rs).
     const CPP_B5_ORACLE: &str =
-        "\nuint1 boolless(void)\n\n{\n  uint1 v1; // acc\n  \n  v1 = dat_52;\n  if (dat_52 <= 10) {\n    v1 = 1;\n  }\n  return v1;\n}\n";
+    // (Header gap adjusted for the kuna DIV-33 brace-placement default.)
+        "\nuint1 boolless(void)\n{\n  uint1 v1; // acc\n  \n  v1 = dat_52;\n  if (dat_52 <= 10) {\n    v1 = 1;\n  }\n  return v1;\n}\n";
 
     let rust = match render_one("boolless", 0) {
         Ok(r) => r,

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_merge_casts.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_merge_casts.rs
@@ -396,7 +396,8 @@ mod harness {
 /// now-active `ActionSetCasts` must leave this *exactly* unchanged — no spurious
 /// CAST/PTRSUB inserted into a typeless integer body.
 const BOOLLESS_CPP_B5: &str =
-    "\nuint1 boolless(void)\n\n{\n  uint1 v1; // acc\n  \n  v1 = dat_52;\n  if (dat_52 <= 10) {\n    v1 = 1;\n  }\n  return v1;\n}\n";
+    // (Header gap adjusted for the kuna DIV-33 brace-placement default.)
+    "\nuint1 boolless(void)\n{\n  uint1 v1; // acc\n  \n  v1 = dat_52;\n  if (dat_52 <= 10) {\n    v1 = 1;\n  }\n  return v1;\n}\n";
 
 #[test]
 fn w10_byte_identical_boolless_unperturbed_by_casts() {

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_merge_cluster.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_merge_cluster.rs
@@ -192,7 +192,8 @@ fn w10_mc_a2_boolless_constant_join_stays_tied_byte_identical() {
 
     // The C++ oracle B5 for boolless (KUNA_DUMP, cpp engine).  The `acc` register
     // stays an explicit whole-function local `v1` (NOT folded into `dat_52`).
-    const CPP: &str = "uint1 boolless(void)\n\n\
+    // (Header gap adjusted for the kuna DIV-33 brace-placement default.)
+    const CPP: &str = "uint1 boolless(void)\n\
 {\n  uint1 v1; // acc\n  \n  v1 = dat_52;\n  \
 if (dat_52 <= 10) {\n    v1 = 1;\n  }\n  return v1;\n}";
     assert_eq!(
@@ -215,7 +216,8 @@ fn w10_mc_a3a_readstruct_pointer_return_byte_identical() {
     let body = slice_function(&block, "readstruct")
         .unwrap_or_else(|| panic!("readstruct not in dump:\n{block}"));
     eprintln!("=== RUST readstruct ===\n{body}");
-    const CPP: &str = "int4 readstruct(twostruct *ptr,int8 a,int8 b)\n\n\
+    // (Header gap adjusted for the kuna DIV-33 brace-placement default.)
+    const CPP: &str = "int4 readstruct(twostruct *ptr,int8 a,int8 b)\n\
 {\n  return ptr->array[b + a];\n}";
     assert_eq!(
         body, CPP,
@@ -245,7 +247,8 @@ fn w10_mc_a3b_condconst_stack_and_void_persist_untouched() {
         .unwrap_or_else(|| panic!("condconst_copy not in dump:\n{block}"));
     eprintln!("=== RUST condconst_conn ===\n{conn}\n=== RUST condconst_copy ===\n{copy}");
 
-    const CPP_CONN: &str = "int4 condconst_conn(int4 x,int4 y)\n\n\
+    // (Header gap adjusted for the kuna DIV-33 brace-placement default.)
+    const CPP_CONN: &str = "int4 condconst_conn(int4 x,int4 y)\n\
 {\n  int4 v1; // stack - 0xc\n  \n  v1 = x;\n  \
 if ((x == 0) && (y != 10)) {\n    v1 = 0x14;\n  }\n  return v1;\n}";
     assert_eq!(
@@ -254,7 +257,8 @@ if ((x == 0) && (y != 10)) {\n    v1 = 0x14;\n  }\n  return v1;\n}";
          --- rust ---\n{conn}\n--- cpp ---\n{CPP_CONN}"
     );
 
-    const CPP_COPY: &str = "void condconst_copy(int4 d)\n\n\
+    // (Header gap adjusted for the kuna DIV-33 brace-placement default.)
+    const CPP_COPY: &str = "void condconst_copy(int4 d)\n\
 {\n  if (d == 0) {\n    glob1 = 0;\n  }\n  glob2 = d;\n  \
 if (d == 10) {\n    glob3 = 10;\n    glob4 = 10;\n  }\n  return;\n}";
     assert_eq!(

--- a/docs/baseline-stages.json
+++ b/docs/baseline-stages.json
@@ -1,12 +1,14 @@
 {
   "data_footer": [
-    278,
-    278
+    280,
+    280
   ],
   "passing": [
     "data:BRANCHFLIP #1: default pipeline keeps the negated `== 0` guard (opt-in is default-off)",
     "data:BRANCHFLIP #2: `option branchflip on` flips to the positive `!= 0` guard (angr-style)",
     "data:BRANCHFLIP #3: the flip is logged so its effect is observable",
+    "data:CNORM-PROTOGAP #1: default has the brace directly under the prototype (DIV-33)",
+    "data:CNORM-PROTOGAP #2: braceformat function skip restores the upstream blank line",
     "data:GH1243 #1: ADDC carry-out preserved, P1 = 2",
     "data:GH1243 #2: buggy truncated-carry result P1 = 0 absent",
     "data:GH1243 #3: already-correct case still holds, P0 = 1",

--- a/docs/history.md
+++ b/docs/history.md
@@ -143,6 +143,7 @@ new default flips add a row here (full original entries with evidence: git histo
 | DIV-30 | uncomputed return half (no flag) | a recovered return PAIR whose half is a callee-saved restore / callee clobber is narrowed to the real half (kills `undefined16 main` + `v[8] = <uninit>`) | 0/675; subsumes `returnpair` on GH-6990 (3 stage assertions re-worded, 261/261) |
 | DIV-31 | x86 `DF` unaffected (no flag) | the ABI's direction-flag guarantee is stated where the cspec is silent, folding `(uint8)df * -2 + 1` strides to `+1` | 0/675; x86-only, spec-silent models only |
 | DIV-32 | whole-binary entry dedup (bug fix, no flag) | `decompile-all`/`functions`/`decompile-project`/wasm report each entry ADDRESS once — extra names move to `aliases[]`, and ARM/Thumb `entry\|1` addresses fold onto the real entry (symbol seeds, the enumeration key, and `--addr`) | 0/675 (analysis tier is parity-isolated); `arm_thumb_linked_le32` 6→2 entries, `fmt_arm` 32→14, x86-64 unchanged; 713/713 surviving functions byte-identical |
+| DIV-33 | `braceformat function next` (upstream option, new default) | no blank line between a function prototype and its `{` (upstream skip_line renders `)\n\n{`); `option braceformat function skip` restores | 0/675; print-only |
 
 ## Upstream provenance & sync
 

--- a/docs/spec/09-emission.md
+++ b/docs/spec/09-emission.md
@@ -27,8 +27,8 @@ generated catalog ([docs/options.md](../options.md)); the upstream console
 knobs (`nocastprinting`, `integerformat`, `nullprinting`, `inplaceops`,
 `maxlinewidth`, `indentincrement`) are surfaceTable rows in `phases.toml`, set
 via the console `option` command, and are not part of the settable catalog.
-The intentional default divergences are DIV-1/2/5/6/7 in
-`docs/history.md`.
+The intentional default divergences are DIV-1/2/5/6/7 and the C-surface
+normalization defaults (DIV-33 brace placement) in `docs/history.md`.
 
 ## 9.1 Casts
 
@@ -225,9 +225,12 @@ overflow permanently raises inner indents to guarantee at least half a line of
 working space (`prettyprint.rs (EmitPrettyPrint::overflow)`), and inside a
 comment every forced break re-emits the comment fill prefix. Defaults: 100
 columns (`option maxlinewidth`), indent step 2 (`option indentincrement`),
-comment indent 20; brace placement per construct (function braces on their own
-line, if/loop/switch braces on the same line) via the four `braceformat`
-fields of `printc.rs (PrintCOptions)`.
+comment indent 20; brace placement per construct via the four `braceformat`
+fields of `printc.rs (PrintCOptions)`: if/loop/switch braces sit on the same
+line as their construct, and a function's brace sits directly under its
+prototype (kuna DIV-33 — upstream's `skip_line` default leaves a blank line
+between the prototype and `{`; `option braceformat function skip` restores
+it, exercised by `tests/stages/kuna-cnorm-protogap.xml`).
 
 **Position maps.** Every token can carry a resolved back-reference,
 `prettyprint.rs (MarkupRef)`: an op reference (the op's `getTime`, the same id

--- a/tests/stages/README.md
+++ b/tests/stages/README.md
@@ -105,6 +105,14 @@ writeup, not here.
 | `ghangr-ite-region-converter-missing-5db28e.xml` | angr `test_ite_region_converter_missing_break_statement` (StackCanarySimplifier) | S7 region recovery (`edge-virtualization`, strip the -fstack-protector canary epilogue so the shared-return goto is eliminated) | `option stackguard on\|off` |
 | `ghdec-whiledo-complex.xml` | decbench `O0-iproute2-ip-lookup_flag_data_by_name` (invalid C: statement inside `while(...)` parens) | S8 structure recovery (whileDo overflow-syntax decision; `FlowBlock::isComplex` virtual-dispatch parity, porting-divergence correctness fix, no option) | default (upstream `isComplex`: BlockList/BlockIf unconditionally complex) |
 
+C-surface normalization testcases (`kuna-cnorm-*.xml`, no GH issue; user-driven
+readability defaults measured on the angr `fmt` corpus binary, DIV-33+ in
+`docs/history.md`):
+
+| File | Normalization | P0 assertion |
+|---|---|---|
+| `kuna-cnorm-protogap.xml` | no blank line between a function prototype and its `{` (DIV-33) | `option braceformat function skip\|next` (upstream option, kuna default flip) |
+
 Infrastructure testcases (no GH issue; they regression-test the kuna stage machinery
 itself): `kuna-console.xml` (registry + `stage list/map/status`), `kuna-assert.xml`
 (`kassert` routing + reported rewind scopes), `kuna-restarts.xml` (restart-reason

--- a/tests/stages/kuna-cnorm-protogap.xml
+++ b/tests/stages/kuna-cnorm-protogap.xml
@@ -1,0 +1,52 @@
+<decompilertest>
+<binaryimage arch="x86:LE:64:default:gcc">
+<!--
+    kuna C-surface normalization: no blank line between the function prototype
+    and the opening brace (user-reported readability issue on the angr fmt
+    corpus binary; no upstream GH issue).
+
+    Upstream Ghidra's resetDefaultsPrintC sets the function brace style to
+    Emit::skip_line, so every function renders as
+
+        int4 f(int4 x)
+        <blank>
+        {
+
+    kuna flips the default to next_line (DIV-33, docs/history.md): the brace
+    follows the prototype immediately.  The upstream form stays reachable via
+    the ported braceformat option.
+
+    Stage model: S9 emission / brace-format surface policy.  P0 assertion:
+    `option braceformat function skip|next` (upstream OptionBraceFormat).
+
+    Pass 1 (default): the fix - prototype line is immediately followed by `{`
+    (assert #1 matches exactly once, and the 3-line blank-gap chain of
+    assert #2 matches zero times in this pass).
+    Pass 2 (option braceformat function skip): the legacy form - `)` then a
+    blank line then `{` (assert #2 matches exactly once; assert #1 cannot
+    match because the blank line breaks the 2-line chain).
+
+    Source: int gh558(int x) { if (x <= 8) return 1; return 0; }  (the
+    gh558-compareform.xml bytes, reused purely as a minimal function body).
+-->
+<bytechunk space="ram" offset="0x100000" readonly="true">
+83ff087f06b801000000c331c0c3
+</bytechunk>
+<symbol space="ram" offset="0x100000" name="protogap_fn"/>
+</binaryimage>
+<script>
+  <com>parse line extern int4 protogap_fn(int4 x);</com>
+  <com>lo fu protogap_fn</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>option braceformat function skip</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="CNORM-PROTOGAP #1: default has the brace directly under the prototype (DIV-33)" min="1" max="1">\)$
+^\{$</stringmatch>
+<stringmatch name="CNORM-PROTOGAP #2: braceformat function skip restores the upstream blank line" min="1" max="1">\)$
+^$
+^\{$</stringmatch>
+</decompilertest>


### PR DESCRIPTION
[AUTOMATED] Opened by an automated agent session (user-directed C-surface normalization batch, measured on the angr `fmt` corpus binary).

## What

Upstream Ghidra's `resetDefaultsPrintC` sets function braces to `Emit::skip_line`, so every function renders as:

```c
int4 main(int4 argc,char **argv)

{
```

This PR flips the kuna default to `next_line`:

```c
int4 main(int4 argc,char **argv)
{
```

`option braceformat function skip` (the already-ported upstream `OptionBraceFormat`, style strings `same|next|skip`) restores the legacy form per run — no new option needed, matching the DIV-1 (`unaryspacing`) default-flip precedent.

## Evidence

- **Ablation: 0/675** datatest assertions change (no re-pin needed); stage corpus unaffected except the new witness.
- Print-only change inside `open_brace_indent` dispatch — no measurable speed delta.
- Two-pass stage test `tests/stages/kuna-cnorm-protogap.xml`: pass 1 (default) asserts `)` immediately followed by `{` via a 2-line chain; pass 2 (`option braceformat function skip`) asserts the 3-line `)`/blank/`{` chain.

## Bookkeeping

- DIV-33 row in `docs/history.md`; brace-placement prose in `docs/spec/09-emission.md` §9.2.
- `kuna-base` XML corpus count 167 → 168 (new stage-test file).
- `docs/baseline-stages.json` re-recorded (280/280).

Gates: `make test` PARITY OK (675/675) · `make test-stages` PARITY OK · `make check-spec` OK · `make rust-test` green except the pre-existing `header_syntax_checks_with_cc` failure (fails on clean main too: `fauxware.h` declares `void main(void)` and `cc -fsyntax-only` rejects it — unrelated to this PR).

Part 1/6 of the C-surface normalization batch; subsequent PRs are stacked on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
