### PR TITLE
perf(analysis): skip disabled Listing consumers

### DIFF
--- a/decompiler/crates/kuna-analysis/src/analyzers/aif/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/aif/mod.rs
@@ -1,6 +1,6 @@
 //! Aggressive Instruction Finder gap-walk — the kuna analog of Ghidra's
-//! `AggressiveInstructionFinderAnalyzer` ("Aggressive Instruction Finder"), the
-//! third Listing/xref consumer.
+//! `AggressiveInstructionFinderAnalyzer` ("Aggressive Instruction Finder"), a
+//! Listing/xref consumer.
 //!
 //! # What this is (the speculative gap-filler)
 //!
@@ -66,10 +66,10 @@
 //! the live SLEIGH decoder (the upstream constructs its own `PseudoDisassembler`).
 //! The decoder is not in `AnalysisCtx`, so AIF is driven by [`run_aif`], invoked
 //! from `passes::run_listing_consumers` with the same `translate`/`code_space` the
-//! Listing build held. It is still gated end-to-end by its own `aif`
-//! `--option` (and the `listing` flag), exactly like the other consumers
-//! (`engine.rs::analysis_pass_enabled`), and its output is the same additive
-//! `entries` fact stream.
+//! Listing build held. It is gated before invocation by its own `aif` `--option`
+//! (and the `listing` flag), exactly like the other consumers; the downstream
+//! `engine.rs::analysis_pass_enabled` check remains as a defensive commit gate.
+//! Its output is the same additive `entries` fact stream.
 //!
 //! # Faithful scope / LOSS
 //!
@@ -130,9 +130,9 @@ const MIN_SUBROUTINE_INSNS: usize = 3;
 /// walk so a pathological gap cannot loop unbounded.
 const MAX_FOLLOW_INSNS: usize = 4000;
 
-/// The Aggressive Instruction Finder gap-walk consumer pass (the third Listing/xref
-/// consumer) — used only for the `AnalysisPass` IDENTITY (the `aif` gate name + the
-/// `S1` stage). The real work is in [`run_aif`] (it needs the live decoder, not just
+/// The Aggressive Instruction Finder gap-walk consumer pass — used only for the
+/// `AnalysisPass` IDENTITY (the `aif` gate name + the `S1` stage). The real work is
+/// in [`run_aif`] (it needs the live decoder, not just
 /// `ctx.listing` — see the module docs). The pass's [`AnalysisPass::run`] is a
 /// deliberate no-op: it carries no decoder, so it cannot probe gaps; registering it
 /// only fixes the gate name/stage for the option machinery.

--- a/decompiler/crates/kuna-analysis/src/analyzers/noreturn_disc/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/noreturn_disc/mod.rs
@@ -76,8 +76,8 @@ const EVIDENCE_THRESHOLD: usize = 3;
 
 /// The discovered-no-return consumer pass (the first Listing/xref consumer).
 ///
-/// Default-OFF (gate id `noreturn_disc`); short-circuits to an empty output when
-/// no Listing is built (`ctx.listing.is_none()`).
+/// Option-gated (gate id `noreturn_disc`, default on); short-circuits to an empty
+/// output when no Listing is built (`ctx.listing.is_none()`).
 #[derive(Default)]
 pub struct NoReturnDiscoveredPass;
 
@@ -93,8 +93,7 @@ impl AnalysisPass for NoReturnDiscoveredPass {
     fn run(&self, ctx: &AnalysisCtx) -> AnalysisOutput {
         let mut out = AnalysisOutput::default();
         // Listing-dependent: a no-op when the Listing is absent (the `--option
-        // listing on` flag is off). This keeps the pass inert by default even if
-        // its own gate is flipped on without the Listing.
+        // listing on` flag is off).
         let Some(listing) = ctx.listing else {
             return out;
         };

--- a/decompiler/crates/kuna-analysis/src/analyzers/noreturn_propagate/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/noreturn_propagate/mod.rs
@@ -93,8 +93,8 @@ use crate::pass::{AnalysisCtx, AnalysisOutput, AnalysisPass, NoReturnFact, Phase
 /// The structural no-return propagation consumer pass (the second Listing/xref
 /// consumer).
 ///
-/// Default-OFF (gate id `noreturn_propagate`); short-circuits to an empty output
-/// when no Listing is built (`ctx.listing.is_none()`).
+/// Option-gated (gate id `noreturn_propagate`, default on); short-circuits to an
+/// empty output when no Listing is built (`ctx.listing.is_none()`).
 #[derive(Default)]
 pub struct NoReturnPropagatePass;
 
@@ -110,8 +110,7 @@ impl AnalysisPass for NoReturnPropagatePass {
     fn run(&self, ctx: &AnalysisCtx) -> AnalysisOutput {
         let mut out = AnalysisOutput::default();
         // Listing-dependent: a no-op when the Listing is absent (the `--option
-        // listing on` flag is off). This keeps the pass inert by default even if
-        // its own gate is flipped on without the Listing.
+        // listing on` flag is off).
         let Some(listing) = ctx.listing else {
             return out;
         };

--- a/decompiler/crates/kuna-analysis/src/passes.rs
+++ b/decompiler/crates/kuna-analysis/src/passes.rs
@@ -209,7 +209,7 @@ pub fn passes_for(compiler: Compiler, format: object::BinaryFormat) -> Vec<Box<d
         // immediate scan over-accepts. See docs/history/analysis-port-buildplan.md §1.2.
 
         // `AggressiveInstructionFinderAnalyzer` (AIF) is NOT a pure-`ctx` pass here:
-        // it is the third *Listing/xref consumer* (`aif`, the sound substitute the
+        // it is a *Listing/xref consumer* (`aif`, the sound substitute the
         // buildplan §1.3 prescribed, gated off-by-default like upstream's
         // `setDefaultEnablement(false)`). It speculatively decodes the undefined gaps
         // the Listing left, which needs the live SLEIGH decoder, so it is driven by
@@ -324,15 +324,25 @@ pub fn listing_seeds(file: &object::File, bytes: &[u8]) -> Vec<u64> {
 /// propagation analyzer (`noreturn_propagate`, the kuna analog of angr's CFGFast
 /// call-graph no-return propagation), and the FID fingerprint matcher (`fid`, the
 /// kuna analog of Ghidra's FID identification analyzer — re-identify a stripped
-/// function by full-hash fingerprint). Each is still gated by its own
-/// `--option <id> on|off` flag at commit time
-/// (`engine.rs::analysis_pass_enabled`), so a default run skips it.
-fn listing_consumer_passes() -> Vec<Box<dyn AnalysisPass>> {
+/// function by full-hash fingerprint). Each is gated by its own
+/// `--option <id> on|off` flag before it runs; the commit-time gate in
+/// `engine.rs::analysis_pass_enabled` remains as a defensive boundary.
+fn listing_consumer_passes(arch: &Architecture) -> Vec<(bool, Box<dyn AnalysisPass>)> {
     vec![
-        Box::new(crate::noreturn_disc::NoReturnDiscoveredPass),
-        Box::new(crate::noreturn_propagate::NoReturnPropagatePass),
-        Box::new(crate::fid::FidPass),
+        (
+            arch.analysis_noreturn_disc,
+            Box::new(crate::noreturn_disc::NoReturnDiscoveredPass),
+        ),
+        (
+            arch.analysis_noreturn_propagate,
+            Box::new(crate::noreturn_propagate::NoReturnPropagatePass),
+        ),
+        (arch.analysis_fid, Box::new(crate::fid::FidPass)),
     ]
+}
+
+fn dispatch_if_enabled<T>(enabled: bool, run: impl FnOnce() -> T) -> Option<T> {
+    enabled.then(run)
 }
 
 /// Build the Listing/xref tier and run the Listing **consumer** passes over it,
@@ -347,7 +357,7 @@ fn listing_consumer_passes() -> Vec<Box<dyn AnalysisPass>> {
 /// The console calls this from `commit_pending_analysis` (reached at `read
 /// symbols`), gated on `arch.analysis_listing`; it parses `bytes`, builds the
 /// Listing with funcsym names + Known-no-return/call-fixup seed metadata, and runs
-/// every [`listing_consumer_passes`] pass.
+/// the enabled [`listing_consumer_passes`] passes.
 ///
 /// A parse failure (or no exec ranges) yields an empty list (additive, never
 /// fails). Bound to the real-ELF path: the XML datatest path never calls this, so
@@ -490,27 +500,32 @@ pub fn run_listing_consumers(
     // treats a Known-no-return callee as terminal.
     let listing = listing.with_noreturn_seeds(noreturn_seeds, callfixup_seeds);
     let ctx = AnalysisCtx { file: &file, bytes, image, arch, listing: Some(&listing) };
-    let mut out: Vec<(&'static str, AnalysisOutput)> = listing_consumer_passes()
-        .iter()
-        .map(|pass| (pass.id(), pass.run(&ctx)))
+    let mut out: Vec<(&'static str, AnalysisOutput)> = listing_consumer_passes(arch)
+        .into_iter()
+        .filter_map(|(enabled, pass)| {
+            let id = pass.id();
+            dispatch_if_enabled(enabled, || (id, pass.run(&ctx)))
+        })
         .collect();
 
-    // The Aggressive Instruction Finder gap-walk (`aif`, the third Listing
-    // consumer) is NOT a pure-`ctx` pass: it speculatively decodes undecoded gap
-    // bytes, so it needs the live SLEIGH decoder (the upstream builds its own
-    // `PseudoDisassembler`). Drive it here with the same `translate`/code-space the
-    // Listing build held, keyed by its `aif` id so the deferred commit gates it via
-    // `analysis_pass_enabled` exactly like the pure consumers. A no-op (empty
-    // `entries`) when there is no code space.
-    if let Some(code_space) = arch.manage().get_default_code_space() {
-        let mut aif_out = AnalysisOutput::default();
-        aif_out.entries = crate::aif::run_aif(
-            &listing,
-            translate,
-            std::rc::Rc::clone(code_space),
-            listing.exec_ranges(),
-        );
-        out.push(("aif", aif_out));
+    // The Aggressive Instruction Finder gap-walk (`aif`) is NOT a pure-`ctx`
+    // pass: it speculatively decodes undecoded gap bytes, so it needs the live
+    // SLEIGH decoder (the upstream builds its own `PseudoDisassembler`). Drive it
+    // here with the same `translate`/code-space the Listing build held. Its option
+    // is checked before this speculative work; the output keeps the `aif` id for
+    // the defensive commit gate. A no-op (empty `entries`) when there is no code
+    // space.
+    if arch.analysis_aif {
+        if let Some(code_space) = arch.manage().get_default_code_space() {
+            let mut aif_out = AnalysisOutput::default();
+            aif_out.entries = crate::aif::run_aif(
+                &listing,
+                translate,
+                std::rc::Rc::clone(code_space),
+                listing.exec_ranges(),
+            );
+            out.push(("aif", aif_out));
+        }
     }
 
     // (kuna, recursive-descent discovery) Promote the walk's discovered functions — the
@@ -656,8 +671,38 @@ pub fn run_default_analyses_per_pass(
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+
     use super::*;
     use crate::pass::AnalysisPass;
+    use kuna_base::address::Address;
+    use kuna_base::error::{KunaError, KunaResult};
+    use kuna_sleigh::globalcontext::ContextInternal;
+    use kuna_sleigh::loadimage::LoadImage;
+    use kuna_sleigh::sleigh::Sleigh;
+
+    struct DummyImage;
+
+    impl LoadImage for DummyImage {
+        fn get_file_name(&self) -> &str {
+            "dummy"
+        }
+
+        fn load_fill(&mut self, _ptr: &mut [u8], _addr: &Address) -> KunaResult<()> {
+            Err(KunaError::data_unavail("dummy"))
+        }
+
+        fn get_arch_type(&self) -> Vec<u8> {
+            Vec::new()
+        }
+
+        fn adjust_vma(&mut self, _adjust: i64) {}
+    }
+
+    fn test_arch() -> Architecture {
+        let sleigh = Sleigh::new(Box::new(DummyImage), Box::new(ContextInternal::new()));
+        Architecture::new("test:LE:32", sleigh)
+    }
 
     fn ids(passes: &[Box<dyn AnalysisPass>]) -> Vec<&'static str> {
         passes.iter().map(|p| p.id()).collect()
@@ -667,6 +712,46 @@ mod tests {
     /// PE-gated and the `objc` pass is Mach-O-gated, so an ELF (neither) format
     /// gives the byte-identical pre-rtti/pre-objc set.
     const NON_PE: object::BinaryFormat = object::BinaryFormat::Elf;
+
+    #[test]
+    fn disabled_dispatch_does_not_invoke_consumer() {
+        let calls = Cell::new(0);
+        let output = dispatch_if_enabled(false, || {
+            calls.set(calls.get() + 1);
+            7
+        });
+        assert_eq!(output, None);
+        assert_eq!(calls.get(), 0);
+
+        let output = dispatch_if_enabled(true, || {
+            calls.set(calls.get() + 1);
+            7
+        });
+        assert_eq!(output, Some(7));
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn listing_consumer_schedule_pairs_each_pass_with_its_option() {
+        let mut arch = test_arch();
+        arch.analysis_noreturn_disc = false;
+        arch.analysis_noreturn_propagate = true;
+        arch.analysis_fid = false;
+
+        let schedule: Vec<(&str, bool)> = listing_consumer_passes(&arch)
+            .into_iter()
+            .map(|(enabled, pass)| (pass.id(), enabled))
+            .collect();
+
+        assert_eq!(
+            schedule,
+            vec![
+                ("noreturn_disc", false),
+                ("noreturn_propagate", true),
+                ("fid", false)
+            ]
+        );
+    }
 
     /// `passes_for(Unknown, non-PE)` MUST be exactly today's `default_passes()`
     /// contents — the no-Rust default must never silently drop a pass (the guard the

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -691,9 +691,9 @@ impl ConsoleProgram {
     /// so the Listing — and any pass that reads it (e.g. discovered-no-return) —
     /// is built/run HERE (when the flag is finally in effect), not at load. When
     /// `arch.analysis_listing` is on, the stashed image bytes are re-parsed, the
-    /// Listing is built, and the Listing-consumer passes run; their (per-pass
-    /// gated) facts merge into the same `merged` output committed below. Default
-    /// (listing off) ⇒ this whole block is skipped ⇒ byte-identical to today.
+    /// Listing is built, and the enabled Listing-consumer passes run; their
+    /// defensively re-gated facts merge into the same `merged` output committed
+    /// below. With Listing off, this whole block is skipped.
     pub fn commit_pending_analysis(&mut self) -> KunaResult<()> {
         if self.pending_analysis.is_empty() && self.loader_data_objects.is_empty() {
             // Drop the deferred-Listing stash too: nothing to commit against, and

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -44,12 +44,17 @@ The passes never touch the pipeline live, and the pipeline never calls an analyz
 the two meet exactly once, at a commit seam. `decompiler/crates/kuna-console/src/engine.rs
 (bootstrap_from_object)` runs every registered pass at `load file`
 (`decompiler/crates/kuna-analysis/src/passes.rs (run_default_analyses_per_pass)`) and
-**stashes** each pass's output keyed by its id. The commit happens later, at
-`read symbols` (`engine.rs (commit_pending_analysis)`) — after the CLI's `option`
-lines have been applied — so a disabled pass's already-computed facts are simply
-dropped at the gate (`engine.rs (analysis_pass_enabled)`; an id with no registered
-gate fails *open*, so a new pass runs by default). The stash is drained on commit, so
-a second `read symbols` cannot double-commit.
+**stashes** each load-time pass's output keyed by its id. The commit happens later,
+at `read symbols` (`engine.rs (commit_pending_analysis)`) — after the CLI's
+`option` lines have been applied — so a disabled load-time pass's already-computed
+facts are simply dropped at the gate (`engine.rs (analysis_pass_enabled)`; an id
+with no registered gate fails *open*, so a new pass runs by default). Deferred
+decoder-dependent work is dispatched after those options are known: a disabled
+Listing consumer, AIF gap walk, or operand-reference scan is not invoked at all,
+and its commit gate remains as a defensive check. This is semantically load-bearing
+for AIF: speculative SLEIGH decoding can paint processor context, so `aif off`
+means no speculative decode, not merely discarding its discovered-entry facts.
+The stash is drained on commit, so a second `read symbols` cannot double-commit.
 
 `engine.rs (commit_analysis_output)` then installs the merged facts into the engine
 once, each arm idempotent against the loader's own funcsym stream: a function fact
@@ -467,7 +472,8 @@ load-bearing gotchas are worth restating: a constant-space branch operand is
 p-code-relative (an intra-instruction branch), never a VMA; fall-through is decided
 by the *last* op only; and delay slots are already folded into the reported length.
 
-Its **consumers** run over the built Listing and are individually gated: the
+Its **consumers** run over the built Listing and are individually gated before
+invocation (with the commit gate retained defensively): the
 no-return consumers of §1.7 (`noreturn_disc`, and `noreturn_propagate` carrying
 the `noreturn_error`/`noreturn_reach` sub-rules), the FID matcher (§1.4), the AIF
 gap-walk, and (kuna) the recursive-descent promotion `funcdisc_recursive`, which


### PR DESCRIPTION
## Summary

- pair each Listing consumer directly with its existing option before dispatch
- skip no-return discovery, no-return propagation, FID, and AIF work when disabled
- keep the downstream commit gate as a defensive boundary
- document that `aif off` performs no speculative decode or context mutation

## Why

`run_listing_consumers` previously ran every consumer and discarded disabled outputs afterward. On large Listings this paid for whole-program/fixpoint work that the user explicitly disabled. AIF is also not observationally pure: speculative SLEIGH decoding can apply processor-context commits, so executing it and dropping only its discovered entries did not fully honor `aif off`.

This uses the existing options rather than adding a new one. Pure consumers retain their existing order when enabled, and `noreturn_error`/`noreturn_reach` remain nested under `noreturn_propagate`.

## Private-binary benchmark

The input is a private PE32/i386 binary, identified only by SHA-256:

`bc4c15d826aaebeace3fec6360eb687e5662cba8745605093254931dcdb3ae1b`

Controlled release command:

```sh
kuna functions ./private/binary.exe --json \
  --option listing on \
  --option funcstart_patterns off \
  --option noreturn_disc off \
  --option noreturn_propagate off \
  --option fid off \
  --option aif off | jq -r .count
```

- before, clean `main`: 28.99 s median (28.70, 28.99, 31.21), 402,400 KiB median peak RSS
- after: 5.89 s median (5.75, 5.89, 6.69), 243,044 KiB median peak RSS
- improvement: 79.7% wall, 39.6% peak RSS
- function count: 693 before and after
- full JSON SHA-256: `d79cbca7be92db5d825658d5a11d6c2d47a0a6fe33cfe529d530bb0e9ee5f1bd` before and after on this i386 target

This benchmark deliberately disables the consumers. The current `decompile-project` policy auto-enables AIF on this i386 target and leaves both no-return consumers on, so this PR unlocks an effective explicit opt-out / future fast mode; it does not claim a speedup for the present default project configuration by itself.

## Tests

- scheduler test pins each pass-to-option pairing
- lazy-dispatch test proves disabled work is not invoked
- existing AIF, FID, and both no-return end-to-end tests pass

## Validation

- `make test` — PARITY OK, 675/675
- `make test-stages` — PARITY OK, 278/278
- `make rust-test` — passed
- `make check-spec` — passed
