### PR TITLE
fix(batch): skip non-executable function symbols

### DIFF
--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -13,7 +13,7 @@
 //! analysis tier every time), this loads and analyzes the binary **once**
 //! in-process (`bootstrap_from_object` → `commit_pending_analysis`, i.e. the
 //! `load file` + `read symbols` seam), then loops `decompile` + `print C` over
-//! every function.  The marginal per-function cost drops from a full image load
+//! every executable entry. The marginal per-function cost drops from a full image load
 //! to just the IR build + pipeline — the load-once shape benchmark harnesses
 //! (decbench) and an LLM driver need.
 //!
@@ -57,7 +57,7 @@ use crate::paths;
 pub(crate) struct Args {
     pub(crate) binary: String,
     pub(crate) json: bool,
-    /// `--functions a,b,c`: restrict to these names (None ⇒ every function).
+    /// `--functions a,b,c`: restrict to these names (None ⇒ CODE-backed entries).
     pub(crate) names: Option<Vec<String>>,
     /// `--addr 0xVMA` (repeatable): decompile specific entry addresses, even if
     /// unnamed (stripped / LLM use).  Combined with `--functions` if both given.
@@ -177,8 +177,8 @@ fn decompile_all(args: &Args) -> Result<Vec<FuncResult>, String> {
     Ok(decompile_targets(&mut prog, targets, args.no_vars, /* want_proto= */ false))
 }
 
-/// Enumerate the program's functions, one [`FunctionEntry`] per entry address
-/// (the `functions` command + the default `decompile-all` target set).
+/// Enumerate the program's full callable-symbol inventory, one
+/// [`FunctionEntry`] per entry address (the `functions` command).
 fn list_functions(args: &Args) -> Result<Vec<FunctionEntry>, String> {
     let prog = load_program(args, /* default_listing= */ false)?;
     // One record per entry address, address-ordered, alias names carried as data
@@ -301,7 +301,7 @@ pub(crate) fn load_program(args: &Args, default_listing: bool) -> Result<Console
 /// Build the target [`FunctionEntry`] list from the filters: `--addr` entries
 /// (the canonical record at that address, else a record named via the symbol
 /// table / `name_function`), `--functions` names or aliases, or — with no filter
-/// — every enumerated function, each exactly once.
+/// — every CODE-backed entry, each exactly once.
 pub(crate) fn resolve_targets(
     prog: &ConsoleProgram,
     args: &Args,
@@ -351,11 +351,11 @@ pub(crate) fn resolve_targets(
     let mut seen = std::collections::HashSet::new();
     targets.retain(|e| seen.insert(e.addr.get_offset()));
 
-    // No filter at all ⇒ every function, exactly once (issue #197: `all` used to
-    // be deduped by (name, offset), so one function appeared once per name it
-    // carried — and on ARM once more per Thumb `entry|1` twin).
+    // No filter at all ⇒ every executable function, exactly once. Import pointer
+    // slots remain explicitly selectable, but are data rather than function
+    // bodies.
     if args.addrs.is_empty() && args.names.is_none() {
-        targets = prog.function_entries_canonical();
+        targets = prog.function_entries_executable();
     }
     Ok(targets)
 }
@@ -632,7 +632,7 @@ fn usage_decompile_all() {
          \x20                   [--no-vars] [--max-fn-seconds N] [--mode reliable|aggressive] \\\n\
          \x20                   [--option N V].. [--slice ARCH] [--target T] [--sleighpath D]\n\
          \n\
-         Decompile every function of a binary in one in-process load (load-once,\n\
+         Decompile every CODE-backed function in one in-process load (load-once,\n\
          decompile-many).  --json emits {{binary,count,functions:[{{name,address,code,variables,..}}]}};\n\
          without it, concatenated C with `// Function:` headers.\n\
          --max-fn-seconds N caps ONE function's decompile at N seconds (default 120,\n\

--- a/decompiler/crates/kuna-cli/src/decompile_project.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_project.rs
@@ -12,7 +12,7 @@
 //! `<binary-filename>.kuna/` next to the binary, `-o DIR` overrides — designed
 //! so a human or LLM can study the binary and attempt recompilation:
 //!
-//! * `<name>.c`   — every decompiled function (`// Function: <name> @ <addr>`
+//! * `<name>.c`   — every selected executable function (`// Function: <name> @ <addr>`
 //!   headers, exactly the `decompile-all` rendering), `#include "<name>.h"`.
 //! * `<name>.h`   — include-guarded recompile prelude (core scalar +
 //!   `undefined` typedefs), the user-defined type definitions
@@ -100,7 +100,7 @@ fn usage() {
          \n\
          Decompile a whole binary in one in-process load and write a project folder\n\
          (default `<binary-filename>.kuna/` next to the binary; -o DIR overrides):\n\
-         \x20 <name>.c    every decompiled function (#include \"<name>.h\")\n\
+         \x20 <name>.c    every selected executable function (#include \"<name>.h\")\n\
          \x20 <name>.h    recompile prelude + type definitions + prototypes\n\
          \x20 <name>.asm  labeled disassembly (function labels, stack-var comments,\n\
          \x20             dat_<hex> data labels with raw bytes)\n\

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -51,7 +51,7 @@ use kuna_decomp::xml_arch::XmlArchitectureCapability;
 use kuna_num::opcodes::OpCode;
 use kuna_num::pcoderaw::VarnodeData;
 
-use kuna_sleigh::loadimage::{LoadImage, LoadImageFunc, LoadImageSection};
+use kuna_sleigh::loadimage::{section_flags, LoadImage, LoadImageFunc, LoadImageSection};
 use kuna_analysis::loadimage_object::ObjectLoadImage;
 use kuna_sleigh::loadimage_xml::LoadImageXml;
 use kuna_sleigh::loadimage_xml::register_loadimage_xml_ids;
@@ -239,8 +239,7 @@ impl ConsoleProgram {
     }
 
     /// (kuna) Iterate every function symbol kuna knows for the loaded program as
-    /// `(name, entry Address)` — the enumeration a whole-binary driver
-    /// (`kuna decompile-all`) loops over.
+    /// `(name, entry Address)` — the full callable-symbol inventory.
     ///
     /// After [`Self::commit_pending_analysis`] (`read symbols`) this covers both
     /// the loader's function symbols (`.symtab`/`.dynsym`/PLT stubs, read at load
@@ -319,6 +318,28 @@ impl ConsoleProgram {
                 });
                 let name = names.remove(0);
                 FunctionEntry { name, addr, aliases: names }
+            })
+            .collect()
+    }
+
+    /// The canonical entries eligible for automatic whole-binary decompilation.
+    ///
+    /// Import pointer slots remain in the canonical inventory for call naming
+    /// and explicit address selection, but data addresses are not function bodies.
+    /// Loaders without section metadata retain the complete inventory.
+    pub fn function_entries_executable(&self) -> Vec<FunctionEntry> {
+        let sections = self.sections();
+        if sections.is_empty() {
+            return self.function_entries_canonical();
+        }
+
+        self.function_entries_canonical()
+            .into_iter()
+            .filter(|entry| {
+                let vma = entry.addr.get_offset();
+                sections.iter().any(|&(start, size, flags)| {
+                    flags & section_flags::CODE != 0 && vma >= start && vma - start < size
+                })
             })
             .collect()
     }

--- a/decompiler/crates/kuna-console/tests/verify_decompile_all.rs
+++ b/decompiler/crates/kuna-console/tests/verify_decompile_all.rs
@@ -68,6 +68,12 @@ fn decompile_all_enumerates_and_decompiles_every_function() {
     let names: Vec<String> = prog.function_entries().map(|(n, _)| n.to_string()).collect();
     assert!(!names.is_empty(), "function_entries returned no functions");
     assert!(names.iter().any(|n| n == "main"), "enumeration missing `main`: {names:?}");
+    assert!(
+        prog.function_entries_executable()
+            .iter()
+            .any(|entry| entry.addr.get_offset() == 0x400510),
+        "executable enumeration must retain the ELF puts PLT stub"
+    );
 
     // The address an entry reports must round-trip back to the same function via
     // the symbol-table lookup (i.e. the addresses are real entry VMAs).

--- a/decompiler/crates/kuna-console/tests/verify_macho_imports.rs
+++ b/decompiler/crates/kuna-console/tests/verify_macho_imports.rs
@@ -80,6 +80,7 @@ fn fixtures() -> PathBuf {
 //     __stubs printf @ 0x1000005a0
 const X64_MAIN_VMA: u64 = 0x1000005b0;
 const X64_PRINTF_STUB: u64 = 0x1000005cc;
+const X64_PRINTF_PTR: u64 = 0x100003000;
 
 /// Bootstrap, run a `load …`-driven `decompile` → `print C`, and return the
 /// captured C. `func_cmd` is the `load function …` / `load addr …` command that
@@ -193,6 +194,33 @@ fn macho_x64_names_printf_stub_by_address() {
     assert!(
         !out.contains(&format!("sub_{X64_PRINTF_STUB:x}")),
         "Mach-O (by addr): the printf stub should no longer be sub_{X64_PRINTF_STUB:x}:\n{out}"
+    );
+}
+
+/// The executable stub remains an automatic batch target while its symbol
+/// pointer remains available only through the full inventory and lookup.
+#[test]
+fn macho_batch_targets_exclude_import_pointer_slots() {
+    let Some(mut prog) = boot("macho_imports") else { return };
+    prog.commit_pending_analysis().expect("Mach-O analysis commit must succeed");
+
+    let canonical = prog.function_entries_canonical();
+    assert!(
+        canonical.iter().any(|entry| entry.addr.get_offset() == X64_PRINTF_PTR),
+        "Mach-O: canonical inventory must retain the printf pointer slot"
+    );
+    let executable = prog.function_entries_executable();
+    assert!(
+        executable.iter().any(|entry| entry.addr.get_offset() == X64_PRINTF_STUB),
+        "Mach-O: executable inventory must retain the printf stub"
+    );
+    assert!(
+        !executable.iter().any(|entry| entry.addr.get_offset() == X64_PRINTF_PTR),
+        "Mach-O: executable inventory must exclude the printf pointer slot"
+    );
+    assert!(
+        prog.find_entry_at(X64_PRINTF_PTR).is_some(),
+        "Mach-O: explicit lookup must retain the printf pointer slot"
     );
 }
 

--- a/decompiler/crates/kuna-console/tests/verify_pe_imports.rs
+++ b/decompiler/crates/kuna-console/tests/verify_pe_imports.rs
@@ -70,6 +70,8 @@ fn fixtures() -> PathBuf {
 //   __imp_puts IAT @ 0x14000d33c   (the slot the thunk jumps through)
 //   printf wrapper @ 0x140001550   (a *local* MinGW fn; not an import)
 const MAIN_VMA: u64 = 0x140001592;
+const PUTS_THUNK_VMA: u64 = 0x140007240;
+const PUTS_IAT_VMA: u64 = 0x14000d33c;
 
 /// Bootstrap, run `load function`/`load addr`-driven `decompile` → `print C`, and
 /// return the captured C. `func_cmd` is the `load function …`/`load addr …`
@@ -183,5 +185,32 @@ fn pe_stripped_exe_names_puts_via_iat_thunk() {
         out.contains("sub_140001550"),
         "stripped PE: the local printf wrapper should stay sub_<addr> (it is not \
          an import), got:\n{out}"
+    );
+}
+
+/// Automatic batch decompilation targets the executable thunk, not the IAT
+/// pointer slot. The slot remains a symbol so calls and explicit lookup work.
+#[test]
+fn pe_batch_targets_exclude_iat_data_slots() {
+    let Some(mut prog) = boot("pe_imports_stripped.exe") else { return };
+    prog.commit_pending_analysis().expect("PE analysis commit must succeed");
+
+    let canonical = prog.function_entries_canonical();
+    assert!(
+        canonical.iter().any(|entry| entry.addr.get_offset() == PUTS_IAT_VMA),
+        "PE: canonical inventory must retain the puts IAT slot"
+    );
+    let executable = prog.function_entries_executable();
+    assert!(
+        executable.iter().any(|entry| entry.addr.get_offset() == PUTS_THUNK_VMA),
+        "PE: executable inventory must retain the puts thunk"
+    );
+    assert!(
+        !executable.iter().any(|entry| entry.addr.get_offset() == PUTS_IAT_VMA),
+        "PE: executable inventory must exclude the puts IAT slot"
+    );
+    assert!(
+        prog.find_entry_at(PUTS_IAT_VMA).is_some(),
+        "PE: explicit lookup must retain the puts IAT slot"
     );
 }

--- a/decompiler/crates/kuna-wasm/src/lib.rs
+++ b/decompiler/crates/kuna-wasm/src/lib.rs
@@ -38,7 +38,7 @@ use classify::Classifier;
 enum Cmd {
     /// Enumerate functions only (cheap: no per-function decompile, Listing off).
     List,
-    /// Decompile every function.
+    /// Decompile every CODE-backed function.
     DecompileAll,
     /// Decompile one function, selected by name.
     DecompileName(String),
@@ -211,8 +211,8 @@ fn resolve_targets(
         .ok_or("no default code space")?;
 
     match command {
-        // One record per entry address, alias names carried as data (issue #197).
-        Cmd::DecompileAll => Ok(prog.function_entries_canonical()),
+        // Automatic whole-binary runs target code, not import pointer slots.
+        Cmd::DecompileAll => Ok(prog.function_entries_executable()),
         // An ALIAS resolves too — collapsing the enumeration must not make a
         // name that used to select a function stop working.
         Cmd::DecompileName(want) => match prog.find_entry_by_name(want) {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,9 +38,9 @@ reliable|aggressive` applies an option preset (`docs/modes.md`).
 ## `kuna decompile-all` / `kuna functions` — whole binary, machine-readable
 
 ```bash
-kuna decompile-all ./a.out --json                      # every function
+kuna decompile-all ./a.out --json                      # every CODE-backed function
 kuna decompile-all ./a.out --functions main,parse --json
-kuna functions ./a.out --json                          # just enumerate (name + address)
+kuna functions ./a.out --json                          # full callable-symbol inventory
 ```
 
 The whole-binary surface (the benchmark + LLM path). Runs **in-process**
@@ -56,6 +56,15 @@ injected defaults below), `error` isolates a single failed function, and `variab
 (params in ABI order + DWARF/stack locals) feed type-recovery scoring.
 
 Behaviors specific to `decompile-all`:
+
+- **Executable default targets** — an unfiltered run decompiles canonical entries
+  contained by loader sections marked `CODE`. Callable import pointer slots in PE
+  IATs, Mach-O symbol-pointer sections, and similar data areas remain in `kuna
+  functions`, remain installed for named calls and prototypes, and remain
+  reachable through explicit `--addr`; they are not automatically decoded as
+  function bodies. `--functions` retains its normal first-match behavior when a
+  stub and slot share a name. Loaders without section metadata retain the
+  complete inventory.
 
 - **One record per function entry** — a whole-binary run reports (and decompiles) each
   entry address exactly once. A function can carry several names: a `.symtab` symbol
@@ -110,9 +119,10 @@ binary and attempt recompilation:
 
 - `<name>.c` — every decompiled function, address-ordered, under
   `// Function: <name> @ <addr>` headers, failures as comments, `#include "<name>.h"`.
-  One definition per entry address: the export shares `decompile-all`'s
-  one-record-per-entry enumeration above, so a function carrying several names cannot
-  produce several (identical, and therefore uncompilable) definitions.
+  One definition per executable entry address: the export shares
+  `decompile-all`'s CODE-backed target policy and one-record-per-entry
+  enumeration above, so data import slots are not rendered as functions and a
+  function carrying several names cannot produce several identical definitions.
 - `<name>.h` — include guard + a generated recompile prelude (core scalar and
   `undefined`-family typedefs), the recovered user-defined type definitions, and one
   prototype per decompiled function, token-identical to the `.c` definition line.

--- a/docs/history.md
+++ b/docs/history.md
@@ -143,6 +143,7 @@ new default flips add a row here (full original entries with evidence: git histo
 | DIV-30 | uncomputed return half (no flag) | a recovered return PAIR whose half is a callee-saved restore / callee clobber is narrowed to the real half (kills `undefined16 main` + `v[8] = <uninit>`) | 0/675; subsumes `returnpair` on GH-6990 (3 stage assertions re-worded, 261/261) |
 | DIV-31 | x86 `DF` unaffected (no flag) | the ABI's direction-flag guarantee is stated where the cspec is silent, folding `(uint8)df * -2 + 1` strides to `+1` | 0/675; x86-only, spec-silent models only |
 | DIV-32 | whole-binary entry dedup (bug fix, no flag) | `decompile-all`/`functions`/`decompile-project`/wasm report each entry ADDRESS once — extra names move to `aliases[]`, and ARM/Thumb `entry\|1` addresses fold onto the real entry (symbol seeds, the enumeration key, and `--addr`) | 0/675 (analysis tier is parity-isolated); `arm_thumb_linked_le32` 6→2 entries, `fmt_arm` 32→14, x86-64 unchanged; 713/713 surviving functions byte-identical |
+| DIV-33 | executable batch targets (bug fix, no flag) | unfiltered `decompile-all`/`decompile-project`/wasm runs skip callable symbols in data sections while preserving them for naming, inventory, and explicit address selection | 0/675 (analysis tier is parity-isolated); private PE `bc4c15d8…3ae1b` 693→351 targets and 63.58→7.78 s; all 351 executable artifacts byte-identical |
 
 ## Upstream provenance & sync
 

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -116,7 +116,7 @@ Four front-ends drive one engine assembly:
   and keeps the Listing off (the build would turn a cheap symbol walk into a
   whole-program decode).
 
-  The enumeration these surfaces walk is
+  The full callable-symbol inventory these surfaces share is
   `decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::function_entries_canonical)`,
   which yields **exactly one record per function entry address**, address-ordered.
   It exists because the raw symbol stream
@@ -144,9 +144,16 @@ Four front-ends drive one engine assembly:
   so `--addr` on an odd ARM address reaches the function rather than decoding
   mid-instruction. Both folds are gated to ARM, where an odd symbol address is
   never an instruction boundary; elsewhere an odd address is genuine and is left
-  alone. All four whole-binary surfaces — `decompile-all`, `functions`,
-  `decompile-project` (`decompiler/crates/kuna-cli/src/decompile_project.rs`), and
-  the wasm front-end (`decompiler/crates/kuna-wasm/src/lib.rs`) — share it.
+  alone. `kuna functions` and wasm `list` report this complete canonical
+  inventory, including callable import pointer slots. Unfiltered
+  `decompile-all`, `decompile-project`, and wasm whole-binary runs derive their
+  default target set through
+  `decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::function_entries_executable)`:
+  only entries inside a loader section carrying `CODE` are treated as function
+  bodies. Import slots remain installed for call naming, prototypes, and
+  unrestricted explicit address selection; name selection keeps its normal
+  first matching canonical-entry behavior when a stub and slot share a name. A
+  loader that publishes no section metadata retains the complete canonical set.
 - **`kuna_ghidra`** (`decompiler/crates/kuna-ghidra/src/bin/kuna_ghidra.rs`) —
   the ghidra-mode process front-end: the stock Ghidra GUI spawns it as its
   decompiler core and talks the burst-framed stdin/stdout protocol

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -205,6 +205,17 @@ funcsym stream:
   calls. `INDIRECT_SYMBOL_LOCAL`/`ABS` entries are skipped; the C-ABI leading `_`
   is stripped.
 
+The import currency deliberately includes both executable linkage stubs and
+pointer slots in data sections: the latter must be function symbols so indirect
+calls resolve to a name and library prototype. They are not function bodies.
+The complete canonical inventory retains both, while automatic whole-binary
+decompilation selects only entries contained by a loader `CODE` section
+(`decompiler/crates/kuna-console/src/engine.rs
+(ConsoleProgram::function_entries_executable)`). Explicit address selection
+remains unrestricted; name selection keeps its normal first-match behavior when
+a stub and slot share a name. Loaders without section metadata keep the complete
+inventory.
+
 Two arch-marker passes paint **decode context** rather than names, because a wrong
 decode mode is unrecoverable downstream. `decompiler/crates/kuna-analysis/src/loader/arm_markers.rs
 (ArmMarkerPass)` (`arm_markers`) ports ARM's `ARM_ElfExtension`/`ArmSymbolAnalyzer`:

--- a/docs/web-integration.md
+++ b/docs/web-integration.md
@@ -74,8 +74,12 @@ bootstrap_from_object(binary, "", [spec_root])   // load image + resolve arch + 
 Its `--json` is `kuna decompile-all --json`'s fields (`name`, `address`, `address_hex`,
 `aliases`, `size`, `code`, `error`, `variables[{name,type,kind,arg_index,stack_offset,size}]`)
 — including the one-record-per-entry contract and the `aliases` array documented in
-`docs/cli.md`, since both front-ends share `ConsoleProgram::function_entries_canonical` —
-plus one kuna-wasm-only per-function field: `"kind"` — `"func"` | `"plt"` | `"thunk"`
+`docs/cli.md`. Wasm `list` reports the full canonical callable-symbol inventory;
+unfiltered `decompile` and `project` use the shared CODE-backed target set, while
+explicit address selection can still reach any canonical symbol (name selection
+keeps its normal first-match behavior). This is the same split as the native
+front-end. The output adds one kuna-wasm-only per-function field: `"kind"` —
+`"func"` | `"plt"` | `"thunk"`
 (`kuna-wasm/src/classify.rs`: an `object`-crate re-parse marks entries inside import-stub
 sections — the `.plt` family, Mach-O symbol stubs — or named as imports as `"plt"`, and
 lone-jump entries (`ConsoleProgram::lone_jump_target`, direct-to-another-function or
@@ -255,7 +259,7 @@ benign PE is committed because this environment has no PE linker.
   Object files (`.o`/Mach-O `MH_OBJECT`) decompile to thin bodies — an engine-level
   relocation limit, not a demo one; linked executables are unaffected.
 - **Re-bootstraps per request** — a WASI *command* module runs `_start` and exits, so
-  "decompile all" (one run over every function) is the efficient path the UI uses. A
+  "decompile all" (one run over every CODE-backed function) is the efficient path the UI uses. A
   `wasm-bindgen` **reactor** front-end (bootstrap once, export `decompile(name)`) would let
   the page keep a warm `Architecture` across clicks; it can be added beside this crate
   without touching the WASI path or the engine.


### PR DESCRIPTION
## Summary

- derive the unfiltered whole-binary target set from canonical entries inside loader sections marked `CODE`
- retain import pointer slots in the full `kuna functions` / wasm `list` inventory for call naming and prototypes
- preserve unrestricted explicit `--addr` selection and the existing named-selection semantics
- share the target policy across native `decompile-all`, `decompile-project`, and wasm whole-binary runs

## Why this is a bug fix

PE IAT and Mach-O symbol-pointer slots are intentionally installed as function symbols: indirect calls need their names and library prototypes. They are data addresses, however, and cannot be valid function bodies. The old batch resolver treated every callable symbol as a body.

The new accessor falls back to the full canonical inventory when a loader publishes no section metadata, preserving the XML/raw loader behavior. Executable PE thunks, Mach-O stubs, and ELF PLT entries remain targets.

No option is added: decoding an import pointer slot as code is not a judgment call. Explicit address selection remains the diagnostic escape hatch.

## Private-binary evidence

Binary SHA-256: `bc4c15d826aaebeace3fec6360eb687e5662cba8745605093254931dcdb3ae1b` (private binary)

Its old canonical target set contained 693 entries:

- 351 entries inside `.text`
- 342 PE IAT slots in `.rdata`
- 243 slots produced bogus “successful” C functions
- 99 slots failed after expensive invalid reads

Isolated command (the expensive program-wide analysis consumers are explicitly disabled so this measures the target-stage change):

```bash
kuna decompile-project PRIVATE.exe -o OUT \
  --option listing off \
  --option funcstart_patterns off \
  --option aif off
```

| | Targets | Wall time | Peak RSS |
|---|---:|---:|---:|
| before | 693 | 63.58 s | 143,196 KiB |
| after | 351 | 7.78 s median (7.59 / 7.78 / 7.94) | 118,712 KiB median |

That is an **87.8% wall-time reduction** and removes all 342 invalid bodies. The 351 legitimate function results were byte-identical. The emitted `.c`, `.h`, and 61,413,410-byte `.asm` artifacts are also byte-identical to an explicit 351-address control run.

The checked-in stripped PE fixture independently changes from 199 callable symbols to 149 automatic executable targets.

## Tests

New cross-format assertions verify:

- PE: IAT slot retained canonically and by explicit lookup, excluded automatically; executable thunk retained
- Mach-O: pointer slot retained canonically and by explicit lookup, excluded automatically; executable stub retained
- ELF: PLT entry retained automatically

All required gates pass:

- `make test` — PARITY OK, 675/675
- `make test-stages` — PARITY OK, 278/278
- `make rust-test`
- `make check-spec`
