### PR TITLE
feat(cli): add speed-first fast mode

### DIFF
--- a/decompiler/crates/kuna-base/src/xml.rs
+++ b/decompiler/crates/kuna-base/src/xml.rs
@@ -1659,8 +1659,8 @@ mod tests {
         // -> `?:` ternary, decbench F5 O0-iproute2-ip-print_link_flags,
         // and ghangr-switchreturn / switchreturn, the continuation of earlyreturn to the
         // WIDE multi-way switch-phi return, O0-libedit-tty__getcharindex,
-        // and modes-aggressive / the `mode reliable|aggressive` preset axis
-        // (Architecture::apply_mode; returndup-only warning as the discriminator),
+        // and modes-aggressive / the `mode reliable|aggressive|fast` preset axis
+        // (Architecture::apply_mode; catalog state and returndup warning as discriminators),
         // and ghangr-iteexpr / the `iteexpr` computed-arm ?: extension of iteregion
         // (angr ITERegionConverter over computed arms; ternary in the on-pass only),
         // and the THREE `condfold` witnesses for the short-circuit fold across a

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -3,9 +3,11 @@
 //!
 //! ```text
 //!   kuna decompile-all <binary> [--json] [--functions a,b,..] [--addr 0xVMA].. \
-//!                       [--no-vars] [--max-fn-seconds N] [--option N V].. \
+//!                       [--no-vars] [--max-fn-seconds N] [--mode MODE] \
+//!                       [--option N V].. \
 //!                       [--slice ARCH] [--target T] [--sleighpath D]
-//!   kuna functions <binary> [--json] [--slice ARCH] [--target T] [--sleighpath D]
+//!   kuna functions <binary> [--json] [--mode MODE] [--slice ARCH] [--target T]
+//!                  [--sleighpath D]
 //! ```
 //!
 //! Unlike `kuna decompile` (which spawns a fresh `decomp_dbg` subprocess **per
@@ -34,9 +36,9 @@
 //! angr-style call-graph no-return fixpoint) actually fires and a call to an
 //! unnamed internal exit/fatal wrapper in a stripped binary terminates the
 //! caller instead of swallowing the following functions.  Opt out with
-//! `--option listing off`.  `kuna functions` and the subprocess
-//! `kuna decompile` / `decomp_dbg` surfaces keep the engine default
-//! (listing off).
+//! `--option listing off`. Single-function `kuna decompile` uses the same
+//! injection; `kuna functions` and the interactive `decomp_dbg` surface keep
+//! the engine default (listing off).
 
 use std::rc::Rc;
 
@@ -516,7 +518,7 @@ fn var_json(v: &VarInfo) -> Json {
 
 // --- argument parsing --------------------------------------------------------
 
-/// Expand a decompiler *mode* name (`reliable` | `aggressive`) into its owned
+/// Expand a decompiler *mode* name (`reliable` | `aggressive` | `fast`) into its owned
 /// `(option, value)` overrides. Callers PREPEND these before the user's
 /// `--option` pairs so an explicit `--option` still wins (last-write, matching
 /// the console's `mode` then `option` ordering). Errors on an unknown mode.
@@ -629,7 +631,7 @@ fn parse_hex(s: &str) -> Result<u64, String> {
 fn usage_decompile_all() {
     eprintln!(
         "usage: kuna decompile-all <binary> [--json] [--functions a,b,..] [--addr 0xVMA].. \\\n\
-         \x20                   [--no-vars] [--max-fn-seconds N] [--mode reliable|aggressive] \\\n\
+         \x20                   [--no-vars] [--max-fn-seconds N] [--mode reliable|aggressive|fast] \\\n\
          \x20                   [--option N V].. [--slice ARCH] [--target T] [--sleighpath D]\n\
          \n\
          Decompile every function of a binary in one in-process load (load-once,\n\
@@ -646,7 +648,7 @@ fn usage_decompile_all() {
 
 fn usage_functions() {
     eprintln!(
-        "usage: kuna functions <binary> [--json] [--mode reliable|aggressive] [--slice ARCH] [--target T] [--sleighpath D]\n\
+        "usage: kuna functions <binary> [--json] [--mode reliable|aggressive|fast] [--slice ARCH] [--target T] [--sleighpath D]\n\
          \n\
          List every function kuna discovers in a binary as `<addr>\\t<name>` (or\n\
          --json: {{binary,count,functions:[{{name,address}}]}})."

--- a/decompiler/crates/kuna-cli/src/decompile_project.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_project.rs
@@ -3,7 +3,7 @@
 //! ```text
 //!   kuna decompile-project <binary> [-o|--output DIR] [--functions a,b,..]
 //!                          [--addr 0xVMA].. [--max-fn-seconds N]
-//!                          [--mode reliable|aggressive] [--option N V]..
+//!                          [--mode reliable|aggressive|fast] [--option N V]..
 //!                          [--slice ARCH] [--target T] [--sleighpath D]
 //! ```
 //!
@@ -95,7 +95,7 @@ pub fn run(argv: &[String]) -> i32 {
 fn usage() {
     eprintln!(
         "usage: kuna decompile-project <binary> [-o|--output DIR] [--functions a,b,..] \\\n\
-         \x20                   [--addr 0xVMA].. [--max-fn-seconds N] [--mode reliable|aggressive] \\\n\
+         \x20                   [--addr 0xVMA].. [--max-fn-seconds N] [--mode reliable|aggressive|fast] \\\n\
          \x20                   [--option N V].. [--slice ARCH] [--target T] [--sleighpath D]\n\
          \n\
          Decompile a whole binary in one in-process load and write a project folder\n\

--- a/decompiler/crates/kuna-cli/src/main.rs
+++ b/decompiler/crates/kuna-cli/src/main.rs
@@ -70,12 +70,12 @@ fn main() -> ExitCode {
 
 fn usage() {
     eprintln!(
-        "usage: kuna <decompile|decompile-all|decompile-project|functions|test|catalog|specs|fid> ...\n\
+        "usage: kuna <decompile|decompile-all|decompile-project|functions|test|catalog|modes|specs|fid> ...\n\
          \n\
-         kuna decompile <binary> <func> [--addr] [--slice ARCH] [--mode reliable|aggressive] [--option NAME VALUE]... [--kassert ARGS]...\n\
-         kuna decompile-all <binary> [--json] [--functions a,b,..] [--addr 0xVMA]... [--no-vars] [--max-fn-seconds N] [--mode reliable|aggressive] [--option N V]...\n\
-         kuna decompile-project <binary> [-o DIR] [--functions a,b,..] [--addr 0xVMA]... [--max-fn-seconds N] [--mode reliable|aggressive] [--option N V]...\n\
-         kuna functions <binary> [--json] [--mode reliable|aggressive]\n\
+         kuna decompile <binary> <func> [--addr] [--slice ARCH] [--mode reliable|aggressive|fast] [--option NAME VALUE]... [--kassert ARGS]...\n\
+         kuna decompile-all <binary> [--json] [--functions a,b,..] [--addr 0xVMA]... [--no-vars] [--max-fn-seconds N] [--mode reliable|aggressive|fast] [--option N V]...\n\
+         kuna decompile-project <binary> [-o DIR] [--functions a,b,..] [--addr 0xVMA]... [--max-fn-seconds N] [--mode reliable|aggressive|fast] [--option N V]...\n\
+         kuna functions <binary> [--json] [--mode reliable|aggressive|fast]\n\
          kuna test [--all|--unittests|--datatests] [--name N]... [--baseline F] [--save-baseline F] [--json]\n\
          kuna catalog [--json|--markdown|--check] [--option NAME] [--tier transform|analysis|core]\n\
          kuna modes [--json]\n\
@@ -344,7 +344,7 @@ fn cmd_catalog(argv: &[String]) -> i32 {
 // --- modes -------------------------------------------------------------------
 
 /// `kuna modes [--json]` — list the decompiler mode presets (`reliable`,
-/// `aggressive`) and the `(option → value)` overrides each applies.  Modes are
+/// `aggressive`, `fast`) and the `(option → value)` overrides each applies. Modes are
 /// *not* settable catalog rows (`kuna catalog` covers those); they are presets
 /// over the option surface, applied via `--mode` / the console `mode` command.
 fn cmd_modes(argv: &[String]) -> i32 {

--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -177,6 +177,88 @@ fn decompile_all_emits_json_for_main() {
     );
 }
 
+#[test]
+fn fast_mode_matches_explicit_options_and_user_override_wins() {
+    let bin = arm_entrymain();
+    let sp = specs();
+    let run = |extra: &[&str]| -> Option<String> {
+        let mut args =
+            vec!["decompile-all", bin.as_str(), "--json", "--no-vars", "--sleighpath", sp.as_str()];
+        args.extend_from_slice(extra);
+        let (stdout, stderr, ok) = run_kuna(&args);
+        if !ok {
+            if is_specs_skip(&stderr) {
+                return None;
+            }
+            panic!("kuna decompile-all failed on the ARM fixture: {stderr}");
+        }
+        Some(stdout)
+    };
+
+    let Some(fast) = run(&["--mode", "fast"]) else {
+        eprintln!("fast mode: skipping (no `.sla`; run `make specs`)");
+        return;
+    };
+    let explicit = run(&[
+        "--option",
+        "listing",
+        "off",
+        "--option",
+        "funcstart_patterns",
+        "off",
+        "--option",
+        "aif",
+        "off",
+    ])
+    .expect("explicit fast-equivalent run");
+    assert_eq!(fast, explicit, "fast must equal its three explicit option overrides");
+
+    let noreturn = noreturn_fixture();
+    let base = [
+        "decompile-all",
+        noreturn.as_str(),
+        "--functions",
+        "compute",
+        "--json",
+        "--no-vars",
+        "--sleighpath",
+        sp.as_str(),
+    ];
+    let mut fast_args = base.to_vec();
+    fast_args.extend_from_slice(&["--mode", "fast"]);
+    let (fast_out, stderr, ok) = run_kuna(&fast_args);
+    assert!(ok, "fast no-return control failed: {stderr}");
+    assert!(
+        !code_field(&fast_out).contains("Subroutine does not return"),
+        "fast must keep the Listing/no-return consumer disabled"
+    );
+
+    let mut restored_args = base.to_vec();
+    restored_args.extend_from_slice(&["--mode", "fast", "--option", "listing", "on"]);
+    let (restored_out, stderr, ok) = run_kuna(&restored_args);
+    assert!(ok, "fast with Listing restored failed: {stderr}");
+    assert!(
+        code_field(&restored_out).contains("Subroutine does not return"),
+        "an explicit option after fast must win with last-write precedence"
+    );
+}
+
+#[test]
+fn modes_command_lists_fast_speed_preset() {
+    let (stdout, stderr, ok) = run_kuna(&["modes", "--json"]);
+    assert!(ok, "kuna modes failed: {stderr}");
+    let fast = stdout
+        .split("\"name\": \"fast\"")
+        .nth(1)
+        .expect("modes JSON must list fast after its name");
+    for option in ["listing", "funcstart_patterns", "aif"] {
+        assert!(
+            fast.contains(&format!("\"option\": \"{option}\"")),
+            "fast mode JSON missing {option}: {stdout}"
+        );
+    }
+}
+
 /// DIV-20: on a **non-x86-64** binary, `decompile-all` defaults
 /// `funcstart_patterns` ON — the primary function-discovery source when oracle 5
 /// (the x86-64-only prologue scan) does not apply. Without it a stripped ARM binary

--- a/decompiler/crates/kuna-console/src/kuna_console.rs
+++ b/decompiler/crates/kuna-console/src/kuna_console.rs
@@ -921,7 +921,7 @@ impl IfaceCommandAction for IfcKunaPipeline {
 // `mode <name>` — IfcKunaMode
 // ---------------------------------------------------------------------------
 
-/// (kuna) `mode <reliable|aggressive>`: apply a decompiler mode preset — a batch
+/// (kuna) `mode <reliable|aggressive|fast>`: apply a decompiler mode preset — a batch
 /// of option overrides fanned out through `Architecture::apply_mode` (see
 /// `kuna_decomp::modes`).  Mirrors `IfcOption`'s dcp/conf access; issue it
 /// before `read symbols` so an analysis-tier override (`listing`/`aif`/…) is
@@ -936,7 +936,7 @@ impl IfaceCommandAction for IfcKunaMode {
         s.skip_ws();
         if name.is_empty() {
             return Err(IfaceError::parse(
-                "Missing mode name (try `mode reliable` or `mode aggressive`)",
+                "Missing mode name (try `mode reliable`, `mode aggressive`, or `mode fast`)",
             ));
         }
         let dcp = dcp_mut(status)?;

--- a/decompiler/crates/kuna-decomp/src/infra/architecture.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/architecture.rs
@@ -1501,12 +1501,13 @@ impl Architecture {
         }
     }
 
-    /// Apply a named decompiler *mode* preset (`reliable` | `aggressive`): a
+    /// Apply a named decompiler *mode* preset (`reliable` | `aggressive` | `fast`): a
     /// batch of `(option, value)` overrides fanned out through
     /// [`Self::set_kuna_option`]. Overrides apply in table order; any later
     /// `set_kuna_option` -- another override or a user `option`/`--option` --
     /// wins (last-write). `reliable` is the shipped defaults (empty override
-    /// list, a no-op alias); `aggressive` turns on every off-by-default pass.
+    /// list, a no-op alias); `aggressive` turns on every off-by-default pass;
+    /// `fast` disables expensive whole-program decode and discovery.
     /// See [`crate::modes`]. Errors on an unknown mode name.
     pub fn apply_mode(&mut self, name: &str) -> KunaResult<String> {
         let overrides = crate::modes::mode_overrides(name).ok_or_else(|| {

--- a/decompiler/crates/kuna-decomp/src/infra/architecture/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/architecture/tests.rs
@@ -171,6 +171,23 @@ fn apply_mode_reliable_is_a_no_op() {
 }
 
 #[test]
+fn apply_mode_fast_disables_only_program_wide_analysis() {
+    let mut arch = Architecture::new("test:LE:32", bare_sleigh());
+    arch.analysis_listing = true;
+    arch.analysis_funcstart_patterns = true;
+    arch.analysis_aif = true;
+
+    arch.apply_mode("fast").expect("fast mode applies");
+
+    assert!(!arch.analysis_listing);
+    assert!(!arch.analysis_funcstart_patterns);
+    assert!(!arch.analysis_aif);
+    assert!(arch.infer_funcentry);
+    assert!(arch.analysis_noreturn_propagate);
+    assert!(!arch.switch_guard_bound);
+}
+
+#[test]
 fn apply_mode_unknown_errors() {
     let mut arch = Architecture::new("test:LE:32", bare_sleigh());
     assert!(arch.apply_mode("turbo").is_err());

--- a/decompiler/crates/kuna-decomp/src/p0_knowledge/modes.rs
+++ b/decompiler/crates/kuna-decomp/src/p0_knowledge/modes.rs
@@ -8,20 +8,23 @@
 //! / the catalog count+tier gates. With no mode selected, behaviour is
 //! byte-identical to the shipped defaults.
 //!
-//! Two modes ship:
+//! Three modes ship:
 //!   - **`reliable`** -- the shipped, well-tested defaults (a stable, named
 //!     alias with an empty override list). Anchors the "give me the safe output"
 //!     product surface and future-proofs the preset if defaults later drift.
 //!   - **`aggressive`** -- turn on every off-by-default quality/recovery/analysis
 //!     pass for the most-recovered (and slowest, most speculative) output.
+//!   - **`fast`** -- disable whole-program decoding and speculative function
+//!     discovery to prioritize latency while retaining per-function transforms.
 //!
 //! The mode is applied through `Architecture::apply_mode` (which fans out to
 //! `set_kuna_option`), reachable from `kuna decompile`, `kuna decompile-all`,
-//! and the interactive console `mode <name>` command.
+//! `kuna decompile-project`, `kuna functions`, and the interactive console
+//! `mode <name>` command.
 
 /// A named preset over the option surface.
 pub struct Mode {
-    /// The mode token (`reliable`, `aggressive`).
+    /// The mode token (`reliable`, `aggressive`, `fast`).
     pub name: &'static str,
     /// One-line human/LLM description.
     pub summary: &'static str,
@@ -31,7 +34,7 @@ pub struct Mode {
     pub overrides: &'static [(&'static str, &'static str)],
 }
 
-/// The two shipped modes.
+/// The three shipped modes.
 pub const MODE_TABLE: &[Mode] = &[
     Mode {
         name: "reliable",
@@ -47,12 +50,20 @@ pub const MODE_TABLE: &[Mode] = &[
                   ceiling, not for guaranteed faithfulness.",
         overrides: AGGRESSIVE_OVERRIDES,
     },
+    Mode {
+        name: "fast",
+        summary: "Speed-first whole-binary analysis: disable the Listing, \
+                  prologue-pattern discovery, and AIF gap walk. Retains the \
+                  shipped per-function transforms and explicit selectors.",
+        overrides: FAST_OVERRIDES,
+    },
 ];
 
 /// `reliable` = the shipped defaults. Deliberately empty: pinning any option
 /// here (e.g. `listing off`) would *change* behaviour vs the defaults -- in
-/// particular `decompile-all` auto-enables the Listing (DIV-15), so an explicit
-/// `listing off` would regress it. An empty list leaves every default untouched.
+/// particular `decompile` and `decompile-all` auto-enable the Listing, so an
+/// explicit `listing off` would change them. An empty list leaves every surface
+/// default untouched.
 const RELIABLE_OVERRIDES: &[(&str, &str)] = &[];
 
 /// `aggressive` = every off-by-default option flipped ON, **except**
@@ -91,6 +102,15 @@ const AGGRESSIVE_OVERRIDES: &[(&str, &str)] = &[
     ("objc", "on"),          // Mach-O-only; no-op off-Mach-O
     ("pdb", "on"),           // PE-only; no-op off-PE
     ("macho-arm64e", "on"),  // Mach-O arm64e-only; no-op elsewhere
+];
+
+/// `fast` = avoid the three program-wide decode/discovery paths that dominate
+/// large-binary latency. Keeping all three explicit also suppresses the
+/// decompile driver defaults that would otherwise enable them.
+const FAST_OVERRIDES: &[(&str, &str)] = &[
+    ("listing", "off"),
+    ("funcstart_patterns", "off"),
+    ("aif", "off"),
 ];
 
 /// The override list for `name`, or `None` if `name` is not a known mode.
@@ -147,14 +167,22 @@ mod tests {
     }
 
     #[test]
+    fn fast_disables_only_program_wide_decode_and_discovery() {
+        assert_eq!(
+            mode_overrides("fast").unwrap(),
+            &[("listing", "off"), ("funcstart_patterns", "off"), ("aif", "off")]
+        );
+    }
+
+    #[test]
     fn unknown_mode_is_none() {
         assert!(mode_overrides("turbo").is_none());
         assert!(mode_overrides("").is_none());
     }
 
     #[test]
-    fn mode_names_lists_both() {
+    fn mode_names_lists_all() {
         let names: Vec<_> = mode_names().collect();
-        assert_eq!(names, vec!["reliable", "aggressive"]);
+        assert_eq!(names, vec!["reliable", "aggressive", "fast"]);
     }
 }

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -134,7 +134,7 @@ phases are **settable assertions/options** (`--option NAME VALUE`, discovered vi
 | `docs/cli.md` | The full `kuna` CLI reference. |
 | `docs/improvement-pipeline.md` | The autonomous improvement pipeline + standing requirements for feature PRs. |
 | `docs/decbench-loop.md` | The decbench benchmark / improvement campaign. |
-| `docs/modes.md` | `--mode reliable\|aggressive` option presets. |
+| `docs/modes.md` | `--mode reliable\|aggressive\|fast` option presets. |
 | `docs/missing-ghidra-analyses.md` | The `kuna-analysis` tier: the analyzer gap vs Ghidra, pass contract, commit gating. |
 | `docs/ghidra-integration.md` | kuna as Ghidra's decompiler core (architecture + wire protocol). |
 | `docs/web-integration.md` | The WASM/browser front-end and the project site. |

--- a/docs/baseline-stages.json
+++ b/docs/baseline-stages.json
@@ -1,7 +1,7 @@
 {
   "data_footer": [
-    278,
-    278
+    279,
+    279
   ],
   "passing": [
     "data:BRANCHFLIP #1: default pipeline keeps the negated `== 0` guard (opt-in is default-off)",
@@ -225,6 +225,7 @@
     "data:iteregion #4: fix (on) -- the rewrite is logged",
     "data:iteregion #5: p-code untouched -- the merged variable still feeds the call in BOTH passes",
     "data:mode aggressive enables returndup (warning appears once); mode reliable does not",
+    "data:mode fast reaches the live engine and leaves Listing off",
     "data:namestyle #1 default: argument renders as aN",
     "data:namestyle #2 default: local renders as vN with a register source-location comment",
     "data:namestyle #3 default: unnamed call target renders as sub_<addr>",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,7 +33,7 @@ kuna decompile ./sparc.elf main --option returnpair single
 Drives `decomp_dbg` as a subprocess and captures `print C` via `openfile write`, so
 interactive prompts never pollute the output. `--option NAME VALUE` (repeatable) and
 `--kassert "<args>"` flip phase-model sub-phase assertions per run; `--mode
-reliable|aggressive` applies an option preset (`docs/modes.md`).
+reliable|aggressive|fast` applies an option preset (`docs/modes.md`).
 
 ## `kuna decompile-all` / `kuna functions` — whole binary, machine-readable
 
@@ -78,7 +78,11 @@ Behaviors specific to `decompile-all`:
   a stripped binary's unnamed exit/fatal wrappers no longer swallow the functions after
   them; on non-x86-64 binaries it likewise injects `funcstart_patterns on` and `aif on`
   unless the caller names them (see `docs/history.md`). `--option listing off` opts
-  out; `kuna functions` and the `kuna decompile`/console path keep listing off.
+  out; single-function `kuna decompile` also injects Listing, while `kuna
+  functions` and the interactive console keep the engine default off.
+  `--mode fast` names and disables all three program-wide decode/discovery
+  options (`listing`, `funcstart_patterns`, `aif`), suppressing these injections;
+  a later explicit `--option` still wins.
 - **Per-function watchdog** — `--max-fn-seconds N` (default 120, `0` disables): a function
   whose decompile drive exceeds the budget is cut off cooperatively (deadline probes at
   the action/rule-pool/heritage loop boundaries) and recorded as that function's `error`

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -1,4 +1,4 @@
-# Decompiler modes (`reliable` | `aggressive`)
+# Decompiler modes (`reliable` | `aggressive` | `fast`)
 
 A **mode** is a named preset over kuna's runtime option surface: an ordered list
 of `(option, value)` overrides layered on top of the shipped defaults. Modes are
@@ -7,16 +7,19 @@ they reference existing option names and live in one table,
 `decompiler/crates/kuna-decomp/src/p0_knowledge/modes.rs` (`MODE_TABLE`), applied
 by `Architecture::apply_mode` (a fan-out over `set_kuna_option`).
 
-Select a mode with `--mode <name>` on `kuna decompile`, `kuna decompile-all`, or
-`kuna functions`, or with the console `mode <name>` command. A mode's overrides
-are applied **before** the user's `--option`/`option` lines, so an explicit
-`--option` always wins (last-write). Discover them with `kuna modes` (or
-`kuna modes --json`).
+Select a mode with `--mode <name>` on `kuna decompile`, `kuna decompile-all`,
+`kuna decompile-project`, or `kuna functions`, or with the console `mode <name>`
+command. A mode's overrides are applied **before** the user's
+`--option`/`option` lines, so an explicit `--option` always wins (last-write).
+Modes are override batches, not resets: applying a second mode in one console
+session changes only the options that second mode names. Discover them with
+`kuna modes` (or `kuna modes --json`).
 
 | Mode | What it does |
 |---|---|
 | `reliable` | The shipped, well-tested defaults — the safe, stable baseline. An **empty** override list, so it is byte-identical to running with no `--mode` at all. |
 | `aggressive` | Maximum recovery: turns **on** every off-by-default quality, structuring, and analysis pass. Slower and more speculative (may over-recover); best for readability and for measuring the recovery ceiling on the benchmark, not for guaranteed faithfulness. |
+| `fast` | Latency first: disables the Listing, prologue-pattern function discovery, and AIF gap walk. Keeps the shipped per-function transforms and explicit selectors, but may discover fewer functions and recover fewer program-wide facts. |
 
 Running with **no** `--mode` is exactly `reliable` (the current defaults) — the
 default path is untouched, so every corpus/test gate is unaffected.
@@ -27,9 +30,10 @@ The current defaults are already a well-tuned, net-positive-on-benchmark set
 (many angr structuring flags are default-on; see `docs/history.md`).
 `reliable` is a stable, named alias for that set — its override list is
 deliberately empty. Pinning options here (e.g. `listing off`) would *change*
-behaviour versus the defaults (`decompile-all` auto-enables the Listing, DIV-15),
-so the empty list is the faithful implementation. It future-proofs the preset: if
-the defaults later drift more aggressive, `reliable` can pin them back.
+behaviour versus the surface defaults (`decompile` and `decompile-all`
+auto-enable the Listing), so the empty list is the faithful implementation. It
+future-proofs the preset: if the defaults later drift more aggressive,
+`reliable` can pin them back.
 
 ## `aggressive`
 
@@ -38,7 +42,7 @@ The options it enables:
 
 - **transform tier**: `switchmodbound`, `switchguardbound` (speed-costly),
   `unrolledguard` (speed-costly), `stackalias`, `sparcstructret`,
-  `regionedgeorder`, `returndup`
+  `regionedgeorder`, `returndup`, `iteexpr`
 - **analysis tier**: `listing` (the master gate that enables the
   Listing-consuming passes — `fid`, `aif`, the discovered-no-return family),
   `eh_frame_full`, `funcstart_patterns`, `dwarf_lines`, `addrtable`,
@@ -69,9 +73,54 @@ faithful default. Use it to read maximally-recovered output or to A/B which
 options net-help; promote an option to a default only when its own ablation shows
 net-positive-zero-regression (the DIV process).
 
+## `fast`
+
+`fast` applies exactly three overrides:
+
+```text
+listing=off
+funcstart_patterns=off
+aif=off
+```
+
+These are the program-wide decode and speculative-discovery paths that dominate
+large-binary latency. Naming `listing` suppresses its default injection on all
+three decompile surfaces; naming `funcstart_patterns` and `aif` suppresses their
+non-x86-64 injections on `decompile-all` and `decompile-project`.
+`funcstart_patterns` is independently important: on private PE
+`bc4c15d826aaebeace3fec6360eb687e5662cba8745605093254931dcdb3ae1b`,
+enabling it with the other two disabled expands the inventory from 693 to 4,452
+entries.
+
+The tradeoff is deliberate. With no Listing, Listing consumers such as
+discovered no-return propagation do not run. With function-start patterns and
+AIF disabled, stripped non-x86-64 binaries can expose fewer functions. Loader
+symbols, architecture context, import naming, explicit function/address
+selection, and all shipped per-function transforms remain active.
+
+On that private PE, the old default `decompile-project` run had not completed
+after 935.91 seconds. `--mode fast` completes in a 64.13-second median
+(62.85/64.13/64.87, 141,548 KiB median peak RSS), an observed lower-bound
+speedup of 14.6×. Its `.c`, `.h`, and `.asm` artifacts are byte-identical to the
+three explicit options above. This measurement isolates the mode; filtering the
+binary's non-code import slots is a separate batch-target concern.
+
+An explicit option selectively restores analysis while keeping the rest of the
+preset:
+
+```bash
+kuna decompile-project ./a.out --mode fast --option listing on
+```
+
+Because explicit options are applied after the mode, that command restores the
+Listing while leaving speculative function discovery and AIF disabled.
+
 ## Measuring with modes
 
-`aggressive` is a first-class measurement lever: run the decbench GED benchmark
-with a `kuna-aggressive` backend (or `kuna decompile-all --mode aggressive`) and
-compare against the default `kuna` (== `reliable`) to find options that net-help,
-which then become candidate default-on flips (a new `docs/history.md` DIV row).
+`aggressive` and `fast` are first-class measurement levers. Run the decbench GED
+benchmark with a `kuna-aggressive` backend (or `kuna decompile-all --mode
+aggressive`) and compare against the default `kuna` (== `reliable`) to find
+options that net-help, which then become candidate default-on flips (a new
+`docs/history.md` DIV row).
+Use `fast` for latency-sensitive bulk export and compare its function inventory
+and output against `reliable` before adopting the coverage tradeoff.

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -301,13 +301,16 @@ and an agent writes:
   a *mode* is a named, ordered list of `(option, value)` overrides layered over the
   shipped defaults — a P0 pipeline-variant preset over the option surface, **not** a
   `[[settable]]` row (it references existing option names, so it never touches the
-  catalog or its count/tier gates). Two ship: **`reliable`** (the shipped defaults, an
-  empty-override alias) and **`aggressive`** (every off-by-default recovery/analysis
-  pass on, except `v850indirectbranch` which would mis-decode register-indirect calls
-  off-V850). Selected with `--mode` on `kuna decompile`/`decompile-all`/`functions` or
-  the console `mode <name>` command; overrides are applied *before* the user's
-  `--option` (last-write, so an explicit `--option` still wins). Discover with
-  `kuna modes`; full membership in [docs/modes.md](../modes.md).
+  catalog or its count/tier gates). Three ship: **`reliable`** (the shipped
+  defaults, an empty-override alias), **`aggressive`** (every off-by-default
+  recovery/analysis pass on, except `v850indirectbranch` which would mis-decode
+  register-indirect calls off-V850), and **`fast`** (`listing`,
+  `funcstart_patterns`, and `aif` off to avoid program-wide decode and
+  speculative discovery). Selected with `--mode` on `kuna decompile`,
+  `decompile-all`, `decompile-project`, or `functions`, or the console
+  `mode <name>` command; overrides are applied *before* the user's `--option`
+  (last-write, so an explicit `--option` still wins). Discover with `kuna modes`;
+  full membership in [docs/modes.md](../modes.md).
 - **The restart log** (kuna)
   (`decompiler/crates/kuna-decomp/src/p0_knowledge/kuna_restartlog.rs (RestartLog)`):
   owned by the engine `Architecture` so it survives function clears; every

--- a/tests/stages/modes-aggressive.xml
+++ b/tests/stages/modes-aggressive.xml
@@ -2,15 +2,17 @@
 <binaryimage arch="x86:LE:64:default:gcc">
 <!--
     Decompiler MODE presets (kuna_decomp::modes, Architecture::apply_mode): the
-    `mode reliable | aggressive` console command applies a named batch of option
-    overrides through the SAME binary to decompile path a real `kuna decompile`
-    / `decompile-all` uses.  This is the end to end proof that a mode reaches the
-    engine (standing requirement: every output changing feature ships a
-    binary to decompile testcase; here the "flag" is the whole preset).
+    `mode reliable | aggressive | fast` console command applies a named batch of
+    option overrides through the SAME binary to decompile path a real
+    `kuna decompile` / `decompile-all` uses. This is the end to end proof that a
+    mode reaches the engine (standing requirement: every output changing feature
+    ships a binary to decompile testcase; here the "flag" is the whole preset).
 
     `reliable` == the shipped defaults (an empty override list, a no op alias);
     `aggressive` turns ON every off by default recovery/analysis pass, INCLUDING
     `returndup` (default OFF, angr ReturnDuplicatorHigh, s8_structure/kuna_returndup.rs).
+    `fast` turns off the three program wide decode/discovery options and reports
+    that exact three override batch before decompiling the same witness.
     So `returndup`s emit only warning ("returndup: duplicated N shared bare
     epilogue return(s)") is the clean discriminator between the two modes:
     it can appear ONLY under `mode aggressive` and NEVER under `mode reliable`.
@@ -21,13 +23,15 @@
     {1,2,3}).  returndup duplicates that shared epilogue into 2 of its 3
     predecessors, logging the warning once.
 
-    Pass 1 (mode reliable): returndup is off, so the warning never appears.
-    Pass 2 (mode aggressive): returndup is on, so the warning appears exactly once.
+    Pass 1 (mode fast): the three speed overrides apply and decompilation succeeds.
+    Pass 2 (mode reliable): returndup is off, so the warning never appears.
+    Pass 3 (mode aggressive): returndup is on, so the warning appears exactly once.
 
     The default on siblings earlyreturn (DIV-23) and switchreturn (DIV-25) are on
-    in BOTH passes (they are shipped defaults, part of `reliable`), so they do not
-    affect the returndup only warning count; they are left at their defaults here
-    precisely to show that `aggressive` adds returndup ON TOP of the default set.
+    in all three passes (they are shipped defaults, part of `reliable`), so they
+    do not affect the returndup only warning count; they are left at their
+    defaults here precisely to show that `aggressive` adds returndup ON TOP of
+    the default set.
 -->
 <bytechunk space="ram" offset="0x100000">
 85ff7507b801000000eb1183ff017507b802000000eb05b803000000c3
@@ -35,17 +39,23 @@
 <symbol space="ram" offset="0x100000" name="f"/>
 </binaryimage>
 <script>
-  <!-- Pass 1: reliable == shipped defaults (returndup OFF). -->
-  <com>mode reliable</com>
+  <!-- Pass 1: fast applies exactly three speed-first overrides. -->
+  <com>mode fast</com>
+  <com>phase catalog listing</com>
   <com>lo fu f</com>
   <com>decompile</com>
   <com>print C</com>
-  <!-- Pass 2: aggressive turns returndup (and the rest of the off by default
+  <!-- Pass 2: reliable == shipped defaults (returndup OFF). -->
+  <com>mode reliable</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <!-- Pass 3: aggressive turns returndup (and the rest of the off by default
        passes) ON.  The only observable that is returndup exclusive is its warning. -->
   <com>mode aggressive</com>
   <com>decompile</com>
   <com>print C</com>
   <com>quit</com>
 </script>
+<stringmatch name="mode fast reaches the live engine and leaves Listing off" min="1" max="1">"current": "off"</stringmatch>
 <stringmatch name="mode aggressive enables returndup (warning appears once); mode reliable does not" min="1" max="1">returndup: duplicated</stringmatch>
 </decompilertest>


### PR DESCRIPTION
## Summary

- add a native fast mode for decompile, decompile-all, decompile-project, functions, and the interactive console
- apply exactly listing=off, funcstart_patterns=off, and aif=off
- preserve last-write precedence so an explicit option can selectively restore analysis
- document coverage tradeoffs and add engine, CLI, catalog, and stage coverage

This is an explicit preset over existing options. It changes no defaults, catalog rows, or option counts.

## Why these three options

Listing removes the dominant whole-image decode/xref tier. Function-start patterns must also be disabled independently: on the private i386 PE, enabling funcstart_patterns while Listing and AIF remain off expands the inventory from 693 to 4,452 entries. Explicitly disabling AIF suppresses batch-driver injection and keeps it off when Listing is selectively restored.

Loader correctness passes and all shipped per-function transforms remain enabled. The tradeoff is fewer program-wide facts and, on stripped non-x86-64 inputs, potentially fewer discovered functions.

## Private-binary benchmark

Private binary SHA-256: bc4c15d826aaebeace3fec6360eb687e5662cba8745605093254931dcdb3ae1b

The old default decompile-project run had not completed after 935.91 seconds. Three release runs with --mode fast completed in 62.85 / 64.13 / 64.87 seconds, for a 64.13-second median and 141,548 KiB median peak RSS. This is an observed lower-bound speedup of 14.6x and at least a 93.1% wall-time reduction.

The C, header, and assembly artifacts were byte-identical to the equivalent three explicit options:

- C: 8aeeab9f635f4463b4aa3cf98e3db1cf135ff64023dcb8e10de1df7e96852329
- H: e556fa6ea4baa6dfef4497d1abc964c16dfcb6462fe9ebb8566f8321b191b31d
- ASM: 7b937c7fad085501141f09bd76ff371502a2cf63e6b6053a0d9142588c6aeba0

This measurement isolates the mode. Executable-only batch target filtering is handled independently in #206.

## Validation

- make test: PARITY OK, 675/675
- make test-stages: PARITY OK, 279/279
- make rust-test: green
- make check-spec: green
- independent review: no blockers

WASM does not currently expose modes or arbitrary options; adding that public API is intentionally out of scope for this PR.