### PR TITLE
perf(sleigh): recycle parser-context arenas

### DIFF
--- a/decompiler/crates/kuna-sleigh/src/sleigh.rs
+++ b/decompiler/crates/kuna-sleigh/src/sleigh.rs
@@ -11,8 +11,9 @@
 //!   (ADR 0001): `ConstructState` nodes live in `ParserContext::state`, child
 //!   links are `Option<usize>` indices, the `ParserWalker` carries a node
 //!   index plus the breadcrumb path.
-//! - [`PcodeCacher`] / [`DisassemblyCache`] / [`SleighBuilder`] / [`Sleigh`]
-//!   from `sleigh.{hh,cc}`.
+//! - [`PcodeCacher`] / [`SleighBuilder`] / [`Sleigh`] from `sleigh.{hh,cc}`.
+//!   Parser contexts are recycled between decodes while retaining their state
+//!   arenas, the allocation-saving part of the C++ `DisassemblyCache`.
 //!
 //! The walker implements the `SymbolWalker`/`SymbolWalkerChange`/
 //! `PatternExpressionContext` hooks (slghsymbol.rs / slghpatexpress.rs):
@@ -28,6 +29,7 @@
 //! re-enters a cache mid-borrow).
 
 use std::cell::RefCell;
+use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 
 use kuna_base::address::{calc_mask, Address};
@@ -66,6 +68,7 @@ const MAX_INSTRUCTION_LEN: i32 = 16;
 const INITIAL_STATE_NUM: i32 = 64;
 /// C++ `ParserContext::STATE_GROWTH`.
 const STATE_GROWTH: i32 = 64;
+const PARSER_CONTEXT_POOL_CAPACITY: usize = 8;
 
 /// C++ `ConstructState`: a node in the subconstructor tree.  Pointers become
 /// arena indices into [`ParserContext::state`] (ADR 0001).
@@ -109,6 +112,16 @@ impl ConstructState {
             offset: 0,
             matched_pattern: None,
         }
+    }
+
+    fn reset(&mut self) {
+        self.ct = None;
+        self.hand = FixedHandle::default();
+        self.resolve.fill(None);
+        self.parent = None;
+        self.length = 0;
+        self.offset = 0;
+        self.matched_pattern = None;
     }
 }
 
@@ -205,6 +218,22 @@ impl ParserContext {
             .map(|_| ConstructState::with_operands(MAX_OPERAND as usize))
             .collect();
         self.base_state = n - 1;
+    }
+
+    fn reset(&mut self, contextsize: i32, spc: Rc<AddrSpace>, addr: Address) {
+        self.parsestate = ParseState::Uninitialized;
+        self.const_space = Some(spc);
+        self.buf.fill(0);
+        self.context.resize(contextsize.max(0) as usize, 0);
+        self.context.fill(0);
+        self.contextcommit.clear();
+        self.set_addr(addr);
+        self.naddr = Address::new_invalid();
+        self.calladdr = Address::new_invalid();
+        self.base_state = self.state.len() - 1;
+        self.alloc = self.state.len() as i32 - 2;
+        self.delayslot = 0;
+        self.state[self.base_state].reset();
     }
 
     /// C++ `getBuffer` write target.
@@ -826,8 +855,8 @@ impl<'a> ParserWalkerChange<'a> {
         let opstate = self.ctx.alloc as usize;
         self.ctx.alloc -= 1;
         let parent = self.point();
+        self.ctx.state[opstate].reset();
         self.ctx.state[opstate].parent = Some(parent);
-        self.ctx.state[opstate].ct = None;
         self.ctx.state[parent].resolve[i as usize] = Some(opstate);
         if self.cur.depth > MAX_DEPTH - 2 {
             return Err(KunaError::lowlevel("SLEIGH exceeded maximum parse depth"));
@@ -1027,6 +1056,35 @@ impl PcodeCacher {
     }
 }
 
+struct ParserContextGuard {
+    context: Option<ParserContext>,
+    pool: Rc<RefCell<Vec<ParserContext>>>,
+}
+
+impl Deref for ParserContextGuard {
+    type Target = ParserContext;
+
+    fn deref(&self) -> &ParserContext {
+        self.context.as_ref().expect("parser context guard is live")
+    }
+}
+
+impl DerefMut for ParserContextGuard {
+    fn deref_mut(&mut self) -> &mut ParserContext {
+        self.context.as_mut().expect("parser context guard is live")
+    }
+}
+
+impl Drop for ParserContextGuard {
+    fn drop(&mut self) {
+        if let Some(context) = self.context.take() {
+            let mut pool = self.pool.borrow_mut();
+            if pool.len() < PARSER_CONTEXT_POOL_CAPACITY {
+                pool.push(context);
+            }
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // SleighBuilder (sleigh.hh/.cc)
@@ -1038,7 +1096,7 @@ impl PcodeCacher {
 /// can walk them by index without re-entering the (RefCell) caches.
 struct ResolvedCtx {
     addr: Address,
-    ctx: ParserContext,
+    ctx: ParserContextGuard,
 }
 
 /// C++ `SleighBuilder : PcodeBuilder`: walks the parse tree and prepares data
@@ -1074,7 +1132,7 @@ impl<'a> SleighBuilder<'a> {
     fn walker(&self) -> ParserWalker<'_> {
         ParserWalker {
             ctx: &self.contexts[self.cur_ctx].ctx,
-            cross: self.cross_ctx.map(|i| &self.contexts[i].ctx),
+            cross: self.cross_ctx.map(|i| &*self.contexts[i].ctx),
             table: self.table,
             engine: self.engine,
             cur: self.cur.clone(),
@@ -1473,11 +1531,10 @@ const SIZEOF_SPACE: u32 = 8;
 
 /// C++ `Sleigh : SleighBase`: a full SLEIGH engine.
 ///
-/// Each `oneInstruction`/`instructionLength` resolves a fresh
-/// [`ParserContext`] (the C++ `DisassemblyCache` is an optimization, not a
-/// correctness requirement — resolution is a pure function of the bytes and
-/// the painted context).  The load image and context database/cache sit behind
-/// `RefCell` so the `const` C++ trait methods stay `&self` (see module docs).
+/// Each `oneInstruction`/`instructionLength` checks out a reset
+/// [`ParserContext`] from a scratch pool. The load image and context
+/// database/cache sit behind `RefCell` so the `const` C++ trait methods stay
+/// `&self` (see module docs).
 pub struct Sleigh {
     /// The SLEIGH spec core (spaces, symbol table, templates, register map).
     base: SleighBase,
@@ -1493,6 +1550,9 @@ pub struct Sleigh {
     context_db: RefCell<Box<dyn ContextDatabase>>,
     /// Cache of recently used context values (C++ `cache`).
     cache: RefCell<ContextCache>,
+    /// Reusable parser arenas. Checked-out contexts are removed from the pool,
+    /// so nested `inst_next2` and delay-slot decodes receive distinct storage.
+    parser_contexts: Rc<RefCell<Vec<ParserContext>>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1554,6 +1614,7 @@ impl Sleigh {
             loader: Rc::new(RefCell::new(loader)),
             context_db: RefCell::new(context_db),
             cache: RefCell::new(ContextCache::new()),
+            parser_contexts: Rc::new(RefCell::new(Vec::new())),
         }
     }
 
@@ -1718,13 +1779,24 @@ impl Sleigh {
         self.loader.borrow_mut().load_fill(buf, &addr)
     }
 
-    /// Build a fresh, uninitialized parser context positioned at `addr`.
-    fn fresh_context(&self, addr: &Address) -> ParserContext {
+    /// Check out a reset parser context positioned at `addr`.
+    fn checkout_context(&self, addr: &Address) -> ParserContextGuard {
         let contextsize = self.context_db.borrow().get_context_size();
-        let mut pos = ParserContext::new(contextsize);
-        pos.initialize(self.const_space(), INITIAL_STATE_NUM);
-        pos.set_addr(addr.clone());
-        pos
+        let const_space = self.const_space();
+        let pooled = {
+            let mut pool = self.parser_contexts.borrow_mut();
+            pool.pop()
+        };
+        let mut pos = pooled.unwrap_or_else(|| {
+            let mut pos = ParserContext::new(contextsize);
+            pos.initialize(Rc::clone(&const_space), INITIAL_STATE_NUM);
+            pos
+        });
+        pos.reset(contextsize, const_space, addr.clone());
+        ParserContextGuard {
+            context: Some(pos),
+            pool: Rc::clone(&self.parser_contexts),
+        }
     }
 
     /// C++ `Sleigh::resolve`: build the constructor tree (disassembly state).
@@ -1734,9 +1806,8 @@ impl Sleigh {
         {
             let db = self.context_db.borrow();
             let mut cache = self.cache.borrow_mut();
-            let mut buf = vec![0u32; pos.context.len()];
-            cache.get_context(&**db, &pos.addr, &mut buf);
-            pos.context = buf;
+            let addr = pos.addr.clone();
+            cache.get_context(&**db, &addr, &mut pos.context);
         }
         pos.set_delay_slot(0);
         pos.clear_commits();
@@ -1908,9 +1979,13 @@ impl Sleigh {
         Ok(())
     }
 
-    /// C++ `Sleigh::obtainContext`: resolve a fresh context up to `state`.
-    fn obtain_context(&self, addr: &Address, state: ParseState) -> KunaResult<ParserContext> {
-        let mut pos = self.fresh_context(addr);
+    /// C++ `Sleigh::obtainContext`: resolve a checked-out context up to `state`.
+    fn obtain_context(
+        &self,
+        addr: &Address,
+        state: ParseState,
+    ) -> KunaResult<ParserContextGuard> {
+        let mut pos = self.checkout_context(addr);
         self.resolve(&mut pos)?;
         if state == ParseState::Disassembly {
             return Ok(pos);

--- a/decompiler/crates/kuna-sleigh/tests/arm_neon_vldm_regression.rs
+++ b/decompiler/crates/kuna-sleigh/tests/arm_neon_vldm_regression.rs
@@ -16,8 +16,10 @@
 //! panicked, producing zero output.
 //!
 //! This test lifts exactly that instruction against the built `ARM8_le.sla`
-//! (`ARM:LE:32:v8`) in Thumb mode and asserts it decodes cleanly (no panic,
-//! 4-byte instruction).  It is skipped when the `.sla` is absent (`make specs`).
+//! (`ARM:LE:32:v8`) in Thumb mode, decodes two shallow instructions, and
+//! repeats the deep assembly and lift. The repeated results gate complete
+//! resets when the expanded parser arena is reused. It is skipped when the
+//! `.sla` is absent (`make specs`).
 
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -29,7 +31,7 @@ use kuna_num::pcoderaw::VarnodeData;
 use kuna_sleigh::globalcontext::ContextInternal;
 use kuna_sleigh::loadimage::LoadImage;
 use kuna_sleigh::sleigh::Sleigh;
-use kuna_sleigh::translate::{PcodeEmit, Translate};
+use kuna_sleigh::translate::{AssemblyEmit, PcodeEmit, Translate};
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
@@ -63,19 +65,29 @@ impl LoadImage for MemImg {
     fn adjust_vma(&mut self, _adjust: i64) {}
 }
 
-/// A p-code sink that only needs to prove the lift ran (counts emitted ops).
-struct CountEmit {
-    ops: usize,
+/// A p-code sink that records the lifted operation sequence.
+struct OpcodeEmit {
+    ops: Vec<OpCode>,
 }
-impl PcodeEmit for CountEmit {
+impl PcodeEmit for OpcodeEmit {
     fn dump(
         &mut self,
         _addr: &Address,
-        _opc: OpCode,
+        opc: OpCode,
         _outvar: Option<&VarnodeData>,
         _vars: &[VarnodeData],
     ) {
-        self.ops += 1;
+        self.ops.push(opc);
+    }
+}
+
+#[derive(Default)]
+struct TextEmit {
+    text: Option<(String, String)>,
+}
+impl AssemblyEmit for TextEmit {
+    fn dump(&mut self, _addr: &Address, mnemonic: &str, body: &str) {
+        self.text = Some((mnemonic.to_string(), body.to_string()));
     }
 }
 
@@ -124,12 +136,34 @@ fn arm_thumb_vldmia_upper_neon_regs_does_not_panic() {
     );
     let addr = Address::new(ram, base);
 
-    let mut emit = CountEmit { ops: 0 };
+    let mut text = TextEmit::default();
+    assert_eq!(sleigh.print_assembly(&mut text, &addr).unwrap(), 4);
+    let first_text = text.text.take().expect("assembly emitted");
+
+    let mut emit = OpcodeEmit { ops: Vec::new() };
     // Before the fix this panicked in ParserWalker::getOperand (depth == -1)
     // while resolving the operand tree after expandState front-inserted nodes.
     let len = sleigh
         .one_instruction(&mut emit, &addr)
         .expect("vldmia {d16-d31} must lift without error");
     assert_eq!(len, 4, "Thumb-2 vldmia is a 4-byte instruction (got len {len})");
-    assert!(emit.ops > 0, "the lift must emit at least one p-code op");
+    assert!(!emit.ops.is_empty(), "the lift must emit at least one p-code op");
+    let first_ops = emit.ops;
+
+    for (offset, expected_len) in [(4, 2), (6, 2)] {
+        let mut shallow = OpcodeEmit { ops: Vec::new() };
+        let shallow_addr = Address::new(Rc::clone(addr.get_space().unwrap()), base + offset);
+        assert_eq!(
+            sleigh.one_instruction(&mut shallow, &shallow_addr).unwrap(),
+            expected_len
+        );
+    }
+
+    let mut second_text = TextEmit::default();
+    assert_eq!(sleigh.print_assembly(&mut second_text, &addr).unwrap(), 4);
+    assert_eq!(second_text.text.as_ref(), Some(&first_text));
+
+    let mut second = OpcodeEmit { ops: Vec::new() };
+    assert_eq!(sleigh.one_instruction(&mut second, &addr).unwrap(), 4);
+    assert_eq!(second.ops, first_ops);
 }

--- a/docs/spec/02-lift-and-flow.md
+++ b/docs/spec/02-lift-and-flow.md
@@ -53,6 +53,17 @@ ops beyond the deepest internal branch time are dead and deleted
 (`delete_remaining_ops`). The op-creation and classification order here is
 observable — it fixes the SeqNum allocation every later phase keys on.
 
+**Decode scratch storage.** Every SLEIGH translation checks out a parser
+context from the engine-local pool
+(`decompiler/crates/kuna-sleigh/src/sleigh.rs (Sleigh::checkout_context)`).
+Checkout resets the parse state, addresses, context words, commit records, and
+root node; each child node is reset before it is allocated. The state arena and
+its allocation capacities are retained across instructions. Simultaneously
+live main-instruction, `inst_next2`, and delay-slot resolutions hold distinct
+contexts, and a guard returns each context after successful translation or an
+error. This is scratch reuse only: instruction results and addresses are not
+cached, and the bytes and painted context are resolved on every translation.
+
 **Decode-error policy** (`flow.rs (FlowInfo::handle_decode_error)`). An
 unimplemented instruction is, per the flags, treated as a NOP
 (`ignore_unimplemented`), re-thrown (`error_unimplemented`), or replaced by an


### PR DESCRIPTION
## Summary

- replace per-translation SLEIGH parser-context construction with a bounded, engine-local reuse pool
- retain parser arenas while completely resetting logical state before each decode
- keep main, `inst_next2`, and delay-slot contexts distinct while live
- return checked-out contexts on success, decode errors, and unwinding through an RAII guard
- extend the deep ARM arena regression to verify repeated assembly and p-code after shallow decodes
- document the scratch-storage contract in the P2 specification

This is a strict allocation optimization. It does not cache decoded instructions, addresses, bytes, or painted context, and it changes no option or default.

## Root cause

Private binary SHA-256: `bc4c15d826aaebeace3fec6360eb687e5662cba8745605093254931dcdb3ae1b`

The project assembly sweep resolves about one million instructions. Before this change, every resolution constructed a 64-node `ParserContext`; every node independently allocated a 20-slot operand vector. Counting-allocation profiling attributed 65.71 million calls and 35.20 GB of cumulative allocation to those two objects alone.

The pool keeps up to eight idle contexts. Each checkout resets addresses, parse state, context words, commit records, the root, and every child as it is allocated. Removing a context from the pool for the full lifetime of a resolution preserves nested-decode behavior.

## Private-binary benchmark

The isolated benchmark calls the same `build_asm` path as `decompile-project`, with no function labels. Current main (`cd0f39ac`) and this commit used release builds, the same host/specs/input, five runs each, and byte-identical 60,411,921-byte / 1,010,978-line outputs.

- internal assembly sweep: median 6.698s -> 2.096s (**68.71% lower, 3.20x faster**)
- external bootstrap + sweep + write: median 8.17s -> 3.82s (**53.24% lower, 2.14x faster**)
- allocation/reallocation calls: 90,033,227 -> 22,298,036 (**75.23% fewer**)
- cumulative allocated bytes: 35,723,449,474 -> 509,238,794 (**98.57% fewer, 70.15x lower**)
- parser-arena allocations: 1,010,974 -> 1
- operand-vector allocations: 64,702,336 -> 64

All five assembly outputs had SHA-256 `2070af123ab971168895002e46409db33a0395d3d6c7f04f53d942afcdfa14d6`.

The isolated-options full command (`listing=off`, `funcstart_patterns=off`, `aif=off`) moved from a 61.45s median to 60.10s across three runs on the noisy shared host. Every run retained 693 targets / 594 successes / 99 failures, and every C, header, ASM, and README artifact was byte-identical. Decompiling all 693 targets dominates that control; executable-only automatic batch targeting remains the independent change in #206.

## Validation

- `make test`: PARITY OK, 675/675
- `make test-stages`: PARITY OK, 278/278
- `make rust-test`: green
- `make check-spec`: green
- exact private C, header, ASM, and README hashes unchanged
- independent review: no blockers

Address-result caching and parallel decoding are intentionally out of scope. The former changes invalidation requirements; the latter needs one stateful SLEIGH engine per worker rather than shared parser scratch.
