### PR TITLE
perf(project): render assembly with reusable scratch buffers

### DIFF
--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -84,28 +84,11 @@ pub struct FunctionEntry {
     pub aliases: Vec<String>,
 }
 
-/// (kuna) A one-shot [`AssemblyEmit`](kuna_sleigh::translate::AssemblyEmit)
-/// sink: `Translate::print_assembly` dumps exactly one instruction, whose
-/// mnemonic/body strings are captured here (the single-instruction form of the
-/// `IfcPrintdisasm` listing emitter in `ifacedecomp.rs`).
-#[derive(Default)]
-struct OneShotAssemblyEmit {
-    mnem: String,
-    body: String,
-}
-
-impl kuna_sleigh::translate::AssemblyEmit for OneShotAssemblyEmit {
-    fn dump(&mut self, _addr: &Address, mnem: &str, body: &str) {
-        self.mnem = mnem.to_string();
-        self.body = body.to_string();
-    }
-}
-
 /// (kuna) A one-shot [`PcodeEmit`](kuna_sleigh::translate::PcodeEmit) sink:
 /// `Translate::one_instruction` dumps exactly one instruction's p-code, each
 /// op captured here as opcode + first input (the single-instruction pcode
-/// analogue of [`OneShotAssemblyEmit`], mirroring `kuna_analysis`'s
-/// `listing/decode.rs::OpCapture` — `in0` is all
+/// analogue of [`ConsoleProgram::disassemble_at_into`], mirroring
+/// `kuna_analysis`'s `listing/decode.rs::OpCapture` — `in0` is all
 /// [`ConsoleProgram::lone_jump_target`]'s shape tests need).
 #[derive(Default)]
 struct OneShotPcodeEmit {
@@ -415,12 +398,31 @@ impl ConsoleProgram {
     /// of the `disassemble` console command (`IfcPrintdisasm`), for a caller
     /// that walks a range itself (advance by `length` per step).
     ///
-    /// Builds the `Address` in the engine's default code space (the
-    /// `function_named_at` idiom) and drives `Translate::print_assembly`
-    /// through a one-shot [`AssemblyEmit`](kuna_sleigh::translate::AssemblyEmit)
-    /// sink. An undecodable/unmapped address surfaces as the translator's
-    /// `Err` (C++ `BadDataError`/`DataUnavailError`).
+    /// This allocating convenience API is retained for callers decoding an
+    /// occasional instruction. Whole-image walks should use
+    /// [`Self::disassemble_at_into`] so the mnemonic and body allocations are
+    /// retained between instructions.
     pub fn disassemble_at(&self, vma: u64) -> KunaResult<(int4, String, String)> {
+        let mut mnem = String::new();
+        let mut body = String::new();
+        let length = self.disassemble_at_into(vma, &mut mnem, &mut body)?;
+        Ok((length, mnem, body))
+    }
+
+    /// (kuna) Disassemble one instruction into caller-owned mnemonic and body
+    /// buffers, retaining their allocations across calls.
+    ///
+    /// Both buffers are cleared before every decode, including failed decodes.
+    /// An undecodable or unmapped address surfaces as the translator's `Err`
+    /// (C++ `BadDataError`/`DataUnavailError`).
+    pub fn disassemble_at_into(
+        &self,
+        vma: u64,
+        mnem: &mut String,
+        body: &mut String,
+    ) -> KunaResult<int4> {
+        mnem.clear();
+        body.clear();
         let code_space = Rc::clone(
             self.arch()
                 .manage()
@@ -428,9 +430,7 @@ impl ConsoleProgram {
                 .ok_or_else(|| KunaError::lowlevel("no default code space"))?,
         );
         let addr = Address::new(code_space, vma);
-        let mut emit = OneShotAssemblyEmit::default();
-        let length = self.arch().translate().print_assembly(&mut emit, &addr)?;
-        Ok((length, emit.mnem, emit.body))
+        self.arch().translate().print_assembly_into(&addr, mnem, body)
     }
 
     /// (kuna) The `kuna_wasm` per-function `kind` classification probe: lift
@@ -500,20 +500,36 @@ impl ConsoleProgram {
         }
     }
 
-    /// (kuna) Read `size` raw image bytes at code-space VMA `vma` through the
-    /// engine's load image (`LoadImage::load`, the `loader_rc()` handle) —
-    /// `None` when the range is not backed by the image (e.g. `.bss`, an
-    /// unmapped address, or a `size` beyond the C++ `int4` read contract).
+    /// This allocating convenience API is retained for occasional reads.
+    /// Whole-image walks should use [`Self::read_bytes_into`] so the byte-buffer
+    /// allocation is retained between reads.
     pub fn read_bytes(&self, vma: u64, size: usize) -> Option<Vec<u8>> {
+        let mut bytes = Vec::new();
+        self.read_bytes_into(vma, size, &mut bytes).then_some(bytes)
+    }
+
+    /// (kuna) Read `size` raw image bytes at code-space VMA `vma` into a
+    /// caller-owned buffer, retaining its allocation across calls.
+    ///
+    /// Returns `false` and leaves `bytes` empty when the range is not backed by
+    /// the image (e.g. `.bss`, an unmapped address, or a `size` beyond the C++
+    /// `int4` read contract).
+    pub fn read_bytes_into(&self, vma: u64, size: usize, bytes: &mut Vec<u8>) -> bool {
+        bytes.clear();
         if size > i32::MAX as usize {
-            return None; // LoadImage::load reads at most int4 bytes (C++ contract).
+            return false;
         }
-        let code_space = Rc::clone(self.arch().manage().get_default_code_space()?);
+        let Some(code_space) = self.arch().manage().get_default_code_space().cloned() else {
+            return false;
+        };
         let addr = Address::new(code_space, vma);
+        bytes.resize(size, 0);
         let loader_rc = self.arch().translate().loader_rc();
-        // `load` is `&mut self` (it seeks/caches); the RefCell covers it.
-        let bytes = loader_rc.borrow_mut().load(size as i32, &addr);
-        bytes.ok()
+        let loaded = loader_rc.borrow_mut().load_fill(bytes, &addr).is_ok();
+        if !loaded {
+            bytes.clear();
+        }
+        loaded
     }
 
     /// (kuna) Every **named global data symbol** mapped into the engine's

--- a/decompiler/crates/kuna-console/src/project.rs
+++ b/decompiler/crates/kuna-console/src/project.rs
@@ -12,6 +12,7 @@
 //! [`ConsoleProgram`] and the resolved [`FunctionEntry`] target list.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
 use std::path::Path;
 
 use kuna_decomp::decompile_drive::{
@@ -298,6 +299,92 @@ pub fn collect_dat_addrs(results: &[FuncResult]) -> BTreeSet<u64> {
 /// address survive `resolve_targets`) results anchored at a normalized VMA.
 type LabelMap<'a> = BTreeMap<u64, Vec<&'a FuncResult>>;
 
+/// Reusable storage for the full-section disassembly sweep.
+struct AssemblyScratch {
+    mnem: String,
+    body: String,
+    raw: Vec<u8>,
+    line: String,
+    db_start: Option<u64>,
+    db: Vec<u8>,
+}
+
+impl AssemblyScratch {
+    fn new() -> Self {
+        Self {
+            mnem: String::with_capacity(16),
+            body: String::with_capacity(64),
+            raw: Vec::with_capacity(16),
+            line: String::with_capacity(128),
+            db_start: None,
+            db: Vec::with_capacity(8),
+        }
+    }
+
+    fn emit_instruction(&mut self, addr: u64, out: &mut String) {
+        self.line.clear();
+        write!(&mut self.line, "  {addr:08x}: ").unwrap();
+        for (idx, &byte) in self.raw.iter().enumerate() {
+            if idx != 0 {
+                self.line.push(' ');
+            }
+            push_lower_hex_byte(&mut self.line, byte);
+        }
+        let raw_width = self.raw.len().saturating_mul(3).saturating_sub(1);
+        for _ in raw_width..24 {
+            self.line.push(' ');
+        }
+        self.line.push_str("  ");
+        self.line.push_str(&self.mnem);
+        for _ in self.mnem.chars().count()..10 {
+            self.line.push(' ');
+        }
+        self.line.push(' ');
+        self.line.push_str(&self.body);
+        self.line.truncate(self.line.trim_end().len());
+        self.line.push('\n');
+        out.push_str(&self.line);
+    }
+
+    fn push_db(&mut self, addr: u64, byte: u8, out: &mut String) {
+        if self.db_start.is_none() {
+            self.db_start = Some(addr);
+        }
+        self.db.push(byte);
+        if self.db.len() == 8 {
+            self.flush_db(out);
+        }
+    }
+
+    fn flush_db(&mut self, out: &mut String) {
+        let Some(addr) = self.db_start.take() else { return };
+        self.line.clear();
+        write!(&mut self.line, "  {addr:08x}: db ").unwrap();
+        for (idx, &byte) in self.db.iter().enumerate() {
+            if idx != 0 {
+                self.line.push_str(", ");
+            }
+            self.line.push_str("0x");
+            push_lower_hex_byte(&mut self.line, byte);
+        }
+        self.line.push('\n');
+        out.push_str(&self.line);
+        self.db.clear();
+    }
+
+    fn emit_unreadable(&mut self, addr: u64, out: &mut String) {
+        self.line.clear();
+        writeln!(&mut self.line, "  {addr:08x}: db ?? (unreadable)").unwrap();
+        out.push_str(&self.line);
+    }
+}
+
+fn push_lower_hex_byte(out: &mut String, byte: u8) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    out.push(HEX[(byte >> 4) as usize] as char);
+    out.push(HEX[(byte & 0xf) as usize] as char);
+}
+
 /// `<name>.asm`: linear sweep of every CODE section with function labels +
 /// stack-var comment blocks, then the `; --- data ---` tail (named globals ∪
 /// the `dat_<hex>` set, with raw bytes).
@@ -328,10 +415,11 @@ pub fn build_asm(
         .map(|&(vma, size, _)| (vma, size))
         .collect();
     code_secs.sort_unstable();
+    let mut scratch = AssemblyScratch::new();
     for (vma, size) in code_secs {
         let end = vma.saturating_add(size);
         out.push_str(&format!("\n; --- code section 0x{vma:x}..0x{end:x} ---\n"));
-        sweep_code(prog, &labels, vma, end, &mut out);
+        sweep_code(prog, &labels, vma, end, &mut scratch, &mut out);
     }
 
     emit_data_tail(prog, &sections, dat_addrs, &mut out);
@@ -341,20 +429,18 @@ pub fn build_asm(
 /// Disassemble `[start, end)` linearly: labels + stack-var headers at function
 /// entries, one instruction line per decode, `db` byte lines (coalesced up to
 /// 8, clamped at the next label) where decoding fails.
-fn sweep_code(prog: &ConsoleProgram, labels: &LabelMap, start: u64, end: u64, out: &mut String) {
-    // Pending `db` bytes not yet flushed: (start VMA, bytes).
-    let mut db: Option<(u64, Vec<u8>)> = None;
-    let flush_db = |db: &mut Option<(u64, Vec<u8>)>, out: &mut String| {
-        if let Some((at, bytes)) = db.take() {
-            let hex = bytes.iter().map(|b| format!("0x{b:02x}")).collect::<Vec<_>>().join(", ");
-            out.push_str(&format!("  {at:08x}: db {hex}\n"));
-        }
-    };
-
+fn sweep_code(
+    prog: &ConsoleProgram,
+    labels: &LabelMap,
+    start: u64,
+    end: u64,
+    scratch: &mut AssemblyScratch,
+    out: &mut String,
+) {
     let mut addr = start;
     while addr < end {
         if let Some(rs) = labels.get(&addr) {
-            flush_db(&mut db, out);
+            scratch.flush_db(out);
             for r in rs {
                 out.push('\n');
                 out.push_str(&format!("{}:  ; 0x{:x}\n", r.name, r.address));
@@ -366,37 +452,131 @@ fn sweep_code(prog: &ConsoleProgram, labels: &LabelMap, start: u64, end: u64, ou
         // section end.
         let next_stop =
             labels.range(addr + 1..).next().map(|(&a, _)| a.min(end)).unwrap_or(end);
-        match prog.disassemble_at(addr) {
-            Ok((len, mnem, body)) if len > 0 && addr + len as u64 <= next_stop => {
-                flush_db(&mut db, out);
-                let bytes = prog.read_bytes(addr, len as usize).unwrap_or_default();
-                let hex = bytes.iter().map(|b| format!("{b:02x}")).collect::<Vec<_>>().join(" ");
-                let line = format!("  {addr:08x}: {hex:<24}  {mnem:<10} {body}");
-                out.push_str(line.trim_end());
-                out.push('\n');
+        match prog.disassemble_at_into(addr, &mut scratch.mnem, &mut scratch.body) {
+            Ok(len) if len > 0 && addr + len as u64 <= next_stop => {
+                scratch.flush_db(out);
+                prog.read_bytes_into(addr, len as usize, &mut scratch.raw);
+                scratch.emit_instruction(addr, out);
                 addr += len as u64;
             }
             _ => {
                 // Decode failure (or a decode that would cross the next label):
                 // one raw byte, coalesced into up-to-8-byte `db` lines.
-                match prog.read_bytes(addr, 1) {
-                    Some(bytes) => {
-                        let (_, pending) = db.get_or_insert_with(|| (addr, Vec::new()));
-                        pending.push(bytes[0]);
-                        if pending.len() >= 8 {
-                            flush_db(&mut db, out);
-                        }
-                    }
-                    None => {
-                        flush_db(&mut db, out);
-                        out.push_str(&format!("  {addr:08x}: db ?? (unreadable)\n"));
-                    }
+                if prog.read_bytes_into(addr, 1, &mut scratch.raw) {
+                    scratch.push_db(addr, scratch.raw[0], out);
+                } else {
+                    scratch.flush_db(out);
+                    scratch.emit_unreadable(addr, out);
                 }
                 addr += 1;
             }
         }
     }
-    flush_db(&mut db, out);
+    scratch.flush_db(out);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AssemblyScratch;
+
+    fn legacy_instruction_line(addr: u64, raw: &[u8], mnem: &str, body: &str) -> String {
+        let hex = raw.iter().map(|b| format!("{b:02x}")).collect::<Vec<_>>().join(" ");
+        let line = format!("  {addr:08x}: {hex:<24}  {mnem:<10} {body}");
+        format!("{}\n", line.trim_end())
+    }
+
+    #[test]
+    fn assembly_scratch_formats_exactly_without_reallocating() {
+        let mut scratch = AssemblyScratch::new();
+        let capacities = (
+            scratch.mnem.capacity(),
+            scratch.body.capacity(),
+            scratch.raw.capacity(),
+            scratch.line.capacity(),
+            scratch.db.capacity(),
+        );
+        let pointers = (
+            scratch.mnem.as_ptr(),
+            scratch.body.as_ptr(),
+            scratch.raw.as_ptr(),
+            scratch.line.as_ptr(),
+            scratch.db.as_ptr(),
+        );
+        let mut out = String::new();
+
+        scratch.mnem.push_str("PUSH");
+        scratch.body.push_str("RBP");
+        scratch.raw.push(0x55);
+        scratch.emit_instruction(0x40071d, &mut out);
+
+        scratch.mnem.clear();
+        scratch.body.clear();
+        scratch.raw.clear();
+        scratch.mnem.push_str("RET");
+        scratch.raw.push(0xc3);
+        scratch.emit_instruction(0x40071e, &mut out);
+
+        for (idx, byte) in [0x00, 0x0f, 0xa5, 0xff].into_iter().enumerate() {
+            scratch.push_db(0x400720 + idx as u64, byte, &mut out);
+        }
+        scratch.flush_db(&mut out);
+
+        assert_eq!(
+            out,
+            concat!(
+                "  0040071d: 55                        PUSH       RBP\n",
+                "  0040071e: c3                        RET\n",
+                "  00400720: db 0x00, 0x0f, 0xa5, 0xff\n",
+            )
+        );
+        assert_eq!(
+            capacities,
+            (
+                scratch.mnem.capacity(),
+                scratch.body.capacity(),
+                scratch.raw.capacity(),
+                scratch.line.capacity(),
+                scratch.db.capacity(),
+            )
+        );
+        assert_eq!(
+            pointers,
+            (
+                scratch.mnem.as_ptr(),
+                scratch.body.as_ptr(),
+                scratch.raw.as_ptr(),
+                scratch.line.as_ptr(),
+                scratch.db.as_ptr(),
+            )
+        );
+    }
+
+    #[test]
+    fn assembly_scratch_matches_legacy_format_edge_cases() {
+        let cases: &[(&[u8], &str, &str)] = &[
+            (&[], "", ""),
+            (&[0x00, 0x01, 0x7f, 0x80, 0xfe, 0xff], "LOAD", "R0,0xff "),
+            (
+                &[0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99],
+                "TENLETTERS",
+                "",
+            ),
+            (&[0xab], "é", "operand"),
+        ];
+        let mut scratch = AssemblyScratch::new();
+        for (idx, &(raw, mnem, body)) in cases.iter().enumerate() {
+            scratch.raw.clear();
+            scratch.raw.extend_from_slice(raw);
+            scratch.mnem.clear();
+            scratch.mnem.push_str(mnem);
+            scratch.body.clear();
+            scratch.body.push_str(body);
+            let mut actual = String::new();
+            let addr = 0x400700 + idx as u64;
+            scratch.emit_instruction(addr, &mut actual);
+            assert_eq!(actual, legacy_instruction_line(addr, raw, mnem, body));
+        }
+    }
 }
 
 /// The per-function variable comment block: `; arg:` lines (ABI order), then

--- a/decompiler/crates/kuna-console/tests/verify_decompile_project_helpers.rs
+++ b/decompiler/crates/kuna-console/tests/verify_decompile_project_helpers.rs
@@ -3,8 +3,8 @@
 //!
 //! ```text
 //!   sections()             (vma, size, flags) — the loader's section map
-//!   disassemble_at(vma)    (length, mnemonic, body) — one instruction
-//!   read_bytes(vma, size)  raw image bytes (None when unmapped)
+//!   disassemble_at[_into]   one instruction, allocating or buffer-reusing
+//!   read_bytes[_into]       raw image bytes, allocating or buffer-reusing
 //!   global_data_symbols()  (name, vma, type_size) — named global data
 //! ```
 //!
@@ -83,6 +83,20 @@ fn export_helpers_report_sections_disasm_bytes_and_globals() {
     let (len, mnem, _body) = prog.disassemble_at(main_vma).expect("disassemble_at(main) failed");
     assert!(len > 0, "instruction length must be positive, got {len}");
     assert!(!mnem.is_empty(), "empty mnemonic at main entry");
+    let mut reuse_mnem = String::with_capacity(32);
+    let mut reuse_body = String::with_capacity(128);
+    reuse_mnem.push_str("stale mnemonic");
+    reuse_body.push_str("stale body");
+    let reuse_caps = (reuse_mnem.capacity(), reuse_body.capacity());
+    let reuse_ptrs = (reuse_mnem.as_ptr(), reuse_body.as_ptr());
+    let reuse_len = prog
+        .disassemble_at_into(main_vma, &mut reuse_mnem, &mut reuse_body)
+        .expect("disassemble_at_into(main) failed");
+    let (_, expected_mnem, expected_body) =
+        prog.disassemble_at(main_vma).expect("second disassemble_at(main) failed");
+    assert_eq!((reuse_len, &reuse_mnem, &reuse_body), (len, &expected_mnem, &expected_body));
+    assert_eq!(reuse_caps, (reuse_mnem.capacity(), reuse_body.capacity()));
+    assert_eq!(reuse_ptrs, (reuse_mnem.as_ptr(), reuse_body.as_ptr()));
 
     // (3) read_bytes: correct length, stable across two calls, and a byte-exact
     // round-trip against the fixture file at the corresponding file offset
@@ -92,6 +106,17 @@ fn export_helpers_report_sections_disasm_bytes_and_globals() {
     assert_eq!(got.len(), n, "read_bytes returned the wrong number of bytes");
     let again = prog.read_bytes(main_vma, n).expect("second read_bytes(main) returned None");
     assert_eq!(got, again, "read_bytes not stable across two calls");
+    let mut reuse_bytes = Vec::with_capacity(n + 16);
+    reuse_bytes.extend_from_slice(b"stale bytes");
+    let reuse_cap = reuse_bytes.capacity();
+    let reuse_ptr = reuse_bytes.as_ptr();
+    assert!(
+        prog.read_bytes_into(main_vma, n, &mut reuse_bytes),
+        "read_bytes_into(main) returned false"
+    );
+    assert_eq!(reuse_bytes, got, "read_bytes_into differs from read_bytes");
+    assert_eq!(reuse_bytes.capacity(), reuse_cap);
+    assert_eq!(reuse_bytes.as_ptr(), reuse_ptr);
     let file = std::fs::read(fauxware()).expect("read fixture file");
     let off = (main_vma - LOAD_BASE) as usize;
     assert_eq!(
@@ -102,6 +127,10 @@ fn export_helpers_report_sections_disasm_bytes_and_globals() {
     // An address far below the image is unmapped: Err maps to None (the `.bss` /
     // hole contract the `.asm` data tail relies on).
     assert!(prog.read_bytes(0x10, 4).is_none(), "read of unmapped address must be None");
+    assert!(!prog.read_bytes_into(0x1000, 4, &mut reuse_bytes));
+    assert!(reuse_bytes.is_empty(), "failed read_bytes_into must clear stale bytes");
+    assert_eq!(reuse_bytes.capacity(), reuse_cap);
+    assert_eq!(reuse_bytes.as_ptr(), reuse_ptr);
 
     // (4) global_data_symbols(): returns without error; every tuple is sane
     // (non-empty name, positive type size) and no function symbol leaks through

--- a/decompiler/crates/kuna-sleigh/src/sleigh.rs
+++ b/decompiler/crates/kuna-sleigh/src/sleigh.rs
@@ -2287,17 +2287,40 @@ impl Sleigh {
         emit: &mut dyn AssemblyEmit,
         baseaddr: &Address,
     ) -> KunaResult<i32> {
-        let pos = self.obtain_context(baseaddr, ParseState::Disassembly)?;
-        let table = &self.base.symtab;
-        let mut walker = ParserWalker::new(&pos, table, self);
-        walker.base_state();
-        let ct = walker.get_constructor_inner()?;
-        let mut mons = String::new();
-        table.get_constructor(ct)?.print_mnemonic(&mut mons, &mut walker, table)?;
+        let mut mnemonic = String::new();
         let mut body = String::new();
-        table.get_constructor(ct)?.print_body(&mut body, &mut walker, table)?;
-        emit.dump(baseaddr, &mons, &body);
-        Ok(pos.get_length())
+        let length = self.print_assembly_into(baseaddr, &mut mnemonic, &mut body)?;
+        emit.dump(baseaddr, &mnemonic, &body);
+        Ok(length)
+    }
+
+    /// Disassemble into reusable caller-owned strings.
+    ///
+    /// Both strings are cleared before decoding and again if decoding returns
+    /// an error.
+    pub fn print_assembly_into(
+        &self,
+        baseaddr: &Address,
+        mnemonic: &mut String,
+        body: &mut String,
+    ) -> KunaResult<i32> {
+        mnemonic.clear();
+        body.clear();
+        let result = (|| {
+            let pos = self.obtain_context(baseaddr, ParseState::Disassembly)?;
+            let table = &self.base.symtab;
+            let mut walker = ParserWalker::new(&pos, table, self);
+            walker.base_state();
+            let ct = walker.get_constructor_inner()?;
+            table.get_constructor(ct)?.print_mnemonic(mnemonic, &mut walker, table)?;
+            table.get_constructor(ct)?.print_body(body, &mut walker, table)?;
+            Ok(pos.get_length())
+        })();
+        if result.is_err() {
+            mnemonic.clear();
+            body.clear();
+        }
+        result
     }
 
     /// C++ `Translate::oneInstruction`.
@@ -2464,5 +2487,13 @@ impl Translate for Sleigh {
     }
     fn print_assembly(&self, emit: &mut dyn AssemblyEmit, baseaddr: &Address) -> KunaResult<i32> {
         Sleigh::print_assembly(self, emit, baseaddr)
+    }
+    fn print_assembly_into(
+        &self,
+        baseaddr: &Address,
+        mnemonic: &mut String,
+        body: &mut String,
+    ) -> KunaResult<i32> {
+        Sleigh::print_assembly_into(self, baseaddr, mnemonic, body)
     }
 }

--- a/decompiler/crates/kuna-sleigh/src/slghsymbol.rs
+++ b/decompiler/crates/kuna-sleigh/src/slghsymbol.rs
@@ -78,7 +78,9 @@
 //! output goes to a `String` with names converted lossily (`.sla`
 //! identifiers are ASCII).
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
 use std::rc::Rc;
 
 use kuna_base::address::Address;
@@ -320,8 +322,8 @@ pub enum SymbolType {
 
 /// Lossy text rendering of a byte-string symbol name for error messages and
 /// printed output (`.sla` identifiers are ASCII in practice).
-fn name_text(name: &[u8]) -> String {
-    String::from_utf8_lossy(name).into_owned()
+fn name_text(name: &[u8]) -> Cow<'_, str> {
+    String::from_utf8_lossy(name)
 }
 
 /// (WS4b renumber) remap the `OperandValue` subtable-id inside a `PatternValue`,
@@ -337,12 +339,12 @@ fn remap_patval_table(pv: Option<&mut PatternValue>, map: &impl Fn(u32) -> u32) 
 /// by the `print` methods (ValueSymbol, ValueMapSymbol, OperandSymbol).
 fn push_hex_intb(s: &mut String, val: i64) {
     if val >= 0 {
-        s.push_str(&format!("0x{val:x}"));
+        write!(s, "0x{val:x}").expect("writing to a String cannot fail");
     } else {
         // C++ `-val`: UB on i64::MIN there, wrapping here; ostream then
         // prints the (possibly still negative) intb as its unsigned
         // representation, which is what {:x} on i64 produces.
-        s.push_str(&format!("-0x{:x}", val.wrapping_neg()));
+        write!(s, "-0x{:x}", val.wrapping_neg()).expect("writing to a String cannot fail");
     }
 }
 
@@ -350,7 +352,7 @@ fn push_hex_intb(s: &mut String, val: i64) {
 /// symbols (Start/End/Next2/FlowDest/FlowRef): ostream prints the signed
 /// value as its unsigned 64-bit representation, i.e. the raw offset.
 fn push_hex_offset(s: &mut String, offset: u64) {
-    s.push_str(&format!("0x{offset:x}"));
+    write!(s, "0x{offset:x}").expect("writing to a String cannot fail");
 }
 
 /// C++ `(PatternValue *)PatternExpression::decodeExpression(decoder,trans)`:
@@ -3321,7 +3323,7 @@ impl SleighSymbol {
             }
             SymbolKind::Varnode(_) => {
                 // C++ `s << getName()`
-                s.push_str(&name_text(&self.name));
+                s.push_str(name_text(&self.name).as_ref());
                 Ok(())
             }
             SymbolKind::Context(v) => {
@@ -3344,7 +3346,7 @@ impl SleighSymbol {
                 let vnid = v.varnode_table[ind as usize].ok_or_else(|| {
                     KunaError::sleigh("null varnode list entry (C++ dereferences unchecked)")
                 })?;
-                s.push_str(&name_text(table.symbol(vnid)?.get_name()));
+                s.push_str(name_text(table.symbol(vnid)?.get_name()).as_ref());
                 Ok(())
             }
             SymbolKind::Operand(op) => op.print(s, walker, table),
@@ -5946,6 +5948,22 @@ mod tests {
     }
 
     #[test]
+    fn print_helpers_append_exact_hex_and_lossy_text() {
+        assert!(matches!(name_text(b"eax"), Cow::Borrowed("eax")));
+        assert_eq!(name_text(b"r\xff\xc3\xa9"), "r\u{fffd}\u{e9}");
+
+        let mut s = String::from("values ");
+        push_hex_intb(&mut s, 0);
+        s.push(' ');
+        push_hex_intb(&mut s, -1);
+        s.push(' ');
+        push_hex_intb(&mut s, i64::MIN);
+        s.push(' ');
+        push_hex_offset(&mut s, u64::MAX);
+        assert_eq!(s, "values 0x0 -0x1 -0x8000000000000000 0xffffffffffffffff");
+    }
+
+    #[test]
     fn operand_print_recurses_through_subtable_and_varnode() {
         let manager = test_manager();
         let mut table = SymbolTable::new();
@@ -6389,8 +6407,6 @@ mod tests {
         }
     }
 }
-
-
 
 
 

--- a/decompiler/crates/kuna-sleigh/src/translate.rs
+++ b/decompiler/crates/kuna-sleigh/src/translate.rs
@@ -217,6 +217,20 @@ pub trait AssemblyEmit {
     fn dump(&mut self, addr: &Address, mnem: &str, body: &str);
 }
 
+struct AssemblyStringEmit<'a> {
+    mnemonic: &'a mut String,
+    body: &'a mut String,
+}
+
+impl AssemblyEmit for AssemblyStringEmit<'_> {
+    fn dump(&mut self, _addr: &Address, mnem: &str, body: &str) {
+        self.mnemonic.clear();
+        self.mnemonic.push_str(mnem);
+        self.body.clear();
+        self.body.push_str(body);
+    }
+}
+
 /// Tagged addresses in the \e unique address space (C++
 /// `Translate::UniqueLayout`)
 #[allow(non_camel_case_types)] // C++ enumerator names (spacetype precedent)
@@ -479,6 +493,30 @@ pub trait Translate: RegisterLookup {
     /// \param emit is the disassembly emitting object
     /// \param baseaddr is the address of the machine instruction to disassemble
     fn print_assembly(&self, emit: &mut dyn AssemblyEmit, baseaddr: &Address) -> KunaResult<i32>;
+
+    /// Disassemble into reusable caller-owned strings.
+    ///
+    /// Both output strings are cleared before decoding and remain empty if
+    /// decoding fails. Implementors can override this to render without
+    /// allocating intermediate strings.
+    fn print_assembly_into(
+        &self,
+        baseaddr: &Address,
+        mnemonic: &mut String,
+        body: &mut String,
+    ) -> KunaResult<i32> {
+        mnemonic.clear();
+        body.clear();
+        let result = {
+            let mut emit = AssemblyStringEmit { mnemonic, body };
+            self.print_assembly(&mut emit, baseaddr)
+        };
+        if result.is_err() {
+            mnemonic.clear();
+            body.clear();
+        }
+        result
+    }
 
     // --- C++ non-virtual members, provided over translate_base() ---
 
@@ -1395,6 +1433,10 @@ mod tests {
             emit: &mut dyn AssemblyEmit,
             baseaddr: &Address,
         ) -> KunaResult<i32> {
+            if baseaddr.get_offset() == 4 {
+                emit.dump(baseaddr, "PARTIAL", "assembly");
+                return Err(KunaError::lowlevel("assembly failed"));
+            }
             emit.dump(baseaddr, "NOP", "");
             Ok(4)
         }
@@ -1461,6 +1503,24 @@ mod tests {
         let mut asm = CollectAsm(Vec::new());
         assert_eq!(dyn_trans.print_assembly(&mut asm, &addr).unwrap(), 4);
         assert_eq!(asm.0, vec![(0, "NOP".to_string(), String::new())]);
+
+        let mut mnemonic = String::from("stale mnemonic");
+        let mut body = String::from("stale body");
+        assert_eq!(
+            dyn_trans.print_assembly_into(&addr, &mut mnemonic, &mut body).unwrap(),
+            4
+        );
+        assert_eq!(mnemonic, "NOP");
+        assert!(body.is_empty());
+
+        let error_addr = Address::new(Rc::clone(&register), 4);
+        mnemonic.push_str(" stale");
+        body.push_str("stale");
+        assert!(dyn_trans
+            .print_assembly_into(&error_addr, &mut mnemonic, &mut body)
+            .is_err());
+        assert!(mnemonic.is_empty());
+        assert!(body.is_empty());
     }
 
     /// The VarnodeStorage <-> VarnodeData conversions are exact and the two

--- a/decompiler/crates/kuna-sleigh/tests/instruction_mask.rs
+++ b/decompiler/crates/kuna-sleigh/tests/instruction_mask.rs
@@ -17,11 +17,11 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use kuna_base::address::Address;
-use kuna_base::error::KunaResult;
+use kuna_base::error::{KunaError, KunaResult};
 use kuna_sleigh::globalcontext::ContextInternal;
 use kuna_sleigh::loadimage::LoadImage;
 use kuna_sleigh::sleigh::{OpObject, Sleigh};
-use kuna_sleigh::translate::Translate;
+use kuna_sleigh::translate::{AssemblyEmit, Translate};
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
@@ -53,6 +53,36 @@ impl LoadImage for MemImg {
         Vec::new()
     }
     fn adjust_vma(&mut self, _adjust: i64) {}
+}
+
+struct MissingImg;
+
+impl LoadImage for MissingImg {
+    fn get_file_name(&self) -> &str {
+        "missing"
+    }
+    fn load_fill(&mut self, _ptr: &mut [u8], _addr: &Address) -> KunaResult<()> {
+        Err(KunaError::data_unavail("missing"))
+    }
+    fn get_arch_type(&self) -> Vec<u8> {
+        Vec::new()
+    }
+    fn adjust_vma(&mut self, _adjust: i64) {}
+}
+
+#[derive(Default)]
+struct TextEmit {
+    mnemonic: String,
+    body: String,
+}
+
+impl AssemblyEmit for TextEmit {
+    fn dump(&mut self, _addr: &Address, mnemonic: &str, body: &str) {
+        self.mnemonic.clear();
+        self.mnemonic.push_str(mnemonic);
+        self.body.clear();
+        self.body.push_str(body);
+    }
 }
 
 /// The full x86-64 context block the language needs to decode 64-bit code
@@ -362,4 +392,47 @@ fn mov_mem_disp32_masks_displacement() {
         "expected a Scalar operand == 0x12345678 (the disp32), got {:?}",
         m.operands
     );
+}
+
+#[test]
+fn assembly_into_matches_legacy_and_clears_reused_buffers() {
+    let code = [0x48, 0x01, 0xfe, 0xb9, 0x44, 0x33, 0x22, 0x11];
+    let mut sleigh = build_x86_64(&code);
+    let first = code_addr(&sleigh, VMA);
+
+    let mut emitted = TextEmit::default();
+    let legacy_len = sleigh.print_assembly(&mut emitted, &first).unwrap();
+    let mut mnemonic = String::from("stale mnemonic");
+    let mut body = String::from("stale body");
+    let direct_len = {
+        let translate: &dyn Translate = &sleigh;
+        translate
+            .print_assembly_into(&first, &mut mnemonic, &mut body)
+            .unwrap()
+    };
+    assert_eq!(direct_len, legacy_len);
+    assert_eq!(mnemonic, emitted.mnemonic);
+    assert_eq!(body, emitted.body);
+
+    let second = code_addr(&sleigh, VMA + legacy_len as u64);
+    let mut second_emit = TextEmit::default();
+    let second_len = sleigh.print_assembly(&mut second_emit, &second).unwrap();
+    let direct_second_len = {
+        let translate: &dyn Translate = &sleigh;
+        translate
+            .print_assembly_into(&second, &mut mnemonic, &mut body)
+            .unwrap()
+    };
+    assert_eq!(direct_second_len, second_len);
+    assert_eq!(mnemonic, second_emit.mnemonic);
+    assert_eq!(body, second_emit.body);
+
+    sleigh.set_loader(Box::new(MissingImg));
+    mnemonic.push_str(" stale");
+    body.push_str(" stale");
+    assert!(sleigh
+        .print_assembly_into(&first, &mut mnemonic, &mut body)
+        .is_err());
+    assert!(mnemonic.is_empty());
+    assert!(body.is_empty());
 }

--- a/docs/spec/09-emission.md
+++ b/docs/spec/09-emission.md
@@ -496,3 +496,14 @@ bytes, named data symbols for the `.asm`/`README.md` artifacts) lives on the
 console engine, `decompiler/crates/kuna-console/src/engine.rs
 (ConsoleProgram::sections, disassemble_at, read_bytes, global_data_symbols)`,
 not in this folder.
+
+**Assembly sweep scratch storage.** The linear code-section walk reuses
+caller-owned mnemonic, operand-body, raw-byte, and line buffers across
+instructions (`decompiler/crates/kuna-console/src/project.rs (sweep_code)`).
+`decompiler/crates/kuna-sleigh/src/translate.rs
+(Translate::print_assembly_into)` lets the concrete translator render into the
+cleared strings directly, and the console engine fills the reusable byte
+buffer through `ConsoleProgram::read_bytes_into`. Failed reads and decodes
+leave their scratch outputs empty. This changes allocation only: section and
+label order, sequential context effects, decode attempts, text formatting, and
+the final bytes are identical, and no instruction result is cached.


### PR DESCRIPTION
## Summary

- add object-safe, caller-buffered assembly rendering while preserving the existing `Translate::print_assembly` API
- reuse mnemonic, body, raw-byte, line, and `db` buffers across the whole project assembly sweep
- render symbol names, numeric operands, raw bytes, and assembly lines directly into those buffers
- clear every caller-owned buffer on entry and on failure

This is a strict output-preserving performance change, so it adds no option. It is complementary to #210: that PR recycles the SLEIGH parse arena; this PR removes transient output-formatting allocation around each decoded instruction.

## Private-binary evidence

Binary SHA-256: `bc4c15d826aaebeace3fec6360eb687e5662cba8745605093254931dcdb3ae1b` (private binary).

Isolated full assembly sweep over 1,010,974 decoded instructions / 60,411,921 output bytes, five release runs:

| Metric | main | this PR | Delta |
|---|---:|---:|---:|
| internal median | 6.697911 s | 6.311954 s | -5.76% |
| external median | 8.17 s | 7.95 s | -2.69% |
| allocation + reallocation calls | 90.03 M | 74.22 M | -17.57% |
| reallocations | 3,407,045 | 103 | -99.997% |

The assembly stayed byte-identical (SHA-256 `2070af123ab971168895002e46409db33a0395d3d6c7f04f53d942afcdfa14d6`). RSS was flat. On this standalone branch, the parse arena still accounts for 99.4% of cumulative allocated bytes, which explains the modest wall-time change.

### Composition with #210

A clean temporary tree containing this PR plus #210 produced:

| Metric | main | #210 + this PR | Delta |
|---|---:|---:|---:|
| internal median | 6.697911 s | 1.322880 s | -80.25% / 5.06x |
| external median | 8.17 s | 2.82 s | -65.48% / 2.90x |
| allocation + reallocation calls | 90.03 M | 6.48 M | -92.80% |
| cumulative allocated bytes | 35.72 GB | 197.38 MB | -99.45% |

Relative to #210 alone, this PR reduces internal time another 36.88%, allocation calls another 70.93%, and allocated bytes another 61.24%. All five stacked runs remained byte-identical to main. This confirms that the two PRs remove distinct layers of allocation and compose cleanly.

The fauxware project assembly also stayed byte-identical (SHA-256 `79067d4debf4a2fb5d725bd937ad0c37fa1df594ea10c076b0888fc8bb3f72f5`).

## Validation

- `make test` — PARITY OK (675/675)
- `make test-stages` — PARITY OK (278/278)
- `make rust-test` — green
- `make check-spec` — green
- full `kuna-sleigh` and `kuna-console` package suites — green
- real x86 legacy-vs-buffered assembly parity and error-clearing tests
- focused formatting parity for Unicode width, trailing whitespace, raw-byte padding, `db` batching, and buffer reuse

The implementation and output/error contracts were independently reviewed before opening this PR.
