### PR TITLE
perf(p0): index global queries by address space

### DIFF
--- a/decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs
+++ b/decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs
@@ -3127,11 +3127,11 @@ impl Database {
             }
         }
         let scope = &self.scopes[gid];
-        crate::context::GlobalQuery {
+        crate::context::GlobalQuery::new(
             entries,
-            owned: scope.rangetree.clone(),
-            flagbase: self.flagbase.clone(),
-        }
+            scope.rangetree.clone(),
+            self.flagbase.clone(),
+        )
     }
 
     /// Snapshot every global FunctionSymbol's source-declared prototype, keyed by

--- a/decompiler/crates/kuna-decomp/src/substrate/context.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/context.rs
@@ -178,8 +178,9 @@ pub struct GlobalEntry {
 /// `Funcdata` at [`build_arch_handle`](crate::architecture::Architecture::build_arch_handle).
 #[derive(Debug, Clone, Default)]
 pub struct GlobalQuery {
-    /// Every whole-and-piece mapped storage in the global scope, all spaces.
-    pub entries: Vec<GlobalEntry>,
+    /// Every whole-and-piece mapped storage in the global scope, stably grouped
+    /// by address-space index by [`GlobalQuery::new`].
+    entries: Vec<GlobalEntry>,
     /// The global scope's owned data ranges (C++ `Scope::rangetree`), for the
     /// `inScope` discovery branch of `queryProperties`.
     pub owned: kuna_base::address::RangeList,
@@ -188,6 +189,31 @@ pub struct GlobalQuery {
 }
 
 impl GlobalQuery {
+    /// Build a snapshot whose entries are grouped by address space while
+    /// retaining their original order within each space.
+    pub fn new(
+        mut entries: Vec<GlobalEntry>,
+        owned: kuna_base::address::RangeList,
+        flagbase: kuna_base::partmap::PartMap<Address, uint4>,
+    ) -> Self {
+        entries.sort_by_key(|entry| entry.space_index);
+        Self {
+            entries,
+            owned,
+            flagbase,
+        }
+    }
+
+    /// Return only entries belonging to one address space.
+    fn entries_for_space(&self, space_index: int4) -> &[GlobalEntry] {
+        let first = self
+            .entries
+            .partition_point(|entry| entry.space_index < space_index);
+        let entries = &self.entries[first..];
+        let len = entries.partition_point(|entry| entry.space_index == space_index);
+        &entries[..len]
+    }
+
     /// C++ `Database::getProperty(addr)` (`database.hh:949`): the boolean
     /// properties (read-only/volatile) painted on a memory range.
     fn get_property(&self, addr: &Address) -> uint4 {
@@ -208,10 +234,7 @@ impl GlobalQuery {
         let end = start.wrapping_add(size as u64).wrapping_sub(1);
         let mut best: Option<&GlobalEntry> = None;
         let mut oldsize: int4 = -1;
-        for e in &self.entries {
-            if e.space_index != space_index {
-                continue;
-            }
+        for e in self.entries_for_space(space_index) {
             // Containment: first <= addr (entries are storage at >= first) and
             // last >= end.  The rangemap subsort walk already filters to
             // first <= addr; here check both bounds explicitly.
@@ -261,10 +284,7 @@ impl GlobalQuery {
         let end = start.wrapping_add(size as u64).wrapping_sub(1);
         let mut best: Option<&GlobalEntry> = None;
         let mut oldsize: int4 = -1;
-        for e in &self.entries {
-            if e.space_index != space_index {
-                continue;
-            }
+        for e in self.entries_for_space(space_index) {
             if e.first > start || e.last < end {
                 continue;
             }
@@ -385,6 +405,10 @@ impl GlobalQuery {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "context_tests.rs"]
+mod tests;
 
 /// Global configuration data for the program being decompiled (C++
 /// `Architecture`, owned by `Funcdata` as `glb`).
@@ -1250,8 +1274,8 @@ impl ArchContext {
         let gq = self.global_query.as_ref()?;
         let space_index = entry.get_space()?.get_index();
         let start = entry.get_offset();
-        for e in &gq.entries {
-            if e.space_index != space_index || e.first != start {
+        for e in gq.entries_for_space(space_index) {
+            if e.first != start {
                 continue;
             }
             if let Some(ct) = &e.symbol_type {
@@ -1282,8 +1306,8 @@ impl ArchContext {
         let space = entry.get_space()?;
         let space_index = space.get_index();
         let start = entry.get_offset();
-        for e in &gq.entries {
-            if e.space_index != space_index || e.first != start {
+        for e in gq.entries_for_space(space_index) {
+            if e.first != start {
                 continue;
             }
             // C++ `Scope::queryFunction(addr)` returns the `FunctionSymbol`'s

--- a/decompiler/crates/kuna-decomp/src/substrate/context_tests.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/context_tests.rs
@@ -1,0 +1,154 @@
+use std::rc::Rc;
+
+use kuna_base::address::{Address, RangeList};
+use kuna_base::partmap::PartMap;
+use kuna_base::space::{spacetype, AddrSpace};
+
+use super::{GlobalEntry, GlobalQuery};
+
+fn space(index: i32) -> Rc<AddrSpace> {
+    Rc::new(AddrSpace::new(
+        spacetype::IPTR_PROCESSOR,
+        "space",
+        false,
+        8,
+        1,
+        index,
+        0,
+        0,
+        0,
+    ))
+}
+
+fn addr(space: &Rc<AddrSpace>, offset: u64) -> Address {
+    Address::new(Rc::clone(space), offset)
+}
+
+fn entry(
+    space: &Rc<AddrSpace>,
+    first: u64,
+    size: i32,
+    flags: u32,
+    name: &str,
+    addrtied: bool,
+    uselimit: RangeList,
+) -> GlobalEntry {
+    GlobalEntry {
+        space_index: space.get_index(),
+        first,
+        last: first.wrapping_add(size as u64).wrapping_sub(1),
+        size,
+        all_flags: flags,
+        addrtied,
+        uselimit,
+        symbol_name: name.to_string(),
+        symbol_offset: 0,
+        symbol_type: None,
+        scope_path: Vec::new(),
+        is_function: false,
+        func_inject_id: -1,
+    }
+}
+
+fn query(entries: Vec<GlobalEntry>) -> GlobalQuery {
+    GlobalQuery::new(entries, RangeList::new(), PartMap::new(0))
+}
+
+#[test]
+fn groups_cross_space_entries_without_changing_within_space_order() {
+    let space3 = space(3);
+    let space9 = space(9);
+    let query = query(vec![
+        entry(
+            &space9,
+            0x100,
+            4,
+            0x91,
+            "first-nine",
+            true,
+            RangeList::new(),
+        ),
+        entry(
+            &space3,
+            0x100,
+            4,
+            0x31,
+            "only-three",
+            true,
+            RangeList::new(),
+        ),
+        entry(
+            &space9,
+            0x200,
+            4,
+            0x92,
+            "second-nine",
+            true,
+            RangeList::new(),
+        ),
+    ]);
+
+    let names: Vec<&str> = query
+        .entries_for_space(9)
+        .iter()
+        .map(|entry| entry.symbol_name.as_str())
+        .collect();
+    assert_eq!(names, ["first-nine", "second-nine"]);
+    assert!(query.entries_for_space(5).is_empty());
+    assert_eq!(
+        query.query_properties(&addr(&space3, 0x100), 4, &Address::new_invalid()),
+        0x31
+    );
+    assert_eq!(
+        query.query_properties(&addr(&space9, 0x100), 4, &Address::new_invalid()),
+        0x91
+    );
+}
+
+#[test]
+fn equal_size_overlap_keeps_the_original_first_match() {
+    let space3 = space(3);
+    let space9 = space(9);
+    let query = query(vec![
+        entry(&space3, 0x100, 4, 0x31, "first", true, RangeList::new()),
+        entry(
+            &space9,
+            0x100,
+            4,
+            0x91,
+            "other-space",
+            true,
+            RangeList::new(),
+        ),
+        entry(&space3, 0x100, 4, 0x32, "second", true, RangeList::new()),
+    ]);
+
+    assert_eq!(
+        query.query_properties(&addr(&space3, 0x100), 4, &Address::new_invalid()),
+        0x31
+    );
+}
+
+#[test]
+fn in_use_filter_still_selects_the_smallest_active_entry() {
+    let data = space(3);
+    let code = space(4);
+    let mut inactive = RangeList::new();
+    inactive.insert_range(Rc::clone(&code), 0x400, 0x4ff);
+    let mut active = RangeList::new();
+    active.insert_range(Rc::clone(&code), 0x500, 0x5ff);
+    let query = query(vec![
+        entry(&data, 0x100, 16, 0x10, "outer", true, RangeList::new()),
+        entry(&data, 0x100, 4, 0x20, "inactive", false, inactive),
+        entry(&data, 0x100, 4, 0x30, "active", false, active),
+    ]);
+
+    assert_eq!(
+        query.query_properties(&addr(&data, 0x100), 4, &addr(&code, 0x500)),
+        0x30
+    );
+    assert_eq!(
+        query.query_properties(&addr(&data, 0x100), 4, &Address::new_invalid()),
+        0x10
+    );
+}

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_global_persist_adversarial.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_global_persist_adversarial.rs
@@ -89,11 +89,11 @@ fn tied_entry(space: &Rc<AddrSpace>, first: u64, last: u64, all_flags: u32) -> G
 fn av1_containment_boundary_is_inclusive_last_and_first() {
     let ram = ram_space(3);
     let flags = varnode_flags::mapped | varnode_flags::addrtied | varnode_flags::persist;
-    let gq = GlobalQuery {
-        entries: vec![tied_entry(&ram, 0x100, 0x103, flags)],
-        owned: RangeList::new(), // no owning-scope fallback for this test
-        flagbase: PartMap::new(0u32),
-    };
+    let gq = GlobalQuery::new(
+        vec![tied_entry(&ram, 0x100, 0x103, flags)],
+        RangeList::new(), // no owning-scope fallback for this test
+        PartMap::new(0u32),
+    );
     let usepoint = Address::new_invalid();
 
     // Exact whole-entry match: returns the entry's flags.
@@ -130,7 +130,7 @@ fn av2_owned_scope_fallback_sets_mapped_addrtied_persist_plus_property() {
     let mut flagbase = PartMap::new(0u32);
     *flagbase.split(&addr(&ram, 0x200)) = varnode_flags::readonly;
     *flagbase.split(&addr(&ram, 0x300)) = 0; // close the painted range at 0x300
-    let gq = GlobalQuery { entries: vec![], owned, flagbase };
+    let gq = GlobalQuery::new(vec![], owned, flagbase);
     let usepoint = Address::new_invalid();
 
     let expected = varnode_flags::mapped
@@ -167,11 +167,11 @@ fn av3_constant_address_never_matches() {
     // owned tree (adversarial: try to trick the owned fallback too).
     let mut owned = RangeList::new();
     owned.insert_range(cst.clone(), 0x40, 0x4f);
-    let gq = GlobalQuery {
-        entries: vec![tied_entry(&ram, 0x40, 0x43, flags)],
+    let gq = GlobalQuery::new(
+        vec![tied_entry(&ram, 0x40, 0x43, flags)],
         owned,
-        flagbase: PartMap::new(0u32),
-    };
+        PartMap::new(0u32),
+    );
     let usepoint = Address::new_invalid();
     assert!(cst.get_type() == spacetype::IPTR_CONSTANT, "fixture sanity: const space");
     // Constant 0x40, size 4 => guarded to 0 regardless of entries/owned.
@@ -208,11 +208,11 @@ fn av4_smallest_in_use_entry_wins() {
     // Order shouldn't matter (non-overlapping symbols don't occur, but nested
     // whole/piece entries do): put the BIG one first so a naive "first match
     // wins" would pick the wrong (larger) entry.
-    let gq = GlobalQuery {
-        entries: vec![big.clone(), small.clone()],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+    let gq = GlobalQuery::new(
+        vec![big.clone(), small.clone()],
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     let usepoint = Address::new_invalid();
     assert_eq!(
         gq.query_properties(&addr(&ram, 0x300), 2, &usepoint),
@@ -238,11 +238,11 @@ fn av4_smallest_in_use_entry_wins() {
         is_function: false,
         func_inject_id: -1,
     };
-    let gq2 = GlobalQuery {
-        entries: vec![big.clone(), limited.clone()],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+    let gq2 = GlobalQuery::new(
+        vec![big.clone(), limited.clone()],
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     // Invalid usepoint: the use-limited (smaller) entry is NOT inUse, so the big
     // addr-tied entry answers.
     assert_eq!(
@@ -278,11 +278,11 @@ fn av5_end_offset_wrap_near_u64_max_does_not_panic() {
     let ram = ram_space(3);
     let flags = varnode_flags::mapped | varnode_flags::persist;
     // An entry at the very top byte.
-    let gq = GlobalQuery {
-        entries: vec![tied_entry(&ram, u64::MAX, u64::MAX, flags)],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+    let gq = GlobalQuery::new(
+        vec![tied_entry(&ram, u64::MAX, u64::MAX, flags)],
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     let usepoint = Address::new_invalid();
     // size 1 at u64::MAX: end = MAX + 1 - 1 = MAX (wrap-safe), exact match.
     assert_eq!(

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_symbol_consolidate.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_symbol_consolidate.rs
@@ -106,8 +106,8 @@ fn typed_entry(
 fn tf1_typelocked_symbol_forces_its_formatted_type() {
     let ram = ram_space(3);
     let octint4 = fmt_int(4, "octint4", 3 /* Symbol::force_oct */);
-    let gq = GlobalQuery {
-        entries: vec![typed_entry(
+    let gq = GlobalQuery::new(
+        vec![typed_entry(
             &ram,
             0x301018,
             0x30101b,
@@ -116,9 +116,9 @@ fn tf1_typelocked_symbol_forces_its_formatted_type() {
             varnode_flags::typelock | varnode_flags::addrtied | varnode_flags::mapped,
             Some(octint4),
         )],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     let up = Address::new_invalid();
 
     let (dt, off) = gq
@@ -146,8 +146,8 @@ fn tf1_typelocked_symbol_forces_its_formatted_type() {
 fn tf2_non_typelocked_symbol_forces_no_type() {
     let ram = ram_space(3);
     let some_int = fmt_int(4, "int4", 0);
-    let gq = GlobalQuery {
-        entries: vec![typed_entry(
+    let gq = GlobalQuery::new(
+        vec![typed_entry(
             &ram,
             0x301014,
             0x301017,
@@ -157,9 +157,9 @@ fn tf2_non_typelocked_symbol_forces_no_type() {
             varnode_flags::addrtied | varnode_flags::mapped,
             Some(some_int),
         )],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     let up = Address::new_invalid();
 
     assert!(
@@ -181,8 +181,8 @@ fn tf2_non_typelocked_symbol_forces_no_type() {
 fn tf3_sized_offset_is_access_minus_first_plus_entry_offset() {
     let ram = ram_space(3);
     let wide = fmt_int(8, "wide_struct", 1 /* force_hex, irrelevant here */);
-    let gq = GlobalQuery {
-        entries: vec![typed_entry(
+    let gq = GlobalQuery::new(
+        vec![typed_entry(
             &ram,
             0x500,
             0x507,
@@ -191,9 +191,9 @@ fn tf3_sized_offset_is_access_minus_first_plus_entry_offset() {
             varnode_flags::typelock | varnode_flags::mapped,
             Some(wide),
         )],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     let up = Address::new_invalid();
 
     let (_dt, off) = gq
@@ -214,8 +214,8 @@ fn tf3_sized_offset_is_access_minus_first_plus_entry_offset() {
 fn tf4_constant_address_is_never_type_forced() {
     let ram = ram_space(3);
     let octint4 = fmt_int(4, "octint4", 3);
-    let gq = GlobalQuery {
-        entries: vec![typed_entry(
+    let gq = GlobalQuery::new(
+        vec![typed_entry(
             &ram,
             0x100,
             0x103,
@@ -224,9 +224,9 @@ fn tf4_constant_address_is_never_type_forced() {
             varnode_flags::typelock | varnode_flags::mapped,
             Some(octint4),
         )],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     let cst = kuna_base::address::Address::new(
         Rc::new(kuna_base::space::ConstantSpace::new()),
         0x100,
@@ -250,8 +250,8 @@ fn tf4_constant_address_is_never_type_forced() {
 #[test]
 fn tf5_typelocked_entry_without_type_yields_none() {
     let ram = ram_space(3);
-    let gq = GlobalQuery {
-        entries: vec![typed_entry(
+    let gq = GlobalQuery::new(
+        vec![typed_entry(
             &ram,
             0x700,
             0x703,
@@ -260,9 +260,9 @@ fn tf5_typelocked_entry_without_type_yields_none() {
             varnode_flags::typelock | varnode_flags::mapped,
             None,
         )],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     let up = Address::new_invalid();
 
     assert!(
@@ -282,9 +282,9 @@ fn tf5_typelocked_entry_without_type_yields_none() {
 fn tf6_query_past_last_byte_forces_no_type() {
     let ram = ram_space(3);
     let octint4 = fmt_int(4, "octint4", 3);
-    let gq = GlobalQuery {
-        // Covers [0x600, 0x603].
-        entries: vec![typed_entry(
+    // Covers [0x600, 0x603].
+    let gq = GlobalQuery::new(
+        vec![typed_entry(
             &ram,
             0x600,
             0x603,
@@ -293,9 +293,9 @@ fn tf6_query_past_last_byte_forces_no_type() {
             varnode_flags::typelock | varnode_flags::mapped,
             Some(octint4),
         )],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     let up = Address::new_invalid();
 
     // A 4-byte access at 0x601 needs [0x601,0x604]; 0x604 > last(0x603): no match.

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_symbol_consolidate_adversarial.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_symbol_consolidate_adversarial.rs
@@ -105,14 +105,14 @@ fn named_entry(
 #[test]
 fn av1_smallest_containing_symbol_name_wins() {
     let ram = ram_space(3);
-    let gq = GlobalQuery {
-        entries: vec![
+    let gq = GlobalQuery::new(
+        vec![
             named_entry(&ram, 0x301014, 0x301017, "glob1", 0),
             named_entry(&ram, 0x301014, 0x30101b, "widepair", 0),
         ],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     let up = Address::new_invalid();
 
     let (name4, off4, _t) = gq
@@ -139,15 +139,15 @@ fn av1_smallest_containing_symbol_name_wins() {
 #[test]
 fn av2_symbol_offset_is_access_minus_first_plus_entry_offset() {
     let ram = ram_space(3);
-    let gq = GlobalQuery {
-        entries: vec![
+    let gq = GlobalQuery::new(
+        vec![
             named_entry(&ram, 0x400, 0x40f, "arr", 0),
             // A piece mapped at 0x500 that is the OFFSET-4 slice of its Symbol.
             named_entry(&ram, 0x500, 0x503, "structpiece", 4),
         ],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     let up = Address::new_invalid();
 
     let (name, off, _t) = gq
@@ -175,12 +175,12 @@ fn av2_symbol_offset_is_access_minus_first_plus_entry_offset() {
 fn av3_constant_address_is_never_named() {
     let cst = the_constant_space();
     let ram = ram_space(3);
-    let gq = GlobalQuery {
-        // An entry in the constant space's index that would "contain" 0x100.
-        entries: vec![named_entry(&ram, 0x100, 0x103, "phantom", 0)],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+    // An entry in the constant space's index that would "contain" 0x100.
+    let gq = GlobalQuery::new(
+        vec![named_entry(&ram, 0x100, 0x103, "phantom", 0)],
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     let up = Address::new_invalid();
     assert!(
         gq.name_for_varnode(&addr(&cst, 0x100), 4, &up).is_none(),
@@ -199,11 +199,11 @@ fn av3_constant_address_is_never_named() {
 #[test]
 fn av4_no_match_returns_none() {
     let ram = ram_space(3);
-    let gq = GlobalQuery {
-        entries: vec![named_entry(&ram, 0x301014, 0x301017, "glob1", 0)],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+    let gq = GlobalQuery::new(
+        vec![named_entry(&ram, 0x301014, 0x301017, "glob1", 0)],
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     let up = Address::new_invalid();
 
     assert!(
@@ -239,11 +239,11 @@ fn av5_inuse_usepoint_gate() {
     let code = code_space(4);
 
     // Address-tied: named at an invalid usepoint.
-    let tied = GlobalQuery {
-        entries: vec![named_entry(&ram, 0x600, 0x603, "tiedglob", 0)],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+    let tied = GlobalQuery::new(
+        vec![named_entry(&ram, 0x600, 0x603, "tiedglob", 0)],
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     assert!(
         tied.name_for_varnode(&addr(&ram, 0x600), 4, &Address::new_invalid()).is_some(),
         "an address-tied global is named regardless of usepoint",
@@ -255,11 +255,7 @@ fn av5_inuse_usepoint_gate() {
     let mut limited = named_entry(&ram, 0x700, 0x703, "limitedglob", 0);
     limited.addrtied = false;
     limited.uselimit = uselimit;
-    let gq = GlobalQuery {
-        entries: vec![limited],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+    let gq = GlobalQuery::new(vec![limited], RangeList::new(), PartMap::new(0u32));
     // Invalid usepoint → not inUse → None.
     assert!(
         gq.name_for_varnode(&addr(&ram, 0x700), 4, &Address::new_invalid()).is_none(),

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_symbol_consolidate_verifier2.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_symbol_consolidate_verifier2.rs
@@ -93,11 +93,11 @@ fn v1_query_properties_returns_covering_symbol_all_flags() {
         | varnode_flags::addrtied
         | varnode_flags::persist
         | varnode_flags::readonly;
-    let gq = GlobalQuery {
-        entries: vec![entry(&ram, 0x4000, 0x4003, fl, None)],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+    let gq = GlobalQuery::new(
+        vec![entry(&ram, 0x4000, 0x4003, fl, None)],
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     let usepoint = Address::new_invalid();
     let got = gq.query_properties(&addr(&ram, 0x4000), 4, &usepoint);
     // C++ `flags = res->getAllFlags()` — verbatim, NOT OR'd with anything extra.
@@ -120,11 +120,11 @@ fn v2_query_properties_owned_no_symbol_is_mapped_addrtied_persist() {
     let mut flagbase = PartMap::new(0u32);
     *flagbase.split(&addr(&ram, 0x5000)) = varnode_flags::readonly;
     *flagbase.split(&addr(&ram, 0x5008)) = 0;
-    let gq = GlobalQuery {
-        entries: Vec::new(), // NO covering symbol
+    let gq = GlobalQuery::new(
+        Vec::new(), // NO covering symbol
         owned,
         flagbase,
-    };
+    );
     let usepoint = Address::new_invalid();
     let got = gq.query_properties(&addr(&ram, 0x5000), 4, &usepoint);
     // C++: flags = mapped|addrtied|persist | getProperty(addr).
@@ -154,11 +154,11 @@ fn v3_query_properties_flagbase_only_and_constant_guard() {
     let mut flagbase = PartMap::new(0u32);
     *flagbase.split(&addr(&ram, 0x9000)) = varnode_flags::readonly;
     *flagbase.split(&addr(&ram, 0x9004)) = 0;
-    let gq = GlobalQuery {
-        entries: Vec::new(),  // no symbol
-        owned: RangeList::new(), // not owned
+    let gq = GlobalQuery::new(
+        Vec::new(), // no symbol
+        RangeList::new(), // not owned
         flagbase,
-    };
+    );
     let usepoint = Address::new_invalid();
     // No symbol, not owned: just getProperty (NOT mapped/addrtied/persist).
     let got = gq.query_properties(&addr(&ram, 0x9000), 4, &usepoint);
@@ -195,14 +195,14 @@ fn v4_smallest_containing_flags_win() {
     // selection is by size, not iteration position.
     let small_fl = varnode_flags::mapped | varnode_flags::addrtied | varnode_flags::persist;
     let big_fl = small_fl | varnode_flags::readonly;
-    let gq = GlobalQuery {
-        entries: vec![
+    let gq = GlobalQuery::new(
+        vec![
             entry(&ram, 0x4000, 0x4007, big_fl, None),
             entry(&ram, 0x4000, 0x4003, small_fl, None),
         ],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     let usepoint = Address::new_invalid();
     let got4 = gq.query_properties(&addr(&ram, 0x4000), 4, &usepoint);
     assert_eq!(
@@ -230,17 +230,17 @@ fn v5_sized_type_only_when_typelocked_and_boundary_inclusive() {
     let usepoint = Address::new_invalid();
 
     // (a) NON-typelocked covering Symbol → None (inference stays free).
-    let gq_nolock = GlobalQuery {
-        entries: vec![entry(
+    let gq_nolock = GlobalQuery::new(
+        vec![entry(
             &ram,
             0x6000,
             0x6003,
             varnode_flags::mapped | varnode_flags::addrtied | varnode_flags::persist,
             Some(ty.clone()),
         )],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     assert!(
         gq_nolock
             .sized_type_geometry(&addr(&ram, 0x6000), 4, &usepoint)
@@ -249,8 +249,8 @@ fn v5_sized_type_only_when_typelocked_and_boundary_inclusive() {
     );
 
     // (b) typelocked covering Symbol → Some((type, off=0)).
-    let gq_lock = GlobalQuery {
-        entries: vec![entry(
+    let gq_lock = GlobalQuery::new(
+        vec![entry(
             &ram,
             0x6000,
             0x6003,
@@ -260,9 +260,9 @@ fn v5_sized_type_only_when_typelocked_and_boundary_inclusive() {
                 | varnode_flags::typelock,
             Some(ty.clone()),
         )],
-        owned: RangeList::new(),
-        flagbase: PartMap::new(0u32),
-    };
+        RangeList::new(),
+        PartMap::new(0u32),
+    );
     let got = gq_lock.sized_type_geometry(&addr(&ram, 0x6000), 4, &usepoint);
     assert!(got.is_some(), "a typelocked covering Symbol forces its type");
     assert_eq!(got.unwrap().1, 0, "whole-symbol access → in-symbol offset 0");

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -381,6 +381,15 @@ scalar configuration — every tuning value and (kuna) every rule gate — plus
 read-only snapshots of the global symbol scope, callee prototypes, and tracked
 registers.
 
+The global-symbol snapshot
+(`decompiler/crates/kuna-decomp/src/substrate/context.rs (GlobalQuery)`) groups
+mapped entries by address-space index once when it is built. Grouping is stable:
+the encounter order of entries within one space is unchanged, preserving
+`findContainer`'s first-match behavior for equal-size overlaps and its
+use-point selection. Property, naming, container, and callee lookups first
+isolate the requested space, so register, stack, and other non-global varnodes
+do not scan mappings from unrelated spaces.
+
 The copy happens in exactly one place:
 `decompiler/crates/kuna-decomp/src/infra/architecture.rs (build_arch_handle)`,
 called from `(Architecture::new_funcdata)` when a function's `Funcdata` is


### PR DESCRIPTION
## Summary

- stable-group each per-function global-symbol snapshot by address-space index
- restrict container, naming, callee-prototype, and function lookups to the
  requested space with `partition_point`
- make the flattened entry vector private so callers cannot bypass the grouping
  invariant
- preserve original encounter order within each space, including equal-size
  overlap and use-point first-match behavior

`GlobalQuery` previously scanned every mapped global entry for each query. That
included register, stack, and other varnodes that could never match the thousands
of RAM/code mappings in a large program. These queries sit on the hot varnode and
heritage paths.

This is an output-preserving implementation optimization, so it has no mode or
settable option.

## Private-binary benchmark

Input SHA-256:
`bc4c15d826aaebeace3fec6360eb687e5662cba8745605093254931dcdb3ae1b`

The binary is private and is identified only by hash.

Command for both runs:

```text
kuna decompile-project <private-binary> --mode fast -o <output>
```

No watchdog override was supplied. The before run is merged main after #215; the
after run adds only this PR.

| Measurement | Before | After | Delta |
|---|---:|---:|---:|
| Wall time | 445.06 s | 259.11 s | -185.95 s (-41.8%) |
| User CPU | 443.12 s | 257.31 s | -185.81 s |
| Peak RSS | 1,511,288 KiB | 1,512,504 KiB | +1,216 KiB |
| Definitions | 3,153 | 3,153 | unchanged |
| Emitted bodies | 3,140 | 3,142 | +2 |
| Failures | 13 | 11 | -2 |
| Watchdog expirations | 9 | 7 | -2 |

The two recovered bodies are `0x53d950` and `0x609470`. The remaining failures
are 7 watchdog expirations, 3 pre-existing LOSS-131 seam failures, and 1
pre-existing render failure.

Both exports contain the same 3,153 address-keyed C blocks. Of those, 3,151 are
byte-for-byte identical. The only changed blocks are the two addresses above,
which changed from timeout comments to real C bodies. Their selected-function
spot checks were also byte-identical before/after when both completed:

- `0x53d950`: 11.24 s to 8.63 s (-23.2%),
  SHA-256 `84c47bf2d46504eda0f3b5493afe232270f100ae98bf6edbb2dca832daf068aa`
- `0x609470`: 8.93 s to 7.28 s (-18.5%),
  SHA-256 `bce74e541aed0117d0f606e72eb6df5352d59b46dd34eb44a36f50b561976a81`

## Semantics and limits

Rust's stable `sort_by_key` keeps the original order of entries inside each
address space. The existing smallest-container, equal-size first-match, and
`inUse` selection rules therefore remain unchanged. The entry vector is private,
and every workspace fixture now constructs it through `GlobalQuery::new`.

Grouping currently happens once per function snapshot, not once per process.
Sharing or caching the immutable snapshot could be a separate optimization.

The 41.8% result is specific to the private hash and its large global table. This
PR does not claim a universal speedup, a hard runtime bound, or a memory
reduction; measured peak RSS was effectively unchanged.

## Validation

- `make test` — PARITY OK, 675/675
- `make test-stages` — PARITY OK, 305/305
- `make rust-test` — green
- `make check-spec` — green
- new cross-space, equal-overlap, and use-point unit tests — 3/3
- migrated GlobalQuery integration regressions — 21/21
- independent read-only semantic review — no blockers
- full private project export and common-function byte comparison — green
