### PR TITLE
[AUTOMATED] web: run decompilation in a cancellable Worker

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Assemble the static demo (dist/)
         run: bash integrations/web/build.sh
 
+      - name: Test the browser Worker boundary
+        run: node integrations/web/test/worker.mjs
+
       # Serve every file verbatim (belt-and-suspenders; the artifact path skips Jekyll).
       - name: Disable Jekyll
         run: touch integrations/web/dist/.nojekyll

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,10 +52,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust (stable)
+      - name: Install Rust (stable) + wasm32-wasip1 target
         run: |
           rustup toolchain install stable --profile minimal
           rustup default stable
+          rustup target add wasm32-wasip1
 
       # Same cache action and workspace the release/pages workflows use.
       - uses: Swatinem/rust-cache@v2
@@ -91,6 +92,11 @@ jobs:
 
       - name: kuna catalog --check
         run: ./decompiler/target/release/kuna catalog --check
+
+      - name: Assemble and test the browser Worker boundary
+        run: |
+          bash integrations/web/build.sh
+          node integrations/web/test/worker.mjs
 
   rust-test:
     name: cargo workspace suite

--- a/docs/web-integration.md
+++ b/docs/web-integration.md
@@ -5,9 +5,10 @@ one seam that makes it work, the virtual-filesystem mapping, the build, and the 
 Audience: kuna developers extending or maintaining the web front-end. The practical
 "build and serve it" guide is `integrations/web/README.md`.
 
-This is a genuine in-browser decompiler: the engine runs *in the page* as WebAssembly.
-Nothing is uploaded and no server participates in decompilation. A WASI runtime
-implemented in JavaScript hosts the module; the browser is the whole stack.
+This is a genuine in-browser decompiler: the engine runs in a module Worker as
+WebAssembly. Nothing is uploaded and no server participates in decompilation. A WASI
+runtime implemented in JavaScript hosts the module; the browser is the whole stack. The
+Worker keeps synchronous `wasi.start()` calls off the UI thread.
 
 ---
 
@@ -112,14 +113,16 @@ selects `reliable`, and `>=2 MiB` selects `fast`. Because `project` is
 whole-binary only, the fast selection runs `fast_funcdisc`: the downloaded C/H
 inventory contains directly reached and validated indirect-only internal
 functions while the exhaustive prologue and AIF scans remain off. The page's
-**Download Binary Source** button runs it and zips the four
-artifacts client-side (`integrations/web/zip.js`, a dependency-free STORE zip writer). The
-only artifact difference vs the CLI is the README's `Path` row, which shows the display
-name instead of a canonicalized host path (there is none in the virtual FS).
+**Download Binary Source** button runs it and zips the four artifacts inside the module
+Worker (`integrations/web/zip.js`, a dependency-free STORE zip writer). Only the final ZIP
+`ArrayBuffer` is transferred to the main thread. The only artifact difference vs the CLI
+is the README's `Path` row, which shows the display name instead of a canonicalized host
+path (there is none in the virtual FS).
 
 ## 3. The virtual filesystem (the whole trick)
 
-`integrations/web/kuna-web.js` drives [`@bjorn3/browser_wasi_shim`](https://github.com/bjorn3/browser_wasi_shim)
+`integrations/web/kuna-worker.js` calls `integrations/web/kuna-web.js`, which drives
+[`@bjorn3/browser_wasi_shim`](https://github.com/bjorn3/browser_wasi_shim)
 (vendored under `integrations/web/vendor/`, pinned in `VERSION`), a pure-JS WASI
 **preview1** implementation. For each decompile it builds a fresh instance with two
 preopened directories:
@@ -134,6 +137,26 @@ then runs `kuna_wasm /work/input.bin /specs decompile --mode auto` with `stdout`
 same preopen model Node's `node:wasi` uses — the parity test (`test/parity.mjs`) drives
 the identical wasm through `node:wasi`, and the glue test (`test/glue.mjs`) drives it
 through the real browser shim; both must agree with native.
+
+The page and Worker communicate through `kuna-worker-client.js`:
+
+```
+upload bytes → Worker `list` → address-only rows
+click row    → Worker `decompile 0xADDR` → one C body
+download     → Worker `project` → Worker `makeZip` → transferred ArrayBuffer
+cancel       → terminate Worker → create Worker → rehydrate binary on next request
+```
+
+Function bodies are cached by address in the page after the first click. Inventory,
+one-function decompilation, and project export all retain `--mode auto`, so the Rust
+front-end remains the source of truth for the 500 KiB and 2 MiB thresholds.
+
+Termination is intentional. WASI execution is synchronous after `wasi.start()` enters
+WebAssembly, so an ordinary cancel message cannot be handled until that call returns.
+`Worker.terminate()` is the browser primitive that can stop it while leaving the UI
+responsive. The client rejects every in-flight RPC with `KunaWorkerCancelledError`,
+creates a clean Worker, and keeps the uploaded bytes on the page side solely to restore
+the session for the next request.
 
 **Robust, format-agnostic specs (whatever the CLI supports).** The demo carries
 **no per-format or per-arch logic** — the *engine* detects the format
@@ -173,12 +196,15 @@ the `specs-small.json` preload bundle. Serve `dist/` with any static file server
 /assets/              css/site.css · fonts/ · img/ · js/highlight-c.js
 /compare-samples.js   the compare section's data (samples + rival outputs)
 /CNAME                kuna.noelo.org — the custom domain, copied into the bundle
-/kuna-web.js /zip.js /kuna_wasm.wasm /specs/ /specs-small.json /vendor/
+/kuna-web.js /kuna-worker.js /kuna-worker-client.js /zip.js
+/kuna_wasm.wasm /specs/ /specs-small.json /vendor/
 ```
 
 The engine-facing files stay at the **root** — `/decompile/` reaches them with `../`, so
-`test/glue.mjs` and `test/parity.mjs` (which serve `dist/` and import `kuna-web.js`
-directly) are unaffected by the page move, and a project subpath still works.
+the Worker is a sibling of `kuna-web.js`/`zip.js`, the existing tests can import the glue
+directly, and a project subpath still works. The RPC client resolves the wasm/spec URLs
+against the document before sending them to the Worker; resolving those `../` paths in
+the root-level Worker would otherwise escape a GitHub Pages project subpath.
 
 The design shares the Noelo Lab site's palette and typefaces (`noelo.org`, BSD-2-Clause;
 provenance note at the top of `assets/css/site.css`) but not its layout: kuna's pages are
@@ -226,7 +252,7 @@ Chrome on the committed fixtures).
 
 ## 5. Testing
 
-Three layers, all runnable without a browser in CI, spanning **multiple formats and
+Four layers, all runnable without a browser in CI, spanning **multiple formats and
 architectures**:
 
 1. **`test/parity.mjs`** — runs the wasm under `node:wasi` (the same WASI preview1 ABI the
@@ -240,10 +266,15 @@ architectures**:
    preloads only `specs-small.json`, then decompiles an ELF (x86-64), an ELF (AArch64), and
    a **Mach-O** through the same handle, lazily fetching each `.sla`, with no per-format JS —
    plus the `project` export the download button uses.
-   (**`test/zip.mjs`**, a fourth gate needing no build, structurally validates the `zip.js`
-   writer: it re-parses its own archive, recomputes every CRC-32 independently, and asserts
-   byte-determinism.)
-3. **Full UI (optional, not committed)** — a `puppeteer-core` script drives
+   (**`test/zip.mjs`**, an independent gate needing no build, structurally validates the
+   `zip.js` writer: it re-parses its own archive, recomputes every CRC-32 independently,
+   and asserts byte-determinism.)
+3. **`test/worker.mjs`** — hosts the shipped module Worker in a Node worker thread and
+   drives the real RPC client over HTTP. It asserts the initial response has inventory but
+   no eager C, a selected address produces one body, cancellation terminates/recreates the
+   Worker and rehydrates the session, and project export transfers a structurally complete
+   ZIP rather than the four-artifact JSON object. The Pages build runs this test.
+4. **Full UI (optional, not committed)** — a `puppeteer-core` script drives
    `decompile/index.html` in real Chrome: uploads an ELF then a Mach-O, waits for the code
    panel / status, asserts the rendered C and the detected format. Verified passing during
    development; kept out of the committed suite to avoid a browser/`puppeteer` dependency.
@@ -272,33 +303,45 @@ benign PE is committed because this environment has no PE linker.
 - The four gates (`make test`, `make test-stages`, `make rust-test`, `make
   check-spec`) remain mandatory. Native/WASI parity and browser-glue tests cover
   the additional frontend policy.
+- The Worker keeps mode resolution and every engine entrypoint in the Rust/WASI front-end:
+  upload uses the inventory command, a click uses explicit-address decompilation, and
+  download uses the existing project command before transport packages its artifacts.
+  `test/worker.mjs` covers that browser boundary; native/WASI and browser-glue tests
+  continue to cover the underlying commands. The lazy selected-function path is
+  intentionally not described as byte-identical to the old eager whole-binary UI path.
 
 ## 7. Limitations & future work
 
 - Fast WASM whole-binary decompile/project arms the same cooperative 10-second
   per-function budget as the native fast batch policy. It isolates probed
   decompile-pipeline stalls as function errors, but it is not a hard timer over
-  discovery, rendering, artifact construction, total wall time, or memory. The
-  current browser harness still runs WASM and ZIP/JSON work on the main thread,
-  so a multi-thousand-function export can freeze the page or exceed a tab's
-  memory budget; worker execution, hard cancellation, and lazy/sharded output
-  remain separate work.
+  discovery, rendering, artifact construction, total wall time, or memory. User
+  cancellation is a separate hard boundary: it terminates the entire Worker and
+  discards that operation's partial output. A multi-thousand-function export can
+  still consume substantial Worker time or exceed a tab's memory budget, but it
+  no longer monopolizes the UI thread.
 
 - **Supports whatever the CLI supports** — every format (ELF/PE/Mach-O/COFF) and every
   architecture kuna ships a `.sla` for, resolved by the engine with no per-format JS (§3).
   Object files (`.o`/Mach-O `MH_OBJECT`) decompile to thin bodies — an engine-level
   relocation limit, not a demo one; linked executables are unaffected.
-- **Re-bootstraps per request** — a WASI *command* module runs `_start` and exits, so
-  "decompile all" (one run over every CODE-backed function) is the efficient path the UI uses. A
-  `wasm-bindgen` **reactor** front-end (bootstrap once, export `decompile(name)`) would let
-  the page keep a warm `Architecture` across clicks; it can be added beside this crate
-  without touching the WASI path or the engine.
+- **Re-bootstraps per request** — a WASI *command* module runs `_start` and exits. The UI
+  deliberately trades that repeated bootstrap cost for inventory-first rendering and lazy
+  one-address bodies. A `wasm-bindgen` **reactor** front-end (bootstrap once, export
+  `decompile(name)`) would preserve lazy rendering while keeping a warm `Architecture`; it
+  can be added beside this crate without touching the WASI path or the engine.
+- **Responsive is not faster or smaller** — moving work to a Worker prevents synchronous
+  WASI from blocking input/paint and makes termination possible. Whole-project export still
+  performs the same work and can still consume substantial Worker time and memory. The ZIP
+  is built off-thread and only its final buffer crosses to the page, but its artifacts and
+  archive coexist transiently inside the Worker.
 - **No `wasm-opt` in the default toolchain** — the shipped wasm is unoptimized (~7 MB raw,
   ~1.7 MB gzipped); installing `binaryen` shrinks it further.
 
 ## 8. Pointers
 
 - Harness & commands: `integrations/web/README.md`
+- Browser worker boundary: `integrations/web/{kuna-worker.js,kuna-worker-client.js}`
 - The crate: `decompiler/crates/kuna-wasm/{Cargo.toml, src/lib.rs, src/main.rs, src/classify.rs}`
 - The shared decompile loop + artifact builders: `decompiler/crates/kuna-console/src/project.rs`
   (the CLI wrappers: `decompiler/crates/kuna-cli/src/{decompile_all.rs, decompile_project.rs}`)

--- a/integrations/web/README.md
+++ b/integrations/web/README.md
@@ -33,16 +33,25 @@ integrations/web/build.sh --serve       # -> http://localhost:8000
 ```
 
 Open the landing page, follow **Try it** to `/decompile/`, click **Load binary**, and pick
-any **ELF, PE, or Mach-O** binary. The decompiler runs in the tab and lists every function;
-click one to see its C, **syntax highlighted** (comments/strings/keywords/types/numbers/calls,
-plus the kuna type family and `dat_<hex>` globals). The sidebar groups **PLT stubs and
-import thunks** (the engine's per-function `kind`) below a divider, in purple, so real code
-stays on top. The **Download Binary Source** button exports the whole binary as a
-recompile-oriented project — `<name>.c` / `<name>.h` / `<name>.asm` / `README.md`, the
-`kuna decompile-project` artifacts — zipped client-side (`zip.js`, a dependency-free STORE
-zip writer) into `<name>.kuna.zip`. It supports whatever the CLI supports — every format and
+any **ELF, PE, or Mach-O** binary. A module Worker inventories the functions without
+blocking the page; click one to decompile just that address and see its C, **syntax
+highlighted** (comments/strings/keywords/types/numbers/calls, plus the kuna type family and
+`dat_<hex>` globals). The sidebar groups **PLT stubs and import thunks** (the engine's
+per-function `kind`) below a divider, in purple, so real code stays on top. The
+**Download Binary Source** button exports the whole binary as a recompile-oriented project
+— `<name>.c` / `<name>.h` / `<name>.asm` / `README.md`, the `kuna decompile-project`
+artifacts — and builds the `<name>.kuna.zip` inside the Worker. Only the final ZIP buffer
+crosses back to the page. It supports whatever the CLI supports — every format and
 architecture kuna has a `.sla` for — with no per-format configuration (the engine resolves
-each binary; the page fetches only the one `.sla` it needs). See `docs/web-integration.md` §3.
+each binary; the Worker fetches only the one `.sla` it needs). See
+`docs/web-integration.md` §3.
+
+WASI execution is synchronous once `wasi.start()` enters the WebAssembly module. The page
+therefore cancels an inventory, function, or project operation by terminating the Worker,
+not by sending it a message that cannot be processed until decompilation finishes. The RPC
+client immediately creates a fresh Worker and retains the selected binary so the next
+operation can rebuild the session. Cancellation is a responsiveness boundary, not a claim
+that the underlying decompilation takes less time or memory.
 
 The WASM front-end also selects a decompiler mode from the uploaded byte length: binaries
 below 500 KiB use `aggressive`, binaries from 500 KiB through just below 2 MiB use
@@ -67,12 +76,14 @@ asset path is relative, so a project subpath just works.
 | Path | Role |
 |---|---|
 | `index.html` | The landing page: hero, the compare section, the three goals. Static — its only script wires the two dropdowns. |
-| `decompile/index.html` | The decompiler application (upload → function list → highlighted C, stubs grouped, project-zip download). Reaches the wasm/specs/glue at the bundle root with `../`. |
+| `decompile/index.html` | The decompiler application (upload → inventory → lazy highlighted C, stubs grouped, cancellable project-zip download). Reaches the worker and shared assets at the bundle root with `../`. |
 | `compare-samples.js` | Data for the compare section: `SAMPLES` (kuna's output per function) × `RIVALS` (the right-hand pane), with each sample's measured DecBench GED. Adding a comparison is a data edit; the header documents the schema. Every pane must be **verbatim** tool output — mine and vet new ones with `python3 -m scripts.decbench.showcase` (`docs/decbench-loop.md` → *Finding good kuna examples*). |
 | `assets/` | The shared design system: `css/site.css`, `fonts/` (Jost, Roboto Mono), `img/` (mark + favicon, derived from `assets/kuna.png`), and `js/highlight-c.js` — the one C highlighter both pages use. |
 | `CNAME` | The custom domain (`kuna.noelo.org`); `build.sh` copies it into `dist/`. Repo *Settings → Pages → Custom domain* must agree. |
 | `kuna-web.js` | The glue: loads the wasm, preloads the small spec bundle, lazily fetches each binary's `.sla` on demand (driven by the engine's own resolution), and runs the decompiler under the WASI shim with the automatic size-based mode policy; `list`/`decompile` return the `decompile-all --json` shape, `project` the whole-binary export. |
-| `zip.js` | Dependency-free STORE-only ZIP writer (CRC-32, UTF-8 names, fixed timestamp → deterministic) for the Download Binary Source button. |
+| `kuna-worker.js` | The module Worker: owns the binary and WASI handle, lists first, decompiles one selected address, and builds whole-project ZIPs off the UI thread. |
+| `kuna-worker-client.js` | The page-side RPC client. Cancellation terminates/recreates its Worker and rehydrates the retained binary on the next request. |
+| `zip.js` | Dependency-free STORE-only ZIP writer (CRC-32, UTF-8 names, fixed timestamp → deterministic), invoked inside the Worker for Download Binary Source. |
 | `vendor/browser_wasi_shim/` | Vendored [`@bjorn3/browser_wasi_shim`](https://github.com/bjorn3/browser_wasi_shim) (MIT/Apache-2.0) — a pure-JS WASI **preview1** implementation. Pinned in `VERSION`. |
 | `build.sh` | Builds `kuna_wasm.wasm`, copies the full runtime SLEIGH tree + the shim + both pages + `assets/` into `dist/`, and bundles the small spec files into `specs-small.json`. `wasm-opt -Oz` is applied if present. |
 | `test/` | Automated gates (below) + committed ELF/Mach-O fixtures. |
@@ -103,6 +114,10 @@ node integrations/web/test/zip.mjs
 
 # D. Automatic-mode argv wiring — no build needed.
 node integrations/web/test/auto-mode.mjs
+
+# E. Worker boundary — real module Worker, lazy address decompile, hard
+#    cancellation/restart, and worker-side project ZIP.
+node integrations/web/test/worker.mjs
 ```
 
 - **`parity.mjs`** proves the decompiler *runs* under a WASI runtime and matches native
@@ -116,6 +131,10 @@ node integrations/web/test/auto-mode.mjs
   byte-deterministic, and (if a system `unzip` exists) runs `unzip -t` as a bonus check.
 - **`auto-mode.mjs`** pins the explicit `--mode auto` WASM argv for all three browser
   operations and the programmatic explicit-mode override.
+- **`worker.mjs`** runs the shipped module Worker and RPC client through Node's worker
+  threads, proving inventory-first/lazy-address behavior, terminate-and-recreate
+  cancellation, session rehydration, and transfer of a complete project ZIP without its
+  intermediate artifact object.
 - **`run-wasm.mjs`** is a small reusable CLI runner (used by `parity.mjs`; also handy for
   driving the wasm by hand under `node:wasi`).
 

--- a/integrations/web/build.sh
+++ b/integrations/web/build.sh
@@ -44,10 +44,12 @@ rm -rf "$DIST"
 mkdir -p "$DIST/specs"
 # The site: the landing page at /, the decompiler application at /decompile/,
 # and the shared design system (css/fonts/images/highlighter) under /assets/.
-# kuna-web.js, zip.js, the wasm and specs stay at the root — /decompile/ reaches
-# them with '../', and the Node tests serve dist/ the same way a browser does.
+# The decompiler glue, Worker, client, zip.js, wasm, and specs stay at the root
+# — /decompile/ reaches them with '../', and the Node tests serve dist/ the same
+# way a browser does.
 # CNAME rides along so the deployed bundle claims kuna.noelo.org.
-cp "$HERE/index.html" "$HERE/compare-samples.js" "$HERE/kuna-web.js" "$HERE/zip.js" \
+cp "$HERE/index.html" "$HERE/compare-samples.js" "$HERE/kuna-web.js" \
+   "$HERE/kuna-worker.js" "$HERE/kuna-worker-client.js" "$HERE/zip.js" \
    "$HERE/CNAME" "$DIST/"
 cp -r "$HERE/assets" "$DIST/assets"
 cp -r "$HERE/decompile" "$DIST/decompile"

--- a/integrations/web/decompile/index.html
+++ b/integrations/web/decompile/index.html
@@ -30,6 +30,7 @@
   <div class="bar">
     <div class="wrap">
       <p class="status busy" id="status" role="status" aria-live="polite"><span class="dot"></span>loading decompiler&hellip;</p>
+      <button class="tinybtn" id="cancelbtn" disabled>Cancel</button>
       <button class="tinybtn" id="dlbtn" disabled>Download binary source</button>
       <label class="tinybtn primary" id="pick" aria-disabled="true">
         Load binary <input type="file" id="file">
@@ -60,9 +61,10 @@
             your file is never uploaded and no server takes part.
           </p>
           <p class="hint">
-            Every function comes back at once. Stubs and import thunks are grouped at the
-            bottom of the list; <code>Download binary source</code> exports the whole
-            binary as a <code>.c</code>/<code>.h</code>/<code>.asm</code> project zip.
+            The function inventory loads first; each body is decompiled when selected.
+            Stubs and import thunks are grouped at the bottom of the list;
+            <code>Download binary source</code> exports the whole binary as a
+            <code>.c</code>/<code>.h</code>/<code>.asm</code> project zip.
           </p>
         </div>
       </div>
@@ -77,8 +79,10 @@
 </main>
 
 <script type="module">
-  import { loadKuna } from '../kuna-web.js';
-  import { makeZip } from '../zip.js';
+  import {
+    KunaWorkerCancelledError,
+    KunaWorkerClient,
+  } from '../kuna-worker-client.js';
   import { highlightC, escapeHtml } from '../assets/js/highlight-c.js';
 
   const statusEl = document.getElementById('status');
@@ -92,6 +96,7 @@
   const vnameEl = document.getElementById('vname');
   const vmetaEl = document.getElementById('vmeta');
   const dlEl = document.getElementById('dlbtn');
+  const cancelEl = document.getElementById('cancelbtn');
 
   const setStatus = (msg, cls = 'busy') => {
     statusEl.className = 'status ' + cls;
@@ -99,9 +104,44 @@
   };
 
   let kuna = null;
-  let loaded = null; // { bytes, fileName } of the last successfully decompiled binary
+  let loaded = null;
+  let active = null;
+  let operationId = 0;
+  let selectedRow = null;
+  let bodies = new Map();
+
+  const syncButtons = () => {
+    cancelEl.disabled = !active;
+    dlEl.disabled = !loaded || !!active;
+  };
+
+  const beginOperation = (kind, clearSession = false) => {
+    if (active) {
+      active = null;
+      operationId++;
+      if (clearSession) kuna.clear('superseded by a new binary');
+      else kuna.cancel('superseded by another operation');
+    }
+    active = { id: ++operationId, kind };
+    syncButtons();
+    return active;
+  };
+
+  const isCurrent = (operation) => active?.id === operation.id;
+
+  const finishOperation = (operation) => {
+    if (!isCurrent(operation)) return false;
+    active = null;
+    syncButtons();
+    return true;
+  };
+
   try {
-    kuna = await loadKuna({ wasmUrl: '../kuna_wasm.wasm', specRoot: '../specs' });
+    kuna = new KunaWorkerClient({
+      wasmUrl: '../kuna_wasm.wasm',
+      specRoot: '../specs',
+    });
+    await kuna.ready();
     setStatus('ready — load an ELF, PE, or Mach-O binary', 'ok');
     pickEl.removeAttribute('aria-disabled');
   } catch (e) {
@@ -112,36 +152,42 @@
   fileEl.addEventListener('change', async () => {
     const f = fileEl.files[0];
     if (!f || !kuna) return;
-    const bytes = new Uint8Array(await f.arrayBuffer());
-    const fmt = kuna.formatName(bytes);
-    setStatus(`decompiling ${f.name} (${fmt}, ${bytes.length.toLocaleString()} bytes)…`);
+    const operation = beginOperation('load', true);
+    setStatus(`reading ${f.name}…`);
     listEl.innerHTML = '';
     codeEl.hidden = true; vheadEl.hidden = true; emptyEl.hidden = false;
-    loaded = null; dlEl.disabled = true;
-    await new Promise((r) => requestAnimationFrame(r)); // let the status paint
+    loaded = null;
+    selectedRow = null;
+    bodies = new Map();
+    headEl.textContent = 'functions';
 
     const t0 = performance.now();
     let result;
     try {
-      result = await kuna.decompile(bytes); // all functions, one wasm run
+      const bytes = new Uint8Array(await f.arrayBuffer());
+      if (!isCurrent(operation)) return;
+      setStatus(`indexing ${f.name} (${bytes.length.toLocaleString()} bytes)…`);
+      result = await kuna.load(bytes, { fileName: f.name, mode: 'auto' });
     } catch (e) {
-      setStatus('decompile failed: ' + e.message, 'err');
+      if (!isCurrent(operation)) return;
+      setStatus('function inventory failed: ' + e.message, 'err');
       console.error(e);
+      finishOperation(operation);
       return;
     }
+    if (!isCurrent(operation)) return;
     const dt = Math.round(performance.now() - t0);
-    loaded = { bytes, fileName: f.name };
-    dlEl.disabled = false;
+    loaded = {
+      fileName: f.name,
+      format: result.format,
+      count: result.functions.length,
+    };
 
-    // Split into normal functions and PLT/import-thunk stubs (`kind` from the
-    // engine; a missing kind means a plain function), each address-ascending:
-    // real code first, the boilerplate stubs grouped after a divider.
     const isStub = (fn) => fn.kind === 'plt' || fn.kind === 'thunk';
-    const shown = result.functions.filter((fn) => fn.code || fn.error);
     const byAddr = (a, b) => a.address - b.address;
-    const normal = shown.filter((fn) => !isStub(fn)).sort(byAddr);
-    const stubs = shown.filter(isStub).sort(byAddr);
-    setStatus(`${f.name} (${fmt}) — ${shown.length} functions in ${dt} ms`, 'ok');
+    const normal = result.functions.filter((fn) => !isStub(fn)).sort(byAddr);
+    const stubs = result.functions.filter(isStub).sort(byAddr);
+    setStatus(`${f.name} (${result.format}) — ${result.functions.length} functions indexed in ${dt} ms`, 'ok');
     headEl.textContent = `${normal.length} functions · ${stubs.length} stubs`;
 
     const rows = [];
@@ -167,40 +213,65 @@
       listEl.appendChild(div);
       stubs.forEach(addRow);
     }
-    const first = rows.find((r) => !isStub(r.fn) && r.fn.code) || rows.find((r) => r.fn.code);
+    const first = rows.find((r) => !isStub(r.fn)) || rows[0];
+    finishOperation(operation);
     if (first) first.row.click();
   });
 
-  // Download binary source: run the whole-binary project export and hand the
-  // four artifacts (<name>.c/.h/.asm/README.md) over as a zip.
   dlEl.addEventListener('click', async () => {
     if (!loaded || !kuna) return;
-    const safeName = loaded.fileName.replace(/[^A-Za-z0-9._-]/g, '_');
-    dlEl.disabled = true;
+    const operation = beginOperation('project');
     setStatus('building project…');
-    await new Promise((r) => requestAnimationFrame(r)); // let the status paint
     try {
-      const proj = await kuna.project(loaded.bytes, safeName); // one wasm run
-      const entries = Object.entries(proj.files)
-        .map(([name, data]) => ({ name: `${safeName}.kuna/${name}`, data }));
-      const zip = makeZip(entries);
-      const url = URL.createObjectURL(new Blob([zip], { type: 'application/zip' }));
+      const project = await kuna.project(loaded.fileName);
+      if (!isCurrent(operation)) return;
+      const url = URL.createObjectURL(new Blob([project.bytes], { type: 'application/zip' }));
       const a = document.createElement('a');
       a.href = url;
-      a.download = `${safeName}.kuna.zip`;
+      a.download = project.downloadName;
       a.click();
       URL.revokeObjectURL(url);
-      setStatus(`${safeName}.kuna.zip downloaded (${zip.length.toLocaleString()} bytes)`, 'ok');
+      setStatus(
+        `${project.downloadName} downloaded (${project.bytes.length.toLocaleString()} bytes)`,
+        'ok',
+      );
     } catch (e) {
+      if (!isCurrent(operation)) return;
       setStatus('project export failed: ' + e.message, 'err');
       console.error(e);
     } finally {
-      if (loaded) dlEl.disabled = false;
+      finishOperation(operation);
     }
   });
 
-  function select(row, fn) {
-    [...listEl.children].forEach((c) => c.classList.remove('sel'));
+  cancelEl.addEventListener('click', () => {
+    if (!active || !kuna) return;
+    const cancelled = active;
+    active = null;
+    operationId++;
+    if (cancelled.kind === 'load') {
+      kuna.clear('cancelled by user');
+      loaded = null;
+      listEl.innerHTML = '';
+      headEl.textContent = 'functions';
+      codeEl.hidden = true; vheadEl.hidden = true; emptyEl.hidden = false;
+    } else {
+      kuna.cancel('cancelled by user');
+      if (cancelled.kind === 'function') {
+        codeEl.textContent =
+          `/* ${vnameEl.textContent || 'function'} — decompilation cancelled */`;
+      }
+    }
+    syncButtons();
+    setStatus(
+      loaded ? `cancelled — ${loaded.fileName} remains loaded` : 'cancelled — load another binary',
+      loaded ? 'ok' : '',
+    );
+  });
+
+  async function select(row, fn) {
+    if (selectedRow) selectedRow.classList.remove('sel');
+    selectedRow = row;
     row.classList.add('sel');
     emptyEl.hidden = true;
     vheadEl.hidden = false;
@@ -208,15 +279,72 @@
     vnameEl.textContent = fn.name;
     const tags = [fn.address_hex];
     if (fn.kind === 'plt' || fn.kind === 'thunk') tags.push(fn.kind);
-    if (fn.error) tags.push('decompile error');
     vmetaEl.textContent = tags.join(' · ');
-    if (fn.error) {
-      codeEl.textContent =
-        `/* ${fn.name} @ ${fn.address_hex} — decompile error:\n   ${fn.error} */`;
-    } else {
-      codeEl.innerHTML = highlightC(fn.code);
+
+    const cached = bodies.get(fn.address_hex);
+    if (cached) {
+      const projectActive = active?.kind === 'project';
+      if (active?.kind === 'function') {
+        active = null;
+        operationId++;
+        kuna.cancel('superseded by a cached function');
+        syncButtons();
+      }
+      renderFunction(row, fn, cached);
+      if (!projectActive) {
+        setStatus(
+          `${loaded.fileName} (${loaded.format}) — ${fn.name} loaded from cache`,
+          cached.error ? 'err' : 'ok',
+        );
+      }
+      return;
+    }
+
+    const operation = beginOperation('function');
+    setStatus(`decompiling ${fn.name} @ ${fn.address_hex}…`);
+    codeEl.textContent = `/* decompiling ${fn.name} @ ${fn.address_hex}… */`;
+    const t0 = performance.now();
+    try {
+      const result = await kuna.decompile(fn.address_hex);
+      if (!isCurrent(operation)) return;
+      const body = result.functions[0];
+      if (!body) throw new Error(`no result returned for ${fn.address_hex}`);
+      bodies.set(fn.address_hex, body);
+      renderFunction(row, fn, body);
+      const dt = Math.round(performance.now() - t0);
+      setStatus(
+        `${loaded.fileName} (${loaded.format}) — ${fn.name} decompiled in ${dt} ms`,
+        body.error ? 'err' : 'ok',
+      );
+    } catch (e) {
+      if (!isCurrent(operation)) return;
+      if (!(e instanceof KunaWorkerCancelledError)) {
+        row.classList.add('bad');
+        codeEl.textContent =
+          `/* ${fn.name} @ ${fn.address_hex} — decompile failed:\n   ${e.message} */`;
+        setStatus('decompile failed: ' + e.message, 'err');
+        console.error(e);
+      }
+    } finally {
+      finishOperation(operation);
     }
   }
+
+  function renderFunction(row, fn, body) {
+    row.classList.toggle('bad', !!body.error);
+    const tags = [fn.address_hex];
+    if (fn.kind === 'plt' || fn.kind === 'thunk') tags.push(fn.kind);
+    if (body.error) tags.push('decompile error');
+    vmetaEl.textContent = tags.join(' · ');
+    if (body.error) {
+      codeEl.textContent =
+        `/* ${fn.name} @ ${fn.address_hex} — decompile error:\n   ${body.error} */`;
+    } else {
+      codeEl.innerHTML = highlightC(body.code);
+    }
+  }
+
+  window.addEventListener('beforeunload', () => kuna?.close());
 </script>
 </body>
 </html>

--- a/integrations/web/kuna-worker-client.js
+++ b/integrations/web/kuna-worker-client.js
@@ -1,0 +1,182 @@
+// kuna-worker-client.js — request/response facade for the decompiler Worker.
+
+export class KunaWorkerCancelledError extends Error {
+  constructor(message = 'decompiler operation cancelled') {
+    super(message);
+    this.name = 'KunaWorkerCancelledError';
+  }
+}
+
+function asUrl(value, base) {
+  return new URL(value, base).href;
+}
+
+export class KunaWorkerClient {
+  constructor({
+    workerUrl = new URL('./kuna-worker.js', import.meta.url),
+    wasmUrl,
+    specRoot,
+    smallBundleUrl,
+    baseUrl = globalThis.document?.baseURI || import.meta.url,
+    workerFactory,
+  }) {
+    if (!wasmUrl || !specRoot) throw new Error('wasmUrl and specRoot are required');
+    this.workerUrl = asUrl(workerUrl, baseUrl);
+    this.initParams = {
+      wasmUrl: asUrl(wasmUrl, baseUrl),
+      specRoot: asUrl(specRoot, baseUrl).replace(/\/$/, ''),
+    };
+    if (smallBundleUrl) this.initParams.smallBundleUrl = asUrl(smallBundleUrl, baseUrl);
+    this.workerFactory = workerFactory || ((url, options) => new Worker(url, options));
+    this.pending = new Map();
+    this.nextId = 1;
+    this.generation = 0;
+    this.session = null;
+    this.workerSession = null;
+    this.closed = false;
+    this.spawn();
+  }
+
+  spawn() {
+    const generation = ++this.generation;
+    const worker = this.workerFactory(this.workerUrl, { type: 'module' });
+    this.worker = worker;
+    this.workerSession = null;
+    worker.onmessage = ({ data }) => {
+      if (generation !== this.generation) return;
+      const pending = this.pending.get(data?.id);
+      if (!pending) return;
+      this.pending.delete(data.id);
+      if (data.ok) pending.resolve(data.result);
+      else pending.reject(new Error(data.error || 'decompiler worker request failed'));
+    };
+    worker.onerror = (event) => {
+      if (generation !== this.generation) return;
+      const message = event?.message || 'decompiler worker failed';
+      this.rejectPending(new Error(message));
+    };
+    this.readyPromise = this.request('init', this.initParams);
+    this.readyPromise.catch(() => {});
+  }
+
+  request(method, params = {}, transfer = []) {
+    if (this.closed) return Promise.reject(new Error('decompiler worker is closed'));
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      try {
+        this.worker.postMessage({ id, method, params }, transfer);
+      } catch (error) {
+        this.pending.delete(id);
+        reject(error);
+      }
+    });
+  }
+
+  rejectPending(error) {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+
+  async ready() {
+    return this.readyPromise;
+  }
+
+  checkGeneration(generation) {
+    if (generation !== this.generation) {
+      throw new KunaWorkerCancelledError();
+    }
+  }
+
+  async setWorkerSession(generation = this.generation) {
+    await this.readyPromise;
+    this.checkGeneration(generation);
+    if (!this.session) throw new Error('no binary is loaded');
+    const session = this.session;
+    if (this.workerSession === session) return;
+    const details = await this.request('setBinary', {
+      bytes: session.bytes,
+      fileName: session.fileName,
+      mode: session.mode,
+    });
+    this.checkGeneration(generation);
+    if (this.session !== session) {
+      throw new KunaWorkerCancelledError('binary session superseded');
+    }
+    session.format = details.format;
+    this.workerSession = session;
+  }
+
+  async load(binaryBytes, { fileName = 'binary', mode = 'auto' } = {}) {
+    const generation = this.generation;
+    const bytes = binaryBytes instanceof Uint8Array
+      ? binaryBytes
+      : new Uint8Array(binaryBytes);
+    const session = { bytes, fileName, mode };
+    this.session = session;
+    this.workerSession = null;
+    await this.setWorkerSession(generation);
+    const inventory = await this.request('list');
+    this.checkGeneration(generation);
+    if (this.session !== session) {
+      throw new KunaWorkerCancelledError('binary session superseded');
+    }
+    return {
+      ...inventory,
+      format: session.format,
+    };
+  }
+
+  async format() {
+    const generation = this.generation;
+    await this.setWorkerSession(generation);
+    return this.session.format;
+  }
+
+  async list() {
+    const generation = this.generation;
+    await this.setWorkerSession(generation);
+    const result = await this.request('list');
+    this.checkGeneration(generation);
+    return result;
+  }
+
+  async decompile(target) {
+    const generation = this.generation;
+    await this.setWorkerSession(generation);
+    const result = await this.request('decompile', { target });
+    this.checkGeneration(generation);
+    return result;
+  }
+
+  async project(displayName) {
+    const generation = this.generation;
+    await this.setWorkerSession(generation);
+    const result = await this.request('project', { displayName });
+    this.checkGeneration(generation);
+    return { ...result, bytes: new Uint8Array(result.bytes) };
+  }
+
+  cancel(message = 'decompiler operation cancelled') {
+    if (this.closed) return;
+    const error = new KunaWorkerCancelledError(message);
+    this.generation++;
+    this.worker.terminate();
+    this.rejectPending(error);
+    this.spawn();
+  }
+
+  clear(message = 'decompiler session cleared') {
+    this.session = null;
+    this.cancel(message);
+  }
+
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    this.generation++;
+    this.worker.terminate();
+    this.rejectPending(new KunaWorkerCancelledError('decompiler worker closed'));
+    this.session = null;
+  }
+}

--- a/integrations/web/kuna-worker.js
+++ b/integrations/web/kuna-worker.js
@@ -1,0 +1,83 @@
+// kuna-worker.js — isolate synchronous WASI execution from the browser UI.
+import { loadKuna } from './kuna-web.js';
+import { makeZip } from './zip.js';
+
+let kuna = null;
+let binary = null;
+let fileName = 'binary';
+let mode = 'auto';
+
+function requireKuna() {
+  if (!kuna) throw new Error('worker is not initialized');
+  return kuna;
+}
+
+function requireBinary() {
+  if (!binary) throw new Error('no binary is loaded');
+  return binary;
+}
+
+function safeName(name) {
+  return String(name || 'binary').replace(/[^A-Za-z0-9._-]/g, '_') || 'binary';
+}
+
+async function dispatch(method, params) {
+  switch (method) {
+    case 'init':
+      kuna = await loadKuna(params);
+      return { result: true };
+    case 'setBinary':
+      requireKuna();
+      binary = params.bytes instanceof Uint8Array ? params.bytes : new Uint8Array(params.bytes);
+      fileName = params.fileName || 'binary';
+      mode = params.mode || 'auto';
+      return {
+        result: {
+          format: kuna.formatName(binary),
+          size: binary.byteLength,
+        },
+      };
+    case 'list':
+      return {
+        result: await requireKuna().list(requireBinary(), { mode }),
+      };
+    case 'decompile':
+      return {
+        result: await requireKuna().decompile(requireBinary(), params.target, { mode }),
+      };
+    case 'project': {
+      const name = safeName(params.displayName || fileName);
+      const project = await requireKuna().project(requireBinary(), name, { mode });
+      const entries = Object.entries(project.files)
+        .map(([entryName, data]) => ({ name: `${name}.kuna/${entryName}`, data }));
+      const zip = makeZip(entries);
+      return {
+        result: {
+          downloadName: `${name}.kuna.zip`,
+          bytes: zip.buffer,
+          count: project.count,
+          ok: project.ok,
+          failed: project.failed,
+        },
+        transfer: [zip.buffer],
+      };
+    }
+    default:
+      throw new Error(`unknown worker method: ${method}`);
+  }
+}
+
+self.onmessage = async ({ data }) => {
+  const { id, method, params = {} } = data || {};
+  if (!Number.isSafeInteger(id) || typeof method !== 'string') return;
+  try {
+    const { result, transfer = [] } = await dispatch(method, params);
+    self.postMessage({ id, ok: true, result }, transfer);
+  } catch (error) {
+    self.postMessage({
+      id,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+};

--- a/integrations/web/test/worker.mjs
+++ b/integrations/web/test/worker.mjs
@@ -1,0 +1,191 @@
+// worker.mjs — exercise the shipped module Worker and its RPC client in Node.
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { dirname, extname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { Worker as NodeWorker } from 'node:worker_threads';
+import {
+  KunaWorkerCancelledError,
+  KunaWorkerClient,
+} from '../kuna-worker-client.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const dist = resolve(here, '../dist');
+const fixture = join(here, 'fixtures', 'sample.elf');
+
+if (!existsSync(join(dist, 'kuna_wasm.wasm')) ||
+    !existsSync(join(dist, 'kuna-worker.js'))) {
+  throw new Error('dist/ not built — run integrations/web/build.sh first');
+}
+
+const MIME = {
+  '.wasm': 'application/wasm',
+  '.js': 'text/javascript',
+  '.json': 'application/json',
+  '.sla': 'application/octet-stream',
+  '.ldefs': 'text/xml',
+  '.pspec': 'text/xml',
+  '.cspec': 'text/xml',
+  '.dwarf': 'application/octet-stream',
+};
+
+const server = createServer(async (req, res) => {
+  try {
+    const rel = decodeURIComponent(new URL(req.url, 'http://worker.test').pathname);
+    const file = resolve(dist, '.' + rel);
+    if (!file.startsWith(dist)) {
+      res.writeHead(403).end();
+      return;
+    }
+    const body = await readFile(file);
+    res.writeHead(200, {
+      'content-type': MIME[extname(file)] || 'application/octet-stream',
+    });
+    res.end(body);
+  } catch {
+    res.writeHead(404).end();
+  }
+});
+
+await new Promise((resolveListen) => server.listen(0, resolveListen));
+const base = `http://localhost:${server.address().port}`;
+
+const bridge = new URL(
+  'data:text/javascript,' + encodeURIComponent(`
+    import { parentPort, workerData } from 'node:worker_threads';
+    globalThis.self = globalThis;
+    globalThis.postMessage = (data, transfer) => parentPort.postMessage(data, transfer);
+    await import(workerData.moduleUrl);
+    parentPort.on('message', (data) => globalThis.onmessage({ data }));
+  `),
+);
+
+let workersCreated = 0;
+let workersTerminated = 0;
+const sessionModes = [];
+
+class BrowserWorker {
+  constructor(moduleUrl) {
+    workersCreated++;
+    this.node = new NodeWorker(bridge, {
+      type: 'module',
+      workerData: { moduleUrl },
+    });
+    this.node.on('message', (data) => this.onmessage?.({ data }));
+    this.node.on('error', (error) => this.onerror?.({
+      message: error.message,
+      error,
+    }));
+  }
+
+  postMessage(data, transfer) {
+    if (data?.method === 'setBinary') sessionModes.push(data.params.mode);
+    this.node.postMessage(data, transfer);
+  }
+
+  terminate() {
+    workersTerminated++;
+    void this.node.terminate();
+  }
+}
+
+function zipNames(bytes) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const eocd = bytes.length - 22;
+  assert.equal(view.getUint32(eocd, true), 0x06054b50, 'project result is a ZIP');
+  const count = view.getUint16(eocd + 10, true);
+  let offset = view.getUint32(eocd + 16, true);
+  const names = [];
+  for (let i = 0; i < count; i++) {
+    assert.equal(view.getUint32(offset, true), 0x02014b50, 'central-directory entry');
+    const nameLength = view.getUint16(offset + 28, true);
+    const extraLength = view.getUint16(offset + 30, true);
+    const commentLength = view.getUint16(offset + 32, true);
+    names.push(new TextDecoder().decode(bytes.subarray(offset + 46, offset + 46 + nameLength)));
+    offset += 46 + nameLength + extraLength + commentLength;
+  }
+  return names.sort();
+}
+
+const client = new KunaWorkerClient({
+  workerUrl: pathToFileURL(join(dist, 'kuna-worker.js')),
+  wasmUrl: `${base}/kuna_wasm.wasm`,
+  specRoot: `${base}/specs`,
+  workerFactory: (url) => new BrowserWorker(url),
+});
+
+try {
+  await client.ready();
+  const binary = new Uint8Array(await readFile(fixture));
+  const inventoryStart = performance.now();
+  const inventory = await client.load(binary, {
+    fileName: 'sample.elf',
+    mode: 'auto',
+  });
+  const inventoryMs = Math.round(performance.now() - inventoryStart);
+  assert.equal(inventory.format, 'ELF');
+  assert.equal(sessionModes[0], 'auto', 'the Worker preserves the automatic mode policy');
+  const main = inventory.functions.find((fn) => fn.name === 'main');
+  assert.ok(main, 'inventory contains main');
+  assert.equal('code' in main, false, 'inventory does not eagerly decompile bodies');
+
+  const bodyStart = performance.now();
+  const first = await client.decompile(main.address_hex);
+  const bodyMs = Math.round(performance.now() - bodyStart);
+  assert.equal(first.functions.length, 1, 'address click decompiles one function');
+  assert.match(first.functions[0].code, /sum_to\(add\(/);
+
+  const cancelled = client.decompile(main.address_hex);
+  await new Promise((resolveImmediate) => setImmediate(resolveImmediate));
+  client.cancel('test hard cancellation');
+  await assert.rejects(
+    cancelled,
+    (error) => error instanceof KunaWorkerCancelledError,
+    'cancelling terminates the active Worker request',
+  );
+  await client.ready();
+  const afterRestart = await client.decompile(main.address_hex);
+  assert.match(afterRestart.functions[0].code, /sum_to\(add\(/);
+  assert.ok(workersCreated >= 2, 'cancellation recreates the Worker');
+  assert.ok(workersTerminated >= 1, 'cancellation terminates the blocked Worker');
+
+  let heartbeat = 0;
+  const timer = setInterval(() => heartbeat++, 10);
+  let project;
+  try {
+    project = await client.project('sample.elf');
+  } finally {
+    clearInterval(timer);
+  }
+  assert.ok(heartbeat > 0, 'the page event loop advances during project export');
+  assert.deepEqual(
+    zipNames(project.bytes),
+    [
+      'sample.elf.kuna/README.md',
+      'sample.elf.kuna/sample.elf.asm',
+      'sample.elf.kuna/sample.elf.c',
+      'sample.elf.kuna/sample.elf.h',
+    ],
+  );
+  assert.deepEqual(
+    Object.keys(project).sort(),
+    ['bytes', 'count', 'downloadName', 'failed', 'ok'],
+    'the Worker returns only ZIP bytes and small metadata',
+  );
+  assert.ok(
+    sessionModes.every((mode) => mode === 'auto'),
+    'session rehydration preserves automatic mode selection',
+  );
+
+  console.log(
+    `WORKER OK — ${inventory.functions.length} functions inventoried, ` +
+    `one address decompiled lazily (${inventoryMs} ms inventory + ${bodyMs} ms body), ` +
+    'cancellation restarted the Worker, the host event loop stayed live, ' +
+    `${project.bytes.length} ZIP bytes transferred`,
+  );
+} finally {
+  client.close();
+  server.close();
+}


### PR DESCRIPTION
## Summary

- run synchronous WASI/WebAssembly decompilation in a module Worker instead of
  the browser UI thread
- inventory functions first, then decompile and cache one explicitly selected
  address at a time
- build whole-project artifacts and the deterministic ZIP inside the Worker,
  transferring only the final `ArrayBuffer` and small metadata to the page
- implement hard cancellation with `Worker.terminate()`, immediate RPC
  rejection, Worker recreation, and lazy binary-session rehydration
- run the real Worker/RPC/WASI boundary in pull-request CI and the Pages build

The existing browser glue enters synchronous `wasi.start()`. Once that call is
running, a cancel message cannot be processed until WebAssembly returns.
Termination is therefore the browser primitive that can interrupt work while
keeping input and paint responsive.

## UI flow

```text
upload bytes -> Worker list -> address-only inventory
click row    -> Worker decompile 0xADDR -> one cached C body
download     -> Worker project -> Worker makeZip -> transferred ArrayBuffer
cancel       -> terminate Worker -> recreate -> rehydrate on next request
```

The automatic mode remains explicit across all three operations, so the Rust
front-end still owns the exact policy:

- below 500 KiB: `aggressive`
- 500 KiB through below 2 MiB: `reliable`
- 2 MiB and above: `fast`

Fast project export therefore also retains the merged 10-second cooperative
per-function watchdog. Worker termination is a separate hard cancellation
boundary over the whole browser operation.

The new lazy body path intentionally uses explicit-address decompilation rather
than claiming byte identity with the old eager `decompile-all` UI path. Project
download continues to use the existing project command and artifact builders.

## Validation

- real module Worker/RPC/WASI integration:
  - 13-function inventory with no eager body payloads
  - one selected address decompiled lazily
  - active RPC terminated, rejected, and successfully retried after recreation
  - host heartbeat advanced during project export
  - structurally valid 19,734-byte Worker-built ZIP transferred
- browser glue: ELF + Mach-O, x86-64 + AArch64, project export, exact auto
  boundaries — green
- native/WASM parity: 19/19
- deterministic ZIP structure/CRC test — green
- automatic-mode argv test — green
- `make test` — PARITY OK, 675/675
- `make test-stages` — PARITY OK, 305/305
- `make rust-test` — green
- `make check-spec` — green
- independent cancellation/transfer/URL/state review — no blockers

The Worker E2E test is added to the PR-triggered `tests.yml` parity job and to
the post-merge Pages build.

## Limits

This is a responsiveness and cancellation feature, not an engine speed or
memory optimization.

- WASI command modules still re-bootstrap for inventory, each uncached selected
  body, and project export.
- the page retains the uploaded bytes for restart while the Worker owns a clone
- whole-project artifacts and the ZIP coexist transiently inside the Worker
- a large export can still consume substantial time or exceed a tab's memory
  budget; cancellation discards partial output
- the committed E2E test drives the shipped Worker stack through Node worker
  threads, not a real-browser DOM automation framework

The motivating private binary is
`bc4c15d826aaebeace3fec6360eb687e5662cba8745605093254931dcdb3ae1b`.
Its merged native fast export is now 259.11 seconds with approximately 1.5 GiB
peak RSS after #216. This PR does not claim to improve either number; it keeps
the browser usable and makes that work interruptible.
