### PR TITLE
[AUTOMATED] perf: bound heritage location scans

### DIFF
--- a/decompiler/crates/kuna-decomp/src/p3_dataflow/heritage.rs
+++ b/decompiler/crates/kuna-decomp/src/p3_dataflow/heritage.rs
@@ -1217,25 +1217,10 @@ impl Heritage {
         write.clear();
         input.clear();
         remove.clear();
-        let start = memrange.addr.get_offset();
         let endaddr = &memrange.addr + i64::from(memrange.size);
-        let spc = memrange.addr.get_space().expect("collect: range space").clone();
+        memrange.addr.get_space().expect("collect: range space");
         let mut maxsize = 0;
-        // The C++ wraparound branch (endaddr < start) scans to the end of the
-        // space (`endLoc(Address(space,highest))` → the whole rest of the
-        // space); otherwise the scan stops at `beginLoc(endaddr)`.  We collect
-        // the space's Varnodes once and bound by offset, which covers both: the
-        // wraparound case is "everything from start to the space's end".
-        let wraparound = endaddr.get_offset() < start;
-        let space_ids = fd.vbank().loc_space_ids(&spc);
-        let ids: Vec<crate::context::VarnodeId> = space_ids
-            .into_iter()
-            .filter(|&id| {
-                let off = fd.vbank().get(id).expect("collect: stale vn").get_addr().get_offset();
-                off >= start && (wraparound || off < endaddr.get_offset())
-            })
-            .collect();
-        for vn in ids {
+        for vn in fd.vbank().iter_loc_addr_range(&memrange.addr, &endaddr) {
             let v = fd.vbank().get(vn).expect("collect: stale vn");
             if v.is_write_mask() {
                 continue;
@@ -4392,6 +4377,56 @@ mod tests {
             let allowed = h.dead_removal_allowed_seen(&ram);
             assert_eq!(allowed, h.pass > h.get_dead_code_delay(&ram));
         }
+    }
+
+    #[test]
+    fn collect_preserves_half_open_range_outputs() {
+        use kuna_num::opcodes::OpCode;
+
+        let mut fd = build_fd();
+        let copy = || crate::context::TypeOp::new(OpCode::CPUI_COPY, 0, "copy");
+
+        let read = fd.new_varnode(1, &raddr(&fd, 0x100), None);
+        let read_op = fd.new_op(1, raddr(&fd, 0x2000));
+        fd.op_set_opcode(read_op, copy());
+        fd.op_set_input(read_op, read, 0).unwrap();
+
+        let write_op = fd.new_op(1, raddr(&fd, 0x2001));
+        fd.op_set_opcode(write_op, copy());
+        let write = fd.new_varnode_out(4, &raddr(&fd, 0x108), write_op).unwrap();
+
+        let input_free = fd.new_varnode(2, &raddr(&fd, 0x10c), None);
+        let input = fd.set_input_varnode(input_free).unwrap();
+
+        let end_op = fd.new_op(1, raddr(&fd, 0x2002));
+        fd.op_set_opcode(end_op, copy());
+        let _end_write = fd.new_varnode_out(8, &raddr(&fd, 0x110), end_op).unwrap();
+
+        let below_op = fd.new_op(1, raddr(&fd, 0x2003));
+        fd.op_set_opcode(below_op, copy());
+        let _below_write = fd.new_varnode_out(8, &raddr(&fd, 0xff), below_op).unwrap();
+
+        let mut range =
+            MemRange::new(raddr(&fd, 0x100), 0x10, memrange_flags::new_addresses);
+        let mut reads = Vec::new();
+        let mut writes = Vec::new();
+        let mut inputs = Vec::new();
+        let mut removes = Vec::new();
+        let maxsize = Heritage::new().collect(
+            &fd,
+            &mut range,
+            &mut reads,
+            &mut writes,
+            &mut inputs,
+            &mut removes,
+        );
+
+        assert_eq!(reads, vec![read], "the start address is inclusive");
+        assert_eq!(writes, vec![write]);
+        assert_eq!(inputs, vec![input]);
+        assert!(removes.is_empty());
+        assert_eq!(maxsize, 4, "the larger writes below and at the end are excluded");
+        assert!(range.new_addresses());
     }
 
     // ---- bumpDeadcodeDelay + restart recorder anchor ----------------------

--- a/decompiler/crates/kuna-decomp/src/substrate/varnode.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/varnode.rs
@@ -1803,33 +1803,35 @@ impl VarnodeBank {
     ///
     /// The C++ pair brackets exactly the Varnodes whose storage address lies in
     /// `[start, end)` of the same space (the comparator orders by address first);
-    /// this yields that membership set in loc order by filtering the ordered
-    /// `loc_tree`.  When `end` wraps below `start` the window runs to the end of
-    /// the space (the C++ `endaddr.getOffset() < off` arm picks `endLoc(space)`).
+    /// this constructs the same lower-bound keys over `loc_tree`.  When `end`
+    /// wraps below `start` the window runs to the end of the space (the C++
+    /// `endaddr.getOffset() < off` arm picks `endLoc(space)`).
     pub fn iter_loc_addr_range(
         &self,
         start: &Address,
         end: &Address,
     ) -> impl Iterator<Item = VarnodeId> + '_ {
         let space_index = start.get_space().map(|s| s.get_index());
-        let start_off = start.get_offset();
-        let end_off = end.get_offset();
-        let wrapped = end_off < start_off;
-        self.loc_tree.values().copied().filter(move |&id| {
-            let v = match self.get(id) {
-                Some(v) => v,
-                None => return false,
-            };
-            let a = v.get_addr();
-            if a.get_space().map(|s| s.get_index()) != space_index {
-                return false;
-            }
-            let off = a.get_offset();
-            if off < start_off {
-                return false;
-            }
-            // Half-open upper bound; a wrapped window runs to the space end.
-            wrapped || off < end_off
+        let begin = LocProbe::Lower(LocKey {
+            addr: start.clone(),
+            size: 0,
+            flagclass: flag_class_of(varnode_flags::input),
+            seqnum: SeqNum::default(),
+            create_index: 0,
+        });
+        let finish = if end.get_offset() < start.get_offset() {
+            LocProbe::End
+        } else {
+            LocProbe::Lower(LocKey {
+                addr: end.clone(),
+                size: 0,
+                flagclass: flag_class_of(varnode_flags::input),
+                seqnum: SeqNum::default(),
+                create_index: 0,
+            })
+        };
+        self.iter_loc_probe(begin, finish).take_while(move |&id| {
+            self.arena[id].get_addr().get_space().map(|s| s.get_index()) == space_index
         })
     }
 
@@ -2634,10 +2636,11 @@ mod tests {
         let sp = space(&m, 2);
         let v100 = bank.create(4, Address::new(Rc::clone(&sp), 0x100), dt(4));
         let v104 = bank.create(4, Address::new(Rc::clone(&sp), 0x104), dt(4));
-        let _v110 = bank.create(4, Address::new(Rc::clone(&sp), 0x110), dt(4));
+        let v110 = bank.create(4, Address::new(Rc::clone(&sp), 0x110), dt(4));
         // A varnode below the window and one in another space — both excluded.
         let _v0f0 = bank.create(4, Address::new(Rc::clone(&sp), 0xf0), dt(4));
         let _other = bank.create(4, Address::new(space(&m, 1), 0x100), dt(4));
+        let _later = bank.create(4, Address::new(space(&m, 3), 0), dt(4));
 
         let start = Address::new(Rc::clone(&sp), 0x100);
         let end = Address::new(Rc::clone(&sp), 0x110); // exclusive
@@ -2647,7 +2650,44 @@ mod tests {
         // A window that wraps below `start` runs to the end of the space.
         let wrap_end = Address::new(Rc::clone(&sp), 0x10);
         let wrapped: Vec<VarnodeId> = bank.iter_loc_addr_range(&start, &wrap_end).collect();
-        assert_eq!(wrapped.len(), 3, "wrapped window covers 0x100, 0x104, 0x110");
+        assert_eq!(
+            wrapped,
+            vec![v100, v104, v110],
+            "wrapped window covers the ram tail but not the following space"
+        );
+    }
+
+    #[test]
+    fn iter_loc_addr_range_matches_loc_order_filter_at_boundaries() {
+        let m = build_manager();
+        let mut bank = VarnodeBank::new(&m, 0).unwrap();
+        let sp = space(&m, 2);
+        let _below = bank.create(4, Address::new(Rc::clone(&sp), 0xff), dt(4));
+        let _start_wide = bank.create(8, Address::new(Rc::clone(&sp), 0x100), dt(8));
+        let _start_narrow = bank.create(1, Address::new(Rc::clone(&sp), 0x100), dt(1));
+        let _middle = bank.create(4, Address::new(Rc::clone(&sp), 0x108), dt(4));
+        let _end = bank.create(4, Address::new(Rc::clone(&sp), 0x110), dt(4));
+        let _other_space = bank.create(4, Address::new(space(&m, 1), 0x108), dt(4));
+
+        let start = Address::new(Rc::clone(&sp), 0x100);
+        let end = Address::new(Rc::clone(&sp), 0x110);
+        let expected: Vec<VarnodeId> = bank
+            .iter_loc()
+            .filter(|&id| {
+                let addr = bank.get(id).unwrap().get_addr();
+                Rc::ptr_eq(addr.get_space().unwrap(), &sp)
+                    && addr.get_offset() >= 0x100
+                    && addr.get_offset() < 0x110
+            })
+            .collect();
+        let actual: Vec<VarnodeId> = bank.iter_loc_addr_range(&start, &end).collect();
+
+        assert_eq!(actual, expected);
+        assert_eq!(actual.len(), 3, "both start-address varnodes and the middle are included");
+        assert!(
+            bank.iter_loc_addr_range(&start, &start).next().is_none(),
+            "an empty half-open window contains no varnodes"
+        );
     }
 
     /// Definition-order iteration: inputs first, then written (by seqnum).

--- a/docs/spec/03-ssa-and-simplification.md
+++ b/docs/spec/03-ssa-and-simplification.md
@@ -56,10 +56,12 @@ load-bearing twice over: only ranges with new addresses get call/return guards
 
 **The simple case.** For each disjoint range, `heritage.rs (Heritage::collect)`
 partitions the range's varnodes into reads (free), writes (defined), and
-inputs. Writes smaller than the range are widened through a PIECE concatenation
-(`normalize_write_size`), reads smaller than the range are served by a SUBPIECE
-(`normalize_read_size`), and input holes are filled and concatenated
-(`guard_input`). Phi placement then runs the Bilardi–Pingali
+inputs. It walks the loc-tree's bounded half-open `[start,end)` slice in
+location order (a wrapped end runs to the current space's end), rather than
+scanning every varnode. Writes smaller than the range are widened through a
+PIECE concatenation (`normalize_write_size`), reads smaller than the range are
+served by a SUBPIECE (`normalize_read_size`), and input holes are filled and
+concatenated (`guard_input`). Phi placement then runs the Bilardi–Pingali
 augmented-dominator-tree algorithm (`heritage.rs (Heritage::build_adt)`,
 `heritage.rs (Heritage::calc_multiequals)`) with a depth-keyed, LIFO-within-depth
 priority queue (`heritage.rs (PriorityQueue)`) — the queue order decides


### PR DESCRIPTION
## Summary

- Make Heritage::collect stream the VarnodeBank location tree bounded half-open address slice instead of materializing and filtering every varnode in the address space for every disjoint range.
- Preserve C++ location ordering, inclusive-start/exclusive-end behavior, empty ranges, and wraparound through the current address-space tail.
- Add boundary/order and collect classification regressions, plus the P3 specification update.

## Private-binary evidence

SHA-256: bc4c15d826aaebeace3fec6360eb687e5662cba8745605093254931dcdb3ae1b

- Full fast decompile-project: 259.11s -> 219.20s (-39.91s, -15.4%).
- Peak RSS: 1,512,504 -> 1,518,432 KiB (+0.4%).
- Successful bodies: 3,142 -> 3,144; failures: 11 -> 9. Functions 0x5c6cf0 and 0x5e2ea0 now finish below the existing 10-second fast watchdog.
- All seven prior watchdog functions with a 120-second budget: 284.55s -> 185.32s (-34.9%), with byte-identical JSON.
- Worst function 0x5c9630: 109.93s -> 70.08s (-36.2%), with byte-identical JSON.
- Project C comparison: the two recovered error blocks became real bodies; every other 3,151 function block remained byte-identical.

## Validation

- make test: PARITY OK (675/675)
- make test-stages: PARITY OK (305/305)
- make rust-test: green
- make check-spec: green
- Independent correctness review: approved
