### PR TITLE
[AUTOMATED] perf(p0): index global container lookup intervals

### DIFF
--- a/decompiler/crates/kuna-decomp/src/substrate/context.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/context.rs
@@ -181,11 +181,87 @@ pub struct GlobalQuery {
     /// Every whole-and-piece mapped storage in the global scope, stably grouped
     /// by address-space index by [`GlobalQuery::new`].
     entries: Vec<GlobalEntry>,
+    /// Per-space offset indexes for mapped-storage containment queries.
+    space_indexes: Vec<GlobalSpaceIndex>,
     /// The global scope's owned data ranges (C++ `Scope::rangetree`), for the
     /// `inScope` discovery branch of `queryProperties`.
     pub owned: kuna_base::address::RangeList,
     /// The boolean-property map (C++ `Database::flagbase`), for `getProperty`.
     pub flagbase: kuna_base::partmap::PartMap<Address, uint4>,
+}
+
+#[derive(Debug, Clone)]
+struct GlobalSpaceIndex {
+    space_index: int4,
+    entry_start: usize,
+    entry_end: usize,
+    interval_order: Vec<usize>,
+    max_last: Vec<u64>,
+    leaf_base: usize,
+}
+
+impl GlobalSpaceIndex {
+    fn new(
+        space_index: int4,
+        entry_start: usize,
+        entry_end: usize,
+        entries: &[GlobalEntry],
+    ) -> Self {
+        let mut interval_order: Vec<usize> = (entry_start..entry_end).collect();
+        interval_order.sort_by_key(|&entry_index| entries[entry_index].first);
+
+        let leaf_base = interval_order.len().next_power_of_two();
+        let mut max_last = vec![0; leaf_base * 2];
+        for (position, &entry_index) in interval_order.iter().enumerate() {
+            max_last[leaf_base + position] = entries[entry_index].last;
+        }
+        for node in (1..leaf_base).rev() {
+            max_last[node] = max_last[node * 2].max(max_last[node * 2 + 1]);
+        }
+
+        Self {
+            space_index,
+            entry_start,
+            entry_end,
+            interval_order,
+            max_last,
+            leaf_base,
+        }
+    }
+
+    fn for_each_candidate(
+        &self,
+        entries: &[GlobalEntry],
+        start: u64,
+        end: u64,
+        visit: &mut impl FnMut(usize),
+    ) {
+        let limit = self
+            .interval_order
+            .partition_point(|&entry_index| entries[entry_index].first <= start);
+        self.visit_candidates(1, 0, self.leaf_base, limit, end, visit);
+    }
+
+    fn visit_candidates(
+        &self,
+        node: usize,
+        node_start: usize,
+        node_end: usize,
+        limit: usize,
+        end: u64,
+        visit: &mut impl FnMut(usize),
+    ) {
+        if node_start >= limit || self.max_last[node] < end {
+            return;
+        }
+        if node_end - node_start == 1 {
+            visit(self.interval_order[node_start]);
+            return;
+        }
+        let midpoint = node_start + (node_end - node_start) / 2;
+        self.visit_candidates(node * 2, node_start, midpoint, limit, end, visit);
+        self.visit_candidates(node * 2 + 1, midpoint, node_end, limit, end, visit);
+    }
 }
 
 impl GlobalQuery {
@@ -197,21 +273,44 @@ impl GlobalQuery {
         flagbase: kuna_base::partmap::PartMap<Address, uint4>,
     ) -> Self {
         entries.sort_by_key(|entry| entry.space_index);
+        let mut space_indexes = Vec::new();
+        let mut entry_start = 0;
+        while entry_start < entries.len() {
+            let space_index = entries[entry_start].space_index;
+            let entry_end = entry_start
+                + entries[entry_start..]
+                    .partition_point(|entry| entry.space_index == space_index);
+            space_indexes.push(GlobalSpaceIndex::new(
+                space_index,
+                entry_start,
+                entry_end,
+                &entries,
+            ));
+            entry_start = entry_end;
+        }
         Self {
             entries,
+            space_indexes,
             owned,
             flagbase,
         }
     }
 
+    fn index_for_space(&self, space_index: int4) -> Option<&GlobalSpaceIndex> {
+        let position = self
+            .space_indexes
+            .partition_point(|index| index.space_index < space_index);
+        self.space_indexes
+            .get(position)
+            .filter(|index| index.space_index == space_index)
+    }
+
     /// Return only entries belonging to one address space.
     fn entries_for_space(&self, space_index: int4) -> &[GlobalEntry] {
-        let first = self
-            .entries
-            .partition_point(|entry| entry.space_index < space_index);
-        let entries = &self.entries[first..];
-        let len = entries.partition_point(|entry| entry.space_index == space_index);
-        &entries[..len]
+        let Some(index) = self.index_for_space(space_index) else {
+            return &[];
+        };
+        &self.entries[index.entry_start..index.entry_end]
     }
 
     /// C++ `Database::getProperty(addr)` (`database.hh:949`): the boolean
@@ -224,44 +323,8 @@ impl GlobalQuery {
     /// global scope: the smallest mapped storage containing `[addr, addr+size-1]`
     /// that is in-use at `usepoint`.  Returns its `getAllFlags()`.
     fn find_container_flags(&self, addr: &Address, size: int4, usepoint: &Address) -> Option<uint4> {
-        let space = addr.get_space()?;
-        let space_index = space.get_index();
-        let start = addr.get_offset();
-        // end = addr + size - 1 (uintb wrap), as in find_container.
-        // cast: int4 -> u64, reproducing the C++ `uintb` widening of the
-        // (non-negative) byte count `size`; sign-extension is irrelevant since a
-        // storage size is never negative.
-        let end = start.wrapping_add(size as u64).wrapping_sub(1);
-        let mut best: Option<&GlobalEntry> = None;
-        let mut oldsize: int4 = -1;
-        for e in self.entries_for_space(space_index) {
-            // Containment: first <= addr (entries are storage at >= first) and
-            // last >= end.  The rangemap subsort walk already filters to
-            // first <= addr; here check both bounds explicitly.
-            if e.first > start || e.last < end {
-                continue;
-            }
-            if e.size < oldsize || oldsize == -1 {
-                // SymbolEntry::inUse(usepoint): addr-tied is valid throughout; an
-                // invalid usepoint never matches a use-limited entry; otherwise
-                // the usepoint must fall in the uselimit ranges.
-                let in_use = if e.addrtied {
-                    true
-                } else if usepoint.is_invalid() {
-                    false
-                } else {
-                    e.uselimit.in_range(usepoint, 1)
-                };
-                if in_use {
-                    best = Some(e);
-                    if e.size == size {
-                        break;
-                    }
-                    oldsize = e.size;
-                }
-            }
-        }
-        best.map(|e| e.all_flags)
+        self.find_container_entry(addr, size, usepoint)
+            .map(|entry| entry.all_flags)
     }
 
     /// C++ `Scope::findContainer` (`database.cc:2278-2310`) restricted to the
@@ -275,37 +338,60 @@ impl GlobalQuery {
         size: int4,
         usepoint: &Address,
     ) -> Option<&GlobalEntry> {
-        let space = addr.get_space()?;
-        let space_index = space.get_index();
+        let space_index = addr.get_space()?.get_index();
+        let index = self.index_for_space(space_index)?;
         let start = addr.get_offset();
         // end = addr + size - 1 (uintb wrap), as in find_container.
         // cast: int4 -> u64, the C++ `uintb` widening of the non-negative byte
         // count; a storage size is never negative so sign-extension is irrelevant.
         let end = start.wrapping_add(size as u64).wrapping_sub(1);
-        let mut best: Option<&GlobalEntry> = None;
-        let mut oldsize: int4 = -1;
-        for e in self.entries_for_space(space_index) {
-            if e.first > start || e.last < end {
-                continue;
+        let mut best: Option<usize> = None;
+        let mut earliest_exact: Option<usize> = None;
+        let mut earliest_smaller: Option<usize> = None;
+        index.for_each_candidate(&self.entries, start, end, &mut |entry_index| {
+            let entry = &self.entries[entry_index];
+            let in_use = if entry.addrtied {
+                true
+            } else if usepoint.is_invalid() {
+                false
+            } else {
+                entry.uselimit.in_range(usepoint, 1)
+            };
+            if !in_use {
+                return;
             }
-            if e.size < oldsize || oldsize == -1 {
-                let in_use = if e.addrtied {
-                    true
-                } else if usepoint.is_invalid() {
-                    false
-                } else {
-                    e.uselimit.in_range(usepoint, 1)
-                };
-                if in_use {
-                    best = Some(e);
-                    if e.size == size {
-                        break;
-                    }
-                    oldsize = e.size;
+
+            if entry.size == size
+                && earliest_exact.is_none_or(|exact_index| entry_index < exact_index)
+            {
+                earliest_exact = Some(entry_index);
+            } else if entry.size < size
+                && earliest_smaller.is_none_or(|smaller_index| entry_index < smaller_index)
+            {
+                earliest_smaller = Some(entry_index);
+            }
+
+            let is_better = match best {
+                Some(best_index) => {
+                    let best_entry = &self.entries[best_index];
+                    entry.size < best_entry.size
+                        || (entry.size == best_entry.size && entry_index < best_index)
                 }
+                None => true,
+            };
+            if is_better {
+                best = Some(entry_index);
             }
-        }
-        best
+        });
+        let selected = match earliest_exact {
+            Some(exact_index)
+                if earliest_smaller.is_none_or(|smaller_index| exact_index < smaller_index) =>
+            {
+                Some(exact_index)
+            }
+            _ => best,
+        };
+        selected.map(|entry_index| &self.entries[entry_index])
     }
 
     /// Resolve the global Symbol covering a Varnode for the naming pass — the C++

--- a/decompiler/crates/kuna-decomp/src/substrate/context_tests.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/context_tests.rs
@@ -54,6 +54,45 @@ fn query(entries: Vec<GlobalEntry>) -> GlobalQuery {
     GlobalQuery::new(entries, RangeList::new(), PartMap::new(0))
 }
 
+fn linear_container_flags(
+    entries: &[GlobalEntry],
+    address: &Address,
+    size: i32,
+    usepoint: &Address,
+) -> Option<u32> {
+    let space_index = address.get_space()?.get_index();
+    let start = address.get_offset();
+    let end = start.wrapping_add(size as u64).wrapping_sub(1);
+    let mut best = None;
+    let mut oldsize = -1;
+    for candidate in entries {
+        if candidate.space_index != space_index
+            || candidate.first > start
+            || candidate.last < end
+        {
+            continue;
+        }
+        if candidate.size >= oldsize && oldsize != -1 {
+            continue;
+        }
+        let in_use = if candidate.addrtied {
+            true
+        } else if usepoint.is_invalid() {
+            false
+        } else {
+            candidate.uselimit.in_range(usepoint, 1)
+        };
+        if in_use {
+            best = Some(candidate.all_flags);
+            if candidate.size == size {
+                break;
+            }
+            oldsize = candidate.size;
+        }
+    }
+    best
+}
+
 #[test]
 fn groups_cross_space_entries_without_changing_within_space_order() {
     let space3 = space(3);
@@ -151,4 +190,125 @@ fn in_use_filter_still_selects_the_smallest_active_entry() {
         query.query_properties(&addr(&data, 0x100), 4, &Address::new_invalid()),
         0x10
     );
+}
+
+#[test]
+fn interval_order_does_not_replace_original_order_for_equal_sizes() {
+    let data = space(3);
+    let query = query(vec![
+        entry(&data, 0x108, 16, 0x11, "original-first", true, RangeList::new()),
+        entry(&data, 0x100, 16, 0x22, "offset-first", true, RangeList::new()),
+    ]);
+
+    assert_eq!(
+        query.find_container_flags(&addr(&data, 0x108), 8, &Address::new_invalid()),
+        Some(0x11)
+    );
+}
+
+#[test]
+fn wrapped_end_preserves_exact_size_break_order() {
+    let data = space(3);
+    let exact = entry(
+        &data,
+        u64::MAX - 1,
+        2,
+        0x11,
+        "exact",
+        true,
+        RangeList::new(),
+    );
+    let smaller = entry(&data, 0, 1, 0x22, "smaller", true, RangeList::new());
+    let address = addr(&data, u64::MAX);
+
+    let exact_first = query(vec![exact.clone(), smaller.clone()]);
+    assert_eq!(
+        exact_first.find_container_flags(&address, 2, &Address::new_invalid()),
+        Some(0x11)
+    );
+
+    let smaller_first = query(vec![smaller, exact]);
+    assert_eq!(
+        smaller_first.find_container_flags(&address, 2, &Address::new_invalid()),
+        Some(0x22)
+    );
+}
+
+#[test]
+fn interval_index_matches_linear_overlap_and_usepoint_semantics() {
+    let data = space(3);
+    let other_data = space(9);
+    let code = space(4);
+
+    let mut use_400 = RangeList::new();
+    use_400.insert_range(Rc::clone(&code), 0x400, 0x4ff);
+    let mut use_500 = RangeList::new();
+    use_500.insert_range(Rc::clone(&code), 0x500, 0x5ff);
+
+    let entries = vec![
+        entry(&data, 0x108, 16, 0x11, "original-first", true, RangeList::new()),
+        entry(
+            &other_data,
+            0x100,
+            64,
+            0x90,
+            "other-space",
+            true,
+            RangeList::new(),
+        ),
+        entry(&data, 0x80, 192, 0x12, "outer", true, RangeList::new()),
+        entry(&data, 0x100, 16, 0x13, "offset-first", true, RangeList::new()),
+        entry(&data, 0x104, 12, 0x14, "limited-400", false, use_400),
+        entry(&data, 0x104, 12, 0x15, "limited-500", false, use_500),
+        entry(&data, 0x108, 4, 0x16, "exact", false, {
+            let mut use_exact = RangeList::new();
+            use_exact.insert_range(Rc::clone(&code), 0x520, 0x52f);
+            use_exact
+        }),
+        entry(&data, 0x200, 8, 0x17, "disjoint", true, RangeList::new()),
+        entry(
+            &data,
+            u64::MAX - 1,
+            2,
+            0x18,
+            "tail-exact",
+            true,
+            RangeList::new(),
+        ),
+        entry(&data, 0, 1, 0x19, "wrapped-smaller", true, RangeList::new()),
+    ];
+    let query = query(entries.clone());
+    let usepoints = [
+        Address::new_invalid(),
+        addr(&code, 0x450),
+        addr(&code, 0x525),
+        addr(&code, 0x580),
+        addr(&code, 0x600),
+    ];
+
+    for offset in (0x70..=0x210).step_by(3) {
+        for size in [1, 2, 4, 8, 12, 16, 24] {
+            for usepoint in &usepoints {
+                let address = addr(&data, offset);
+                assert_eq!(
+                    query.find_container_flags(&address, size, usepoint),
+                    linear_container_flags(&entries, &address, size, usepoint),
+                    "offset={offset:#x} size={size} usepoint={usepoint:?}"
+                );
+            }
+        }
+    }
+
+    for offset in [u64::MAX - 4, u64::MAX - 3, u64::MAX - 2, u64::MAX - 1, u64::MAX] {
+        for size in [1, 2, 3, 4, 8] {
+            for usepoint in &usepoints {
+                let address = addr(&data, offset);
+                assert_eq!(
+                    query.find_container_flags(&address, size, usepoint),
+                    linear_container_flags(&entries, &address, size, usepoint),
+                    "wrapped offset={offset:#x} size={size} usepoint={usepoint:?}"
+                );
+            }
+        }
+    }
 }

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -386,9 +386,14 @@ The global-symbol snapshot
 mapped entries by address-space index once when it is built. Grouping is stable:
 the encounter order of entries within one space is unchanged, preserving
 `findContainer`'s first-match behavior for equal-size overlaps and its
-use-point selection. Property, naming, container, and callee lookups first
-isolate the requested space, so register, stack, and other non-global varnodes
-do not scan mappings from unrelated spaces.
+use-point selection. Within each space, an offset interval index restricts
+container candidates to entries whose first offset is at or below the query
+start and whose last offset reaches the query end. The final reduction still
+uses stable encounter order for equal-size entries, preserves the effect of the
+exact-size early break, and applies the original use-point validity test.
+Property, naming, container, and callee lookups first isolate the requested
+space, so register, stack, and other non-global varnodes do not scan mappings
+from unrelated spaces.
 
 The copy happens in exactly one place:
 `decompiler/crates/kuna-decomp/src/infra/architecture.rs (build_arch_handle)`,


### PR DESCRIPTION
## Summary

- Add a stable per-address-space interval index to GlobalQuery containment lookups, pruning entries that cannot cover the requested storage.
- Preserve original encounter-order ties, use-point filtering, wrapped-offset behavior, and the exact-size early-break result.
- Test the index against the former linear algorithm across overlaps, spaces, use limits, boundaries, and 125 wrapped-address cases; document the snapshot lookup contract.

## Private-binary evidence

SHA-256: bc4c15d826aaebeace3fec6360eb687e5662cba8745605093254931dcdb3ae1b

- Full fast decompile-project versus merged main: 219.20s -> 162.59s elapsed (-25.8%); 216.31s -> 161.05s user CPU (-25.5%).
- Peak RSS in those runs: 1,518,432 -> 1,606,596 KiB (+5.8%).
- Successful bodies: 3,144 -> 3,147; failures: 9 -> 6. Functions 0x4842c0, 0x4f39e0, and 0x5b58f0 now finish below the existing 10-second fast watchdog.
- Project C comparison: those three recovered error blocks became real bodies; every other 3,150 function block remained byte-identical.
- Hotspot 0x609470: 11.85s -> 7.05s mean user CPU (-40.5%), exact JSON.
- Hotspot 0x53d950: 11.79s -> 8.59s mean user CPU (-27.1%), exact JSON.
- The corrected build is artifact-identical to the initially benchmarked index build, and 0x402d80 still emits its full 26-line body in fast mode.
- Combined with the already-merged project fixes, the first valid fast-project baseline is now 445.06s -> 162.59s (-63.5%).

## Validation

- make test: PARITY OK (675/675)
- make test-stages: PARITY OK (305/305)
- make rust-test: green
- make check-spec: green
- Independent correctness review: approved
