### PR TITLE
[AUTOMATED] campaign(decbench): round-1 triage records + feature menu

### DIFF
--- a/docs/decbench/features.md
+++ b/docs/decbench/features.md
@@ -1,0 +1,65 @@
+# decbench campaign — the feature menu (round 1, 2026-08-01)
+
+Output of `mine` → `triage` → cluster on the 2026-07-27 benchmark run. 16 cases triaged, one
+agent each, verify-first on today's build; every feature-candidate verdict then handed to a
+second agent briefed to **refute** it. 11 survived, 1 was refuted on its diagnosis (and turned
+out to be worse than filed), 4 were not defects.
+
+Two columns matter and they are not the same column:
+
+- **GED value** — does fixing it move the benchmark? GED is a CFG edit distance, so it is blind
+  to types, argument lists, declarations, operator spelling and anything else that does not
+  change basic-block count.
+- **Correctness value** — does the emitted C stop being wrong? Several items below score **zero**
+  on the benchmark and are still the most important things in this table, because kuna already
+  wins those panes and emits code that does not compile or does not compute the right value.
+
+Ranking is by correctness first. A campaign that optimizes only the metric it can see will
+happily ship a decompiler that scores well and lies.
+
+## Tier 0 — kuna emits WRONG CODE (fix regardless of benchmark value)
+
+| slug | phase | cases | what is wrong | GED | scope | status |
+|---|---|---|---|---|---|---|
+| **p6-lost-restore** | P6 | `O0-gnutls-ocsptool-port_to_service`, `O0-coreutils-ptx-output_one_dumb_line` | A value live across a merge point is lost or aliased. In `port_to_service` kuna hoists `v2 = a0` to the entry, clobbers it with the `getservbyport` result and never restores it, though the binary reloads `sport` at `0x114e8` — **kuna's C returns NULL where the binary returns a value**. Proven executable: the real binary prints `99999`, kuna's transcribed C segfaults. Ghidra, IDA, angr, binja and phoenix are all correct here. In `output_one_dumb_line` two distinct selects merge into one HighVariable, so the C subtracts 0 where the binary subtracts `truncation_string_length`. | 0 | investigating | agent running |
+| **stackargs** / **callsite-stack-args** | P4 | `O0-mydoom-mydoom-msg_b64enc`, `O2-noinline-openssh-portable-ssh-add-parse_dest_constraint` | kuna never registers a **spacebase (stack) trial** at a call site, so stack-passed arguments do not exist: calls print with arguments missing, and the code that computes them is dead-code eliminated. **707 of 738 i386 call sites in `mydoom.exe` render with an empty argument list**; reproduced architecture-independently on x86-64 past the 6th argument. Only bites call sites with an unlocked callee prototype (DWARF/`libproto` hide it). The callee side is correct, so the cspec and trial map are fine — it is the caller-relative→callee-frame translation that is missing. | small | proposal | queued |
+
+## Tier 1 — emitted C is not valid C (strict bug fixes, no option)
+
+| slug | phase | case | what is wrong | GED | status |
+|---|---|---|---|---|---|
+| **spacebase-unnamed-location** | P9 | `O2-noinline-mydoom-mydoom-scan_textfile` | With no Symbol bound to the offset, `op_ptrsub_ir`'s SPACEBASE arm falls back to the functional render and prints `PTRSUB(ESP,8)` — the raw p-code operator plus the raw register, neither declared. Ghidra prints a stack-location leaf. Reproduces on ARM too (`PTRSUB(sp,0)`). | 0 | **PR in flight** |
+| **realtypes-pointee-size** | P9 | `O2-noinline-libacl-libacl.so.1.1-set_acl_fd` | `realtype_unknown_base` returns `void` unconditionally under a pointer, collapsing `undefined1/4/8 *` to `void *` — but only in the DECLARATION. Index and cast expressions keep the original pointee size, so declaration and expression disagree about the stride, and `gcc -c` gives *invalid use of void expression*. 150 width-carrying casts collapse to `*(void *)` in one library. | 0 | queued |
+| **symbol-keyed-local-decls** | P9 | `O2-noinline-betaflight-…-applyLedFixedLayers` | One declaration per HighVariable instead of one per ScopeLocal Symbol, so a single stack slot is declared **twice under the same name** with two different types. | 0 | queued |
+| **jumptable-callother-inject** | P2 | `O2-noinline-betaflight-…-accDetect`, `O0-libopencm3-sdram-main` | `<callotherfixup>` injects are drained once, before jump-table recovery; the CALLOTHERs queued by the post-recovery `fallthru()` re-drain are never injected, so `setISAMode(1);` survives into the C as a call to a function that does not exist. kuna erases it correctly for 3703/3798 functions in the same binary — internally inconsistent. | 0 | **PR in flight** |
+| **finalorder-entry-first** | P8 | `O0-libopencm3-sdram-main` | `BlockGraph::orderBlocks()` is an explicit STUB (`blockaction.rs:3792`), so `ActionFinalStructure` never orders the components. The function body is emitted starting at a mid-function label with the real entry after an unconditional `goto`, as unreachable code. The ordering key is already ported; only the sort is missing. | 0 | queued |
+
+## Tier 2 — structure recovery (moves the metric)
+
+| slug | phase | case | mechanism | GED win | scope |
+|---|---|---|---|---|---|
+| **iteboolean** | P3/P8 | `O0-bash-bash-time_command` | `RuleConditionalMove` requires every MULTIEQUAL input block to be the CBRANCH root or a single-predecessor pass-through; an `&&`/`||` chain gives the constant arm 2+ predecessors, so a short-circuit boolean assignment stays an explicit 0/1 diamond. Relaxing that bail is the whole fix. High breadth — `-O0` code materializes booleans everywhere. | 26 → 6 on this function | small |
+| **iteregion-merged-dest** | P8 | `O0-coreutils-ptx-output_one_dumb_line` | `same_storage()` demands the two arms write the same RAW storage; P6 relocated one arm into a copy-shadow `unique` and unified it through the join MULTIEQUAL, so the arms write different storage but the **same HighVariable**. Key on the high, not the storage. | 66 → 0 | small |
+| **paramcopyhoist** | P6 | `O0-e2fsprogs-e2fsck-save_output` | `trim_op_input_prep` always anchors the trim COPY at the tail of the phi's incoming predecessor block. **The record's own proposed fix is a no-op** (the skeptic showed `pc` only reaches `new_op`) — re-derive the mechanism before building. | — | small |
+| **switchstagedindex** | P2 | `O0-cronie-crontab-load_env` | Jump-table recovery runs once over a partial flow in which the case bodies are not yet decoded, so the index slot has one reaching definition and the 7-case `switch (state)` collapses to a 0/1-entry table — **deleting the state-machine loop and 3 of 4 case bodies**. The skeptic REFUTED the record's proposed mechanism (upstream Ghidra recovers it without multistage), so re-derive before proposing. | large | proposal |
+
+## Not defects
+
+| case | verdict |
+|---|---|
+| `O0-coreutils-factor-factor` | **already-fixed** — today's default (`auto` → `aggressive`) emits the source's early-return shape; `returndup`, which `aggressive` turns on, closes the 12-point gap. |
+| `O2-noinline-iproute2-ip-netns_add` | **covered-by-option** — `readonly` stops the 16 phantom byte-stores into a `.rodata` string. Default-flip candidate. |
+| `O0-bash-bash-rl_vi_redo` | **covered-by-option** — `branchflip off` makes kuna's CFG isomorphic to the source (GED 40 → 0). `branchflip` is default-ON, so this is a default question worth measuring, not a new feature. |
+| `O2-openssh-portable-sshd-mm_answer_auth2_read_banner` | **metric-artifact** — the GED floor for any output that recovers the CMOV null-check is 8; angr's 0 comes from dropping the check entirely. |
+
+## What round 1 says about the campaign
+
+Nine of the eleven survivors have **zero GED value**. Eight of them came from the pools that do
+not rank by margin at all — the NOVEL pool (kuna is already best and the output is still bad)
+and the recall pool. The angr/ida margin pools, which the campaign has mined for months,
+produced mostly small structuring gaps plus one metric artifact.
+
+The reading: kuna's *structural* recovery is now competitive (2nd of 11 on GED, and it wins
+several of the panes where a case was mined against it), and the remaining defects are in what
+the metric cannot see — argument lists, declarations, types, and values. Rank by correctness,
+use GED as a filter, and keep mining the NOVEL and recall pools.

--- a/docs/decbench/triage/O0-e2fsprogs-e2fsck-save_output.md
+++ b/docs/decbench/triage/O0-e2fsprogs-e2fsck-save_output.md
@@ -1,0 +1,275 @@
+---
+case_id: O0-e2fsprogs-e2fsck-save_output
+pool: ida
+status: feature-candidate
+tier: M
+margin: 56
+fresh_verdict: today's no-flag run is 27 GED points better than the recorded run (56 -> 29, measured with scripts.decbench.rescore) purely from DIV-36 `truthycond`; the residual 29 is 7 extra CFG nodes, the largest single contributor (-12) being two parameter copy-shadows emitted mid-guard-cascade instead of in the entry block
+option_closing: null
+feature_slug: paramcopyhoist
+scope: small
+confidence: medium
+---
+
+## Side-by-side
+
+Recorded: ida GED=0 (isomorphic to source), kuna GED=56, margin 56. Source CFG
+46 nodes / 72 edges, so the GED is a real edit distance, not the >60-node
+approximation. Other panes on `ged_new.json`: binja 8, angr 14, r2dec 33,
+**ghidra 61** (the queue's `others_ged` mislabels r2dec's 33 as ghidra — ghidra
+is *worse* than kuna here, so this is not a kuna-vs-ghidra regression).
+
+Measured CFG sizes (pyjoern, same extractor decbench uses):
+
+| pane | nodes / edges | GED |
+|---|---|---|
+| source | 46 / 72 | — |
+| ida (stored) | 46 / 72 | 0 |
+| binja (stored) | 48 / 73 | 8 |
+| angr (stored) | 50 / 73 | 14 |
+| kuna (stored, 2026-07-27) | 60 / 87 | 56 |
+| **kuna (fresh, today, no flags)** | **53 / 77** | **29** |
+| ghidra (stored) | 61 / 90 | 61 |
+
+`--mode auto` and `--mode reliable` produce **byte-identical** output on this
+function, so the improvement is a code fix, not a mode default.
+
+The whole 56 -> 29 drop is attributable to one shipped option: `--option
+truthycond off` reproduces the stored artifact exactly (60 n / 87 e, GED 56).
+DIV-36 turned `if ((a0 != (char *)0x0) && (*a0 == '\0'))` into
+`if ((a0) && (!*a0))`, which is the shape the source itself uses.
+
+### ida (stored, GED 0) — the entry block is whole
+
+```c
+FILE *save_output(char *a1, char *a2, char *a3)
+{
+  file = a1;
+  v5 = a2;
+  v4 = a3;                       // all three copies in the ENTRY block
+  v13 = __readfsqword(0x28u);
+  if ( a1 && !*a1 )
+    file = 0;
+  if ( a2 && !*a2 )
+    v5 = 0;
+  if ( a3 && !*a3 )
+    v4 = 0;
+  ...
+  while ( dword_DE648 > 0 )      // one loop, matches source
+  {
+    v9 = write(fd, buf, dword_DE648);
+    if ( v9 >= 0 ) { dword_DE648 -= v9; buf += v9; }
+    else if ( *__errno_location() != 11 && *__errno_location() != 4 ) break;
+  }
+  exit(0);
+```
+
+### kuna (fresh, today) — the entry block is split into three
+
+```c
+  v11 = *(void *)(v4 + 0x28);
+  v7 = a0;
+  if ((a0) && (!*a0))
+    v7 = NULL;
+  v6 = a1;                       // <-- sunk out of the entry block  (+1 CFG node)
+  if ((a1) && (!*a1))
+    v6 = NULL;
+  v5 = a2;                       // <-- sunk out of the entry block  (+1 CFG node)
+  if ((a2) && (!*a2))
+    v5 = NULL;
+  if (((!v7) && (!v6)) && (!v5))
+    return 0;
+  ...
+  do {
+    v1 = sub_4edb4(v3);          // source/ida: while (do_read(fds[0]) > 0) ;
+  } while (0 < v1);
+  ...
+  do {
+    while( true ) {              // "true" is an IDENTIFIER to joern  (+1 node)
+      if (dat_de648 <= 0) {
+        exit(0); // return-dupe, no-return   <-- taildup copy         (+1 node)
+      }
+      v1 = write(v8,v9,(int8)dat_de648);
+      if (v1 <= -1) break;
+      dat_de648 -= v1;
+      v9 += v1;
+    }
+  } while ((*(int4 *)__errno_location() == 0xb) || (*(int4 *)__errno_location() == 4));
+  exit(0);
+```
+
+Note the nested `do { while(true) ... } while(...)` is **not** a GED cost: the
+node-by-node mapping shows it is the same graph as the source's single
+`while (outbufsize > 0)` with a `continue`, just rendered with two loop
+keywords. Only the taildup'd `exit(0)` copy adds a node there.
+
+## Source
+
+`~/github/decbench/results/full_run/O0/e2fsprogs/compiled/logfile.i:10892`
+(e2fsprogs `e2fsck/logfile.c`), macros expanded:
+
+```c
+static FILE *save_output(const char *s0, const char *s1, const char *s2)
+{
+ int c, fd, fds[2];
+ char *cp;
+ pid_t pid;
+ FILE *ret;
+
+ if (s0 && *s0 == 0) s0 = 0;          /* no copies at all: s0/s1/s2 assigned in place */
+ if (s1 && *s1 == 0) s1 = 0;
+ if (s2 && *s2 == 0) s2 = 0;
+ if (!s0 && !s1 && !s2) return ((void *)0);
+ ...
+ close(fds[1]);
+ while (do_read(fds[0]) > 0) ;        /* empty-body while, call in the condition */
+ close(fds[0]);
+ fd = -1;
+ while (1) { ... }
+ cp = outbuf;
+ while (outbufsize > 0) {             /* ONE loop */
+  c = write(fd, cp, outbufsize);
+  if (c < 0) {
+   if ((errno == 11) || (errno == 4)) continue;
+   break;
+  }
+  outbufsize -= c;
+  cp += c;
+ }
+ exit(0);
+}
+```
+
+The three guards write **through** the parameter, so the source's entry block
+holds only the frame setup. In the binary the three spills are likewise all in
+the entry basic block:
+
+```
+4eec2: mov %rdi,-0x38(%rbp)
+4eec6: mov %rsi,-0x40(%rbp)     <- kuna prints this after the FIRST if
+4eeca: mov %rdx,-0x48(%rbp)     <- kuna prints this after the SECOND if
+4eece: mov %fs:0x28,%rax
+4eedd: cmpq $0x0,-0x38(%rbp)
+4eee2: je   4eef7               <- entry block ends here
+```
+
+## Analysis
+
+**The one structural symptom.** kuna splits the source's single entry basic
+block into three by emitting the parameter -> stack-slot copy shadows
+(`v6 = a1;`, `v5 = a2;`) at the tail of each guard's *join predecessor* instead
+of at the function entry where the spill instructions actually live. Measured
+cost: +2 CFG nodes, **GED 29 -> 17** when the two lines are textually hoisted
+back to the top (semantics-preserving: `a1`/`a2` are unmodified inputs and
+`v6`/`v5` are not read before). ida hoists all three and is isomorphic to
+source; ghidra sinks them exactly like kuna and scores 61.
+
+**Root cause / owning phase: P6 (variables — HighVariable merge).** The
+original spill stores are folded away in P3; P6's merge then has to trim a
+MULTIEQUAL input that cannot join the output's HighVariable, and the trim COPY
+is anchored at the *end of the phi's incoming predecessor block*. From
+`decompiler/crates/kuna-decomp/src/p6_variables/funcdata_merge.rs:840`
+(`trim_op_input_prep`, the `Merge::trimOpInput` port):
+
+```rust
+        let pc = if is_multiequal {
+            let parent = o.get_parent().expect("trim_op_input_prep: no parent");
+            let pred = self.bblocks_ref().block(parent).get_in(slot);
+            self.block_stop_addr(pred)          // <-- always the predecessor's tail
+        } else {
+            o.get_addr().clone()
+        };
+```
+
+`print raw` confirms it: the copy for `a1` is created *inside* block 3, the
+join after the first guard, not in block 0 where the spill was:
+
+```
+Basic Block 0 0x0004eeba-0x0004eee2
+0x0004eee2:8ce: u0x10000269(0x0004eee2:8ce) = RDI(i)            <- prints "v7 = a0;"
+Basic Block 3 0x0004eef7-0x0004eefc
+0x0004eef7:77c: s0xff..ffc0 = u0x10000269 ? u0x10000269 ? s0xff..ffc0   (phi for v7)
+0x0004eefc:8cc: u0x10000259(0x0004eefc:8cc) = RSI(i)            <- prints "v6 = a1;"
+```
+
+Because the trimmed input is a *function input* varnode (SSA-defined once, at
+entry, and provably unmodified along the dominator path), the predecessor tail
+is the most pessimistic legal anchor rather than the necessary one.
+
+**Why ida wins:** it emits the same three copies, but at the spill site, so
+they merge into the entry basic block and the CFG is isomorphic to source.
+
+**No option closes it.** Swept every P7/P8 structurer option
+(`regionstructure`, `regionlooprefine`, `regionedgeorder`, `condfold on|wide`,
+`gotoreduce`, `ifelseflatten`, `crossjumprevert`, `taildup`, `earlyreturn`,
+`returndup`, `loopbreak_recovery`, `branchflip`) — the emitted structure is
+invariant except for `taildup`.
+
+### The rest of the residual 29 (secondary, recorded so it is not re-mined)
+
+Textual ablations against the fresh block, each measured with the real GED:
+
+| divergence | Δnodes | GED | verdict |
+|---|---|---|---|
+| `v6 = a1;` / `v5 = a2;` sunk out of entry | +2 | 29 -> **17** | **real defect (above)** |
+| `while( true )` vs source `while (1)` | +2 | 29 -> 21 | **metric artifact** |
+| `do { v=sub_4edb4(x); } while (0<v)` vs `while (f(x) > 0) ;` | +2 | 29 -> 23 | mostly artifact |
+| taildup'd second `exit(0)` | +1 | 29 -> 24 | real, minor; `taildup off` gives 26 |
+| all three of the above together | -6 | 29 -> **7** | (better than binja's 8) |
+
+* `while( true )`: pyjoern parses bare `true` as an IDENTIFIER and gives the
+  loop header its own CFG block; `while (1)` folds into its predecessor. The
+  control flow is identical, and kuna's project export emits
+  `#include <stdbool.h>` (`infra/decompile_drive.rs:1032`), so the C is valid.
+  This is a decbench-harness penalty that hits **every** kuna and ghidra
+  function containing an unconditional loop — worth reporting upstream rather
+  than "fixing" in the printer.
+* the `do_read` loop: the source writes `while (do_read(fds[0]) > 0) ;` and
+  pyjoern loses the back edge of that empty-body while entirely (source block
+  30 has no self-edge). ida reproduces the same text and inherits the same
+  dropped edge; kuna's faithful `do {} while` is *penalised for being correct*.
+  Residual real content: kuna never folds a single-call loop body into the loop
+  condition. Low value, mostly artifact.
+* `taildup` duplicating a **no-return call** tail (`exit(0)`) rather than a
+  `return` tail is worth a look on its own — its documented gate is "return-call
+  tail", and duplicating an `exit()` costs a node against a source that reaches
+  one `exit(0)` from two paths.
+
+## Proposed fix
+
+**Feature `paramcopyhoist` (P6, default-off), new module
+`decompiler/crates/kuna-decomp/src/p6_variables/kuna_paramcopyhoist.rs`.**
+
+Mechanism: in `trim_op_input_prep`
+(`p6_variables/funcdata_merge.rs:838-849`), when the MULTIEQUAL input being
+trimmed is a function-input varnode (`isInput`) and the phi's predecessor block
+is strictly dominated by the entry block, anchor the trim COPY at the entry
+block's stop address (or, better, at the address of the original addr-tied
+spill store, which the varmap still knows) instead of `block_stop_addr(pred)`.
+`snip_reads`/`allocate_copy_trim` in `p6_variables/merge.rs:1825` already take
+a `(block, addr, after_op)` triple, so only the anchor computation changes.
+
+Owning files:
+- `decompiler/crates/kuna-decomp/src/p6_variables/kuna_paramcopyhoist.rs` (new: eligibility + anchor)
+- `decompiler/crates/kuna-decomp/src/p6_variables/funcdata_merge.rs` (`trim_op_input_prep` calls it)
+- `decompiler/crates/kuna-decomp/phases.toml` + `src/p0_knowledge/options.rs` (option row)
+- `docs/spec/` P6 chapter; `tests/stages/` two-pass testcase; catalog count bumps
+
+Risks:
+- **Cover widening is the whole point of the trim.** Hoisting the COPY extends
+  its output's cover from one block to the entry-to-phi dominator path, which
+  can re-introduce the HighVariable interference `Merge::trimOpInput` exists to
+  avoid. The eligibility test must re-run the intersection check on the widened
+  cover and decline on any conflict — that is the load-bearing part of the
+  feature, not the anchor change.
+- Statement placement shifts in many functions, so it must ship default-off
+  (byte-identical to upstream); default-on needs a 0/675 datatest flip plus a
+  decbench aggregate ablation, since sinking is upstream Ghidra behaviour and
+  some functions may read better sunk.
+- Payoff is bounded: -12 GED here, and the pattern (a parameter conditionally
+  overwritten by a guard, so its spill feeds a phi) is common at O0 but rare at
+  O2 where the spills are gone.
+
+**Nothing to fix** for `while( true )` (harness-side) or the `do_read` loop
+(source-side parse loss). `taildup`'s no-return-tail duplication is a separate,
+smaller ticket.


### PR DESCRIPTION
Docs only — 15 triage records plus `docs/decbench/features.md`, the go/no-go menu for round 1.
No change under `decompiler/**`.

## Method

16 mined cases (angr pool / ida pool / NOVEL pool), one agent each, **verify-first on today's
build**. Every `feature-candidate` verdict was then handed to a second agent whose brief was to
**refute** it — reproduce independently, check whether the reference decompiler is genuinely
better or merely truncated, check whether the "defect" is correct decompilation of what the
binary actually does, check for a scoring artifact, check whether an existing option already
covers it.

**11 survived · 1 refuted on diagnosis · 4 were not defects.**

The skeptic pass earned its keep. It killed one root cause outright, corrected the stale margin
on three more (the DIV-34…39 print-normalization wave means every recorded margin from the
2026-07-27 run is now an upper bound), and on two cases found the record had *understated* the
problem.

## The finding that reorders the campaign

**Nine of the eleven survivors have zero GED value**, and eight of them came from the two pools
that do not rank by margin at all — the NOVEL pool (kuna is already best of every production
decompiler and the output is still bad) and the recall pool (no output at all). The angr and ida
margin pools, which this campaign has mined for months, produced mostly small structuring gaps
plus one metric artifact.

Two survivors are kuna emitting **wrong code**, and neither is visible to a CFG edit distance:

1. `gnutls ocsptool port_to_service` — a value live across a merge point is dropped. kuna's C
   returns NULL where the binary returns `sport`. Proven executable, not argued: the real binary
   prints `99999`; kuna's transcribed output segfaults. Ghidra, IDA, angr, binja and phoenix are
   all correct on this function, so it is kuna-specific.
2. `mydoom msg_b64enc` / `openssh parse_dest_constraint` — kuna never registers a spacebase
   (stack) trial at a call site, so stack-passed arguments do not exist. **707 of 738 i386 call
   sites in `mydoom.exe` render with an empty argument list**, and the code computing those
   arguments is dead-code eliminated. Reproduced architecture-independently on x86-64 past the
   6th argument.

`docs/decbench/features.md` therefore ranks by **correctness first** and uses GED as a filter.
A campaign that optimizes only the metric it can see will ship a decompiler that scores well and
lies.

## Menu summary

- **Tier 0 — wrong code**: `p6-lost-restore` (P6), `stackargs`/`callsite-stack-args` (P4).
- **Tier 1 — not valid C** (strict bug fixes, no option): `spacebase-unnamed-location` (P9),
  `realtypes-pointee-size` (P9), `symbol-keyed-local-decls` (P9),
  `jumptable-callother-inject` (P2), `finalorder-entry-first` (P8 — `BlockGraph::orderBlocks()`
  is an explicit STUB, so a function body can be emitted starting at a mid-function label with
  the real entry after an unconditional `goto`).
- **Tier 2 — structure recovery** (moves the metric): `iteboolean`, `iteregion-merged-dest`,
  `paramcopyhoist`, `switchstagedindex`.
- **Not defects**: one already-fixed, two covered-by-option (`readonly`; `branchflip off`, which
  is a default question worth measuring), one metric artifact.

Where a skeptic refuted a record's *proposed mechanism* (`paramcopyhoist`, `switchstagedindex`),
the menu says so — those need re-derivation before anyone builds them.