### PR TITLE
[AUTOMATED] campaign(decbench): correct both Tier-0 root causes

### DIFF
--- a/docs/decbench/features.md
+++ b/docs/decbench/features.md
@@ -17,12 +17,25 @@ Two columns matter and they are not the same column:
 Ranking is by correctness first. A campaign that optimizes only the metric it can see will
 happily ship a decompiler that scores well and lies.
 
+**A triage record's *symptom* is evidence; its *diagnosis* is a hypothesis.** Both Tier-0 items
+were filed with root causes that a later agent, instrumenting rather than reading, disproved:
+
+- `callsitestackargs` was filed as "kuna never registers a spacebase trial". It does register
+  them — `tryregister` is true, `register_trial` and `op_insert_input` both run. They are
+  mis-scored one pass later by a single mis-ported argument.
+- `p6-lost-restore` (ptx) was filed as a P8 structuring gap and its record explicitly concluded
+  the merge was "cover-legal". It is neither: two P6 Cover extensions the port dropped.
+
+Both records also claimed DWARF hides the defect; both are wrong — the `-g` builds decompile
+correctly for a different reason. Treat every "root cause" line below as a starting point to
+disprove.
+
 ## Tier 0 — kuna emits WRONG CODE (fix regardless of benchmark value)
 
 | slug | phase | cases | what is wrong | GED | scope | status |
 |---|---|---|---|---|---|---|
 | **p6-lost-restore** | P6 | `O0-gnutls-ocsptool-port_to_service`, `O0-coreutils-ptx-output_one_dumb_line` | A value live across a merge point is lost or aliased. In `port_to_service` kuna hoists `v2 = a0` to the entry, clobbers it with the `getservbyport` result and never restores it, though the binary reloads `sport` at `0x114e8` — **kuna's C returns NULL where the binary returns a value**. Proven executable: the real binary prints `99999`, kuna's transcribed C segfaults. Ghidra, IDA, angr, binja and phoenix are all correct here. In `output_one_dumb_line` two distinct selects merge into one HighVariable, so the C subtracts 0 where the binary subtracts `truncation_string_length`. | 0 | investigating | agent running |
-| **stackargs** / **callsite-stack-args** | P4 | `O0-mydoom-mydoom-msg_b64enc`, `O2-noinline-openssh-portable-ssh-add-parse_dest_constraint` | kuna never registers a **spacebase (stack) trial** at a call site, so stack-passed arguments do not exist: calls print with arguments missing, and the code that computes them is dead-code eliminated. **707 of 738 i386 call sites in `mydoom.exe` render with an empty argument list**; reproduced architecture-independently on x86-64 past the 6th argument. Only bites call sites with an unlocked callee prototype (DWARF/`libproto` hide it). The callee side is correct, so the cspec and trial map are fine — it is the caller-relative→callee-frame translation that is missing. | small | proposal | queued |
+| **callsitestackargs** | P4 | `O0-mydoom-mydoom-msg_b64enc`, `O2-noinline-openssh-portable-ssh-add-parse_dest_constraint` | Stack-passed call arguments are discarded, so calls print with arguments missing and the code computing them is dead-code eliminated. **ONE MIS-PORTED ARGUMENT**: `check_input_trial_use` (`p4_calls/funcdata_callsite.rs:116`) hands the trial's **callee-relative** address to `FuncProto::get_local_range().in_range()`, where upstream (`fspec.cc:5618`) hands the argument Varnode's **caller-relative** address. `data.getFuncProto()` is the *caller's* prototype, so on a downward-growing stack the callee-relative offsets (always positive) can never fall in the negative caller-frame range: every stack trial at every unlocked call site scores `no-use`, its CALL input is replaced with constant `0`, and that feeds the producer to DCE. Corpus: `calls_ge7_args` **7 → 250**, i386 empty-argument-list fraction **42.5% → 2.5%**. Ablation: **0/675**. | small (one argument) | **implementing** |
 
 ## Tier 1 — emitted C is not valid C (strict bug fixes, no option)
 


### PR DESCRIPTION
Docs only. Follow-up to #222/#223.

Two implementation agents instrumented what the triage records had only read, and **disproved both filed root causes**. The menu now carries the measured ones, plus a standing note that a triage record's *symptom* is evidence while its *diagnosis* is a hypothesis.

## `callsitestackargs`

Filed as: *kuna never registers a spacebase (stack) trial at a call site.*

Measured: it does. The placeholder is created, `RuleLoadVarnode` resolves it, `stackoffset` is recovered, `tryregister` is **true**, and `register_trial` + `op_insert_input` both run. The trials exist.

The actual defect is **one mis-ported argument**. `check_input_trial_use` (`p4_calls/funcdata_callsite.rs:116`) hands the trial's **callee-relative** address to `FuncProto::get_local_range().in_range()`; upstream (`fspec.cc:5618`) hands the argument Varnode's **caller-relative** address. `data.getFuncProto()` is the *caller's* prototype, so on a downward-growing stack the callee-relative offsets — always positive — can never fall inside a negative caller-frame range. Every stack trial at every unlocked call site scores `no-use`; being *definitely* unused, its CALL input is replaced with constant `0`; that feeds the producer to dead-code elimination.

Three things confirm mis-port rather than deliberate simplification: the port comment records the wrong intent ("the *callee's* local range"), **kuna's own spec chapter already states the correct rule** ("the *caller's* local stack range") so the code contradicted its normative doc, and every other link in the chain is line-for-line faithful with no `STUB` and no `(kuna)` marker.

Corpus: `calls_ge7_args` **7 → 250**, i386 empty-argument-list fraction **42.5% → 2.5%** (mydoom O0: 58% → 1.8%). Ablation: **0/675**.

## `p6-lost-restore`

The ptx record explicitly concluded the over-merge was **"cover-legal"**. It is not — two `Cover` extensions upstream performs were dropped in the port, so a cover-based legality test passed on a Cover built too small.

## Both records also claimed DWARF hides the defect

Both are wrong; the `-g` builds decompile correctly for a different reason. For `callsitestackargs` the split is only half true — short-call metrics move by *exactly zero* with DWARF, but `calls_ge7_args` still nearly doubles, because DWARF locks only the prototypes it describes.