### PR TITLE
[AUTOMATED] docs(agents): record three parallel-worktree hazards

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -123,6 +123,19 @@ phases are **settable assertions/options** (`--option NAME VALUE`, discovered vi
   name methods after their C++ originals).
 - Don't commit build artifacts (`decompiler/target/`, `*.sla`).
 - Commit at milestones with descriptive messages.
+- **Never `git stash` when other agents may be working in sibling worktrees.** `refs/stash` is
+  a single stack shared by every worktree of the repo, so a concurrent `stash pop` can hand
+  your uncommitted work to another worktree — this has already happened. To A/B a pre-change
+  build, copy the file aside (`cp x.rs /tmp/…`) or build from a second checkout.
+- In a worktree, build with `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0
+  CARGO_PROFILE_TEST_DEBUG=0` and delete `decompiler/target/debug` when the workspace suite
+  finishes — the default debug profile costs ~20-30 GB per worktree and has filled this
+  machine's disk mid-run. Never `make specs` in a worktree; reuse the main tree's via
+  `KUNA_SPECS`/`SLEIGHHOME`.
+- Adding a `tests/stages/*.xml` also bumps a hard-coded corpus file count in
+  `decompiler/crates/kuna-base/src/xml.rs` and requires re-recording
+  `docs/baseline-stages.json`. Two such PRs in flight WILL conflict on both; resolve the count
+  to base + all merged, and re-record the baseline rather than hand-merging it.
 - Any time any public thing is created fully automatically, it should start with `[AUTOMATED]`. That goes for PRs, Issues (opening and responses). It should also be in the commit message, but can go outside of the tagline and more inside the extended part.
 
 ## Doc map (look up on demand — don't preload)


### PR DESCRIPTION
Docs only. Three traps this campaign hit for real while running six implementation agents in parallel worktrees.

**1. `git stash` is shared across worktrees.** `refs/stash` is a single stack for the whole repo, not per-worktree. An agent that stashed in order to A/B a pre-fix build popped **another agent's uncommitted WIP** into its own worktree (`p2_lift/jumptable.rs`, `p9_emit/coreaction_render.rs`, `substrate/funcdata_block.rs`). Nothing was lost — only because the agent noticed, recovered its own change by explicit SHA, and pushed the foreign one back labelled for recovery. The guidance is now: copy the file aside or use a second checkout.

**2. The debug profile costs 20-30 GB per worktree.** Two agents hit a 100%-full root filesystem and lost builds to ENOSPC. `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0` plus deleting `target/debug` after the workspace suite keeps a worktree around 200 MB instead.

**3. Adding a `tests/stages/*.xml` collides in two places at once** — the hard-coded corpus file count in `kuna-base/src/xml.rs` and `docs/baseline-stages.json`. Four PRs in this wave each added one; every pair conflicted. The count resolves to base + *all* merged (not either side), and the baseline must be **regenerated**, never hand-merged — a textually merged baseline looks fine in review and fails the gate.