### PR TITLE
[PROPOSAL] arm-entry-granularity: the ARM entry-recall gap is a discovery hole, not absorption

### DIFF
--- a/docs/decbench/recall-measurement.md
+++ b/docs/decbench/recall-measurement.md
@@ -80,6 +80,26 @@ tail-call get absorbed into the preceding function (`_usbd_standard_request_devi
 
 The remaining 35: 24 error records, 8 nearby-but-not-contained, 3 absent.
 
+> **Corrected 2026-08-01 by the follow-up investigation
+> ([`docs/features/arm-entry-granularity/`](../features/arm-entry-granularity/analysis.md)).**
+> The *count* holds — an independent address-based re-measurement on this build reproduces the
+> per-project distribution (libopencm3 136 and nuttx 87 exactly). The *mechanism* and the
+> *noise* claim above do not:
+>
+> - It is **not absorption**. Of 2,941 missed addresses, **1,896 sit past the end of the nearest
+>   kuna function and exactly 3 are strictly inside a kuna body**. The 24-byte median measures
+>   proximity, not containment. `devnull_read`/`devnull_write` and
+>   `_usbd_standard_request_device` are not merged into a neighbour — their bytes produce **no
+>   output at all**. This is missing decompilation, not a naming/boundary problem.
+> - The `NMI_Handler` / `PendSV_Handler` / `DebugMon_Handler` example is **not noise**: in
+>   cleanflight they are three *distinct* two-byte `bx lr` stubs at `0x803b060`/`0x803b062`/
+>   `0x803b064`, each with its own vector-table slot, and Ghidra, IDA, angr and Binary Ninja all
+>   recover all three. Real ground-truth noise is **3.4%** — 105 alias/ICF names on addresses
+>   already counted once.
+> - The dominant sub-class is not fall-through/tail-call but **code-pointer-referenced entries
+>   (57%, 1,402 of them decbench-measured)** that `aif::code_pointer_table_seeds` already finds
+>   and rejects on its frame-prologue and >2-instruction guards.
+
 ## Remaining error records
 
 240 pre-wave → **137** now, across the 191-binary sweep. The generic

--- a/docs/features/arm-entry-granularity/analysis.md
+++ b/docs/features/arm-entry-granularity/analysis.md
@@ -1,0 +1,244 @@
+# arm-entry-granularity — what the 2,026-function recall gap actually is
+
+`docs/decbench/recall-measurement.md` closed with one headline: **2,026 of the 2,061 live
+recall misses (98.3%) are function-entry granularity on embedded ARM** — "kuna emits a body
+for code *containing* the DWARF `low_pc` but does not start a function *at* it", median 24
+bytes from the containing kuna entry.
+
+That number is right. The mechanism sentence is wrong, and the difference decides the fix.
+
+All numbers below are re-measured on this build (HEAD `36641d35`) against the `stripped/`
+binaries decbench actually feeds the decompilers, with ground truth taken from the
+`compiled/` binary's DWARF. The full tables are in `rivals-vs-kuna.txt`.
+
+---
+
+## 1. First, the framing correction: kuna is winning this metric
+
+Entry recall over the whole ARM Cortex-M corpus (36,360 DWARF function addresses,
+8 projects x 3 optimisation levels):
+
+| | recovered | recall |
+|---|---|---|
+| angr | 34,295 | 95.3% |
+| **kuna** | **33,326** | **91.7%** |
+| ghidra | 29,530 | 81.2% |
+| binja | 29,364 | 80.8% |
+| ida | 17,632 | 76.1% |
+
+kuna is second of five and roughly 3,800 entries ahead of Ghidra. So "Ghidra and IDA recover
+these, name the analyzer and port it" is not the right frame: Ghidra finds only 1,859 of the
+2,941 addresses kuna misses, and misses several thousand kuna finds. The remaining gap is a
+*tail against angr*, not a deficit against Ghidra.
+
+## 2. The mechanism claim, tested: it is not absorption, it is a hole
+
+For every missed address, is it inside the ground-truth body of the nearest lower kuna entry?
+
+| | count |
+|---|---|
+| **dropped** — past the end of the nearest kuna function | **1,896** |
+| unknown extent — nearest kuna entry is a kuna-invented `sub_` | 1,040 |
+| **absorbed** — strictly inside a kuna body | **3** |
+
+Three. The 24-byte median distance is real, but it measures "there happens to be another kuna
+function nearby", not containment. Two witnesses, both from the recall doc's own example list:
+
+`nuttx` O2 `devnull_read` @ `0x8003aa0` (4 bytes: `movs r0,#0; bx lr`). The nearest kuna entry
+is `0x8003a8c`, whose real body ends at `0x8003a9e`:
+
+```c
+=== 0x8003a8c ===                       // the whole of kuna's output for this region
+void sub_8003a8c(void) {
+  sub_8004b24(); sub_8003acc();
+  sub_800db20(dat_8003b30,dat_8003b2c,0x1b6,0); // tail-call
+  return;
+}
+=== 0x8003aa8 ===                       // devnull_poll — the NEXT kuna entry
+```
+
+`devnull_read` and `devnull_write` are not absorbed into anything. Their eight bytes are
+simply **not decompiled**. Same for `libopencm3` O2 `cdcacm`: kuna emits `0x80016f4` and then
+`0x8001740`, and the whole of `0x80016b4`-`0x80016f4` — including
+`_usbd_standard_request_device` — produces no output at all.
+
+**Consequence for the campaign:** this is not a boundary/split problem that "only" costs a
+name. It is missing output, and it is worth exactly what the recall pool says it is.
+
+## 3. The sub-classes, counted
+
+2,941 missed addresses (the address-level pool; decbench counts names, see §5):
+
+| sub-class | n | share | measured by decbench | what reaches the entry |
+|---|---|---|---|---|
+| **pointer** | 1,671 | 56.8% | 1,402 | only a code-pointer word (vtable / fops struct / ISR table / literal pool) |
+| **tailcall** | 513 | 17.4% | 226 | only an unconditional `B` |
+| **called** | 297 | 10.1% | 146 | a direct `BL` — and kuna still has no entry |
+| **fallthrough** | 194 | 6.6% | 43 | only fall-through from the previous instruction |
+| **unreferenced** | 146 | 5.0% | 19 | nothing in the image |
+| **after-terminator** | 118 | 4.0% | 2 | nothing; previous instruction ends the flow |
+| condbranch | 2 | — | — | a conditional branch from outside |
+
+Two shape facts that decide the design:
+
+- **93.3% of the missed entries have no canonical Thumb frame prologue** (2,744 of 2,941).
+  Every existing kuna ARM discovery stage requires one.
+- **41% are tiny leaves** — ground-truth size <= 8 bytes (1,205; 852 of them pointer-referenced).
+  `movs r0,#0; bx lr`, `mov r0,r2; bx lr`, a bare `bx lr`. Every existing stage rejects a
+  routine of <= 2 instructions.
+
+## 4. Owning pass per sub-class, and why the evidence was rejected
+
+Discovery on a stripped Cortex-M image is
+`decompiler/crates/kuna-analysis/src/passes.rs::run_listing_consumers`, four stages feeding
+one recursive-descent walk (`src/listing/walk.rs`):
+
+| stage | code | what it seeds |
+|---|---|---|
+| 1 | `entry/mod.rs::full_pattern_starts` | Ghidra `<patternpairs>` epilogue-paired prologues |
+| 2 | `aif/mod.rs::raw_thumb_prologue_seeds` | raw `PUSH {..,lr}` / `PUSH.W {..,lr}` |
+| 3 | `aif/mod.rs::code_pointer_table_seeds` | code pointers whose target has a frame prologue |
+| 4 | `aif/mod.rs::run_aif` | fingerprint-matched gap starts |
+
+**pointer (56.8%) — evidence present, rejected by two predicates.** Stage 3 already scans every
+allocated section for Thumb code pointers and already finds these words. It then rejects them:
+`is_thumb_function_prologue` (the target must open with `PUSH`/`SUB SP`/`VPUSH`/`STMDB SP!`)
+and `check_valid_subroutine`'s `MIN_SUBROUTINE_INSNS = 3`. A 2-instruction leaf callback fails
+both. `devnull_read`'s pointer is in `.text`; `NMI_Handler`'s is at `.isr_vector+0x8`. Both are
+found and both are thrown away. The third guard, `listing.is_undefined(target)` ("never split a
+discovered function"), turns out to reject almost nothing here — see §2.
+
+**tailcall (17.4%) — the walk has no notion of a tail call.** `walk.rs` treats a CALL target as
+a new function and every other flow target as a same-function successor (lines 155-166). An
+unconditional `B` to a different function is therefore intra-function flow. In practice the
+branch source is usually itself inside the dark region, so nothing is emitted at all rather
+than being merged.
+
+**called (10.1%) — a second-order effect of unresolved switches.** These have a direct `BL`
+*and* a discovered caller (273 of 297). Worked example: betaflight O0
+`blackboxLogInflightAdjustmentEvent` @ `0x8031688` has 46 direct `BL`s, all from
+`applyStepAdjustment` @ `0x80316b4` — whose third instruction is `tbh [pc, r3, lsl #1]`. The
+walk records an indirect branch with no static successor (`walk.rs` module doc: "Indirect
+targets contribute NO static successor"), so every case body past the switch, and every `BL`
+in them, is never decoded. Ghidra, angr and Binary Ninja all recover this entry. The owning gap
+here is **jump-table resolution in the Listing tier**, not entry discovery.
+
+**fallthrough / after-terminator (10.6%)** — a static placed immediately after its neighbour,
+with no reference at all. Only a byte-pattern or a gap scan can find these; both are already
+tried and both reject on the prologue.
+
+**unreferenced (5.0%)** — 137 of 146 are found by some rival, 72 share an address with another
+DWARF name. Mostly compiler-runtime aliases (`__floatundidf`/`__aeabi_ul2d`).
+
+### Two incidental defects found on the way
+
+1. **The Cortex-M vector-table oracle silently no-ops on the four biggest contributors.**
+   `entry/mod.rs::cortexm_vector_table` requires the table's section to be `SHF_EXECINSTR` (or
+   inside an executable `PT_LOAD`), word[0] in `0x2000_0000..0x3FFF_FFFF`, and
+   `word[1] == e_entry`. Measured:
+
+   | project | `.isr_vector` | detected |
+   |---|---|---|
+   | chibios / riot-os / libopencm3 | inside `.text` / exec `.vectors` | yes |
+   | cleanflight | `A`-only section, SP word `0x1000fff0` (CCM RAM) | **no** |
+   | betaflight | `A`-only section at `0x20000000` (RAM-relocated table) | **no** |
+   | crazyflie | `A`-only section, reset word `0x08025239` != `e_entry` `0x080041c0` | **no** |
+   | nuttx | table at `.text+0`, `word[1] 0x0800122f` != `e_entry` `0x8000189` | **no** |
+
+   So `NMI_Handler` and friends have to be rediscovered by Stage 3, which then rejects them for
+   having no prologue. Widening the signature is small and independent of the main proposal.
+
+2. **AIF's accepted gap starts are never re-walked.** Stages 2 and 3 re-seed the walk and
+   rebuild the Listing; `run_aif` (`passes.rs:535`) emits its entries straight to the commit
+   stream, so their `BL` edges are never followed. Measured worth on its own: +39 entries over
+   9 binaries (+0.4pp). Real, tiny, and subsumed once the other seeds trigger a re-walk.
+
+## 5. How much is ground-truth noise
+
+Small, and not where the recall doc guessed.
+
+- **Alias / ICF surplus: 105 names, 3.4% of the name-based pool.** decbench counts names;
+  105 missed addresses carry more than one DWARF name (`__floatundidf`/`__aeabi_ul2d`,
+  `__gtdf2`/`__gedf2`, ...). Recovering one address scores all of them, so this inflates the
+  pool but is not unrecoverable.
+- The `NMI_Handler` / `PendSV_Handler` / `DebugMon_Handler` example in the recall doc **is not
+  the noise it was labelled**. In cleanflight they sit at `0x803b060`, `0x803b062`, `0x803b064`
+  — three *distinct* two-byte functions, each a real `bx lr` stub, each pointed at by its own
+  vector-table slot, and all three recovered by Ghidra, IDA, angr and Binary Ninja. They are
+  ordinary members of the pointer sub-class.
+- **309 misses (10.5%) no rival found either** — 176 tailcall, 104 pointer. This is the
+  genuinely hard residue; 102 of them are alias/ICF cases.
+
+Honest total that is *not* worth chasing: **~105 alias names plus, at most, the 309 nobody
+recovers** — call it 10-14% of the pool. The other ~86% is recoverable code.
+
+## 6. What Ghidra and IDA actually do
+
+The pointer sub-class in Ghidra is recovered by a **pair**: `ArmAnalyzer` (Processors/ARM,
+constant propagation) resolves `LDR Rx,[pc,#k]` literal-pool loads, sets `TMode` from the
+pointer's LSB and disassembles the target; then `OperandReferenceAnalyzer` ("Reference",
+default-on, option *Subroutine References* default true) calls `createFunctions()` on those
+disassembly targets (`OperandReferenceAnalyzer.java:508,614`). Notably its data-side sibling
+`DataOperandReferenceAnalyzer` overrides `createFunctions` to a no-op with the comment
+*"don't ever create a function from a data pointer"* — Ghidra creates these functions from
+**instruction operands**, not from a raw data scan, which is exactly the precision guard kuna
+would need.
+
+`docs/missing-ghidra-analyses.md` §6 currently classifies the whole `OperandReferenceAnalyzer`
+family as *"out-of-scope-at-tier ... function creation -> §4 (`s1-entry-disc`)"*. The function
+creation half is **not** subsumed by `s1-entry-disc`, and kuna's ported `operand_refs` only
+plants string-data facts. That row needs correcting; this document is the evidence.
+
+For the tailcall sub-class the closest Ghidra machinery is `CreateThunkFunctionCmd` /
+"Create Thunk Functions"; angr's `CFGFast` gets it from its job-based traversal, where a
+`b` to an address outside the current function's block set starts a new function.
+
+## 7. Does anything already shipped close it? No.
+
+`--mode aggressive`, `--option addrtable on`, `fast_funcdisc on`, `eh_frame_full on` and
+`operand_refs on` each recover **exactly zero** additional entries, on every binary tried
+(§7 of `rivals-vs-kuna.txt`). `aggressive` resolves to the same
+`listing`+`funcstart_patterns`+`aif` set the `decompile-all` driver already injects on ARM,
+so it is the baseline, not an improvement. The earlier "aggressive recovers zero of
+betaflight's residual 277" finding replicates and generalises. This is a **new-mechanism**
+question, not a default-flip question.
+
+## 8. What a fix is worth (measured, not estimated)
+
+A throw-away env-gated scratch build (reverted; not in this diff) with the Stage-3 guards
+removed (`p`) and a first-cut tail-call rule (`t`), both re-seeding the walk:
+
+| | ground truth | base | `p` | `t` | `apt` |
+|---|---|---|---|---|---|
+| 9 binaries | 9,802 | 8,926 (91.1%) | 9,520 (97.1%) | 9,092 (92.8%) | **9,722 (99.2%)** |
+
+**91% of the residual gap is reachable by relaxing predicates that already run.** On
+`msc.elf` the combined arm reaches 63/63.
+
+The cost is precision, and it is real. Of the new entries (7 binaries):
+
+| arm | new | ground truth | splits a real body | outside any DWARF body |
+|---|---|---|---|---|
+| `p` | 560 | 348 (62%) | 117 (21%) | 95 (17%) |
+| `t` | 384 | 149 (39%) | **213 (55%)** | 22 (6%) |
+| `tT` (stricter) | 222 | 120 (54%) | 84 (38%) | 18 (8%) |
+
+`p` at 62% precision unrefined is a workable starting point (the "outside any DWARF body" 17%
+is largely real newlib/compiler-rt code with no debug info, not error). `t` at 39-54% is not
+shippable as written: without a containment predicate it splits loop heads.
+
+Projected benchmark value, honestly bounded: 1,838 of the 2,941 misses are decbench-measured.
+At the `p`-arm's measured recall on the pointer sub-class this is worth roughly **1,100-1,400
+measured functions**, plus ~1,135 more u-boot functions of the same class the moment decbench
+PR #58 lifts the `.text` filter — but only if the precision work lands with it.
+
+## 9. Reproduction
+
+The tables every number here comes from are checked in as `rivals-vs-kuna.txt`. The one-line
+reproduction of the core claim:
+
+```bash
+kuna functions <stripped-arm-elf> --json \
+    --option listing on --option funcstart_patterns on --option aif on
+# compare the addresses against DW_AT_low_pc of the matching compiled/ binary
+```

--- a/docs/features/arm-entry-granularity/proposal.md
+++ b/docs/features/arm-entry-granularity/proposal.md
@@ -1,0 +1,145 @@
+# arm-entry-granularity — proposal
+
+**Size: LARGE.** Two new discovery mechanisms in the analysis tier, each needing its own
+precision work, plus two small independent repairs. Not one predicate, not one flag.
+
+**Recommendation: approve as a 4-PR sequence, in the order below. Ship every step
+default-OFF first; earn the default flips one at a time on measured precision.**
+
+The evidence is in `analysis.md`; the raw tables are in `rivals-vs-kuna.txt`. Headlines:
+
+- The gap is **2,941 addresses / 1,838 decbench-measured** on the ARM corpus. The code is
+  **not decompiled at all** (1,896 dropped vs 3 absorbed) — the recall doc's
+  "absorbed into the preceding function" framing does not survive measurement.
+- **57% is one sub-class**: entries reachable only through a code-pointer word, which
+  `code_pointer_table_seeds` *already finds* and then rejects on two precision predicates.
+- **No existing option closes any of it** — `aggressive`/`addrtable`/`fast_funcdisc`/
+  `eh_frame_full`/`operand_refs` each recover exactly 0.
+- A scratch build with the predicates relaxed reaches **99.2% entry recall (from 91.1%)** on
+  9 binaries — at 53-62% precision, which is the whole of the remaining work.
+
+---
+
+## The sequence
+
+### PR 1 — `cortexmvectors`: widen the Cortex-M vector-table signature (SMALL, do first)
+
+`entry/mod.rs::cortexm_vector_table` demands (a) the table's section is `SHF_EXECINSTR` or in
+an executable `PT_LOAD`, (b) `word[0]` in `0x2000_0000..=0x3FFF_FFFF`, (c) `word[1] == e_entry`.
+Measured against the corpus, **all four of the biggest miss contributors fail it**:
+cleanflight and betaflight because their `.isr_vector` is an `A`-only section whose stack word
+is `0x1000fff0` (STM32F4 CCM RAM, and betaflight's table is linked at `0x20000000` for runtime
+relocation); crazyflie and nuttx because their reset word legitimately differs from `e_entry`.
+
+Proposed signature, in the same "confirm, then harvest" shape:
+
+- allow any **allocated** section (the table is data the CPU reads; what must be executable is
+  what its slots point at, which `harvest_vector_words` already checks — the existing comment
+  at `entry/mod.rs:1098` already argues this, it just did not go far enough);
+- accept `word[0]` in any plausible SRAM window — add `0x1000_0000..=0x1FFF_FFFF` (CCM/TCM),
+  keep the existing `0x2000_0000..=0x3FFF_FFFF`;
+- replace `word[1] == e_entry` with `word[1]` is odd and in an executable section, and require
+  **N >= 3 consecutive conforming slots** so a coincidental two-word match cannot arm it.
+
+Worth on its own: it re-arms the Thumb region paint and the handler seeds on four projects.
+Independent of everything below. Gate: `cortexmvectors`, default-OFF until the corpus sweep
+shows no regression, then a DIV row.
+
+### PR 2 — `ptrentry`: pointer-referenced entries, with a real precision model (LARGE, the prize)
+
+`aif/mod.rs::code_pointer_table_seeds` already collects every 4-byte-aligned Thumb code pointer
+in every allocated section. Today it accepts a target only if it is in an undefined gap, opens
+with a stack-frame prologue, and disassembles into a >2-instruction valid subroutine. The
+second and third reject **1,632 of the 1,671** pointer-class misses; they are why
+`devnull_read` (`movs r0,#0; bx lr`) and `NMI_Handler` (`bx lr`) are dropped.
+
+Relaxing them naively gets 62% precision (348 of 560 new entries are ground truth, 117 split a
+real function). That is not shippable. The design work *is* the precision model, and the
+measurement says where it must come from — corroboration, not shape:
+
+1. **Table-run corroboration.** A pointer that is part of a run of >= 2 consecutive
+   code-pointer words at the same stride is a vtable / fops struct / ISR table; a lone word
+   that happens to look like a code pointer is usually a switch-table entry or a constant.
+   The 21% mid-body splits are dominated by `ldr pc,[pc,r]`-style switch tables, whose entries
+   point *into* a function — a run test plus "reject a target whose containing kuna function
+   also contains the pointer word" should remove most of them.
+2. **Terminating-routine validity, not length.** Replace `MIN_SUBROUTINE_INSNS = 3` on this
+   path with "reaches a clean RET / computed jump within N instructions, no undecodable byte,
+   no out-of-image flow" — the same walk, without the length floor. A 1-instruction `bx lr`
+   IS a valid Cortex-M handler.
+3. **Keep the frame-prologue signal as a tie-breaker, not a gate**: accept prologue-shaped
+   targets on a single pointer, require the run for prologue-less ones.
+4. **Re-seed the recursive-descent walk** with the accepted targets (as Stages 2 and 3 already
+   do), so their `BL` edges are followed. This is where the `called` sub-class partly comes
+   back for free.
+
+Ship as `--option ptrentry on|off`, default-OFF, tier `analysis-enablement`, wired the same way
+`funcstart_patterns`/`aif` are (commit-time gate + the `decompile-all` non-x86-64 injection).
+The default flip is a separate decision, taken on a corpus precision sweep, not on this PR.
+
+Acceptance target for the implementation: **>= 80% of new entries are ground truth and
+zero regression in already-recovered entries**, measured with the same harness as
+`rivals-vs-kuna.txt` §8.
+
+### PR 3 — `tailcallentry`: split at unconditional-branch targets (MEDIUM, needs a containment predicate)
+
+`walk.rs` makes a new function only at CALL targets; an unconditional `B` is same-function
+flow. 513 misses (226 measured) are reachable only that way.
+
+The naive rule ("target of an unconditional `B`, and the preceding instruction ends the flow")
+measures 39% precision — it splits rotated loop heads. Tightening "preceding instruction must
+RETURN" gets 54%. Neither is enough. A shippable version needs the containment fact the walk
+does not currently keep: **track each walked function's claimed instruction set, and split only
+when the branch source and the target belong to different claimed sets** (angr's `CFGFast`
+job model in miniature). That is a real change to `WalkState`, hence its own PR after PR 2.
+
+Ship as `--option tailcallentry on|off`, default-OFF.
+
+### PR 4 — Listing-tier `TBB`/`TBH` switch resolution (SEPARATE GAP, sequence last)
+
+The `called` sub-class (297 misses, 146 measured) is not an entry-discovery failure at all:
+these addresses have a direct `BL` from a *discovered* caller, but the call site sits past an
+unresolved Thumb table branch, so the walk never decodes it. Worked example in `analysis.md`
+§4. Resolving `TBB`/`TBH` (and `ldr pc,[pc,r,lsl#2]`) in the Listing walk is the fix; it also
+improves the Listing's coverage for every other consumer. Treat as its own investigation —
+the engine already has jump-table machinery (P2 + feedback) that the analysis tier does not
+reuse.
+
+## What is explicitly NOT proposed
+
+- **Re-walking AIF's accepted gap starts** as a standalone change. It is a one-line-shaped
+  omission (`passes.rs:535` emits `run_aif`'s entries without a re-walk, unlike Stages 2/3)
+  but it is worth **+39 entries over 9 binaries** and is subsumed by PR 2's re-seed. Fold it
+  into PR 2; do not spend a PR on it.
+- **Chasing the last 10-14%.** 105 of the missed names are alias/ICF surplus on an address
+  that is already counted, and 309 misses were recovered by no rival at all. Those are the
+  floor.
+- **Porting Ghidra's analyzer wholesale.** kuna already out-recalls Ghidra by ~3,800 entries on
+  this corpus. The useful import is the *shape* of Ghidra's precision guard — create functions
+  from **instruction operands** (`OperandReferenceAnalyzer`, *Subroutine References*), never
+  from a raw data-pointer scan (`DataOperandReferenceAnalyzer` overrides `createFunctions` to
+  nothing, explicitly) — not its analyzer list.
+
+## Risks
+
+- **Over-discovery is not free even when it does not split.** Extra `sub_` entries cost
+  decompile time on `decompile-all` and can confuse `decompile-project` output. Every step
+  must carry a speed measurement; PR 2 adds a second Listing rebuild.
+- **The benchmark is insensitive to precision.** decbench scores per ground-truth function, so
+  a false start costs nothing on GED and everything on real use. Precision must be gated on the
+  `splits-a-real-body` metric in `rivals-vs-kuna.txt` §8, not on GED.
+- **Every recovered entry is new emitted C**, so each step needs the full four gates plus a
+  two-pass `tests/stages/` case (option off = the function is absent; default/on = it is
+  emitted). Suggested first testcase: `nuttx` O2 `devnull_read` @ `0x8003aa0` — 4 bytes, one
+  pointer reference, currently zero output.
+
+## Open questions for the reviewer
+
+1. Should `ptrentry` be ARM-gated (like Stages 2/3) or run on every architecture? The
+   mechanism is arch-neutral; only the Thumb-LSB pointer test is ARM-specific. Recommend
+   ARM-first, generalise on evidence.
+2. Is the `decompile-all` non-x86-64 auto-injection (DIV-20's pattern) the right default
+   surface for `ptrentry`, or should it wait for an explicit `--mode aggressive`?
+3. PR 4 (`TBB`/`TBH`) overlaps the "jump-table post-typing refinement" row already tracked in
+   `docs/missing-ghidra-analyses.md` §7 as an engine-tier item. Confirm whether the
+   analysis-tier Listing should get its own resolver or consume the engine's.

--- a/docs/features/arm-entry-granularity/record.json
+++ b/docs/features/arm-entry-granularity/record.json
@@ -1,0 +1,171 @@
+{
+  "slug": "arm-entry-granularity",
+  "opportunity": "decbench:cases-missing pool; ARM Cortex-M entry granularity, 2026 functions",
+  "test_name": "O2-nuttx-nuttx-devnull_read",
+  "binary": "/home/mahaloz/github/decbench/results/full_run/O2/nuttx/stripped/nuttx",
+  "selector": "0x8003aa0",
+  "func_addr": "0x8003aa0",
+  "angr_version": null,
+  "option": null,
+  "flag": null,
+  "element_id": null,
+  "phase": "P1",
+  "subphase": "function-entry-discovery",
+  "tier": "analysis-enablement",
+  "change_kind": "new-discovery-mechanism",
+  "source_decompiler": "angr",
+  "inspiration": "decbench:cases-missing pool; ARM Cortex-M entry granularity, 2026 functions",
+  "scope": "proposal",
+  "proposal": true,
+  "default_on": false,
+  "default_on_recommended": false,
+  "ablation_changed": null,
+  "parity": null,
+  "root_cause_class": "unported-discovery-mechanism + over-tight precision predicate",
+  "owning_file": "decompiler/crates/kuna-analysis/src/analyzers/aif/mod.rs",
+  "owning_function": "code_pointer_table_seeds",
+  "upstream_anchor": "OperandReferenceAnalyzer.java:508,614 (createFunctions on Subroutine References); ArmAnalyzer.java:847 (doArmThumbDisassembly); DataOperandReferenceAnalyzer.java:39 (explicitly NOT from data pointers)",
+  "spec_chapter": "docs/spec/01-partition-and-listing.md",
+  "decisions": [
+    "MECHANISM CORRECTION to docs/decbench/recall-measurement.md: the gap is NOT 'kuna emits a body for code containing the low_pc'. Measured over 2,941 missed addresses, 1,896 sit PAST the end of the nearest kuna function and exactly 3 are strictly inside a kuna body. The code is not decompiled at all. The 24-byte median distance measures proximity, not containment. Two witnesses verified against emitted C: nuttx O2 devnull_read/devnull_write (8 bytes, zero output) and libopencm3 O2 cdcacm _usbd_standard_request_device (kuna emits 0x80016f4 then jumps to 0x8001740).",
+    "FRAMING CORRECTION: kuna is second of five on entry recall over this corpus (kuna 33,326/36,360 = 91.7%; angr 95.3%; ghidra 81.2%; binja 80.8%; ida 76.1%). Ghidra finds only 1,859 of the 2,941 addresses kuna misses. 'Port the Ghidra analyzer' is the wrong frame; the tail is against angr.",
+    "SUB-CLASS BREAKDOWN (address-based, 2,941; decbench-measured in parentheses): pointer 1,671 (1,402) / tailcall 513 (226) / called 297 (146) / fallthrough 194 (43) / unreferenced 146 (19) / after-terminator 118 (2) / condbranch 2 (0). The measured total 1,838 independently reproduces the recall doc's per-project distribution (libopencm3 136 exact, nuttx 87 exact, chibios 116 vs 115, riot-os 36 vs 33).",
+    "OWNING PASS, pointer class (57%): aif/mod.rs::code_pointer_table_seeds ALREADY collects every one of these pointer words and then rejects the target on is_thumb_function_prologue and check_valid_subroutine's MIN_SUBROUTINE_INSNS=3. Evidence present, rejected. 93.3% of missed entries have no canonical Thumb frame prologue and 41% are <=8-byte leaves (<=4 instructions), so both predicates are structurally wrong for this population. The third guard (listing.is_undefined, 'never split a discovered function') turns out to reject almost nothing, since the targets are in holes, not bodies.",
+    "OWNING PASS, tailcall class (17%): listing/walk.rs treats every non-CALL flow target as a same-function successor, so an unconditional B to another function is intra-function flow. There is no tail-call notion in the walk.",
+    "OWNING GAP, called class (10%): NOT entry discovery. 273 of 297 have a direct BL from a caller kuna DID discover; the call site sits past an unresolved Thumb TBB/TBH table branch, which walk.rs deliberately gives no static successor. Worked example: betaflight O0 blackboxLogInflightAdjustmentEvent @0x8031688 has 46 direct BLs, all from applyStepAdjustment @0x80316b4 whose third instruction is `tbh [pc, r3, lsl #1]`. Sequenced as its own investigation (Listing-tier jump-table resolution).",
+    "GROUND-TRUTH NOISE is 3.4% of the name-based pool: 105 alias/ICF surplus names (__floatundidf/__aeabi_ul2d, __gtdf2/__gedf2) on addresses already counted once. A further 309 misses (10.5%) were recovered by NO rival. Total not-worth-chasing: 10-14%.",
+    "The recall doc's cited noise example is WRONG. cleanflight's NMI_Handler/SVC_Handler/DebugMon_Handler are at 0x803b060/0x803b062/0x803b064 - three DISTINCT two-byte `bx lr` functions, each with its own vector-table slot, all four rivals recover all three. They are ordinary pointer-class misses, not one `b .` loop with three names.",
+    "INCIDENTAL DEFECT 1: entry/mod.rs::cortexm_vector_table silently no-ops on the four biggest contributors. cleanflight/betaflight fail the SHF_EXECINSTR/exec-PT_LOAD gate AND the 0x20000000-0x3FFFFFFF stack-word range (both use 0x1000fff0 CCM RAM; betaflight's table is linked at 0x20000000 for runtime relocation); crazyflie and nuttx fail word[1]==e_entry because their reset vector legitimately differs from the ELF entry. Only chibios/riot-os/libopencm3 arm the oracle.",
+    "INCIDENTAL DEFECT 2: run_aif's accepted gap starts are committed as entries but never re-seed the walk (passes.rs:535), unlike Stages 2 and 3 which rebuild the Listing. Measured worth alone: +39 entries over 9 binaries (+0.4pp). Fold into the pointer PR rather than spending a PR.",
+    "OPTION SWEEP: --mode aggressive, addrtable, fast_funcdisc, eh_frame_full and operand_refs each recover EXACTLY ZERO additional entries on every binary tried (msc, usart-stdio, chibios ch, nuttx, riot-os, crazyflie cf2, cleanflight, betaflight). aggressive resolves to the same listing+funcstart_patterns+aif set decompile-all already injects on ARM. The earlier betaflight-only 'aggressive recovers zero of 277' finding replicates and generalises. This is a new-mechanism question, not a default-flip question.",
+    "SIZING (scratch env-gated build, reverted, not in this diff): relaxing the Stage-3 guards (arm p) plus a first-cut tail-call rule (arm t), both re-seeding the walk, takes 9 binaries from 8,926/9,802 (91.1%) to 9,722/9,802 (99.2%) - 91% of the residual gap. Precision of the new entries over 7 binaries: p 62% ground truth / 21% splits a real body; t 39% / 55%; strict-t 54% / 38%. The precision model IS the remaining work.",
+    "VERDICT: PROPOSAL, 4-PR sequence. (1) cortexmvectors - widen the vector-table signature, SMALL, independent. (2) ptrentry - pointer-referenced entries with table-run corroboration + terminating-routine validity replacing the length floor, LARGE, the prize. (3) tailcallentry - needs WalkState to track per-function claimed instruction sets before it is shippable. (4) Listing-tier TBB/TBH resolution - a separate gap. All default-OFF first.",
+    "NOT a contained fix. The dominant class is two predicates in one function, which is tempting, but relaxing them unrefined splits a real function 21% of the time. Shipping that would trade 1,400 recovered functions for several hundred wrongly-split ones on a benchmark that scores per ground-truth function and therefore cannot see the damage."
+  ],
+  "measured": {
+    "corpus": {
+      "method": "kuna functions <stripped> --json --option listing on --option funcstart_patterns on --option aif on (reproduces decompile-all --mode reliable's entry set: betaflight O0 5798 vs 5797). Ground truth = DW_TAG_subprogram DW_AT_low_pc != 0 from the compiled/ counterpart, Thumb bit masked. Rival sets from the stored decbench decompiled/<tool>_<bin>.toml address= lines. 8 ARM projects x 3 opt levels, crazyflie/firmware.elf dropped as a byte-identical duplicate of cf2.elf.",
+      "ground_truth_addresses": 36360,
+      "entry_recall": {
+        "kuna": 33326,
+        "angr": 34295,
+        "ghidra": 29530,
+        "binja": 29364,
+        "ida": 17632
+      },
+      "misses_total": 2941,
+      "misses_decbench_measured": 1838,
+      "misses_by_subclass": {
+        "pointer": 1671,
+        "tailcall": 513,
+        "called": 297,
+        "fallthrough": 194,
+        "unreferenced": 146,
+        "after_terminator": 118,
+        "condbranch": 2
+      },
+      "misses_by_subclass_measured": {
+        "pointer": 1402,
+        "tailcall": 226,
+        "called": 146,
+        "fallthrough": 43,
+        "unreferenced": 19,
+        "after_terminator": 2
+      },
+      "misses_by_project": {
+        "betaflight": 942,
+        "crazyflie": 663,
+        "cleanflight": 457,
+        "libopencm3": 443,
+        "nuttx": 185,
+        "chibios": 167,
+        "riot-os": 59,
+        "freertos": 25
+      },
+      "absorbed_vs_dropped": {
+        "dropped_past_containing_function_end": 1896,
+        "unknown_extent": 1040,
+        "absorbed_inside_a_kuna_body": 3,
+        "no_containing_entry": 2
+      },
+      "noise": {
+        "name_based_pool": 3046,
+        "alias_or_icf_surplus_names": 105,
+        "misses_no_rival_found": 309
+      },
+      "shape": {
+        "canonical_thumb_frame_prologue_at_low_pc": 197,
+        "no_canonical_prologue": 2744,
+        "size_le_8_bytes": 1205,
+        "size_le_8_bytes_pointer_referenced": 852
+      },
+      "distance_to_nearest_lower_kuna_entry": {
+        "median": 28,
+        "p25": 10,
+        "p75": 72,
+        "within_64B_pct": 73
+      }
+    },
+    "option_ablation": {
+      "note": "hits = DWARF low_pc addresses recovered; baseline = listing+funcstart_patterns+aif",
+      "binaries": [
+        "O2/libopencm3/msc.elf",
+        "O2/libopencm3/usart-stdio.elf",
+        "O2/chibios/ch.elf",
+        "O2/nuttx/nuttx",
+        "O2-noinline/riot-os/hello-world.elf",
+        "O2/crazyflie/cf2.elf"
+      ],
+      "delta_vs_baseline": {
+        "aggressive": 0,
+        "addrtable": 0,
+        "fast_funcdisc": 0,
+        "eh_frame_full": 0,
+        "operand_refs": 0
+      },
+      "funcstart_patterns_off_cost": "6 to 490 entries per binary (the existing discovery is load-bearing and saturated)"
+    },
+    "scaffold_experiment": {
+      "note": "env-gated scratch build, REVERTED; not in this diff. Arms: a = re-seed the walk with AIF gap starts; p = code-pointer targets with the gap-only/frame-prologue/>2-instruction guards removed; t = unconditional-branch targets opening a block; T = stricter variant requiring the previous instruction to RETURN.",
+      "binaries": 9,
+      "ground_truth": 9802,
+      "hits": {
+        "base": 8926,
+        "a": 8965,
+        "p": 9520,
+        "t": 9092,
+        "apt": 9722
+      },
+      "recall_pct": {
+        "base": 91.1,
+        "a": 91.5,
+        "p": 97.1,
+        "t": 92.8,
+        "apt": 99.2
+      },
+      "precision_7_binaries": {
+        "p": {"new": 560, "ground_truth": 348, "splits_a_real_body": 117, "outside_any_dwarf_body": 95},
+        "t": {"new": 384, "ground_truth": 149, "splits_a_real_body": 213, "outside_any_dwarf_body": 22},
+        "tT": {"new": 222, "ground_truth": 120, "splits_a_real_body": 84, "outside_any_dwarf_body": 18},
+        "ptT": {"new": 778, "ground_truth": 468, "splits_a_real_body": 198, "outside_any_dwarf_body": 112}
+      }
+    },
+    "cortexm_vector_table_detection": {
+      "detected": ["chibios", "riot-os", "libopencm3"],
+      "not_detected": ["cleanflight", "betaflight", "crazyflie", "nuttx", "freertos"],
+      "reasons": {
+        "cleanflight": "A-only .isr_vector section; stack word 0x1000fff0 outside the 0x20000000-0x3FFFFFFF window",
+        "betaflight": "A-only .isr_vector linked at 0x20000000 (RAM-relocated); same CCM stack word",
+        "crazyflie": "A-only section; reset word 0x08025239 != e_entry 0x080041c0",
+        "nuttx": "table at .text+0; word[1] 0x0800122f != e_entry 0x8000189",
+        "freertos": "-ffunction-sections, no single vector section presenting the signature"
+      }
+    }
+  },
+  "ged_before": null,
+  "ged_after": null,
+  "speed_off_median_s": null,
+  "speed_on_median_s": null,
+  "speed_delta_pct": null,
+  "speed_forced_off": false
+}

--- a/docs/features/arm-entry-granularity/rivals-vs-kuna.txt
+++ b/docs/features/arm-entry-granularity/rivals-vs-kuna.txt
@@ -1,0 +1,157 @@
+arm-entry-granularity — the raw measured tables
+===============================================
+
+Method
+------
+Ground truth = every DW_TAG_subprogram with a non-zero DW_AT_low_pc in the
+`compiled/` binary (Thumb bit masked).  Recovered set = the function-entry
+addresses each decompiler reports for the `stripped/` binary decbench actually
+feeds them.  kuna's set is re-measured live on this build with
+
+    kuna functions <stripped> --json --option listing on \
+        --option funcstart_patterns on --option aif on
+
+which reproduces `kuna decompile-all --mode reliable`'s entry set exactly
+(betaflight O0: 5798 vs 5797, the one difference being the address-0 alias
+record).  The rival sets are read out of the stored decbench
+`decompiled/<tool>_<bin>.toml` per-function `address =` lines.
+
+Corpus: 8 ARM Cortex-M projects x 3 optimisation levels (crazyflie/firmware.elf
+dropped as a byte-identical duplicate of cf2.elf).
+
+
+1. Entry recall on the ARM corpus (addresses, all opt levels)
+------------------------------------------------------------
+    ground truth  36,360
+    kuna          33,326   91.7%
+    angr          34,295   95.3%   (of the 35,984 it was run on)
+    ghidra        29,530   81.2%
+    binja         29,364   80.8%
+    ida           17,632   76.1%   (of the 23,158 it was run on)
+
+kuna is second only to angr and ~4,000 entries ahead of Ghidra/Binary Ninja.
+This gap is a *tail*, not a deficit.
+
+
+2. The 2,941 missed addresses, by sub-class
+-------------------------------------------
+    pointer            1,671   56.8%   only a code-pointer word references it
+    tailcall             513   17.4%   only an unconditional B reaches it
+    called               297   10.1%   a direct BL reaches it, kuna still has no entry
+    fallthrough          194    6.6%   only fall-through from the previous instruction
+    unreferenced         146    5.0%   nothing in the image points at it
+    after-terminator     118    4.0%   no reference; previous instruction is terminal
+    condbranch             2    0.1%
+
+    by project: betaflight 942, crazyflie 663, cleanflight 457, libopencm3 443,
+                nuttx 185, chibios 167, riot-os 59, freertos 25
+
+
+3. Intersection with decbench's measured set
+--------------------------------------------
+A miss is *measured* when at least one non-LLM rival has decompiled: true for
+that name in the run's function_results.json.
+
+    measured        1,838
+    not measured    1,103
+
+    measured, by sub-class:  pointer 1,402 · tailcall 226 · called 146 ·
+                             fallthrough 43 · unreferenced 19 · after-terminator 2
+    measured, by project:    betaflight 779 · cleanflight 370 · crazyflie 310 ·
+                             libopencm3 136 · chibios 116 · nuttx 87 ·
+                             riot-os 36 · freertos 4
+
+This independently reproduces `docs/decbench/recall-measurement.md`'s
+per-project distribution (it reports libopencm3 136, nuttx 87, chibios 115,
+riot-os 33 against 136 / 87 / 116 / 36 here).
+
+
+4. Absorbed vs dropped  (the campaign's mechanism claim, tested)
+---------------------------------------------------------------
+For each miss, is the address inside the ground-truth body of the nearest lower
+kuna entry (absorbed), or past that function's end (dropped)?
+
+    dropped (past the containing function's end)   1,896
+    unknown extent (nearest kuna entry is a
+        kuna-invented sub_, no ground truth)       1,040
+    absorbed (strictly inside a kuna body)             3
+    no containing entry                                2
+
+    per sub-class (dropped / unknown):
+      pointer            1054 / 615
+      tailcall            479 /  34
+      called               90 / 207
+      fallthrough          92 / 102
+      unreferenced         80 /  63   (+3 absorbed)
+      after-terminator    101 /  17
+
+
+5. Ground-truth noise
+---------------------
+    address-based misses                                     2,941
+    name-based pool (what decbench counts)                   3,046
+    alias / ICF surplus (extra names on one low_pc)            105   3.4%
+    misses whose low_pc carries more than one DWARF name        105
+    misses no rival found either                               309
+
+
+6. Prologue shape of the missed entries
+---------------------------------------
+    canonical Thumb frame prologue at the missed low_pc   197   6.7%
+    no canonical prologue                               2,744  93.3%
+
+    tiny leaf functions (ground-truth size <= 8 bytes)    1,205  41%
+      of which pointer-referenced                           852
+
+
+7. Option ablation — does anything already shipped close it?
+------------------------------------------------------------
+baseline = listing + funcstart_patterns + aif (what decompile-all injects on ARM)
+
+O2/libopencm3/msc.elf           gt=63   base 51 | aggressive 51 | +addrtable 51 | +fast_funcdisc 51 | +eh_frame_full 51 | +operand_refs 51
+O2/libopencm3/usart-stdio.elf   gt=138  base 103 | aggressive 103 | +addrtable 103 | +fast_funcdisc 103 | +eh_frame_full 103 | +operand_refs 103
+O2/chibios/ch.elf               gt=323  base 273 | aggressive 273 | +addrtable 273 | +fast_funcdisc 273 | +eh_frame_full 273 | +operand_refs 273
+O2/nuttx/nuttx                  gt=691  base 611 | aggressive 611 | +addrtable 611 | +fast_funcdisc 611 | +eh_frame_full 611 | +operand_refs 611
+O2-noinline/riot-os/hello.elf   gt=151  base 128 | aggressive 128 | +addrtable 128 | +fast_funcdisc 128 | +eh_frame_full 128 | +operand_refs 128
+O2/crazyflie/cf2.elf            gt=1421 base 1293 | aggressive 1293 | +addrtable 1293 | +fast_funcdisc 1293 | +eh_frame_full 1293 | +operand_refs 1293
+
+Zero.  `--mode aggressive` is exactly the baseline on ARM (both resolve to
+listing+funcstart_patterns+aif), and addrtable / fast_funcdisc / eh_frame_full /
+operand_refs each add exactly 0 entries on every binary tried.  Removing
+funcstart_patterns instead costs 6-490 entries per binary, so the existing
+discovery is load-bearing and saturated.
+
+
+8. Scaffold experiment — what a relaxed predicate would recover
+--------------------------------------------------------------
+Env-gated scratch build (reverted; not in this diff).  Arms:
+  a = re-seed the recursive-descent walk with AIF's accepted gap starts
+  p = code-pointer targets with the gap-only + frame-prologue + >2-instruction
+      guards of `code_pointer_table_seeds` removed
+  t = unconditional-branch targets that open a block (previous instruction ends
+      the flow); T = the stricter variant, previous instruction must RETURN
+
+  binary                            gt    base     a      p      t     apt
+  O2/libopencm3/msc.elf             63      51    51     58     56      63
+  O2/libopencm3/usart-stdio.elf    138     103   103    107    112     116
+  O2/chibios/ch.elf                323     273   274    310    284     321
+  O2-noinline/chibios/ch.elf       654     539   540    580    610     651
+  O2/nuttx/nuttx                   691     611   612    664    630     684
+  O2-noinline/riot-os/hello.elf    151     128   128    130    144     146
+  O2/crazyflie/cf2.elf            1421    1293  1296   1387   1316    1412
+  O0/cleanflight/…F405.elf        2193    2056  2067   2169   2059    2183
+  O0/betaflight/…F405.elf         4168    3872  3894   4115   3881    4146
+  TOTAL                           9802    8926  8965   9520   9092    9722
+                                          91.1% 91.5%  97.1%  92.8%   99.2%
+
+Precision of the NEW entries (7 binaries, ground truth from symtab sizes):
+
+  arm   new    is ground truth   splits a real body   outside any DWARF body
+  p     560    348 (62%)         117 (21%)             95 (17%)
+  t     384    149 (39%)         213 (55%)             22 ( 6%)
+  tT    222    120 (54%)          84 (38%)             18 ( 8%)
+  ptT   778    468 (60%)         198 (25%)            112 (14%)
+
+The `a` arm is worth ~0.4pp on its own and is subsumed once p/t re-seed the walk.
+`p` is the high-value, tunable arm; `t` needs a real containment predicate before
+it is shippable.

--- a/docs/missing-ghidra-analyses.md
+++ b/docs/missing-ghidra-analyses.md
@@ -195,6 +195,19 @@ need the disassembled Listing + ReferenceManager, neither of which exists at thi
 references never reach kuna's decompiler (it reads loadimage bytes + the symbol/type tables,
 not the ReferenceManager). Their products are already covered: strings → `s1-strings`
 (disabled, this section), address/switch tables → §7, function creation → §4 (`s1-entry-disc`).
+
+> **Correction (2026-08-01):** the "function creation → §4" half of that sentence is **wrong**,
+> and it is now the largest measured recall gap. `OperandReferenceAnalyzer`'s *Subroutine
+> References* option (default-on upstream) calls `createFunctions()` on the code targets it
+> resolves out of instruction operands (`OperandReferenceAnalyzer.java:508,614`); on ARM those
+> targets come from `ArmAnalyzer`'s constant propagation over `LDR Rx,[pc,#k]` literal-pool
+> loads. `s1-entry-disc` does **not** subsume this: it and the AIF stages require a canonical
+> frame prologue and a >2-instruction body, which 93% of the affected entries do not have.
+> Measured cost: **1,671 missed function entries on the ARM Cortex-M corpus, 1,402 of them
+> decbench-measured**. See [`features/arm-entry-granularity/`](features/arm-entry-granularity/analysis.md).
+> Note the precision guard Ghidra ships with it: its data-side sibling
+> `DataOperandReferenceAnalyzer` overrides `createFunctions` to a no-op — *"don't ever create a
+> function from a data pointer"*.
 `ScalarOperandAnalyzer` is even default-OFF for ELF upstream, and `ElfScalarOperandAnalyzer`
 only *removes* bad `.got`/`.plt` references (which `elf_plt.rs` already names correctly). The
 one relevant idea — typing a scalar that points at a `.rodata` string as `char*` — is blocked


### PR DESCRIPTION
**[PROPOSAL] — investigation only. No code in this diff. Do not merge until approved; approval re-dispatches implementation on this branch.**

`docs/decbench/recall-measurement.md` closed with one headline: **2,026 of the 2,061 live recall misses (98.3%) are function-entry granularity on embedded ARM** — "kuna emits a body for code *containing* the DWARF `low_pc` but does not start a function *at* it", median 24 bytes away.

The count holds. The mechanism sentence does not, and the difference decides the fix.

## The correction that matters

**It is not absorption — it is a hole.** For every missed address, is it inside the ground-truth body of the nearest lower kuna entry?

| | count |
|---|---|
| **dropped** — past the end of the nearest kuna function | **1,896** |
| unknown extent (nearest kuna entry is a kuna-invented `sub_`) | 1,040 |
| **absorbed** — strictly inside a kuna body | **3** |

Three. `nuttx` O2 `devnull_read`/`devnull_write` (8 bytes total) and `libopencm3` O2 `cdcacm` `_usbd_standard_request_device` are not merged into a neighbour — they produce **no output at all**. kuna emits `0x8003a8c`, then `0x8003aa8`; the four bytes in between are never decompiled. This is missing decompilation, not a naming or boundary problem, and it is worth exactly what the recall pool says.

## Framing: kuna is second of five here

Entry recall over 36,360 DWARF function addresses (8 ARM Cortex-M projects × 3 opt levels), re-measured live on this build against the *stripped* binaries decbench actually feeds:

| | recovered | recall |
|---|---|---|
| angr | 34,295 | 95.3% |
| **kuna** | **33,326** | **91.7%** |
| ghidra | 29,530 | 81.2% |
| binja | 29,364 | 80.8% |
| ida | 17,632 | 76.1% |

Ghidra finds only 1,859 of the 2,941 addresses kuna misses. "Name the Ghidra analyzer and port it" is the wrong frame — this is a tail against angr.

## Sub-classes, counts, and the owning pass

| sub-class | n | decbench-measured | owning pass | why the evidence was rejected |
|---|---|---|---|---|
| **pointer** | 1,671 | 1,402 | `aif::code_pointer_table_seeds` | finds the pointer word, then rejects on `is_thumb_function_prologue` + `MIN_SUBROUTINE_INSNS = 3` |
| **tailcall** | 513 | 226 | `listing/walk.rs` | the walk has no tail-call notion — every non-CALL flow target is a same-function successor |
| **called** | 297 | 146 | *not entry discovery* | 273/297 have a discovered caller; the call site sits past an unresolved Thumb `TBB`/`TBH` |
| **fallthrough** | 194 | 43 | Stages 1–2 | no reference at all, and no canonical prologue |
| **unreferenced** | 146 | 19 | — | mostly compiler-runtime aliases |
| **after-terminator** | 118 | 2 | Stages 1–2 | same |

Two shape facts decide the design: **93.3% of missed entries have no canonical Thumb frame prologue**, and **41% are ≤ 8-byte leaves** (`movs r0,#0; bx lr`, a bare `bx lr`). Every existing ARM discovery stage requires a prologue and rejects routines of ≤ 2 instructions.

Worked example for the `called` class: betaflight O0 `blackboxLogInflightAdjustmentEvent` @ `0x8031688` has **46 direct `BL`s**, all from `applyStepAdjustment` @ `0x80316b4` — whose third instruction is `tbh [pc, r3, lsl #1]`. The walk gives an indirect branch no static successor, so every case body past the switch, and every `BL` in it, is never decoded.

## Ground-truth noise: 3.4%, and the cited example is not it

`NMI_Handler` / `PendSV_Handler` / `DebugMon_Handler` were labelled "three DWARF symbols on one `b .` loop". In cleanflight they are at `0x803b060`, `0x803b062`, `0x803b064` — three **distinct** two-byte `bx lr` stubs, each with its own vector-table slot, and Ghidra, IDA, angr and Binary Ninja all recover all three. They are ordinary pointer-class misses.

Real noise: **105 alias/ICF surplus names** (`__floatundidf`/`__aeabi_ul2d`, …) on addresses already counted once — 3.4% of the name-based pool. A further 309 misses (10.5%) were recovered by no rival at all. Not worth chasing: **10–14%**.

## No existing option closes any of it

`--mode aggressive`, `addrtable`, `fast_funcdisc`, `eh_frame_full`, `operand_refs` each recover **exactly 0** additional entries, on every binary tried. `aggressive` resolves to the same `listing`+`funcstart_patterns`+`aif` set the `decompile-all` driver already injects on ARM, so it *is* the baseline. The earlier "aggressive recovers zero of betaflight's residual 277" replicates and generalises. Removing `funcstart_patterns` instead costs 6–490 entries per binary — the existing discovery is load-bearing and saturated.

## What a fix is worth (measured on a reverted scratch build)

| | ground truth | base | pointer-relax | tail-call | both + re-walk |
|---|---|---|---|---|---|
| 9 binaries | 9,802 | 8,926 (91.1%) | 9,520 (97.1%) | 9,092 (92.8%) | **9,722 (99.2%)** |

**91% of the residual gap is reachable by relaxing predicates that already run** — and the cost is precision, which is the whole of the remaining work:

| arm | new entries | ground truth | splits a real body | outside any DWARF body |
|---|---|---|---|---|
| pointer-relax | 560 | 348 (62%) | 117 (21%) | 95 (17%) |
| tail-call | 384 | 149 (39%) | **213 (55%)** | 22 (6%) |
| tail-call, stricter | 222 | 120 (54%) | 84 (38%) | 18 (8%) |

decbench scores per ground-truth function, so a false start costs nothing on GED and everything in real use. Shipping the naive relaxation would trade ~1,400 recovered functions for several hundred wrongly-split ones that the benchmark cannot see.

## Verdict: PROPOSAL, 4-PR sequence, all default-OFF first

1. **`cortexmvectors`** (SMALL, independent) — widen the Cortex-M vector-table signature. It silently no-ops on the four biggest contributors today: cleanflight/betaflight fail the `SHF_EXECINSTR` gate *and* the SRAM window (stack word `0x1000fff0`, CCM RAM; betaflight's table is linked at `0x20000000` for runtime relocation); crazyflie and nuttx fail `word[1] == e_entry` because their reset vector legitimately differs from the ELF entry.
2. **`ptrentry`** (LARGE, the prize) — pointer-referenced entries, with table-run corroboration and a terminating-routine validity check replacing the length floor. Acceptance target: ≥ 80% of new entries are ground truth, zero regression.
3. **`tailcallentry`** (MEDIUM) — needs `WalkState` to track per-function claimed instruction sets first; without containment it splits rotated loop heads.
4. **Listing-tier `TBB`/`TBH` resolution** — a separate gap, sequenced last.

Explicitly *not* proposed: a standalone PR for re-walking AIF's gap starts (`passes.rs:535` omits the re-seed Stages 2/3 do) — real, but worth +39 entries over 9 binaries and subsumed by PR 2.

## Also in this diff

Corrections to the two docs this contradicts: the mechanism paragraph in `docs/decbench/recall-measurement.md`, and `docs/missing-ghidra-analyses.md` §6's claim that `OperandReferenceAnalyzer`'s function creation is "subsumed by `s1-entry-disc`" — it is not, and that is the 1,671-entry gap. (Ghidra creates these from **instruction operands**; its data-side sibling `DataOperandReferenceAnalyzer` overrides `createFunctions` to a no-op — *"don't ever create a function from a data pointer"* — which is the precision guard kuna would need.)

Bundle: `docs/features/arm-entry-granularity/` — `analysis.md` (the map), `proposal.md` (the sequence), `rivals-vs-kuna.txt` (every raw table), `record.json`.

Gates: `make check-spec` green. No code changed, so the parity/workspace gates are structurally unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RXVU58TKJxb518oViChwo
