### PR TITLE
[AUTOMATED] ci: release nightly instead of on every push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,30 @@
 name: Release binaries
 
 # Builds the user-facing binaries (kuna + its engine siblings decomp_dbg and
-# slacomp) for Linux, macOS, and Windows on every push to main, then tags the
-# commit vMAJOR.MINOR and publishes a GitHub Release with the archives plus a
-# platform-independent compiled SLEIGH spec tree (the engine needs .sla files
-# at runtime). The version scheme -- VERSION file = MAJOR, commits since it
-# last changed = MINOR -- lives in scripts/version.sh and docs/release.md.
+# slacomp) for Linux, macOS, and Windows, then tags the commit vMAJOR.MINOR and
+# publishes a GitHub Release with the archives plus a platform-independent
+# compiled SLEIGH spec tree (the engine needs .sla files at runtime). The
+# version scheme -- VERSION file = MAJOR, commits since it last changed = MINOR
+# -- lives in scripts/version.sh and docs/release.md.
+#
+# Cadence: ONE release a night, batching whatever landed that day, not one per
+# merge. A busy day used to publish ~18 releases and ~18 tags.
+#
+# No "did anything change?" guard is needed, because the minor version IS the
+# commit count: a nightly run on an unchanged main computes the same MAJOR.MINOR,
+# the `version` job sees that tag already exists, and build/specs/release all
+# skip. Quiet days cost one 30-second job and publish nothing.
 
 on:
+  # Nightly, 06:00 UTC (~02:00 America/New_York) -- after the day's merges.
+  schedule:
+    - cron: "0 6 * * *"
+  # A MAJOR bump is an intentional milestone, so release it the moment it lands
+  # instead of waiting for the night's run.
   push:
     branches: [main]
-  # Allow a manual (re-)release from the Actions tab.
+    paths: [VERSION]
+  # Cut a release on demand from the Actions tab (also re-runs a failed one).
   workflow_dispatch:
 
 # `gh release create` pushes the tag and the release.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,7 +1,7 @@
 # Versioning & binary releases
 
 How kuna versions itself and how the binary release CI
-(`.github/workflows/release.yml`) turns every commit on `main` into a tagged
+(`.github/workflows/release.yml`) turns a day's work on `main` into a tagged
 GitHub Release.
 
 ## The version scheme: MAJOR.MINOR
@@ -18,8 +18,10 @@ Consequences worth knowing:
 
 - A commit that edits `VERSION` is itself version `MAJOR.0` — bumping the major
   resets the minor.
-- The minor number can skip values as seen in releases only if a release run is
-  ever skipped/failed; the numbering itself is gap-free per commit.
+- **Released minor numbers skip, by design.** The minor is gap-free *per commit*,
+  but releases are nightly and batch a whole day, so a night that merged eight
+  PRs jumps the published version by eight. `v1.89` following `v1.81` is the
+  system working, not a failed run.
 - Merge strategy matters: a squash-merge bumps the minor by 1 per PR; a merge
   or rebase of N commits bumps it by N.
 
@@ -42,11 +44,31 @@ version.
 
 ## The release workflow
 
-`.github/workflows/release.yml`, on every push to `main` (plus manual
-`workflow_dispatch`):
+### When it runs
+
+**One release a night, batching the day's merges** — not one per push. Three
+triggers:
+
+| Trigger | When | Why |
+|---|---|---|
+| `schedule` | 06:00 UTC daily (~02:00 America/New_York) | The normal path. Whatever landed that day ships together. |
+| `push` to `main`, `paths: [VERSION]` | A MAJOR bump lands | A major is an intentional milestone; it should not wait for the night. |
+| `workflow_dispatch` | On demand, Actions tab | Cut a release now, or re-run a failed one. |
+
+There is deliberately **no "has anything changed?" guard**, because the version
+scheme already is one: the minor *is* the commit count, so a nightly run on an
+unchanged `main` recomputes the same `MAJOR.MINOR`, the `version` job finds that
+tag already published, and every downstream job skips. A quiet day costs one
+~30-second job and publishes nothing.
+
+Before this, every push to `main` released: one busy day produced **18 releases
+and 18 tags**.
+
+### The jobs
 
 1. **version** — computes `MAJOR.MINOR` from a full-history checkout and skips
-   the whole run if tag `vMAJOR.MINOR` already exists (safe re-runs).
+   the whole run if tag `vMAJOR.MINOR` already exists (safe re-runs, and the
+   no-op guard above).
 2. **build** (matrix) — `cargo build --release` of `kuna-cli`, `kuna-console`,
    and `kuna-slacomp` for:
    - Linux `x86_64-unknown-linux-gnu`


### PR DESCRIPTION
Today merged 18 PRs and so cut **18 releases and 18 tags** (v1.72 → v1.89). At that rate the release feed stops carrying information.

## The change

| Trigger | When | Why |
|---|---|---|
| `schedule` | 06:00 UTC daily (~02:00 America/New_York) | The normal path — the day's merges ship together. |
| `push` to `main`, `paths: [VERSION]` | A MAJOR bump lands | An intentional milestone shouldn't wait for the night. |
| `workflow_dispatch` | On demand | Cut one now, or re-run a failed one. |

## No new guard was needed — the version scheme already is one

I did not add a "has anything changed?" check, because the minor version **is** the commit count. A nightly run on an unchanged `main` recomputes the same `MAJOR.MINOR`, the `version` job's existing `git ls-remote --exit-code --tags` check sees the tag already published, and `build`/`specs`/`release` all skip (they are gated on `exists == 'false'`, and `release` needs both). **A quiet day costs one ~30-second job and publishes nothing.**

## The one visible consequence

Published minor numbers now **skip** — a night that merged eight PRs jumps the version by eight, e.g. `v1.81` → `v1.89`. `docs/release.md` previously described skipping as something that happens only when a run is skipped or failed; it is now the normal case, so the doc says so plainly. The numbering remains gap-free *per commit*; only the *published* set is sparse.

Release notes need no change — `gh release create --generate-notes` already enumerates everything since the previous tag, which is exactly the batch.

## Alternatives considered

- **Threshold ("release after N commits")** — rejected: it delays releases in quiet periods, which is the opposite of the goal, and makes cadence unpredictable.
- **Tag-only nightly, build on demand** — rejected: it splits the tag from its artifacts, and the whole point of the tag is that binaries exist for it.