### PR TITLE
[AUTOMATED] campaign(decbench): round-2 triage — 9 tracks, verify-first, adversarially refuted

### DIFF
--- a/docs/decbench/triage/O0-bash-bash-shell_initialize.md
+++ b/docs/decbench/triage/O0-bash-bash-shell_initialize.md
@@ -1,0 +1,261 @@
+---
+case_id: O0-bash-bash-shell_initialize
+pool: ida
+group_id: bash::shell_initialize
+status: feature-candidate
+tier: L
+margin: 105
+fresh_verdict: reproduces on today's build in BOTH modes (no-flag/auto and --mode reliable are byte-identical here); the function has three *structurally identical* `x = a||b||c||d;` call arguments and `iteboolean` re-rolls exactly ONE of them, leaving two explicit `if (...) x=1; else {x=0;}` diamonds where IDA and the source have one statement
+option_closing: null
+feature_slug: itecondlist
+scope: small
+confidence: high
+---
+
+## Side-by-side
+
+Only the residual region is shown; the rest of the pane matches IDA
+statement-for-statement (fresh kuna 6 `if`s vs IDA 4; the delta is exactly the two
+un-re-rolled diamonds).
+
+**IDA (stored)** — three identical boolean assignments:
+
+```c
+  v2 = privileged_mode || restricted || is_restricted || dword_172330;
+  initialize_shell_variables(shell_environment, v2);
+  ...
+  v3 = privileged_mode || restricted || is_restricted || dword_172330;
+  initialize_shell_options(v3);
+  v4 = privileged_mode || restricted || is_restricted || dword_172330;
+  initialize_bashopts(v4);
+```
+
+**kuna (fresh, today's build, no flags)** — one re-rolled, two not:
+
+```c
+  v1 = shell_is_restricted(shell_name);
+  if (((privileged_mode) || (restricted)) || ((v1 || (dat_172330))))   // NOT re-rolled
+    v4 = 1;
+  else {
+    v4 = 0;
+  }
+  initialize_shell_variables(shell_environment,v4);
+  initialize_job_control(jobs_m_flag);
+  initialize_bash_input();
+  initialize_flags();
+  v2 = (((privileged_mode) || (restricted)) || ((v1 || (dat_172330))));   // re-rolled
+  initialize_shell_options(v2);
+  if (((privileged_mode) || (restricted)) || ((v1 || (dat_172330))))   // NOT re-rolled
+    v2 = 1;
+  else {
+    v2 = 0;
+  }
+  initialize_bashopts(v2);
+```
+
+Header says it plainly: `// warn: iteboolean: re-rolled 1 0/1 select diamond(s)`.
+
+`--mode reliable` (the option surface the benchmark measured) produces the identical
+text, so this is a live code gap, not a mode artifact.
+
+**Option sweep** (all re-run on the stripped binary at `0x34684`): `condfold on`,
+`condfold wide`, `iteexpr on`, `iteregion off`, `branchflip off`, `gotoreduce off`,
+`taildup off`, `dedupitetail off`, `crossjumprevert off`, `ifelseflatten off`,
+`truthycond off`, `braceelide off`, `returndup off`, `earlyreturn off`,
+`foldcallret off`, `condexeplace off`, `loopbreak_recovery off` — **none** changes the
+count. `regionstructure off` changes *which* diamond is re-rolled (2 instead of 1, and
+a different two), which is the first clue.
+
+## Source
+
+`~/github/decbench/results/full_run/O0/bash/compiled/shell.i`:
+
+```c
+  should_be_restricted = shell_is_restricted (shell_name);
+  initialize_shell_variables (shell_environment,
+       privileged_mode||restricted||should_be_restricted||running_setuid);
+  initialize_job_control (jobs_m_flag);
+  initialize_bash_input ();
+  initialize_flags ();
+  initialize_shell_options (privileged_mode||restricted||should_be_restricted||running_setuid);
+  initialize_bashopts     (privileged_mode||restricted||should_be_restricted||running_setuid);
+```
+
+Three occurrences of the identical 4-clause `||` chain, all in argument position.
+The correct shape is one boolean expression per call — which is what `iteboolean`
+(PR #241) exists to produce and what it produces for exactly one of the three.
+
+## Analysis
+
+### Symptom (one, named)
+
+**In a run of consecutive assignment diamonds, the P8 diamond matcher declines every
+other one.** The declined diamonds stay as `if (c) x = 1; else { x = 0; }` — 3 extra
+CFG blocks and 4 extra edges each against both the source and IDA.
+
+### Reduction: a 3-line reproducer
+
+`gcc -O0 -shared -fPIC`, decompiled with today's `kuna decompile`:
+
+```c
+int a,b,c,d;
+void g(void); void f1(int);void f2(int);void f3(int);
+void t(void){ g(); f1(a||b||c||d); g(); f2(a||b||c||d); g(); f3(a||b||c||d); }
+```
+
+```
+void t(void) // warn: iteboolean: re-rolled 2 0/1 select diamond(s) ...
+  v1 = (((*dat_3ff0) || (*dat_3fc0)) || ((*dat_3fd8 || (*dat_3fe8))));
+  f1(v1);
+  g();
+  if (((*dat_3ff0) || (*dat_3fc0)) || ((*dat_3fd8 || (*dat_3fe8))))   <-- declined
+    v1 = 1;
+  else { v1 = 0; }
+  f2(v1);
+  g();
+  v1 = (((*dat_3ff0) || (*dat_3fc0)) || ((*dat_3fd8 || (*dat_3fe8))));
+  f3(v1);
+```
+
+Scaling N (same generator): re-rolled = 1, 1, 2, 2, 3, 3 for N = 1…6 — **strict
+even-index decline**. The raw CFG (`decomp_dbg` → `print raw`) is a perfectly
+symmetric chain of three identical diamonds (blocks 4/5→6, 10/11→12, 16/17→18), so
+nothing distinguishes them before structuring.
+
+### The defect is NOT in `iteboolean` — it is in the shared matcher
+
+`iteregion` (P8, default-on, DIV-17, a *different* pass with a *different* mark)
+shows the identical alternation on a plain ternary chain:
+
+```c
+int a,p,q; void g(void); void f1(int);void f2(int);void f3(int);
+void t(void){ int x; g(); if(a) x=p; else x=q; f1(x);
+                     g(); if(a) x=p; else x=q; f2(x);
+                     g(); if(a) x=p; else x=q; f3(x); }
+```
+```
+void t(void) // ternary x2
+  v1 = (*dat_3fe8) ? *dat_3fc8 : *dat_3ff0;
+  ...
+  if (*dat_3fe8)          <-- declined
+    v1 = *dat_3fc8;
+  else { v1 = *dat_3ff0; }
+  ...
+  v1 = (*dat_3fe8) ? *dat_3fc8 : *dat_3ff0;
+```
+
+Both passes share `match_*`'s preconditions and the leaf helpers in
+`p8_structure/kuna_iteregion.rs` (`leaf_bblock`, `printed_ops`, `same_storage`), so
+the failing predicate is in the shared half, not in `iteboolean`'s `BlockCondition`
+requirement. It is also independent of the structurer: `--option regionstructure off`
+alternates too (it just alternates on a different phase).
+
+### The trigger, isolated
+
+Three one-diamond probes, identical except for what precedes the diamond:
+
+| probe | preceding code | ternary fires? |
+|---|---|---|
+| `v_pre_str` | `g(); h();` (straight-line, same basic block) | **yes** |
+| `v_pre_loop` | `while(b) g();` | **yes** |
+| `v_pre_if` | `if(a) g();` | **no** |
+| `v_pre_if2` | `if(a) g(); h();` | **no** |
+| `v_pre_ifelse` | `if(a) g(); else h();` | **no** |
+| `v_tight` | a preceding *diamond*, nothing between | **no** (2nd declines) |
+
+So: **an immediately preceding structured `if` statement suppresses the rewrite of
+the very next diamond.** A chain of diamonds is exactly that situation repeated,
+which produces the parity.
+
+That is the signature of `leaf_bblock` (`kuna_iteregion.rs:232`) declining a
+multi-component list:
+
+```rust
+BlockType::Ls | BlockType::Graph => {
+    if blk.get_size() != 1 { return None; }   // <-- declines a 2+ component list
+    leaf_bblock(data, blk.get_block(0))
+}
+```
+
+When the preceding `if` collapses first, the block-concatenation rule folds it
+together with the following condition block into a `BlockList` of two components,
+and that list becomes component 0 of the next `BlockIf`. `iteregion`'s `cond_cbranch`
+and `iteboolean`'s `cond_terminal_cbranch` both bottom out in `leaf_bblock`, get
+`None`, and decline — even though the printer renders that same list perfectly well
+(the leading component is printed as a statement and the trailing block's CBRANCH
+becomes the `if` header; you can see it in `v_tight`, where diamond 1's ternary is
+printed on the line *above* diamond 2's `if`).
+
+Two honest caveats, both worth re-deriving at fix time rather than trusting:
+
+1. I could not print the `sblocks` tree to read the node types directly —
+   **`print tree block` and `structure blocks` in `decomp_dbg` are unported stubs**
+   (`engine integration not yet ported: Funcdata::printBlockTree`). That is itself a
+   tooling gap for P8 work. The list-shape conclusion is inferred from the
+   preceding-statement probe table plus the printed nesting, not read off the tree.
+2. The exact parity in longer chains (why diamond 3 recovers) depends on collapse
+   bookkeeping I did not instrument. It does not change the symptom or the owning
+   predicate.
+
+### Owning phase
+
+**P8** — Structured AST & Goto Quality (`decompiler/crates/kuna-decomp/src/p8_structure/`).
+
+### Breadth
+
+`kuna decompile-all --json` over four O0 corpus binaries (2,444 emitted functions),
+counting residual `if (c) V = A; else { V = B; }` diamonds:
+
+| binary | fns | residual 0/1 diamonds | in fns | residual any-arm diamonds | in fns | `iteboolean` successes |
+|---|---|---|---|---|---|---|
+| coreutils `ls` | 617 | 3 | 3 | 34 | 14 | 26 |
+| diffutils `diff` | 532 | 32 | 14 | 62 | 23 | 24 |
+| gzip `gzip` | 263 | 0 | 0 | 0 | 0 | 2 |
+| openssh `ssh-add` | 1032 | 6 | 6 | 16 | 15 | 1 |
+| **total** | **2444** | **41** | **23** | **112** | **52** | **53** |
+
+41 residual 0/1 diamonds against 53 successful re-rolls: **kuna leaves behind roughly
+as many as it fixes.** The wider `any-arm` count (112 in 52 functions) is the
+`iteregion` half of the same predicate.
+
+### Siblings
+
+`O2-noinline-bash-bash-shell_initialize` (margin 72) does **not** show this: at -O2
+gcc computes the boolean without a materialization diamond and kuna prints
+`initialize_shell_options(((privileged_mode || restricted) || dat_1409d4) || v1);`
+directly. The defect is an -O0 shape, which is where it matters most (the corpus is
+one third -O0 and -O0 materializes booleans everywhere).
+
+## Proposed fix
+
+**Slug `itecondlist`, P8, one module** —
+`decompiler/crates/kuna-decomp/src/p8_structure/kuna_iteregion.rs`.
+
+Mechanism: in the **condition position only**, let the matcher descend a
+multi-component `Ls`/`Graph` to its **last** component and take that as the condition
+leaf. Concretely, add a `cond_leaf_bblock` next to `leaf_bblock` that on
+`BlockType::Ls | BlockType::Graph` recurses into `get_block(size-1)` instead of
+bailing, and call it from `cond_cbranch` (`kuna_iteregion.rs:260`) and
+`cond_terminal_cbranch` (`kuna_iteboolean.rs:265`). The **arms** keep the strict
+`leaf_bblock` (an arm must remain a single statement — that is what makes the
+rewrite sound). `iteboolean`'s `BlockType::Condition` requirement then applies to
+that same tail node.
+
+Why this is safe: the printer already emits the leading components of the list as
+ordinary statements *before* the `if` header — the shape is visible in `v_tight`
+above — so folding only the tail changes nothing about what precedes it. It is the
+same tolerance `cond_cbranch` already documents for leading statements *inside* one
+basic block ("Leading statements are allowed … the printer emits them normally
+before the ternary"); this is that same rule spelled across a block boundary.
+
+Guards to keep: `f_unstructured_targ` on the descended leaf (a labelled goto target
+must still decline), and `printed_ops(...).last()` must still be the CBRANCH.
+
+Gating: `iteregion`/`iteboolean` are already option-gated and default-on, and this is
+a widening of an existing matcher, not new behaviour — but it *does* change emitted C,
+so it needs its own named option per the standing rules, plus a two-pass
+`tests/stages/` testcase built from the `v_tight` reproducer (option off = the second
+diamond stays an `if/else`, default = both fold), and the usual datatest ablation.
+
+Risk: the shipped `iteregion`/`iteboolean` ablations are 0/675; widening the match set
+can move that, so the ablation has to be re-measured before any default-on claim.

--- a/docs/decbench/triage/O0-betaflight-betaflight_STM32F405-mavlinkSendRCChannelsAndRSSI.md
+++ b/docs/decbench/triage/O0-betaflight-betaflight_STM32F405-mavlinkSendRCChannelsAndRSSI.md
@@ -1,0 +1,258 @@
+---
+case_id: O0-betaflight-betaflight_STM32F405-mavlinkSendRCChannelsAndRSSI
+pool: angr
+group_id: betaflight::mavlinkSendRCChannelsAndRSSI
+status: feature-candidate
+tier: M
+margin: 66
+fresh_verdict: half the margin is already paid — today's build recovers all 13 call arguments and the 8 assignment diamonds the run-era output had deleted (GED 66 -> 24, measured). The whole residual 24 is that the source's EIGHT identical `?:` ternaries render as `if/else`: kuna's own `iteregion`/`iteexpr` matcher re-rolls only 2 of the 8, and which 2 depends on the *neighbouring* structure, not on the diamond.
+option_closing: null
+feature_slug: itecondlist
+scope: small
+confidence: high
+---
+
+## Verify-first
+
+```
+$ ~/.virtualenvs/decbench/bin/python -m scripts.decbench.rescore \
+      --case O0-betaflight-betaflight_STM32F405-mavlinkSendRCChannelsAndRSSI --siblings
+ "ged_recorded": 66.0, "ged_before": 66.0, "ged_after": 24.0, "ged_delta": -42.0,
+ "ged_kuna_commit": "9623dc27"
+ siblings: O2-noinline-...-mavlinkSendRCChannelsAndRSSI  before 24.0  after 24.0
+```
+
+`before` reproduces `recorded` exactly, so there is **no metric drift on this case** — the
+42-point move is a kuna code change (the round-1 `callsitestackargs` fix; the run-era pane
+below had every stack-passed argument deleted).
+
+`betaflight_STM32F405.elf` is 533,396 B, i.e. just over the 500 KiB `auto` threshold, so a
+no-flag run today is **`reliable`** — the same option surface the benchmark measured.
+`--mode aggressive` (which carries `iteexpr on`) recovers 2 of the 8 ternaries; nothing
+else in the catalog moves it.
+
+## Side-by-side
+
+Source (`mavlink.i`) — eight identical ternaries, one per RC channel:
+
+```c
+void mavlinkSendRCChannelsAndRSSI(void)
+{
+    uint16_t msgLength;
+    mavlink_msg_rc_channels_raw_pack(0, 200, &mavMsg, millis(), 0,
+        (rxRuntimeState.channelCount >= 1) ? rcData[0] : 0,
+        (rxRuntimeState.channelCount >= 2) ? rcData[1] : 0,
+        ... (8 in total) ...
+        scaleRange(getRssi(), 0, 1023, 0, 254));
+    msgLength = mavlink_msg_to_send_buffer(mavBuffer, &mavMsg);
+    mavlinkSerialWrite(mavBuffer, msgLength);
+}
+```
+
+angr (stored, GED 0) — all eight as ternaries, inline in the call:
+
+```c
+    sub_805c3c7(0, 200, &g_20013b98, v1, 0, v2,
+        (g_2000fbd2 <= 1 ? 0 : g_2000fc3c & 0xffff),
+        (g_2000fbd2 <= 2 ? 0 : g_2000fc40 & 0xffff), ... , v3);
+```
+
+kuna (stored, run-time, GED 66) — the arguments and every diamond are **gone**:
+
+```c
+void mavlinkSendRCChannelsAndRSSI(void)
+{
+  unsigned int v1; // r0
+  v1 = sub_8023ef8();
+  sub_8016f30(sub_803e1c0(),0,0x3ff);
+  sub_805c3c6(0,200,dat_805c9c4,v1);
+  sub_805c650(dat_805c9c0,sub_805c3a0(dat_805c9c0,dat_805c9c4));
+  return;
+}
+```
+
+kuna (fresh, `--mode aggressive`, GED 24) — arguments recovered; 2 of 8 diamonds re-rolled:
+
+```c
+  v2 = sub_8023ef8();
+  v1 = *(uint1 *)(dat_805c9b8 + 2);
+  if (v1) // branch-flip
+    v11 = (uint4)(0.0 < *dat_805c9bc) * (int4)*dat_805c9bc & 0xffff;
+  else {
+    v11 = 0;
+  }
+  if (2 <= v1) // branch-flip
+    v4 = (uint4)(0.0 < dat_805c9bc[1]) * (int4)dat_805c9bc[1] & 0xffff;
+  else {
+    v4 = 0;
+  }
+  v5 = (3 <= v1) ? (uint4)(0.0 < dat_805c9bc[2]) * (int4)dat_805c9bc[2] & 0xffff : 0;   <- re-rolled
+  if (4 <= v1) ... else { v6 = 0; }
+  v7 = (5 <= v1) ? ... : 0;                                                            <- re-rolled
+  if (6 <= v1) ... else { v8 = 0; }
+  if (7 <= v1) ... else { v9 = 0; }
+  if (8 <= v1) ... else { v10 = 0; }
+  v3 = sub_803e1c0();
+  sub_805c3c6(0,200,dat_805c9c4,v2,0,v11,v4,v5,v6,v7,v8,v9,v10,sub_8016f30(v3,0,0x3ff,0,0xfe));
+```
+
+## The symptom, isolated
+
+Eight structurally identical diamonds; two are re-rolled and six are not. That is an
+internal inconsistency, not a judgement call. Minimal x86-64 repro (`gcc -O0 -c`):
+
+```c
+extern int sinkn(int,int,int,int,int,int,int,int);
+extern int cnt;
+int repron(void){ return sinkn((cnt>=1)?7:0, (cnt>=2)?8:0, ... (cnt>=8)?14:0); }
+```
+
+```
+$ kuna decompile rep8.o repron              # default-ON iteregion, plain COPY arms
+void repron(void) // ternary x4
+  v6 = (8 <= dat_402000) ? 0xe : 0;         <- re-rolled
+  if (7 <= dat_402000) v5 = 0xd; else { v5 = 0; }
+  v7 = (6 <= dat_402000) ? 0xc : 0;         <- re-rolled
+  if (5 <= dat_402000) v8 = 0xb; else { v8 = 0; }
+  ...                                        (exactly every other one)
+```
+
+Sweeping N = 1..8 diamonds gives `ternaries = ceil(N/2)` every time:
+
+```
+N=1 ternaries=1 ifs=0     N=5 ternaries=3 ifs=2
+N=2 ternaries=1 ifs=1     N=6 ternaries=3 ifs=3
+N=3 ternaries=2 ifs=1     N=7 ternaries=4 ifs=3
+N=4 ternaries=2 ifs=2     N=8 ternaries=4 ifs=4
+```
+
+It is not the diamond. `print raw` shows all eight p-code diamonds are byte-for-byte the
+same shape — condition block ending in `CBRANCH`, each arm a single `COPY` of a constant
+**to the same register**, joined by a `MULTIEQUAL`:
+
+```
+Basic Block 3  0x00400021:fe: R8(...) = R8(0x00400013:13) ? R8(0x0040001b:ae)   <- MULTIEQUAL
+               0x0040002a:22: u0x00025f00:1 = #0x7:4 <= r0x00402000:4(i)
+               0x0040002a:23: goto Block_5 if (...) else Block_4
+Basic Block 4  0x00400033:ad: RDI(...) = #0x0            [ goto Block_6 ]
+Basic Block 5  0x0040002c:24: RDI(...) = #0xd             goto Block_6
+Basic Block 6  0x00400038:f9: RDI(...) = RDI(...) ? RDI(...)
+```
+
+(the failing `RDI` diamond and the matching `R8` one differ in nothing), and the P7 region
+tree is a clean right-leaning chain of 3-node regions, one per diamond. Nor is it any other
+pass — ablating `regionlooprefine`, `gotoreduce`, `ifelseflatten`, `crossjumprevert`,
+`taildup`, `dedupitetail`, `iteboolean`, `returndup`, `earlyreturn`, `branchflip`,
+`loopbreak_recovery`, `condfold on|wide` all leave 4/8 (`regionstructure off` gives 5/8 —
+a *different* structurer, a different split, still not 8).
+
+And it is positional, not content-based:
+
+```
+# diamonds separated by opaque calls -> still every other one (2 of 4)
+# a plain `if (cnt==5) barrier();` placed BEFORE the chain -> the parity flips:
+#   the first diamond now fails and the remaining three all re-roll (3 of 4)
+```
+
+## Analysis — root cause (P8)
+
+Everything the matcher tests *about the diamond* is identical across all eight, so the
+declining predicate has to be the one that depends on the diamond's **neighbours**: the
+condition component.
+
+`p8_structure/kuna_iteregion.rs::match_ite_assignment` requires the `BlockIf`'s component 0
+to be a single leaf:
+
+```rust
+let cbranch = cond_cbranch(data, cond_block)?;   // -> leaf_bblock(data, id)?
+...
+pub(crate) fn leaf_bblock(data: &Funcdata, id: BlockId) -> Option<BlockId> {
+    match blk.get_type() {
+        BlockType::Basic => Some(id),
+        BlockType::Copy  => { ...; blk.get_copy() }
+        BlockType::Ls | BlockType::Graph => {
+            if blk.get_size() != 1 { return None; }     // <-- declines a real list
+            leaf_bblock(data, blk.get_block(0))
+        }
+        _ => None,
+    }
+}
+```
+
+In a chain of diamonds the collapse structurer folds the preceding structured `if` and the
+next diamond's condition basic block into **one multi-component `BlockList`** before
+`structureIf` runs, so the next `BlockIf`'s component 0 is a 2-component `Ls` and
+`leaf_bblock` returns `None`. That is the only predicate in the matcher whose value can
+change when a neighbour changes, and it is exactly what makes the miss alternate and makes
+the parity flip when an unrelated `if` is prepended.
+
+The **printer already handles this shape** — both `emit_block_if` and the ternary path
+`emit_block_if_ite` emit `emit_block(cond_block)` once under `NO_BRANCH` (leading
+statements) and once under `ONLY_BRANCH` (the condition), and `emit_block_ls` under
+`ONLY_BRANCH` emits *only the last component*:
+
+```rust
+fn emit_block_ls(...) {
+    if self.context.is_set(modifiers::ONLY_BRANCH) {
+        if let Some(&last) = list.last() { self.emit_block(fd, arch, last); }
+        return;
+    }
+```
+
+So the render is already correct for a list condition; only the *matcher* refuses. The
+sibling pass `kuna_iteboolean.rs` already generalises past `leaf_bblock` in exactly this
+spirit (`cond_terminal_cbranch` descends a `BlockType::Condition` tree to its terminal
+`CBRANCH`) — it just never learned about `Ls`.
+
+Owning phase: **P8** (structured AST & goto quality), module
+`decompiler/crates/kuna-decomp/src/p8_structure/kuna_iteregion.rs`.
+
+**Instrumentation gap found on the way**: kuna cannot dump its own P8 structured tree —
+`print tree block`, `print C xml` and `structure blocks` are all
+`Err(engine_unavailable(...))` stubs (`kuna-console/src/ifacedecomp.rs:2416, 2134, 3576`).
+The list shape above is therefore established by elimination + the printer's own handling
+of it, not by reading the tree. **The implementer's first step should be a throwaway
+`eprintln!` of `blk.get_block(0)`'s type/size in `match_ite_assignment` to confirm `Ls(2)`
+before writing the fix** — and un-stubbing `print tree block` is worth its own small PR.
+
+## Breadth
+
+`if (c) V = A; else { V = B; }` with the same `V` — a diamond kuna already knows how to
+render as a ternary and declined — counted over whole-binary `decompile-all` on each
+binary's shipped default mode (the regex only catches the braceelided shape, so these are
+lower bounds):
+
+| binary | arch / default mode | fns | missed diamonds | in fns | ternaries recovered |
+|---|---|---|---|---|---|
+| `betaflight_STM32F405.elf` | ARM / reliable | 5795 | **615** | 403 | 312 |
+| `crazyflie cf2.elf` | ARM / aggressive | 2790 | **113** | 90 | 116 |
+| `iproute2 ip` | x86-64 / reliable | 1962 | **112** | 84 | 172 |
+| `coreutils ls` | x86-64 / aggressive | 617 | **81** | 45 | 77 |
+| `coreutils sort` | x86-64 / aggressive | 506 | **31** | 26 | 22 |
+| **total** | | 11670 | **952** | **648** | 699 |
+
+kuna declines ~58% of the diamonds it already knows how to render, in **648 functions
+across five binaries and two architectures**. The defect is on the **default-ON `iteregion`
+path** (the 8-diamond repro above uses plain constant `COPY` arms with `iteexpr` off), so
+the fix improves shipped default output in every mode, and it hits `iteboolean` too —
+`O0` bash `shell_initialize` re-rolls 1 of 3 identical 0/1 diamonds on today's build.
+
+## Proposed fix
+
+`itecondlist` — in `kuna_iteregion.rs::cond_cbranch`, when the condition component is a
+multi-component `Ls`/`Graph`, descend to its **last** component and take the `CBRANCH` from
+there (the earlier components keep printing as ordinary statements ahead of the ternary,
+which `emit_block_if_ite`'s `NO_BRANCH` pass already does). Optionally lift the same
+descent into `kuna_iteboolean.rs::cond_terminal_cbranch` so all three passes agree.
+
+- Files: `p8_structure/kuna_iteregion.rs` (one function), optionally
+  `p8_structure/kuna_iteboolean.rs` (one call site). Printer unchanged.
+- Risks: a `Ls` component that is not a plain statement run (a loop, a labelled goto
+  target) must still decline — keep the existing per-component leaf checks on the last
+  element and reject when the list's non-final components contain an unstructured target.
+- Gating: it broadens the existing `iteregion` (default-ON) and `iteexpr` (default-off,
+  in `aggressive`) matches, so it changes emitted C; per the standing rules it needs its
+  own named option or an explicit DIV row for widening a default-ON transform, plus a
+  two-pass `tests/stages/ghangr-itecondlist.xml`.
+- Expected GED: this case 24 -> low single digits (angr's ternary-for-ternary pane is the
+  0). Sibling `O2-noinline-...-mavlinkSendRCChannelsAndRSSI` is at 24 too.

--- a/docs/decbench/triage/O0-crazyflie-cf2-brightnessEffect.md
+++ b/docs/decbench/triage/O0-crazyflie-cf2-brightnessEffect.md
@@ -1,0 +1,166 @@
+---
+case_id: O0-crazyflie-cf2-brightnessEffect
+pool: angr
+group_id: crazyflie::brightnessEffect
+status: needs-proposal
+tier: M
+margin: 68
+fresh_verdict: reproduces — the source is 18 `?:` ternaries in 4 families and kuna renders 5 of them (aggressive) / 2 (reliable) as ternaries and the rest as if/else. One family is the high-breadth `itecondlist` bug filed from the mavlink case; the other three need CHAINED (`a ? x : (b ? y : z)`) and IDENTITY-ARM (`v = c ? A : v`) ternary recovery, and the identity arm has no arm op to render, so it does not fit one module.
+option_closing: null
+feature_slug: iteternarychain
+scope: proposal
+confidence: medium
+---
+
+## Verify-first
+
+```
+$ ~/.virtualenvs/decbench/bin/python -m scripts.decbench.rescore \
+      --case O0-crazyflie-cf2-brightnessEffect --siblings
+ "ged_recorded": 68.0, "ged_before": 68.0, "ged_after": 60.0, "ged_delta": -8.0,
+ "ged_perfect_after": false, "ged_kuna_commit": "9623dc27"
+ siblings: O0-crazyflie-firmware-brightnessEffect  before 60.0  after 60.0  (METRIC-DRIFT)
+```
+
+`before` reproduces `recorded` exactly on the mined case (the stored `kuna_cf2.c` is
+run-era, `mtime Jul 15`), so there is no metric drift here and the -8 is a real code/mode
+move. `cf2.elf` is 491,004 B — just **under** the 500 KiB threshold — so a no-flag run
+today is `aggressive`, which is *not* what the benchmark measured:
+
+```
+$ kuna decompile-all .../O0/crazyflie/stripped/cf2.elf --json --addr 0x800d00d <mode>
+--mode reliable  : loc 82  ternaries 2  ifs 17    <- the benchmark's option surface
+--mode aggressive: loc 76  ternaries 5  ifs 14    <- today's product default (iteexpr on)
+```
+
+Neither closes it. Sweep of every default-off catalog option (`iteexpr`, `condfold on`,
+`condfold wide`) on this function: 5 ternaries in all cases.
+
+## Source (`ledring12.i`) — 18 ternaries, no `if/else` except the outer guard
+
+```c
+static void brightnessEffect(uint8_t buffer[][3], _Bool reset)
+{
+  static int gyroYid, gyroZid, gyroXid =- 1;
+  static uint8_t brightness = 0;
+  if (gyroXid < 0) { gyroXid = logGetVarId("gyro","x"); ... }
+  else {
+    int i;
+    int gyroX = (int)logGetFloat(gyroXid); ... gyroZ ...
+    gyroX = (gyroX>512) ? 512:(gyroX<-512) ? -512:gyroX;      /* x3  - chained + identity */
+    gyroX = ((gyroX>=0)?1:-1) * gyroX / 2;                    /* x3  - plain diamond      */
+    gyroX = ((gyroX<5) ? 0:gyroX);                            /* x3  - identity arm       */
+    for (i=0; i < 12; i++) {
+      buffer[i][0] = (uint8_t)(((gyroZ>255)?255:(gyroZ<0)?0:gyroZ));   /* x3 - chained  */
+      ...
+    }
+    brightness++;
+  }
+}
+```
+
+angr (stored, GED 0) reproduces every one of them, including the identity arms:
+
+```c
+    v3 = (0x200 < v3 ? 0x200 : (v3 < 0xfffffe00 ? 0xfffffe00 : v3));
+    v8 = (v3 < 0 ? 4294967295 : 1);
+    v3 = v3 * v8 + (v3 * v8 >> 31) >> 1;
+    if (v3 <= 4) v3 = 0;
+    ...
+    *((char *)(idx * 3 + a0)) = (0xff < v1 ? 255 : (v1 < 0 ? 0 : (char)v1));
+```
+
+## kuna (fresh, `aggressive`) — 5 of 18
+
+```c
+    if (0x201 <= v4) // branch-flip           <- (A) chained: else-arm is a 2-component if
+      v4 = 0x200;
+    else if (v4 < dat_800d220)
+      v4 = dat_800d220;
+    ... x3 ...
+    v3 = (0 <= v4) ? 1 : -1; // branch-flip   <- (B) plain diamond, re-rolled
+    v4 = (v4 * v3) / 2;
+    if (0 <= v5) // branch-flip               <- (B) IDENTICAL diamond, NOT re-rolled
+      v3 = 1;
+    else {
+      v3 = -1;
+    }
+    v5 = (v5 * v3) / 2;
+    v3 = (0 <= v6) ? 1 : -1; // branch-flip   <- (B) re-rolled
+    v6 = (v6 * v3) / 2;
+    if (v4 <= 4)                              <- (C) identity arm: no else, v4 unchanged
+      v4 = 0;
+    ... x3 ...
+    for (v7 = 0; v7 <= 0xb; v7 = v7 + 1) {
+      if (0x100 <= v6) // branch-flip         <- (D) chained: else-arm is itself a ternary
+        v2 = 0xff;
+      else {
+        v2 = (0 <= v6) ? (char)v6 : 0; // branch-flip
+      }
+      *(char *)(v7 * 3 + a0) = v2;
+      ... x3 ...
+```
+
+## Analysis — four distinct sub-symptoms, only one is small
+
+Owning phase for all four: **P8**,
+`decompiler/crates/kuna-decomp/src/p8_structure/kuna_iteregion.rs`
+(`match_ite_assignment` / `single_assign_arm` / `cond_cbranch`).
+
+**(B) plain diamond, 2 of 3 re-rolled — the `itecondlist` bug.** Three byte-identical
+diamonds; the middle one declines. This is the same defect filed in detail from
+`O0-betaflight-betaflight_STM32F405-mavlinkSendRCChannelsAndRSSI` (the matcher's condition
+component must be a single leaf, but the collapse structurer folds the previous `if` and the
+next condition block into one multi-component `BlockList`). High breadth (952 declined
+diamonds in 648 functions over five binaries), one-module fix, tracked there.
+
+**(D) chained ternary, else-arm is itself a matched diamond.** `single_assign_arm` calls
+`leaf_bblock`, which returns `None` for a `BlockIf`, so an arm that is itself an
+`IteAssignMatch` writing the same destination declines. A recursive extension of
+`single_assign_arm` (accept an arm that `match_ite_assignment` matches with a
+storage-equal destination, render it as the nested `?:`) is contained to the same module.
+Breadth is small, though — scanning whole-binary output for
+`if (c) V = A; else { V = <ternary>; }`: **4 occurrences in `cf2.elf` (2790 fns), 7 in
+`ls` (617 fns)**. It is 3 of this function's 4 families but not a campaign-scale lever on
+its own.
+
+**(A) + (C) identity arm.** `(g<5) ? 0 : g` and the tail of `(g>512)?512:(g<-512)?-512:g`
+compile to a **2-component** `BlockIf` — one arm assigns, the fall-through leaves the
+variable at its incoming value, and the join `MULTIEQUAL` takes the pre-diamond definition.
+There is no second arm op, so `single_assign_arm` has nothing to hand the printer for the
+`:` side: `emit_block_if_ite` renders both arms via `op_push_ir` on an arm op. Recovering
+`v = c ? A : v` therefore needs a **printer** change (render the join `MULTIEQUAL`'s other
+input as the false expression) on top of a matcher change — i.e. two modules and a new
+value-safety argument (the false expression must be the *pre-diamond* SSA definition, not
+the post-join HighVariable, or the ternary reads its own output).
+
+That last point is why this is `needs-proposal` and not `feature-candidate`: (A)+(C) are 9
+of this function's 18 ternaries and they do not fit one module.
+
+## Metric-artifact check
+
+Not an artifact. Source CFG is 30 nodes / 42 edges (real, not degenerate), not
+approximated, and Joern parses every pane; `before` reproduces the recorded 68 exactly.
+Today's 60 is real distance. ida scores 56 and ghidra 71 here, so kuna is already ahead of
+its own ancestor — the remaining distance is genuinely angr's aggressive `?:` recovery.
+(The `firmware.elf` sibling's stored artifact *does* drift, 68 recorded vs 60 recomputed —
+same binary content, so that one is the 2026-07-28 decbench GED overhaul `e6e6b0f`.)
+
+## Siblings
+
+`O0-crazyflie-firmware-brightnessEffect` is the same function in a second binary (same
+address `0x800d00d`, same margin 68) and shows the identical pane.
+
+## Proposed fix
+
+Stage it, do not do it in one PR:
+
+1. **`itecondlist`** (small, filed under the mavlink case) — picks up (B) here and 952
+   diamonds corpus-wide.
+2. **`iteternarychain`** (small-to-medium, one module) — recursive `single_assign_arm`, for
+   (D). Low breadth; ship it only bundled with 3, or as a readability follow-up.
+3. **`iteidentityarm`** (`[PROPOSAL]`) — 2-component diamond whose fall-through leaves the
+   destination unchanged, rendered `v = c ? A : v`. Needs the printer to source the false
+   expression from the join `MULTIEQUAL`'s non-arm input; the value-safety argument (that
+   input must be the pre-diamond definition) is the whole review. This is also the family
+   angr recovers most aggressively, so it is where the remaining GED lives.

--- a/docs/decbench/triage/O0-e2fsprogs-e2fsck-save_output-rederive.md
+++ b/docs/decbench/triage/O0-e2fsprogs-e2fsck-save_output-rederive.md
@@ -1,0 +1,285 @@
+---
+case_id: O0-e2fsprogs-e2fsck-save_output
+pool: ida
+group_id: e2fsprogs::save_output
+status: feature-candidate
+tier: M
+margin: 56
+fresh_verdict: the symptom still reproduces byte-for-byte on today's build (GED 29, identical to the round-1 fresh number; auto == reliable, and aggressive differs only in an unrelated string constant) -- but the round-1 MECHANISM is confirmed dead and the real anchor is a THIRD site neither the record nor its skeptic named
+option_closing: null
+feature_slug: paramcopyhoist
+scope: small
+confidence: medium
+---
+
+This record SUPERSEDES the mechanism half of
+`docs/decbench/triage/O0-e2fsprogs-e2fsck-save_output.md`. That record's symptom,
+GED numbers and option sweep all hold up; its root cause does not, and neither
+does the obvious repair the skeptic's refutation implies.
+
+## Verify-first: what today's build actually does
+
+```
+$ python3 -m scripts.decbench.triage --case O0-e2fsprogs-e2fsck-save_output --also ida,ghidra
+| output       | loc | gotos | labels | ifs | loops |
+| ida(stored)  |  84 |     0 |      0 |  16 |     3 |
+| ghidra(stored)| 103 |    1 |      1 |  17 |     4 |
+| kuna(stored) |  93 |     1 |      0 |  16 |     4 |
+| kuna(fresh)  |  78 |     0 |      0 |  16 |     4 |
+```
+
+```
+$ ~/.virtualenvs/decbench/bin/python -m scripts.decbench.rescore \
+      --case O0-e2fsprogs-e2fsck-save_output
+ "ged_recorded": 56.0, "ged_before": 56.0, "ged_after": 29.0, "ged_delta": -27.0
+ "source_nodes": 46, "ged_approximated": false
+```
+
+The residual 29 is unchanged from round 1, so nothing that landed since (PR #228's
+two restored Cover extensions included) touched this. The two sunk copies are
+still there:
+
+```c
+  v11 = *(unsigned long *)(v4 + 0x28);
+  v7 = a0;
+  if ((a0) && (!*a0))
+    v7 = NULL;
+  v6 = a1;                       // <-- NOT in the entry block  (+1 CFG node)
+  if ((a1) && (!*a1))
+    v6 = NULL;
+  v5 = a2;                       // <-- NOT in the entry block  (+1 CFG node)
+  if ((a2) && (!*a2))
+    v5 = NULL;
+```
+
+**Modes.** `e2fsck` is 908 KiB, i.e. ABOVE the 500 KiB aggressive threshold, so
+`--mode auto` resolves to `reliable` here and the two are byte-identical (which is
+why round 1 saw no mode effect). Forcing `--mode aggressive` changes exactly one
+line and does not touch the copies:
+
+```
+$ diff mode-auto.c mode-aggressive.c
+38c38
+<     v2 = fdopen(v10,0xaba35);
+---
+>     v2 = fdopen(v10,"w");
+```
+
+**Option sweep.** `condfold on`, `condfold wide`, `iteexpr on`, `regionedgeorder on`,
+`stackalias on` are all byte-identical to the default run (md5 verified). Nothing in
+the 83-row catalog moves the copies. `option_closing: null` stands.
+
+**The measured value of the fix**, re-measured today with the real GED (not the
+recorded one), by hoisting only those two lines into the entry block:
+
+```
+source nodes 46 edges 72
+base       nodes=53 edges=77 GED=29.0
+hoisted    nodes=51 edges=77 GED=17.0
+```
+
+So -12 GED, confirming round 1's textual ablation with the actual metric.
+
+## Source
+
+`~/github/decbench/results/full_run/O0/e2fsprogs/compiled/logfile.i` -- three guards
+that write **through** the parameter, so the source's entry block holds only frame
+setup, and in the binary all three spills are likewise in the entry basic block
+(`4eec2/4eec6/4eeca`, entry block ends at the `je` at `4eee2`).
+
+## Analysis -- the mechanism, re-derived by instrumenting
+
+### 1. The filed fix is a no-op (confirmed)
+
+`trim_op_input_prep` (`p6_variables/funcdata_merge.rs:844`) returns `pc`; `pc` is
+consumed by `allocate_copy_trim` -> `copy_trim_op(in_vn, addr, trim_op)`, i.e. it
+becomes the new op's **Address** only. The physical placement is the next statement:
+
+```rust
+// p6_variables/merge.rs:1610  Merge::trimOpInput
+fn trim_op_input(&mut self, ctx: &mut dyn MergeContext, op: OpId, slot: int4) -> KunaResult<()> {
+    let (in_vn, pc, is_multiequal) = ctx.trim_op_input_prep(op, slot);
+    let copy_op = self.allocate_copy_trim(ctx, in_vn, pc, op)?;
+    ...
+    if is_multiequal {
+        ctx.op_insert_end_pred(copy_op, op, slot);   // <-- the placement
+    } else {
+        ctx.op_insert_before(copy_op, op);
+    }
+```
+
+Changing `pc` moves nothing. The skeptic was right.
+
+### 2. But `op_insert_end_pred` is not the deciding site either
+
+`print raw` on the fresh build (`decomp_dbg`, stripped `e2fsck`, `load addr 0x4eeb6`):
+
+```
+Basic Block 0 0x0004eeba-0x0004eee2
+0x0004eee2:8ce:	u0x10000269(0x0004eee2:8ce) = RDI(i)
+0x0004eee2:32:	goto Block_1:0x0004eee4 if (ZF != 0) else Block_3:0x0004eef7
+Basic Block 3 0x0004eef7-0x0004eefc
+0x0004eef7:77c:	s0xff..ffc0 = u0x10000269(0x0004eee2:8ce) ? u0x10000269(0x0004eee2:8ce) ? s0xff..ffc0(0x0004eeef:46)
+0x0004eefc:8cc:	u0x10000259(0x0004eefc:8cc) = RSI(i)
+Basic Block 6 0x0004ef11-0x0004ef16
+0x0004ef11:758:	s0xff..ffb8 = u0x10000259(0x0004eefc:8cc) ? u0x10000259(0x0004eefc:8cc) ? s0xff..ffb8(0x0004ef09:67)
+0x0004ef16:8ca:	u0x10000249(0x0004ef16:8ca) = RDX(i)
+```
+
+**Read the phi inputs.** Slot 0 AND slot 1 of each MULTIEQUAL reference the *same*
+unique. `trim_op_input` cannot produce that: it is called once per failing slot and
+each call allocates a **fresh** COPY with a **fresh** unique, inserted at a
+**different** predecessor (slot 0 -> BB0, slot 1 -> BB1). Two slots sharing one
+unique can only come from `total_replace(outVn, domVn)` + `opDestroy` inside
+`Merge::buildDominantCopy`.
+
+So the real chain is three passes deep:
+
+1. `merge_op` (`merge.rs:1415`) fails `merge_test_required` for the input-register
+   high against the addr-tied stack-slot high, and calls `trim_op_input` for slot 0
+   and again for slot 1.
+2. `trim_op_input` puts one COPY at the tail of BB0 and one at the tail of BB1
+   (a0's phi) / BB3 and BB4 (a1's phi) / BB6 and BB7 (a2's phi).
+3. `process_copy_trims` -> `process_high_dominant_copy` (`merge.rs:2042`) groups the
+   two by identical root varnode and calls `build_dominant_copy` ->
+   `build_dominant_copy_impl` (`substrate/funcdata.rs:2945`):
+
+```rust
+let dom_bl = self.bblocks.find_common_block_set(&block_set);
+...
+let stop_addr = self.block_stop_addr(dom_bl);
+let new_copy = self.new_op(1, stop_addr);
+...
+self.op_insert_end(new_copy, dom_bl);
+```
+
+**`find_common_block_set` over the two trim sites is what decides where the printed
+`vN = aM;` lands.** For `a0` that is BB0 -- the entry block -- so parameter 1 renders
+correctly. For `a1` it is BB3, for `a2` BB6. kuna is internally inconsistent about the
+identical construct, and the discriminator is nothing but whether the guard's join
+happens to be the entry block.
+
+Second, independent witness (different binary, different register width) --
+`O0/gzip/gzip` `sub_40fe`:
+
+```
+Basic Block 2 0x00004147-0x00004193
+0x00004193:635:	u0x100000a4:4(0x00004193:635) = EDI(i)
+Basic Block 4 0x00004199-0x000041b5
+0x00004199:616:	s0xff..ffbc:4 = u0x100000a4:4(0x00004193:635) ? u0x100000a4:4(0x00004193:635) ? EAX(0x00004326:474)
+```
+
+Same signature: two phi slots, one unique, anchored at the common dominator of the
+two trim sites (BB2), which is not the entry block (BB0).
+
+### 3. Owning phase
+
+**P6 (variable & storage model)** -- `Merge`/HighVariable, `p6_variables/`. Not P8:
+every P7/P8 structurer option is byte-identical here (re-verified today).
+
+### 4. This is a divergence, not a port bug
+
+Ghidra's stored pane sinks `local_48 = param_2;` to exactly the same place. The port
+is faithful; hoisting is a deliberate DIV, so it needs an option.
+
+## Breadth
+
+`kuna decompile-all --json` over four O0 binaries, counting **top-level** (brace depth 1)
+`vN = aM;` statements that appear after the first top-level control-flow statement --
+i.e. copy-shadows of an unmodified incoming parameter emitted outside the entry block:
+
+| binary | fns | fns with a sunk top-level param copy | sunk | in entry |
+|---|---|---|---|---|
+| O0 e2fsprogs/e2fsck | 1991 | 101 (5.1%) | 173 | 240 |
+| O0 coreutils/ls | 617 | 14 (2.3%) | 21 | 54 |
+| O0 gzip/gzip | 263 | 8 (3.0%) | 10 | 34 |
+| O0 bzip2/bzip2 | 160 | 4 (2.5%) | 4 | 5 |
+| **total** | **3031** | **127 (4.2%)** | **208** | **333** |
+
+So **~4 in 10 parameter copy-shadows kuna emits at top level are outside the entry
+block.** At O2 the same scan over `O2/{bzip2,gzip}` gives 9/318 functions (2.8%) and
+only 1 of 16 in the guard shape -- the pattern is O0-dominated, as round 1 guessed.
+
+Classifying each sunk copy by what follows it (rough textual split, 143 classified):
+**41 guard-cascade shape** (`vN = aM;` immediately followed by a guard on `aM` -- the
+`save_output` shape, MULTIEQUAL trim), **75 call-adjacent**, 27 other.
+
+The call-adjacent ones are a **different anchor site**, and this matters for scoping.
+`e2fsck sub_1e497` instrumented:
+
+```
+Basic Block 5 0x0001e603-0x0001e642
+0x0001e634:859:	u0x1000020c(0x0001e634:859) = RDI(i)
+0x0001e634:6eb:	s0xff..ff98(0x0001e634:6eb) = u0x1000020c(0x0001e634:859) [] i0x0001e634:172(free)
+```
+
+That COPY feeds an **INDIRECT**, not a MULTIEQUAL: it comes from `merge_indirect`
+(`merge.rs:1506`, `allocate_copy_trim(ctx, invn0, indaddr, indop)` + `op_insert_before`),
+anchored at the call. Same user-visible symptom, second producer.
+
+## Proposed fix
+
+**Feature `paramcopyhoist` (P6, default-off), new module
+`decompiler/crates/kuna-decomp/src/p6_variables/kuna_paramcopyhoist.rs`.**
+
+One decision, one call site:
+
+- Export `hoist_trim_anchor(fd, high, root_vn, default_bl) -> BlockId`. It returns
+  `default_bl` unless `root_vn.is_input()` (`substrate/varnode.rs:777` -- a function
+  input varnode is defined at entry and dominates every block); when it is, it walks
+  the `immed_dom` chain from `default_bl` up toward the entry and returns the
+  **highest** block whose hypothetical widened Cover is still legal.
+- Legality is the test `build_dominant_copy_impl` already computes, applied to the
+  dominant copy's own placement instead of only to the redirected ones: build
+  `b_cover` from the high's non-copy-shadow instances (`full_varnode_cover`), build
+  the candidate `a_cover` with `add_def_point` at the candidate block's stop and
+  `add_ref_point_for` at each read, and reject any candidate with
+  `b_cover.intersect(&a_cover) > 1`. The only structural change needed in the callee
+  is computing `b_cover` **before** the copy is materialised rather than after.
+- Call it from `op_insert_end_pred` (`p6_variables/funcdata_merge.rs:801`), the
+  `is_multiequal` arm of `trim_op_input`. Hoisting there is sufficient: with both
+  trim copies already in the entry block, `find_common_block_set` in
+  `build_dominant_copy_impl` collapses them there for free -- which is precisely why
+  parameter 1 already renders correctly today. `build_dominant_copy_impl` itself
+  needs no edit.
+
+Owning files:
+- `decompiler/crates/kuna-decomp/src/p6_variables/kuna_paramcopyhoist.rs` (new)
+- `decompiler/crates/kuna-decomp/src/p6_variables/funcdata_merge.rs` (`op_insert_end_pred` consults it)
+- `phases.toml` + `p0_knowledge/options.rs` row; catalog count bumps
+- `docs/spec/` P6 chapter; `tests/stages/ghdec-paramcopyhoist.xml` two-pass testcase
+
+Scope: **small** -- one module, one call site, one option row.
+
+Risks / what is NOT yet proven:
+
+- **The Cover legality test is the load-bearing half, and it is the one link I could
+  not measure** (this triage is read-only, so no A/B build). Reasoning for
+  `save_output`: for the `a1` slot the high's non-copy instances are the const-0 def
+  in BB5 and the phi in BB6, so `b_cover` is confined to BB5/BB6 while the hoisted
+  `a_cover` spans BB0..BB3 -- disjoint, so the hoist should be accepted. Without the
+  guard the transform is **wrong code** on any reused slot (hoisting `x = param` above
+  an earlier live value of the same slot clobbers it), so it must not ship without it.
+- **It is a divergence from upstream Ghidra**, which sinks identically. Ship
+  default-off; a default-on flip needs 0/675 on the datatests plus a decbench
+  aggregate ablation, because it moves statements in ~4% of O0 functions.
+- **Bounded payoff on this case**: -12 of the residual 29. The rest is the
+  `while( true )` harness penalty (round 1 measured -8, a pyjoern artifact), the
+  `do_read` empty-body loop (-6, mostly source-side parse loss) and one taildup'd
+  `exit(0)` (-5).
+- **Half the family is out of scope for this PR.** The 75 call-adjacent occurrences
+  come from `merge_indirect`'s copy (`merge.rs:1506`), a separate anchor. Same slug
+  could cover it in a follow-up by routing that `op_insert_before` through the same
+  helper, but it is a different Cover shape (a call clobber) and should be measured
+  separately.
+
+## Loose thread found while triaging
+
+`fdopen(v10,0xaba35)` -- the `"w"` string literal is resolved only under
+`--option operand_refs on` (verified: `listing`, `formatstring`, `funcstart_patterns`,
+`aif` all leave the raw address). `operand_refs` is default-off and lives in the
+`aggressive` preset, and `--mode auto` picks `reliable` for anything >= 500 KiB, so
+**every default run on a binary over 500 KiB prints a raw address in a `char *`
+argument slot where IDA/ghidra print the string.** That is the "constants kuna alone
+fails to resolve" reject criterion from `docs/decbench-loop.md` firing on the product
+default. Worth its own case.

--- a/docs/decbench/triage/O0-mydoom-mydoom-mmsender_th.md
+++ b/docs/decbench/triage/O0-mydoom-mydoom-mmsender_th.md
@@ -1,0 +1,291 @@
+---
+case_id: O0-mydoom-mydoom-mmsender_th
+pool: ida
+group_id: mydoom::mmsender_th
+status: feature-candidate
+tier: M
+margin: 37
+fresh_verdict: reproduces on today's build in BOTH modes — the function body runs straight past `ExitThread(0)` and swallows the whole of the next function (which kuna separately emits as `sub_40424c`, byte-identical); the call renders as `(*dat_4112c4)(0)` because kuna never binds a `call [IAT slot]` to the import symbol it already resolved
+option_closing: null
+feature_slug: peimportcall
+scope: small
+confidence: high
+---
+
+## Side-by-side
+
+**IDA (stored)** — 14 LOC, 2 `if`s, no loop:
+
+```c
+void mmsender_th(char *lpThreadParameter)
+{
+  _InterlockedExchangeAdd(&dword_4102E4, 1u);
+  if ( lpThreadParameter ) {
+    lpThreadParameter[8] = 1;
+    sub_4040EB((int)lpThreadParameter);
+    lpThreadParameter[8] = 2;
+  }
+  if ( dword_4102E4 )
+    _InterlockedExchangeAdd(&dword_4102E4, 0xFFFFFFFF);
+  ExitThread(0);
+}
+```
+
+Ghidra's pane is the same 14 statements and ends with
+`/* WARNING: Subroutine does not return */ ExitThread(0);`. angr, ghidra and phoenix
+all score GED 0 here; kuna scores 37. Bucket: **kuna-specific**.
+
+**kuna (fresh, today's build, no flags — and identical under `--mode reliable`)**:
+
+```c
+void sub_4041e2(int4 a0)
+{
+  ...
+  if (dat_4102e4) { LOCK(); UNLOCK(); }
+  (*dat_4112c4)(0);                       // <-- this is ExitThread(0)
+  v7 = (unsigned int *)0x4102e0;          // <-- everything below belongs to
+  v3 = dat_4102e0;                        //     the NEXT function
+  while (v7 = v3, v8 = v7 != NULL, v8) {
+    v1 = (char *)&v7[2];
+    if (*v1 != '\x02')
+      v3 = (unsigned int *)*v7;
+    else {
+      v4 = (*dat_411324)();
+      v2 = &v7[1];
+      v5 = (uint4)(v4 - *v2) / 1000;
+      if ((-5 <= (int4)v5) && (v5 <= 0x1c20)) v3 = (unsigned int *)*v7;
+      else { ... (*dat_411308)(); (*dat_41133c)(v6,0,v7); }
+    }
+  }
+  return;
+}
+```
+
+50 LOC, 4 `if`s and **1 loop that does not exist in this function**.
+
+**The proof that this is an overrun, not a discovery difference**: kuna's *own*
+function list contains an entry at `0x40424c`, and `kuna decompile-all` emits it
+separately as `sub_40424c` — whose body is the trailing `while` loop above,
+statement for statement. kuna emits the same code twice.
+
+```c
+void sub_40424c(void)
+{
+  v7 = (unsigned int *)0x4102e0;
+  v3 = dat_4102e0;
+  while (v7 = v3, v8 = v7 != NULL, v8) { ... }      // identical text
+  return;
+}
+```
+
+**Option sweep**: `readonly on`, `noreturn_disc on`, `listing on` — no change.
+`--mode reliable` — no change. And the decisive counterfactual:
+`--option noreturn ExitThread` (the explicit per-name override) **also changes
+nothing**, because no name is ever queried for this call site.
+
+## Source
+
+mydoom is a leaked-source worm; the corpus ships no `.i` for it
+(`~/github/decbench/results/full_run/O0/mydoom/compiled/` has the PE and the rival
+artifacts only, and `mydoom.exe` is a PE with `do-not-execute` labels). The
+source-side ground truth used here is therefore the decbench-recorded source CFG for
+`mmsender_th`: **5 nodes / 6 edges, non-degenerate** — a body with two `if`s and no
+loop, which is exactly IDA's and Ghidra's shape and is not compatible with kuna's
+extra `while`. The function is a thread entry point: bump a refcount, run the worker,
+drop the refcount, `ExitThread(0)`. The trailing loop kuna appends walks a linked
+list at `0x4102e0` calling `GetTickCount`/`GetProcessHeap`/`HeapFree` — a different
+routine's body.
+
+## Analysis
+
+### Symptom (one, named)
+
+**Function-boundary overrun past a no-return Windows import.** Flow does not stop at
+`call dword ptr [ExitThread]`, so the decompiled function absorbs the following
+function's entire body.
+
+### Root cause (instrumented, not read)
+
+kuna's PE loader **does** resolve the import table. `kuna functions mydoom.exe --json`
+lists 149 named symbols, including exactly the right one:
+
+```
+0x4112c0 ExitProcess
+0x4112c4 ExitThread          <-- the slot the call reads
+0x411308 GetProcessHeap
+0x411324 GetTickCount
+0x41133c HeapFree
+```
+
+So the name is in the symbol table at the slot VA. The decompiler never asks for it.
+`ArchFlowEnv::query_call` / `query_call_no_return`
+(`decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs:92`) are keyed on a
+**direct** call's entry address. The post-decompile IR for this call site
+(`decomp_dbg` → `print raw`) is:
+
+```
+0x0040424a:80:  callind r0x004112c4(0x00404220:22b)(#0x0)
+```
+
+— a `CALLIND` whose target is the **contents** of the global at `0x4112c4` (an
+unmodified read of the IAT slot, carried as an input Varnode). There is no entry
+address to query, so no name, no prototype, and no no-return flow effect. The call
+keeps its fall-through and flow walks into the next function.
+
+`p2_lift`'s module doc for the PE import path (`kuna-analysis/src/loader/pe_iat.rs`)
+says the slot-VA naming works because "the decompiler constant-folds the `[slot]`
+load (the IAT lives in a read-only `.idata` page)". On this corpus **that primary path
+is inert**: `--option readonly on` changes nothing, and folding would be wrong anyway
+— the on-disk IAT slot holds the RVA of the `IMAGE_IMPORT_BY_NAME` entry, not a
+function address. Only the module's *fallback* (case 2: naming `FF 25` thunk veneers
+so a **direct** `call thunk` resolves) actually fires.
+
+That split is visible inside a single function. `sub_4013e0` in the same binary:
+
+```c
+  v4 = (unsigned int *)malloc(dat_41001c * 4 + 4);   // msvcrt, via named thunk
+  memcpy(v5,*v8,v1);                                 // named
+  _cexit();      // no-return                        // named AND no-return honoured
+  exit(dat_410010); // no-return
+  ...
+  dat_4102a0 = (*dat_411360)(sub_40a420);            // kernel32, via `call [IAT]`
+  if (dat_40d464) (*dat_40d464)(0,2,0);              // kernel32, via `call [IAT]`
+```
+
+Same function, same binary: the thunked imports get names, prototypes and no-return;
+the slot-called imports get `(*dat_XXXXXX)()`. kuna is internally inconsistent, which
+is the same shape of evidence that carried `jumptable-callother-inject` in round 1.
+
+**Second, subordinate gap**: even once the call is bound,
+`decompiler/crates/kuna-analysis/data/PeMacFunctionsThatDoNotReturn` lists only
+`exit / quick_exit / abort / fastfail / invoke_watson /
+invalid_parameter_noinfo_noreturn / terminate / abort_handler4`. Ghidra additionally
+ships the Win32 API names (`ExitProcess`, `ExitThread`, …). Both halves are needed;
+the binding is the blocker (proved by the `--option noreturn ExitThread`
+counterfactual above).
+
+### Owning phase
+
+**P2** — Flow & Op-Graph Recovery (`decompiler/crates/kuna-decomp/src/p2_lift/`).
+The flow decision "does this call fall through" is made there, at the same seam
+`kuna_tailcalljump` / `kuna_noreturn_externmatch` already hook. The no-return name
+list is a P1 (`kuna-analysis`) data file.
+
+### Correctness value, beyond GED
+
+- **Wrong function extent** — the emitted C for `mmsender_th` contains a loop the
+  function does not have, and the same code is emitted twice in one project export.
+- **Unnamed API calls with guessed argument lists** — `(*dat_4112c4)(0)` has no
+  prototype, so arguments are recovered by trial rather than from the API signature.
+  In `sub_4041e2` alone, four call sites lose their names.
+
+### Metric-artifact check
+
+Not an artifact. Source CFG 5 nodes / 6 edges, `degenerate_source: false`,
+`approximated: false`, `artifact_suspect: false`. Three other decompilers score 0.
+
+### Breadth
+
+`kuna decompile-all --json` on the two PE projects in the corpus:
+
+| binary | fns emitted | `(*dat_…)()` IAT-slot calls | fns overrunning a Win32 exit |
+|---|---|---|---|
+| mydoom `mydoom.exe` | 156 | **501** | **5** |
+| dexter `dexter.dll` | 110 | **426** | (not measured) |
+
+**927 unnamed Windows API call sites across two binaries**, and zero Win32 API names
+anywhere in either pane (`ExitThread`, `ExitProcess`, `CreateThread`, `GetTickCount`,
+`HeapFree` — all 0 occurrences in the emitted C, all present in the symbol table).
+
+The five mydoom functions whose body continues past a no-return exit:
+
+```
+sub_402a62 calls ExitThread  : 21 residual statement-lines after
+sub_402eda calls ExitProcess : 53 residual statement-lines after
+sub_4041e2 calls ExitThread  : 18 residual statement-lines after   <-- this case
+sub_40451c calls ExitThread  : 18 residual statement-lines after
+sub_407107 calls ExitThread  : 16 residual statement-lines after
+```
+
+`sub_402a62` is `mydoom::sync_visual_th` — **backlog-ida row 34, margin 34, its own
+un-triaged group** — so one fix closes at least two ida-pool rows, and `sub_402eda`
+(53 residual lines) is the worst of the five.
+
+### Siblings
+
+`O2-noinline-mydoom-mydoom-mmsender_th` (margin 8, `artifact_suspect`) is the same
+function at -O2; the small margin there means the overrun costs less once the
+following function is inlined away. The real siblings are the four other mydoom
+functions listed above.
+
+## Proposed fix
+
+**Slug `peimportcall`, P2, one module** — a new
+`decompiler/crates/kuna-decomp/src/p2_lift/kuna_peimportcall.rs`, built on the
+`kuna_tailcalljump` template (which already rewrites one flow-level call shape into
+another at this seam).
+
+Mechanism: match a `CALLIND` whose target Varnode is an **unmodified read of a global
+at a constant address `A`** (the shape in the `print raw` dump above — in kuna's IR
+the IAT slot read is a global Varnode, *not* a `LOAD` op, which is why an
+`INT_ZEXT`/`LOAD`-shaped matcher would miss it), and for which
+`FlowEnvironment::query_call(A)` resolves a function symbol (i.e. `A` is a registered
+import slot). Rewrite the op to a direct `CALL` to `A`, so the existing machinery —
+`query_call` (name), the callee prototype, and `query_call_no_return` (flow effect,
+the artificial-halt path) — all apply unchanged. This is the PE analog of what
+already works for an ELF PLT stub, where the slot happens to be code and the call
+happens to be direct.
+
+Owning files:
+- `p2_lift/kuna_peimportcall.rs` (new): the matcher + rewrite.
+- `p2_lift/flow.rs`: one hook at the CALLIND classification point.
+- `p0_knowledge/options.rs` + `phases.toml`: the `peimportcall on|off` row
+  (plus the hard-coded catalog counts listed in `kuna-adding-option-count-tests`).
+- `kuna-analysis/data/PeMacFunctionsThatDoNotReturn`: add the Win32 no-return names
+  Ghidra ships (`ExitProcess`, `ExitThread`, `TerminateProcess`, `FatalExit`, …).
+  Data-only; no code change.
+
+Risks to settle at build time:
+- The callee address is in a **data** space with no decodable body. Direct calls to
+  known functions are not decoded (only `inline` decodes), so this should be inert —
+  but it must be checked, and the rewrite should decline if the address is inside the
+  current function's flow range.
+- A `call [reg]` that happens to load a slot value into a register first (two-step)
+  is *not* matched by the constant-LOAD pattern; that is deliberate for a first cut.
+- Guard on "the address has an import-origin FunctionSymbol", not merely "any
+  symbol", so a genuine indirect call through a data pointer is untouched.
+
+Stage test: `tests/stages/ghdec-peimportcall.xml` (no angr analog), two-pass — option
+off = the overrun body, default = the function ends at the no-return call. Speed via
+`scripts.pipeline.timeit`; benchmark delta via
+`scripts.decbench.rescore --case O0-mydoom-mydoom-mmsender_th --siblings`, and it
+should also be rescored against `O0-mydoom-mydoom-sync_visual_th`.
+
+### One loose thread found while triaging (not this feature)
+
+kuna prints the `lock`-prefixed read-modify-write as **`LOCK(); UNLOCK();` with the
+body missing**:
+
+```c
+  LOCK();
+  UNLOCK();                       // kuna
+```
+```c
+  LOCK();
+  DAT_004102e4 = DAT_004102e4 + 1;
+  UNLOCK();                       // ghidra
+```
+
+The atomic increment is simply gone — twice in this one function — and it is gone in
+the IR too, not just in the printer: block 0 of the post-decompile `print raw` dump is
+
+```
+0x004041fd:1a:  LOCK
+0x004041fd:2b:  UNLOCK
+```
+
+with nothing between, and the later `ZF = r0x004102e4(i) != #0x0` reads the
+**unincremented input** value. I did not determine whether the RMW is never lifted or
+is lifted and then dropped, so this needs its own case rather than a guess. It is a
+wrong-value defect independent of the boundary overrun, and it is the sort of item
+round 1 ranked above metric wins.

--- a/docs/decbench/triage/O2-coreutils-_-binop.md
+++ b/docs/decbench/triage/O2-coreutils-_-binop.md
@@ -1,0 +1,164 @@
+---
+case_id: O2-coreutils-_-binop
+pool: ida
+group_id: coreutils::binop
+status: covered-by-option
+tier: M
+margin: 50
+fresh_verdict: reproduces unchanged on today's build (fresh == stored, 11 nested `if`s); `--option condfold wide` collapses them to 4 (`if` count 11 -> 4, LOC 29 -> 15) and is the only thing that moves it — `condfold on` does nothing here
+option_closing: condfold=wide
+feature_slug: null
+scope: small
+confidence: high
+---
+
+## Side-by-side
+
+**IDA (stored)** — one `if` with an 11-term `&&` chain:
+
+```c
+long long binop(char *s1)
+{
+  unsigned int v1 = 1;
+  if ( strcmp(s1, "=") && strcmp(s1, "!=") && strcmp(s1, "==") && strcmp(s1, "-nt")
+    && strcmp(s1, "-ot") && strcmp(s1, "-ef") && strcmp(s1, "-eq") && strcmp(s1, "-ne")
+    && strcmp(s1, "-lt") && strcmp(s1, "-le") && strcmp(s1, "-gt") )
+    LOBYTE(v1) = strcmp(s1, "-ge") == 0;
+  return v1;
+}
+```
+
+**kuna (fresh, no flags — identical to the stored pane)** — 11 nested `if`s:
+
+```c
+bool binop(char *a0)
+{
+  bool v1 = 1;
+  if (strcmp(a0,"=")) { if (strcmp(a0,"!=")) { if (strcmp(a0,"==")) { ...
+    ... if (strcmp(a0,"-gt")) v1 = strcmp(a0,"-ge") == 0; ... } } }
+  return v1;
+}
+```
+
+Ghidra's pane is the same 11-deep nest (bucket `inherited`; binja = 0, angr = 26).
+
+**kuna with `--option condfold wide`** — 4 `if`s:
+
+```c
+bool sub_2920(char *a0)
+{
+  bool v1 = 1;
+  if (((strcmp(a0,"=")) && (strcmp(a0,"!="))) && (strcmp(a0,"=="))) {
+    if ((strcmp(a0,"-nt")) && (strcmp(a0,"-ot"))) {
+      if (((strcmp(a0,"-ef")) && ((strcmp(a0,"-eq") && (strcmp(a0,"-ne"))))) && (strcmp(a0,"-lt"))) {
+        if ((strcmp(a0,"-le")) && (strcmp(a0,"-gt")))
+          v1 = strcmp(a0,"-ge") == 0;
+      }
+    }
+  }
+  return v1;
+}
+```
+
+Metrics from `triage --case O2-coreutils-_-binop --option condfold wide`:
+
+| output | loc | ifs |
+|---|---|---|
+| ida(stored) | 21 | 1 |
+| kuna(stored) | 29 | 11 |
+| kuna(fresh, condfold wide) | 15 | 4 |
+
+`--option condfold on` produces **no change at all** on this function — only `wide`
+moves it.
+
+## Source
+
+`~/github/decbench/results/full_run/O0/coreutils/compiled/lbracket.i` (and `test.i`,
+identical — that is why the group has 6 cases across two binaries):
+
+```c
+binop (char const *s)
+{
+  return (((strcmp (s, "=") == 0)) || ((strcmp (s, "!=") == 0)) || ((strcmp (s, "==") == 0)) ||
+          ((strcmp (s, "-nt") == 0)) || ((strcmp (s, "-ot") == 0)) || ((strcmp (s, "-ef") == 0)) ||
+          ((strcmp (s, "-eq") == 0)) || ((strcmp (s, "-ne") == 0)) || ((strcmp (s, "-lt") == 0)) ||
+          ((strcmp (s, "-le") == 0)) || ((strcmp (s, "-gt") == 0)) || ((strcmp (s, "-ge") == 0)));
+}
+```
+
+One 12-clause short-circuit chain. IDA's single `if` with 11 `&&`s plus the trailing
+`strcmp(...) == 0` is that chain, De Morgan'd. kuna's 11-deep nest is the *same*
+short-circuit CFG spelled as statements — semantically right, structurally noisy.
+
+## Analysis
+
+### Symptom (one, named)
+
+**A 12-clause short-circuit condition is emitted as an 11-deep `if` nest instead of a
+folded `&&` chain.** No gotos, no missing blocks, no wrong values — the condition
+tree is correct; only its rendering is unfolded.
+
+### Root cause
+
+This is the known `condfold` family (`docs/options.md`, and the memory note
+`kuna-condfold-isComplex-root`): upstream Ghidra's `ruleBlockOr` declines to fold a
+condition operand whose block `isComplex()` (more than a couple of printed
+statements), and each `iVar1 = strcmp(a0, "-xx");` clause is exactly that. kuna
+already ships the relaxation as `--option condfold off|on|wide`
+(`p8_structure/kuna_condfold.rs`), default **off**, and it is **not** in the
+`aggressive` preset — which is why a no-flag run on today's build still shows the
+full nest.
+
+`wide` is a *bounded* relaxation: both admission rules share a printed-width budget
+(5 statements at `on`, 9 at `wide` — `MAX_SHAPE_STMTS` / `ShapeVerdict` in
+`kuna_condfold.rs`). Twelve `strcmp` clauses do not fit in 9, so the fold breaks into
+groups of 3/2/4/2 and four `if`s survive. That is the entire residual: **11 → 4 is a
+budget artifact, not a matcher failure.**
+
+### Owning phase
+
+**P8** — Structured AST & Goto Quality (`p8_structure/kuna_condfold.rs`).
+
+### Metric-artifact check
+
+Not an artifact. Source CFG is 23 nodes / 33 edges and non-degenerate; the case is
+not `approximated`; `source_ambiguous` is set only because two translation units
+(`test.i`, `lbracket.i`) carry the identical function. binja scores 0 here, so a 0 is
+reachable.
+
+### Siblings
+
+All 6 cases in the group are the same function in two binaries (`[` and `test`) at
+three optimisation levels.
+
+- `O2-coreutils-test-binop`, `O2-noinline-coreutils-{_,test}-binop`: identical
+  symptom (same margins 50/50/50).
+- `O0-coreutils-{_,test}-binop` (margin 18, flagged `artifact? yes`): a **different
+  and much better** shape — today's build emits a clean early-return cascade
+  (`if (!strcmp(a0,"=")) return 1; …`, `// return-dupe x11`), which is arguably closer
+  to the source than IDA's. No `condfold` work is needed there.
+
+## Proposed fix
+
+**No new feature. This is a default-flip / policy question, and a narrow one.**
+
+1. **The flip candidate**: `condfold` is default-off and outside the `aggressive`
+   preset. Every un-folded short-circuit condition in the ida pool is a `condfold`
+   case; a measured `condfold=wide` default (or adding it to `aggressive`) is the
+   real decision, and it needs the full DIV-row treatment: datatest ablation, speed
+   budget, and a benchmark rescore over the whole group.
+
+2. **The residual, if anyone wants the last 3 `if`s**: the only thing standing
+   between `wide` and IDA's single `if` is the shared printed-width budget in
+   `p8_structure/kuna_condfold.rs`. A third policy level (an `unbounded`/`max` value
+   on the existing option — options take values, not just on/off) would close it in
+   one module. I would rank that *below* the default-flip: an unbounded fold produces
+   a 12-term condition on one source line, and whether that reads better than a
+   4-deep nest is a taste call, which is precisely what a value-carrying option is
+   for. It is not a correctness item — kuna's output here compiles and computes the
+   right value.
+
+GED value: real but capped. The Joern CFG for `A && B` and for `if(A){if(B){}}` are
+close, so the 11→4 collapse is worth less than the `if`-count suggests; measure with
+`scripts.decbench.rescore --case O2-coreutils-_-binop --siblings` before promising a
+number.

--- a/docs/decbench/triage/O2-noinline-bash-bash-shell_initialize.md
+++ b/docs/decbench/triage/O2-noinline-bash-bash-shell_initialize.md
@@ -1,0 +1,142 @@
+---
+case_id: O2-noinline-bash-bash-shell_initialize
+pool: angr
+group_id: bash::shell_initialize
+status: already-fixed
+tier: M
+margin: 72
+fresh_verdict: today's build scores GED 0 — kuna's CFG is *isomorphic* to the source (9 nodes / 12 edges, same as angr and ida). The recorded 72 was three `if (chain) v = 1; else v = 0;` boolean-materialization diamonds that `iteboolean` (DIV-51, PR #241) now folds into the short-circuit chain. Mode-independent (identical output under `--mode reliable`, `aggressive` and no-flag).
+option_closing: null
+feature_slug: null
+scope: small
+confidence: high
+---
+
+## Verify-first
+
+```
+$ ~/.virtualenvs/decbench/bin/python -m scripts.decbench.rescore \
+      --case O2-noinline-bash-bash-shell_initialize
+[rescore] METRIC-DRIFT: recorded 72 vs recomputed 0
+ "ged_recorded": 72.0,  "ged_before": 0.0,  "ged_after": 0.0,
+ "ged_perfect_after": true,  "ged_kuna_commit": "9623dc27"
+```
+
+Per-decompiler CFG probe on the stored artifacts (today's evaluator):
+
+```
+source shell.i:   9n/12e
+kuna:   9n/12e  ged=0.0   iso=True    method=isomorphism
+angr:   9n/12e  ged=0.0   iso=True
+ida:    9n/12e  ged=0.0   iso=True
+ghidra: 29n/41e ged=84.0  iso=False   method=vj_ged
+binja:  11n/14e ged=12.0  iso=False
+```
+
+Mode sweep (bash O2-noinline stripped is 1.31 MB, so `auto` -> `reliable` = exactly the
+benchmark's option surface):
+
+```
+$ kuna decompile-all .../O2-noinline/bash/stripped/bash --json --addr 0x34460 [<mode>]
+[]                 loc 37  ifs 4  gotos 0
+[--mode reliable]  loc 37  ifs 4  gotos 0
+[--mode aggressive]loc 37  ifs 4  gotos 0
+```
+
+## Not a metric artifact — the code changed
+
+`ghidra`, `ida`, `angr` and `binja` all reproduce their recorded values exactly, so the
+2026-07-28 decbench GED overhaul (`e6e6b0f`, isomorphism early-out before `vj_ged`) is not
+what moved kuna. Running the *old* evaluator (raw `cfgutils.similarity.vj_ged`, no
+isomorphism early-out) on the stored kuna artifact also gives **0.0**:
+
+```
+$ vjprobe O2-noinline-bash-bash-shell_initialize kuna
+source shell.i: 9n/12e
+kuna: 9n/12e  iso=True  RAW_vj_ged=0.0
+```
+
+So kuna's *output* changed. (The `O2-noinline` kuna artifact in the results tree was
+regenerated on Aug 1 — `mtime 2026-08-01 23:28` — which is why `triage`'s "stored" pane
+already equals the fresh one. **The results tree is live user WIP and is being written
+concurrently**; several `O0/*/decompiled/kuna_*.c` files carry `Aug 3 05:10` mtimes.
+Never treat a "stored" pane as run-era without checking its mtime.)
+
+## What the run-era output looked like
+
+The `O0` bash artifact is still run-era (`mtime Jul 15`) and shows the defect on the same
+function:
+
+```c
+  v1 = shell_is_restricted(shell_name);
+  if (((privileged_mode) || (restricted)) || ((v1 || (dat_172330))))
+    v4 = 1;
+  else {
+    v4 = 0;
+  }
+  initialize_shell_variables(shell_environment,v4);
+  ...
+  v2 = (((privileged_mode) || (restricted)) || ((v1 || (dat_172330))));   <- re-rolled
+  initialize_shell_options(v2);
+  if (((privileged_mode) || (restricted)) || ((v1 || (dat_172330))))
+    v2 = 1;
+  else {
+    v2 = 0;
+  }
+  initialize_bashopts(v2);
+```
+
+Three identical 0/1 select diamonds; each un-rolled one adds 2 nodes / 2 edges to the CFG.
+At `O2-noinline` all three were still if/else at run time (9 -> 15 nodes), which is the 72.
+
+## Source (bash `shell.c`)
+
+```c
+  initialize_shell_variables (shell_environment,
+      privileged_mode||restricted||should_be_restricted||running_setuid);
+  initialize_job_control (jobs_m_flag);
+  initialize_bash_input ();
+  initialize_flags ();
+  initialize_shell_options (privileged_mode||restricted||should_be_restricted||running_setuid);
+  initialize_bashopts (privileged_mode||restricted||should_be_restricted||running_setuid);
+```
+
+Today kuna prints the chain inline at all three call sites, matching the source, angr and
+IDA:
+
+```c
+  v1 = shell_is_restricted(shell_name);
+  initialize_shell_variables(shell_environment,((privileged_mode || restricted) || dat_1409d4) || v1);
+  initialize_job_control(jobs_m_flag);
+  initialize_bash_input();
+  initialize_flags();
+  initialize_shell_options(((privileged_mode || restricted) || dat_1409d4) || v1);
+  initialize_bashopts(((privileged_mode || restricted) || dat_1409d4) || v1);
+```
+
+## Analysis
+
+Closed by **`iteboolean`** (P8, DIV-51 / PR #241 — "re-roll short-circuit 0/1 select
+diamonds into a boolean assignment"), default-ON and mode-independent. Ghidra still scores
+84 here, so this is a kuna-only win over its own ancestor.
+
+**But the run-era O0 pane above is also a live witness of a different defect**: `iteboolean`
+re-rolled only *one* of the three identical diamonds, and it still does today —
+
+```
+$ kuna decompile-all .../O0/bash/stripped/bash --json --addr 0x34684
+  ... if (chain) v4 = 1; else { v4 = 0; }        <- missed
+  ... v2 = (chain);                              <- re-rolled
+  ... if (chain) v2 = 1; else { v2 = 0; }        <- missed
+```
+
+That is the `itecondlist` candidate filed from
+`O0-betaflight-betaflight_STM32F405-mavlinkSendRCChannelsAndRSSI`; `iteboolean` shares
+`leaf_bblock` with `iteregion`, so the same one-module fix covers it.
+
+## Proposed fix
+
+None for this case. Update `docs/decbench/backlog.md` rank #4 to closed on the next mine.
+Campaign note: `bash::shell_initialize` is the second angr-pool row (after
+`coreutils::factor`) whose margin was already paid by a shipped feature — always rescore
+before triaging.

--- a/docs/decbench/triage/O2-noinline-sysvinit-utmpdump-print_utline.md
+++ b/docs/decbench/triage/O2-noinline-sysvinit-utmpdump-print_utline.md
@@ -1,0 +1,304 @@
+---
+case_id: O2-noinline-sysvinit-utmpdump-print_utline
+pool: novel
+group_id: sysvinit::print_utline
+status: already-fixed
+tier: N
+margin: 0
+fresh_verdict: today's build emits zero raw register identifiers in either NOVEL raw_reg row — PR #226 (694ab8ef) closed the whole class; corpus re-verification of all 267 stored raw-register functions comes back 267/267 clean under every mode
+option_closing: null
+feature_slug: null
+scope: small
+confidence: high
+---
+
+Track: **raw register names appearing as variables in emitted C** (NOVEL pool) —
+`mydoom::scan_textfile` (`raw_regx8`) and `sysvinit::print_utline` (`raw_regx6`).
+This record covers both rows plus the corpus-wide sweep; the mydoom row already has its
+own record (`O2-noinline-mydoom-mydoom-scan_textfile.md`, which proposed the fix that
+shipped).
+
+## Verdict in one line
+
+**Disproven as a live defect.** Both rows, and every other raw-register leak in the
+2026-07-27 corpus, were the `PTRSUB(spacebase, off)` render that PR #226 fixed on
+2026-08-01. It is *not* the copy-shadow/printer diagnosis on file. A separate, much
+smaller residual (28 functions / 83,168) survives through a different code path and is
+described at the bottom — it is not campaign-grade at that breadth.
+
+## The stored panes are stale, and this one is stale twice over
+
+Two traps a follow-up agent will hit:
+
+1. The `kuna_*.c` artifacts under `~/github/decbench/results/full_run` were **partially
+   regenerated after the pool was mined**. `docs/decbench/novel.json` was written
+   2026-08-01 17:28 UTC; `O2-noinline/sysvinit/decompiled/kuna_utmpdump.c` was rewritten
+   2026-08-01 23:54 UTC and `O2-noinline/mydoom/decompiled/kuna_mydoom.c` at 23:49 UTC,
+   both by a post-#226 build. So `triage --case` prints a "stored" pane with **zero**
+   raw registers while the pool row says `raw_reg: 6`. That is not a mining bug — it is
+   an artifact that no longer matches the snapshot it was mined from.
+2. The benchmark-era artifacts (2026-07-15) that were *not* regenerated still carry the
+   original form, and they are the honest "before" evidence. Both are quoted below.
+
+## Side-by-side
+
+### `print_utline` — before (benchmark-era artifact, `O0/sysvinit/decompiled/kuna_utmpdump.c`, 2026-07-15)
+
+```c
+// Function: print_utline @ 0x18ff
+void print_utline(void)
+{
+  ...
+  v13 = PTRSUB(RSP,0x164);
+  if (inet_ntop(v12,v13,v1,v14) == 0) {
+    v1[0] = 0;
+  }
+  sub_1727((int8)v7);
+  sub_182f(PTRSUB(RSP,0x30),4);
+  sub_182f(PTRSUB(RSP,0x34),0x20);
+  sub_182f(PTRSUB(RSP,0x10),0x20);
+  sub_182f(PTRSUB(RSP,0x54),0x100);
+  printf("[%d] [%05d] ...",(uint8)(uint4)(int4)v3,(uint8)v5,PTRSUB(RSP,0x30),8,0x20);
+  return;
+}
+```
+
+Six `PTRSUB(RSP, …)` — exactly the `raw_reg: 6` the miner scored. `RSP` and `PTRSUB` are
+both undeclared; the body is not C.
+
+### `print_utline` — after (today's build, `9623dc27`, no flags = `--mode auto`)
+
+```
+$ SLEIGHHOME=/home/mahaloz/github/kuna/specs \
+  ./decompiler/target/release/kuna decompile \
+      ~/github/decbench/results/full_run/O2-noinline/sysvinit/stripped/utmpdump --addr 0x1a00
+```
+```c
+void sub_1a00(void)
+{
+  char *v1;
+  ...
+  v14 = *(unsigned long *)(v4 + 0x28);
+  v1 = (char *)inet_ntop((-(uint4)((!v10 && !v12) && !v13) & 0xfffffff8) + 10,
+                         &Stack0000000000000164,v3,
+                         (-(uint4)((!v10 && !v12) && !v13) & 0xffffffe2) + 0x2e);
+  if (!v1) {
+    v3[0] = 0;
+    v1 = v3;
+  }
+  v2 = sub_1840((int8)v9);
+  sub_1940(&Stack0000000000000030,4);
+  sub_1940(&Stack0000000000000034,0x20);
+  sub_1940(&Stack0000000000000010,0x20);
+  sub_1940(&Stack0000000000000054,0x100);
+  __printf_chk(1,"[%d] [%05d] [%-4.4s] [%-*.*s] [%-*.*s] [%-*.*s] [%-15.15s] [%-28.28s]\n",
+               (int4)v5,v7,&Stack0000000000000030,8,0x20,&Stack0000000000000034,0xc,0x20,
+               &Stack0000000000000010,0x14,0x100,&Stack0000000000000054,v1,v2);
+  return;
+}
+```
+
+Six `PTRSUB(RSP,…)` → six `&Stack<hex>`. Zero register identifiers, zero p-code operators.
+Same result under `--mode reliable`, `--mode aggressive` and `--mode fast` (transcript
+below), so this is a **code fix**, not a mode-preset effect.
+
+### `scan_textfile` — before (`O0/mydoom/decompiled/kuna_mydoom.c`, 2026-07-15) / after
+
+```c
+  *(void *)&PTRSUB(ESP,0x14)[v2] = 0;          //  before  (x8, i386 PE, MSVC _chkstk frame)
+  *(void *)&PTRSUB(ESP,0x10)[v2] = 0x80;
+```
+```c
+  *(unsigned int *)&(&Stack00000008)[v2] = 0;  //  today
+  *(unsigned int *)&(&Stack00000004)[v2] = 0x80;
+```
+
+### Mode sweep (both rows)
+
+```
+########## mode=reliable  mydoom scan_textfile 0x405af0
+15:  *(unsigned int *)&(&Stack00000008)[v2] = 0;
+...
+########## mode=aggressive mydoom scan_textfile 0x405af0     (identical)
+########## mode=fast       mydoom scan_textfile 0x405af0     (identical)
+########## mode=reliable/aggressive/fast  utmpdump print_utline 0x1a00
+19:  v1 = (char *)inet_ntop(...,&Stack0000000000000164,v3,...);
+25:  sub_1940(&Stack0000000000000030,4);
+```
+
+`kuna catalog --json` (83 options) has **no** option whose `use_when`/`symptoms` mention
+registers, spacebases, stack locations or undeclared identifiers — nothing to sweep, and
+nothing to flip. The change was unflagged, as a strict output-correctness fix should be.
+
+## Corpus-wide re-verification (the number that settles it)
+
+**Before.** Scanning all 803 stored `kuna_*.c` artifacts (89,143 function blocks) with a
+register-name matcher over comment- and string-stripped text:
+
+| form | occurrences | functions |
+|---|---|---|
+| `PTRSUB(RSP, …)` | 277 | 259 |
+| `PTRSUB(ESP, …)` | 6 | (in the 259) |
+| `PTRSUB(sp, …)` (ARM Cortex-M) | 12 | 8 |
+| **total** | **295** | **267** |
+
+Every single occurrence is the operand of a `PTRSUB`. There is no other form.
+
+**After.** I re-decompiled **all 267** of those functions on today's build — 53 binaries,
+`decompile-all --json --addr …` per binary, default flags:
+
+```
+stored raw-reg functions: 259                       (x86/x86-64 subset)
+  re-decompiled clean (no raw register today): 259   (of which now print &Stack<hex>: 259)
+  STILL raw register today: 0
+  no output today: 0
+```
+
+plus the 8 ARM `PTRSUB(sp,…)` functions checked individually (betaflight ×3, crazyflie,
+nuttx, riot-os ×2) — e.g. betaflight `0x802181c`:
+
+```c
+  *(unsigned int *)&(&Stackfffffff0)[v3 * 4 + v1] = 0xffffffff;   // was PTRSUB(sp,-0x10)
+```
+
+**267 / 267 closed.** Independently, a fresh sweep of 109 `decompile-all` runs
+(**83,168 functions**, x86-64 / i386-PE / ARM Thumb) finds **0** functions leaking a
+register through the PTRSUB path.
+
+## Analysis
+
+### The mechanism was (a) — the `PTRSUB` form, closed by #226
+
+`PrintC::op_ptrsub_ir`'s SPACEBASE arm bailed to `op_func_ir` when no Symbol covered the
+offset, which prints the opcode as a call token and pushes input 0 — the spacebase
+register varnode — through `push_vn_explicit_ir` → `get_register_name` → `RSP`/`ESP`/`sp`.
+PR #226 (`694ab8ef`, "fix(p9): (NOVEL) render unnamed spacebase refs as stack locations")
+added `push_spacebase_unnamed_ir`, the upstream `PrintC::pushUnnamedLocation` leaf, so the
+arm now names the storage instead of printing the operator. `git log -S
+push_spacebase_unnamed_ir` returns exactly that one commit.
+
+### It is **not** (b), the copy-shadow/printer diagnosis — refuted for both rows
+
+The filed diagnosis (raw `EAX`/`Unique` on `fmt/main` = a register↔global copy-shadow
+merge rendered by member address instead of by high symbol, in
+`printc.rs::push_vn_explicit_ir`) does not apply here:
+
+- The copy-shadow mirror already exists in-tree and is a *different* branch — the
+  `renders_as_global` loop in the unnamed-location tail of `push_vn_explicit_ir`
+  (`printc.rs:6913-6959`), which walks the high's instances looking for an addr-tied
+  **global** member and re-renders as `dat_<addr>`. Its output token is `dat_<hex>`,
+  never `&Stack<hex>`.
+- All 295 corpus occurrences were syntactically inside `PTRSUB(...)`, i.e. an *operand of
+  an op render*, not a leaf reached through the high-name path at all.
+- Instrumented confirmation: `decomp_dbg` `print raw` on `find` `sub_28e28`
+  (`O2-noinline/findutils`) shows the two shapes explicitly —
+
+  ```
+  0x0002943b:5cca:  u0x0000a600(...) = ->(RSP(i),#0xc7)      <- PTRSUB, renders &Stack00000000000000c7
+  0x00028f69:5e2e:  u0x10001682(...) = (cast)(RSP(i))        <- CAST,   renders (int8)RSP
+  0x00028f69:5cb7:  u0x1000168a(...) = u0x10001682 + #0xae
+  ```
+
+  The `->` (PTRSUB) op now prints a stack location; the `(cast)` op still prints `RSP`.
+  Two different printer paths on the *same* input varnode.
+
+### Owning phase
+
+P9 emit for the closed class (`p9_emit/printc.rs`, `op_ptrsub_ir` SPACEBASE arm). The
+residual below is not P9's.
+
+## The residual: 28 functions, a third mechanism (not #226, not the copy-shadow)
+
+The fresh 83,168-function sweep finds **28 functions (0.034%)** that still print an
+undeclared register identifier — via a different route:
+
+| project | functions | form |
+|---|---|---|
+| betaflight | 9 | `(char *)((int4)sp + 6)` |
+| crazyflie | 6 | `(char *)((int4)sp + 6)` |
+| u-boot | 4 | `*(undefined0 **)(a2 - 0xc) = sp;` |
+| cleanflight | 3 | `(char *)((int4)sp + 6)` |
+| nuttx | 3 | `*(undefined0 **)a0 = sp;` |
+| findutils (`find`, x86-64) | 2 | `v5 = (char *)((int8)RSP + 0xae);` |
+| libopencm3 | 1 | `(char *)((int4)sp + 6)` |
+
+85 occurrences total. Root cause, from the `print raw` transcript above: the frame
+reference **stayed an `INT_ADD` on a `CAST` of the spacebase input** instead of being
+normalized to a spacebase `PTRSUB`. The bare input varnode then reaches
+`push_vn_explicit_ir`'s no-bound-name tail. It has no name because
+`HighVariable::has_name` (`p6_variables/variable.rs:883-886`) returns `false` for the
+unaffected stack-pointer input — a *faithful* port of upstream — and
+`kuna_unnamed_location_name` (`printc.rs:8451-8460`) then returns the register name.
+
+So the leaf render is upstream-faithful; the divergence is upstream that reference would
+already be a PTRSUB. That makes this a **P5/P3 pointer-arithmetic normalization** gap
+(the `INT_ADD(spacebase, const)` → `PTRSUB` rewrite blocked by an interposed CAST), with
+only a *containment* available in P9 — and neither containment is clean: naming the leaf
+`in_RSP` would diverge from `has_name`, and rendering it `&Stack00000000` would still be
+an undeclared identifier. **No one-module mechanism, so this residual is
+`needs-proposal`, not a feature candidate** — and at 0.034% breadth it does not earn a
+proposal yet.
+
+For scale, the same scanner over the *stored* corpus per decompiler (undeclared register
+identifiers; `DH`/`pc` hits are string-literal false positives in every column):
+
+| decompiler | functions | leaking |
+|---|---|---|
+| angr | 101,140 | ~0 |
+| ghidra | 77,262 | 0 (66 = `DH` in gnutls strings) |
+| ida | 88,725 | 51 (`R8`/`R9`/`R10`/`R11`, real) |
+| binja | 61,096 | 7,450 (`r4`–`r15`, real) |
+| kuna (stored, pre-#226) | 89,143 | 267 |
+| **kuna (fresh, today)** | **83,168** | **28** |
+
+#226 moved kuna from worse-than-IDA to better-than-IDA on this symptom.
+
+## What actually replaced it, and why that is the bigger case
+
+`&Stack00000008` is Ghidra-parity (`&stack0x00000008`) but it is **still an undeclared
+identifier**. Fresh corpus: **7,381 occurrences across 1,248 functions (1.5%)**. And it is
+not alone — a gcc-verified taxonomy of undeclared identifiers over the 83,168-function
+fresh sweep:
+
+| bucket | occurrences | functions |
+|---|---|---|
+| `dat_<hex>` globals | 221,159 | 24,350 |
+| `label_<hex>` (implicit, fine) | 60,065 | 6,273 |
+| libc externs (`stderr`, `optind`, …) | 13,486 | 7,478 |
+| **`Stack<hex>` unnamed locations** | **7,381** | **1,248** |
+| `sub_<hex>` used as a value | 3,072 | 1,279 |
+| `name._4_4_` member tokens | 1,886 | 400 |
+
+Confirmed with a real compiler on a whole-project export (which is the artifact that is
+*supposed* to compile):
+
+```
+$ kuna decompile-project .../O2-noinline/sysvinit/stripped/utmpdump -o /tmp/proj
+$ gcc -fsyntax-only -w /tmp/proj/utmpdump.c
+error: 'dat_3fe8' undeclared (first use in this function)
+error: 'Stack0000000000000054' undeclared (first use in this function)
+error: 'Stack0000000000000010' undeclared (first use in this function)
+error: 'stderr' undeclared (first use in this function)
+...
+```
+
+`utmpdump.h` (the "recompile prelude") declares **neither** the `dat_<hex>` globals nor
+the `Stack<hex>` locations. That is the live invalid-C lever now, at 20× the breadth of
+anything in this track, and it is a **P9 declaration-emission / project-export** case, not
+a naming case. It deserves its own record; flagging it here rather than folding it into a
+track whose own symptom is closed.
+
+## Proposed fix
+
+None for this track. Both rows are `already-fixed` by #226 (`694ab8ef`); the record's
+`status` for `O2-noinline-mydoom-mydoom-scan_textfile` should move from
+`feature-candidate` to `already-fixed` and `docs/decbench/features.md`'s
+`spacebase-unnamed-location` row from "PR in flight" to shipped.
+
+Two follow-ups worth their own cases, in priority order:
+
+1. **`dat_<hex>` / `Stack<hex>` are never declared** — 24,350 and 1,248 functions
+   respectively; the project export does not compile. P9 emit + project export.
+2. **Spacebase `INT_ADD`-through-`CAST` never becomes a `PTRSUB`** — 28 functions,
+   85 occurrences, concentrated in ARM Cortex-M firmware. P5/P3. `needs-proposal`,
+   low priority at this breadth.

--- a/docs/decbench/triage/audit-uncatalogued-options.md
+++ b/docs/decbench/triage/audit-uncatalogued-options.md
@@ -1,0 +1,275 @@
+---
+case_id: audit-uncatalogued-options
+pool: novel
+group_id: kuna::option-catalog
+status: feature-candidate
+tier: A
+margin: 0
+fresh_verdict: "`readonly` is not the exception — ALL 38 upstream-inherited ArchOptions are absent from `kuna catalog`, and at least 8 of them measurably change emitted C on today's build via `--option`."
+option_closing: null
+feature_slug: catalog-upstream-options
+scope: small
+confidence: high
+---
+
+## What was filed
+
+Round 1's loose thread (`docs/decbench/features.md`): *"`readonly` is registered without a
+`settableTable` row, so it is invisible to `kuna catalog` and therefore to any agent
+sweeping options by symptom. Check whether other Ghidra-inherited options share that gap."*
+
+They all do. `readonly` is not an oversight; it is one member of an entire uncatalogued
+family.
+
+## Verify-first: what today's build actually does
+
+### 1. The kuna-owned half is perfectly in sync — the gap is elsewhere
+
+```
+$ kuna catalog --json | (count) -> 83
+KUNA_OPTION_NAMES                  -> 83
+in KUNA_OPTION_NAMES not in phases.toml settableTable: []
+in phases.toml settableTable not in KUNA_OPTION_NAMES: []
+```
+
+`kuna catalog --check` (`kuna-cli/src/catalog.rs:221`) enforces **bidirectional** equality
+between the emitted catalog and `KUNA_OPTION_NAMES`, and it is green. So the contract that
+exists is being honoured; the problem is what the contract does not cover.
+
+### 2. All 38 upstream ArchOptions are invisible
+
+`decompiler/crates/kuna-decomp/src/p0_knowledge/options.rs` contains 38 `impl ArchOption`
+blocks whose names are the ported Ghidra `OptionDatabase` set. Probing each against the
+catalog:
+
+```
+$ for o in <38 names>; do kuna catalog --option $o; done
+aliasblock               invisible      inplaceops               invisible
+allowcontextset          invisible      integerformat            invisible
+analyzeforloops          invisible      jumpload                 invisible
+braceformat              invisible      jumptablemax             invisible
+commentheader            invisible      maxinstruction           invisible
+commentindent            invisible      maxlinewidth             invisible
+commentinstruction       invisible      namespacestrategy        invisible
+commentstyle             invisible      nanignore                invisible
+conventionprinting       invisible      nocastprinting           invisible
+currentaction            invisible      noreturn                 invisible
+defaultprototype         invisible      nullprinting             invisible
+errorreinterpreted       invisible      protoeval                invisible
+errortoomanyinstructions invisible      readonly                 invisible
+errorunimplemented       invisible      setaction                invisible
+extrapop                 invisible      setlanguage              invisible
+hideextensions           invisible      splitdatatype            invisible
+ignoreunimplemented      invisible      togglerule               invisible
+indentincrement          invisible      warning                  invisible
+inferconstptr            invisible
+```
+
+**38 / 38 invisible.** Zero of them appear in `kuna catalog`, `kuna catalog --json`,
+`docs/options.md`, or the `symptoms` index an agent greps.
+
+### 3. They are nonetheless a live `--option` surface that changes emitted C
+
+`kuna-cli/src/decompile_all.rs:455 apply_runtime_options` routes any name **not** in
+`KUNA_OPTION_NAMES` through `registry().find_element(name, 0)` into `OptionDatabase::set`.
+So `kuna decompile-all <bin> --option readonly on` works today. A/B on three stripped
+corpus binaries (changed lines in the full `decompile-all` output vs a no-flag run):
+
+| option | value | O0 coreutils/factor | O0 coreutils/ptx | O0 cronie/crontab | O2-noinline iproute2/ip |
+|---|---|---|---|---|---|
+| `integerformat` | `hex` | **2616** | — | — | — |
+| `nocastprinting` | `on` | **1126** | **1096** | **576** | — |
+| `jumptablemax` | `32` | **668** | **1214** | **212** | — |
+| `analyzeforloops` | `off` | **321** | **183** | **43** | — |
+| `inferconstptr` | `off` | **220** | **296** | **339** | — |
+| `inplaceops` | `off` | **240** | **122** | **58** | — |
+| `nullprinting` | `off` | **46** | **78** | **26** | — |
+| `readonly` | `on` | 0 | 0 | **87** | **159** (63168 → 63107 lines) |
+| `aliasblock` | `all` | 0 | 0 | 0 | — |
+| `nanignore` | `all` | 0 | 0 | 0 | — |
+| `conventionprinting` | `off` | 0 | — | — | — |
+| `maxlinewidth` | `40` | 0 | — | — | — |
+
+`readonly on` is the one round 1 already named — it is what closes
+`O2-noinline-iproute2-ip-netns_add` — and it is reproduced here on today's build: 159
+changed lines on `ip`, 87 on `crontab`. Seven more upstream options change output on
+*every* binary tried.
+
+### 4. Three of the 38 are not even reachable
+
+```
+$ kuna decompile-all factor --option hideextensions on
+error: option hideextensions: Unknown option
+$ kuna decompile-all factor --option splitdatatype off
+error: option splitdatatype: Unknown data-type split option: off
+$ kuna decompile-all factor --option warning off
+error: option warning: Bad action/rule specifier: off
+```
+
+`hideextensions` is genuinely dead: its `ELEM_HIDEEXTENSIONS` (kuna-local id 4090) is
+deliberately **not** in `UPSTREAM_OPTION_ELEMENTS`, so `find_element` returns 0 from both
+the CLI (`decompile_all.rs:465`) and the console (`ifacedecomp.rs:761`). It is an
+`ArchOption` impl with no caller. `splitdatatype`/`warning` are reachable but take
+multi-token values the single-`p1` `--option NAME VALUE` form cannot express.
+
+## Analysis
+
+**Symptom (one, named):** the option catalog — kuna's entire discovery surface for the LLM
+control API — documents 83 of the 121 options the binary actually accepts, and the 38 it
+omits include the ones that flip read-only constant propagation, constant-pointer
+inference, for-loop recovery, jump-table bounds, cast printing, and integer radix. An agent
+sweeping `use_when`/`symptoms` for "stores into .rodata that the binary never performs"
+cannot find `readonly`, because as far as `kuna catalog --json` is concerned it does not
+exist. Round 1 hit this exact wall on `netns_add`.
+
+This is the `docs/improvement-pipeline.md` *provenance contract* being satisfied only on the
+half of the surface that was born after the contract. CLAUDE.md's rule — *"anything that can
+change emitted C ships behind a named option ... `kuna catalog --check` must stay green"* —
+is enforced by a check that structurally cannot see the upstream family, because
+`cmd_check` compares the catalog to `KUNA_OPTION_NAMES` and the upstream options are not in
+that list by construction.
+
+**Owning phase: P0** (knowledge/configuration plane). Owning files:
+`decompiler/crates/kuna-decomp/phases.toml`,
+`decompiler/crates/kuna-decomp/src/p0_knowledge/options.rs`,
+`decompiler/crates/kuna-cli/src/catalog.rs`.
+
+**Not a metric artifact, not covered by an option, not already fixed.** It has zero GED
+value and zero direct correctness value — it is a *discoverability* defect, which is exactly
+the class the campaign says to rank on: round 1 lost a case to it.
+
+## Classification of the 38
+
+Not all 38 deserve a row. The settableTable models a **per-run decision point with a closed
+value set**; several upstream options are console verbs or per-function facts.
+
+### Tier A — 16 rows to add. Per-run knobs, closed enum values, drop straight into today's row model
+
+| option | values | current default | phase | evidence |
+|---|---|---|---|---|
+| `readonly` | `on\|off` | `off` (`architecture.rs:1208`) | P3 | 159 lines on `ip`, 87 on `crontab`; the `netns_add` case |
+| `inferconstptr` | `on\|off` | on | P5 | 220 / 296 / 339 |
+| `analyzeforloops` | `on\|off` | `true` (`architecture.rs:1206`) | P8 | 321 / 183 / 43 |
+| `aliasblock` | `none\|struct\|array\|all` | `array` (level 2, `:1211`) | P6 | 0 observed (default already blocks) |
+| `nanignore` | `none\|compare\|all` | `compare` (`:1210`) | P3 | 0 observed |
+| `jumpload` | `on\|off` | off | P2 | unmeasured |
+| `ignoreunimplemented` | `on\|off` | off | P2 | unmeasured |
+| `errorunimplemented` | `on\|off` | off | P2 | unmeasured |
+| `errorreinterpreted` | `on\|off` | on | P2 | unmeasured |
+| `errortoomanyinstructions` | `on\|off` | off | P2 | unmeasured |
+| `allowcontextset` | `on\|off` | on | P0 | unmeasured |
+| `namespacestrategy` | `minimal\|all\|none` | `minimal` | P9 | 0 observed |
+| `nullprinting` | `on\|off` | on | P9 | 46 / 78 / 26 |
+| `inplaceops` | `on\|off` | — | P9 | 240 / 122 / 58 |
+| `nocastprinting` | `on\|off` | off | P9 | 1126 / 1096 / 576 |
+| `conventionprinting` | `on\|off` | on | P9 | 0 observed |
+| `integerformat` | `hex\|dec\|best` | `best` (`printlanguage.rs:606`) | P9 | 2616 |
+
+(17 lines listed; `allowcontextset` is the judgement call — drop it and it is 16.)
+
+The four P9 printing toggles are the **same class** as the already-catalogued
+`truthycond` / `braceelide` / `arraynotation` / `warnstyle` / `compareform`, which carry
+`tier = "core"`, `change_kind = "presentation-default"`. There is no principled reason
+`truthycond` has a row and `nullprinting` does not.
+
+### Tier B — 6 options that need a `values` grammar extension first
+
+`jumptablemax`, `maxinstruction`, `maxlinewidth`, `indentincrement`, `commentindent`,
+`extrapop`. All take an integer. `build.rs:399` validates with
+`if !st.values.split('|').any(|v| v == value) { return false; }` and `gen_option_values`
+emits one enum-typed field per settable, so an open integer domain does not fit. All 83
+existing rows are closed enums (`on|off` ×78, plus `pair|single`, `off|on|wide`,
+`inline|banner`, `canonical|original`, `angr|ghidra`).
+
+`jumptablemax` is the one that matters — 668/1214/212 changed lines, and it is the direct
+sibling of the already-catalogued `switchmodbound` / `switchguardbound`. It should get a row
+once a `values = "<int>"` (or `"<int:1..65536>"`) form exists.
+
+### Tier C — 15 correctly excluded
+
+`inline`, `noreturn`, `extrapop`(also B), `defaultprototype`, `protoeval`, `setaction`,
+`currentaction`, `setlanguage`, `togglerule`, `warning`, `commentheader`,
+`commentinstruction`, `commentstyle`, `braceformat`, `splitdatatype`, `hideextensions`.
+These are console verbs (`setaction`, `togglerule`), per-function facts requiring a name
+argument (`inline`, `noreturn`), or multi-token configurations — not per-run decision
+points with a closed value set. `hideextensions` is dead code and should be either wired
+into `UPSTREAM_OPTION_ELEMENTS` or deleted; that is a separate one-line judgement.
+
+## Proposed fix
+
+### The blocker nobody has noticed
+
+Adding a `settableTable` row alone **fails `kuna catalog --check`**: `cmd_check`
+(`catalog.rs:233-246`) reports `catalog row "readonly" matches no registered kuna option
+(stale)`. Adding the name to `KUNA_OPTION_NAMES` instead **breaks dispatch**, because both
+`apply_runtime_options` (`decompile_all.rs:457`) and the console `IfcOption`
+(`ifacedecomp.rs:748`) check `KUNA_OPTION_NAMES.contains()` **first** and route to
+`Architecture::set_kuna_option`, whose `match name` (`architecture.rs:1283`) has no arm for
+upstream names and would return a parse error. So the naive "just add the rows" PR
+regresses `--option readonly on` from working to erroring.
+
+### Mechanism (fits in one module of code)
+
+Two viable shapes; recommend the second.
+
+1. **Passthrough arm.** Add the 16 names to `KUNA_OPTION_NAMES` and give
+   `Architecture::set_kuna_option` a fallback arm that forwards to
+   `OptionDatabase::new().set(self, find_element(name), p1, "", "")`. One new match arm +
+   one helper in `infra/architecture.rs`. Keeps `cmd_check` unchanged.
+2. **Teach `cmd_check` the upstream class** (recommended, smaller and truthful). Leave
+   `KUNA_OPTION_NAMES` alone; relax `cmd_check`'s `cat.difference(&registered)` arm to also
+   accept a name that resolves in `UPSTREAM_OPTION_ELEMENTS`. ~6 lines in
+   `kuna-cli/src/catalog.rs`, no dispatch change, and the two dispatch sites keep working
+   unmodified because upstream names still fall through to `OptionDatabase`. Rows omit
+   `live_field`/`live_true`/`live_false` — an established pattern (18 analysis gates and
+   `loweredswitch`/`stackguard`/`namestyle` already do).
+
+### True size of the fix
+
+`docs/improvement-pipeline.md` §3.4 names three count sites; measured against the actual
+files, adding 16 rows costs:
+
+| site | what | 83 → 99 |
+|---|---|---|
+| `src/p0_knowledge/kuna_phases/tests.rs:48,49` | `kuna_num_settables()`, `SETTABLE_TABLE.len()` | 2 edits |
+| `tests/catalog_bytecompat.rs:82,84,86` | `"option":` / `"tier":` / `"symptoms":` counts | 3 edits |
+| `tests/fixtures/phase_catalog.json` | the **byte-for-byte** catalog fixture (`assert_eq!(rust, FIXTURE)`) | regenerate |
+| `tests/stages/kuna-catalog.xml:40,44` | `#5 use_when` / `#9 change_kind` are `min="10" max="160"` | **no bump** (99 < 160) |
+| `tests/stages/kuna-catalog.xml:41,42,43` | `#6/#7/#8` exact buckets keyed on `source_decompiler: "angr"` / `change_kind: "structure-recovery"` / `"opt-in-tool"` | **no bump** if every new row uses `source_decompiler = "ghidra-upstream"` and `change_kind = "presentation-default"` or `"analysis-enablement"` |
+| `docs/options.md` | `kuna catalog --markdown >` | regenerate |
+| `docs/spec/` | the P0 chapter | prose |
+
+So: ~5 hand-edited count asserts, one regenerated fixture, one regenerated doc, 16 TOML rows
+of ~18 fields each, and ~6 lines of Rust. The genuinely expensive part is **writing 16
+honest `use_when` + `symptoms` strings** — the whole point of the exercise is that they are
+greppable by symptom, and a lazy row is worse than no row.
+
+Standing requirement 5 (a two-pass `tests/stages/` testcase per option) does **not** apply:
+no behavior is being added, and the underlying `apply` bodies are already covered by
+`p0_knowledge/options/tests.rs`. `tests/stages/kuna-catalog.xml` is the right regression
+fence — extend it with a `min="1" max="1"` stringmatch on the `readonly` row.
+
+### Recommendation: ONE PR for Tier A, with a per-option judgement pass inside it
+
+The blocker (`cmd_check` / dispatch) is shared, the count-bump surface is shared, and the
+fixture must be regenerated exactly once — splitting this into 16 PRs would collide on
+`phases.toml`, the fixture, and every count assert (the known two-PRs-in-flight conflict
+from CLAUDE.md). One PR, `catalog-upstream-options`.
+
+But each **row** is a judgement call and must be written as one: `readonly`'s `use_when`
+has to say *"upstream Ghidra keeps this off for RELRO reasons; turning it on folds
+read-only loads to constants and hides — not fixes — the `rodata-phantom-store` defect"*,
+which is the opposite advice from `nocastprinting`'s. Do not template them.
+
+Tier B (`jumptablemax` + 5 integer options) is a **follow-up PR** and needs the `values`
+grammar extension in `build.rs` first; it is not blocked on Tier A. Tier C stays out, with
+one line in the P0 spec chapter recording *why*, so the next auditor does not re-open this.
+
+## Risks
+
+- Regenerating `tests/fixtures/phase_catalog.json` is a byte-exact recapture (the header of
+  `catalog_bytecompat.rs` documents the console `openfile write` / `phase catalog`
+  procedure); getting it wrong fails opaquely.
+- `docs/options.md` grows by 16 rows and is checked by `make rust-test` freshness.
+- Zero emitted-C risk: no default changes, so `make test` / `make test-stages` stay
+  byte-identical. No DIV row needed.

--- a/docs/decbench/triage/novel-code-ptr-cluster.md
+++ b/docs/decbench/triage/novel-code-ptr-cluster.md
@@ -1,0 +1,361 @@
+---
+case_id: O2-noinline-crazyflie-cf2-dwHandleInterrupt
+pool: novel
+group_id: crazyflie::dwHandleInterrupt (cluster record — 8 cases, 5 projects, 3 arches)
+status: feature-candidate
+tier: N
+margin: 0
+fresh_verdict: the `(code *)` wart is THREE unrelated causes, not one. 80% of kuna's excess over ghidra is ARM/Thumb only and comes from ONE dead accessor — `RuleFuncPtrEncoding` reads a hard-coded `funcptr_align() = 0` stub, so the SLEIGH `BXWritePC` mask `& 0xfffffffe` survives to the C and blocks the `code *` back-propagation; kuna emits 4,673 masks corpus-wide vs ghidra's 579 and ZERO `(code **)` on any ARM binary. A second, smaller cause is the default-ON `inferfuncentry` mis-firing on integer constants that collide with a function entry (wrong code, closed by an existing flag). The third and largest by raw COUNT is ghidra-identical untyped-callback rendering and is not a kuna defect at all.
+option_closing: inferfuncentry off (for the second cause only; nothing closes the ARM cause — all 84 non-default option settings swept)
+feature_slug: funcptralign
+scope: small
+confidence: high
+---
+
+## What was actually verified
+
+Eight NOVEL rows whose `defects` column is driven by `code_ptr`, re-decompiled today
+(`decompiler/target/release/kuna`, `SLEIGHHOME=/home/mahaloz/github/kuna/specs`), each
+against the stripped binary at the case address, plus the ghidra/ida panes and the original
+`.i` source.
+
+| case | arch | kuna `(code *)` | ghidra `(code *)` | cause | verdict |
+|---|---|---|---|---|---|
+| `O2-noinline-crazyflie-cf2-dwHandleInterrupt` | ARM Cortex-M4 | 6 | 3 | **thumb-mask** | feature-candidate |
+| `O2-noinline-libopencm3-msc-msc_data_rx_cb` | ARM Cortex-M | 6 | 3 | **thumb-mask** | feature-candidate |
+| `O2-noinline-nuttx-nuttx-med3` | ARM Cortex-M4 | 5 | **0** | **thumb-mask** | feature-candidate |
+| `O2-noinline-coreutils-head-copy_fd` | x86-64 PIE | 1 | 0 | **inferfuncentry** | covered-by-option |
+| `O2-noinline-x0r-usb-x0r-usb-IRC_Login` | i386 PE | 11 | 11 | untyped callback | not-a-defect |
+| `O2-noinline-e2fsprogs-e2fsck-e2fsck_pass3` | x86-64 | 3 | 6 | untyped callback | not-a-defect |
+| `O2-noinline-libacl-libacl.so.1.1-set_acl_fd` | x86-64 | 12 | 19 | untyped callback | not-a-defect (already recorded) |
+| `O2-noinline-tar-tar-verify_volume` | x86-64 | **0** | 5 | — | already-fixed (DIV-34/36) |
+
+Four of the eight top-ranked `code_ptr` rows are rows where kuna emits **fewer or equal**
+`(code *)` than the co-best rival. The wart counter is measuring an inherited Ghidra
+rendering convention, not a kuna defect (see *Metric note*).
+
+---
+
+## Cause 1 (dominant) — the ARM/Thumb ISA-mode mask: `funcptr_align` is a dead stub
+
+### The pane
+
+`crazyflie::dwHandleInterrupt` @ 0x804001c, fresh, today's default (`--mode auto`):
+
+```c
+  if ((sub_803f1b4(a0)) && (*(uint4 *)(a0 + 0x44)))
+    (*(code *)(*(uint4 *)(a0 + 0x44) & 0xfffffffe))(a0);
+  if ((sub_803f138(a0)) && (*(int4 *)(a0 + 0x40))) {
+    sub_803f238(a0);
+    (*(code *)(*(uint4 *)(a0 + 0x40) & 0xfffffffe))(a0);
+  }
+```
+
+ghidra, same function:
+
+```c
+  if ((iVar2 != 0) && (*(code **)(param_1 + 0x44) != (code *)0x0)) {
+    (**(code **)(param_1 + 0x44))(param_1);
+  }
+```
+
+Source — `crazyflie/O2-noinline/compiled/libdw1000.i`, `dwHandleInterrupt`:
+
+```c
+void dwHandleInterrupt(dwDevice_t *dev) {
+ dwReadSystemEventStatusRegister(dev);
+ if(dwIsClockProblem(dev) && dev->handleError != 0) {
+  (*dev->handleError)(dev);
+ }
+ if(dwIsTransmitDone(dev) && dev->handleSent != 0) {
+  dwClearTransmitStatus(dev);
+  (*dev->handleSent)(dev);
+ }
+ ...
+```
+
+The fields are `dwHandler_t` function pointers. The source performs **no** bit-clear. So
+kuna's C asserts the program computes `handler & ~1` before every callback — bookkeeping the
+machine does for ISA mode, not program semantics — and, because the mask is in the way, the
+field never acquires a function-pointer type, so the load stays `*(uint4 *)` and every call
+site needs an extra `(code *)` cast that ghidra does not need.
+
+`libopencm3::msc_data_rx_cb` and `nuttx::med3` are the same shape.  `med3` is the sharpest
+version: the source parameter is genuinely `int (*cmp)(...)`, ida prints
+`int (*a4)(void)`, ghidra prints `code *param_4`, kuna prints `uint4 a3` and then
+`(*(code *)(a3 & 0xfffffffe))(a0,a2)` five times.
+
+### Root cause, by instrumentation
+
+**Step 1 — what the lifter emits.** `specs/Ghidra/Processors/ARM/data/languages/ARM.sinc:221`
+
+```
+macro BXWritePC(addr) {
+   SetThumbMode((addr & 0x1) != 0);
+   local tmp = addr & 0xfffffffe;
+   pc = tmp;
+}
+```
+`ARMTHUMBinstructions.sinc:1576` — `:blx Hrm0305 { BXWritePC(Hrm0305); lr = inst_next|1; call [pc]; }`.
+So **every** Thumb indirect call lowers to `AND target, 0xfffffffe` → `CALLIND`.
+PR #231 erased the first line of that macro (the `setISAMode` CALLOTHER); this is the
+second line, and #231 did not touch it.
+
+`decomp_dbg` on `msc.elf` @ 0x8001000, `print raw`:
+
+```
+0x080010b0:14e:  r3(0x080010b0:14e) = *(ram,u0x00150200(0x080010b0:54f))
+0x080010b6:15d:  u0x1000012a(0x080010b6:15d) = r3(0x080010b0:14e) & #0xfffffffe
+0x080010b6:550:  pc(0x080010b6:550) = (cast)(u0x1000012a(0x080010b6:15d))
+0x080010b6:15f:  callind pc(0x080010b6:550)
+```
+
+The AND (op `15d`, an original lifted op) is the sole producer of the CALLIND target; the
+`(cast)` at op `550` is late-allocated (P9 `ActionSetCasts`, same op-number band as the
+`(cast)` inserted before every LOAD in the same dump).
+
+**Step 2 — the rule that is supposed to erase it exists and is fully ported.**
+`decompiler/crates/kuna-decomp/src/p3_dataflow/ruleaction_8.rs`, `RuleFuncPtrEncoding`
+(registered as `funcptrencoding` at `infra/universalaction.rs:515`) transcribes upstream
+`ruleaction.cc:9929` line for line: match `CALLIND`, require `in(0)` written by
+`CPUI_INT_AND` with a constant mask, accept when `testmask & (!0 << align) == val`,
+then `op_remove_input` + rewrite the AND to `CPUI_COPY`. For ARM (`align == 1`, size 4)
+that test is `0xFFFFFFFF & 0xFFFFFFFE == 0xfffffffe` — an exact match.
+
+**Step 3 — its only input is hard-coded to zero.** `ruleaction_8.rs:251-257`:
+
+```rust
+/// `data.getArch()->funcptr_align` (C++).  // STUB(W4)
+///
+/// The W4 `Architecture` skeleton does not carry `funcptr_align`; it defaults to
+/// 0 ("encoding disabled"), so `RuleFuncPtrEncoding` no-ops.  Recorded as a loss.
+fn funcptr_align(_data: &Funcdata) -> int4 {
+    0
+}
+```
+
+and the rule's first two lines are `let align = funcptr_align(data); if align == 0 { return 0; }`.
+**The rule can never fire on any architecture.**
+
+**Step 4 — the stub's premise is stale; `funcptr_align` is live.** The comment says the
+`Architecture` skeleton does not carry the field. It does:
+`infra/architecture.rs:244` declares it, `:2105 decode_funcptr_align()` parses
+`<funcptr align="2"/>` (present in `ARM.cspec:33`, `ARM_v45`, `ARM_win`, `ARM_apcs`,
+AARCH64, MIPS, Loongarch) into the bit position, `:3902` calls it during
+`parse_compiler_config`, and `:1869` copies it into the ArchSeam that `Funcdata`
+reads (`substrate/context.rs:797`). Two other consumers already read it live —
+`p2_lift/jumptable.rs:3661` and `p9_emit/coreaction_render.rs:1190`.
+
+Proved live at runtime rather than by reading: `tests/stages/gh8471-thumbfuncptr.xml`
+runs on `ARM:LE:32:v8:default` and its assertion #2 (`call_function(&fn[1])`, the
+default/`thumbfuncptr on` pass) is reachable only through
+`RulePtrsubUndo::preserve_thumb_funcptr`, which short-circuits on
+`funcptr_align == 0` (`p3_dataflow/ruleaction_6.rs:612`). It passes today:
+
+```
+$ decomp_test_dbg -usesleighenv -path tests/stages datatests gh8471-thumbfuncptr.xml
+Success -- GH8471 #1: thumbfuncptr off restores the raw-hex form (old behavior, opt-in)
+Success -- GH8471 #2: default pipeline preserves the symbolic form, &fn[1] via DIV-2 arraynotation
+Total tests applied = 2 / Total passing tests = 2
+```
+
+So the architecture-side plumbing is complete and only the rule's own accessor is dead.
+
+**Step 5 — the consequence on the type, measured.** With the AND out of the way, upstream's
+`TypeOpCallind` types `in(0)` as pointer-to-code and `TypeOpLoad` back-propagates it onto
+the LOAD pointer, giving ghidra's `*(code **)(p)`. Corpus evidence that kuna's machinery
+does exactly this whenever no mask intervenes:
+
+| | kuna `(code **)` | note |
+|---|---|---|
+| x86 / x86-64 projects | 2,914 (openssh 902, x0r-usb 663, zlib 369, bash 230, coreutils 181, …) | no mask on the target → type propagates |
+| **every ARM project** (crazyflie, betaflight, cleanflight, libopencm3, nuttx, chibios, riot-os, freertos, u-boot) | **0** | mask on every target |
+
+Fresh `decompile-all` on today's build confirms: `msc.elf` 108 fns → 50 `(code *)`,
+**0** `(code **)`, 39 masked indirect calls; `cf2.elf` 2,914 fns → 384 `(code *)`,
+**0** `(code **)`, 363 masked indirect calls in 225 functions.
+
+### Option sweep — nothing covers it
+
+All 84 non-default settings of the 83-row catalog were run on
+`cf2.elf --addr 0x804001c`, counting `0xfffffffe`. Every one returned **6** — the baseline.
+`--mode aggressive` = 6, `--mode fast` = 0 and `--mode reliable` = 0 only because both
+degrade this Cortex-M function to an empty `void sub_804001c(void) { return; }` (a separate
+recall issue, not a fix). `condfold on|wide` swept explicitly: 6.
+
+### Breadth
+
+Stored kuna artifacts (regenerated 2026-08-01 23:35, verified identical to today's build on
+all four cases re-run here):
+
+- `& 0xfffffffe` in emitted C: **kuna 4,673 vs ghidra 579** corpus-wide. The excess is
+  entirely ARM: crazyflie 1808/38, betaflight 927/0, libopencm3 637/131, cleanflight 564/24,
+  nuttx 288/0, chibios 64/…; the x86 projects are at parity (openssh 121/131, bash 74/72,
+  iproute2 79/73, coreutils 23/25 — those are real source-level `& ~1`).
+- Thumb-masked indirect calls: **4,027 occurrences in 2,496 function-instances across 97
+  binary-instances** in 9 projects.
+- Of the 3,804 `(code *)` occurrences where kuna exceeds ghidra on the same function,
+  **3,033 (80%) carry the Thumb mask**.
+
+### Owning phase & mechanism
+
+**P3 — definition web** (`p3_dataflow/`, rule pool). One module, one function body:
+
+- `decompiler/crates/kuna-decomp/src/p3_dataflow/ruleaction_8.rs` — replace the
+  `funcptr_align(_data) -> 0` stub with the live read (`data.get_arch().funcptr_align`,
+  the same accessor `p2_lift/jumptable.rs:3661` already uses), delete the two `STUB(W4)`
+  comment blocks at `:71-72`, `:251-257` and the `// -- STUB(W4): funcptr_align defaults to 0`
+  line inside `apply_op`, and update the unit test at `:2163-2169` that currently asserts
+  the rule no-ops *because* of the stub (plus the note at `:2511`).
+- `docs/spec/03-ssa-and-simplification.md` (which already lists `RuleFuncPtrEncoding` as
+  ported — the prose is currently wrong) and `docs/spec/02-lift-and-flow.md` §ISA-mode,
+  the natural companion to #231's paragraph.
+
+**Gating.** This is a strict bug fix in the same sense as #231: the *processor cspec*, not
+kuna, declares `<funcptr align="2"/>`, upstream Ghidra honours it, and the emitted C
+currently states an operation the program does not perform. No new option, no DIV row (it
+removes a divergence). Blast radius is bounded by the cspec: x86/x86-64 declare no
+`<funcptr>` (`funcptr_align == 0`), so the rule stays inert there and the whole datatest
+corpus is untouched except for its ARM/MIPS/AARCH64 members.
+
+**Risks.**
+1. Broad ARM text churn — ~4,000 masks disappear and ~3,000 `(code *)` casts turn into
+   `(code **)` loads. `docs/baseline.json` / `baseline-stages.json` assertions that
+   string-match a masked ARM call will move; inspect each, do not re-pin wholesale.
+2. The rule rewrites the AND to a `COPY`, so a masked value that is *also* used as an
+   integer elsewhere keeps its value (COPY is transparent) — but check that
+   `RulePtrsubUndo::preserve_thumb_funcptr` (GH-8471/DIV-2) still sees the shape it
+   expects; the two features touch the same low bit from opposite ends, and
+   `tests/stages/gh8471-thumbfuncptr.xml` is the guard.
+3. MIPS/AARCH64/Loongarch/8051 also declare `<funcptr>`; the rule becomes live there too.
+   Corpus has no such target, so measure separately before claiming coverage.
+
+**Stage testcase.** `tests/stages/ghdec-funcptralign.xml` is straightforward on the ARM
+Thumb fixture #231 already vendored (`kuna-analysis/tests/fixtures/arm_thumb_switch_le32`)
+or a 3-instruction `ldr r3,[r0,#4]; blx r3` chunk: two-pass, mask present vs absent.
+Note the corpus-file-count bump in `kuna-base/src/xml.rs` + stages baseline re-record.
+
+---
+
+## Cause 2 (small, but WRONG CODE) — `inferfuncentry` collisions
+
+`coreutils::copy_fd` @ 0x3290, fresh, today's default:
+
+```c
+unsigned long copy_fd(unsigned int a0,code *a1) // return-dupe
+{
+  code *v2;
+  ...
+  while( true ) {
+    v2 = _DT_INIT;                 // <-- the constant 0x2000
+    if (a1 <= (code *)0x2000)
+      v2 = a1;
+    v1 = sub_6e00(a0,v3,v2);
+    ...
+    a1 = &a1[-v1];                 // <-- nbytes -= n_read
+```
+
+Source is `copy_fd (int src_fd, uintmax_t n_bytes)` with `BUFSIZ`-style chunking; ida prints
+`size_t nbytes`, ghidra `ulong param_2` and the plain literal `0x2000`. kuna types a
+`size_t` as `code *` and prints the loop chunk size as a **function name**.
+
+Closed by an existing flag:
+
+```
+$ kuna decompile head --addr 0x3290 --option inferfuncentry off
+unsigned long sub_3290(unsigned int a0,uint8 a1)
+    v2 = 0x2000;
+    if (a1 <= 0x2000)
+      v2 = a1;
+    a1 -= v1;
+```
+
+The worst instance found is `gnutls ocsptool::cipher_to_flags` @ 0xdae3 (O0):
+
+```c
+code * sub_dae3(char *a0)          // default
+{
+  if (!a0) return (code *)0x20;
+  ...
+  return (code *)0x4000;
+  return gnutls_ocsp_status_request_is_checked;   // <-- this is the integer 0x8000
+  return (code *)0x1;
+```
+
+`gnutls_ocsp_status_request_is_checked` lives at **0x8000**, and one of the cipher flag
+constants *is* 0x8000. One accidental collision retypes the whole return HighVariable
+`code *`, so all 13 returns take a cast and the C returns a code address where the source
+returns a bit flag. `--option inferfuncentry off` restores `unsigned long` and every
+literal.
+
+**Mechanism.** `inferfuncentry` (P5 / `const-pointer`, default **on**, kuna's own, GH-6930,
+`p5_types/kuna_inferfuncentry.rs`) exists to skip `ActionConstantPtr::isPointer`'s
+`bit_transitions < 3` rejection when the constant resolves exactly to a function entry —
+written for a real function at a power-of-two *image base* (`0x100000`). In a stripped PIE
+ELF the image base is 0, kuna's analysis tier synthesises `_DT_INIT`/`_DT_FINI` function
+symbols from the dynamic tags, and ordinary `.text` entries sit at low addresses — so
+0x2000, 0x8000, 0x1000 are all "exact function entries" and every buffer size and bit flag
+in the binary is a candidate.
+
+**Breadth.** `_DT_INIT`/`_DT_FINI` leaks into 45 functions / 100 occurrences (coreutils 92,
+openssh 5, libacl 2, gnutls 1). A/B over whole binaries: `head` (O2-noinline, 204 fns) goes
+18 code-ptr texts in 5 functions → **0**; `od` (O0, 252 fns) 8 → 2. `tar` (1,585 fns) and
+`libacl` (142 fns) are **unchanged** — there the `(code *)` is the genuine-callback family.
+Corpus-wide 431 functions declare a `code *X` that is never called in the body.
+
+**Verdict:** `covered-by-option`, i.e. a default-narrowing question, not a new feature. The
+honest narrowing is not "flip it off" (it fixes the real GH-6930 case) but "require the
+resolved entry to be at a non-zero image base, or refuse when the constant also feeds an
+arithmetic/comparison chain" — that is a separate one-module change in
+`kuna_inferfuncentry.rs` and should be its own case.
+
+---
+
+## Cause 3 (the largest by raw count) — untyped callback fields: NOT a defect
+
+`libacl::set_acl_fd`, `e2fsprogs::e2fsck_pass3`, `x0r-usb::IRC_Login`: `(code *)a3[1]`,
+`(*(code *)a0[0x2c])(...)`, `(code *)&v5`. Every one is the standard Ghidra-lineage
+rendering for an indirect call through a pointer with no recovered prototype, and ghidra
+emits it identically or more often (19 vs 12, 6 vs 3, 11 vs 11). Neither ida nor ghidra
+recovers `struct error_context` / `e2fsck_ctx->progress` either. Nothing to fix; the
+`realtypes-pointee-size` follow-up on `set_acl_fd` was the real defect there and shipped as
+#232.
+
+`tar::verify_volume` is `already-fixed`: the 5 stored `(code *)0x0` are gone because
+DIV-34 renders zero pointers as `NULL` and DIV-36 elides the comparison entirely
+(`if (dat_84d50)`); `--option truthycond off` brings back `if (dat_84d50 != NULL)`, never
+`(code *)0x0`. This is exactly the print-normalization staleness `docs/decbench-loop.md`
+warns about.
+
+---
+
+## Metric note — the `code_ptr` wart column mis-ranks the NOVEL pool
+
+Two independent problems with `scripts/decbench/novel.py:50`
+(`"code_ptr": (re.compile(r"\(code\s*\*\)"), 8)`):
+
+1. **It is absolute, not relative.** `(code *)` is inherited Ghidra rendering; four of the
+   eight top `code_ptr` rows are rows where kuna emits **fewer** than the co-best rival.
+   The pool's #1 entry — `libacl::set_acl_fd`, defect score 152, entirely `code_ptrx19` —
+   is a pane where ghidra emits 19 and kuna 12. Weight 8 (the second-highest after
+   `halt_baddata`) then dominates the ranking. Scoring `max(0, kuna − best_rival)`, or
+   restricting the pattern to the ARM-masked form
+   `\(code \*\)\([^;\n]*&\s*0xfffffffe`, would surface the 2,496 genuinely-defective ARM
+   functions instead.
+2. **The published counts are stale.** `docs/decbench/novel.json` was mined 2026-08-01
+   17:28; the tree's kuna artifacts were regenerated 23:35–23:55 the same day. Recomputing
+   `defect_profile` over the current artifacts: 212 `code_ptr` cases, **408 → 303**
+   occurrences, 47 of them now zero (`tar::verify_volume` 5→0,
+   `coreutils::copy_fd` 4→1, `bash::edit_and_execute_command` 2→0). Re-run `novel` before
+   trusting the column.
+
+---
+
+## Recommendation
+
+One PR, `feat/decbench-funcptralign`, P3, strict bug fix, no flag: make
+`RuleFuncPtrEncoding` read the live `funcptr_align`. It is the single largest
+kuna-specific correctness/readability defect in the NOVEL pool by breadth (2,496 function
+instances, 9 projects, 3 of the 4 cases triaged here), it has zero GED value, and it is a
+one-function change whose plumbing already exists and is already proven live by an existing
+stage test. File the `inferfuncentry` collision narrowing as a separate, smaller case.

--- a/docs/decbench/triage/novel-concat-subpiece-soup.md
+++ b/docs/decbench/triage/novel-concat-subpiece-soup.md
@@ -1,0 +1,278 @@
+---
+case_id: novel-concat-subpiece-soup
+pool: novel
+group_id: cluster (betaflight/cleanflight::applyLedFixedLayers, cleanflight::ftoa, betaflight/cleanflight::hsvToRgb24, e2fsprogs::parse_int_node, e2fsprogs::ask_yn, iproute2::netns_add, openssh-portable::mux_master_process_close_fwd)
+status: feature-candidate
+tier: N
+margin: 0
+fresh_verdict: the cluster splits in two — CONCAT is INHERITED (kuna 4198 vs ghidra 3700 over 76046 matched functions, and kuna is *better* on the two rows that named it), while SUBPIECE-with-nonzero-offset is a kuna-specific 329x regression (kuna 5919 in 2394 functions vs ghidra 18 in 13) caused by `RuleSubRight::apply_op` being a stub that returns 0 before the `sub(V,c) => sub(V>>c*8,0)` rewrite
+option_closing: null
+feature_slug: subright
+scope: small
+confidence: high
+---
+
+## Verdict in one line
+
+`CONCAT` soup is **not a kuna defect** — Ghidra prints the same or more of it, and the
+source really is byte manipulation. `SUBPIECE` soup **is** a kuna defect, and it is one
+stubbed rule: kuna emits `SUB81(a1,7)` on 2,394 corpus functions where upstream Ghidra
+emits `(char)(a1 >> 0x38)` on 13.
+
+## The witness (fresh, today's build)
+
+`openssh-portable/ssh` `sshbuf_put_u64` @ `0x4cd60`, stripped binary, no flags and
+`--mode reliable` identical:
+
+```
+$ export SLEIGHHOME=/home/mahaloz/github/kuna/specs
+$ ./decompiler/target/release/kuna decompile \
+    ~/github/decbench/results/full_run/O2-noinline/openssh-portable/stripped/ssh \
+    --addr 0x4cd60 --mode reliable
+
+unsigned long sub_4cd60(unsigned long a0,unsigned long a1) // early-return
+{
+  unsigned long v1; // rax
+  char *v2; // stack - 0x18
+  int8 v3; // fs_offset
+  unsigned long v4; // stack - 0x10
+
+  v4 = *(unsigned long *)(v3 + 0x28);
+  v1 = sub_3ea00(a0,8,&v2);
+  if ((int4)v1 <= -1)
+    return v1;
+  *v2 = SUB81(a1,7);
+  v2[1] = SUB81(a1,6);
+  v2[2] = SUB81(a1,5);
+  v2[3] = SUB81(a1,4);
+  v2[4] = SUB81(a1,3);
+  v2[5] = SUB81(a1,2);
+  v2[6] = SUB81(a1,1);
+  v2[7] = (char)a1;          <-- the offset-0 one DOES render as a cast
+  return 0;
+}
+```
+
+Ghidra (stored pane, same function, same binary):
+
+```c
+    *local_18 = (char)((ulong)param_2 >> 0x38);
+    local_18[1] = (char)((ulong)param_2 >> 0x30);
+    local_18[2] = (char)((ulong)param_2 >> 0x28);
+    local_18[3] = (char)((ulong)param_2 >> 0x20);
+    local_18[4] = (char)((ulong)param_2 >> 0x18);
+    local_18[5] = (char)((ulong)param_2 >> 0x10);
+    local_18[6] = (char)((ulong)param_2 >> 8);
+    local_18[7] = (char)param_2;
+```
+
+IDA: `HIBYTE(a2)` / `BYTE6(a2)` / … (its own macro family).
+
+The last line of kuna's own output is the proof: the *offset-0* SUBPIECE already renders
+as `(char)a1`. Nothing is wrong with the printer. The only thing missing is the
+normalization that turns a nonzero-offset SUBPIECE into `shift + offset-0 SUBPIECE`.
+
+### The source (the thing "correct" means)
+
+`~/github/decbench/results/full_run/O2-noinline/openssh-portable/compiled/sshbuf-getput-basic.i`:
+
+```c
+sshbuf_put_u64(struct sshbuf *buf, u_int64_t val)
+{
+ ...
+ do { const u_int64_t __v = (val);
+      ((u_char *)(p))[0] = (__v >> 56) & 0xff;
+      ((u_char *)(p))[1] = (__v >> 48) & 0xff;
+      ... } while (0);
+```
+
+The source is a **shift**. Ghidra's `(char)(param_2 >> 0x38)` is literally the source
+line. kuna's `SUB81(a1,7)` is a p-code operator standing in for ordinary 64-bit
+arithmetic. This answers the track's question 3 for the SUBPIECE half: **not honest
+bitfield code — ordinary shift/mask arithmetic kuna failed to reassemble.**
+
+Same answer for `hsvToRgb24`
+(`.../O0/cleanflight/compiled/colorconversion.i`), which is plain 32-bit integer math:
+
+```c
+    base = ((255 - sat) * val) >> 8;
+    switch (hue / 60) {
+        case 0: r.rgb.g = (((val - base) * hue) / 60) + base;
+```
+
+kuna (fresh) vs ghidra (stored) on the same two expressions:
+
+| | kuna today | ghidra |
+|---|---|---|
+| `((255-sat)*val) >> 8` | `v2 = SUB41(v6,1);` | `bVar2 = (byte)((uint)iVar7 >> 8);` |
+| `hue / 60` | `SUB84((uint8)dat_80164e8 * (uint8)v3,4) >> 5` | `(uint)((ulonglong)DAT_080164e8 * (ulonglong)uVar4 >> 0x25)` |
+
+`0x25 == 37 == 32 + 5` — that is upstream `RuleSubRight` lumping the lone descendant
+right-shift into the synthesized shift. Neither decompiler recovers `/ 60` (a separate
+`RuleDivOpt`/ARM-UMULL gap); the delta kuna owns is only the SUBPIECE lowering.
+
+## Root cause (instrumented, not read)
+
+IR dump for the witness, after full decompilation
+(`decomp_dbg` → `load function sshbuf_put_u64` → `decompile` → `print raw`):
+
+```
+0x0004cd98:2ce:	DL(0x0004cd98:2ce)  = SUB81(RSI(i),#0x7:4)
+0x0004cda5:2cf:	DL(0x0004cda5:2cf)  = SUB81(RSI(i),#0x6:4)
+0x0004cdb3:2d0:	DL(0x0004cdb3:2d0)  = SUB81(RSI(i),#0x5:4)
+...
+0x0004cdeb:2df:	BL(0x0004cdeb:2df)  = SUB81(RSI(i),#0x0:4)
+```
+
+The SUBPIECEs survive to the final IR with their nonzero constant offsets, and their
+input `RSI` is a distinct register from the outputs `DL`/`BL` (so upstream's
+`outvn->overlap(*a) == c` bail cannot fire).
+
+`decompiler/crates/kuna-decomp/src/p3_dataflow/ruleaction_6.rs:912-947` —
+`RuleSubRight::apply_op` — is a **stub**:
+
+```rust
+        let a = in_vn(data, op, 0);
+        let in0_piece = data.vn_type_read_facing(a, op).is_piece_structured();
+        if in0_piece {
+            data.op_mark_special_print(op); // Print this as a field extraction
+            return 0;
+        }
+        // Remainder transcribed for the next wave; unreachable at this merge base:
+        //   PcodeOp *lone = outvn->loneDescend();  ... lump a lone right-shift ...
+        // W6
+        0
+```
+
+Only the special-print half of the rule was ported. Upstream
+(`ruleaction.cc:7271`, `GHIDRA_REV=cef869af`) continues past that point with ~45 lines:
+`c = in(1)->getOffset()`; bail if 0; bail if `outvn`/`a` are both addr-tied and
+`overlap == c`; lump a lone `INT_RIGHT`/`INT_SRIGHT` descendant with a constant shift
+into `d` when `outvn->getSize() + c == a->getSize()`; synthesize the shift op before the
+SUBPIECE; rewrite the SUBPIECE's offset input to 0.
+
+The rule is already **registered and scheduled correctly** —
+`infra/universalaction.rs:552`, `rrow!("subright", "cleanup", ...)` in the cleanup pool,
+which sits after `fullloop` and before `ActionAssignHigh`/`ActionMergeRequired`, exactly
+where upstream puts it. So the new INT_RIGHT and its unique get Highs assigned normally.
+
+## Breadth (corpus-wide)
+
+Matched per-function comparison, kuna vs ghidra, over **788 binaries / 76,046 functions
+that both tools recovered** in `~/github/decbench/results/full_run`
+(scanner is nesting-aware; args parsed with a balanced scan, so `CONCAT71(SUB87(x,1),y)`
+counts as one of each):
+
+| | SUBPIECE, offset != 0 | CONCAT |
+|---|---|---|
+| **kuna** | **5,919 in 2,394 fns (3.1%)** | 4,198 |
+| **ghidra** | **18 in 13 fns (0.017%)** | 3,700 |
+| **ida** | 0 | 0 (uses BYTEn/LOWORD macros) |
+
+Ratio on SUBPIECE: **329x**. On CONCAT: **1.13x**.
+
+Stored-pane sweep validated against fresh `kuna decompile-all` on four binaries — the
+metric is stable across the DIV-34..39 print wave, so the corpus number is trustworthy:
+
+| binary (matched fns) | kuna fresh | kuna stored | ghidra | ida |
+|---|---|---|---|---|
+| O0/cleanflight ARM (1506) | 203 SUB / 63 CONCAT | 196 / 62 | **2** / 72 | 0 / 0 |
+| O2ni/iproute2 ip (615) | 25 / 122 | 25 / 122 | **0** / 102 | 0 / 0 |
+| O2ni/e2fsprogs e2fsck (367) | 12 / 35 | 12 / 35 | **0** / 33 | 0 / 0 |
+| O2ni/openssh ssh (1250) | 60 / 41 | 60 / 41 | **0** / 19 | 0 / 0 |
+
+Top affected binaries (kuna SUB / ghidra SUB): betaflight O2ni 236/2, cleanflight O2ni
+234/2, betaflight O0 230/2, crazyflie O0 154/0, openssh ssh-keyscan O0 115/0.
+Shape distribution over all kuna panes (7,839 occurrences): SUB41 2640, SUB84 2568,
+SUB81 1021, SUB87 496, SUB42 472, SUB21 377, rest < 200.
+
+**Not double-counting `rodata-phantom-store`.** Only 102 of those 7,839 (1.3%) have a
+global-array-indexed first argument — the `s_822f0[1] = SUB81(s_822f0[0],1);` family in
+`iproute2/ip` that round 1 already filed as `rodata-phantom-store`. Upstream's
+addr-tied/`overlap == c` guard would bail on those too; upstream just never *creates*
+them. So `subright` and `rodata-phantom-store` are disjoint fixes, and `subright` owns
+≥98% of the symptom.
+
+## What is DISPROVEN
+
+1. **CONCAT is not a kuna regression.** On the two rows that named it:
+   - `cleanflight::ftoa` (`concatx10`): ghidra's own pane is `local_28 = CONCAT31(...)`,
+     `CONCAT11(0x30,(undefined1)local_28)`, `CONCAT12`, `CONCAT13`, `SUB41(uVar1,3)` —
+     the same soup. The `.i` source is `sprintf`-style byte poking into a 4-byte char
+     buffer, so some CONCAT is honest.
+   - `betaflight/cleanflight::applyLedFixedLayers` (`concatx8`): ghidra emits
+     `CONCAT22`/`CONCAT12`/`CONCAT13` in the same arms. Matched CONCAT counts on the
+     whole cleanflight binary: **kuna 63 vs ghidra 72 — kuna is better.**
+   The corpus-wide +13% CONCAT excess is a thin tail with no single mechanism (worst
+   single function is +7 on `ssh` 0x1e830, `CONCAT44(dat_4,vN)` — an unresolved
+   high-half global, a different bug). **Not a campaign item.**
+
+2. **`openssh-portable::mux_master_process_close_fwd` is already clean.** novel.md lists
+   `concatx1,subpiecex1`; today's build emits **zero** of either in that function. That
+   row's wart component is stale.
+
+3. **`e2fsprogs::parse_int_node` is inherited and identical.** kuna 1 CONCAT, ghidra 1
+   CONCAT, same expression (`CONCAT71(SUB87(v7,1), v4 != 0)` vs
+   `CONCAT71((int7)((ulong)extraout_RDX >> 8), iVar4 != 0)`). Only the inner truncation
+   differs — the same `subright` gap. `ask_yn` is kuna 1 / ghidra 0 (one `CONCAT26`).
+   Both rows are **goto-dominated** (`gotox11` / `gotox8`); their concat/subpiece
+   components are noise and should not have clustered them here.
+
+4. **PR #242 verified fixed on `applyLedFixedLayers`.** The stored pane declares the
+   0x24 stack slot twice under the same name (`unsigned int v12;` **and** `uint4 v12;`).
+   Today's build emits only `unsigned int v12; // stack - 0x24`. The remaining
+   CONCAT/SUB in that function is the inherited kind above plus `SUB42(v12,2)` /
+   `SUB41(v12,3)` where ghidra prints `local_24._2_2_` / `local_24._3_1_` — that residue
+   is the P6 partial-symbol/merge thread, not `subright` (kuna does render `v20._2_1_`
+   elsewhere in the same function, so the printer path exists).
+
+## Option / mode sweep (all negative)
+
+```
+$ for m in auto reliable aggressive fast; do kuna decompile ssh --addr 0x4cd60 --mode $m | grep -c SUB81; done
+7
+7
+7
+7
+$ kuna decompile ssh --addr 0x4cd60 --option condfold on | grep -c SUB81
+7
+```
+
+None of the 83 catalog rows controls SUBPIECE truncation lowering (grepped
+`kuna catalog --json` for subpiece/truncat/piece — hits are `returnpair`,
+`switchmultipred`, `unrolledguard`, `callsitestackargs`, `iteregion`, `iteexpr`,
+`noreturn_*`, none relevant). `option_closing: null`.
+
+## Proposed fix
+
+- **Owning phase: P3** (Definition Web — the simplification rule pools). The symptom is
+  visible at P9 but the decision is a P3 rule, per `docs/phases.md`'s own caveat.
+- **One module, one function**: complete the port of
+  `decompiler/crates/kuna-decomp/src/p3_dataflow/ruleaction_6.rs`
+  `RuleSubRight::apply_op` — the ~45-line tail after the existing `is_piece_structured`
+  early return. Every primitive it needs already exists in kuna:
+  `Varnode::is_addr_tied` / `Varnode::overlap` (`substrate/varnode.rs:813,1345`),
+  `Funcdata::new_op` / `new_unique` / `op_set_output` / `op_set_input` /
+  `op_insert_before` / `new_constant` / `op_unlink` / `op_set_opcode`
+  (`substrate/funcdata_op.rs`, `funcdata_varnode.rs`), and
+  `data.get_arch().types().get_base(size, TYPE_UINT|TYPE_INT)` (pattern already used at
+  `p3_dataflow/ruleaction_8.rs:1773`). No new registration, no schedule change — the
+  rule is already in the cleanup pool at the upstream position.
+- **Option**: `subright` (on = lower `SUB(V,c)` to `(T)(V >> 8c)`, off = keep the raw
+  operator). This is a faithful-port completion whose *only* effect is emitted C, so per
+  AGENTS.md's "when in doubt, gate it" it should ship as a settable row in `phases.toml`
+  + `p0_knowledge/options.rs`, with the default-ON flip carried by the 0/675 ablation.
+- **Stage test**: `tests/stages/ghdec-subright.xml` (no angr analog) — two-pass, an
+  8-byte big-endian store loop; option off = `SUB81(x,7)`, default = `(char)(x >> 0x38)`.
+- **Correctness value**: `SUB81` / `SUB84` are undeclared identifiers — kuna emits no
+  helper header for them (grepped `kuna-cli`/`kuna-console`), so 5,919 call sites across
+  2,394 functions make the exported `.c` non-compilable. Same tier as round 1's
+  `spacebase-unnamed-location` and `realtypes-pointee-size`.
+- **GED value: 0.** No basic-block count changes. Rank this by correctness, not metric.
+- **Risks to measure**: (a) the datatest corpus — the rewrite runs on every function, so
+  a 0/675 ablation is the gate and the likeliest source of churn is cast/type rendering
+  on the new `INT_RIGHT` unique; (b) `ActionCopyMarker` interaction — the addr-tied
+  bail must be ported verbatim or stack-piece writes that currently render as
+  `sym._n_m_` would regress to shift chains; (c) the lone-descend lumping destroys the
+  descendant op, so `op_unlink` ordering must match upstream; (d) speed — one extra op
+  per lowered SUBPIECE, ~6k corpus-wide, measure with `scripts.pipeline.timeit`.

--- a/docs/decbench/triage/rodata-phantom-store.md
+++ b/docs/decbench/triage/rodata-phantom-store.md
@@ -1,0 +1,327 @@
+---
+case_id: O2-noinline-iproute2-ip-netns_add
+pool: novel
+group_id: iproute2::netns_add
+status: feature-candidate
+tier: N
+margin: 0
+fresh_verdict: reproduces on today's product default (both binaries are >500 KiB so `--mode auto` == `reliable`); the round-1 diagnosis is REFUTED by op identity -- `Heritage::refine_write` is not involved, and the ram-addressed `build_in_subpieces` outputs are not the phantom stores
+option_closing: null
+feature_slug: returncopysplit
+scope: small
+confidence: high
+---
+
+Re-triage of the round-1 Tier-1 item `rodata-phantom-store`
+(supersedes the diagnosis in `docs/decbench/triage/O2-noinline-iproute2-ip-netns_add.md`;
+the *symptom* in that record stands, the *mechanism* does not).
+
+## 1. Verify-first: it still reproduces
+
+`ip` is 739,976 B and `sshd` is 1,191,064 B, both > 500 KiB, so `--mode auto` selects
+`reliable` — the fresh no-flag run and `--mode reliable` are the same run, and both are
+what a user gets today.
+
+```
+$ export SLEIGHHOME=/home/mahaloz/github/kuna/specs
+$ ./decompiler/target/release/kuna decompile \
+    ~/github/decbench/results/full_run/O2-noinline/iproute2/stripped/ip --addr 0x20e10
+...
+label_21004:
+      if (v3 == -1) {
+        s_822f0[0] = (char)s_822f0[0];
+        s_822f0[1] = SUB81(s_822f0[0],1);
+        s_822f0[2] = SUB81(s_822f0[0],2);
+        s_822f0[3] = SUB81(s_822f0[0],3);
+        s_822f0[4] = SUB81(s_822f0[0],4);
+        s_822f0[5] = SUB81(s_822f0[0],5);
+        s_822f0[6] = SUB81(s_822f0[0],6);
+        s_822f0[7] = SUB81(s_822f0[0],7);
+        s_822f0[8] = (char)s_822f0[8];
+        s_822f0[9] = SUB81(s_822f0[8],1);
+        s_822f0[10] = SUB81(s_822f0[8],2);
+        s_822f0[0xb] = SUB81(s_822f0[8],3);
+        s_822f0[0xc] = SUB81(s_822f0[8],4);
+        s_822f0[0xd] = SUB81(s_822f0[8],5);
+        s_822f0[0xe] = SUB81(s_822f0[8],6);
+        s_822f0[0xf] = SUB81(s_822f0[8],7);
+        return 0xffffffff;
+      }
+      flock(v3,8);
+      close(v3);
+      return 0xffffffff;
+```
+
+Mode / option sweep, counting emitted lines that mention `s_822f0[`
+(16 phantom LHS + 16 legitimate RHS at the real copy site = 32):
+
+| run | lines |
+|---|---|
+| no flag (`auto` -> `reliable`) | 32 |
+| `--mode reliable` | 32 |
+| `--mode aggressive` | 0 |
+| `--option readonly on` | 0 |
+| `--option strings off` | 0 |
+| `--option formatstring on` | 0 |
+| `--option stackguard off` | **16** (real site only) |
+| `--option condfold on` | 32 |
+| `--option memsetrecover off` | 32 |
+| `--option returndup off` / `earlyreturn off` / `switchreturn off` / `gotoreduce off` | 32 |
+
+`--mode aggressive` closes it only because the aggressive preset carries `formatstring`
+(same finding as round 1). It is not a fix, and it is not the default at this binary size.
+
+## 2. The stores really are into `.rodata`, and really are not in the binary
+
+`readelf -SW ip` — `.rodata` is `0x7e000 .. 0x95335`, flags `A` (no `W`).
+`0x822f0` is inside it.
+
+The whole binary contains **exactly one** instruction that references `0x822f0`, and it is
+a load:
+
+```
+$ objdump -d ip | grep -E '# +822f0'
+   21140:  66 0f 6f 05 a8 11 06 00   movdqa 0x611a8(%rip),%xmm0   # 822f0
+```
+
+The block kuna decorates (`0x20f7f`, reached by `je 20f7f` at `0x21004`) contains no
+stores at all:
+
+```
+   20f7f:  41 bd ff ff ff ff        mov    $0xffffffff,%r13d
+   20f85:  48 8b 84 24 38 20 00 00  mov    0x2038(%rsp),%rax
+   20f8d:  64 48 2b 04 25 28 00 00  sub    %fs:0x28,%rax
+   20f96:  0f 85 89 03 00 00        jne    21325
+   20f9c:  48 81 c4 48 20 00 00     add    $0x2048,%rsp
+   20fa3:  44 89 e8                 mov    %r13d,%eax
+   20fa6..20fae:                    pop    %rbx/%rbp/%r12/%r13/%r14/%r15
+   20fb0:  c3                       ret
+```
+
+## Source
+
+`~/github/decbench/results/full_run/O2-noinline/iproute2/compiled/ipnetns.i` (ipnetns.c:883-891)
+— the path kuna decorates:
+
+```c
+   if (lock != -1) {
+    flock(lock, LOCK_UN);
+    close(lock);
+   }
+   return -1;
+```
+
+The only copy in the function (ipnetns.c:914) is on a completely different path:
+
+```c
+  strcpy(proc_path, "/proc/self/ns/net");
+```
+
+## 3. The filed mechanism is REFUTED (instrumented, not read)
+
+Round 1 filed: *"`SplitDatatype::build_in_subpieces` splits a 16-byte read-only copy into
+ram-addressed SUBPIECE outputs; heritage refinement then synthesises write-backs into
+.rodata"*, with the fix living in `build_in_subpieces` + `Heritage::refine_write`.
+Two independent lines of evidence say no.
+
+**(a) There is no heritage pass after the split.** `RuleSplitCopy` is registered at
+`infra/universalaction.rs:558` — which is inside `cleanup_rules` (the list runs
+`:547`..`:571`), *not* `oppool2` (which ends at `:545` and holds only pushptr /
+structoffset0 / ptrarith / loadvarnode / storevarnode). That pool is scheduled at
+`:715`, **after `fullloop`**, i.e. after the last `ActionHeritage`. This is faithful to
+upstream (`coreaction.cc:5853`, `actcleanup`). `Heritage::refine_write` therefore cannot
+be the producer of the write-backs, and in fact nothing in this function is refined.
+
+**(b) Op identity.** Console `print raw` on the same function, with and without the
+trigger, identifies the exact op that is destroyed and what replaces it.
+
+`--option strings off` (no `char[]` typelock at `0x822f0`), block 24:
+
+```
+Basic Block 24 0x00020f7f-0x00020fb0
+0x00020fa3:1185:  EAX(0x00020fa3:1185) = #0xffffffff:4
+0x00020fb0:1186:  r0x000822f0(0x00020fb0:1186) = u0x1000044a(0x00021004:112e)
+0x00020fb0:1187:  r0x000822f8(0x00020fb0:1187) = u0x10000452(0x00021004:112f)
+0x00020fb0:1188:  r0x000b5200(0x00020fb0:1188) = u0x1000045a(0x00021004:1130)
+0x00020fb0:1189:  return(#0x0) EAX(0x00020fa3:1185)
+```
+
+Three plain COPYs at the address of the `ret`, one per persistent global, all invisible in
+the emitted C (`if (v3 == -1) return 0xffffffff;`).
+
+Default (`strings` on), same block:
+
+```
+Basic Block 24 0x00020f7f-0x00020fb0
+0x00020fa3:119a:  EAX(0x00020fa3:119a) = #0xffffffff:4
+0x00020fb0:11aa:  u0x1000044a:1(0x00020fb0:11aa) = SUB81(u0x1000044a(0x00021004:112e),#0x0:4)
+...                                                (8 SUBPIECEs)
+0x00020fb0:11b2:  r0x000822f0:1(0x00020fb0:11b2) = u0x1000044a:1(0x00020fb0:11aa)
+...                                                (8 COPYs into ram:0x822f0..f7)
+0x00020fb0:11ba:  u0x10000452:1(0x00020fb0:11ba) = SUB81(u0x10000452(0x00021004:112f),#0x0:4)
+...                                                (8 SUBPIECEs)
+0x00020fb0:11c2:  r0x000822f8:1(0x00020fb0:11c2) = u0x10000452:1(0x00020fb0:11ba)
+...                                                (8 COPYs into ram:0x822f8..ff)
+0x00020fb0:119d:  r0x000b5200(0x00020fb0:119d) = u0x1000045a(0x00021004:1130)
+0x00020fb0:119e:  return(#0x0) EAX(0x00020fa3:119a)
+```
+
+Seqnums `119b` and `119c` — the two 8-byte return-COPYs for `0x822f0` / `0x822f8` — are
+**gone from the whole dump** (`grep ':119[bc]:' -> no match`); the 32 ops `11aa..11c9`
+stand in their place. `119d` (the `stderr` return-COPY, a pointer type, not splittable)
+survives untouched. The SUBPIECE outputs are at **unique** addresses (`u0x1000044a+k`),
+which is `build_in_subpieces` deriving piece addresses from *the copy's input root*, and
+the ram-addressed varnodes are `build_out_varnodes` outputs — the signature of
+`SplitDatatype::split_copy`, not of `Heritage::split_pieces`.
+
+For completeness: `build_in_subpieces` *does* create ram-addressed SUBPIECE outputs, but at
+the **real** copy site, and they are reads of the literal, not the phantom stores:
+
+```
+0x00021160:11ca:  r0x000822f0:1 = SUB81(r0x000822f0(0x00021123:b44),#0x0:4)
+0x00021160:11d9:  s0xffffffffffffefb8:1 = r0x000822f0:1(0x00021160:11ca)
+```
+
+So the round-1 narrow fix ("emit per-piece constants when the root is address-tied into a
+read-only range") would clean up the *real* site's rendering and **would not remove a
+single phantom store**: the phantom copy's root is `u0x1000044a`, a unique, on which
+`Varnode::is_read_only()` is false and `generate_constants` cannot fire.
+
+## Analysis — the actual chain
+
+One structural symptom: **kuna emits a block of per-byte assignments storing into a
+`.rodata` string literal, on a return path where the binary performs no store at all.**
+
+1. `strings` (P1 analysis tier, default ON) plants a typelocked `char[N]` at `ram:0x822f0`.
+2. The 16-byte `movdqa` read makes `ram:0x822f0(8)` and `ram:0x822f8(8)` heritaged
+   **persistent** ranges.
+3. `Heritage::guard_returns` (`p3_dataflow/heritage.rs:1784`, persist branch; upstream
+   `heritage.cc:1677-1692`) inserts, **before every RETURN**, a synthetic COPY
+   `glob = glob` whose output is `addrForce` + flagged `return_copy`
+   (`heritage.rs:1851`). Its only job is to hold the global's value past the end of the
+   function so `ActionDeadCode` keeps the defining chain alive. It is upstream behavior and
+   is normally invisible: `Merge::mark_internal_copies` (`p6_variables/merge.rs:2120`)
+   marks a COPY whose in and out share a HighVariable as non-printing.
+4. `RuleSplitCopy` -> `SplitDatatype::split_copy` (P3, `cleanup` pool) then splits that
+   synthetic COPY, because its input/output data type is the `char[]`. The gate that should
+   have declined it is `SplitDatatype::test_copy_constraints`
+   (`p3_dataflow/subflow.rs:3552`; upstream `subflow.cc:2390`), which bails when input and
+   output are address-tied at the *same* address. On the sibling return path (block 23) the
+   copy is `r0x822f0 = r0x822f0(INDIRECT)` and the gate fires. On this path the reaching
+   def is a MULTIEQUAL whose output lives at a unique (`u0x1000044a`), so the input is not
+   address-tied and the gate does not fire.
+5. After the split there are 16 one-byte COPYs whose input and output are in *different*
+   HighVariables, so `mark_internal_copies` can no longer hide them, and P9 prints them.
+
+`--option stackguard off` removes the phantom because the canary-strip is what leaves this
+return path reading the unique-addressed MULTIEQUAL directly; with the canary in place the
+paths funnel through a ram-addressed MULTIEQUAL at `0x20f85` and the return-COPY is
+`r0x822f0 = r0x822f0`, which the gate declines. `stackguard` is a **contributor via CFG
+shape, not the root** — the root is that a synthetic `return_copy` is eligible for a
+datatype split at all.
+
+**Owning phase: P3 (definition web).** The bad decision is "may a datatype-driven copy
+split rewrite a heritage RETURN-COPY into per-element stores". Not P9 (the ops genuinely
+exist in the IR), not P1 (`strings` planting a `char[]` at a string literal is correct),
+not P7 (`stackguard` only changes which def the copy reads).
+
+## Breadth
+
+`kuna decompile-all <bin> --json --mode reliable`, counting assignment statements whose LHS
+is an address-named global that lands in a non-writable PROGBITS section
+(scanner: `/tmp/.../scratchpad/scan.py`):
+
+| binary (O2-noinline unless noted) | functions | rodata stores | functions hit |
+|---|---|---|---|
+| iproute2 `ip` | 1912 | **48** | 2 (`netns_add` @0x20e10, `__get_hz` @0x6cbf0) |
+| openssh `sshd` | 2042 | **64** | 1 (`sub_230a0` @0x230a0) |
+| tar `tar` | 1585 | 1 | 1 (`dat_6a7d6 += v18` — a *different* symptom, not this family) |
+| bash `bash` | 3077 | 0 | 0 |
+| gnutls `certtool` | 794 | 0 | 0 |
+| gnutls `gnutls-cli` | 436 | 0 | 0 |
+| dpkg `dpkg` | 975 | 0 | 0 |
+| findutils `find` | 873 | 0 | 0 |
+| coreutils `ls` | 597 | 0 | 0 |
+| coreutils `sort` | 489 | 0 | 0 |
+| shadow `useradd` | 484 | 0 | 0 |
+| iproute2 `ip` (O0) | 1962 | 0 | 0 |
+
+**112 phantom statements across 3 functions in 11,817 functions scanned** (0.025% of
+functions). Rare but concentrated and severe: 16-64 illegal statements per hit. The count
+is arithmetically consistent with the mechanism — one split per (RETURN-COPY x 8-byte
+half): `netns_add` has 1 affected return block x 2 halves x 8 = 16; `__get_hz` has 2 x 2 x 8
+= 32; 16 + 32 = 48. `sshd`'s `sub_230a0` copies a 64-byte literal (8 halves x 8 = 64).
+
+Preconditions, which explain the sparsity: an O2 SIMD/word copy **out of** a `.rodata`
+literal, in a function with `-fstack-protector` (so `stackguard` reshapes the returns), on a
+path where the global's reaching def is not address-tied. `-O0` never produces it.
+
+## Proposed fix — one module, no option
+
+`decompiler/crates/kuna-decomp/src/p3_dataflow/subflow.rs`,
+`SplitDatatype::test_copy_constraints` (`:3552`): decline the split when the COPY is a
+heritage return-copy.
+
+```rust
+// a return_copy is a synthetic op held only to keep a persistent global's final
+// value live past the RETURN; it is not a store the program performs.
+if data.obank().get(copy_op).expect("stale copy").is_return_copy() {
+    return false;
+}
+```
+
+The predicate already exists (`substrate/op.rs:822 is_return_copy`, set at
+`heritage.rs:1851`, preserved across `set_opcode` by the flag mask at `op.rs:489`), and
+upstream already special-cases `isReturnCopy()` in a sibling rule
+(`ruleaction.cc:3951` / kuna `ruleaction_3.rs:1900`, `RulePropagateCopy`) — so the shape of
+the change has precedent, it is just missing at this site. Adding it is a divergence from
+upstream `subflow.cc:2390` and therefore wants a **DIV row in `docs/history.md`**, but it
+needs **no option gate**: it can only ever delete statements that the program does not
+execute (a real program store is a STORE, or a COPY that is not marked `return_copy`), so
+it strictly corrects wrong output.
+
+Evidence that declining is a *complete* fix rather than a partial one: with `strings off`
+the same three return-copies stay unsplit and print as **nothing** (step 3 above —
+`mark_internal_copies` hides them), and the real copy site collapses to
+`v11 = dat_822f0; v14 = dat_822f8;`.
+
+Belt-and-braces companion, same function, same module (catches any other producer):
+decline when the COPY's **output** is address-tied into a read-only range
+(`Varnode::is_read_only`, already used at `p2_lift/jumptable.rs:1700,2155`). Note that
+kuna already has a "read-only address is written" warning path
+(`substrate/funcdata_varnode.rs:1826` in `fillin_read_only`, upstream
+`Funcdata::fillinReadOnly`), so the invariant is one Ghidra already recognizes — it is just
+gated behind `readonlypropagate`.
+
+**Rejected alternatives.**
+
+- *Round-1 fix #1* (constants in `build_in_subpieces` when the root is read-only): does not
+  touch the phantom, see §3.
+- *Round-1 fix #2 / `--option readonly on` default flip*: closes the case, but it is a
+  global semantic policy (every read-only load becomes a constant), default-off in upstream
+  Ghidra for RELRO / `.data.rel.ro` reasons, and `readonly` is still not in the catalog
+  (registered in `p0_knowledge/options.rs` with no `settableTable` row) — an 83-row catalog
+  addition plus a DIV, to fix 3 functions, when a one-predicate fix exists.
+- *`Heritage::refine_write`*: not on the path at all.
+
+**Risk.** Low and local. The only behavior change is that a `return_copy` COPY stays whole.
+Regression surface to check in the PR: functions where a *writable* global array is
+copied and the return-copy split was producing the assignment that made the global's final
+value visible — none observed in 11,817 functions, but `make test` / `make test-stages` /
+`make rust-test` are the gate, plus a `tests/stages/ghdec-returncopysplit.xml` asserting the
+phantom block is absent (single-pass: no option to toggle).
+
+## Loose threads (unchanged from round 1, still open)
+
+- `$$undef00000004[0] = s_822f0[8];` — an internal placeholder name leaking into emitted C
+  at the *real* copy site; 92 of the 94 `$$undef` occurrences in `ip` are untouched by this
+  fix.
+- One 16-byte stack buffer split across three symbols (`v11` + `$$undef00000004` + `v14`),
+  P6 variable merging.
+- `SUB81(...)` is a Ghidra pseudo-op with no C definition; every pane that contains one does
+  not compile. Same family as `spacebase-unnamed-location`.
+- `tar`'s `dat_6a7d6 += v18;` is a store into `.rodata` from a *different* mechanism —
+  worth its own look.
+- `kuna decompile-project <ip> --functions sub_20e10` panics in
+  `kuna-analysis/src/loadimage_object.rs:716` (`range end index 973 out of range for slice
+  of length 512`) — unrelated, found while trying to read the global's declaration.

--- a/docs/decbench/triage/undefname-leak.md
+++ b/docs/decbench/triage/undefname-leak.md
@@ -1,0 +1,339 @@
+---
+case_id: loose-undefname-leak
+pool: novel
+group_id: iproute2::ip (filed) / tar::xstrcat (best witness)
+status: feature-candidate
+tier: N
+margin: 0
+fresh_verdict: reproduces on today's build and is WORSE than filed — the `$$undefNNNNNNNN` identifier is not a cosmetic placeholder, it is a SECOND identifier for a stack Symbol that is already declared under its `vN` name, so the emitted C reads a variable that is never written (221 of 283 affected functions) while the real update lands on the other name
+option_closing: null
+feature_slug: undefname-leak
+scope: small
+confidence: high
+---
+
+## Summary
+
+`$$undefNNNNNNNN` is Ghidra's `Scope::buildUndefinedName()` placeholder for a Symbol
+created with an empty name (`database.cc:2854`). It is supposed to be invisible: upstream
+`ActionNameVars::apply` renames every such Symbol before the printer runs
+(`coreaction.cc:3075-3079`), and `PrintC` reads `sym->getDisplayName()` **live at emit
+time**, so it can never print a stale name.
+
+kuna binds the name **per HighVariable** (`HighVariable::kuna_name`, a cached `String`) and
+the printer reads that cache. Two consequences, both live today:
+
+* **(A) stale cache — 264 of 283 affected functions.** One ScopeLocal Symbol, two
+  HighVariables. The partial-cover high is visited first, caches `$$undef000000NN`; the
+  whole-cover high is visited later and renames the *same* Symbol to `vN`. Nothing
+  back-fills the first cache, so one stack slot is declared **twice, under two different
+  identifiers**, and the body uses both.
+* **(B) never renamed — 19 functions in the sample, 101 Symbols across 72 functions.**
+  No high reaches the whole-cover rename gate at all, so the Symbol keeps `$$undefNN` in
+  the database. kuna's port of the upstream catch-all,
+  `Database::assign_default_names` (`p0_knowledge/database.rs:4031`), **has zero call
+  sites in the entire tree** — the `coreaction.cc:3079` line was never wired.
+
+(A) is the correctness story. (B) additionally leaks the placeholder out of the C into the
+structured surfaces (`decompile-all --json` `variables`, `decompile-project`'s `.asm`
+stack-frame comments), where consumers read it as a variable *name*.
+
+## Verify-first transcript (today's build, main @ bb2bdb9a)
+
+### The filed case still reproduces
+
+```
+$ export SLEIGHHOME=/home/mahaloz/github/kuna/specs
+$ kuna decompile-all ~/github/decbench/results/full_run/O2-noinline/iproute2/stripped/ip --json
+  -> 1912 functions, 95 occurrences of `$$undef[0-9a-f]{8}` across 33 functions
+```
+
+Filed observation was 92 in `ip`; the stored 2026-07-27 pane has 47 (the run stores a
+sampled subset). Unchanged by the `rodata-phantom-store` work, as filed.
+
+`ip` is 722 KiB, so a no-flag run is `--mode reliable` — i.e. **the benchmark's own option
+surface**. Mode makes no difference:
+
+```
+$ kuna decompile <ip> --addr 0x2b420 --mode reliable   # and aggressive, and fast
+unsigned long sub_2b420(unsigned long a0,unsigned int a1) // return-dupe x2
+{
+  char $$undef00000001 [16]; // stack - 0x38
+  int4 v1; // eax
+  char v2 [16]; // stack - 0x48
+  int8 v3; // fs_offset
+  char v4 [12]; // stack - 0x34
+  ...
+  v4[0] = SUB1612(0,4);
+  $$undef00000001 = CONCAT124(v4[0],a1);
+```
+
+### Option sweep: 84 non-default option values, none closes it
+
+```
+$ # every non-default value of every one of the 83 catalog options, on tar::xstrcat
+$ bash sweep.sh | grep -v ': 3$'
+(no output — all 84 flips leave exactly 3 occurrences)
+```
+
+Explicitly checked, per the loop's standing instruction: `--option condfold on`,
+`--option condfold wide`, `--mode aggressive` (the 21-option preset), `namestyle ghidra`,
+`dedupvardecls off`, `realtypes off`. All 3/3. **Not covered by an option.**
+
+## The correctness witness — `tar::xstrcat` (O2, `sub_611a0`, DWARF name `xstrcat`)
+
+Fresh, no flags (518 KiB ⇒ `reliable`):
+
+```c
+char * sub_611a0(int8 a0,uint8 *a1)
+{
+  uint4 $$undef00000000; // stack - 0x58     <-- declared, READ TWICE, NEVER WRITTEN
+  ...
+  uint8 v12; // stack - 0x58                 <-- SAME SLOT, written twice, read once
+  unsigned long *v13; // stack - 0x50
+
+  v12 = *a1;
+  v13 = (unsigned long *)a1[1];
+  v6 = a1[2];
+  if (a0) { // branch-flip
+    v8 = 0;
+    v9 = a0;
+    do {
+      v4 = v12 & 0xffffffff;
+      if (0x30 <= (uint4)$$undef00000000) { // branch-flip
+        v1 = &v13[1];
+        v7 = v13;
+        v13 = v1;
+      }
+      else {
+        v12 = (uint8)((uint4)$$undef00000000 + 8);
+        v7 = (unsigned long *)(v4 + v6);
+      }
+      ...
+```
+
+`a1` is a `va_list`; the loop is the x86-64 `va_arg` expansion
+(`if (gp_offset >= 48) use overflow_arg_area else reg_save_area + gp_offset;
+gp_offset += 8`). As emitted, the loop **tests and increments an uninitialised
+variable** and the induction update it does perform (`v12 = ...`) is never read again.
+Recompiled, this loop does not terminate correctly. This is wrong code, not a spelling
+problem.
+
+### Instrumented proof that the two identifiers are ONE Symbol
+
+`print map` / `print high` are engine stubs in `decomp_dbg`, so the discriminator used was
+the console `rename`, which renames a **Symbol** in the local scope:
+
+```
+$ decomp_dbg
+[decomp]> load file .../O2/tar/stripped/tar
+[decomp]> load addr 0x611a0
+[decomp]> decompile
+[decomp]> rename v12 QQQ
+[decomp]> decompile
+[decomp]> print C
+
+char * sub_611a0(int8 a0,uint8 *a1)
+{
+  uint8 QQQ; // stack - 0x58          <-- ONE declaration now
+  unsigned long *v12; // stack - 0x50
+  ...
+      v4 = QQQ & 0xffffffff;
+      if (0x30 <= (uint4)QQQ) { ... }
+      else { QQQ = (uint8)((uint4)QQQ + 8); ... }
+```
+
+Renaming the **one** Symbol collapsed *both* identifiers and the loop became correct;
+everything else in the body is byte-identical. Repeated on `iproute2::ip sub_10290`
+(`rename v7 ZZZ` ⇒ `char ZZZ [16]` once, `ZZZ[0] = 0; ... v2 = ZZZ[0];` instead of
+`v7[0] = 0; ... v2 = $$undef00000001[0];`). Two binaries, same result.
+
+That rules out the "two distinct Symbols at one address" hypothesis (a
+`handleSymbolConflict` spawn) and pins mechanism (A).
+
+### Instrumented proof of mechanism (B)
+
+`kuna decompile-all --json` exposes `extract_variables`
+(`infra/decompile_drive.rs:1193-1211`), which reads the ScopeLocal **Symbol table**
+directly. For `ip sub_2b420` that table itself carries the placeholder:
+
+```json
+{"name": "$$undef00000001", "type": "unsigned int", "kind": "stack",
+ "stack_offset": -56, "size": 4}
+```
+
+— whereas for `sub_10290` (mechanism A) the table is clean (`v7` only) even though the C
+prints `$$undef00000001`. That split is the discriminator used for the corpus counts below.
+
+Same leak in the project export (`kuna decompile-project`):
+
+```
+lcd-serial.elf.c:2327:  unsigned int $$undef00000002; // stack - 0x30
+lcd-serial.elf.c:2443:      return sub_80030c8((unsigned int)$$undef00000002,v80._4_4_,v37,v73);
+lcd-serial.elf.asm:2897:; stack: $$undef00000005 @ [stack-0x158] (int4[34])
+```
+
+## Source
+
+`iproute2 ip sub_2b420` is `set_qlen` (`iplink.c`):
+
+```c
+static int set_qlen(const char *dev, int qlen)
+{
+  struct ifreq ifr = { .ifr_ifru.ifru_ivalue = qlen };
+  int s;
+  s = get_ctl_fd();
+  if (s < 0) return -1;
+  strlcpy(ifr.ifr_ifrn.ifrn_name, dev, 16);
+  if (ioctl(s, 0x8943, &ifr) < 0) { perror("SIOCSIFXQLEN"); close(s); return -1; }
+  close(s);
+  return 0;
+}
+```
+
+One `struct ifreq ifr`. kuna splits it into `char v2[16]` (the name field, `stack - 0x48`)
+plus a 4-byte slot at `stack - 0x38` (the `ifru_ivalue` union member) that never gets a
+name — the frame layout is a separate, known issue (the "one 16-byte buffer split across
+three symbols" loose thread); what this record is about is that the un-named piece is
+*printed*.
+
+`tar sub_611a0` = `xstrcat` (`readelf -sW .../O2/tar/compiled/tar` ⇒
+`743: 00000000000611a0 341 FUNC LOCAL DEFAULT 16 xstrcat`) — a varargs string
+concatenator; its source file is not in the vendored `.i` set, but the `va_arg` shape is
+unambiguous in the binary.
+
+## Breadth (corpus-wide, measured)
+
+Fresh `kuna decompile-all --json` over a stratified sample: **101 stripped binaries**
+(one per project × {O0, O2, O2-noinline}), **78,787 functions**, today's build, no flags:
+
+| measure | value |
+|---|---|
+| binaries with ≥1 leaked identifier | **58 / 101 (57%)** |
+| functions with ≥1 leaked identifier in the emitted C | **283 (0.36%)** |
+| total `$$undefNNNNNNNN` occurrences in emitted C | **1,573** (1,030 reads / 141 writes) |
+| functions where the placeholder is declared next to a same-storage `vN` (mechanism A) | **259** |
+| functions where a placeholder is **read and never written** (uninitialised read) | **221** |
+| functions whose ScopeLocal Symbol table itself carries a placeholder (mechanism B) | **72 (101 Symbols)** |
+| mechanism split (functions) | A only 264 · B only 11 · both 8 |
+
+Top projects by leaking functions: e2fsprogs 45, betaflight 42, iproute2 34, tar 28,
+libedit 22, cleanflight 21, findutils 12, rsyslog 10, grep 8, gzip 8, openssh 8. Both
+x86-64 and ARM Cortex-M, all three optimisation levels.
+
+**Nobody else does this.** Across the full stored 2026-07-27 run (803 binaries × 11
+decompilers):
+
+```
+kuna:    152 of 803 stored panes contain $$undef
+angr:      0 / ida: 0 / ghidra: 0 / binja: 0 / phoenix: 0 / dewolf: 0 / r2dec: 0
+```
+
+GED value: **zero** — an identifier rename never changes the CFG. This is a Tier-0/Tier-1
+correctness item in the `features.md` sense, mined out of the pool that does not rank by
+margin.
+
+Regression risk today: **none measured.** Full `KUNA_DUMP=1` renders of both test corpora
+grep clean for `$$undef` — datatests 675/675 assertions, 0 occurrences; stages 356/356,
+0 occurrences. (The `verify_w10_spacebase_render.rs` comment claiming "the whole corpus
+carries exactly ONE pre-existing `&$$undef` in `forloop_thruspecial`" is stale — that stem
+now renders `int4 *v2; // stack - 0x28`.)
+
+## Analysis — root cause
+
+Owning phase: **P6** (variable & storage model — `ActionNameVars` lives in
+`p6_variables/`). The symptom appears at P9, but P9 only reads a cache P6 wrote; per
+`docs/phases.md`, "a symptom's phase is not always its decision's phase".
+
+The divergence from upstream is already documented in kuna's own source, one paragraph
+short of the bug (`p6_variables/coreaction_cleanup.rs:2777-2790`):
+
+> ORDER (the load-bearing detail): in C++ a single shared `Symbol` object is attached to
+> BOTH the offset-constant high and the stack-slot high, and the undefined ones are
+> renamed ONCE at the end of `apply` … The render reads `getSymbol()->getDisplayName()` at
+> print time, so it always sees the FINAL name. **The kuna model binds the name PER-HIGH
+> off the database Symbol**, so the spacebase pass must run AFTER the main naming loop …
+
+The port fixed that ordering hazard for the *spacebase* pass. The same hazard **inside**
+the main loop, between two highs of the same Symbol, was not fixed:
+
+1. `p6_variables/varmap.rs:1520` `resolve_default_name_override` renames the covering
+   Symbol only when it is `is_name_undefined() && sym_off == 0 && size == entry_size` —
+   the faithful port of the C++ `namerec` gate (`sym->isNameUndefined() &&
+   high->getSymbolOffset() < 0`, `coreaction.cc:3046`). On a miss it returns
+   `symbol.get_display_name()` **as-is**, i.e. `$$undefNN`.
+2. `p6_variables/coreaction_cleanup.rs:2637` `h.set_kuna_name(sym_name)` caches whatever
+   that returned onto the HighVariable, permanently.
+3. `p9_emit/printc.rs:2394` (`emit_local_var_decls`) and `printc.rs:6728` (the body
+   render) read `h.kuna_name()`. Upstream `PrintC::emitVarDecl`/`pushSymbol` read
+   `sym->getDisplayName()`. The deferral that is harmless in C++ is not harmless here.
+4. `p0_knowledge/database.rs:4031` `Database::assign_default_names` — a complete,
+   tested port of `ScopeInternal::assignDefaultNames` — is **never called**. Upstream calls
+   it as the last statement of `ActionNameVars::apply`
+   (`coreaction.cc:3079: data.getScopeLocal()->assignDefaultNames(base);`), which is what
+   guarantees no `$$undef` Symbol survives the pass. `grep -rn assign_default_names
+   decompiler/` returns the definition and nothing else.
+
+So (A) is step 2+3 (cache written before the rename that step 1 defers to a later high),
+and (B) is step 4 (the catch-all was ported but not wired).
+
+## Proposed fix — `undefname-leak`, one module, no option
+
+All of it lands at the **tail of `name_local_highs_angr`**
+(`decompiler/crates/kuna-decomp/src/p6_variables/coreaction_cleanup.rs:2378-2799`), after
+the existing spacebase pass — the same place the port already chose to resolve this class
+of ordering hazard:
+
+1. **Wire the catch-all (mechanism B).** Call the already-ported
+   `Database::assign_default_names(scope_local, &mut base, arch)` — a one-line
+   `Funcdata`/`ScopeLocal` accessor away — reproducing `coreaction.cc:3079`. Every
+   remaining `$$undef` Symbol gets its `buildDefaultName`. This also cleans
+   `extract_variables` and the project `.asm` annotations for free, because those read the
+   Symbol table.
+2. **Repair the stale caches (mechanism A).** Re-walk the highs; for any whose
+   `kuna_name()` matches the placeholder shape (`len == 15 && starts_with("$$undef")`,
+   i.e. `Symbol::is_name_undefined`), re-resolve the covering Symbol through the **existing**
+   `ScopeLocal::query_container_for_link(addr, usepoint)` (`p6_variables/varmap.rs:1638`,
+   which already returns `display_name`) on the high's name representative, and
+   `set_kuna_name` to the now-final name. This is exactly upstream's "read the Symbol name
+   at print time", applied once at the end of the pass.
+
+**Why this ordering is the zero-churn form.** Neither step can renumber an existing local:
+step 1 runs after every `vN` has been handed out and only names Symbols that had none;
+step 2 consumes no `base` at all. The tempting one-liner — drop the
+`sym_off == 0 && size == entry_size` gate in `resolve_default_name_override` so the first
+touch always renames — would work too, but it moves *when* a Symbol consumes `base`, which
+renumbers every later local in any function where a partial high precedes its whole-cover
+sibling. Prefer the repair form; keep the C++-faithful gate.
+
+Owning files:
+
+* `decompiler/crates/kuna-decomp/src/p6_variables/coreaction_cleanup.rs` — the two-step
+  tail in `name_local_highs_angr` (the whole feature).
+* `decompiler/crates/kuna-decomp/src/substrate/funcdata.rs` (or `funcdata_varnode.rs`) —
+  one thin accessor to reach `Database::assign_default_names` on the local scope.
+* No change to `p9_emit/printc.rs`.
+
+**No option.** This is a strict bug fix that only corrects wrong output (AGENTS.md
+*Adding features*: "a strict bug fix that only corrects wrong output needs no flag"), of
+the same family as `spacebase-unnamed-location` and `symbol-keyed-local-decls`, both of
+which shipped unflagged. It ships with a `tests/stages/ghdec-undefname-leak.xml` two-pass
+testcase and a DIV row.
+
+Risks:
+
+* `assign_default_names` walks `nametree` by the `$$undef` name prefix; kuna's `NameKey`
+  ordering must place every placeholder in one contiguous run (it does —
+  `database.rs:4044-4048` already relies on this and is unit-tested at `database.rs:4286`).
+* Step 2 must skip highs bound through the **global** scope (`kuna_global`) and
+  proto-partial pieces, which take their name from a different query; the existing
+  `query_container_for_link` local-first / global-fallback split already handles that.
+* A Symbol renamed in step 1 gets a `vN` number higher than every other local in the
+  function. Cosmetic; the alternative (renumbering) is worse.
+
+Measurement for the PR: re-run the 101-binary sweep and require **0** occurrences of
+`$$undef` in emitted C and in `--json` `variables`; datatests 675/675 and stages 356/356
+byte-identical (both already grep clean, so any diff is a regression); `scripts.pipeline.timeit`
+within the 5% budget (the added work is one scope walk plus one high walk per function).
+GED delta is expected to be exactly 0 — this item is worth doing for the 221 functions
+whose C currently reads an uninitialised variable, not for the metric.


### PR DESCRIPTION
Round 2 of the decbench improvement loop (`docs/decbench-loop.md`). Nine investigation tracks, one agent each, **every finding re-derived on today's build before it was allowed to count**, then handed to a second agent briefed to refute it.

No code changes — triage records only.

## Outcome

**8 live candidates, 1 confirmed already-fixed.**

| track | verdict | slug | phase | impact | breadth |
|---|---|---|---|---|---|
| CONCAT/SUBPIECE soup | feature-candidate | `subright` | P3 | **invalid C** | 5,919 sites / 2,394 fns (3.1%) |
| `(code *)` casts | feature-candidate | `funcptralign` | P3 | readability + lost type | 4,027 sites / 2,496 fns / 9 ARM projects |
| `$$undef` leak | feature-candidate | `undefname-leak` | P6 | **wrong code** | 283 fns, 221 with uninitialised reads |
| paramcopyhoist (re-derive) | feature-candidate | `paramcopyhoist` | P6 | structure | 4.2% of fns; GED 29 → 17 on the witness |
| rodata phantom stores | feature-candidate | `returncopysplit` | P3 | **wrong code** | 112 statements / 3 fns |
| PE import overrun | feature-candidate | `peimportcall` | P1/P2 | **wrong code** | 927 IAT call sites, both PE projects |
| ternary re-roll | feature-candidate | `itecondlist` | P8 | structure | ceil(N/2) of N diamonds |
| uncatalogued options | feature-candidate | `catalog-upstream-options` | P0 | control surface | 38 of 121 options invisible |
| raw registers / PTRSUB | **already-fixed** | — | P9 | — | 267 corpus instances closed by #226 |

## The refuters earned their keep again

They overturned the **filed diagnosis on three of eight** while leaving the symptom standing, and **two rebuilt kuna with the proposed fix** to prove the mechanism was not a no-op. Round 1's filed-mechanism record is now **2-for-5**.

Overturned: `returncopysplit` (the proposed `RuleSplitCopy` seam is scheduled after `fullloop`, so `Heritage::refine_write` provably cannot produce the write-backs), `peimportcall` (the named P2 seam cannot see the shape — at that point the CALLIND target is a free unique and raw flow IR carries no def-use links at all), `itecondlist` (right defect, wrong case and wrong reach).

## Two findings are much larger than the cases that surfaced them

- **`RuleSubRight::apply_op` is a stub.** Every nonzero-offset SUBPIECE prints as a raw p-code operator (`SUB81(a1,7)`) instead of upstream's `(char)(a1 >> 0x38)`. **5,919 occurrences in 2,394 functions vs ghidra's 18 in 13 — a 329x ratio**, and `SUBnn` is an undeclared identifier, so those panes are not valid C. The refuter transcribed upstream `ruleaction.cc:7291-7340` into the stub and rebuilt to confirm.
- **The `funcptr_align` seam is stubbed.** Every ARM/Thumb indirect call emits an invented ISA-mode bit-clear (`(*(code *)(ptr & 0xfffffffe))()`) and loses the function-pointer type on the loaded field. Not ARM-only: every AARCH64 (align=4, so it strips an *address-alignment* mask), MIPS, Loongarch and 8051 cspec carrying `<funcptr>` is affected.

## Verify-first mattered

The mined pools were built from kuna output that is stale — O2/O2-noinline by a day, **O0 by ~100 commits** (older than the 2026-07-27 date the docs cite). One track resolved to `already-fixed` purely because today's build closed it. A kuna-only O0 refresh is running separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dPFaKJanfLSf7mWGhkzkL