### PR TITLE
[AUTOMATED] fix(decbench): rebase PE case addresses onto the binary's ImageBase

### DIFF
--- a/docs/decbench-loop.md
+++ b/docs/decbench-loop.md
@@ -31,6 +31,13 @@ Decisions baked in:
   to stay comparable.
 - **Verify-first is mandatory, and it is not optional bookkeeping** — see the next
   section for exactly how stale the stored output is.
+- **PE addresses: the pools carry RVAs, kuna wants VAs.** decbench records a PE
+  function's address as an RVA (`function_results.json`, and every rival's
+  `// Function: <fn> @ 0x..` marker — only kuna's own artifact writes VAs), so a mined
+  case may hold either form. `triage`/`rescore`/`showcase` rebase it off the binary's
+  own PE `ImageBase` before calling `kuna --addr` (`config.kuna_addr`), which differs
+  per binary — `mydoom.exe`/`x0r-usb.exe` 0x400000, `dexter.dll` 0x69940000. ELF
+  addresses are already VAs and pass through untouched.
 - GED quirks to respect in triage: graphs > 60 nodes are **approximated** as
   |Δnodes| + |Δedges| (`approximated: true` on a case, taken from the run's own
   `ged_large_graph_audit.json`); `inf` means missing/unparseable, not "bad"; a

--- a/scripts/decbench/config.py
+++ b/scripts/decbench/config.py
@@ -139,3 +139,61 @@ def group_id(project: str, function: str) -> str:
 def stripped_path(binary_path: str) -> str:
     """The stripped sibling of a results-tree compiled binary path."""
     return binary_path.replace("/compiled/", "/stripped/")
+
+
+_IMAGE_BASE: dict[str, int | None] = {}
+
+
+def image_base(binary_path: str | None) -> int | None:
+    """PE ImageBase of a corpus binary; None for anything that is not a PE.
+
+    Detected from the file's own headers (``MZ`` + ``PE\\0\\0`` at ``e_lfanew``),
+    never from the name — the corpus binaries are stripped and not all are named
+    ``.exe``. The base differs per binary (``mydoom.exe`` 0x400000,
+    ``dexter.dll`` 0x69940000), so it is always read, never assumed.
+    """
+    if not binary_path:
+        return None
+    if binary_path not in _IMAGE_BASE:
+        _IMAGE_BASE[binary_path] = _read_image_base(binary_path)
+    return _IMAGE_BASE[binary_path]
+
+
+def _read_image_base(binary_path: str) -> int | None:
+    try:
+        with open(binary_path, "rb") as fh:
+            if fh.read(2) != b"MZ":
+                return None
+            fh.seek(0x3C)
+            fh.seek(int.from_bytes(fh.read(4), "little"))
+            if fh.read(4) != b"PE\0\0":
+                return None
+            fh.seek(20, 1)  # past the COFF header, at the optional header
+            magic = int.from_bytes(fh.read(2), "little")
+            if magic == 0x10B:  # PE32: ImageBase at optional+28
+                fh.seek(26, 1)
+                return int.from_bytes(fh.read(4), "little")
+            if magic == 0x20B:  # PE32+: ImageBase at optional+24
+                fh.seek(22, 1)
+                return int.from_bytes(fh.read(8), "little")
+            return None
+    except (OSError, ValueError):
+        return None
+
+
+def kuna_addr(binary_path: str | None, address: int | str | None) -> str | None:
+    """The ``kuna --addr`` (VA) form of a mined case address.
+
+    decbench records PE addresses as RVAs — ``function_results.json`` and every
+    rival's ``// Function: <fn> @ 0x..`` marker do, while kuna's own artifacts
+    use VAs — so a mined pool carries either form depending on where the address
+    came from. kuna addresses a PE by VA, so an address below the image base can
+    only be an RVA and is rebased; ELF (no image base) and VAs pass through.
+    """
+    if address is None:
+        return None
+    addr = int(address, 16) if isinstance(address, str) else int(address)
+    base = image_base(binary_path)
+    if base is not None and addr < base:
+        addr += base
+    return f"0x{addr:x}"

--- a/scripts/decbench/rescore.py
+++ b/scripts/decbench/rescore.py
@@ -36,7 +36,7 @@ import tempfile
 from pathlib import Path
 
 from . import config
-from .triage import MARKER, load_case, split_blocks
+from .triage import MARKER, case_addr, load_case, split_blocks
 
 SRC_CACHE = Path(os.environ.get(
     "KUNA_DECBENCH_SRC_CACHE",
@@ -109,8 +109,9 @@ def artifact_path(case: dict) -> Path:
 
 
 def fresh_block(case: dict, options: list[list[str]], kuna_bin: str) -> str:
+    addr = case_addr(case)
     cmd = [kuna_bin, "decompile-all", case["stripped_path"], "--json",
-           "--addr", case["address_hex"]]
+           "--addr", addr]
     for name, value in options:
         cmd += ["--option", name, value]
     out = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
@@ -121,7 +122,7 @@ def fresh_block(case: dict, options: list[list[str]], kuna_bin: str) -> str:
         raise RuntimeError(f"no fresh code: {fns[0].get('error') if fns else 'no record'}")
     rec = fns[0]
     code = re.sub(rf"\b{re.escape(rec['name'])}\b", case["function"], rec["code"])
-    return f"// Function: {case['function']} @ {case['address_hex']}\n" + code
+    return f"// Function: {case['function']} @ {addr}\n" + code
 
 
 def spliced_cfgs(case: dict, new_block: str, extract, stable_hash) -> dict:

--- a/scripts/decbench/showcase.py
+++ b/scripts/decbench/showcase.py
@@ -281,7 +281,8 @@ def verify_bundle(d: Path, timeout: int = 900) -> dict:
     if not stripped or addr is None or not Path(stripped).is_file():
         return out | {"status": "no-binary", "identical": False}
 
-    cmd = [config.kuna_bin(), "decompile-all", stripped, "--addr", hex(addr)]
+    cmd = [config.kuna_bin(), "decompile-all", stripped,
+           "--addr", config.kuna_addr(stripped, addr)]
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
     except subprocess.TimeoutExpired:

--- a/scripts/decbench/triage.py
+++ b/scripts/decbench/triage.py
@@ -39,6 +39,12 @@ def load_case(case_id: str) -> dict:
              f"({len(paths)} searched)")
 
 
+def case_addr(case: dict) -> str | None:
+    """The address a mined case is decompiled at, in kuna's ``--addr`` (VA) form."""
+    return config.kuna_addr(case.get("stripped_path"),
+                            case.get("address_hex") or case.get("address"))
+
+
 def split_blocks(c_path: Path) -> dict[str, str]:
     """function name -> its block (marker line included) from a stored artifact."""
     if not c_path.exists():
@@ -60,8 +66,9 @@ def stored_block(case: dict, dec: str) -> str:
 
 def fresh_kuna(case: dict, options: list[list[str]]) -> tuple[str, str | None]:
     """Fresh decompile of the case function; returns (relabeled block, error)."""
+    addr = case_addr(case)
     cmd = [config.kuna_bin(), "decompile-all", case["stripped_path"], "--json",
-           "--addr", case["address_hex"] or hex(case["address"])]
+           "--addr", addr]
     for name, value in options:
         cmd += ["--option", name, value]
     out = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
@@ -77,7 +84,7 @@ def fresh_kuna(case: dict, options: list[list[str]]) -> tuple[str, str | None]:
     code = rec.get("code") or ""
     # Self-relabel exactly like the benchmark run (own name only; callees stay sub_*).
     code = re.sub(rf"\b{re.escape(rec['name'])}\b", case["function"], code)
-    header = f"// Function: {case['function']} @ {case['address_hex']}\n"
+    header = f"// Function: {case['function']} @ {addr}\n"
     return header + code, None
 
 
@@ -120,7 +127,11 @@ def main(argv=None) -> None:
         print(f"- source CFG: {src_n} nodes / {case.get('source_edges')} edges{note}")
     print(f"- binary: {case['binary_path']}")
     print(f"- stripped: {case['stripped_path']}")
-    print(f"- function: {case['function']} @ {case['address_hex']}  labels: {case.get('labels')}")
+    va = case_addr(case)
+    shown = case.get("address_hex") or va
+    rebased = "" if va == shown else f" (PE RVA; kuna --addr {va})"
+    print(f"- function: {case['function']} @ {shown}{rebased}  "
+          f"labels: {case.get('labels')}")
     print()
 
     extra = [d for d in args.also.split(",") if d.strip()]


### PR DESCRIPTION
## The bug

`scripts.decbench.rescore` and `scripts.decbench.triage` passed a mined case's
`address_hex` straight to `kuna decompile-all --addr`. decbench records a **PE**
function's address as an **RVA**; kuna addresses a PE by **VA**. So every PE case
failed before any comparison could happen:

```
$ python3 -m scripts.decbench.triage --case O0-mydoom-mydoom-mmsender_th
- function: mmsender_th @ 0x41e2  labels: [... 'windows', 'pe']
## kuna (fresh): UNAVAILABLE — per-function error: Unable to load 512 bytes at r0x000041e2

$ ~/.virtualenvs/decbench/bin/python -m scripts.decbench.rescore --case O0-mydoom-mydoom-mmsender_th
  "ged_after": null,
  "ged_delta": null,
  "after_error": "no fresh code: Unable to load 512 bytes at r0x000041e2"
```

That silently blocked the campaign's benchmark gate (`docs/decbench-loop.md` standing
requirement 6 — every output-changing PR records its GED delta) for every PE case.
Independently hit by the agents on #254 and #257, who had to hand-patch addresses.

**Measured scope** (audit over every pool, incl. the gitignored `cases*.json`):
**84 distinct mined PE cases** carry an RVA — 36 in the angr pool, 48 in the ida pool
(the committed `triage-queue*.json` re-list 5 of them, so the raw row count below is 89). The **novel pool is not affected** (its 35/37 PE cases already carry
VAs, because `novel.py` reads addresses from *kuna's own* artifact markers, which are
the only ones written as VAs). The brief's "35 novel cases" turned out not to reproduce
— but the novel address source falls back to a rival's marker when kuna's artifact
lacks the function, and rivals write RVAs, so the pools genuinely hold **both** forms.

## Where the fix went, and why

**Use time, in a shared, form-tolerant helper** (`config.kuna_addr`), applied at the
three `kuna --addr` call sites (`triage.fresh_kuna`, `rescore.fresh_block`,
`showcase.verify_bundle`) — not at mine time:

- The pool JSONs are gitignored and regenerable, but the committed
  `backlog*.md` / `triage-queue*.json` are **not**, and existing triage records cite the
  recorded address. A mine-time fix would need those regenerated and would leave the
  84 already-mined cases broken until then.
- The pools hold **both** forms today (mine.py → RVA from `function_results.json`,
  novel.py → VA from kuna's markers, with an RVA fallback to a rival's markers). A
  caller must therefore be form-tolerant regardless of what mining does.
- Keeping the pool faithful to decbench's own `function_results.json` value also keeps
  a case row cross-referenceable with the rest of the results tree, where every rival
  artifact is RVA-keyed.

The helper is **sound in one direction**: a VA can never be below the image base, so it
can never mis-convert a VA; only an address strictly below the base is rebased. ELF has
no image base and passes through byte-identically.

## How the image base is derived

Parsed from the binary's own PE headers — `MZ` magic, then `PE\0\0` at the `e_lfanew`
offset (0x3C), then `ImageBase` at optional-header +28 for PE32 (magic 0x10b) or +24 for
PE32+ (magic 0x20b). **Not** by file extension (the corpus binaries are stripped) and
**not** hard-coded — the bases really do differ:

| binary | ImageBase |
|---|---|
| `mydoom.exe` | `0x400000` |
| `x0r-usb.exe` | `0x400000` |
| `dexter.dll` | `0x69940000` |

kuna itself does not expose an image base (checked `kuna functions --json`,
`kuna decompile-all --json`, `kuna --help`) — `functions --json` emits VAs but no base,
so there was nothing to reuse. The 20-line stdlib parse was cross-checked against
`objdump -p` on 8 PE32+ repo fixtures, the 3 PE32 corpus binaries and 2 ELF files:
**0 mismatches**.

## After: PE cases produce real GED numbers

`triage` (mydoom.exe, base 0x400000 — and it now says so):

```
- function: mmsender_th @ 0x41e2 (PE RVA; kuna --addr 0x4041e2)  labels: [...]
## kuna (fresh, current build)
// Function: mmsender_th @ 0x4041e2
void mmsender_th(int4 a0)
{
  LOCK();
  UNLOCK();
  if (a0) { *(char *)(a0 + 8) = 1; sub_4040eb(a0); *(char *)(a0 + 8) = 2; }
  if (dat_4102e4) { LOCK(); UNLOCK(); }
  ExitThread(0); // no-return
}
```

`triage` (dexter.dll, base 0x69940000 — a different base, a DLL):

```
- function: Uninstall @ 0x694c (PE RVA; kuna --addr 0x6994694c)  labels: [...]
## kuna (fresh, current build)
// Function: Uninstall @ 0x6994694c
void Uninstall(void) { TerminateThread(dat_6994cc08,0); ... ExitProcess(0); }
```

`rescore --siblings` — a real GED delta, which is the acceptance criterion:

```json
{"ged_case": "O0-mydoom-mydoom-mmsender_th",
 "ged_recorded": 37.0, "ged_before": 37.0, "ged_after": 0.0, "ged_delta": -37.0,
 "ged_perfect_after": true,
 "ged_siblings": {"O2-noinline-mydoom-mydoom-mmsender_th": {"before": 8.0, "after": 0.0}}}
```

More PE rescores, all previously `after_error`:

| case | binary | before | after |
|---|---|---|---|
| `O0-mydoom-mydoom-mmsender_th` | mydoom.exe | 37.0 | **0.0** |
| `O2-noinline-mydoom-mydoom-mmsender_th` | mydoom.exe | 8.0 | **0.0** |
| `O0-mydoom-mydoom-rot13c` | mydoom.exe | 7.0 | 7.0 |
| `O0-x0r-usb-x0r-usb-Decode` | x0r-usb.exe | 10.0 | 10.0 |

(Those two 0.0s are a genuine already-fixed verdict that could not be recorded before.)

## ELF is a provable no-op

Every case in every pool (`cases*.json`, `cases-missing*.json`, `novel.json`, all three
`triage-queue*.json`) run through the transform:

```
{'ELF unchanged': 14435, 'PE rebased': 89, 'PE unchanged': 37}
ELF cases whose address changed: 0
```

End-to-end, one ELF case per pool — the address line is unchanged and the fresh
decompile still works:

```
angr pool   - function: output_one_dumb_line @ 0x574f   (fresh block OK)
ida pool    - function: load_env @ 0x983d               (fresh block OK)
novel pool  - function: set_acl_fd @ 0x56c0             (fresh block OK)

rescore O0-coreutils-ptx-output_one_dumb_line: before 66.0 → after 66.0, delta 0.0
```

## Tests + gates

- **No Python test harness exists in this repo** to add a regression test to — no
  pytest/unittest anywhere, nothing under `tests/` is Python, and neither the `Makefile`
  nor `.github/workflows/` invokes a Python test runner (`tools/check_spec.py` is a
  standalone doc checker). Per the brief, the verified command output above stands in
  for one rather than inventing a harness.
- `make check-spec` → `check-spec OK (lenient mode)`.
- `make test` / `make test-stages` / `make rust-test` are unaffected **by construction**:
  the diff is 4 files under `scripts/decbench/` plus `docs/decbench-loop.md`. Nothing
  Rust reads, no option, no `phases.toml` row, no catalog count, no stage test, no DIV
  row — emitted C does not change.

## Out of scope, found while verifying

`rescore.source_cfg` picks the first `.i` whose text matches `\b<fn>\s*\(` — which also
matches a **declaration** in a shared header. Every `dexter` case therefore resolves to
`dexter.dll-CRC32.i`, gets a 1-node CFG, and scores `inf` on **both** sides
(`before == after == inf`, so no delta). Pre-existing and independent of addressing —
the dexter fresh decompile now runs fine (verified via `triage` above); it is the source
side that is mis-resolved. Left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dPFaKJanfLSf7mWGhkzkL
