### PR TITLE
[AUTOMATED] campaign(decbench): round-3 census — the NOVEL wart classes are closed

### DIFF
--- a/docs/decbench/triage/O2-noinline-cleanflight-cleanflight_DALRCF405-ftoa.md
+++ b/docs/decbench/triage/O2-noinline-cleanflight-cleanflight_DALRCF405-ftoa.md
@@ -1,0 +1,428 @@
+---
+case_id: O2-noinline-cleanflight-cleanflight_DALRCF405-ftoa
+pool: novel
+group_id: cleanflight::ftoa
+status: feature-candidate
+tier: N
+margin: 0
+fresh_verdict: reproduces on HEAD e38ffc31 in every mode — one 4-byte stack slot carries SEVEN overlapping declarations (`v2`/`v5`/`v6`/`v7` all `// stack - 0x28`, `v8` `-0x27`, `v9` `-0x26`, `v10` `-0x25`) and the body READS `v8` twice and `v5` once on paths where neither is ever assigned; the P6 symbol map is CORRECT (instrumented: `ScopeLocal::restructure` builds exactly one `xunknown4 @ -0x28` entry, ghidra's `local_28`), and the defect is one predicate in `ActionNameVars::linkSymbols` (`narrower_addrtied_local`, coreaction_cleanup.rs:2567) refusing to reuse it — an env-gated ablation of that predicate reproduces Ghidra's render exactly at 675/675 + 394/394 and 13 changed functions in 24,379
+option_closing: null
+feature_slug: tiedpartialname
+scope: small
+confidence: high
+---
+
+## Verdict in one line
+
+The `concat`/`subpiece`/`undefined` counters on this row are **inherited and do not
+move** — what is kuna-specific here is that a partial write to a mapped scalar stack
+local is named as its **own local** instead of a **field of the parent symbol**, which
+makes the emitted C **read variables that are never assigned**. One predicate, one
+module, measured green.
+
+## Reproduction (today's build, pasted)
+
+`make binaries` at HEAD `e38ffc31`. The stripped binary is 346,852 bytes (< 500 KiB), so a
+no-flag run resolves `auto -> aggressive`.
+
+```
+$ export SLEIGHHOME=/home/mahaloz/github/kuna/specs
+$ ./decompiler/target/release/kuna decompile \
+    ~/github/decbench/results/full_run/O2-noinline/cleanflight/stripped/cleanflight_DALRCF405.elf \
+    --addr 0x800f04c
+
+int4 sub_800f04c(float4 a0,int4 a1) // ternary x2
+{
+  unsigned int v1;
+  char v10; // stack - 0x25
+  unsigned int v11; // stack - 0x24
+  unsigned int v12; // stack - 0x20
+  unsigned int v2; // stack - 0x28
+  char v3 [16];
+  uint4 v4; // r4
+  char v5; // stack - 0x28
+  unsigned short v6; // stack - 0x28
+  undefined3 v7; // stack - 0x28
+  undefined3 v8; // stack - 0x27
+  unsigned short v9; // stack - 0x26
+
+  v2 = 0;
+  v11 = 0;
+  v12 = 0;
+  a0 = (a0 <= 0.0) ? a0 - 0.0005 : a0 + 0.0005;
+  v4 = (uint4)(a0 * 1000.0);
+  sub_800f018((v4 ^ (int4)v4 >> 0x1f) - ((int4)v4 >> 0x1f),v3,10);
+  v2 = (0 <= (int4)v4) ? CONCAT31(v8,0x20) : CONCAT31(v8,0x2d); // branch-flip   <-- v8 NEVER ASSIGNED
+  if (sub_8008a00(v3) != 1) { // branch-flip
+    v1 = v2;
+    if (sub_8008a00(v3) != 2) { // branch-flip
+      if (sub_8008a00(v3) != 3) // branch-flip
+        sub_80088dc(&v2,v3);
+      else {
+        v9 = SUB42(v2,2);
+        v5 = (char)v2;
+        v6 = CONCAT11(0x30,v5);
+        v2 = CONCAT22(v9,v6);
+        sub_80088dc(&v2,v3);
+      }
+    }
+    else {
+      v5 = (char)v2;
+      v6 = CONCAT11(0x30,v5);
+      v10 = SUB41(v1,3);
+      v7 = CONCAT12(0x30,v6);
+      v2 = CONCAT13(v10,v7);
+      sub_80088dc(&v2,v3);
+    }
+  }
+  else {
+    v6 = CONCAT11(0x30,v5);          <-- v5 NEVER ASSIGNED ON THIS PATH
+    v7 = CONCAT12(0x30,v6);
+    v2 = CONCAT13(0x30,v7);
+    sub_80088dc(&v2,v3);
+  }
+  v4 = (uint4)(uint1)sub_8008a00(&v2) - 3 & 0xff;
+  sub_8009014(a1,&v2,v4);
+  *(char *)(a1 + v4) = 0;
+  sub_80088dc(a1,".");
+  sub_80088dc(a1,(int4)&v2 + v4);
+  return a1;
+}
+```
+
+`v8` (`undefined3 @ -0x27`) is read in both ternary arms and assigned nowhere; `v5`
+(`char @ -0x28`) is read on the `strlen(intString1) == 1` path and assigned only on the
+other two. Both are supposed to be **bytes of the same 4-byte slot as `v2`**, which IS
+assigned — the aliasing is real in the IR and lost in the C.
+
+Mode / option sweep — nothing closes it:
+
+```
+$ for m in auto aggressive; do kuna decompile ... --mode $m | grep -c '// stack - 0x2[5678]$'; done
+7
+7
+$ kuna decompile-all <bin> --json --mode reliable      # the option surface the benchmark scored
+  ... identical body, same 7 declarations ...
+$ for o in <all 26 default-off catalog rows>; do kuna decompile ... --option $o on | grep -c ...; done
+   -> 7 for every one of the 26
+$ kuna decompile ... --option condfold on   -> 7
+$ kuna decompile ... --option condfold wide -> 7
+```
+
+So `option_closing: null`, and the disagreement between `auto` and `reliable` is nil —
+this is a code-level defect, not a mode difference.
+
+> Side observation, not this track: `kuna decompile --addr 0x800f04c --mode reliable` and
+> `--mode fast` **fail to load the function at all** on this Cortex-M binary
+> (`Execution error: Unable to load 512 bytes at r0x0644a8dc`) while `--mode auto`/
+> `aggressive` and `decompile-all --mode reliable` succeed. The single-function
+> `load addr` path depends on an analysis option carried only by the aggressive preset.
+
+## Side-by-side
+
+**ghidra** (stored pane, same binary, same address) — one symbol, partial fields:
+
+```c
+  undefined4 local_28;
+  undefined4 local_24;
+  undefined4 local_20;
+  undefined1 auStack_1c [16];
+  ...
+  if ((int)uVar4 < 0) { local_28 = CONCAT31(local_28._1_3_,0x2d); }
+  else                { local_28 = CONCAT31(local_28._1_3_,0x20); }
+  ...
+    local_28._0_2_ = CONCAT11(0x30,(undefined1)local_28);
+    local_28._0_3_ = CONCAT12(0x30,(undefined2)local_28);
+    local_28       = CONCAT13(0x30,(undefined3)local_28);
+  ...
+      local_28._3_1_ = SUB41(uVar1,3);
+```
+
+8 `CONCAT` + 1 `SUB41` + 2 `undefinedN` casts — i.e. **ghidra emits the same operator
+soup**; what it does not emit is a second name for the same bytes.
+
+**ida** — `int v7[3]` plus `LOBYTE/BYTE1/HIBYTE` macros, 0 CONCAT.
+**angr** — declares `char v1/v2/v3` at `-0x27/-0x26/-0x25` and **assigns each of them**
+(`v1 = 48;`), so its separate-names model is at least self-consistent; 0 CONCAT.
+**binja** — `*(&var_28 + 1) = 0x30`, 0 CONCAT.
+
+**kuna with the one-predicate ablation applied** (private build, see *Analysis*):
+
+```c
+  unsigned int v1;
+  unsigned int v2; // stack - 0x28
+  char v3 [16];
+  uint4 v4; // r4
+  unsigned int v5; // stack - 0x24
+  unsigned int v6; // stack - 0x20
+
+  v2 = (0 <= (int4)v4) ? CONCAT31(v2._1_3_,0x20) : CONCAT31(v2._1_3_,0x2d);
+  ...
+        v2._2_2_ = SUB42(v2,2);
+        v2._0_1_ = (char)v2;
+        v2._0_2_ = CONCAT11(0x30,(char)v2);
+        v2 = CONCAT22(v2._2_2_,(unsigned short)v2);
+  ...
+    v2._0_2_ = CONCAT11(0x30,(char)v2);
+    v2._0_3_ = CONCAT12(0x30,(unsigned short)v2);
+    v2 = CONCAT13(0x30,(undefined3)v2);
+```
+
+Ghidra's shape exactly: 3 stack declarations instead of 9, every partial read
+re-derived from the parent, **no read of an unassigned variable**.
+
+## Source
+
+`~/github/decbench/results/full_run/O0/cleanflight/compiled/typeconversion.i:1239`:
+
+```c
+char *ftoa(float x, char *floatString)
+{
+    int32_t value;
+    char intString1[12];
+    char intString2[12] = { 0, };
+    ...
+    if (value >= 0) intString2[0] = ' ';
+    else            intString2[0] = '-';
+
+    if (strlen(intString1) == 1) {
+        intString2[1] = '0'; intString2[2] = '0'; intString2[3] = '0';
+        strcat(intString2, intString1);
+    } else if (strlen(intString1) == 2) { ... }
+```
+
+The `char intString2[12] = {0,}` zero-init compiles to three word stores, so **every**
+Ghidra-family decompiler models the array as three 4-byte scalars and turns the
+subsequent byte writes into read-modify-write `CONCAT` chains. That reassembly failure is
+**inherited** (ghidra 8 CONCAT vs kuna 10 on this function) and is not what this record
+files. What the source makes unambiguous is that `intString2[0]` has a defined value
+(`' '` or `'-'`) at the point kuna reads `v5`, and that `intString2[1..3]` are zero at the
+point kuna reads `v8` — kuna's C says otherwise.
+
+## Analysis (instrumented, not read)
+
+Owning phase: **P6 — Variable & Storage Model** (`docs/phases.md`); the symptom is visible
+at P9 but the decision is P6's `ActionNameVars`.
+
+**Step 1 — the symbol map is CORRECT.** `ScopeLocal::restructure` already has an
+env-gated dump (`KUNA_DBG_VARMAP`, varmap.rs:1382/1399). On this function it builds
+exactly the three entries ghidra has:
+
+```
+$ KUNA_DBG_VARMAP=1 decomp_dbg < probe.dbg 2>&1 >/dev/null | grep ENTRY
+[varmap] ENTRY addr=0xffffffd8 size=4 type=xunknown4     <-- ghidra's local_28
+[varmap] ENTRY addr=0xffffffdc size=4 type=
+[varmap] ENTRY addr=0xffffffe0 size=4 type=
+[varmap] ENTRY addr=0xffffffe4 size=16 type=
+```
+
+All seven sub-ranges (`-0x28:1/2/3/4`, `-0x27:3`, `-0x26:2`, `-0x25:1` — visible as
+distinct `RangeHint`s in the same dump) are absorbed into the single 4-byte entry. So this
+is **not** a `MapState`/`RangeHint` defect, and it is not the `subright` thread either:
+the final IR carries the partials as ordinary addr-tied stack varnodes
+(`print raw`: `s0xffffffd9:3 = SUB43(s0xffffffd8,#0x1)`, `s0xffffffd8:1 = SUB41(...)`).
+
+Independent corroboration from the product surface: `kuna decompile-all --json`'s
+`variables` array for this function lists **only** `v2`, `v11`, `v12`, `v3` — the four
+real symbols. `v5`…`v10` are declared in the body with no symbol behind them.
+
+**Step 2 — the naming pass refuses to reuse the entry.** Instrumenting the
+`handleSymbolConflict` port in `ActionNameVars::linkSymbols`
+(`p6_variables/coreaction_cleanup.rs:2540-2614`):
+
+```
+[name] addr=0xffffffd8 size=4 tied=true ... entry_size=4 narrower=false reuse=true  conflict=false entry_name=v2
+[name] addr=0xffffffd8 size=1 tied=true ... entry_size=4 narrower=true  reuse=false conflict=true  entry_name=v2
+[name] addr=0xffffffd8 size=2 tied=true ... entry_size=4 narrower=true  reuse=false conflict=true  entry_name=v2
+[name] addr=0xffffffd8 size=3 tied=true ... entry_size=4 narrower=true  reuse=false conflict=true  entry_name=v2
+[name] addr=0xffffffd9 size=3 tied=true ... entry_size=4 narrower=true  reuse=false conflict=true  entry_name=v2
+[name] addr=0xffffffda size=2 tied=true ... entry_size=4 narrower=true  reuse=false conflict=true  entry_name=v2
+[name] addr=0xffffffdb size=1 tied=true ... entry_size=4 narrower=true  reuse=false conflict=true  entry_name=v2
+```
+
+Every partial finds the right entry (`entry_name=v2`) and is then rejected by
+`narrower_addrtied_local` (coreaction_cleanup.rs:2567) — an **addr-tied, non-input,
+non-persist, non-constant Varnode strictly narrower than a non-composite containing
+entry**. That flips `reuse_directly` off and runs the conflict scan, which finds a 4-byte
+varnode at `-0x28` in a different HighVariable:
+
+```
+[name]   scan other_vn_addr=0xffffffd8 size=4 same_group=false oh_has_piece=false high_has_piece=true
+[name]   scan other_vn_addr=0xffffffd8 size=4 same_group=true  oh_has_piece=true  high_has_piece=true
+```
+
+The scan's escape hatch (`is_same_group`, the `Merge::mergeAddrTied` -> `groupWith`
+`VariableGroup` test) saves the second candidate but not the first: **one of the 4-byte
+highs at that address was never given a `VariablePiece`**, so `conflict = true` and the
+partial falls through to the fresh-`vN` tail and is given its own Symbol.
+
+That the escape hatch *can* work is visible in the same binary: in
+`applyLedFixedLayers` (`0x8030a88`) the two partials of the `-0xe4` slot come back
+`narrower=true, conflict=false` and render correctly as `v19._2_1_` / `v19._3_1_`, while
+the `-0xdc` slot in the same function comes back `conflict=true` and splits into five
+names. Same predicate, two outcomes, decided by whether the merge happened to group the
+highs.
+
+**Step 3 — why a name instead of a field turns into a read-before-def.** The
+`SUB41(v2,0)` in the `strlen == 1` arm is an *implied* varnode: no statement is emitted for
+it in either build (ghidra does not emit one either). C++
+`PrintLanguage::pushVnImplied` prints an implied varnode through its **Symbol** when it has
+one — the whole-symbol arm prints the bare name, the partial arm calls `pushPartialSymbol`.
+With the entry reused, that is `(char)v2`, which re-derives the value and is always
+correct. With a private Symbol it is the bare name `v5`, and because the definition was
+elided there is nothing that ever assigns it. The identical chain explains `v8`
+(`SUB43(v2,1)`, one implied use in each ternary arm).
+
+**Step 4 — the divergence is kuna's, and its own witness no longer needs it.** Upstream
+`Funcdata::handleSymbolConflict` (`funcdata_varnode.cc:1018`) returns the entry
+**unconditionally** for `vn->isAddrTied()`; `narrower_addrtied_local` is a kuna carve-out
+added for LOSS-234 `zeroprop` (the 1-byte char return overlapping the 4-byte `int4 *ptrint`
+parameter). Instrumenting its own datatest, `tests/datatests/condconst2.xml`:
+
+```
+$ KUNA_DBG_NAME=1 decomp_test_dbg -path <dir-with-only-condconst2.xml> datatests 2>&1 >/dev/null | grep '\[name\]'
+[name] addr=0x20 size=4 tied=false in=true ... narrower=false reuse=true conflict=false entry_name=ptrint
+[name] addr=0x24 size=4 tied=false in=true ... narrower=false reuse=true conflict=false entry_name=val
+   ... (six rows, every one in=true / narrower=false)
+$ KUNA_DBG_VARMAP=1 ... | grep ENTRY     -> (no output: zeroprop has no stack entries at all)
+```
+
+The guard **never fires on the case it was written for**. Its char-return high has no
+covering entry today and takes the no-symbol tail instead.
+
+**Step 5 — ablation.** An env-gated `narrower_addrtied_local = false`, compiled into a
+private binary (`KUNA_ABL_NARROWER`; the repository tree was restored and rebuilt
+afterwards, `git status` clean):
+
+| gate | control (same binary, env unset) | ablated |
+|---|---|---|
+| `kuna test --datatests --baseline docs/baseline.json` | 675/675, PARITY OK | **675/675, PARITY OK** |
+| `kuna test --datatests --datatests-dir tests/stages --baseline docs/baseline-stages.json` | 394/394, PARITY OK | **394/394, PARITY OK** |
+
+and on `ftoa` it produces the Ghidra-shaped pane quoted above.
+
+## Breadth (corpus-wide)
+
+**A/B `decompile-all` over 24,379 functions / 15 binaries / 5 arch-format families**
+(ARM Cortex-M ELF, x86-64 ELF, x86-64 PIE, PE32, MIPS-family `mirai`):
+
+| | value |
+|---|---|
+| functions compared | 24,379 |
+| **functions changed by the ablation** | **13 (0.053%)** |
+| stack-local declarations | 19,657 -> 19,620 (**-37**) |
+| `sym._n_m_` partial-field renders | 691 -> **797** (+106) |
+| `undefinedN` tokens | 257 -> 266 (+9) |
+
+Per-binary: betaflight O0 4, cleanflight O2ni 2, e2fsck O2ni 2, ssh O2ni 2, bash O0 1,
+ip O2ni 1, x0r-usb O2ni 1; crazyflie / nuttx / tar / ocsptool / mydoom / factor / usbmidi 0.
+
+**Every one of the 13 diffs was read** (the standing "diff every changed function"
+requirement). All 13 are the same shape — N overlapping declarations collapse to 1, and
+their uses rebind to `parent._off_size_` / `(type)parent`. No statement is dropped, no
+call or argument changes, no control flow changes, no function boundary moves. The
+largest are `betaflight 0x8018378` and `cleanflight 0x800f04c` (both `ftoa`) and
+`betaflight 0x8051f32`/`0x8051f38` at 9 -> 3 and 8 -> 3 declarations.
+
+A static scan of the same 24,372 panes for the *symptom* (declared stack locals whose
+byte ranges overlap) finds **35 functions (0.14%)**, of which **4** additionally read a
+never-assigned overlapping local. Extrapolated to the benchmark's 94,575 functions that is
+~135 functions carrying aliased declarations, ~50 the fix would change and ~16 with a
+genuine read-before-def. **This is a narrow, correctness-shaped fix, not a volume fix** —
+rank it the way round 1 ranked `spacebase-unnamed-location`, not by GED.
+
+**GED delta: 0.** No basic block appears or disappears; the case is tied at 8 with ghidra
+and ida already. The novel-pool wart counters do not move either (see below).
+
+## What this does NOT fix (and what is disproven)
+
+1. **The `concat` counter does not move.** kuna emits 10 `CONCAT` before and after; ghidra
+   emits 8 on the identical statements. Confirms the census: CONCAT here is failed
+   reassembly of source-level byte writes into a zero-initialised `char[12]`, which the
+   whole Ghidra family fails the same way. Not a campaign item.
+2. **The `subpiece` counter does not move** (2 before, 2 after) and this is *not* the
+   `subright` thread (#251): these SUBPIECEs are at nonzero offsets of a **stack symbol**,
+   which upstream's own addr-tied/`overlap == c` guard deliberately leaves alone.
+3. **The `undefined` counter does not move** (2 before, 2 after): the two `undefined3 v7`
+   / `undefined3 v8` declarations are replaced by two `(undefined3)v2` casts, which ghidra
+   also emits. As the census already corrected, novel.md's `undefined` tag is the
+   `undefinedN` **type token**, not the `$$undef` placeholder #257 removed.
+4. **Not a metric artifact**: `approximated: false`, `degenerate_source: false`,
+   `source_nodes: 16`, `source_edges: 21`, kuna 8 = ghidra 8 = ida 8, angr/binja 19. The
+   row is in the novel pool because the pane is bad, not because the score is.
+5. **Not closed by any option or mode**: all 26 default-off catalog rows, `condfold on`
+   and `condfold wide`, and all four modes leave the seven declarations in place.
+
+## Relation to the sibling records
+
+`novel-concat-subpiece-soup.md` (the cluster record) already flagged the residue in
+`applyLedFixedLayers` as "the P6 partial-symbol/merge thread, not `subright`". This record
+names that thread and gives it a measured lever.
+
+`novel-tiedslot-partial-symbol.md` triages the **same cluster** and lands on
+`needs-proposal` with a different proximate cause: a skipped forced
+`Merge::mergeAddrTied` at the slot. **The two findings are consistent, not competing** —
+the skipped merge is precisely why a second, *ungrouped* 4-byte HighVariable exists at
+`-0x28` for the conflict scan to trip over (`oh_has_piece=false` in the Step-2 transcript).
+The difference is what each identifies as the actionable lever:
+
+* the merge-side repair is the deeper one (it would also collapse the self-piece CONCAT
+  rebuild traffic), and that record is right that upstream's `eliminateIntersect` cannot
+  snip a full-block-cover intersection — hence `needs-proposal`;
+* the **naming-side** repair is sufficient for the rendering defect on its own, is one
+  predicate in one module, and is measured at 0/675 + 0/394 with 13 changed functions.
+
+They should be sequenced, not merged: ship the naming predicate first (it is a strict
+correctness fix and cannot regress the merge work), then treat the merge as a separate
+proposal whose payoff is the CONCAT/SUBPIECE traffic this record explicitly does not claim.
+
+## Proposed fix
+
+* **Owning phase**: P6 (Variable & Storage Model) — `ActionNameVars` / the
+  `Funcdata::linkSymbol` + `handleSymbolConflict` port.
+* **One module, one predicate**:
+  `decompiler/crates/kuna-decomp/src/p6_variables/coreaction_cleanup.rs:2567`. Restrict
+  `narrower_addrtied_local` to the shape it was written for. The zeroprop witness is a
+  narrower addr-tied local overlapping a wider **input/parameter** entry; the ftoa shape is
+  a narrower addr-tied local overlapping a wider **ordinary mapped stack local**. Two
+  candidate gates, in order of preference:
+  1. require the containing entry's category to be a **parameter** (`info.category`, already
+     fetched and currently discarded at the `let _ = info.category;` line) — the tightest
+     restatement of LOSS-234;
+  2. require the entry's space to be a **register** space rather than the stack spacebase —
+     zeroprop's conflict is at `r0`, every case in this record is at a stack offset.
+  The wholesale removal measured above is the upper bound of the behaviour change: if the
+  tightened gate lands anywhere between "removal" and "today", it is bounded by 13
+  functions in 24,379.
+* **Option**: `tiedpartialname` (`on` = a narrower addr-tied Varnode reuses its containing
+  scalar Symbol and renders `sym._off_size_`; `off` = today's fresh-`vN`). Per AGENTS.md
+  this only ever changes emitted C, so gate it; the default-ON flip is carried by the
+  0/675 ablation already measured.
+* **Stage test**: `tests/stages/ghdec-tiedpartialname.xml` (no angr analog), two-pass — a
+  4-byte stack slot zero-initialised then byte-poked; option off = `v5`/`v8` declared and
+  read unassigned, default = `v2._1_3_` / `(char)v2` and three declarations.
+* **Risks to measure on the PR**:
+  (a) the `zeroprop` regression the gate was added to prevent — the datatest
+  (`condconst2.xml`, assertion `\(char\)ptrint` `min=0 max=0`) is green under full removal
+  today, but the tightened gate must be verified against it explicitly, not by the corpus;
+  (b) the `undefinedN` token count rises slightly (257 -> 266 on the sample) because a
+  partial that used to carry a concrete type now renders as an `(undefinedN)` cast of the
+  parent — expected, matches ghidra, but it will show in a wart re-mine;
+  (c) `x0r-usb 0x4036d0` and `bash 0x9c2e3` are the only two changed functions where the
+  parent symbol is 8 bytes rather than 4 — re-read those two panes in the PR sweep;
+  (d) speed — the change removes work (a scan is skipped), but run
+  `scripts.pipeline.timeit` anyway for the ≤5% budget.
+
+## Siblings (all verified to move together under the ablation)
+
+| case | binary | address |
+|---|---|---|
+| `O0-cleanflight-cleanflight_DALRCF405-ftoa` | O0 cleanflight | `0x800effc` |
+| `ftoa` (betaflight build of the same source) | O0 betaflight | `0x8018378` |
+| `applyLedFixedLayers` | O2ni cleanflight | `0x8030a88` |
+| unnamed | O0 betaflight | `0x8051f32`, `0x8051f38`, `0x802a338` |
+| unnamed | O2ni e2fsck | `0x6d630`, `0x71860` |
+| unnamed | O2ni ssh | `0x57110`, `0x61aa0` |
+| unnamed | O2ni ip | `0x78dc0` |
+| unnamed | O0 bash | `0x9c2e3` |
+| unnamed | O2ni x0r-usb | `0x4036d0` |

--- a/docs/decbench/triage/O2-noinline-rsyslog-rsyslogd-queryEtryPt.md
+++ b/docs/decbench/triage/O2-noinline-rsyslog-rsyslogd-queryEtryPt.md
@@ -1,0 +1,413 @@
+---
+case_id: O2-noinline-rsyslog-rsyslogd-queryEtryPt
+pool: novel
+group_id: rsyslog::queryEtryPt (12 module-entry-point siblings in one binary)
+status: feature-candidate
+tier: N
+margin: 0
+fresh_verdict: reproduces on e38ffc31. The `(code *)` is NOT a type-propagation or cast-insertion defect — it is a P6 FORCED merge. kuna's own `mark_output_storage_addr_tied` (a "W4 ScopeLocal stand-in" in ActionMergeRequired) paints the whole return register `mapped|addrtied` whenever ANY same-register SSA version is a phi/indirect join, and `Merge::mergeAddrTied` then force-merges all 27 RAX versions into ONE HighVariable whose type representative is the most specific member. In queryEtryPt the join is the function-pointer table (`*pEtryPoint = modExit`), which never reaches a RETURN, so `code *` wins over the `rsRetVal` error codes and the function is declared `code *` returning `(code *)0xfffffc18`. Gating the paint on "the join must actually reach a RETURN" reproduces ghidra's shape exactly, keeps 675/675 datatests and 394/394 stages green, and is 9% FASTER.
+option_closing: null
+feature_slug: retjointie
+scope: small
+confidence: high
+---
+
+## Side-by-side
+
+### fresh kuna — today's build (`e38ffc31`), `--mode auto` (= aggressive, 916 KiB binary)
+
+```
+$ export SLEIGHHOME=/home/mahaloz/github/kuna/specs
+$ ./decompiler/target/release/kuna decompile \
+      ~/github/decbench/results/full_run/O2-noinline/rsyslog/stripped/rsyslogd --addr 0x20f60
+code * sub_20f60(char *a0,unsigned long *a1) // return-dupe
+{
+  int4 v1; // eax
+  code *v2; // rax
+
+  if (!a0) {
+    v2 = (code *)0xfffffc18;
+    return v2;
+  }
+  if (a1) {
+    *a1 = 0;
+    v1 = strcmp(a0,"modExit");
+    if (v1) { // branch-flip
+      ...                                     (22 nested strcmp arms)
+                                                r_dbgprintf("omfile.c","entry point '%s' not present in module\n",a0);
+                                                v2 = (code *)0xfffffc14;
+                                                return v2;
+      ...
+    else { v2 = sub_20d40; }
+    *a1 = v2;
+    v2 = NULL;
+    return v2;
+  }
+  v2 = (code *)0xfffffc18;
+  return v2;
+}
+```
+
+151 lines, 24 `if`s, 0 gotos. One `code *v2; // rax` carries **both** the handler
+address (`v2 = sub_20d40; *a1 = v2;`) and the integer return code
+(`v2 = (code *)0xfffffc18; return v2;`).
+
+### ghidra (stored) — note: a DIFFERENT instance, see *Metric-artifact check*
+
+```c
+undefined8 queryEtryPt(char *param_1,undefined8 *param_2)
+{
+  int iVar1;
+  code *pcVar2;          // <- the handler
+  undefined8 uVar3;      // <- the return value; SEPARATE variable
+
+  if (param_1 == (char *)0x0) { return 0xfffffc18; }
+  if (param_2 == (undefined8 *)0x0) { uVar3 = 0xfffffc18; }
+  else {
+    *param_2 = 0;
+    iVar1 = strcmp(param_1,"modExit");
+    if (iVar1 == 0) { pcVar2 = FUN_00127760; } else { ... }
+    *param_2 = pcVar2;
+    uVar3 = 0;
+  }
+  return uVar3;
+}
+```
+
+### ida (stored)
+
+```c
+long long queryEtryPt(char *s1, long long (**a2)())
+{
+  long long (*v2)(); // rax
+  if ( !s1 )  return 4294966296LL;      /* 0xfffffc18, printed as an integer */
+  ...
+}
+```
+
+### kuna with the proposed gate (measured, worktree build)
+
+```c
+unsigned long sub_20f60(char *a0,unsigned long *a1) // return-dupe
+{
+  code *v1; // rax
+
+  if (!a0)
+    return 0xfffffc18;
+  if (a1) {
+    *a1 = 0;
+    if (strcmp(a0,"modExit")) { // branch-flip
+      ...
+                                                r_dbgprintf("omfile.c","entry point '%s' not present in module\n",a0);
+                                                return 0xfffffc14;
+      ...
+    else { v1 = sub_20d40; }
+    *a1 = v1;
+    return 0;
+  }
+  return 0xfffffc18;
+}
+```
+
+123 lines (was 151). Return type `unsigned long` (ghidra: `undefined8`; ida: `long long`),
+handler still `code *v1` (ghidra: `code *pcVar2`), constants no longer cast.
+Structurally identical to ghidra's pane and 13 lines shorter than it on the
+address-matched instance (0x27790: kuna 42 lines vs ghidra 55).
+
+## Source
+
+`~/github/decbench/results/full_run/O2-noinline/rsyslog/compiled/rsyslogd-omfile.i:14175`
+
+```c
+static rsRetVal queryEtryPt(uchar *name, rsRetVal (**pEtryPoint)())
+{
+  rsRetVal iRet = RS_RET_OK;
+  if ((name == NULL) || (pEtryPoint == NULL)) { return RS_RET_PARAM_ERROR; }
+  *pEtryPoint = NULL;
+  if     (!strcmp((char*)name,"modExit"))   { *pEtryPoint = modExit; }
+  else if(!strcmp((char*)name,"modGetID"))  { *pEtryPoint = modGetID; }
+  ...                                        /* 22 arms */
+  if (iRet == RS_RET_OK)
+    if (*pEtryPoint == NULL) {
+      r_dbgprintf("omfile.c","entry point '%s' not present in module\n", name);
+      iRet = RS_RET_MODULE_ENTRY_POINT_NOT_FOUND;
+    }
+  return iRet;
+}
+```
+
+`rsRetVal` is an **enum/int**; `pEtryPoint` is a function-pointer out-parameter.
+`0xfffffc18` = `RS_RET_PARAM_ERROR` (-1000), `0xfffffc14` = -1004.  kuna's
+`code * queryEtryPt(...)` returning `(code *)0xfffffc18` is therefore wrong against
+the source, not merely a rendering-convention difference.
+
+## Analysis
+
+### Symptom (one)
+
+The function's **return register is force-merged with an unrelated same-register phi**,
+so a single HighVariable has to carry both a `code *` and an integer, and the pointer
+type wins — for the local declaration *and* for the function's declared return type.
+
+### Root cause — instrumented, not read
+
+`kuna decompile` shells out to `decomp_dbg`, and `break action` / `print high` /
+`print C xml` are all `engine_unavailable` stubs, so the trace was taken by building an
+instrumented `decomp_dbg` in a throwaway detached worktree (no branch, no main-tree edit).
+
+**Step 1 — the SSA is clean.** `print raw` on `sub_20f60` shows the two roles as
+disjoint varnodes:
+
+```
+0x00020fa1:2ed:  RAX(2ed) = RAX(0x20f9a:36) ? RAX(0x2118f:193) ? ... (22-way MULTIEQUAL of function entries)
+0x00020fa1:38:   *(ram,RSI(i)) = RAX(2ed)            <- the join feeds the STORE, and only the STORE
+0x00020fa6:2ee:  RAX(2ee) = #0x0                     -+
+0x00020fa6:44f:  RAX(44f) = #0xfffffc14               |  four independent return values
+0x00020fa6:451:  RAX(451) = #0xfffffc18               |
+0x00021260:1d1:  RAX(1d1) = #0xfffffc18              -+
+```
+
+The join (`2ed`) has **no path to any `return`**; the returned varnodes are four
+separate constants.
+
+**Step 2 — which pass merges them.** Instrumenting `Merge::merge` with a per-pass label
+(`p6_variables/merge.rs`, driven from `coreaction_cleanup.rs`) attributes every one of
+these merges to **`mergeAddrTied`** — the *required*, non-speculative pass — not to
+`mergeByDatatype` / `mergeAdjacent`:
+
+```
+[MERGE mergeAddrTied spec=false] H173[1]{vn#141@0x20f9a} ty=/m9/sz8  <=  H174[1]{vn#1961@0x20fa1} ty=/m9/sz8
+[MERGE mergeAddrTied spec=false] H173[2]{...}            ty=/m9/sz8  <=  H175[1]{vn#1984@0x20fa6} ty=xunknown8/m15/sz8
+[MERGE mergeAddrTied spec=false] H173[3]{...}            ty=/m9/sz8  <=  H176[1]{vn#3470@0x20fa6} ty=xunknown8/m15/sz8
+... 27 members in total
+```
+
+The existing `KUNA_DBG_MERGE` hook confirms the range:
+
+```
+[mergeAddrTied] sub n=22 addr=0x0 size=4 -> OK     (EAX)
+[mergeAddrTied] sub n=27 addr=0x0 size=8 -> OK     (RAX)
+[mergeAddrTied] groupWith off=0 h2=HighVariableId(173) h1=HighVariableId(151)
+```
+
+**Step 3 — why a *register* is address-tied at all.** Instrumenting
+`Funcdata::addr_tied_ranges` (`p6_variables/funcdata_merge.rs:886`) to print the window
+flags:
+
+```
+[ATIED] space=register off=0x0 winflags=0x1288130 addrtied=true members=49
+   [ATIED-MEMBER] vn#141  off=0x0 sz=8 flags=0x1288130 ...   (0x8000 = addrtied, 0x200000 = mapped)
+   [ATIED-MEMBER] vn#1961 off=0x0 sz=8 flags=0x1288030 ...
+   ... every RAX version carries addrtied
+```
+
+The painter is kuna's own, not the port:
+`p6_variables/coreaction_cleanup.rs` → `ActionMergeRequired::apply` calls
+**`mark_output_storage_addr_tied(data)`** immediately before `merge_addr_tied`, described
+in its own comment as a *"(kuna W4-ScopeLocal stand-in)"*. Its whole-function comment
+block states the upstream fact it is standing in for:
+
+> C++ `syncVarnodesWithSymbols` (funcdata_varnode.cc:993) ties an un-symboled processor
+> register ONLY via `lm->inScope`, ALWAYS false for a register, so C++ never restructures
+> this loop-carried register into a whole-function local.
+
+It fires when **any** same-address SSA version is a `marker` write (MULTIEQUAL/INDIRECT),
+subject to five existing escape hatches (all-marker-inputs-persist, all-writes-const-COPY,
+forwarding-register-alias, transient-self-chain, loop-carried-marker — LOSS-206/229/231/
+234/241). None of them asks the one question that matters here: **is the join the value
+the function returns?**
+
+**Step 4 — the type follows the merge.** `HighVariable::updateType` picks the most
+specific member type, so `code *` (from the 22-way function-entry phi) beats
+`xunknown8` (the return constants); the printed return type follows the returned
+HighVariable, so the *function signature* becomes `code *` too.
+
+**Step 5 — ablation.** Building the same tree with `mark_output_storage_addr_tied`
+skipped reproduces ghidra's shape exactly:
+
+```
+$ KUNA_NO_OUTTIE=1 decomp_dbg  ... load addr 0x20f60 ; decompile ; print C
+unsigned long sub_20f60(char *a0,unsigned long *a1) // return-dupe
+{
+  code *v1; // rax
+  if (!a0)
+    return 0xfffffc18;
+  ...
+```
+
+### Owning phase
+
+**P6 — variables / merge** (`decompiler/crates/kuna-decomp/src/p6_variables/`). The
+`(code *)` is a *symptom* of a forced-merge decision; nothing in P3 (cast insertion) or
+P5 (type inference) is wrong here. This is the fourth distinct cause hiding under
+`novel.md`'s `code_ptr` column (see `novel-code-ptr-cluster.md` for causes 1–3).
+
+## Option sweep — nothing covers it
+
+All 88 catalog options at every non-default value, plus `--mode reliable|aggressive|fast`,
+run on `--addr 0x20f60`, counting lines containing `code *` (baseline 5):
+
+| setting | count |
+|---|---|
+| DEFAULT / `--mode reliable` / `aggressive` / `fast` | 5 |
+| `inferfuncentry off`, `returndup off`, `earlyreturn off`, `realtypes off`, `dedupvardecls off`, `foldcallret off`, `condfold on`, `condfold wide`, `paramcopyhoist on`, `ptrentry on`, `namestyle ghidra`, … (all 88 rows) | 5 |
+| `entry_disc off` | 0 — **not a fix**: function discovery is off, so the callee entries are never resolved and the whole binary degrades |
+
+`condfold on|wide` swept explicitly, as required. No option closes it.
+
+## Metric-artifact check
+
+- `approximated: false`, `degenerate_source: false`, `artifact_suspect: false`,
+  source CFG 54 nodes / 79 edges — the score is a real edit distance.
+- **`source_ambiguous: true`, and it bites here.** rsyslog compiles 12 modules that each
+  define a `static rsRetVal queryEtryPt(...)`; decbench's `_relabel_to_dwarf` is
+  name-keyed, so the tools' panes are for *different* instances — kuna's artifact is
+  `@ 0x20f60` (omfile.c, 22 entry points) while ghidra's and ida's are `@ 0x27790`
+  (smtradfwd.c, 6 entry points). The group's GED spread (kuna 22 vs ghidra 145 / ida 150)
+  is therefore **not** a like-for-like comparison and must not be quoted as one.
+  It does not weaken the case: the defect reproduces at every one of the 12 addresses,
+  *including* 0x27790, which is where ghidra's pane comes from — so the ghidra contrast
+  above is address-matched after all.
+
+## Breadth
+
+**Within rsyslogd (O2-noinline, 1,907 functions).** All 12 module-entry-point siblings
+carry it, 3 casts each:
+
+| addr | `(code *)` now | with gate | return type now → gated | lines now/gated |
+|---|---|---|---|---|
+| 0x20f60 (the case) | 3 | 0 | `code *` → `unsigned long` | 150 / 122 |
+| 0x1bbc0 0x1c220 0x1d290 0x241c0 0x25090 0x255c0 0x25d80 0x26a60 0x26eb0 0x272f0 0x27790 | 3 each | 0 | `code *` → `unsigned long` | −12…−28 each |
+
+36 occurrences → 0, matching the census (24× `0xfffffc18` + 12× `0xfffffc14`).
+
+**Corpus-wide A/B** — `kuna decompile-all --json`, 13 binaries across 3 arches / 2 opt
+levels / ELF+PE, every changed function diffed:
+
+| binary | fns | changed | `(code *)` before→after | Δlines |
+|---|---:|---:|---:|---:|
+| O0 bash | 3,278 | 50 | 157 → 156 | −904 |
+| O0 iproute2 ip | 1,962 | 8 | 19 → 19 | −276 |
+| O2-noinline betaflight (ARM) | 6,388 | 10 | 634 → 634 | −81 |
+| O2-noinline coreutils ls | 639 | 9 | 17 → 17 | −141 |
+| O2-noinline crazyflie (ARM) | 2,914 | 13 | 393 → 393 | −79 |
+| O2-noinline e2fsck | 1,909 | 29 | 391 → 391 | −254 |
+| O2-noinline certtool | 833 | 2 | 18 → 18 | −14 |
+| O2-noinline mydoom.exe (PE) | 161 | 1 | 39 → 32 | −8 |
+| O2-noinline nuttx (ARM) | 890 | 7 | 461 → 460 | −26 |
+| O2-noinline sshd | 2,042 | 63 | 100 → 99 | −585 |
+| O2-noinline tar | 1,585 | 24 | 71 → 70 | −154 |
+| O2-noinline x0r-usb.exe (PE) | 15 | 0 | 261 → 261 | 0 |
+| O2-noinline rsyslogd | 1,907 | 48 | 433 → 397 | −419 |
+| **total** | **24,523** | **264 (1.1%)** | **2,994 → 2,947 (−47)** | **−2,941** |
+
+The `code_ptr` counter under-states it. The real class is *"the return register absorbs
+an unrelated pointer type"*, whatever that type is:
+
+- **pointer-cast-on-integer-constant** occurrences (`(code *)0x…`, `(char *)0xffffffff`,
+  `(int4 *)0xd5a5a`, …): **911 → 784, −127**.
+- functions whose **declared return type** changes: **173 of the 264**; 15 lose a bogus
+  `code *`, **0 gain one**; 22 lose `char *`, 4 lose `void *`.
+- functions declaring a `code *` **return type**: **16 → 1**.
+
+A second witness, unrelated to `code_ptr`, is `bash::unbind_array_element` @ 0xa3738
+(source returns `int`): today `char * unbind_array_element(...)` with
+`v4 = (char *)0xfffffffe; return v4;` five times; gated, `unsigned long` with
+`return 0xfffffffe;`.
+
+**Speed.** Faster, because 27-member forced merges stop happening:
+`decompile-all` on sshd, 3 runs each — 51.24 / 48.83 / 49.52 s → 45.28 / 44.58 / 45.75 s
+(**−9%**). Well inside the ≤5% *regression* budget.
+
+## Proposed fix
+
+**One module.** `decompiler/crates/kuna-decomp/src/p6_variables/coreaction_cleanup.rs`,
+inside `mark_output_storage_addr_tied` — add a sixth escape hatch next to the five
+existing LOSS-* ones:
+
+> The `marker` join that justifies the tie must be the value the function **returns**.
+> If no `marker`-written same-address Varnode has a `CPUI_RETURN` among its descendants,
+> the register is carrying somebody else's value through a join, not a whole-function
+> return local, and C++ `inScope` would leave it un-tied.
+
+This is the same class of IR-shape test as the four already there (transient-self-chain,
+loop-carried-marker, forwarding-alias, all-persist), and it is the one that distinguishes
+`multiret`'s `getval` (the phi **is** the return value → keep tying) from `queryEtryPt`
+(the phi feeds a `STORE` → do not tie).
+
+**Measured, not proposed.** Implemented and run in the throwaway worktree behind
+`KUNA_GATE_RET`:
+
+```
+$ KUNA_GATE_RET=1 kuna test --datatests                              -> 675/675  exit 0
+$ KUNA_GATE_RET=1 kuna test --datatests --datatests-dir tests/stages -> 394/394  exit 0
+```
+
+(The crude whole-ablation, for contrast, fails exactly 3 of 675 —
+`multiret.xml` *Multi-size return #1/#2/#3* — and 0 of 394 stages. The narrow gate
+recovers all three.)
+
+**Gating.** Output-changing on 1.1% of functions and a judgment call about kuna's own
+stand-in heuristic ⇒ it ships as a named option per `docs/agents.md` (`retjointie`,
+P6 / variable-merge, `transform` tier), with a DIV row if it ever goes default-on.
+Stage test: `tests/stages/ghdec-retjointie.xml`, two-pass — `off` reproduces
+`code *` + `(code *)0x…`, default emits the integer. Remember the catalog-count bumps
+(`kuna_phases/tests.rs`, `tests/catalog_bytecompat.rs`, `tests/stages/kuna-catalog.xml`,
+`kuna-base/src/xml.rs` corpus count) and the stages-baseline re-record.
+
+### Risks — every one of the 264 changed functions was diffed
+
+No function loses a call. Three need a companion fix or an explicit accept:
+
+1. **A folded call can be rendered twice.** `rsyslogd sub_6a8e0` and
+   `sshd sub_6daa0` gain an extra `__ctype_b_loc()` / `__errno_location()` occurrence
+   against **one** `CALL` op in the p-code (`print raw` confirms a single
+   `0x0006a911:3f: u… = call f__ctype_b_loc`, and `objdump` a single `call` site).
+   Root-caused: `foldcallret` (kuna's angr-derived call-return folding, **default-ON**)
+   inlines the single-use call output into a `LOAD` that is itself implied at *two*
+   references under `max_implied_ref = 2`, so the whole folded expression prints twice.
+   Proved by knob: `KUNA_GATE_RET=1 --option foldcallret off` → 1 occurrence,
+   `KUNA_GATE_RET=1` alone → 2, default → 1. This is a **pre-existing `foldcallret`
+   bug that the un-tie merely exposes** (the tie was forcing the call output explicit),
+   and its fix belongs in `p6_variables/kuna_callretfold.rs::call_output_foldable`:
+   refuse to fold when the consumer chain is implied at more than one reference.
+   File it as its own case; ship it with, or before, `retjointie`.
+2. **A dead partial-register `CONCAT44` can appear.** `sshd sub_97bc0` gains
+   `v3 = CONCAT44(dat_4,v1);`, immediately overwritten — the same shape #251 accepted in
+   2 of 14,720 functions. 1 occurrence in 24,523 here.
+3. **Some pointer return types flatten to `unsigned long`** (22 `char *`, 4 `void *`).
+   Spot-checked both bash witnesses: in `unbind_array_element` (source returns `int`) the
+   flatten is a strict fix; in `parse_string_to_command` (source returns `COMMAND *`) it
+   trades a wrong-but-pointer type for a right-but-untyped one — the same trade ghidra
+   makes (`undefined8`). Net −127 bogus pointer casts, 0 new `code *` return types.
+
+`make rust-test` was **not** run for this triage (the workspace suite is the CI long
+pole and the record touches no `.rs`); the implementing PR owns it, along with
+`kuna catalog --check` and `make check-spec`.
+
+### Spec
+
+`docs/spec/06-variables-and-merge.md` (the chapter owning `p6_variables/`) — the
+return-register address-tie stand-in and its escape hatches are described there; the
+new gate is prose in the same paragraph.
+
+## Siblings
+
+- **11 in-binary siblings** (0x1bbc0 0x1c220 0x1d290 0x241c0 0x25090 0x255c0 0x25d80
+  0x26a60 0x26eb0 0x272f0 0x27790) — identical shape, identical fix, table above.
+- **`O0-rsyslog-rsyslogd-queryEtryPt`** (the pool's other case, @ 0x2734d) —
+  **already clean on today's build**: at `-O0` the handler lives in a stack slot, not in
+  RAX, so nothing joins the return register. `unsigned int sub_2734d(...)` with
+  `return 0xfffffc18;`. The defect is optimized-build-only.
+- Cross-project: 264 functions in the 13-binary sample, above.
+
+## Related records
+
+- `novel-code-ptr-cluster.md` — causes 1 (ARM Thumb `funcptr_align`, closed by #249),
+  2 (`inferfuncentry` collisions), 3 (untyped callbacks, not a defect). This is
+  **cause 4**, and it is the only one that is a *merge* defect.
+- The census that opened this track also closed `raw_reg` (dead since #226/DIV-46) and
+  recommended scoring `code_ptr` relatively (`max(0, kuna − min_rival)`); this record
+  independently supports that — kuna emits 2,994 `(code *)` on the sample and the change
+  removes 47 of them, while 173 functions improve with no `code_ptr` movement at all.
+  **The wart column is measuring the wrong thing; the return-type flip is the signal.**

--- a/docs/decbench/triage/novel-concat-global-piece-naming.md
+++ b/docs/decbench/triage/novel-concat-global-piece-naming.md
@@ -1,0 +1,331 @@
+---
+case_id: novel-concat-global-piece-naming
+pool: novel
+group_id: cluster (bash::yyparse, bash::save_tty_chars, iproute2::print_ndtparams, iproute2::print_namespace, openssh-portable::client_suspend_self, openssh-portable::main, openssh-portable::sshkey_dump_ec_key, tar::xclose, betaflight::decodeEscFrame)
+status: feature-candidate
+tier: N
+margin: 0
+fresh_verdict: the CONCAT is INHERITED — ghidra emits the byte-identical `CONCAT44(<hi-piece>,1)` on the same statement of bash/yyparse — and the only kuna-specific residue is the LEAF NAME of the high piece; one half of that residue (a RAM global spelled `dat_<addr+k>` where ghidra says `DAT_<addr>._k_n_`) is a symbol-map difference with no kuna-side mechanism, the other half is a real one-predicate printer bug that spells an UNNAMED REGISTER piece as a fabricated memory global `dat_<register-offset>`
+option_closing: null
+feature_slug: regpiecename
+scope: small
+confidence: high
+---
+
+## Verdict in one line
+
+The `concat` wart in `novel.md` is **not a CONCAT defect** — kuna 513 vs ghidra 449 on
+10,068 matched functions (1.14x), and on the row that named it ghidra emits the *identical*
+operator. What survives is a **leaf-naming** defect, and the kuna-only half of it is
+`kuna_global_naming()` accepting the **register space** — so an unnamed sub-register piece
+prints as `dat_4`, a RAM global at address 4 that does not exist.
+
+## Side-by-side
+
+### A. the assigned symptom — `dat_172790 = CONCAT44(dat_172794,1);` (bash `yyparse` @ 0x35806)
+
+Fresh, HEAD `e38ffc31`, `make binaries` run at the start of this triage,
+`SLEIGHHOME=/home/mahaloz/github/kuna/specs`.
+
+> Tree provenance: another agent held five `p6_variables/` + `p9_emit/` files dirty in this
+> worktree for the whole session (`coreaction_cleanup.rs`, `funcdata_merge.rs`, `merge.rs`,
+> `varmap.rs`, `printc.rs`) and rebuilt `target/release/kuna` mid-run. Every hunk is an
+> `eprintln!` behind `KUNA_DBG_{DECL,MERGE,NAME,TIED,VARMAP}` or an ablation behind
+> `KUNA_ABL_NARROWER` / `KUNA_EXP_NOCONFLICT`, all of which default to the HEAD behavior and
+> none of which were set here — the two headline witnesses were re-run last with every one of
+> those variables explicitly unset and are byte-identical to the transcripts below.
+
+```
+$ kuna decompile .../O0/bash/stripped/bash --addr 0x35806        # --mode auto == reliable here (bash is 1.44 MiB)
+        dat_172790 = CONCAT44(dat_172794,1);
+        dat_172790 = CONCAT44(dat_172794,(int4)v25[-4]);
+        ...  (28 occurrences)
+        dat_172798 = CONCAT44(dat_17279c,(int4)*v25);
+```
+
+Ghidra, stored pane, **same function, same statements** (ghidra's image base is 0x100000,
+so `DAT_00272790` == kuna's `dat_172790`):
+
+```c
+      DAT_00272790 = CONCAT44(DAT_00272790._4_4_,1);
+      DAT_00272798 = *local_eb8;
+      local_e58 = make_redirection(DAT_00272790,0,DAT_00272798,0);
+      ...
+      DAT_00272790 = CONCAT44(DAT_00272790._4_4_,(int)local_eb8[-4]);
+```
+
+Same operator, same nesting, same operand order. The **only** difference is that ghidra
+names the high half as a member of the containing 8-byte symbol and kuna names it by its
+own address. kuna already emits the member form for *stack* symbols in the very same
+function — `CONCAT44(v26._4_4_,10)`, 60 such in the matched set — so the printer path
+exists; what is missing is a sized global data symbol to be partial *of*.
+
+### B. the kuna-only residue — `CONCAT44(dat_4,v1)` (tar `xclose` @ 0xd2c0)
+
+```
+$ kuna decompile .../O2-noinline/tar/stripped/tar --addr 0xd2c0
+void sub_d2c0(void)
+{
+  unsigned int v1; // eax
+
+  if (!close())
+    return;
+  dcgettext(0,"(pipe)",5);
+  sub_32680(CONCAT44(dat_4,v1)); // tail-call
+  return;
+}
+```
+
+ghidra / ida on the same address:
+
+```c
+/* ghidra */  uVar1 = dcgettext(0,"(pipe)",5);   FUN_00132680(uVar1);
+/* ida    */  v2   = dcgettext(0, "(pipe)", 5);  return sub_32680(v2);
+```
+
+And where ghidra *does* hit the same split (iproute2 `ip` `print_namespace` @ 0x67900) it
+names the pieces instead of inventing memory:
+
+```c
+/* kuna   */  sub_67870(CONCAT44(dat_4,CONCAT22(dat_2,v3)));
+/* ghidra */  FUN_00167870(CONCAT44(extraout_var_00,CONCAT22(extraout_var,extraout_AX)));
+/* ida    */  v6 = sub_67540();  sub_67870(v6);
+```
+
+## Source
+
+`~/github/decbench/results/full_run/O2-noinline/tar/compiled/buffer.i`:
+
+```c
+xclose (int fd)
+{
+  if (close (fd) != 0)
+    close_error (dcgettext (NULL, "(pipe)", 5));
+}
+```
+
+`dcgettext` returns `char *` — one 8-byte value in RAX. There is no memory object in this
+program, so `dat_4` is not a mis-typed global, it is a **fabricated** one.
+
+`~/github/decbench/results/full_run/O0/bash/compiled/rltty.i` (case A's sibling
+`save_tty_chars`) is `_rl_last_tty_chars = _rl_tty_chars;` — a 16-byte struct of 16
+`unsigned char` fields, which the O0 codegen lowers to two 8-byte loads. kuna's
+`CONCAT17(dat_17bed7,CONCAT16(...))` chain is a semantically exact reassembly of that copy;
+Heritage refinement split the 8-byte read because the function also writes each byte
+individually (the CONCAT ops carry the load's own address `0x000ff7aa` and late seqnums
+`0x127..0x12d` in `print raw`). Ghidra has no pane for that address in this run, but the
+mechanism is upstream `Heritage::refinement` + `concatPieces`, so it is Ghidra-family
+behavior, not a kuna invention. IDA models the 8-byte object as primary instead
+(`qword_17BEE0 = qword_17BED0;` + `LOBYTE(qword_17BED0) = ...`), which is why the pane
+reads better there.
+
+## Analysis
+
+### The mechanism (instrumented, not read)
+
+`decomp_dbg` → `load addr 0xd2c0` → `decompile` → `print raw` on tar:
+
+```
+0x0000d2ee:50:	EAX(0x0000d2ee:50)            = [create] i0x0000d2ee:31(free)
+0x0000d2ee:53:	%0x00000004:4(0x0000d2ee:53)  = [create] i0x0000d2ee:31(free)
+0x0000d2ee:31:	call fdcgettext(free)(#0x0,u0x10000043(0x0000d2ee:7f),#0x5)
+0x0000d2f7:4e:	u0x1000001b(0x0000d2f7:4e)    = CONCAT44(%0x00000004:4(...),EAX(...))
+```
+
+`%0x00000004:4` is a **register-space** varnode (kuna's raw printer gives the register space
+the `%` shortcut — `kuna-base/src/space.rs:2586-2593`, `IPTR_PROCESSOR` + `get_name() ==
+"register"`), size 4 at register offset 4, i.e. the top half of RAX. It prints as `dat_4`.
+
+The printer path:
+
+- `p9_emit/printc.rs:8451` `kuna_unnamed_location_name()` — `get_register_name(spc, off,
+  size)` returns empty (x86-64 has no named 4-byte register at register offset 4), so it
+  falls to the next arm;
+- `p9_emit/printc.rs:8413` `kuna_global_naming(spc)` is
+  `matches!(spc.get_type(), spacetype::IPTR_PROCESSOR)` — and in the Ghidra space model the
+  **register space is `IPTR_PROCESSOR` too**, exactly as `assign_shortcut` above proves;
+- so it returns `kuna_global_data_name(spc, 4)` = `"dat_4"` instead of falling through to
+  kuna's own `Space<hex>` tail (`Register00000004`).
+
+The intent was already to exclude registers — the comment at `printc.rs:6944` says "a
+**non-register** `IPTR_PROCESSOR` address that renders `dat_<addr>`" — but the predicate only
+excludes *named* registers, via the `get_register_name(...).is_empty()` companion check.
+Unnamed sub-register pieces walk straight through the hole. `namestyle ghidra` does not gate
+this arm either, so the fabricated token survives both naming policies.
+
+Upstream `PrintC::pushUnnamedLocation` (printc.cc:1957-1974) has no such arm at all — it
+prints `space->printRaw(offset)`, and Ghidra additionally gives an indirect-creation output
+the `extraout_<REG>` / `extraout_var` recommendation (which kuna *already implements*, at
+`p0_knowledge/database.rs:3444` — the varnode here simply never reaches
+`Scope::buildVariableName`, which is the second, separate half noted under *Risks*).
+
+### Downstream harm, measured
+
+`kuna decompile-project` collects every `dat_<hex>` token out of the emitted C
+(`kuna-console/src/project.rs:278` `collect_dat_addrs`) and labels it in the `.asm` data
+tail. On tar it therefore emits a data object that is really the ELF header:
+
+```
+$ kuna decompile-project .../O2-noinline/tar/stripped/tar -o ptar --addr 0xd2c0
+$ grep -A2 'dat_4:' ptar/tar.asm
+dat_4:  ; 0x4
+  00000004: 02 01 01 00 00 00 00 00 00 00 00 00 03 00 3e 00  |..............>.|
+```
+
+### Owning phase
+
+**P9 — Surface Rendering & Refinement** (`docs/phases.md:32,58`; `p9_emit/`, spec chapter
+`docs/spec/09-emission.md`). The symptom is a leaf token; the decision is a printer
+predicate, and it is not destroyed in Band B.
+
+## Breadth (corpus-wide, measured)
+
+Scanner is nesting-aware (balanced-paren argument split, `scan.py` from the round-3 census);
+"fresh" is `kuna decompile-all --mode auto` on HEAD over 15 stripped binaries covering
+5 arch/format families.
+
+**CONCAT is not a regression.** Matched set = functions present in the fresh run *and* the
+stored kuna pane *and* the stored ghidra pane (**10,068 functions**):
+
+| CONCAT high-argument shape | kuna (fresh, HEAD) | ghidra (stored) |
+|---|---:|---:|
+| bare global leaf (`dat_<hex>` / `DAT_<hex>`) | 99 | 20 |
+| partial-symbol member (`sym._k_n_`) | 60 | 110 |
+| nested CONCAT | 1 | 3 |
+| other | 353 | 316 |
+| **total** | **513** | **449** |
+
+ghidra's 20 "global leaf" rows are ARM literal-pool derefs (`*(undefined1 *)(DAT_x + i)`), a
+different construct. The 99-vs-110 pair is the same expressions with different spellings.
+
+**The fabricated-register-global slice.** Counting `dat_<off>` tokens whose offset is
+covered by no allocated section of the image:
+
+| population | occurrences | functions | denominator |
+|---|---:|---:|---|
+| decbench-scored functions only (fresh ∩ stored kuna pane) | 60 | 28 | 13,775 |
+| x86-64 ELF binaries, all fresh functions | 94 | 46 | 11,399 |
+| whole fresh corpus, all functions | 3,397 | 480 | 24,372 |
+
+Use the first two. The 3,397 figure is **not** this defect's breadth: 3,294 of it is
+betaflight/cleanflight/crazyflie functions that `decompile-all` produced for misdecoded
+non-function regions (ARM-mode decode of Thumb data — e.g. `sub_807ae04` reads
+uninitialized `v7` and stores through `dat_ffffffe6`), which decbench never scored. That is
+a separate recall/discovery artifact, not a naming bug.
+
+Space verified per offset with `print raw`, not inferred:
+
+| offset | space | witness |
+|---|---|---|
+| `0x2`, `0x4` | **register** (`%0x00000002:2`, `%0x00000004:4`) | ip `print_namespace` 0x67900 |
+| `0x4` | **register** (`%0x00000004:4`) | tar `xclose` 0xd2c0, ssh `client_suspend_self` 0x1e830 |
+| `0x3` | **register** (`%0x00000003:1`) | tar 0xc290 |
+| `0x0` | ram (`r0x00000000:2`) | e2fsck 0x3c010 — a null-pointer read, a DIFFERENT bug |
+| `0xa4`, `0xa8`, `0xb0` | ram (`r0x000000a4:4`, …) | e2fsck 0x55ee0 — also a different bug |
+
+So on the x86-64 subset, **80 of the 94** are register-space (offsets 2/3/4) and 14 are
+genuine-but-nonsensical RAM addresses. **76 of the 94 (81%) sit in the high argument of a
+CONCAT** — i.e. the majority of the `concat` wart on x86-64 in this pool is this naming bug
+wearing a CONCAT costume. 3 are assignment targets, and all 3 are the RAM `dat_0` family,
+not the register family.
+
+## Option / mode sweep (all negative)
+
+```
+$ for m in auto reliable aggressive fast; do kuna decompile tar --addr 0xd2c0 --mode $m; done
+   -> all four: sub_32680(CONCAT44(dat_4,v1));
+$ for o in "condfold on" "condfold wide" "cortexmvectors on" "ptrentry on" \
+           "paramcopyhoist on" "dwarf_lines on" "namestyle ghidra" "returnpair on"; do ... done
+   -> all eight: 1 occurrence of dat_4
+```
+
+Same result on the case-A witness (`bash save_tty_chars` @ 0xff79e keeps its 2 CONCAT17
+chains under all four modes and all six non-aggressive options). No row of the 88-option
+catalog mentions the unnamed-location naming policy. `option_closing: null`.
+
+## Metric-artifact check
+
+No metric claim is being made: the fix changes leaf tokens only, so **GED delta is 0** by
+construction (no basic-block, edge or statement count moves). This case must be ranked on
+correctness, not on the benchmark — as with round 1's `spacebase-unnamed-location`. Two of
+the witnesses would in any case be unusable as GED evidence: `bash yyparse` has a 1,142-line
+ghidra pane and an approximated large graph, and `tar xclose` has a 2-node source CFG.
+
+## What is DISPROVEN
+
+1. **`CONCAT44(dat_<hi>,<lo>)` is not kuna-only.** The census round that fed this track
+   reported "93 of kuna's 627 matched CONCATs; ghidra 0 on the identical 13,775 functions".
+   That scanner classified on the *spelling of the leaf*, so ghidra's identical operator was
+   invisible to it: ghidra writes `DAT_00272790._4_4_` where kuna writes `dat_172794`. On the
+   tightest matched set ghidra has **110** such CONCATs to kuna's 99. Nothing here is a
+   CONCAT-generation defect, and there is no CONCAT fix to write.
+2. **`save_tty_chars`' CONCAT17 chain is faithful, not soup.** The source is a 16-byte struct
+   copy; the reassembly comes from upstream `Heritage::refinement` splitting the 8-byte load
+   against the eight 1-byte writes, visible as late-seqnum ops at the load's own address.
+   Fixing it would mean adopting IDA's whole-object model, which is not a Ghidra-family
+   change and is not a one-module change.
+3. **The `dat_<addr+k>` half has no kuna-side mechanism.** Ghidra prints `._4_4_` because its
+   Program DB carries a *sized* `DAT_00272790` symbol created by auto-analysis; kuna has no
+   global data-symbol map at all, so every global sub-access renders by its own address. That
+   is an analysis-tier (P0/`kuna-analysis`) capability, not a printer change, and it is worth
+   less than it looks — `dat_172794` is arguably the more honest spelling of the two, and IDA
+   beats both by keeping the object whole.
+4. The census's other two verdicts hold on HEAD. `subright` (#251): `ssh sub_4cd60` now emits
+   `*v2 = (char)((uint8)a1 >> 0x38);` — ghidra's exact shape, zero raw `SUB81`. `undefname`
+   (#257): zero `$$undef` in 24,372 freshly decompiled functions.
+
+## Proposed fix
+
+- **Owning phase / module: P9, `decompiler/crates/kuna-decomp/src/p9_emit/printc.rs`.** One
+  predicate: `kuna_global_naming()` (printc.rs:8413) must accept only the architecture's
+  default data space, not every `IPTR_PROCESSOR` space. `arch.manage().get_default_data_space()`
+  already exists and is used across the tree (`p5_types/coreaction_infertypes.rs:512`,
+  `p2_lift/jumptable.rs:3561`, …). All three call sites are in this file
+  (printc.rs:6522, 6937, 8461) and all three already hold `arch`, so the signature change is
+  local. With the predicate tightened, an unnamed register piece falls to kuna's existing
+  `Space<hex>` tail and prints `Register00000004` — honest, and it stops the
+  `decompile-project` data tail from labelling the ELF header.
+- **Second half, same PR: give it a name instead of a raw location.** The varnode is an
+  `indirect_creation` output of a CALL, and kuna already renders that as `extraout_<REG>` /
+  `extraout_var` in `Scope::buildVariableName` (`p0_knowledge/database.rs:3444`) — it simply
+  never reaches that function here, so no Symbol is bound and the printer falls to the
+  unnamed tail. Confirming *why* needs an `eprintln!` in the P6 naming pass driven through
+  the in-process `decompile-all` path; that instrumentation was out of scope for this record
+  (no `.rs` edits), so treat this half as unproven. **If it does not reduce to a naming-pass
+  gate, ship only the predicate fix and file the `extraout` half separately** — the predicate
+  alone already removes the fabricated memory reference, which is the correctness claim.
+- **Option**: this is a strict bug fix (the emitted token names an object that does not
+  exist), so per `AGENTS.md` it needs no flag. If the `extraout_` half lands in the same PR
+  it becomes a naming-policy change and should be gated.
+- **Stage test**: `tests/stages/ghdec-regpiecename.xml` (no angr analog), two-pass: a call
+  whose return width is under-declared so the caller reassembles the return register —
+  before, `CONCAT44(dat_4,…)`; after, no `dat_` token at a register offset.
+- **Risks to measure**: (a) `renders_as_global` at printc.rs:6944 currently treats an unnamed
+  register piece as a *global instance*, so it can hijack the canonical storage of a whole
+  mixed HighVariable (the `kuna-regglobal-render-bug` path) — tightening the predicate changes
+  that resolution too, and the whole-corpus before/after sweep must cover every function whose
+  text moves, not just the witness; (b) the datatest corpus — `dat_<hex>` appears in stored
+  expectations, so run the 0/675 ablation before assuming this is invisible; (c) speed is
+  unaffected (one extra space comparison per unnamed leaf), but measure with
+  `scripts.pipeline.timeit` anyway; (d) **GED delta is 0** — do not let `rescore` be the gate.
+
+## Siblings
+
+Reproduce identically on HEAD, all `--mode auto` and `--mode reliable`:
+`openssh-portable/ssh` `client_suspend_self` 0x1e830 (7), `main` 0xcdf0 (4),
+`sshkey_dump_ec_key` 0x4b0b0 (4), `safe_path` 0x84e80 (3), `mac_setup` 0x7d540,
+`channel_from_packet_id` 0x5b300, `config_has_permitted_cnames` 0x17470,
+`crypto_hash_sha512` 0x982c0; `iproute2/ip` `print_ndtparams` 0x29a20 (9),
+`print_namespace` 0x67900 (4), `xfrm_str_to_policy` 0x3aa40, `print_attrs` 0x5eec0,
+`gtp_print_opt` 0x68c40; `tar` `xclose` 0xd2c0, `xfork` 0x24f80, `xpipe` 0x24fc0,
+`bzr_addfn` 0x164d0, `uname_to_uid` 0x269f0, `gname_to_gid` 0x26aa0,
+`page_aligned_alloc` 0x25000 (2), `xattrs_kw_included` 0x31600;
+`e2fsprogs/e2fsck` `e2fsck_discard_blocks` 0x2e530.
+
+The other cases the track named belong to the disproven halves and should NOT be attached to
+this feature: `bash yyparse` 0x35806 and `add_undo_redirect` 0xb9166,
+`iproute2/ip strxf_share` 0x331b0 and `mroute_list` 0x30d40, `openssh-portable/ssh main`'s
+`dat_114748`, `tar oldgnu_sparse_member_p` 0x27f10 are genuine RAM globals (disproof 3);
+`bash save_tty_chars` 0xff79e and the betaflight/cleanflight `decodeEscFrame` /
+`saCmsCommence` / `hmc5883lRead` / `isChecksumOkIa6` rows are refinement reassembly of real
+memory (disproof 2).

--- a/docs/decbench/triage/novel-raw-sp-leaf.md
+++ b/docs/decbench/triage/novel-raw-sp-leaf.md
@@ -1,0 +1,298 @@
+---
+case_id: novel-raw-sp-leaf
+pool: novel
+group_id: crazyflie::USBD_GetDescriptor (switch-arm fragments) + 17 siblings across 7 ARM binaries
+status: feature-candidate
+tier: N
+margin: 0
+fresh_verdict: the track's `code_ptr` and x86 `raw_reg` halves are both dead on today's build — the mined row `O2-noinline-crazyflie-cf2-USBD_GetDescriptor` goes code_ptrx8 -> code_ptrx1 and Thumb-mask 8 -> 0 (#249 funcptralign), and 34,102 fresh functions across 25 binaries contain ZERO bare x86/ARM GPR tokens. One leaf survives: the entry **stack-pointer register** renders as a bare, undeclared `sp` — 46 occurrences in 18 functions across 7 ARM binaries (0 on x86/x86-64/PE). It is the *leaf* form of the exact bug DIV-46 fixed for the PTRSUB form, and it has ZERO benchmark value: none of the 18 functions is in decbench's scored set.
+option_closing: null
+feature_slug: spleaf
+scope: small
+confidence: medium
+---
+
+## Side-by-side
+
+### The mined row — `USBD_GetDescriptor` @ `0x801ddac` (NOVEL #3, `code_ptrx8,gotox3,subpiecex1`, score 76)
+
+kuna GED 10 · angr 11 · ida 11 · ghidra 18 · source 20 nodes/28 edges · `approximated: false` ·
+`degenerate_source: false` · `artifact_suspect: false`.
+
+**stored kuna** (pinned 9623dc27) — the `(code *)` + Thumb-mask form the pool scored:
+
+```c
+    v3 = (*(code *)(*(uint4 *)(*(int4 *)(a0 + 0x5ec) + 4) & 0xfffffffe))(*(char *)(a0 + 2),&v4);
+```
+
+**fresh kuna** (today, `--mode auto` = aggressive on this 318 KiB binary), same line:
+
+```c
+      v3 = (**(code **)(*(int4 *)(a0 + 0x5ec) + 4))(*(char *)(a0 + 2),&v4);
+```
+
+`(code *)` 8 → **1**, `0xfffffffe` 8 → **0**. Structure is byte-identical in shape
+(`triage --case ...`: kuna stored 58 loc / 3 gotos / 2 labels / 1 switch / 6 cases;
+kuna fresh 58 / 3 / 2 / 1 / 6). The `gotox3` residue belongs to the crossing-edge/`condfold`
+track, not this one, and is untouched by every option swept below.
+
+### The survivor — six "functions" that are one source function's switch arms
+
+`kuna decompile cf2.elf --addr 0x801de30` (transcript, today's build):
+
+```
+[decomp]> load file .../O2-noinline/crazyflie/stripped/cf2.elf
+.../cf2.elf successfully loaded: ARM:LE:32:v8:default
+[decomp]> option listing on
+[decomp]> option aif on
+[decomp]> option funcstart_patterns on
+[decomp]> read symbols
+[decomp]> load addr 0x801de30
+[decomp]> decompile
+Decompiling sub_801de30
+Decompilation complete
+[decomp]> print C
+
+void sub_801de30(unsigned int a0,unsigned int a1,unsigned int a2,int4 a3,unsigned int a4,unsigned int a5) // return-dupe x2
+{
+  uint2 v1;
+  int4 v2; // r4
+
+  (**(code **)(a3 + 0x18))(a0,(char *)((int4)sp + 6));
+  if (!a5._2_2_)
+    return;
+  v1 = *(uint2 *)(v2 + 6);
+  if (!v1)
+    return;
+  if (v1 <= a5._2_2_)
+    a5._2_2_ = v1;
+  sub_801dbe8();
+  return;
+}
+```
+
+`sp` is declared nowhere — not in the function, not in `<name>.h` of
+`kuna decompile-project`. `v2 // r4` is read before any write. `sub_801de40/50/60/70/80` are
+the same body with offsets `0x14/0x10/0xc/8/4`.
+
+The same binary, same run, emits the *correct* function at `0x801ddac` — the six arms
+included, with the stack slot named:
+
+```c
+  uint2 v4; // stack - 0x12
+  ...
+      v3 = (**(code **)(*(int4 *)(a0 + 0x5ec) + 4))(*(char *)(a0 + 2),&v4);
+```
+
+And `betaflight sub_805e4b4` emits **both** conventions in one body:
+
+```c
+    v5 = &Stack000002ac;          // the DIV-46 unnamed-stack token
+    v5[v7] = (&v5[(int4)sp])[4];  // the raw register leaf
+```
+
+## Source
+
+`O2-noinline/crazyflie/compiled/usbd_req.i`, the single function the six fragments come from:
+
+```c
+static void USBD_GetDescriptor(USB_OTG_CORE_HANDLE *pdev, USB_SETUP_REQ *req)
+{
+  uint16_t len;
+  uint8_t *pbuf;
+  len = req->wLength ;
+  switch (req->wValue >> 8) {
+  ...
+  case 3:
+    switch ((uint8_t)(req->wValue)) {
+    case 0x00: pbuf = pdev->dev.usr_device->GetLangIDStrDescriptor(pdev->cfg.speed, &len); break;
+    case 0x01: pbuf = pdev->dev.usr_device->GetManufacturerStrDescriptor(pdev->cfg.speed, &len); break;
+    ...
+```
+
+There is no source function corresponding to `sub_801de30`. `(char *)((int4)sp + 6)` is
+`&len` — the stack slot kuna names `v4 // stack - 0x12` when it decompiles the whole
+function — seen from a frame whose prologue is outside the pseudo-function's body.
+
+## Analysis
+
+### 1. The two halves the track was mined for are closed (verified, not assumed)
+
+**`code_ptr`.** `(code **)` / `(code *)` / `0xfffffffe` counts, fresh whole-binary
+`decompile-all` today vs the stored panes (the fresh column covers kuna's whole discovered
+list, the stored column only decbench's scored subset — **not address-matched**, so read the
+ratio, not the absolute):
+
+| binary | stored kuna `code**`/`code*`/mask | fresh kuna | stored ghidra |
+|---|---|---|---|
+| crazyflie cf2 | 0 / 239 / 246 | **251 / 142 / 13** | 178 / 76 / 7 |
+| betaflight | 0 / 347 / 346 | **466 / 168 / 29** | 148 / 86 / 9 |
+| nuttx | 0 / 88 / 118 | **425 / 36 / 40** | 59 / 42 / 14 |
+| cleanflight | 0 / 186 / 191 | **232 / 78 / 12** | 92 / 61 / 10 |
+
+Every ARM binary goes 0 → hundreds of `(code **)`, and the Thumb ISA-mode mask collapses by
+~10x. That is exactly what `novel-code-ptr-cluster.md` predicted and #249 shipped.
+
+**`raw_reg`.** A declaration-aware token scan (comments and string literals stripped) over
+**34,102 functions in 25 binaries** — x86-64 ELF, i386 PE, ARM Cortex-M, ARM u-boot — for
+every x86 and ARM register identifier: **zero** occurrences of any GPR/flag token. The only
+survivor is `sp`. (The 7 apparent rsyslog hits the pool reports are the string literal
+`"sp-if-no-1st-sp"`.)
+
+### 2. The survivor: 46 occurrences, 18 functions, 7 ARM binaries, 0 elsewhere
+
+| binary | leaking fns | occurrences |
+|---|---:|---:|
+| O2-noinline crazyflie cf2 | 6 | 6 |
+| O2-noinline betaflight | 3 | 12 |
+| O0 betaflight | 3 | 12 |
+| O2-noinline cleanflight | 1 | 6 |
+| O0 cleanflight | 1 | 6 |
+| O2-noinline / O0 nuttx | 2 | 2 |
+| O2-noinline u-boot | 2 | 2 |
+| **13 non-ARM binaries** (tar, rsyslogd, coreutils, zlib, libacl, utmpdump, mydoom.exe, x0r-usb.exe, minipig.exe, dexter.dll, …) | **0** | **0** |
+
+### 3. Why the leaf leaks — P9, the arm DIV-46 did not cover
+
+`print raw` on `sub_801de30`:
+
+```
+0x0801de32:a7:	u0x1000001e(0x0801de32:a7) = (cast)(sp(i))
+0x0801de32:a3:	u0x10000022(0x0801de32:a3) = u0x1000001e(0x0801de32:a7) + #0x6
+```
+
+`sp(i)` is a function **input** Varnode at the stack-pointer register with no bound Symbol.
+The same instruction inside the correctly-bounded `0x801ddac` lifts to the spacebase form:
+
+```
+0x0801de32:2c7:	r1(0x0801de32:2c7) = ->(sp(i),#0xffffffee)      # PTRSUB(sp,-0x12) -> &v4
+```
+
+A symbol-less leaf reaches `PrintC::push_vn_explicit_ir`'s `pushUnnamedLocation` tail
+(`decompiler/crates/kuna-decomp/src/p9_emit/printc.rs:6960`), which calls
+`kuna_unnamed_location_name` (`printc.rs:8469`). That helper returns, **in order**: the
+register name, then `dat_<addr>` for a processor space, then the `Space<hex>` leaf — so a
+stack-pointer-register leaf takes the *first* branch and prints `sp`, never reaching the
+`Stack<hex>` tail that produces `&Stack00000000`. This is the same helper and the same
+"no Symbol covers this storage" situation DIV-46 repaired for the **PTRSUB** arm
+(`op_ptrsub_ir`, `tests/stages/ghdec-spacebase-unnamed.xml`, which already asserts
+`&Stack00000008` for a positive frame offset). The leaf arm was not covered.
+
+**Owning phase: P9 — emit** (`p9_emit/printc.rs`). The upstream cause of *why a raw `sp`
+read exists at all* is P1 (below), but the token itself is a render decision, and it is the
+only part with a one-module mechanism.
+
+### 4. Why the raw `sp` read exists — P1, and the obvious diagnosis is WRONG
+
+16 of the 18 leaking entries are **mid-basic-block**: the instruction immediately before the
+entry falls straight through into it (Thumb linear sweep, per entry):
+
+```
+cf2.elf        0801de30  prev@0801de2e: ldrb r0,[r0,#2]   entry: ldr r3,[r3,#0x18]   falls-through=True
+betaflight     08068ee8  prev@08068ee6: uxtb r2,r2        entry: cmp r2,#5           falls-through=True
+cleanflight    0803b344  prev@0803b342: uxtb r2,r2        entry: cmp r2,#5           falls-through=True
+betaflight     0805e4b4  prev@0805e4b0: tbb [pc,r3]       entry: ldr r4,[r2,r5]      falls-through=True
+```
+
+The crazyflie six sit exactly 6 bytes past each true `tbb` target
+(table base `0x801de14`, bytes `33 2b 23 1b 13 0b`; the accepted entries are
+`table_end + 2*byte`). The listing tier cannot know that: `listing/walk.rs:11-12` records
+BRANCHIND/CALLIND "with the computed/indirect predicates but **no static successor**
+(deferred jump-table resolution)", so a Thumb `tbb`/`tbh` leaves its whole arm region an
+**undefined gap**, and the gap-walkers probe it. Resolving TBB/TBH in the Listing tier is
+**PR #239 step 4** (approved sequence, not started) — it would delete both the gap and these
+entries, and it is a recall win as well.
+
+**The obvious diagnosis — "AIF invents them, so turn AIF off" — is refuted by measurement.**
+`--option aif off` on cf2 does remove the six (2,914 → 2,379 functions, and all six vanish),
+but the same run then leaks `sp` in **16 different functions / 17 occurrences**, all of which
+are present in the default run and clean there; and the count of functions that declare an
+ARM condition flag (`ng`/`zr`/`cy`/`ov`/`q`) as an unwritten input — a state no ABI can pass,
+so a proof of mid-body entry — **rises from 57 to 119** (1.96% → 5.00% of the list). Without
+AIF the same bytes get decoded as A32 instead of Thumb, which is worse. AIF is net positive
+here. That flag-input rate is the honest breadth number for the mid-body-entry class:
+crazyflie 1.96%, betaflight 1.03%, u-boot 2.78%, nuttx 1.12%, cleanflight 0.42%, chibios
+0.13%, **tar 0.00%, rsyslogd 0.00%**.
+
+The remaining 2 of 18 (nuttx `0x8006494` @ O2-noinline, `0x800b1b6` @ O0 — one preceded by
+padding, one by `bx lr`) are **real** functions: a hand-written Cortex-M context-save routine
+(`*(undefined0 **)a0 = sp;`) with no `.i` source, which angr also discovers (`sub_8006495`).
+There kuna's C is semantically right and only the token is wrong — which is why the fix has
+to be at the leaf, not upstream.
+
+### 5. Metric-artifact check
+
+- `approximated: false`, `degenerate_source: false`, `source_nodes: 20` — the mined row is a
+  clean measurement, and the source parses (the `.i` function is a real 6-case switch).
+- **None of the 18 leaking functions appears in any decbench pane** (checked by
+  `// Function: <name> @ 0x<addr>` marker in `kuna_*.c` for all 18): decbench decompiles the
+  DWARF ground-truth function list, and these pseudo-functions are not in it. The class is
+  **unscoreable** — it can never move GED, and `rescore` has nothing to run.
+- Consequence for the census's metric recommendation: **widening `novel.py`'s `raw_reg`
+  pattern to `sp|lr|pc` would surface ZERO new rows**, for the same reason. The stored kuna
+  panes for all four ARM projects contain 0 bare register tokens. The useful metric change is
+  the other one the prior record asked for: score `code_ptr` as `max(0, kuna − min_rival)` or
+  drop it — today it scores kuna 269 against rivals emitting 600+, which is what put this
+  closed defect at NOVEL #3 in the first place.
+
+### 6. Option sweep
+
+Every non-default value of all **88 catalog options** (≈90 settings) plus all three modes,
+on `cf2.elf --addr 0x801de30`, counting bare `sp`:
+
+```
+BASELINE(default) sp=1
+mode aggressive   sp=1
+mode reliable     sp=0      <-- emits `void sub_801de30(void) { return; }`
+mode fast         sp=0      <-- same stub
+SWEEPDONE                   <-- no option changed the count
+```
+
+The six options `aggressive` does not carry were swept explicitly on the parent row too
+(`condfold on`, `condfold wide`, `ptrentry on`, `cortexmvectors on`, `paramcopyhoist on`,
+`dwarf_lines`): gotos 3, `(code *)` 1, mask 0 in every case. `reliable`/`fast` "close" it
+only by not discovering the function (`reliable` decodes nuttx `0x8006494` as A32 garbage:
+`(*(code *)(a0 - (a0 >> 0x11)))();`). **`option_closing: null`.**
+
+## Proposed fix
+
+**Slug `spleaf`. P9. One module. Strict bug fix — no flag** (the same argument DIV-46 shipped
+under: emitting a raw machine register into the C body is not a judgment call, and the fix
+removes a divergence rather than adding a behavior).
+
+- `decompiler/crates/kuna-decomp/src/p9_emit/printc.rs`, `kuna_unnamed_location_name`
+  (`:8469`) — before the `get_register_name` branch, test whether `(loc,size)` **is** the
+  architecture's stack-pointer/spacebase register, and if so name the storage it holds at
+  entry (`Address(stack_space, 0)`), which falls to the existing `Space<hex>` tail and
+  yields the established `Stack00000000` token. Semantically exact under kuna's own model:
+  stack varnode offsets are entry-SP-relative (the same pane already carries
+  `s0x00000006` for `[sp,#6]`), so entry `sp` ≡ `&Stack00000000` — which is literally what
+  `betaflight sub_805e4b4` and `sub_803c3c6` already print for the same register in the same
+  binaries. The call site to check is `push_vn_explicit_ir` (`:6960`); the PTRSUB call site
+  (`:7035`) already behaves.
+- `docs/spec/09-emission.md` (the chapter whose `Anchors:` own `p9_emit/`) — extend the
+  DIV-46 paragraph in §9.3 to say the spacebase *register leaf* takes the same
+  unnamed-location convention.
+- `tests/stages/ghdec-spleaf.xml`, modelled on `tests/stages/ghdec-spacebase-unnamed.xml`
+  (two-pass, register token vs `Stack00000000`). Note the corpus-file-count bump in
+  `kuna-base/src/xml.rs` and the stages-baseline re-record.
+
+**Risks / the "would this produce WRONG output?" axis.**
+
+1. **It buys consistency, not compilability.** `&Stack…` and `dat_…` are already undeclared
+   extern-like tokens by design (DIV-46); `kuna decompile-project` on nuttx today produces
+   2,537 `gcc -fsyntax-only` errors of which the `sp` leak is **one**. Do not sell this as
+   "makes the output compile" — sell it as "no raw machine register survives into the C",
+   which is the DIV-46 invariant.
+2. **Blast radius is 46 tokens in 18 functions corpus-wide**, all ARM, so the whole-corpus
+   before/after sweep the loop requires is cheap and should be run at whole-binary scope on
+   all 25 binaries — but note that 16 of those 18 functions are garbage regardless, so the
+   diff will look like nothing changed anywhere else. Confirm that, do not assume it.
+3. **Do not "fix" this upstream instead.** Folding `INT_ADD(sp,c)` into `PTRSUB(sp,c)` would
+   render the prettier `&Stack00000006`, but it is a P3/P5 rule change with a corpus-wide
+   blast radius, and it cannot cover the nuttx case where the stack pointer is *stored*, not
+   offset. The leaf covers 18/18.
+4. **Priority.** ZERO GED value (§5) and 0.05% of functions. This is a correctness-hygiene
+   item, not a campaign lever. The lever hiding behind this track is **PR #239 step 4
+   (Listing-tier TBB/TBH)**: it deletes 13 of the 18 witnesses *and* is already-approved
+   recall work — and, unlike "turn AIF off", it is not refuted by measurement.

--- a/docs/decbench/triage/novel-stdcall-extrapop-drift.md
+++ b/docs/decbench/triage/novel-stdcall-extrapop-drift.md
@@ -1,0 +1,477 @@
+---
+case_id: O2-noinline-dexter-dexter-GetProcList
+pool: novel
+group_id: dexter::GetProcList (track record for `code_ptr` + `raw_reg`; dominant witness dexter::_entryPoint @ 0x69943550; 42 functions / 4 PE projects)
+status: feature-candidate
+tier: N
+margin: 0
+fresh_verdict: The `code_ptr` survivors on i386 PE are not a cast, type or naming defect at all — they are the visible residue of a **stack-pointer model that drifts**. kuna guesses `extrapop = 4` for every `__stdcall` callee (upstream `StackSolver::build`'s fallback, `coreaction_stackptr.rs:317`), so at each Win32 import that pops N argument bytes the modeled ESP sinks N bytes below the true frame and never recovers. Two independent binary probes prove the chain end to end — zeroing only the compensating `sub $N,%esp` displacements turns `_entryPoint` from 265 lines / 46 locals / 24 `code *` / 31 argument-less API calls into 125 lines / 10 locals / 0 `code *` / every argument recovered, byte-identical frame to ghidra and ida. `raw_reg` is confirmed dead: 0 bare register identifiers in 1,031 PE functions.
+option_closing: null
+feature_slug: stdcallpop
+scope: small
+confidence: high
+---
+
+## What this record covers
+
+The triage brief pointed at the `(code *)` / `(code **)` + `raw_reg` family, whose only
+surviving witnesses after round 2 are i386 PE: `dexter.dll::_entryPoint` and its eight named
+siblings, plus `minipig.exe::Infects`. The census called it "a P4/P6 stack-frame +
+call-argument recovery failure … kuna's local frame extends BELOW the outgoing-argument
+area, so the push cannot be dead-coded and the argument trials are rejected."
+
+That description is the **effect**, stated as the cause. This record instruments the cause
+one level up and finds a single, measurable defect that explains the frame, the dropped
+arguments, the surviving return-address pushes and the `code *` casts at once.
+
+---
+
+## Side-by-side
+
+### fresh kuna — today's build (`e38ffc31`), default `--mode auto` → `aggressive`
+
+```
+$ export SLEIGHHOME=/home/mahaloz/github/kuna/specs
+$ kuna decompile ~/github/decbench/results/full_run/O2-noinline/dexter/stripped/dexter.dll \
+      --addr 0x69943550
+```
+
+```c
+unsigned int sub_69943550(void) // ternary
+{
+  ...                                     // 46 declared locals, 24 of them `code *`
+  unsigned int v24; // stack - 0x100      // <-- 0x44 bytes BELOW the real frame bottom
+  ...
+  code *v40; // stack - 0xc0
+  code *v42; // stack - 0xb8
+
+  v40 = 0x69943560;
+  v18 = GetCommandLineA();
+  if (v18) {
+    v42 = (char *)s_69948160;
+    v40 = 0x6994357b;
+    if (StrStrA()) {                      // <-- both arguments dropped
+      v42 = NULL;
+      v41 = NULL;
+      v40 = 0x699435a1;
+      v19 = CreateMutexA();               // <-- three arguments dropped
+      ...
+      v35 = "urlmon.dll";
+      v34 = (char *)0x69943770;
+      LoadLibraryA();
+      v34 = "wininet.dll";
+      v33 = (code *)0x6994377c;           // <-- the return address of the NEXT call,
+      LoadLibraryA();                     //     typed `code *` because the same slot
+```
+
+265 lines · 46 locals · 24 `code *` · **31 argument-less calls to Win32 imports** ·
+**31 surviving return-address pushes** (52 in-range constants total).
+Runtime 1.05 s.
+
+### ghidra (stored pane, same stripped binary)
+
+```c
+void __cdecl _entryPoint(void)
+{
+  _SECURITY_ATTRIBUTES local_84;
+  _MEMORY_BASIC_INFORMATION local_78;
+  CHAR local_5c [76];
+
+  lpFirst = GetCommandLineA();
+  if ((lpFirst != (LPSTR)0x0) &&
+     (pCVar2 = StrStrA(lpFirst,s_UpdateMutex__69948160), pCVar2 != (LPSTR)0x0)) {
+    pvVar3 = CreateMutexA((LPSECURITY_ATTRIBUTES)0x0,0,lpFirst);
+    ...
+    LoadLibraryA("urlmon.dll");
+    LoadLibraryA("wininet.dll");
+```
+
+### ida (stored pane)
+
+```c
+  struct _SECURITY_ATTRIBUTES FileMappingAttributes; // [esp+38h] [ebp-84h] BYREF
+  struct _MEMORY_BASIC_INFORMATION Buffer;           // [esp+44h] [ebp-78h] BYREF
+  CHAR Name[92];                                     // [esp+60h] [ebp-5Ch] BYREF
+  ...
+      hObject = CreateMutexA(0, 0, lpName);
+```
+
+Both rivals recover every argument **and** Windows types (`LPSECURITY_ATTRIBUTES`,
+`_MEMORY_BASIC_INFORMATION`) — i.e. both applied a Win32 type archive
+(Ghidra `windows_vs12_32.gdt`, IDA `.til`). Neither shows an algorithm kuna is missing;
+they show *knowledge* kuna is missing. That is why this stayed in the NOVEL pool.
+
+### stored kuna (2026-08-03 pinned build 9623dc27)
+
+Identical frame and identical drift, pre-`peimportcall`, so the calls are still unnamed:
+
+```c
+  code *v24; // stack - 0x100   ...   code *v40; // stack - 0xc0
+  v40 = (code *)0x69943560;
+  v17 = (code *)(*dat_6994e350)();
+```
+
+The staleness is cosmetic (#254 named the imports). The defect is unchanged.
+
+### PROBE — the same binary with the stack drift removed
+
+```
+$ # zero the immediate of every `sub $N,%esp` that follows a call in 0x69943550..0x69943cd8
+$ #   (47 sites; `83 ec NN` -> `83 ec 00`)
+$ kuna decompile dexter_sub0.dll --addr 0x69943550
+```
+
+```c
+unsigned int sub_69943550(void) // ternary
+{
+  unsigned int v1;
+  unsigned int v10; // stack - 0x74
+  int4 v2; // eax
+  unsigned int v3;
+  unsigned int v4;
+  char v5 [76];
+  char v6 [4];
+  unsigned int v7; // stack - 0x84
+  unsigned int v8; // stack - 0x80
+  unsigned int v9; // stack - 0x7c
+
+  v2 = GetCommandLineA();
+  if ((v2) && (StrStrA(v2,s_69948160))) {
+    v3 = CreateMutexA(0,0,v2);
+    _memset(v5,0,0x40);
+    wsprintfA(v5,"%s%d",v2,GetCurrentProcessId());
+    while( true ) {
+      SetLastError(0);
+      v4 = CreateMutexA(0,0,v5);
+      if (GetLastError() == 0xb7) break;
+      CloseHandle(v4);
+      Sleep(1000);
+    }
+    ...
+    LoadLibraryA("urlmon.dll");
+    LoadLibraryA("wininet.dll");
+```
+
+**125 lines · 10 locals · 0 `code *` · 0 leaked return addresses · every argument
+recovered.** The recovered frame is `-0x84` / `-0x78` / `[76]` — byte-for-byte ghidra's
+`local_84` / `local_78` / `local_5c[76]` and ida's `ebp-84h` / `ebp-78h` / `ebp-5Ch`.
+Ghidra's pane is 123 lines; kuna's probe pane is 125.
+
+---
+
+## Source
+
+`~/github/decbench/results/full_run/O2-noinline/dexter/compiled/dexter.dll-POSGrabber.i:78965`
+(`#line` noise stripped):
+
+```c
+void _entryPoint() {
+  BYTE *pCommandLine;  DWORD CSIDL;  MEMORY_BASIC_INFORMATION MBI;
+  char UpdateMutexString[64];  HANDLE hUpdateMutexOne,hUpdateMutexTwo,hProcess;
+  SECURITY_ATTRIBUTES sa;
+
+  pCommandLine = GetCommandLineA();
+  if (pCommandLine != NULL) {
+    if (StrStrA(pCommandLine, UpdateMutexMark) != NULL) {
+      hUpdateMutexOne = CreateMutexA(NULL, 0, pCommandLine);
+      _memset(UpdateMutexString, 0x00, sizeof(UpdateMutexString));
+      wsprintfA(UpdateMutexString, "%s%d", pCommandLine, GetCurrentProcessId());
+      while (1) {
+        SetLastError(0l);
+        hUpdateMutexTwo = CreateMutexA(NULL, 0, UpdateMutexString);
+        if (GetLastError() == 183l) { ... }
+        CloseHandle(hUpdateMutexTwo);
+        Sleep(1000);
+      }
+```
+
+Four source locals (`sa` 12 B, `MBI` 0x1c, `UpdateMutexString[64]`, plus scalars) — a frame
+of 0x84 bytes below the outgoing-argument area, exactly what the probe recovers and exactly
+what kuna's default run does **not**: it declares 46 locals reaching 0x100, i.e. 0x44 bytes
+of pure fiction below the real frame. Every call in the source has arguments.
+
+---
+
+## Analysis
+
+### The one symptom
+
+> **The modeled stack pointer drifts N bytes below the true frame at every `__stdcall`
+> call whose callee pops N bytes of arguments, and never recovers.**
+
+Measured directly from the return-address push offsets in `print raw`
+(`decomp_dbg`, `load addr 0x69943550; decompile; print raw`):
+
+| call | true ESP | kuna's ESP | drift |
+|---|---:|---:|---:|
+| `GetCommandLineA` @0x6994355a (0 args) | -0xbc | -0xbc | 0 |
+| `StrStrA` @0x69943575 (2 args) | -0xbc | -0xbc | 0 |
+| `CreateMutexA` @0x6994359f (3 args) | -0xbc | -0xbc | 0 |
+| `_memset` @0x699435bf (internal, cdecl) | -0xbc | **-0xc8** | **-0xc** |
+| `SetLastError` @0x6994360f (1 arg) | -0xbc | -0xc8 | -0xc |
+| `CreateMutexA` @0x6994362b | -0xbc | **-0xd0** | **-0x10** |
+| … | | | |
+| `HeapAlloc` @0x69943828 | -0xbc | **-0xfc** | **-0x40** |
+
+Each step down equals exactly the immediate of the preceding `sub $N,%esp` — GCC's
+`-maccumulate-outgoing-args` compensation that undoes the `__stdcall` callee's pop:
+
+```
+69943568: movl $0x69948160,0x4(%esp)     ; arg2
+69943572: mov  %eax,(%esp)               ; arg1
+69943575: call *0x6994e478               ; StrStrA — __stdcall, `ret 8`
+6994357b: sub  $0x8,%esp                 ; put ESP back where GCC assumes it is
+```
+
+True: `esp_after = esp_before + N` (the callee popped `4 + N`), then `sub $N` restores
+`esp_before`. kuna's model: `esp_after = esp_before` (extrapop 4), then `sub $N` →
+`esp_before - N`. The residual **is** the drift.
+
+I verified the correspondence against the source for all 18 stdcall call sites in
+`_entryPoint`: `StrStrA` 2 args ↔ `sub $8`, `CreateMutexA` 3 ↔ `sub $0xc`,
+`SetLastError`/`CloseHandle`/`Sleep`/`LoadLibraryA` 1 ↔ `sub $4`, `GetProcAddress` 2 ↔
+`sub $8`, `HeapAlloc` 3 ↔ `sub $0xc`, `CreateEventA`/`VirtualAlloc` 4 ↔ `sub $0x10`,
+`SHGetFolderPathW`/`MapViewOfFile` 5 ↔ `sub $0x14`, `CreateThread`/`CreateFileMappingA` 6 ↔
+`sub $0x18`. The two genuinely `__cdecl` callees in the same function — `wsprintfA`
+(varargs) and the internal `_memset` — carry **no** post-call `sub`, and kuna's ESP is
+correct across both. 18/18, 0 false positives.
+
+Corpus-wide the idiom is regular: **1,727** post-call `sub $N,%esp` sites across the eight
+O2/O2-noinline PE binaries, `N` always a multiple of 4, `N ≤ 40` (10 arguments), zero
+exceptions.
+
+### Why the first three calls are right
+
+`StackSolver::solve` propagates **hard** equations from the entry Varnode first, and only
+then fills unknowns with the `rhs = 4` guesses. At a CFG merge whose two paths must agree
+(here the `je 0x69943668` join that bypasses `StrStrA`/`CreateMutexA`), the MULTIEQUAL is a
+hard equation, so the pop is *derived* rather than guessed. Everywhere no merge pins both
+sides, the guess wins and the drift starts. This is not a mis-port — it is the algorithm
+working as upstream specifies with the knowledge it has.
+
+### The chain from drift to `code_ptr`
+
+1. No frame pointer at O2/O2-noinline ⇒ **both** the locals and the outgoing-argument area
+   are ESP-relative, so the drift moves every call's argument slots to a fresh offset.
+2. `ScopeLocal::restructure` therefore carves the wandering argument area into ~35 named
+   frame locals reaching `stack - 0x100` (P6 §6.2).
+3. `check_input_trial_use` (`p4_calls/funcdata_callsite.rs:47`) can no longer accept the
+   trials — `callee_pop` is false because `get_extra_pop()` is still 4, and ancestor
+   realism fails on slots that now look like ordinary caller locals — so it zeroes each
+   trial's CALL input and the arguments are dead-coded. 31 Win32 calls in this one function
+   lose every argument.
+4. The `call`'s own return-address push is not dead-codable (its slot is now a live named
+   local), so it prints as `v40 = 0x6994357b;`.
+5. Some of those slots also carry a real function pointer elsewhere in the merged
+   HighVariable, so the slot's type is `code *` — and the return address, an address inside
+   `.text`, is a perfectly plausible member of it. **The `(code *)` is honest; the frame
+   underneath it is not.**
+
+This is why no cast/type/naming option touches it, and why #249 (`funcptralign`) was inert:
+i386 declares no `<funcptr align>`, and the defect is three phases upstream of casting.
+
+### Why O0 is clean and O2 is not
+
+At `-O0` GCC keeps `%ebp` as a frame pointer. The drift still happens on ESP, but every
+real local is EBP-relative, so `ScopeLocal` is unaffected and the per-call argument slots
+stay self-consistent relative to each call's own (drifted) ESP. Measured: `O0/dexter`
+`_entryPoint` decompiles *perfectly today* — `CreateMutexA(0,0,v13)`,
+`LoadLibraryA("urlmon.dll")`, `GetProcAddress(GetModuleHandleA("kernel32.dll"),…)`. The
+whole defect lives in frame-pointer-less builds.
+
+### Metric-artifact check
+
+- Mined row `O2-noinline-dexter-dexter-GetProcList`: `approximated: false`,
+  `degenerate_source: false`, `source_nodes: 7`, and **all six** decompilers tie at
+  GED 8.0. Not an artifact — a genuine, universal tie.
+- The dominant witness `_entryPoint` @O2-noinline is **in no pool at all**, at any base.
+  That is the finding, not an omission: dropping a call's arguments does not change the
+  CFG, so GED is structurally blind to it. 140 lines of fabricated stack traffic and 31
+  calls missing every argument cost ~0 GED. Only the wart column (`code_ptr`) surfaced it,
+  which is exactly what the NOVEL pool is for. Any future re-weighting of `code_ptr` (the
+  prior record proposed `max(0, kuna − min_rival)`) must keep this class visible — under
+  that formula dexter still scores 52-8 = 44 and stays at the top, so the proposal is safe.
+
+### `raw_reg`, the second half of the track
+
+Dead, and confirmed independently of the census: **0** bare/undeclared register identifiers
+(`eax…esp`, `sp/lr/pc`, `r0…r15`) across all **1,031** functions of the twelve PE binaries,
+on today's build. Nothing to fix; the pool column reads zero because it is zero.
+
+---
+
+## Breadth
+
+Twelve PE binaries (`dexter.dll`, `minipig.exe`, `mydoom.exe`, `x0r-usb.exe` × O0/O2/
+O2-noinline), whole-binary `kuna decompile-all --json` on today's build, then the same run
+against a drift-neutralised copy of each (every `sub $N,%esp` that *immediately* follows a
+call rewritten to `sub $0,%esp` — a conservative filter that never touches a prologue and
+misses the sites where scheduling put a `mov` between the call and the `sub`):
+
+| measure | today | drift removed | ghidra |
+|---|---:|---:|---:|
+| functions leaking a return address | **42** / 1031 | 7 | — |
+| leaked return-address pushes | **448** | 74 | — |
+| argument-less Win32 import call sites | **646** | 404 | 162 |
+| `(code *)` / `(code **)` occurrences | **1189** | 1066 | — |
+| total emitted lines | **34,103** | 32,472 | — |
+
+Per level: at O0 nothing moves (0/0/0 leaks in dexter/minipig/x0r-usb, 6 in mydoom); the
+whole delta is O2 and O2-noinline. `dexter` 100 → 0 leaks and 108 → 34 argument-less calls;
+`minipig` 21 → 0 and 58 → 37; `mydoom` 60 → 9; `x0r-usb` 62 → 34 (its residual is the
+scheduling case the conservative probe cannot reach, plus COM-vtable `call *0x44(%eax)`
+sites, so **the true impact is larger than the probe's delta**).
+
+Reach beyond this corpus is bounded by the compiler spec: the defect requires
+`default_proto` with `extrapop="unknown"`, which only `x86win.cspec`, `x86-16.cspec`,
+`x86borland.cspec`, `x86delphi.cspec`, `M16C_60.cspec`, `avr32a.cspec` and the Toy specs
+declare. Every ELF and every x86-64 target has a fixed extrapop and cannot drift.
+
+---
+
+## Option sweep — nothing closes it
+
+All **89** non-default settings of the 88-row catalog, run on
+`dexter.dll --addr 0x69943550`, counting argument-less named calls:
+
+- 87 settings → **31**, the baseline. `condfold on` and `condfold wide` swept explicitly:
+  31 and 31. `--mode reliable` 31, `--mode aggressive` 31, `--mode fast` 31 (the binary is
+  50,190 bytes, so `auto` = `aggressive`; mode is not the variable here).
+- `peimportcall off` → 7, purely because the calls re-render as unnamed
+  `(*dat_6994e478)()`; the leaked return-address pushes go **up**, 31 → 44. Not a fix.
+- `callsitestackargs off` → 48 argument-less calls / 0 pushes — the documented pre-#229
+  ablation: every stack trial is scored no-use, so the whole argument computation is
+  dead-coded. Strictly worse, and the reason the census mistook it for a fix.
+- The non-catalog console knob the spec references (`option extrapop`, `OptionExtraPop`) was
+  swept too: `unknown` → 31, `4` → 41, `8` → 40, `12` → 40. It sets one global value; the
+  problem needs a per-call-site one.
+
+---
+
+## Owning phase
+
+**P6 — Variable & Storage Model.**
+`decompiler/crates/kuna-decomp/src/p6_variables/coreaction_stackptr.rs`
+(`ActionStackPtrFlow` / `StackSolver`, scheduled in `stackstall`), spec chapter
+`docs/spec/06-variables-and-merge.md` §"The exception that proves the rule", which already
+names the exact line: *"an underdetermined call contributes the guessed equation
+`extrapop = 4`"*. The prose then describes the failure mode as *"an unsolvable system
+leaves the INDIRECTs in place … the affected frame offsets never promote"*. **That is not
+the failure mode observed here.** Here the solve *succeeds* — consistently, silently, and
+wrongly. The chapter needs that second failure mode written down whatever the fix.
+
+The consumers are P4 (`p4_calls/funcdata_callsite.rs::check_input_trial_use`, the
+`callee_pop` branch that would have accepted the trials) and P6 §6.2
+(`varmap.rs::ScopeLocal::restructure`, which carves the fictitious locals). Neither is where
+the decision is made.
+
+---
+
+## Proposed fix
+
+`feat/decbench-stdcallpop` — option `stdcallpop {on|off}`, P6 /
+`stack-pointer-flow`, tier `transform`.
+
+**Mechanism (one module).** New `p6_variables/kuna_stdcallpop.rs`, consulted from the single
+site in `StackSolver::build` that currently pushes the fallback guess
+(`coreaction_stackptr.rs:317`, `self.guess.push(StackEqn { var1: i, var2: idx, rhs: 4 })`):
+
+> When a call's spacebase INDIRECT has `extrapop == EXTRAPOP_UNKNOWN` and its output
+> Varnode's sole spacebase descendant is `INT_ADD(sp, -N)` with `N > 0` and `N % 4 == 0`,
+> the caller is compensating a callee pop of `N` bytes. Emit the **hard** equation
+> `rhs = stackshift + N` instead of the `rhs = 4` guess.
+
+`analyze_extra_pop`'s existing L1 keystone then latches the solved value back onto the call
+spec via `set_effective_extra_pop`, which is exactly what `check_input_trial_use`'s
+`callee_pop` branch already reads — so no P4 change is needed. Everything downstream is
+existing, exercised machinery.
+
+**The probe is a positive control, not just a negative one.** Crediting the call with
+`extrapop = 4 + N` while leaving `sub $N,%esp` in place is arithmetically identical to
+leaving extrapop at 4 and making the `sub` displacement zero. That is precisely the
+`sub $0x0` probe, and its output is byte-identical to the `nop` probe and matches ghidra's
+frame exactly. So the fix's *output* is already measured — 265 → 125 lines, 46 → 10 locals,
+24 → 0 `code *`, 31 → 0 leaked return addresses on the witness; the corpus table above for
+the rest.
+
+**Owning files.**
+`decompiler/crates/kuna-decomp/src/p6_variables/kuna_stdcallpop.rs` (new),
+`p6_variables/coreaction_stackptr.rs` (one call site),
+`p0_knowledge/options.rs` + `phases.toml` (option row, `tier` + `symptoms`),
+`docs/spec/06-variables-and-merge.md` (the second failure mode + the new equation),
+`tests/stages/ghdec-stdcallpop.xml`, `docs/options.md` regen, plus the hard-coded catalog
+counts (`kuna_phases/tests.rs`, `tests/catalog_bytecompat.rs`,
+`tests/stages/kuna-catalog.xml`, `kuna-base/src/xml.rs` corpus count,
+`docs/baseline-stages.json` re-record).
+
+**Risks — and the "would this produce WRONG output?" axis.**
+
+1. **A post-call `sub $N,%esp` that is a genuine frame extension** (an `alloca`, or a
+   dynamically sized outgoing area) would be mis-credited to the callee and shift the frame
+   the *other* way. The sole-descendant requirement and the `N % 4` filter narrow it, but
+   this is the failure this feature can actually cause and the audit must target it. The
+   existing `check_clog` path in the same file handles `SP = SP + *(SP+k)` alloca and should
+   be given precedence.
+2. **Conflict with an already-derived solve.** `propagate` refuses to overwrite a set
+   solution, so a contradictory hard equation is dropped silently rather than loudly. On
+   this witness the merge-derived values (`StrStrA` 12, `CreateMutexA` 16) agree with the
+   new equation, but an assertion/diagnostic on disagreement is worth having.
+3. **Baseline movement.** Four corpus testcases run on `x86:LE:32:default:win*` —
+   `tests/datatests/retstruct.xml`, `tests/datatests/statuscmp.xml`,
+   `tests/stages/ghangr-optimized-memcpy-6301a9.xml`,
+   `tests/stages/ghdec-spacebase-unnamed.xml`. Inspect each; do **not** re-pin.
+   Everything else in both corpora is x86-64/gcc or ARM, where extrapop is fixed and the
+   rule is provably inert.
+4. **Audit set (rule 8).** All 1,031 PE functions before/after, plus the x86-64 and ARM
+   control set to prove byte-identity off i386-Windows. Classify each hunk; the expected
+   shapes are "arguments appear", "frame shrinks", "stack local disappears". Anything else
+   is the alloca case.
+
+**Alternative mechanism, deliberately not recommended as the first PR.** Extend
+`kuna-analysis/src/analyzers/protos/mod.rs` (`libproto`, P1/external-refinement — already
+the "kuna analog of Ghidra's ApplyDataArchiveAnalyzer") with a Win32 `__stdcall` signature
+table. This is literally what ghidra and ida do, and it fixes types as well as arity. But it
+is a data-curation task, incomplete by construction, and a single wrong arity corrupts a
+frame; it also cannot reach `x0r-usb`'s COM-vtable `call *0x44(%eax)` sites, which no
+archive covers and which the drift also breaks. Worth doing as its own PR *after*
+`stdcallpop`, for the types.
+
+**Speed.** The new test is a two-op def-use walk per unknown-extrapop call inside an
+existing loop; expected well inside the 5% budget, but measure with
+`scripts.pipeline.timeit` as usual. Whole-function runtime on the witness today is 1.05 s.
+
+**GED.** Expect ~0. This is a readability/correctness fix that the campaign metric cannot
+see (see *Metric-artifact check*); `rescore --case O2-noinline-dexter-dexter-GetProcList`
+will report a flat delta and that is the correct outcome, not a failure. The evidence for
+the PR is the argument-recovery and frame table above.
+
+---
+
+## Siblings
+
+Same mechanism, confirmed on today's build: `dexter::Update` 0x699465a0,
+`dexter::AddItem` 0x69943de0, `dexter::Infect` 0x69942940, `dexter::ExecCommands` 0x69946a30,
+`dexter::BeginInjection` 0x69943320, `dexter::GetParentProcessId`, `dexter::GetOSVersion`,
+`minipig::Infects` 0x4014e0 (`v29 = 0x4014ff; v33 = FindFirstFileA();`), plus 34 more
+functions across `mydoom.exe` and `x0r-usb.exe` — 42 in total by the leaked-return-address
+signature, 4.1% of the PE corpus and 6.2% of its O2 + O2-noinline half (41 of 665).
+
+One sibling in the pool, `dexter::GetProcList` @0x69941910, additionally shows the
+*mis-attributed* form rather than the *dropped* form — `v4 = (*v1)(dat_6994c948,8,v10)`
+where the source says `HeapAlloc(hHeap, 8, size)` and `v1` is the
+`CreateToolhelp32Snapshot` handle, plus `_memset(v5,0)` (2 args) and
+`_memset(&v7,0,0x104,v11,v12,v13)` (6 args) against a 3-argument callee. It sits outside the
+probed range so it is not covered by the measurement above; it should be re-checked against
+the implemented fix before being filed separately.
+
+---
+
+## Artifacts
+
+Read-only; no `.rs` file, branch or PR was touched and `make specs` was not run.
+Scratchpad `…/scratchpad/censustrack/`: `ep.c` (fresh witness), `probe_ep.c` /
+`nosub_ep.c` (the two probes, byte-identical), `ep_raw.txt` (`print raw`),
+`sweep/` (89 option settings), `ex_*.c` (`option extrapop`), `pe/*.json` (12 whole-binary
+runs, today's build), `probejson/*.json` (the same 12 drift-neutralised),
+`dexter_sub0.dll` / `dexter_nosub.dll` / `dexter_keepfirst.dll` / `probe/*` (patched
+copies), `r1s.so` (the i386-ELF control, which recovers every stack argument correctly).

--- a/docs/decbench/triage/novel-tiedslot-partial-symbol.md
+++ b/docs/decbench/triage/novel-tiedslot-partial-symbol.md
@@ -1,0 +1,386 @@
+---
+case_id: novel-tiedslot-partial-symbol
+pool: novel
+group_id: cluster (cleanflight/betaflight::applyLedFixedLayers @ 0x8030a88 / 0x8052b04, cleanflight::ftoa @ 0x800f04c, siblings sub_8030aee, sub_8030cbc, sub_8052b6e, sub_8052d50)
+status: needs-proposal
+tier: N
+margin: 0
+fresh_verdict: reproduces exactly on HEAD e38ffc31 — one 4-byte stack slot that the source writes field-by-field is emitted as SIX aliasing locals (`v12`/`v13`/`v14` all `// stack - 0x24`, `v15`/`v16` `// stack - 0x22`, `v17` `// stack - 0x21`) instead of Ghidra's single `undefined4 local_24` with `local_24._2_2_` partial writes; the proximate cause is instrumented and proved (a SKIPPED forced `Merge::mergeAddrTied` at that slot, 37 addr-tied varnodes, already a documented kuna divergence at `p6_variables/merge.rs:1640-1657`), but the FIX is not — the intersection that blocks the merge is a full-block cover overlap that upstream's `eliminateIntersect` structurally cannot snip, so "complete the port" is a direction, not a mechanism
+option_closing: null
+feature_slug: tiedslotunify
+scope: proposal
+confidence: high
+---
+
+## Verdict in one line
+
+The census's surviving `concat`/`subpiece` thread is **one P6 defect**: when
+`Merge::mergeAddrTied`'s **forced** merge of a stack slot is skipped, that slot's
+sub-width accesses lose the mapped Symbol and become **separate aliasing locals**, and the
+refinement `SUBPIECE`/`PIECE` that would have been hidden become **raw `SUBnn`/`CONCATnn`
+statements**. The symptom, the chain and the blast radius are measured; the repair is not
+identified, so this is `needs-proposal`, not `feature-candidate`.
+
+## Reproduction (today's build, pasted)
+
+`make binaries` at HEAD `e38ffc31`. The 346,852-byte binary is under 500 KiB, so a no-flag
+run is `--mode auto` == `--mode aggressive`.
+
+```
+$ export SLEIGHHOME=/home/mahaloz/github/kuna/specs
+$ ./decompiler/target/release/kuna decompile \
+    ~/github/decbench/results/full_run/O2-noinline/cleanflight/stripped/cleanflight_DALRCF405.elf \
+    --addr 0x8030a88
+
+void sub_8030a88(void)
+{
+  uint2 v1;
+  uint4 v10; // r4
+  int4 v11; // r7
+  unsigned int v12; // stack - 0x24      <-- ONE 4-byte slot ...
+  unsigned short v13; // stack - 0x24    <-- ... six locals
+  undefined3 v14; // stack - 0x24
+  char v15; // stack - 0x22
+  unsigned short v16; // stack - 0x22
+  char v17; // stack - 0x21
+  uint4 v18; // stack - 0x20
+  uint4 v19; // stack - 0x1c
+  ...
+          if (0x5dc <= dat_200079b8) { // branch-flip
+            v9 = v12;
+            v3 = sub_800e454(dat_200079b8,0x5dc,2000,v12 & 0xffff,v18 & 0xffff);
+            v16 = SUB42(v12,2);
+            v12 = CONCAT22(v16,v3);
+            v15 = SUB41(v9,2);
+            v2 = sub_800e454(dat_200079b8,0x5dc,2000,v15,v18 >> 0x10 & 0xff);
+            v17 = SUB41(v12,3);
+            v13 = (unsigned short)v12;
+            v14 = CONCAT12(v2,v13);
+            v12 = CONCAT13(v17,v14);
+            v2 = sub_800e454(dat_200079b8,0x5dc,2000,v17,v18 >> 0x18);
+            v14 = (undefined3)v12;
+            v12 = CONCAT13(v2,v14);
+```
+
+Ghidra (stored pane, same function, same binary) — **one** declaration, and every partial
+access rendered as a field of it:
+
+```c
+  undefined4 local_24;
+  uint local_20;
+  undefined4 local_1c;
+  ...
+        else {
+          uVar4 = FUN_0800e454(iVar8,0x5dc,2000,local_24 & 0xffff,local_20 & 0xffff);
+          uVar11 = local_24;
+          local_24 = CONCAT22(local_24._2_2_,uVar4);
+          uVar7 = local_24;
+          local_24._2_1_ = SUB41(uVar11,2);
+          uVar3 = local_24._2_1_;
+          local_24 = uVar7;
+          uVar3 = FUN_0800e454(*DAT_08030d10,0x5dc,2000,uVar3,local_20 >> 0x10 & 0xff);
+          local_24._0_3_ = CONCAT12(uVar3,(undefined2)local_24);
+          uVar3 = FUN_0800e454(*piVar2,0x5dc,2000,local_24._3_1_,local_20 >> 0x18);
+          local_24 = CONCAT13(uVar3,(undefined3)local_24);
+```
+
+Counted with the census scanner:
+
+| pane | raw nonzero-offset `SUBnn` | `CONCAT` | `sym._o_n_` refs | decls for the slot |
+|---|---:|---:|---:|---:|
+| ghidra (stored) | **1** | **7** | **9** | **1** |
+| kuna (HEAD) | 6 | 9 | 0 | **6** |
+
+`--option dedupvardecls off` exposes the underlying multiplicity — **nine** HighVariables
+are whole 4-byte covers of that one slot:
+
+```
+  unsigned int v12; // stack - 0x24
+  uint4 v12; // stack - 0x24
+  uint4 v12; // stack - 0x24
+  uint4 v12; // stack - 0x24
+  unsigned int v12; // stack - 0x24
+  unsigned int v12; // stack - 0x24
+  uint4 v12; // stack - 0x24
+  unsigned int v12; // stack - 0x24
+  unsigned int v12; // stack - 0x24
+  unsigned short v13; // stack - 0x24
+  undefined3 v14; // stack - 0x24
+```
+
+`decompile-all --mode reliable` (the benchmark's own option surface) emits the identical
+declaration block, so this is not a mode artifact.
+
+## Source
+
+`~/github/decbench/results/full_run/O2-noinline/cleanflight/compiled/ledstrip.i`
+
+```c
+typedef struct hsvColor_s { uint16_t h; uint8_t s; uint8_t v; } hsvColor_t;  /* 4 bytes */
+
+static void applyLedFixedLayers(void)
+{
+    for (int ledIndex = 0; ledIndex < ledCounts.count; ledIndex++) {
+        ...
+        hsvColor_t color = *getSC(LED_SCOLOR_BACKGROUND);      /* the stack - 0x24 slot */
+        ...
+                if (auxInput < centerPWM) {
+                    color.h = scaleRange(auxInput, 1000, centerPWM, previousColor.h, color.h);
+                    color.s = scaleRange(auxInput, 1000, centerPWM, previousColor.s, color.s);
+                    color.v = scaleRange(auxInput, 1000, centerPWM, previousColor.v, color.v);
+                } else { ... }
+        color.h = (color.h + hOffset) % (359 + 1);
+        setLedHsv(ledIndex, &color);
+    }
+}
+```
+
+**One** local, written at 2-byte and 1-byte granularity. The stripped binary carries no
+struct type, so *some* CONCAT/SUBPIECE reassembly is honest and Ghidra emits it too — but
+"one variable" is not a judgement call, it is what the source says, and Ghidra recovers it.
+kuna recovers six.
+
+## Root cause — instrumented, in four steps
+
+All four measured with temporary env-gated `eprintln!` instrumentation on
+`p6_variables/{merge.rs, varmap.rs, coreaction_cleanup.rs}` and `p9_emit/printc.rs`, run
+through `decomp_dbg` directly (the `kuna decompile` wrapper pipes stderr). **The
+instrumentation was reverted; the tree carries no `.rs` change from this triage, and the
+restored build reproduces the pane above byte-identically (md5 `1533cc66…`).**
+
+**1. The stack layout is CORRECT.** `ScopeLocal::restructure` creates exactly one Symbol
+per slot — the same layout Ghidra has:
+
+```
+[varmap] ENTRY addr=0xffffffdc size=4 type=xunknown4     <-- the `color` slot, ONE entry
+[varmap] ENTRY addr=0xffffffe0 size=4 type=uint4
+[varmap] ENTRY addr=0xffffffe4 size=4 type=xunknown4
+```
+
+So this is **not** a P6 stack-layout (`RangeHint`/`MapState`) defect, and not `subright`.
+
+**2. The forced addr-tied merge at that ONE slot is skipped.** Every other slot merges:
+
+```
+[mergeAddrTied] sub n=28 addr=0xffffffe0 size=4 -> OK
+[mergeAddrTied] sub n=28 addr=0xffffffe4 size=4 -> OK
+[mergeAddrTied] sub n=37 addr=0xffffffdc size=4 -> SKIPPED(intersect)
+[mergeRangeMust] FAIL at vn=VarnodeId(1826v3) off=0xffffffdc sz=4 written=true input=false
+                 defop=Some(CPUI_INDIRECT)
+[isect] blk=0 vn=VarnodeId(570v5) off=0xffffffdc sz=4 def=None
+             | vn2=VarnodeId(1826v3) off=0xffffffdc sz=4 def=Some(CPUI_INDIRECT)
+```
+
+This is the **already-documented kuna divergence**, `p6_variables/merge.rs:1640-1657`:
+`merge_range_must`'s error is swallowed instead of aborting the loop, and the comment
+names this exact outcome —
+
+> "…so `mark_internal_copies` can hide no partial-preserve SUBPIECE and the function
+> renders `SUB84(x,4)`/`CONCAT44(…)` reconstruction soup instead of Ghidra's inline
+> `x._4_4_` member access. … The residual conflicting slot is the follow-up (match
+> Ghidra's `eliminateIntersect` on the INPUT-vs-INDIRECT reused-slot intersection)."
+
+**3. The un-unified slot then costs the partial accesses their Symbol.**
+`ActionNameVars`/`linkSymbols` (`p6_variables/coreaction_cleanup.rs:2567-2613`) treats a
+**narrower addr-tied** representative as a storage *conflict* when another HighVariable
+sits at the entry's exact storage in a different `VariableGroup` — which is exactly what
+nine un-unified whole covers produce:
+
+```
+[name] addr=0xffffffdc size=2 tied=true ... entry_size=4 narrower=true reuse=false conflict=true  entry_name=v12
+[name] addr=0xffffffdc size=3 tied=true ... entry_size=4 narrower=true reuse=false conflict=true  entry_name=v12
+[name] addr=0xffffffde size=1 tied=true ... entry_size=4 narrower=true reuse=false conflict=true  entry_name=v12
+[name] addr=0xffffffde size=2 tied=true ... entry_size=4 narrower=true reuse=false conflict=true  entry_name=v12
+[name] addr=0xffffffdf size=1 tied=true ... entry_size=4 narrower=true reuse=false conflict=true  entry_name=v12
+[name] addr=0xffffffe6 size=1 tied=true ... entry_size=4 narrower=true reuse=false conflict=FALSE entry_name=v19
+[name] addr=0xffffffe7 size=1 tied=true ... entry_size=4 narrower=true reuse=false conflict=FALSE entry_name=v19
+```
+
+The last two lines are the control: the **same** narrower-addr-tied shape at the slot that
+*did* merge takes `conflict=false`, keeps the Symbol, and renders `v19._2_1_` /
+`v19._3_1_` in the body — Ghidra's exact form. The printer path is fine; the highs at
+`-0x24` simply carry no symbol at all (`[decl] name=v13 symoff=-1 symtype=None
+rep=off0xffffffdc/sz2`), so `PrintC` falls to the unnamed-location arm and mints `v13`.
+
+**4. Counterfactual, to close the chain.** Forcing `conflict = false` (temporary
+`KUNA_EXP_NOCONFLICT` gate) collapses the six declarations to one and converts every
+aliasing local into a partial-symbol reference:
+
+```c
+  unsigned int v12; // stack - 0x24      <-- the only decl for the slot now
+  ...
+            v12._2_2_ = SUB42(v12,2);
+            v12 = CONCAT22(v12._2_2_,v3);
+            v12._2_1_ = SUB41(v9,2);
+            v2 = sub_800e454(dat_200079b8,0x5dc,2000,v12._2_1_,v13 >> 0x10 & 0xff);
+            v12._3_1_ = SUB41(v12,3);
+            v12._0_3_ = CONCAT12(v2,(unsigned short)v12);
+            v12 = CONCAT13(v12._3_1_,(undefined3)v12);
+```
+
+Measured effect of that counterfactual alone: declarations for the slot **6 → 1**,
+`v12._o_n_` references **0 → 20**, raw `SUBnn` **6 → 6**, `CONCAT` **9 → 9**. That is the
+important split: **the aliasing-locals half of the symptom is downstream of naming; the
+raw-operator half is downstream of the merge itself**, because
+`Merge::mark_internal_copies` only hides a `PIECE`/`SUBPIECE` when
+`piece_group(out) == piece_group(in)` (`p6_variables/merge.rs:2168`/`:2218`), and two
+`VariableGroup`s at one slot can never satisfy that.
+
+## Why this is `needs-proposal` and not `feature-candidate`
+
+The proximate cause is proved, but the repair is not, and the campaign's own rule is that
+a diagnosis is a hypothesis until it is instrumented:
+
+- **The intersection is structural, not a missed guard.** `eliminate_intersect` only
+  examines varnodes whose **def block** equals a block in the read's single-read cover
+  (`BlockVarnode::find_front`). Instrumented: for the input varnode `570v5` the single-read
+  cover is `[0, 1]` and `blocksort` holds exactly one entry with index 0 — `570v5` itself.
+  The varnode it actually intersects (`1826v3`, an `INDIRECT` defined in block 27) is
+  **never examined**, because the two covers overlap block 0 *in full* rather than one
+  stepping over the other's def. No `continue`-guard in the ported `merge.cc:489-572` body
+  is responsible; the only bails that fire anywhere in this function are
+  `!addrforce` (14) and `op != indirect_effect_op` (21), none on this pair. So "finish the
+  `eliminateIntersect` port" — the follow-up the merge.rs comment names — is **not**
+  supported by the evidence.
+- That pushes the real question upstream of P6: why kuna's IR has a **function-input**
+  varnode at a slot the loop unconditionally writes before reading, whose cover spans the
+  same block as the loop-back `INDIRECT`. That is P3 heritage/cover shape, and answering it
+  is a separate investigation. A change there is a Band-B fixed-point change, not a module.
+- The narrow alternative that *is* demonstrated — teach the `linkSymbols` conflict scan
+  that a different-group high resolving to the **same SymbolEntry/name** is not a genuine
+  storage conflict — fits one module (`p6_variables/coreaction_cleanup.rs`) and is measured
+  above, but it buys only half the symptom and it re-opens the LOSS-234 `zeroprop` guard it
+  was written for. It is a candidate *inside* the proposal, not a standalone feature.
+
+## Breadth (corpus-wide, measured on today's build)
+
+Instrumented `kuna decompile-all --mode reliable` over the census's 7-binary reliable set
+(`ssh`, `ip`, `e2fsck`, `gzip`, `bzip2`, `betaflight_STM32F405.elf`,
+`cleanflight_DALRCF405.elf`):
+
+| binary | functions | fns with ≥1 skipped forced merge | skip events |
+|---|---:|---:|---:|
+| O0 gzip | 262 | 2 | 2 |
+| O2ni bzip2 | 153 | 3 | 4 |
+| O2ni iproute2 ip | 1,912 | 28 | 39 |
+| O2ni e2fsprogs e2fsck | 1,909 | 53 | 65 |
+| O2ni openssh ssh | 1,853 | 78 | 108 |
+| O2ni cleanflight | 3,114 | 150 | 225 |
+| O2ni betaflight | 6,387 | 345 | 526 |
+| **total** | **15,590** | **659 (4.23%)** | **969** |
+
+The skip is **not** ARM-specific (x86-64 `ssh` 4.2%, `e2fsck` 2.8%); what is ARM-heavy is
+the *visible* damage, because Cortex-M firmware writes packed 4-byte structs field by
+field. Two independent damage proxies on the same run:
+
+- **Aliasing locals**: 46 functions emit two or more locals carrying the same
+  `// stack ± 0xNN` storage comment. **37 of the 46 (80%)** are in the skip set.
+- **Residual raw nonzero-offset `SUBnn`**: the total on this set is **85**, reproducing the
+  census exactly. **42 of the 85 (49%), in 14 functions, are in the skip set** — including
+  every ARM function the census's "class B addr-tied LOCAL partial-symbol write" bucket
+  named except the two `sub_8069d2x` global-store cases:
+
+```
+  sub_801853c 2   sub_802ab10 1   sub_8052b04 6   sub_8052b6e 5   sub_8052d50 5
+  sub_800f04c 2   sub_8030a88 6   sub_8030aee 5   sub_8030cbc 5
+  e2fsck sub_71860 1   ip sub_11290 1   ip sub_78dc0 1   ssh sub_387f0 1   ssh sub_68960 1
+```
+
+So the census's arithmetic holds up: this one thread owns roughly **half** of what is left
+of the `subpiece` wart, and essentially all of its ARM Cortex-M mass.
+
+## Siblings — all reproduce
+
+| case | pane |
+|---|---|
+| O0 cleanflight `applyLedFixedLayers` @ 0x80301d4 | 6 locals at the `- 0x1c` slot (`v15`..`v20`), same shape |
+| O2ni betaflight `sub_8052b04` @ 0x8052b04 | 6 locals at `- 0x24` (`v12`,`v14`,`v15`,`v16`,`v17`,`v18`) |
+| O2ni betaflight `sub_8052b6e` / `sub_8052d50` | **ten** locals at `stack + 0xc` alone |
+| O2ni cleanflight `sub_8030aee` / `sub_8030cbc` | same, 5 raw `SUBnn` each |
+| O0/O2ni cleanflight `ftoa` @ 0x800f04c | 6 locals at the `- 0x28` slot |
+
+`ftoa` is the case where the rendering becomes **semantically wrong**, not just verbose.
+kuna:
+
+```c
+  unsigned int v2; // stack - 0x28
+  char v5; // stack - 0x28
+  unsigned short v6; // stack - 0x28
+  undefined3 v7; // stack - 0x28
+  undefined3 v8; // stack - 0x27
+  ...
+  v2 = 0;
+  ...
+  v2 = (0 <= (int4)v4) ? CONCAT31(v8,0x20) : CONCAT31(v8,0x2d); // branch-flip
+```
+
+`v8` is **read and never assigned**. Ghidra emits `local_28 = CONCAT31(local_28._1_3_,0x20)`
+— a read of the upper three bytes of a slot the same function set to `0` two lines earlier.
+Splitting the slot into independent C objects turns a defined partial read into a read of an
+uninitialized local, so the exported `.c` is not merely unreadable, it is wrong.
+
+## Option / mode sweep (all negative)
+
+`kuna decompile … --addr 0x8030a88 --option <X>`, diffed against the no-flag pane:
+
+| option | diff lines | decls at `- 0x24` | raw `SUBnn` |
+|---|---:|---:|---:|
+| `condfold on` / `condfold wide` | 0 | 3 | 6 |
+| `cortexmvectors on`, `ptrentry on`, `paramcopyhoist on`, `dwarf_lines on` | 0 | 3 | 6 |
+| `stackalias off`, `iteexpr off`, `subright off` | 0 | 3 | 6 |
+| `realtypes off` | 32 | 3 | 6 |
+| `dedupvardecls off` | 9 | **11** (worse) | 6 |
+
+`--mode auto`, `--mode aggressive` and `decompile-all --mode reliable` all show the same
+declaration block. `option_closing: null`.
+
+## Metric-artifact check — clean
+
+Source CFG **26 nodes / 40 edges** (exact GED, not the >60-node approximation, not
+degenerate). kuna GED **25**, tied best with ghidra 25 (angr 42, ida 41, binja 32). Joern
+parsed every pane. This is a NOVEL-pool readability/correctness defect with **GED value 0** —
+no basic block moves. Rank it by correctness, not by the metric.
+
+## Owning phase
+
+**P6 — Variable & Storage Model** (`p6_variables/`), per `docs/phases.md`: HighVariables,
+merge, stack layout. Every step of the chain is in that folder
+(`merge.rs::merge_addr_tied` → `coreaction_cleanup.rs::linkSymbols` →
+`merge.rs::mark_internal_copies`); P9 only renders the result. The *origin* of the blocking
+cover intersection is plausibly P3 (heritage/`INDIRECT` placement, the spurious slot input),
+which is the Band-B feedback edge the proposal has to settle.
+
+## What a proposal has to answer
+
+1. Why kuna materializes a function-**input** varnode at a stack slot the loop always
+   writes before reading, and whether that input is what makes the entry-block cover
+   overlap the loop-carried `INDIRECT` (compare against `- 0x20` / `- 0x1c`, which have
+   inputs too and merge fine).
+2. Whether `unify_address`/`eliminate_intersect` can be made to resolve a **full-block**
+   cover overlap at all, or whether upstream simply never produces one here.
+3. Whether the narrow `linkSymbols` conflict discriminator ("same SymbolEntry ⇒ not a
+   conflict") is safe against LOSS-234 `zeroprop`, and whether shipping only that half —
+   one declaration per slot, partial-symbol writes, but the raw operators still printed —
+   is worth landing on its own.
+4. The blast radius: 659 functions on the 7-binary set would change merge behaviour. Per
+   the standing rule, a whole-corpus before/after diff of **every changed function** is the
+   gate, not the witness; and the datatest corpus is the parity gate (`ActionMergeCopy` /
+   `mergeAddrTied` sit under every fixture).
+
+## Secondary observations (separate cases, recorded so they are not lost)
+
+1. **`v18` / `v19` are read but never assigned in `applyLedFixedLayers`.** Ghidra emits
+   `local_20 = *(uint *)(iVar8 + (uVar6 + 0x20) * 4);` and `local_1c = …`; kuna emits
+   `v9 = *(uint4 *)(v7 + (v4 + 0x20) * 4);` for both — the store lands on a register high
+   and the stack locals are then read undefined. The `- 0x20` / `- 0x1c` slots **merge
+   cleanly** (`n=28 OK`), so this is *not* the mechanism above. It refines secondary
+   observation #1 of `O2-noinline-betaflight-betaflight_STM32F405-applyLedFixedLayers.md`
+   (filed there as a dropped call argument; the LHS is wrong, which is a stronger claim).
+2. **`kuna decompile --addr` collapses on ≥500 KiB ARM binaries.** On the 537,492-byte
+   `betaflight_STM32F405.elf` (`--mode auto` ⇒ `reliable`),
+   `kuna decompile … --addr 0x8052b04` returns a 9-line stub reading `&Stack00000000`,
+   while `decompile-all --mode reliable` on the same binary/address returns the full
+   145-line body. The same happens on cleanflight under an explicit `--mode reliable`
+   (4 lines vs 139). Per-function `--addr` decompilation is losing the discovery context
+   that whole-binary loading provides; any triage that quotes a single-address reliable-mode
+   pane on an embedded ARM target is quoting an artifact.


### PR DESCRIPTION
Round 3 re-censused the three NOVEL wart classes on today's build **before** triaging anything, because the mined pools were scored with a pinned binary at `9623dc27` — one commit behind all nine of round 2's fixes. Triaging those rows as filed would have spent the round investigating defects that no longer exist.

Triage records only; no code changes.

## Census verdicts

| class | verdict |
|---|---|
| `code_ptr` / `raw_reg` | **largely-closed** |
| `concat` / `subpiece` / `undefined` | **largely-closed** |
| goto density | **never real** |

Like-for-like over **7,531 functions matched BY ADDRESS** against the pinned artifacts, so the discovery gains from #248/#255 cannot skew the comparison:

| token | pinned `9623dc27` | today | |
|---|---|---|---|
| `(code *)` | 950 | **329** | −65% |
| `(code **)` | 233 | **867** | +272% — the real type surviving |
| `& 0xfffffffe` | 875 | **172** | −80% |
| `SUBnn` | 789 | **27** | −97% |
| `$$undef` | — | **0** | |
| x86 raw GPR | 0 | 0 | already closed by #226 |

Against rivals on the 5,135 functions present in both panes, **kuna now emits 2.5× fewer `(code *)` than ghidra**. Of the 217 surviving `0xfffffffe` masks, **zero sit on an indirect-call target** — the invented ISA-mode mask is gone from every call site.

**Two of `novel.md`'s top-ranked cases were never defects.** `libacl::set_acl_fd` (row #1, defect score 152): kuna 12, ghidra 19. `x0r-usb::IRC_Login` (row #2): kuna and ghidra emit an identical 11 + 17.

**The goto class was never real.** A fresh sweep of all 803 benchmark binaries found the ranking was counting kuna's own documented transform banners and honest source-level gotos, not excess control flow.

## The wrong-output axis earned its place immediately

Round 2's lesson was that *"not a no-op" is not the same as "correct"* — a mechanism can be proven to reach the printer and still emit semantically wrong C. Round 3's refuters were given that as an explicit axis. **It fired on six of six survivors:**

| slug | verdict | how the wrong output was established |
|---|---|---|
| `regpiecename` | refuted | **built the proposed mechanism** and A/B'd it — wrong output by construction |
| `stdcallpop` | refuted | wrong output on the proposal's **own witness function** |
| `spleaf` | **drop** | wrong output on **all 46 witnesses**, including two the record certified correct |
| `tiedpartialname` | re-derive | concrete witnesses in `coreutils/ls` the filer never sampled |
| `retjointie` | proposal-first | wrong output in `bash rl_translate_keyseq`, a case the filing never examined |
| `tiedslotunify` | proposal | scope, not mechanism |

Every one answered **YES** to *"would this produce wrong output?"*, and five were refuted or downgraded on that basis alone. **None would have been caught by the round-2 refute brief**, which only asked whether the mechanism would change output at all.

## What this means for the campaign

Round 2 closed the cheap wins. What remains in the NOVEL pool is **proposal-grade**: P4/P6 stack-frame and call-argument recovery on i386 PE (`stdcallpop` — 24 argument-less Win32 calls in `dexter.dll` alone, where the modeled stack pointer drifts below the true frame at every `__stdcall` call and never recovers), and addr-tied partial-symbol unification in P6 (`tiedslotunify` — one 4-byte stack slot emitted as six aliasing locals; 659 of 15,590 functions hit at least one skipped forced merge).

Both are real, both are wrong code, and neither fits in one module. They are filed as such rather than forced into a small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dPFaKJanfLSf7mWGhkzkL