### PR TITLE
[AUTOMATED] ci: scope the workspace suite to fork PRs and to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: Tests
 
 # Runs the repository's own gates -- the checks AGENTS.md requires green before
-# every commit -- on every pull request and every push to main:
+# every commit -- on pull requests and on every push to main:
 #
 #   make test              datatest corpus vs docs/baseline.json          (PARITY OK)
 #   make test-stages       stage corpus vs docs/baseline-stages.json      (PARITY OK)
@@ -17,6 +17,16 @@ name: Tests
 # The gates are split across two jobs that run in parallel: the parity gates
 # answer in minutes and catch the common regression, while the workspace suite
 # (a debug build of the whole workspace plus ~4300 tests) is the long pole.
+#
+# The parity gates run on EVERY event. The workspace suite is scoped -- see the
+# `if:` on that job: an internal PR (a branch in this repo, i.e. the automated
+# agent PRs, whose author runs `make rust-test` locally before pushing) skips it
+# and gets the answer at merge instead, on the push to main. A fork PR is the
+# case nobody ran locally, so it always runs. The reason is runner supply: one
+# push fans out ~10 concurrent jobs (2 here + CodeQL's 8 configured languages),
+# and on 2026-08-06 that exhausted the pool -- four jobs sat 98-101 minutes
+# without ever being assigned a runner and were swept, presenting as a red PR
+# that had executed no code at all.
 
 on:
   pull_request:
@@ -100,6 +110,22 @@ jobs:
 
   rust-test:
     name: cargo workspace suite
+    # Runs on: every push to main, manual dispatch, any PR from a FORK, and any
+    # PR carrying the `full-ci` label. It is skipped only for a PR from a branch
+    # in this repo -- the automated agent PRs, where AGENTS.md already requires
+    # `make rust-test` green locally before the commit, so this job re-derives an
+    # answer we have. Skipping it halves this workflow's runner demand per PR
+    # and still leaves the parity gates (the cheap regression net) on every PR.
+    #
+    # The safety net for the skip is the `push: branches: [main]` trigger above:
+    # the suite always runs on the merge commit, so nothing reaches main without
+    # it -- the answer just arrives at merge rather than before it. To demand it
+    # BEFORE merging a particular internal PR, label that PR `full-ci` and push
+    # (or re-run the workflow); no workflow edit needed.
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.fork
+      || contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,6 +103,21 @@ jobs:
       - name: kuna catalog --check
         run: ./decompiler/target/release/kuna catalog --check
 
+      # `catalog --check` above proves options.md documents the same option SET;
+      # this proves it is the generator's exact bytes. That is the assertion in
+      # kuna-decomp/tests/options_md_fresh.rs, which lives in the workspace suite
+      # -- skipped on an internal PR. Forgetting to regenerate options.md after
+      # touching option metadata is a routine miss (AGENTS.md calls it out), so
+      # the cheap job carries it rather than deferring it to the push to main.
+      # Free: it reuses the release binary this job already built.
+      - name: docs/options.md is the generator's bytes
+        run: |
+          ./decompiler/target/release/kuna catalog --markdown > /tmp/options.generated.md
+          if ! diff -u docs/options.md /tmp/options.generated.md; then
+            echo "::error file=docs/options.md::stale -- regenerate with 'decompiler/target/release/kuna catalog --markdown > docs/options.md'"
+            exit 1
+          fi
+
       - name: Assemble and test the browser Worker boundary
         run: |
           bash integrations/web/build.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,14 @@ name: Tests
 
 on:
   pull_request:
+    # `labeled` is here so the `full-ci` escape hatch works by labelling alone.
+    # Without it the hatch is a lie: the default set is opened/synchronize/
+    # reopened, and re-running a finished run REPLAYS ITS ORIGINAL PAYLOAD -- so
+    # a label added afterwards is invisible to the `if:` and you would have to
+    # push a commit to be believed. The cost is one extra run per label added to
+    # a PR, which is rare here; `unlabeled` is deliberately NOT included, so
+    # removing a label does not re-run anything.
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches: [main]
   workflow_dispatch:
@@ -135,8 +143,9 @@ jobs:
     # The safety net for the skip is the `push: branches: [main]` trigger above:
     # the suite always runs on the merge commit, so nothing reaches main without
     # it -- the answer just arrives at merge rather than before it. To demand it
-    # BEFORE merging a particular internal PR, label that PR `full-ci` and push
-    # (or re-run the workflow); no workflow edit needed.
+    # BEFORE merging a particular internal PR, add the `full-ci` label: that is
+    # itself a trigger (see `types:` above), so the suite starts on the label
+    # alone -- no push, no re-run, no workflow edit.
     if: >-
       github.event_name != 'pull_request'
       || github.event.pull_request.head.repo.fork

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -45,9 +45,13 @@ make specs      # compile all .slaspec → .sla with slacomp
 | `make rust-test` | full cargo workspace suite + `docs/options.md` freshness | green |
 | `make check-spec` | `docs/spec/` anchors + inline code paths resolve; each phase folder owned by exactly one chapter (`--strict` adds option-mention coverage) | green |
 
-CI runs all four (plus `kuna catalog --check`) on every pull request and every push to
-main — `.github/workflows/tests.yml`. Run them locally anyway: the workspace suite is the
-long pole in CI, so local failures are found far sooner.
+CI runs all four (plus `kuna catalog --check`) on every push to main —
+`.github/workflows/tests.yml`. On a **pull request from a branch in this repo** the
+workspace suite is skipped and only the parity gates run; **you are the gate for
+`make rust-test` on those PRs**, which is why it is on the list above. (It still runs
+pre-merge on a fork PR, on any PR labelled `full-ci`, and via *Run workflow*.) Run all
+four locally regardless: the workspace suite is the long pole in CI, so local failures
+are found far sooner.
 
 - **Never re-pin `docs/baseline.json` to absorb a regression** — fix the code or make the
   change opt-in. The only sanctioned re-pins are an intentional upstream sync or a

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -48,10 +48,11 @@ make specs      # compile all .slaspec → .sla with slacomp
 CI runs all four (plus `kuna catalog --check`) on every push to main —
 `.github/workflows/tests.yml`. On a **pull request from a branch in this repo** the
 workspace suite is skipped and only the parity gates run; **you are the gate for
-`make rust-test` on those PRs**, which is why it is on the list above. (It still runs
-pre-merge on a fork PR, on any PR labelled `full-ci`, and via *Run workflow*.) Run all
-four locally regardless: the workspace suite is the long pole in CI, so local failures
-are found far sooner.
+`make rust-test` on those PRs**, which is why it is on the list above. To demand it from
+CI on a particular PR, add the **`full-ci`** label — that label is itself a trigger, so
+the suite starts on the label alone. (It also always runs pre-merge on a fork PR, and via
+*Run workflow*.) Run all four locally regardless: the workspace suite is the long pole in
+CI, so local failures are found far sooner.
 
 - **Never re-pin `docs/baseline.json` to absorb a regression** — fix the code or make the
   change opt-in. The only sanctioned re-pins are an intentional upstream sync or a


### PR DESCRIPTION
## Why

One push to this repo fans out **~10 concurrent jobs**: 2 from this workflow plus CodeQL default setup's **8 configured languages** (`actions, c-cpp, java-kotlin, javascript, javascript-typescript, python, rust, typescript`).

On 2026-08-06 that exhausted the runner pool. Eight jobs were created inside a 33-second window and exactly **four** got runners. The other four — `parity gates`, `Analyze (c-cpp)`, `Analyze (python)`, `Analyze (rust)` — sat **98–101 minutes** and were swept. The API record for the gates job:

```
"conclusion": "cancelled",
"runner_id":   0,
"runner_name": "",
"steps":       [],
"created_at":  "2026-08-06T17:17:41Z"   <- identical to started_at
"completed_at":"2026-08-06T18:56:17Z"
```

`runner_id: 0` with `started_at == created_at` and zero step records is the signature of a job that was **never dispatched**. Not one of its nine steps ran. It presented PR #272 as red having executed no code at all, and the same commit passed in **3m31s** on the next attempt.

(Two independent confirmations that this was supply, not workload: the sibling `cargo workspace suite` job in the same run got a runner in 37s and passed; and `Analyze (python)` — which a Rust change cannot touch — starved identically. The uniform ~100-minute death across two workflows with *different* `timeout-minutes` (90 here, CodeQL's default 360) also rules out a per-job timeout as the trigger.)

## What this does

Halve this workflow's share of that demand.

`cargo workspace suite` — a debug build of the whole workspace plus ~4300 tests, the long pole at 6–9 min — no longer runs on **a pull request from a branch in this repo**. Those are the automated agent PRs, where `AGENTS.md` already requires `make rust-test` green locally before the commit, so the job re-derives an answer we already have.

It still runs, unchanged, on:

| Trigger | Why |
|---|---|
| every **push to main** | the safety net — the suite always runs on the merge commit, so nothing reaches main without it; the answer just arrives *at* merge rather than before it |
| a PR from a **fork** | the case nobody ran locally |
| any PR labelled **`full-ci`** | per-PR escape hatch, no workflow edit needed |
| `workflow_dispatch` | manual |

```yaml
if: >-
  github.event_name != 'pull_request'
  || github.event.pull_request.head.repo.fork
  || contains(github.event.pull_request.labels.*.name, 'full-ci')
```

**`parity gates` is untouched and still runs on every event** — 2.3–3.2 min, and it is the cheap net that catches the common regression (`make test`, `make test-stages`, `make check-spec`, `kuna catalog --check`, and the browser Worker boundary).

## Trade-off, stated plainly

An internal PR no longer proves `make rust-test` before merge — the author does. If an agent skips it locally, the failure now surfaces on main instead of on the PR. That is the deal being made; `docs/agents.md` is updated to say so explicitly, so the obligation is written down where the four gates are listed rather than assumed.

`full-ci` is the escape hatch when a particular internal PR warrants the pre-merge proof anyway.

## Verification

- `.github/workflows/tests.yml` parses (PyYAML); `gates` carries no `if:`; the `rust-test` condition retains all three clauses.
- Both jobs' step lists are unchanged.

## One assertion pulled forward

Skipping the suite defers everything in it to the push to main. One of those is worth keeping pre-merge: `kuna-decomp/tests/options_md_fresh.rs`, which asserts `docs/options.md` is the catalog generator's exact bytes. Forgetting to regenerate it after touching option metadata is a routine miss — `AGENTS.md` calls it out by name — and it should land on the PR, not on main.

`kuna catalog --check` (already in this job) proves options.md documents the same option *set*; it does not prove the *bytes* match. A new gates step does, by diffing against `kuna catalog --markdown`. It reuses the release binary the job already built, so it costs nothing. Verified both directions locally: byte-identical tree passes; a one-line append to `docs/options.md` fails with the `::error` annotation.

## Not included

CodeQL owns 8 of the ~10 jobs, so it is the larger half of the problem — but it is **default setup** (repo Settings), not a file in this repo, and its REST API does not accept `rust` as a language value, so trimming it from here would silently drop Rust scanning. Left alone deliberately; it needs a Settings-UI edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZfprhsXxBXEM1sMP1XX8d
