### PR TITLE
[AUTOMATED] fix(p9): branchflip armswap - an else-if collapse must not steal a nested if's brace

### DIFF
--- a/decompiler/crates/kuna-base/src/xml.rs
+++ b/decompiler/crates/kuna-base/src/xml.rs
@@ -1727,7 +1727,9 @@ mod tests {
         // masked-off tail read past the 16-byte buffer no longer aborts the decode)
         // and funcboundflow / a fall-through into a known function entry is truncated
         // instead of decoding the next function's body into the current one
-        assert_eq!(count, 194, "corpus file count drifted");
+        // and ghdec-branchflip-armswap / a swapped `if` arm keeps its whole body
+        // (the else-if collapse hoisted the arm's tail statement out of the arm)
+        assert_eq!(count, 195, "corpus file count drifted");
     }
 
     /// ~20 representative SLEIGH spec files across varied processors

--- a/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
@@ -3415,10 +3415,22 @@ impl PrintC {
         // line.  When it *did* fire, snapshot the indent
         // id it opened into a local — the shared emitter slot can be overwritten
         // by a deeper BlockIf's own pending brace before we read it back.
+        //
+        // C++ asks `emit->hasPendingPrint(&pendingBrace)` — a *pointer-identity*
+        // test against this frame's own `PendingBrace`, not "is any brace
+        // pending".  Only the frame that registered the brace may collapse it into
+        // `else if`; a nested `BlockIf` reached while emitting this if's condition
+        // block (a condition list can lead with a whole `if` statement) must let
+        // the ancestor's brace fire instead, or the ancestor's own `if` header
+        // lands outside the `else` and its body escapes the arm.
         let mut my_pending_indent = -1;
-        if self.emit.has_pending_brace() {
+        let my_brace_pending =
+            registered_pending && self.emit.has_pending_brace() && self.emit.pending_reg_gen() == my_pending_gen;
+        let mut my_brace_canceled = false;
+        if my_brace_pending {
             self.emit.cancel_pending_brace();
             self.emit.spaces(1, 0);
+            my_brace_canceled = true;
         } else {
             if registered_pending {
                 // C++ `pendingBrace.getIndentId()`: close a lazy `else { … }`
@@ -3430,6 +3442,16 @@ impl PrintC {
             }
             self.emit.tag_line();
         }
+        // Guard rail for the whole pending-brace family (debug builds only): a
+        // frame that registers a lazy `else` brace must resolve its OWN
+        // registration — either it fired (a real `else { … }`) or the frame
+        // canceled it (the `else if` collapse).  Neither holding means some other
+        // frame consumed the brace and this if's header is about to print outside
+        // the `else` it belongs to.
+        debug_assert!(
+            !registered_pending || my_brace_canceled || my_pending_indent >= 0,
+            "emit_block_if: pending else-brace consumed by another frame"
+        );
 
         // ... then `if ` + the branch condition (only_branch).
         self.emit.tag_op(keywords::KEYWORD_IF, SyntaxHighlight::KeywordColor, &MarkupRef::none());

--- a/decompiler/crates/kuna-decomp/src/substrate/funcdata_block.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/funcdata_block.rs
@@ -3715,11 +3715,47 @@ impl Funcdata {
                 &ad,
             );
         }
+        // The flip is a pure arm swap: the set of statements printed under this
+        // `if` must be exactly the same afterwards, only their arms exchanged.
+        // Snapshot the reachable leaf multiset so the debug assertion below can
+        // police that — any structural pass in this family that drops, duplicates
+        // or re-parents a component trips it (debug builds only).
+        #[cfg(debug_assertions)]
+        let leaves_before = self.kuna_flip_leaf_multiset(sif);
         self.split_flip_in_place_execute(split);
         self.op_flip_in_place_execute(&fliplist)?;
         // Swap the BlockIf's true/false children to match.
         self.sblocks_mut().swap_blocks(sif, 1, 2);
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(
+            self.kuna_flip_leaf_multiset(sif),
+            leaves_before,
+            "branchflip: arm swap changed the leaf set under the BlockIf"
+        );
         Ok(true)
+    }
+
+    /// The sorted multiset of leaf components reachable under the sblocks node
+    /// `sbl` — the guard-rail instrument for the arm-swapping structuring family
+    /// (debug builds only; see [`Self::block_if_flip_negated_guard`]).
+    #[cfg(debug_assertions)]
+    fn kuna_flip_leaf_multiset(&self, sbl: BlockId) -> Vec<BlockId> {
+        use crate::block::BlockType;
+        let mut leaves: Vec<BlockId> = Vec::new();
+        let mut stack: Vec<BlockId> = vec![sbl];
+        while let Some(cur) = stack.pop() {
+            let n = self.sblocks_ref().block(cur).get_size();
+            let ty = self.sblocks_ref().block(cur).get_type();
+            if n == 0 || ty == BlockType::Copy || ty == BlockType::Basic {
+                leaves.push(cur);
+                continue;
+            }
+            for i in 0..n {
+                stack.push(self.sblocks_ref().block(cur).get_block(i));
+            }
+        }
+        leaves.sort_unstable();
+        leaves
     }
 
     /// The address of a split point's guard op (the bblocks `BlockBasic`'s tail

--- a/docs/baseline-stages.json
+++ b/docs/baseline-stages.json
@@ -1,12 +1,18 @@
 {
   "data_footer": [
-    407,
-    407
+    413,
+    413
   ],
   "passing": [
     "data:BRANCHFLIP #1: default pipeline keeps the negated `== 0` guard (opt-in is default-off)",
     "data:BRANCHFLIP #2: `option branchflip on` flips to the positive `!= 0` guard (angr-style)",
     "data:BRANCHFLIP #3: the flip is logged so its effect is observable",
+    "data:BRANCHFLIP-ARMSWAP #1: the swapped guard reads positively (the flip still happens)",
+    "data:BRANCHFLIP-ARMSWAP #2: the else arm opens a real block, not an else-if collapse",
+    "data:BRANCHFLIP-ARMSWAP #3: the second sibling if stays inside the arm in both passes",
+    "data:BRANCHFLIP-ARMSWAP #4: branchflip off is the un-flipped reference, both siblings nested",
+    "data:BRANCHFLIP-ARMSWAP #5: no else-if collapse of a statement-carrying arm",
+    "data:BRANCHFLIP-ARMSWAP #6: no sibling if escapes to the outer statement indent",
     "data:CNORM-BRACEELIDE #1: default renders the single-statement body braceless, indented (DIV-37)",
     "data:CNORM-BRACEELIDE #2: braceelide off restores the upstream braced body",
     "data:CNORM-INPLACE #1: default renders the self-add as += (DIV-35)",

--- a/docs/spec/08-structuring.md
+++ b/docs/spec/08-structuring.md
@@ -408,7 +408,17 @@ warning at the guard's CBRANCH. Failure mode: anything that is not a clean
 is `preferComplement`'s job; result `2` cannot be flipped). Option
 `branchflip`, default flipped on by DIV-14 (which lists the datatest files
 that pin the pre-flip polarity via per-test opt-outs); registered at the
-`readability-rewrites` subphase in `phases.toml`.
+`readability-rewrites` subphase in `phases.toml`. Invariant: the flip is a
+*pure* arm swap, so the multiset of leaf components reachable under the
+`BlockIf` is identical before and after it — a debug-build assertion in
+`decompiler/crates/kuna-decomp/src/substrate/funcdata_block.rs
+(Funcdata::block_if_flip_negated_guard)` checks exactly that, and polices the
+whole arm-rearranging family against a dropped or re-parented component. What
+the swap *does* change is which arm the printer sees in the else slot; when
+that arm is an `if` whose condition component carries statements, the `else if`
+collapse governs the result, and its ownership rule is chapter 09's
+*pending-brace ownership* (a nested frame that steals the collapse hoists the
+arm's body onto the then-path).
 
 ## 8.2 The region structurer (angr)
 

--- a/docs/spec/09-emission.md
+++ b/docs/spec/09-emission.md
@@ -222,6 +222,29 @@ addl-flag on the condition's `CBRANCH` and emit the condition through the same
 parenthesization, short-circuiting and any comma-expression side effects are
 identical to the `if` form they replace.
 
+**Pending-brace ownership.** The `else if` collapse is a *lazy* brace. An
+if-node that is itself the else-clause of its parent registers a brace with the
+emitter (`printc.rs (PrintC::emit_block_if)`); the brace opens only if
+something forces a line break before that clause prints its own `if (` header —
+a statement in the clause's condition block, a goto label, or a comment. If
+nothing does, the frame cancels its own registration and the header prints on
+the `else` line, giving `else if`. The cancel decision belongs to the
+*registering frame*, not to whoever happens to be printing when the emitter's
+shared slot is non-empty: a clause's condition block can itself lead with a
+whole nested if-statement (S8 folds a run of sibling guards into one `BlockIf`
+whose condition component is a `BlockList` of the earlier guards), and that
+nested frame must let the ancestor's brace fire instead of consuming it. This
+mirrors upstream's pointer-identity test (`emit->hasPendingPrint(&pendingBrace)`
+against the frame's own object) and is not cosmetic: a nested frame that
+cancels the ancestor's brace renders *itself* as the `else if` and leaves the
+real clause's `if` header on a fresh line at the parent's indent, so that
+clause's body executes on the then-path too. It is reachable whenever a
+statement-carrying clause lands in the else slot — in practice after a
+§8.1 `branchflip` arm swap. A debug-build assertion in
+`printc.rs (PrintC::emit_block_if)` requires every registered brace to be
+resolved by its own frame, either fired or self-cancelled; the shape is pinned
+end-to-end by `tests/stages/ghdec-branchflip-armswap.xml`.
+
 **The declined-structure shell.** If the structured tree is *absent* (S8
 produced no `sblocks`), the printer does not emit a flat op listing: it keeps
 the brace-matched prototype shell and plants a single comment in the body

--- a/tests/stages/ghdec-branchflip-armswap.xml
+++ b/tests/stages/ghdec-branchflip-armswap.xml
@@ -1,0 +1,92 @@
+<decompilertest>
+<binaryimage arch="x86:LE:64:default:gcc">
+<!--
+    decbench campaign case O0-cleanflight-cleanflight_DALRCF405-serialUART (8a):
+    kuna emitted SEMANTICALLY WRONG C - a statement escaped an `else` arm and
+    executed on the then-path too.
+
+    The source shape (cleanflight serial_uart_stm32f4xx.c:240, and again in
+    iproute2 ipnetns.c:829) is an if/else whose else arm holds two sibling
+    `if` statements:
+
+        if (opts &amp; 8) { p[0] = x; }
+        else            { if (mode &amp; 2) p[1] = x;
+                          if (mode &amp; 1) p[2] = y; }
+
+    S8 structuring collapses that arm into ONE BlockIf whose *condition block*
+    is a BlockList leading with the first `if` statement - the standard Ghidra
+    "condition block carries statements" shape.  The default-on `branchflip`
+    pass then swaps the arms (the guard is the equality-to-zero form), so that
+    statement-carrying BlockIf lands in the else slot and the printer takes the
+    `else if` collapse path.
+
+    The collapse is a lazy brace: emit_block_if registers a pending brace and
+    cancels it only if the clause's condition emitted nothing.  kuna's port
+    asked the emitter "is ANY brace pending" where C++ asks
+    `emit->hasPendingPrint(&amp;pendingBrace)` - pointer identity against the
+    frame's own brace (decompiler/cpp/printc.cc, emitBlockIf).  So the FIRST
+    nested `if` inside the arm's condition block grabbed the ancestor's brace,
+    cancelled it, and rendered itself as the `else if`; the arm's own `if`
+    header then printed on a fresh line at the PARENT's indent, hoisting its
+    body out of the `else`:
+
+        if (opts &amp; 8)      p[0] = x;
+        else if (mode &amp; 2) p[1] = x;
+        if (mode &amp; 1)      p[2] = y;     &lt;- escaped the else arm
+
+    On cleanflight serialUART that put IOInit(rxIO)/IOConfigGPIOAF(rxIO) on the
+    SERIAL_BIDIR path, which the Thumb code never takes (800bab6 branches to
+    the BIDIR body at 800bb06, which falls straight through to the join at
+    800bb22, never reaching the RX guard at 800bada).
+
+    Stage model: S8 structure recovery (`branchflip` arm swap,
+    substrate/funcdata_block.rs block_if_flip_negated_guard) with the
+    rendering consequence in S9 emission (p9_emit/printc.rs emit_block_if
+    pending-brace ownership).  The tree is NOT corrupted by the swap - a
+    debug-only leaf-multiset assertion in block_if_flip_negated_guard now
+    polices that - the defect was entirely in the printer.
+
+    No option: this is a strict correctness fix (emitting a statement on a path
+    the machine code never takes is never desired), so `branchflip` stays
+    default-ON and the fix is unconditional.
+
+    armswap (0x100000):
+      int armswap(int opts,int mode,int x,int y,int *p) {
+          if (opts &amp; 8) p[0] = x;
+          else { if (mode &amp; 2) p[1] = x; if (mode &amp; 1) p[2] = y; }
+          return x + y; }
+      gcc -O0 x86-64.
+
+    Pass 1 (default, branchflip ON): the arms are swapped to the positive
+    guard AND the whole else arm stays nested - `else {` opening a real block
+    that holds both sibling ifs (asserts #1/#2/#3).
+    Pass 2 (option branchflip off): the un-flipped reference shape, both
+    siblings nested under the negated guard (assert #4).
+    Asserts #5/#6 are the regression guards: the `else if` collapse must not
+    appear at all in this function, and no sibling `if` may sit at the outer
+    (2-space) statement indent in either pass.
+-->
+<bytechunk space="ram" offset="0x100000" readonly="true">
+f30f1efa554889e5897dfc8975f88955f4894df04c8945e88b45fc83e00885c0740b488b45e8
+8b55f48910eb2e8b45f883e00285c0740d488b45e8488d50048b45f489028b45f883e00185c0
+740d488b45e8488d50088b45f089028b55f48b45f001d05dc3
+</bytechunk>
+<symbol space="ram" offset="0x100000" name="armswap"/>
+</binaryimage>
+<script>
+  <com>lo fu armswap</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>option branchflip off</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="BRANCHFLIP-ARMSWAP #1: the swapped guard reads positively (the flip still happens)" min="1" max="1">if \(a0 &amp; 8\) // branch-flip</stringmatch>
+<stringmatch name="BRANCHFLIP-ARMSWAP #2: the else arm opens a real block, not an else-if collapse" min="1" max="1">  else \{$
+^ {4}if \(a1 &amp; 2\)$</stringmatch>
+<stringmatch name="BRANCHFLIP-ARMSWAP #3: the second sibling if stays inside the arm in both passes" min="2" max="2">^ {4}if \(a1 &amp; 1\)$</stringmatch>
+<stringmatch name="BRANCHFLIP-ARMSWAP #4: branchflip off is the un-flipped reference, both siblings nested" min="1" max="1">if \(!\(a0 &amp; 8\)\) \{</stringmatch>
+<stringmatch name="BRANCHFLIP-ARMSWAP #5: no else-if collapse of a statement-carrying arm" min="0" max="0">else if</stringmatch>
+<stringmatch name="BRANCHFLIP-ARMSWAP #6: no sibling if escapes to the outer statement indent" min="0" max="0">^ {2}if \(a1 &amp; 1\)$</stringmatch>
+</decompilertest>


### PR DESCRIPTION
## The defect

A statement escaped its `else` arm and executed on the then-path too, so kuna
shipped **semantically wrong C** on a default-ON pass. Two independent witnesses,
both checked against the disassembly:

**cleanflight `serialUART` @0x800ba0c (ARM Thumb, O0).** kuna called
`IOInit(rxIO)` / `IOConfigGPIOAF(rxIO)` on the `SERIAL_BIDIR` path. The machine
code never takes it:

```
 800bab2: tst.w r8, #8
 800bab6: bne.n 0x800bb06        <- BIDIR arm
 800bada: tst.w r7, #1 ; beq 0x800bb22    <- RX guard (BIDIR never reaches it)
 800bb06-800bb20: BIDIR body, falls through to
 800bb22: <join>
```

```diff
       if (a3 & 8) { // branch-flip                <- options & SERIAL_BIDIR
         ...BIDIR body...
       }
-      else if ((a2 & 2) && (v2)) { ...TX... }
-      if ((a2 & 1) && (v3)) { ...RX... }          <- ESCAPED the else arm
+      else {
+        if ((a2 & 2) && (v2)) { ...TX... }
+        if ((a2 & 1) && (v3)) { ...RX... }
+      }
```

**iproute2 `ip netns_add` @0x281bb (x86-64, O0).** kuna read `argv[1]` and ran
`get_s32` on the create path; `2821d: jg 282e5` jumps straight past that block.
Same fix re-nests it.

Both witnesses were **re-derived on the rebased base** (`11f40f46`, i.e. with
#280 `funcboundflow` merged). `funcboundflow` bounds fall-through at a known
function entry and so could have moved a stripped-ARM boundary, but it did not
touch this one: the `serialUART` body is **byte-identical** between the pre-#280
build and the `11f40f46` base (both `sha1[:10] = 4343611222`, 68 lines, one
`else if`), so the disassembly correspondence above still holds verbatim. The
fixed build is the only one that differs (70 lines, zero `else if`).

## The filed root cause was wrong

The triage record named `Funcdata::block_if_flip_negated_guard`'s
`swap_blocks(sif, 1, 2)` as the site, on the theory that an arm which was a
`BlockList` of two `BlockIf`s lost its tail child. **It did not.** Dumping the
`sblocks` tree before and after the flip on `serialUART` shows a clean swap of
components 1 and 2 with every child intact, and nothing between the swap and
emission re-parents anything. The block tree is never corrupted; the defect is
entirely in the **printer**. It is also not architecture-specific (the record
reported three x86-64 reproducers that did not corrupt): a 12-line `gcc -O0`
x86-64 function reproduces it, and that is the stage test shipped here.

## The real mechanism

S8 folds a run of sibling guards into ONE `BlockIf` whose **condition
component** is a `BlockList` that leads with a whole `if` *statement* — the
standard Ghidra "condition block carries statements" shape. When `branchflip`
swaps the arms, that statement-carrying `BlockIf` lands in the else slot and
`PrintC::emit_block_if` takes the `else if` collapse path.

That collapse is a *lazy brace*: the clause frame registers a brace that opens
at the first line break, and cancels it if nothing forced one. Upstream decides
with `emit->hasPendingPrint(&pendingBrace)` — a **pointer-identity** test
against the frame's own `PendingBrace`. kuna's port asked the emitter "is *any*
brace pending", so the first nested `if` inside the clause's condition block
grabbed the ancestor's brace, cancelled it, rendered **itself** as the `else if`,
and left the real clause's `if` header on a fresh line at the parent's indent —
hoisting its body out of the arm.

## The fix

Only the frame whose registration is still the active one (generation-stamp
match, kuna's existing stand-in for C++ pointer identity) may cancel and
collapse. Strict bug fix per `docs/agents.md`, **no option**: `branchflip` stays
default-ON, and `branchflip off` was only ever a workaround. No default changes,
so **no DIV row** (and no catalog counters move: 96 settables on both sides).

## Guard rails (debug-only, zero cost in release) — and what they caught

* **`PrintC::emit_block_if`** asserts that every registered pending brace is
  resolved by its own frame — fired or self-cancelled.
* **`Funcdata::block_if_flip_negated_guard`** asserts that the multiset of leaf
  components reachable under the `BlockIf` is unchanged across the flip, since
  the flip is a pure arm swap. This is the guard rail the triage asked for; it
  polices the whole arm-rearranging family. It does **not** fire here, which is
  itself the evidence that the tree was never the problem.

Both were verified rather than assumed. Applying **only the printer assertion**
(not the fix) to the unfixed `11f40f46` base and running every corpus file
through it, the assertion **fires on 3 of the 195 files** — and two of them are
**pre-existing instances already in kuna's own corpus that no assertion covered**:

| file | before the fix |
|---|---|
| `tests/stages/switchsharedcase-b2sum.xml` | four statements incl. `goto label_401403` / `goto label_401572` chains escape the `else` arm |
| `tests/stages/ghangr-x8664-cvs-863633.xml` | a labelled `label_4059c4:` block and its body escape the `else` arm |
| `tests/stages/ghdec-branchflip-armswap.xml` | the new reproducer |

On the fixed tree the same corpus (112 stages + 83 datatests = 195 files,
413 + 675 assertions) runs under both assertions with **0 firings**, and the
whole debug workspace suite (4,540 tests) passes with them live.

## Corpus sweep (standing requirement 8)

Re-run against a **base binary built at `11f40f46`** so the A/B isolates this fix
on the current base rather than conflating it with #280. `decompile-all`, base vs
branch, over **155 decbench binaries / 86,634 functions** — x86-64 ELF at
O0/O2/O2-noinline, ARM Cortex-M firmware, i386 PE:

| arch | binaries | functions | changed |
|---|---|---|---|
| x86-64 ELF | 117 | 48,733 | 324 (0.66%) |
| ARM Cortex-M | 26 | 36,870 | 111 (0.30%) |
| i386 PE | 12 | 1,031 | 0 |
| **total** | **155** | **86,634** | **435 (0.50%)** |

Every one of the 435 was re-decompiled with both binaries and classified:

* **435/435 byte-identical after stripping all whitespace and all braces** — no
  statement added, removed, reordered or altered. The only change is bracing and
  indentation.
* **435/435 carry the exact expected signature** (an `else if` becoming a braced
  `else {`).
* **435 nest strictly deeper, 0 shallower, 0 brace-balance changes.**

(The earlier sweep against the pre-#280 base gave 441 changed with the same
verdict; the 6-function difference is #280's own effect on which bodies exist.)

## Speed

Interleaved min-of-13 on an idle box (load 3.6), base `11f40f46` vs branch — no
option to flip, so this is `scripts.pipeline.timeit`'s binary-flip analogue:

| case | min-of-13 | median |
|---|---|---|
| cleanflight serialUART, one function | -0.49% | +0.30% |
| iproute2 netns_add, one function | +0.01% | +0.23% |
| `decompile-all` coreutils sort | -0.12% | -0.02% |
| `decompile-all` crazyflie CMSIS_DAP | -0.13% | +0.01% |

Within the 5% budget — the change is two integer comparisons per `BlockIf`.

## Ships with

* `tests/stages/ghdec-branchflip-armswap.xml` — two-pass end-to-end testcase on a
  12-line x86-64 reproducer. 4 of its 6 asserts **fail on the pre-fix binary** and
  all 6 pass after. Corpus file count in `kuna-base/src/xml.rs` re-derived from the
  tree (83 datatests + 112 stages = **195**, not by arithmetic) and
  `docs/baseline-stages.json` re-recorded (407 -> 413, additions only — no existing
  key moved).
* Spec prose: `docs/spec/09-emission.md` gains a *Pending-brace ownership*
  paragraph (the normative rule); `docs/spec/08-structuring.md` records the
  arm-swap leaf-multiset invariant and points at it.
* No option, no DIV row, no catalog counter changes.

## Gates (verbatim, on this exact tree, rebased onto `11f40f46`)

```
$ make test
datatests: 675/675 assertions passed
exit: 0

=== baseline parity ===
PARITY OK

$ make test-stages
datatests: 413/413 assertions passed
exit: 0

=== baseline parity ===
PARITY OK

$ make rust-test
MAKE_EXIT=0
workspace suite: 4540 passed; 0 failed; 37 ignored

$ make check-spec
check-spec OK (lenient mode)

$ kuna catalog --check
catalog OK: documents exactly the registered kuna options
```

Note for whoever merges the sibling option PRs (#281 `guardarm`, #283
`loopcondhoist`): each bumps settables 96 -> 97 and the corpus file count, so
this PR will conflict with them on `kuna-base/src/xml.rs` and
`docs/baseline-stages.json`. Resolve by re-deriving both from the merged tree,
not by hand-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8UQbPqALzdUQ3cLLjUeKH
