### PR TITLE
[AUTOMATED] fix(tests): catalog_bytecompat asserted 102 settables against a 103-row table

### DIFF
--- a/decompiler/crates/kuna-decomp/src/p0_knowledge/kuna_phases/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/p0_knowledge/kuna_phases/tests.rs
@@ -25,7 +25,7 @@ fn subphase_count_is_43() {
 }
 
 #[test]
-fn surface_count_is_101() {
+fn surface_count_is_102() {
     // +1 for the `option switchguardbound` surface row (angr missing-function-call),
     // +1 for the `option switchsharedcase` surface row (angr shared-case-node b2sum),
     // +1 for the `option switchmultipred` surface row (angr abnormal-switch-case-case3),

--- a/decompiler/crates/kuna-decomp/tests/catalog_bytecompat.rs
+++ b/decompiler/crates/kuna-decomp/tests/catalog_bytecompat.rs
@@ -76,14 +76,14 @@ fn fixture_has_no_current_field() {
 }
 
 #[test]
-fn fixture_has_all_102_settables() {
+fn fixture_has_all_103_settables() {
     // One `"option":` per settable row; the authoritative per-option list is
     // phases.toml settableTable (counts asserted in kuna_phases/tests.rs).
-    assert_eq!(FIXTURE.matches("\"option\": ").count(), 102);
+    assert_eq!(FIXTURE.matches("\"option\": ").count(), 103);
     // Every row carries the tier field appended after change_kind.
-    assert_eq!(FIXTURE.matches("\"tier\": ").count(), 102);
+    assert_eq!(FIXTURE.matches("\"tier\": ").count(), 103);
     // ... and the symptoms array appended after tier (C3).
-    assert_eq!(FIXTURE.matches("\"symptoms\": ").count(), 102);
+    assert_eq!(FIXTURE.matches("\"symptoms\": ").count(), 103);
 }
 
 #[test]


### PR DESCRIPTION
## What

`make rust-test` is red on `main` and has been since #287 merged.

#287 (`ifuncfpret`) added the 103rd `settableTable` row and bumped two of the three
hard-coded counters — `phases.toml` and `kuna_phases/tests.rs` — but not
`tests/catalog_bytecompat.rs`:

```
test fixture_has_all_102_settables ... FAILED
assertion `left == right` failed
  left: 103
 right: 102
```

CI did not catch it: internal PRs skip the workspace suite (#274), which leaves the
author as that gate.

## Changes

- `tests/catalog_bytecompat.rs` — the three `102` asserts (`"option"`, `"tier"`,
  `"symptoms"`) become `103`, and the test is renamed to match.
- `kuna_phases/tests.rs` — renames `surface_count_is_101`, which has asserted `102`
  since the surface table last grew, so the name stops contradicting the body.

Counts only; no production code touched.

## Verification

```
cargo test -p kuna-decomp --test catalog_bytecompat
test result: ok. 5 passed; 0 failed
```

Found while starting work on inline-identification/outlining, which adds two more
settable rows and would otherwise have inherited a red gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTrU5w3qoWMyu38FprpfXZ