### PR TITLE
[AUTOMATED] fix(test): catalog_bytecompat was left at 102 settables while the catalog is 103

### DIFF
--- a/decompiler/crates/kuna-decomp/tests/catalog_bytecompat.rs
+++ b/decompiler/crates/kuna-decomp/tests/catalog_bytecompat.rs
@@ -76,14 +76,14 @@ fn fixture_has_no_current_field() {
 }
 
 #[test]
-fn fixture_has_all_102_settables() {
+fn fixture_has_all_103_settables() {
     // One `"option":` per settable row; the authoritative per-option list is
     // phases.toml settableTable (counts asserted in kuna_phases/tests.rs).
-    assert_eq!(FIXTURE.matches("\"option\": ").count(), 102);
+    assert_eq!(FIXTURE.matches("\"option\": ").count(), 103);
     // Every row carries the tier field appended after change_kind.
-    assert_eq!(FIXTURE.matches("\"tier\": ").count(), 102);
+    assert_eq!(FIXTURE.matches("\"tier\": ").count(), 103);
     // ... and the symptoms array appended after tier (C3).
-    assert_eq!(FIXTURE.matches("\"symptoms\": ").count(), 102);
+    assert_eq!(FIXTURE.matches("\"symptoms\": ").count(), 103);
 }
 
 #[test]


### PR DESCRIPTION
`main` is red on the cargo workspace suite at 80f8f290:

```
thread 'fixture_has_all_102_settables' panicked at
crates/kuna-decomp/tests/catalog_bytecompat.rs:82:5:
assertion `left == right` failed
  left: 103
 right: 102
```

Nothing is wrong with the catalog. `phases.toml` has 103 settable rows, the fixture
`tests/fixtures/phase_catalog.json` carries 103, and `kuna_phases/tests.rs` correctly
asserts 103. Only this one test's three hard-coded copies of the same number were left
behind: #287 regenerated the fixture and bumped `kuna_phases/tests.rs`, but did not touch
`catalog_bytecompat.rs`, which #290 had last set to 102.

Exactly one test failed in the whole CI run and the spec-tree guards never fired, so this
assert is the entire breakage. The diff is four lines in one file.

## Why this keeps happening

Fourth break of this counter class in two days. Three of the four were during the round-4
merge train, where `main` and a branch had made the identical `N -> N+1` edit and git
auto-merged them **silently at the wrong value with no conflict marker** — in one case the
file did not even appear in `git status`. It reaches `main` because the workspace suite is
skipped for internal PRs (#274), so nothing runs it until after the merge.

## Gates (clean worktree at 22d56232, real exit codes)

```
make test        -> TEST_EXIT=0        675/675  PARITY OK
make test-stages -> STAGES_EXIT=0               PARITY OK
make check-spec  -> SPEC_EXIT=0                 OK (lenient + strict)
kuna catalog --check                            catalog OK
kuna catalog --markdown vs docs/options.md      byte-identical
make rust-test                                  running; will confirm before merge
```

`docs/baseline.json` untouched.

## Recommendation, deliberately NOT in this diff

`fixture_has_all_N_settables` is the only one of these counters that is pure redundancy.
The test directly above it, `catalog_bytes_match`, already does `assert_eq!(rust, FIXTURE)`
against the live catalog — so a fixture that disagrees with the code fails there regardless,
and this test's own comment already defers authority elsewhere ("the authoritative per-option
list is phases.toml settableTable (counts asserted in kuna_phases/tests.rs)"). Its three
constants can only produce false failures.

Deriving them from `kuna_num_settables()` — which this same file already calls twelve lines
later — would remove one recurring breakage without weakening the intentional tripwire in
`kuna_phases/tests.rs`. Left out because the hard-coded counts are a deliberate convention
here and that is the maintainer's call. It is a three-line change if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8UQbPqALzdUQ3cLLjUeKH