### PR TITLE
[AUTOMATED] fix(p8): emitted wrong C two ways - no prototype model, and an invisible return-value live-out

### DIFF
--- a/decompiler/crates/kuna-base/src/xml.rs
+++ b/decompiler/crates/kuna-base/src/xml.rs
@@ -1737,7 +1737,7 @@ mod tests {
         // short-circuit (option off = the guard cascade, on = the folded condition)
         // and kuna-evalcurrentproto / the compiler spec's <eval_current_prototype>
         // model recovers a __fastcall function's ECX/EDX arguments
-        assert_eq!(count, 201, "corpus file count drifted");
+        assert_eq!(count, 202, "corpus file count drifted");
     }
 
     /// ~20 representative SLEIGH spec files across varied processors

--- a/decompiler/crates/kuna-decomp/src/p8_structure/kuna_outline.rs
+++ b/decompiler/crates/kuna-decomp/src/p8_structure/kuna_outline.rs
@@ -436,6 +436,55 @@ fn op_output(data: &Funcdata, op: OpId) -> Option<Store> {
     store_of(data, out)
 }
 
+
+/// Does any continuation block end in a `RETURN`?
+fn continuation_returns(data: &Funcdata, cont: &BTreeSet<BlockId>) -> bool {
+    cont.iter().any(|&bl| {
+        data.bb_ops(bl).iter().any(|&op| {
+            data.obank().get(op).map(|o| o.code() == OpCode::CPUI_RETURN).unwrap_or(false)
+        })
+    })
+}
+
+/// Storage the region wrote that the continuation never redefines and that is a
+/// plausible return value.
+///
+/// Restricted to the storage the *containing function's own prototype* names as its
+/// output, so this cannot invent a result for a void function. Returns `None` when
+/// the function has no output storage or the region did not write it.
+fn returned_storage(
+    data: &Funcdata,
+    members: &BTreeSet<BlockId>,
+    cont: &BTreeSet<BlockId>,
+) -> Option<Store> {
+    let out = data.get_func_proto().get_output();
+    let addr = out.get_address().clone();
+    let size = out.get_size();
+    if size <= 0 {
+        return None;
+    }
+    let space = addr.get_space()?.clone();
+    let key = (space.get_index(), addr.get_offset(), size);
+
+    let wrote = members.iter().any(|&bl| {
+        data.bb_ops(bl)
+            .iter()
+            .any(|&op| op_output(data, op).map(|st| st.key == key).unwrap_or(false))
+    });
+    if !wrote {
+        return None;
+    }
+    let redefined = cont.iter().any(|&bl| {
+        data.bb_ops(bl)
+            .iter()
+            .any(|&op| op_output(data, op).map(|st| st.key == key).unwrap_or(false))
+    });
+    if redefined {
+        return None;
+    }
+    Some(Store { key, space, offset: addr.get_offset(), size })
+}
+
 /// Does any member block hold a call or a store this pass will not reason about?
 fn has_unmodelled_side_effect(data: &Funcdata, members: &BTreeSet<BlockId>) -> bool {
     for &bl in members {
@@ -521,7 +570,24 @@ fn outline_one(data: &mut Funcdata, run: &OutlineRun) -> KunaResult<bool> {
     // re-entering the region.  A read BEFORE the region (the entry block's own
     // flag test, say) is not a live-out, and counting it rejected every region.
     let cont = reachable_from(data, exit_bl, &members);
-    let (live_in, live_out) = region_liveness(data, &members, &cont);
+    let (live_in, mut live_out) = region_liveness(data, &members, &cont);
+
+    // Pre-SSA the RETURN op does not yet carry the return VALUE as an input - return
+    // storage is recovered later - so a region whose only live-out is the value the
+    // function returns shows zero live-outs, and excising it silently drops the
+    // result.  That is an UNDER-approximation, the one direction the liveness is not
+    // allowed to err in.  Found by the coreutils LLM evaluation on two independent
+    // `du` witnesses, both reporting "0 result(s)" for a region computing the return.
+    //
+    // If the continuation can reach a RETURN, treat storage the region wrote and the
+    // continuation never redefines as potentially returned, and fold it in.  Pushing
+    // past one live-out simply declines, which is the safe outcome.
+    if !live_out.iter().any(|_| true) && continuation_returns(data, &cont) {
+        let maybe = returned_storage(data, &members, &cont);
+        if let Some(st) = maybe {
+            live_out.push(st);
+        }
+    }
     if live_out.len() > 1 {
         return Ok(false);
     }
@@ -555,15 +621,28 @@ fn outline_one(data: &mut Funcdata, run: &OutlineRun) -> KunaResult<bool> {
 
     let mut fc = FuncCallSpecs::new(callop, head_addr.clone());
     fc.set_funcdata(head_addr.clone(), &name)?;
-    // A hand-built FuncCallSpecs has no prototype store, and every later query
-    // (`FuncProto::store`) panics on the null.  The decoder-produced call specs get
-    // theirs from ActionDefaultParams; give this one the same no-symbol-scope
-    // internal store directly.
+    // A hand-built FuncCallSpecs has neither a prototype store nor a MODEL.
+    //
+    // `attach_internal_store` alone is not enough and the difference is not cosmetic:
+    // it installs the store and leaves `model = None` (`p4_calls/fspec.rs:5081`),
+    // whereas `set_internal` (`:5000`) installs the store *and* the model.  Without a
+    // model the call has no known stack-pointer effect, and `ActionDefaultParams`
+    // does not repair it because this spec already reports a known callee.  The
+    // observable damage is in the code the region never touched: stack-pointer
+    // normalization fails for the calls that FOLLOW the outlined one, raw `RSP` leaks
+    // into the C as `&Stack...`, and a later `memcpy` prints with four arguments.
+    // Found by the coreutils LLM evaluation on `factor::lbuf_putc`.
     let void_ty = match data.get_arch().types().map(|t| t.get_type_void()) {
         Some(Ok(t)) => t,
         _ => return Ok(false),
     };
-    fc.proto_mut().attach_internal_store(void_ty);
+    let model = match data.get_arch().eval_fp_called().cloned() {
+        Some(m) => m,
+        // No default model registered (hand-built fixture): decline rather than
+        // synthesize a call whose stack effect is unknown.
+        None => return Ok(false),
+    };
+    fc.proto_mut().set_internal(model, void_ty);
     let idx = data.push_call_specs(fc);
     let handle = crate::flow::next_fspec_handle();
     let angr = data.get_arch().name_style_angr;

--- a/docs/baseline-stages.json
+++ b/docs/baseline-stages.json
@@ -1,7 +1,7 @@
 {
   "data_footer": [
-    443,
-    443
+    449,
+    449
   ],
   "passing": [
     "data:BRANCHFLIP #1: default pipeline keeps the negated `== 0` guard (opt-in is default-off)",
@@ -350,6 +350,12 @@
     "data:outline #5: ON - the excised body is gone, so its multiply appears in pass 1 only",
     "data:outline #6: the surrounding function is untouched in both passes (off plus on = 2)",
     "data:outline #7: the guard that reaches the region is untouched in both passes (off plus on = 2)",
+    "data:outline-proto #1: OFF is the bug - the region is inline (pass 1 only)",
+    "data:outline-proto #2: ON - the region becomes one call, and the RETURN VALUE is recovered as its result, not dropped (pass 2 only)",
+    "data:outline-proto #3: ON - the report shows one argument AND one result; a 0-result banner here is defect 2 (pass 2 only)",
+    "data:outline-proto #4: the call AFTER the region keeps exactly one argument in both passes - defect 1 gave it stack junk (off plus on = 2)",
+    "data:outline-proto #5: no raw stack pointer leaks into the C in either pass - defect 1 emitted `&Stack...`",
+    "data:outline-proto #6: no rsp-typed local is introduced in either pass - defect 1 emitted `// rsp`",
     "data:paramcopyhoist #1: option off sinks the second parameter's copy-shadow below the first guard (gap reproduced)",
     "data:paramcopyhoist #2: option on anchors both copy-shadows in the entry block, ahead of every guard",
     "data:paramcopyhoist #3: both passes keep the guard writing NULL through each parameter",

--- a/docs/spec/08-structuring.md
+++ b/docs/spec/08-structuring.md
@@ -1165,3 +1165,31 @@ It does not emit a pseudofunction **body**. There is no seam:
 `PrintC::doc_function_full` is one `Funcdata` per document. The call is emitted and
 named; the bytes remain in the binary and can be decompiled separately at the head
 address.
+
+### Measured coverage on real code
+
+An LLM-driven evaluation over 15 coreutils `-O2` functions — agents read the
+decompiled C plus the disassembly, chose a region, and applied the option — outlined
+**0 of 15**, on cases selected so that a DWARF-confirmed inlined callee spanning at
+least two whole basic blocks existed in every one. Two of those failures were the
+pass emitting wrong C (both fixed, and pinned by
+`tests/stages/kuna-outline-proto.xml`); the rest were correct declines against two
+classes v1 cannot take at all:
+
+* **Multi-exit inlines.** The compiler routinely fuses a callee's return-value
+  dispatch into the caller's control flow, so the inlined body has two exits reaching
+  two different places. No single join block exists, so no `exit` address bounds the
+  region and `kuna_check_region` can never accept it.
+  `__xargmatch_internal` — present in every coreutils binary — is this shape: the
+  inlined `argmatch_exact` scan exits both to the "not found" tail and to the
+  "return the index" tail.
+* **Regions containing a genuine external call** (`strcmp`, `error`, `dcgettext`).
+  Correctly refused; a function that is mostly I/O has no outlinable region at all.
+
+These sit on top of the 63.8% of inlined instances that span fewer than two whole
+basic blocks and are unaddressable by any block-set method. Taken together, the
+single-entry/single-exit/one-live-out model fits the stage witness and comparatively
+little real optimized code. Widening it — multi-exit regions returning a value through
+a caller-side branch, and a purity allowlist so compiler intrinsics such as
+`__addvsi3` under `-ftrapv` stop blocking otherwise-clean regions — is the work that
+would make the transform generally applicable.

--- a/tests/stages/kuna-outline-proto.xml
+++ b/tests/stages/kuna-outline-proto.xml
@@ -1,0 +1,71 @@
+<decompilertest>
+<binaryimage arch="x86:LE:64:default:gcc">
+<!--
+    Regression witness for two wrong-output defects in the S8 `outline` pass, both
+    found by an LLM-driven evaluation over coreutils O2 functions (an agent chose
+    regions from the decompiled C and applied the outline option).  Neither was
+    caught by tests/stages/kuna-outline.xml, because that witness has no call after
+    the region and does not return the region's value.
+
+    DEFECT 1 - the synthesized call had a STORE but no prototype MODEL.
+    `outline_one` called `FuncProto::attach_internal_store`, which installs a
+    ProtoStoreInternal and leaves `model = None` (p4_calls/fspec.rs:5081); the
+    sibling `set_internal` (:5000) installs the store AND the model, and that is
+    what ActionDefaultParams uses for an unknown callee.  With no model the
+    synthesized call has no known stack-pointer effect, and the damage lands in
+    code the region never touched: stack-pointer normalization fails for the calls
+    that FOLLOW the outlined one, raw RSP leaks into the C as Stack-address text, return
+    addresses are stored into locals, and on coreutils/factor::lbuf_putc a later
+    `memcpy` printed with FOUR arguments.  Fixed by calling `set_internal`.
+
+    DEFECT 2 - a live-out that is the function's RETURN VALUE was invisible.
+    Pre-SSA the RETURN op does not yet carry the return value as an input (return
+    storage is recovered later), so a region whose only live-out is the returned
+    value measured ZERO live-outs and was excised, silently dropping the result -
+    an UNDER-approximation, the one direction the liveness must never err in.
+    Two independent coreutils/du witnesses reported "0 result(s)" for regions
+    computing the return.  Fixed by folding the containing function's own output
+    storage into live-out when the continuation can reach a RETURN.
+
+    THE WITNESS.  A three-block region whose value flows on into BOTH a following
+    call and the return:
+
+        reg:    ebx = edi ; if (esi == 0) goto JOIN
+        BODY:   ebx += 7 ; if (ebx is at most 50) goto BODY2 ; ebx -= 3
+        BODY2:  ebx *= 3
+        JOIN:   edi = ebx ; call helper ; eax += ebx ; ret
+
+    The `call helper` after the join is what defect 1 corrupted.
+
+    PASS 1 (`option outline off`, the default) = the region inline.
+    PASS 2 (region supplied) = one call, and - critically - `helper` still takes
+    exactly one argument and no stack artefact appears anywhere.
+
+    Asserts are counted across BOTH passes, so a token appearing once per pass
+    asserts min=max=2 and a token unique to one pass asserts min=max=1.
+-->
+<bytechunk space="ram" offset="0x401000">
+f30f1efa5389fb85f6740e83c30783fb327e0383eb036bdb0389dfe80400000001d85bc38d4701c3
+</bytechunk>
+<symbol space="ram" offset="0x401000" name="reg"/>
+<symbol space="ram" offset="0x401024" name="helper"/>
+</binaryimage>
+<script>
+  <com>option warnstyle banner</com>
+  <com>option outline off</com>
+  <com>lo fu reg</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>option outline 0x401000:0x40100b-0x401019</com>
+  <com>lo fu reg</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="outline-proto #1: OFF is the bug - the region is inline (pass 1 only)" min="1" max="1">v1 = a0 \+ 7;</stringmatch>
+<stringmatch name="outline-proto #2: ON - the region becomes one call, and the RETURN VALUE is recovered as its result, not dropped (pass 2 only)" min="1" max="1">a0 = outlined_0x40100b\(a0\);</stringmatch>
+<stringmatch name="outline-proto #3: ON - the report shows one argument AND one result; a 0-result banner here is defect 2 (pass 2 only)" min="1" max="1">outline: excised 3 block\(s\) at 0x40100b into outlined_0x40100b\(\) \(1 argument\(s\), 1 result\(s\)\)</stringmatch>
+<stringmatch name="outline-proto #4: the call AFTER the region keeps exactly one argument in both passes - defect 1 gave it stack junk (off plus on = 2)" min="2" max="2">return helper\(a0\) \+ a0;</stringmatch>
+<stringmatch name="outline-proto #5: no raw stack pointer leaks into the C in either pass - defect 1 emitted `&amp;Stack...`" min="0" max="0">Stack[0-9a-f]{8}</stringmatch>
+<stringmatch name="outline-proto #6: no rsp-typed local is introduced in either pass - defect 1 emitted `// rsp`" min="0" max="0">// rsp</stringmatch>
+</decompilertest>


### PR DESCRIPTION
Two **wrong-output** defects in the `outline` pass merged by #294, both found by an LLM-driven evaluation over coreutils `-O2` functions and both fixed here.

## How they were found

Agents were given kuna's decompiled C plus the function's disassembly for 15 coreutils functions, asked to choose a region that looked inlined, and to apply `option outline` — the exact workflow the `outlining` skill documents. Every case was winnable by construction: each had a DWARF-confirmed inlined callee spanning ≥2 whole basic blocks.

**0 of 15 succeeded.** Two of the failures were the pass emitting wrong C rather than declining.

## Defect 1 — the synthesized call had a store but no prototype model

`outline_one` called `FuncProto::attach_internal_store`, which installs a `ProtoStoreInternal` and leaves `model = None` (`p4_calls/fspec.rs:5081`). The sibling `set_internal` (`:5000`) installs the store **and** the model, and is what `ActionDefaultParams` uses for an unknown callee — it does not repair this spec, because the spec already reports a known callee.

With no model the call has no known stack-pointer effect, and the damage lands in **code the region never touched** — stack-pointer normalization fails for the calls that *follow* the outlined one. On `coreutils/factor::lbuf_putc`, outlining `0x37dc-0x37f4` made the untouched tail gain:

```c
v3 = &Stackffffffffffffffe8;                              // raw RSP in the C
*(unsigned long *)&v3[-8] = 0x3803;                       // return-address store
v2 = memcpy(dat_150f0,v5,(int8)v4 - (int8)v5,v3[-8]);     // memcpy with FOUR args
```

Fixed by calling `set_internal(model, void_ty)` with the architecture's `eval_fp_called` model, declining when no default model is registered.

## Defect 2 — a live-out that is the function's return value was invisible

Pre-SSA the `RETURN` op does not yet carry the return value as an input (return storage is recovered later), so a region whose only live-out is the returned value measured **zero** live-outs and was excised, silently dropping the result.

That is an **under**-approximation — the one direction this liveness must never err in, and the module header explicitly claimed it could not happen ("Over-approximating can only cause extra declines, never a wrong excision"). Two independent `coreutils/du` witnesses reported `0 result(s)` for regions computing the return; on `0xebc0` the function afterwards returned an unrelated pointer.

Fixed by folding the containing function's own output storage into live-out when the continuation can reach a `RETURN`, gated on the region having written that storage and the continuation never redefining it. Pushing past one live-out simply declines.

## Regression witness

`tests/stages/kuna-outline-proto.xml` — a region whose value flows into **both** a following call and the return. The existing `kuna-outline.xml` has neither property, which is exactly why it caught neither defect. Six assertions, two of which must match **zero** times in both passes (no `Stack` text, no rsp-typed local).

Incidental gotcha for future stage tests: `--` is illegal inside an XML comment and kuna's parser enforces it, so a comment cannot spell an option with its leading dashes.

## What the evaluation says about coverage

Recorded in `docs/spec/08-structuring.md` §8.5 rather than left implicit. Two classes are structurally unreachable for v1, and they dominate real `-O2` code:

- **Multi-exit inlines** — the compiler fuses a callee's return-value dispatch into the caller's control flow, so the body has two exits to two different places. No single join exists, so no `exit` address bounds it. `__xargmatch_internal` is this shape in every coreutils binary (10 of the 15 cases).
- **Regions containing a genuine external call** (`strcmp`, `error`, `dcgettext`). Correctly refused.

Those sit on top of the 63.8% of inlined instances spanning fewer than two whole blocks. The single-entry/single-exit/one-live-out model fits the stage witness and comparatively little real optimized code; widening it (multi-exit regions, and a purity allowlist so `__addvsi3` under `-ftrapv` stops blocking clean regions) is what would make the transform generally applicable.

## Separately: the CLI swallows malformed option values

`kuna decompile --option outline 0xecf0:zzz-0xed37` exits 0 with no diagnostic and output byte-identical to a legitimate decline. `OptionOutline::apply` *does* reject it, but the CLI discards `decomp_dbg`'s stderr unless the whole run fails (`kuna-cli/src/decompile.rs` `check_errors`). This is general `--option` laxity — `--option notarealoption 1` is also accepted silently — so it is **not** fixed here, but it is poisonous for this workflow specifically: a typo'd address is indistinguishable from the conservative decline the user is trying to reason about. Worth its own PR.

## Gates

| gate | result |
|---|---|
| `make test` | **PARITY OK** 675/675 |
| `make test-stages` | **PARITY OK** 449/449 (6 new) |
| `make rust-test` | 4,565 passed, 0 failed |
| `make check-spec` | OK, lenient and `--strict` |
| `kuna catalog --check` | catalog OK |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTrU5w3qoWMyu38FprpfXZ
