### PR TITLE
[AUTOMATED] feat(web): the browser UI could not ask for more than `fast` on a large binary

### DIFF
--- a/docs/web-integration.md
+++ b/docs/web-integration.md
@@ -98,6 +98,17 @@ reach a function, so an entry the inventory omits is a function the UI cannot op
 mode with no discovery overrides of its own; `aggressive` already turns all three on and
 `fast` turns all three off, so those two were consistent before and after.
 
+That makes the mode a *product* decision in the browser, not just a speed dial, so the
+page exposes it: a **Mode** control beside the file picker (`auto` — the default — plus
+`fast` / `reliable` / `aggressive`), whose value is passed to `kuna.load` and carried by
+the Worker session to `list`, `decompile` and `project` alike. Changing it re-indexes the
+binary already loaded, because the mode changes the inventory itself and a sidebar that
+disagrees with the bodies below it would be worse than either. Without the control a
+binary at or above 2 MiB was pinned to `fast` with no way to ask for more: on a 3.4 MB
+i386 PE the browser listed **3,495** functions where `reliable` finds **14,014** (IDA Pro
+finds 14,576), and the page held the only copy of the uploaded bytes, so there was nowhere
+else to go.
+
 Unfiltered `decompile` and `project` use the shared CODE-backed target set, while
 explicit address decompile suppresses that whole-image discovery pass and
 reaches the requested entry directly. Name selection keeps discovery active so

--- a/integrations/web/assets/css/site.css
+++ b/integrations/web/assets/css/site.css
@@ -264,6 +264,12 @@ body.app main{flex:1 1 auto;min-height:0;display:flex;flex-direction:column;}
 .tinybtn.primary{background:var(--ink);border-color:var(--ink);color:var(--paper);}
 .tinybtn.primary:hover:not([aria-disabled=true]){background:var(--red);border-color:var(--red);}
 .tinybtn input[type=file]{display:none;}
+.tinybtn.modepick{display:inline-flex;align-items:center;gap:8px;cursor:default;}
+.tinybtn.modepick:hover{background:var(--paper);border-color:var(--rule-2);color:var(--ink);}
+.tinybtn.modepick select{
+  font:inherit;letter-spacing:inherit;text-transform:inherit;
+  border:0;background:transparent;color:inherit;cursor:pointer;padding:0;
+}
 
 /* the two-pane workspace */
 .work{flex:1 1 auto;min-height:0;display:grid;grid-template-columns:290px minmax(0,1fr);}

--- a/integrations/web/decompile/index.html
+++ b/integrations/web/decompile/index.html
@@ -32,6 +32,15 @@
       <p class="status busy" id="status" role="status" aria-live="polite"><span class="dot"></span>loading decompiler&hellip;</p>
       <button class="tinybtn" id="cancelbtn" disabled>Cancel</button>
       <button class="tinybtn" id="dlbtn" disabled>Download binary source</button>
+      <label class="tinybtn modepick" id="modelabel" title="How hard the engine works: auto picks by binary size (fast above 2 MiB, which turns the discovery passes off)">
+        Mode
+        <select id="mode">
+          <option value="auto" selected>auto</option>
+          <option value="fast">fast</option>
+          <option value="reliable">reliable</option>
+          <option value="aggressive">aggressive</option>
+        </select>
+      </label>
       <label class="tinybtn primary" id="pick" aria-disabled="true">
         Load binary <input type="file" id="file">
       </label>
@@ -103,6 +112,7 @@
   const statusEl = document.getElementById('status');
   const pickEl = document.getElementById('pick');
   const fileEl = document.getElementById('file');
+  const modeEl = document.getElementById('mode');
   const listEl = document.getElementById('fnlist');
   const headEl = document.getElementById('fnhead');
   const codeEl = document.getElementById('code');
@@ -226,9 +236,13 @@
     console.error(e);
   }
 
-  fileEl.addEventListener('change', async () => {
-    const f = fileEl.files[0];
+  // The File the inventory was built from, so changing the mode can re-index the
+  // same binary without asking for it again. A File is a handle, not the bytes.
+  let loadedFile = null;
+
+  async function indexBinary(f) {
     if (!f || !kuna) return;
+    loadedFile = f;
     const operation = beginOperation('load', true);
     setStatus(`reading ${f.name}…`);
     resetList();
@@ -243,7 +257,7 @@
       const bytes = new Uint8Array(await f.arrayBuffer());
       if (!isCurrent(operation)) return;
       setStatus(`indexing ${f.name} (${bytes.length.toLocaleString()} bytes)…`);
-      result = await kuna.load(bytes, { fileName: f.name, mode: 'auto' });
+      result = await kuna.load(bytes, { fileName: f.name, mode: modeEl.value });
     } catch (e) {
       if (!isCurrent(operation)) return;
       setStatus('function inventory failed: ' + e.message, 'err');
@@ -301,6 +315,15 @@
     const first = rows.find((r) => !r.stub) || rows[0];
     finishOperation(operation);
     if (first) first.row.click();
+  }
+
+  fileEl.addEventListener('change', () => indexBinary(fileEl.files[0]));
+
+  // The mode decides how much discovery runs, so it changes the inventory
+  // itself, not just how hard each body is worked: re-index the binary already
+  // loaded rather than leave a sidebar that disagrees with the bodies below it.
+  modeEl.addEventListener('change', () => {
+    if (loadedFile) indexBinary(loadedFile);
   });
 
   dlEl.addEventListener('click', async () => {


### PR DESCRIPTION
## The gap

The page hard-codes `mode: 'auto'`, and `auto` resolves by input size: **at or above 2 MiB it selects `fast`**, which turns the discovery passes off. In the browser the sidebar is the *only* way to reach a function, so on a 3.4 MB i386 PE the inventory was **3,495** functions where `reliable` finds **14,014** (IDA Pro, for reference, finds 14,576). And because the page holds the only copy of the uploaded bytes, there was nowhere else for a user to go — no flag, no CLI, no re-upload that would help.

## The change

The mode plumbing already ran end to end — `kuna.load(bytes, {mode})` → `session.mode` → `list` / `decompile` / `project` in the Worker. Only a **control** was missing:

- a `Mode` select beside the file picker (`auto` | `fast` | `reliable` | `aggressive`, defaulting to `auto`), passed straight to `kuna.load`;
- changing it **re-indexes the binary already loaded** — the mode changes the inventory itself, so leaving a sidebar that disagrees with the bodies below it would be worse than either state;
- the load handler becomes a named `indexBinary(file)` that both the file input and the mode control call, and the page keeps the `File` **handle** (not a second copy of the bytes), so a re-index costs nothing until it runs.

No engine change — the wasm binary is untouched by this commit; it is HTML + CSS + one doc section.

## Verified in the real page

Headless Chrome over CDP, dispatching the actual `change` events (not calling internals):

```
control present: true | options: auto,fast,reliable,aggressive

  mode "auto" (= fast, 3.4 MB PE)  ->  3,495 sidebar rows
  mode "reliable"                  -> 14,014 sidebar rows
```

Web suite: `parity` **19/19** native==wasm, `glue` / `worker` / `fnfilter` / `auto-mode` / `zip` green.

`docs/web-integration.md` gains the rationale beside the existing DIV-53 discovery-policy section — the mode is a *product* decision in the browser, not just a speed dial, because an entry the inventory omits is a function the UI cannot open at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQNaY1pwg8rskYRksC9qbh
