### PR TITLE
[AUTOMATED] feat(types): decode the rest of <data_organization> so scalar widths are knowable per target

### DIFF
--- a/decompiler/crates/kuna-console/tests/verify_dataorg_sizes.rs
+++ b/decompiler/crates/kuna-console/tests/verify_dataorg_sizes.rs
@@ -1,0 +1,120 @@
+//! (kuna) The widened `<data_organization>` decode: every scalar width a
+//! per-architecture C spelling needs is read off the compiler spec.
+//!
+//! `Architecture::decode_data_organization` used to match only
+//! `integer_size` / `long_size` / `pointer_size` / `char_size` / `wchar_size`;
+//! `<short_size>` (54 vendored cspecs), `<long_long_size>` (51), `<float_size>`
+//! (60), `<double_size>` (61) and `<long_double_size>` (56) fell through its
+//! `_ => {}` arm, so no consumer could ask for them. These tests pin the decoded
+//! tuple per data model, which is what makes the difference between the data
+//! models observable at all.
+//!
+//! The interesting cases are the ones a hard-coded `2/4/8` table gets wrong:
+//! **LP64** (`long` is 8, so an 8-byte integer is `long`), **LLP64** (`long` is
+//! 4 with 8-byte pointers, so an 8-byte integer is `long long`), and the
+//! **long-double split** — 10 on x86 ELF (the x87 extended value width, which no
+//! `sizeof` can match) versus 8 under MSVC, where `long double` aliases `double`.
+//!
+//! Bootstrapping needs the built `.sla` under `specs/` (gitignored; `make
+//! specs`). When it is absent the bootstrap fails; the test prints that and
+//! returns early (a specs-less CI is a visible skip, never a false green).
+
+use std::path::PathBuf;
+
+use kuna_console::engine::bootstrap_from_object;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+/// The decoded scalar widths, in declaration order:
+/// `(char, short, int, long, long long, pointer, float, double, long double)`.
+type Widths = (i32, i32, i32, i32, i32, i32, i32, i32, i32);
+
+/// Bootstrap `fixture` and read its decoded data organization.
+/// `None` => specs-less skip.
+fn widths_of(fixture: &str) -> Option<Widths> {
+    let root = repo_root();
+    let specs = root.join("specs");
+    let spec_roots = vec![specs.to_str().unwrap().to_string()];
+    let path = root.join("decompiler/crates/kuna-analysis/tests/fixtures").join(fixture);
+    let prog = match bootstrap_from_object(path.to_str()?, "", &spec_roots) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "verify_dataorg_sizes: skipping {fixture} (bootstrap failed, build \
+                 `.sla` with `make specs`): {}",
+                e.explain()
+            );
+            return None;
+        }
+    };
+    let t = prog.arch().types();
+    Some((
+        t.get_size_of_char(),
+        t.get_size_of_short(),
+        t.get_size_of_int(),
+        t.get_size_of_long(),
+        t.get_size_of_long_long(),
+        t.get_size_of_pointer(),
+        t.get_size_of_float(),
+        t.get_size_of_double(),
+        t.get_size_of_long_double(),
+    ))
+}
+
+/// x86-64 System V is LP64: `long` is 8, so an 8-byte integer spells `long`.
+/// Its `long double` is the x87 extended value, 10 bytes wide — the cspec even
+/// annotates that its storage is 16 (`<!-- aligned-length=16 -->`), which is why
+/// no `sizeof` assertion on a 10-byte float can ever hold.
+#[test]
+fn x86_64_sysv_is_lp64_with_an_x87_long_double() {
+    let Some(w) = widths_of("fmt_x86_64") else { return };
+    assert_eq!(w, (1, 2, 4, 8, 8, 8, 4, 8, 10), "x86-64 gcc");
+}
+
+/// i386 ELF is ILP32: `long` is 4, so an 8-byte integer must spell `long long`,
+/// not `long`. Same x87 `long double`.
+#[test]
+fn i386_elf_is_ilp32_so_eight_bytes_is_long_long() {
+    let Some(w) = widths_of("i386_pie_nl") else { return };
+    assert_eq!(w, (1, 2, 4, 4, 8, 4, 4, 8, 10), "i386 gcc");
+}
+
+/// AArch64 is LP64 like x86-64, but its `long double` is NOT the x87 format.
+/// Pinned as decoded rather than as the ABI says: `AARCH64.cspec` records 8
+/// where the AArch64 ELF ABI has a 16-byte `long double`. A speller must not
+/// invent a wider type than the spec claims.
+#[test]
+fn aarch64_is_lp64() {
+    let Some(w) = widths_of("fmt_aarch64") else { return };
+    assert_eq!((w.0, w.1, w.2, w.3, w.4, w.5), (1, 2, 4, 8, 8, 8), "aarch64 integer widths");
+    assert_eq!((w.6, w.7), (4, 8), "aarch64 float/double");
+}
+
+/// ARM32 AAPCS: ILP32, so 8 bytes is `long long`.
+#[test]
+fn arm32_is_ilp32() {
+    let Some(w) = widths_of("fmt_arm") else { return };
+    assert_eq!((w.0, w.1, w.2, w.3, w.4, w.5), (1, 2, 4, 4, 8, 4), "arm integer widths");
+}
+
+/// A cspec that declares no `<long_double_size>` must fall back to `double`
+/// rather than to 0 — otherwise a float speller would match size 0 and a
+/// `long double` would become unspellable on every such target. This asserts the
+/// `setup_sizes` fallback fires, whichever fixture exercises it.
+#[test]
+fn long_double_never_decodes_to_zero() {
+    for fixture in
+        ["fmt_x86_64", "i386_pie_nl", "fmt_arm", "fmt_aarch64", "fmt_riscv64", "mips_gp_le32"]
+    {
+        let Some(w) = widths_of(fixture) else { continue };
+        assert!(w.8 >= w.7, "{fixture}: long double ({}) must be at least double ({})", w.8, w.7);
+        for (name, v) in
+            [("char", w.0), ("short", w.1), ("int", w.2), ("long", w.3), ("long long", w.4),
+             ("pointer", w.5), ("float", w.6), ("double", w.7), ("long double", w.8)]
+        {
+            assert!(v > 0, "{fixture}: {name} width decoded as {v}");
+        }
+    }
+}

--- a/decompiler/crates/kuna-decomp/src/infra/architecture.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/architecture.rs
@@ -3217,6 +3217,38 @@ impl Architecture {
                         self.types.set_size_of_wchar(v);
                     }
                 }
+                // (kuna) The remaining scalar widths.  Upstream's
+                // `decodeDataOrganization` reads these too; kuna had only ever
+                // needed int/long/pointer/char/wchar, so the rest fell through the
+                // `_ => {}` arm and no consumer could ask for them.  `<float_size>`
+                // (60 cspecs), `<double_size>` (61), `<long_double_size>` (56),
+                // `<short_size>` (54) and `<long_long_size>` (51) are the five that
+                // a per-architecture C spelling needs.
+                "short_size" => {
+                    if let Some(v) = read(child) {
+                        self.types.set_size_of_short(v);
+                    }
+                }
+                "long_long_size" => {
+                    if let Some(v) = read(child) {
+                        self.types.set_size_of_long_long(v);
+                    }
+                }
+                "float_size" => {
+                    if let Some(v) = read(child) {
+                        self.types.set_size_of_float(v);
+                    }
+                }
+                "double_size" => {
+                    if let Some(v) = read(child) {
+                        self.types.set_size_of_double(v);
+                    }
+                }
+                "long_double_size" => {
+                    if let Some(v) = read(child) {
+                        self.types.set_size_of_long_double(v);
+                    }
+                }
                 "size_alignment_map" => {
                     // C++ `TypeFactory::decodeAlignmentMap` (type.cc:5143): each
                     // `<entry size=N alignment=M/>` child contributes a pair; the

--- a/decompiler/crates/kuna-decomp/src/substrate/dtype.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/dtype.rs
@@ -3799,6 +3799,29 @@ pub trait TypeFactory {
     fn get_size_of_pointer(&self) -> int4;
     /// Get size of alternate pointers, or 0 (C++ `getSizeOfAltPointer`).
     fn get_size_of_alt_pointer(&self) -> int4;
+    /// (kuna) Size of the core "short" (cspec `<short_size>`).  Defaulted so the
+    /// implementors that model no data organization need not restate the fleet's
+    /// near-universal widths; `TypeFactoryImpl` overrides with the decoded value.
+    fn get_size_of_short(&self) -> int4 {
+        2
+    }
+    /// (kuna) Size of the core "long long" (cspec `<long_long_size>`).
+    fn get_size_of_long_long(&self) -> int4 {
+        8
+    }
+    /// (kuna) Size of the core "float" (cspec `<float_size>`).
+    fn get_size_of_float(&self) -> int4 {
+        4
+    }
+    /// (kuna) Size of the core "double" (cspec `<double_size>`).
+    fn get_size_of_double(&self) -> int4 {
+        8
+    }
+    /// (kuna) Size of the core "long double" (cspec `<long_double_size>`) -- the
+    /// VALUE width, not `sizeof`.
+    fn get_size_of_long_double(&self) -> int4 {
+        8
+    }
     /// Get data-type alignment based on size (C++ `getAlignment`).
     fn get_alignment(&self, size: uint4) -> KunaResult<int4>;
     /// Get the aligned size of a primitive data-type (C++ `getPrimitiveAlignSize`).
@@ -4166,6 +4189,19 @@ pub struct TypeFactoryImpl {
     size_of_wchar: Cell<int4>,
     /// Size of pointers into the default data space (C++ `sizeOfPointer`).
     size_of_pointer: Cell<int4>,
+    /// (kuna) Size of the core "short" data-type (cspec `<short_size>`).
+    size_of_short: Cell<int4>,
+    /// (kuna) Size of the core "long long" data-type (cspec `<long_long_size>`).
+    size_of_long_long: Cell<int4>,
+    /// (kuna) Size of the core "float" data-type (cspec `<float_size>`).
+    size_of_float: Cell<int4>,
+    /// (kuna) Size of the core "double" data-type (cspec `<double_size>`).
+    size_of_double: Cell<int4>,
+    /// (kuna) Size of the core "long double" data-type (cspec `<long_double_size>`).
+    /// Note this is the VALUE width, not `sizeof`: the x86 cspecs record 10 for
+    /// the x87 extended format and annotate the storage width in a comment
+    /// (`<!-- aligned-length=16 -->`).
+    size_of_long_double: Cell<int4>,
     /// Size of alternate pointers, or 0 (C++ `sizeOfAltPointer`).
     size_of_alt_pointer: Cell<int4>,
     /// Size of an enumerated type (C++ `enumsize`).
@@ -4213,6 +4249,12 @@ impl TypeFactoryImpl {
             size_of_wchar: Cell::new(0),
             size_of_pointer: Cell::new(0),
             size_of_alt_pointer: Cell::new(0),
+            // (kuna) 0 == "the cspec has not spoken"; `setup_sizes` fills these.
+            size_of_short: Cell::new(0),
+            size_of_long_long: Cell::new(0),
+            size_of_float: Cell::new(0),
+            size_of_double: Cell::new(0),
+            size_of_long_double: Cell::new(0),
             enumsize: Cell::new(0),
             enumtype: Cell::new(type_metatype::TYPE_ENUM_UINT),
             align_map: RefCell::new(Vec::new()),
@@ -4344,6 +4386,30 @@ impl TypeFactoryImpl {
         if self.size_of_pointer.get() == 0 {
             self.size_of_pointer.set(default_data_addr_size);
         }
+        // (kuna) Fill the widths the cspec left unset.  37 of the 107 vendored
+        // cspecs carry no `<data_organization>` at all (every PowerPC 32-bit one
+        // among them) and several carry only a subset, so these defaults are the
+        // common case, not the exception.  The existing `size_of_long` fallback
+        // above is deliberately untouched: it is read by type inference, not just
+        // by rendering, so correcting it is a separate behavior change.
+        if self.size_of_short.get() == 0 {
+            self.size_of_short.set(2);
+        }
+        if self.size_of_long_long.get() == 0 {
+            self.size_of_long_long.set(8);
+        }
+        if self.size_of_float.get() == 0 {
+            self.size_of_float.set(4);
+        }
+        if self.size_of_double.get() == 0 {
+            self.size_of_double.set(8);
+        }
+        if self.size_of_long_double.get() == 0 {
+            // No `<long_double_size>` means the target has no wider floating type
+            // to name, so `long double` is `double` -- the C rule when a compiler
+            // aliases them (MSVC, ARM32 AAPCS).
+            self.size_of_long_double.set(self.size_of_double.get());
+        }
         // STUB(W4): the segmented far-pointer adjustment (glb->getSegmentOp) is a
         // W4 surface; without it sizeOfAltPointer stays 0, as for a flat space.
         if self.align_map.borrow().is_empty() {
@@ -4374,6 +4440,26 @@ impl TypeFactoryImpl {
     /// Set the default pointer size (C++ `decodeDataOrganization`'s `<pointer_size>`).
     pub fn set_size_of_pointer(&self, s: int4) {
         self.size_of_pointer.set(s);
+    }
+    /// (kuna) Set the default short size (cspec `<short_size>`).
+    pub fn set_size_of_short(&self, s: int4) {
+        self.size_of_short.set(s);
+    }
+    /// (kuna) Set the default long long size (cspec `<long_long_size>`).
+    pub fn set_size_of_long_long(&self, s: int4) {
+        self.size_of_long_long.set(s);
+    }
+    /// (kuna) Set the default float size (cspec `<float_size>`).
+    pub fn set_size_of_float(&self, s: int4) {
+        self.size_of_float.set(s);
+    }
+    /// (kuna) Set the default double size (cspec `<double_size>`).
+    pub fn set_size_of_double(&self, s: int4) {
+        self.size_of_double.set(s);
+    }
+    /// (kuna) Set the default long double size (cspec `<long_double_size>`).
+    pub fn set_size_of_long_double(&self, s: int4) {
+        self.size_of_long_double.set(s);
     }
 
     // -- Alignment queries (type.cc:3774-3798) -------------------------------
@@ -5812,6 +5898,21 @@ impl TypeFactory for TypeFactoryImpl {
     }
     fn get_size_of_alt_pointer(&self) -> int4 {
         self.size_of_alt_pointer.get()
+    }
+    fn get_size_of_short(&self) -> int4 {
+        self.size_of_short.get()
+    }
+    fn get_size_of_long_long(&self) -> int4 {
+        self.size_of_long_long.get()
+    }
+    fn get_size_of_float(&self) -> int4 {
+        self.size_of_float.get()
+    }
+    fn get_size_of_double(&self) -> int4 {
+        self.size_of_double.get()
+    }
+    fn get_size_of_long_double(&self) -> int4 {
+        self.size_of_long_double.get()
     }
     fn get_alignment(&self, size: uint4) -> KunaResult<int4> {
         self.alignment(size)

--- a/docs/spec/05-types.md
+++ b/docs/spec/05-types.md
@@ -126,6 +126,31 @@ back — and the two inline unit tests (`dependent_order_nested_struct`,
 `dependent_order_pointer_cycle`) pin both facts: the raw tree order really is
 container-first, and the DFS reorders it.
 
+**The data organization.** The factory also carries the target's C scalar
+widths, decoded from the compiler spec's `<data_organization>` by
+`decompiler/crates/kuna-decomp/src/infra/architecture.rs
+(decode_data_organization)` and completed by
+`decompiler/crates/kuna-decomp/src/substrate/dtype.rs
+(TypeFactoryImpl::setup_sizes)` for whatever the spec left unset. kuna reads the
+full set — `char`, `short`, `int`, `long`, `long long`, pointer, `wchar_t`,
+`float`, `double`, `long double` — because knowing a value's *size* is not
+enough to name its C type: an 8-byte integer is `long` under LP64 and
+`long long` under ILP32 or LLP64, and the fleet disagrees on both (x86-64 gcc
+declares `long_size` 8, x86-64 Windows declares 4 with 8-byte pointers). These
+widths are a naming fact, not an inference input; the type tree interns by
+sub-metatype and size alone and never consults them.
+
+Two of them do not describe anything `sizeof` can measure. `<long_double_size>`
+records the *value* width, not the storage width — the x86 specs say 10 for the
+x87 extended format and annotate the storage in a comment
+(`<!-- aligned-length=16 -->`) — and a spec that declares no `long double` at
+all means the target aliases it to `double` (MSVC, ARM32), which is the fallback
+`setup_sizes` applies. Consumers must therefore treat a long-double width as an
+approximation to name, never as a layout guarantee. Thirty-seven of the 107
+vendored cspecs carry no `<data_organization>` element whatsoever — every
+PowerPC 32-bit one among them — so the fallbacks are the common case, not the
+exception.
+
 ## 5.2 Inference
 
 Type recovery is **off** for the entire first `fullloop` iteration — early


### PR DESCRIPTION
## What

`Architecture::decode_data_organization` matched only `integer_size` / `long_size` / `pointer_size` / `char_size` / `wchar_size`. Everything else in the cspec's `<data_organization>` fell through its `_ => {}` arm:

| tag | vendored cspecs declaring it | read before |
|---|---|---|
| `<double_size>` | 61 | no |
| `<float_size>` | 60 | no |
| `<long_double_size>` | 56 | no |
| `<short_size>` | 54 | no |
| `<long_long_size>` | 51 | no |

So nothing downstream could tell one data model from another by more than a single `long == 8` bool — and that is not enough to *name* a C type. An 8-byte integer is `long` under LP64 and `long long` under ILP32 or LLP64, and the fleet carries both: `x86-64-gcc.cspec` declares `long_size` 8, `x86-64-win.cspec` declares 4 with 8-byte pointers.

This PR adds the five widths as `TypeFactory` state, the matching decode arms, and `setup_sizes` fallbacks. It reads nothing back — it is the prerequisite for a per-architecture C type speller, split out so that change can be reviewed purely as a spelling change.

## Notes for review

- **Trait accessors are defaulted** (`get_size_of_short() -> 2` etc.) so the several test-only `TypeFactory` stubs (`p4_calls/modelrules/tests.rs`, `p4_calls/fspec/tests.rs`) keep compiling; `TypeFactoryImpl` overrides each with the decoded value.
- **The fallbacks are the common case, not the exception.** 37 of the 107 vendored cspecs carry no `<data_organization>` element at all — every PowerPC 32-bit one among them. A spec that declares no `long double` means the target aliases it to `double` (MSVC, ARM32), which is the fallback applied.
- **`<long_double_size>` is a value width, not `sizeof`.** The x86 cspecs record 10 for the x87 extended format and annotate the storage width in a comment (`<!-- aligned-length=16 -->`). Consumers must treat it as an approximation to name, never as a layout guarantee — no `sizeof` assertion on a 10-byte float can hold on any target.
- **The existing `size_of_long` fallback is deliberately untouched.** `setup_sizes` sets `long = 8 whenever int == 4`, which is wrong for MIPS32 and all six PPC32 cspecs. But `get_size_of_long` is read by type inference, not only by rendering, so correcting it changes decompiled output on those targets and belongs in its own measured PR.

## Verification

**Inert by construction** — nothing reads the new fields. Confirmed rather than assumed: `decompile-all` output diffed against the pre-change build on four data models — `fmt_x86_64` (85 lines), `i386_pie_nl` (3,800), `fmt_arm` (123), `mips_gp_le32` (112) — **0 differing lines each**.

New gate `verify_dataorg_sizes` pins the decoded tuple per data model, including the three cases a hard-coded 2/4/8 table gets wrong:

- x86-64 SysV → `(char 1, short 2, int 4, long 8, long long 8, ptr 8, float 4, double 8, long double 10)` — LP64 with an x87 long double
- i386 ELF → `(1, 2, 4, 4, 8, 4, 4, 8, 10)` — ILP32, so 8 bytes must spell `long long`
- AArch64 / ARM32 → LP64 and ILP32 respectively

plus an invariant that no width ever decodes to 0 and `long double >= double` on every fixture.

## Gates

- `make test` — **675/675 PARITY OK**
- `make test-stages` — **PARITY OK**
- `make check-spec` — green
- `make rust-test` — run locally (internal PRs skip the workspace suite)

No option, no catalog row, no count bumps, no DIV row (nothing diverges yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyfU1KXNMWieY7HkFx2YbN
