### PR TITLE
[AUTOMATED] feat(ghidra): ship a ready-to-install multi-platform KunaDecompiler extension zip on releases (airgapped installs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ name: Release binaries
 # version scheme -- VERSION file = MAJOR, commits since it last changed = MINOR
 # -- lives in scripts/version.sh and docs/release.md.
 #
+# The release also ships a ready-to-install KunaDecompiler Ghidra extension
+# zip with prebuilt kuna_ghidra backends for every platform (the ghidra-ext
+# job), so airgapped users can install without cargo or network access.
+#
 # Cadence: ONE release a night, batching whatever landed that day, not one per
 # merge. A busy day used to publish ~18 releases and ~18 tags.
 #
@@ -35,6 +39,14 @@ permissions:
 concurrency:
   group: release
   cancel-in-progress: false
+
+# The Ghidra release the extension zip is built against (and version-locked to;
+# other 12.x installs need "Install Anyway" at the version-mismatch dialog).
+# The asset filename embeds a build date not derivable from the version, so the
+# full URL is pinned alongside it -- bump both together to retarget.
+env:
+  GHIDRA_VERSION: "12.1.2"
+  GHIDRA_ZIP_URL: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.1.2_build/ghidra_12.1.2_PUBLIC_20260605.zip"
 
 jobs:
   # Compute MAJOR.MINOR once; everything downstream consumes it.
@@ -70,6 +82,9 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             name: linux-x86_64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            name: linux-arm64
           - target: aarch64-apple-darwin
             os: macos-latest
             name: macos-arm64
@@ -104,7 +119,7 @@ jobs:
       - name: Build release binaries
         working-directory: decompiler
         shell: bash
-        run: cargo build --release --target ${{ matrix.target }} -p kuna-cli -p kuna-console -p kuna-slacomp
+        run: cargo build --release --target ${{ matrix.target }} -p kuna-cli -p kuna-console -p kuna-slacomp -p kuna-ghidra
 
       # x86_64-apple-darwin is cross-compiled on the arm64 runner; skip running it.
       - name: Smoke test (kuna --version reports the release version)
@@ -142,6 +157,24 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
+      # The kuna_ghidra backend for the Ghidra extension zip (ghidra-ext job).
+      # Not named kuna-* on purpose: the release job downloads pattern kuna-*
+      # and must not attach these raw binaries as assets. Artifact uploads drop
+      # unix permissions; ghidra-ext restores the exec bits when staging.
+      - name: Stage kuna_ghidra for the extension job
+        shell: bash
+        run: |
+          ext=""
+          if [ "${{ runner.os }}" = "Windows" ]; then ext=".exe"; fi
+          mkdir -p ghidra-bin
+          cp "decompiler/target/${{ matrix.target }}/release/kuna_ghidra$ext" ghidra-bin/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ghidra-bin-${{ matrix.name }}
+          path: ghidra-bin/*
+          if-no-files-found: error
+
   # The compiled SLEIGH tree the binaries need at runtime -- .sla files are
   # platform-independent, so build once and ship one asset for all OSes.
   specs:
@@ -175,14 +208,99 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
-  release:
-    needs: [version, build, specs]
+  # The ready-to-install KunaDecompiler Ghidra extension: one fat zip carrying
+  # prebuilt kuna_ghidra backends for all five platforms, built with Ghidra's
+  # own support/buildExtension.gradle against the pinned Ghidra release (which
+  # stamps the extension version so the installer's version gate matches).
+  # The zip must carry unix modes with 0755 on the four unix binaries --
+  # Ghidra's extension installer re-applies them at install time. Gradle 9
+  # normalizes archive modes (reproducible archives), so the extension's
+  # build.gradle pins 0755 on the kuna_ghidra entries; the zipinfo step below
+  # is the gate. kuna_ghidra needs no .sla files at runtime (all specs arrive
+  # over the wire), so the zip is fully self-contained -- it installs
+  # airgapped.
+  ghidra-ext:
+    needs: [version, build]
+    if: needs.version.outputs.exists == 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v4
         with:
+          pattern: ghidra-bin-*
+          path: ghidra-bins
+
+      - name: Cache the Ghidra release zip
+        id: ghidra-cache
+        uses: actions/cache@v4
+        with:
+          path: ghidra-dist
+          key: ghidra-${{ env.GHIDRA_VERSION }}
+
+      - name: Download Ghidra ${{ env.GHIDRA_VERSION }}
+        if: steps.ghidra-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ghidra-dist
+          curl -fL --retry 3 -o ghidra-dist/ghidra.zip "$GHIDRA_ZIP_URL"
+
+      - name: Unzip Ghidra
+        run: unzip -q ghidra-dist/ghidra.zip -d ghidra-install
+
+      - name: Stage the per-platform kuna_ghidra binaries
+        run: |
+          ext=integrations/ghidra/KunaDecompiler
+          install -D -m 755 ghidra-bins/ghidra-bin-linux-x86_64/kuna_ghidra "$ext/os/linux_x86_64/kuna_ghidra"
+          install -D -m 755 ghidra-bins/ghidra-bin-linux-arm64/kuna_ghidra "$ext/os/linux_arm_64/kuna_ghidra"
+          install -D -m 755 ghidra-bins/ghidra-bin-macos-x86_64/kuna_ghidra "$ext/os/mac_x86_64/kuna_ghidra"
+          install -D -m 755 ghidra-bins/ghidra-bin-macos-arm64/kuna_ghidra "$ext/os/mac_arm_64/kuna_ghidra"
+          install -D -m 644 ghidra-bins/ghidra-bin-windows-x86_64/kuna_ghidra.exe "$ext/os/win_x86_64/kuna_ghidra.exe"
+
+      # Ghidra 12.x needs Java 21 (runner default is 17); Gradle >= 8.5 is
+      # required and the runner's preinstalled Gradle satisfies it (verified
+      # against 9.7.0 and 8.5). GHIDRA_INSTALL_DIR is passed as an env var
+      # because build.gradle gives it precedence over the -P property.
+      - name: Build the extension zip
+        working-directory: integrations/ghidra/KunaDecompiler
+        run: |
+          export JAVA_HOME="$JAVA_HOME_21_X64"
+          export GHIDRA_INSTALL_DIR="$GITHUB_WORKSPACE/ghidra-install/ghidra_${GHIDRA_VERSION}_PUBLIC"
+          gradle buildExtension
+
+      # Install-correctness gate: all five os/ binaries present, the four unix
+      # ones mode 0755 (Ghidra's installer re-applies exactly these bits), the
+      # version gate satisfied. Then rename so the asset states both versions.
+      - name: Verify the zip and stage it for release
+        run: |
+          zip="$(ls integrations/ghidra/KunaDecompiler/dist/ghidra_*_KunaDecompiler.zip)"
+          zipinfo "$zip"
+          listing="$(zipinfo "$zip")"
+          for p in linux_x86_64 linux_arm_64 mac_x86_64 mac_arm_64; do
+            echo "$listing" | grep -E "^-rwxr-xr-x .* KunaDecompiler/os/$p/kuna_ghidra$"
+          done
+          echo "$listing" | grep -E " KunaDecompiler/os/win_x86_64/kuna_ghidra\.exe$"
+          [ "$(zipinfo -1 "$zip" | cut -d/ -f1 | sort -u)" = "KunaDecompiler" ]
+          unzip -p "$zip" KunaDecompiler/extension.properties | grep -qx "version=$GHIDRA_VERSION"
+          mkdir -p dist
+          cp "$zip" "dist/kuna-v${{ needs.version.outputs.version }}-KunaDecompiler-ghidra_${GHIDRA_VERSION}.zip"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: kuna-ghidra-extension
+          path: dist/*
+          if-no-files-found: error
+
+  release:
+    needs: [version, build, specs, ghidra-ext]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # kuna-* only: the ghidra-bin-* artifacts are job-to-job plumbing for
+      # ghidra-ext, not release assets.
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: kuna-*
           path: dist
           merge-multiple: true
 
@@ -196,5 +314,5 @@ jobs:
             --target "$GITHUB_SHA" \
             --title "kuna v$ver" \
             --generate-notes \
-            --notes "$(printf 'Each archive ships `kuna` (the CLI), `decomp_dbg` (the decompiler console), and `slacomp` (the SLEIGH compiler).\n\nThe engine needs compiled SLEIGH specs at runtime: extract `kuna-v%s-specs.tar.gz` and point `KUNA_SPECS` at the extracted `specs/` directory. See docs/release.md.' "$ver")" \
+            --notes "$(printf 'Each archive ships `kuna` (the CLI), `decomp_dbg` (the decompiler console), and `slacomp` (the SLEIGH compiler).\n\nThe engine needs compiled SLEIGH specs at runtime: extract `kuna-v%s-specs.tar.gz` and point `KUNA_SPECS` at the extracted `specs/` directory. See docs/release.md.\n\n`kuna-v%s-KunaDecompiler-ghidra_%s.zip` is the ready-to-install KunaDecompiler extension for **Ghidra %s** (in Ghidra: File -> Install Extensions... -> `+` -> pick the zip -> restart -> enable KunaDecompilerPlugin). It bundles prebuilt `kuna_ghidra` backends for Linux x86_64/arm64, macOS x86_64/arm64, and Windows x86_64, so it installs fully airgapped: the Ghidra release zip plus this zip are the only two files needed -- no network, no Rust toolchain. The zip is version-locked to Ghidra %s; other Ghidra 12.x versions can choose "Install Anyway" at the version-mismatch dialog (compatibility unverified).' "$ver" "$ver" "$GHIDRA_VERSION" "$GHIDRA_VERSION" "$GHIDRA_VERSION")" \
             dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,12 +231,19 @@ jobs:
           pattern: ghidra-bin-*
           path: ghidra-bins
 
+      # The key derives from the URL's basename (version + build date), so a
+      # re-spun same-version asset -- only GHIDRA_ZIP_URL bumped -- can never
+      # be shadowed by a stale cached zip.
+      - name: Compute the Ghidra cache key
+        id: ghidra-key
+        run: echo "key=ghidra-zip-$(basename "$GHIDRA_ZIP_URL" .zip)" >> "$GITHUB_OUTPUT"
+
       - name: Cache the Ghidra release zip
         id: ghidra-cache
         uses: actions/cache@v4
         with:
           path: ghidra-dist
-          key: ghidra-${{ env.GHIDRA_VERSION }}
+          key: ${{ steps.ghidra-key.outputs.key }}
 
       - name: Download Ghidra ${{ env.GHIDRA_VERSION }}
         if: steps.ghidra-cache.outputs.cache-hit != 'true'

--- a/docs/release.md
+++ b/docs/release.md
@@ -70,21 +70,44 @@ and 18 tags**.
    the whole run if tag `vMAJOR.MINOR` already exists (safe re-runs, and the
    no-op guard above).
 2. **build** (matrix) — `cargo build --release` of `kuna-cli`, `kuna-console`,
-   and `kuna-slacomp` for:
-   - Linux `x86_64-unknown-linux-gnu`
+   `kuna-slacomp`, and `kuna-ghidra` for:
+   - Linux `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu` (native,
+     on the `ubuntu-24.04-arm` runner)
    - macOS `aarch64-apple-darwin` and `x86_64-apple-darwin` (the latter
      cross-compiled on the arm64 runner)
    - Windows `x86_64-pc-windows-msvc`
    Each archive (`kuna-v<ver>-<os-arch>.tar.gz`, `.zip` on Windows) contains
    `kuna`, `decomp_dbg`, `slacomp`, `LICENSE`, `NOTICE`. A smoke test asserts
    `kuna --version` prints the release version. (`decomp_test_dbg` is not
-   shipped — the datatest harness only makes sense inside the repo.)
+   shipped — the datatest harness only makes sense inside the repo.) The
+   `kuna_ghidra` binaries are not in the archives: each row uploads its binary
+   as a `ghidra-bin-<platform>` workflow artifact for the **ghidra-ext** job.
 3. **specs** — compiles every `.slaspec` → `.sla` once on Linux and packages
    the whole `specs/` tree as `kuna-v<ver>-specs.tar.gz`. `.sla` files are
    platform-independent, so one asset serves every OS.
-4. **release** — `gh release create v<ver>` with all assets, tagging the built
+4. **ghidra-ext** — packages the ready-to-install KunaDecompiler Ghidra
+   extension, `kuna-v<ver>-KunaDecompiler-ghidra_<ghidra-version>.zip`. It
+   downloads the pinned Ghidra release (version *and* full asset URL are
+   pinned in the workflow's `env`, since the asset filename embeds a build
+   date; the zip is cached with `actions/cache`), stages the five
+   `ghidra-bin-*` binaries into the extension's `os/<platform>/` dirs
+   (restoring the exec bits that artifact upload drops), and runs Ghidra's own
+   `support/buildExtension.gradle` via the runner's preinstalled Gradle under
+   Java 21. The job asserts with `zipinfo` that all five `os/` binaries are in
+   the zip and the four unix ones carry mode 0755 — Ghidra's extension
+   installer re-applies exactly those bits at install time. (Gradle 9
+   normalizes archive entry modes for reproducibility, which would strip the
+   exec bits; the extension's `build.gradle` pins 0755 on the `kuna_ghidra`
+   entries explicitly, so the zip is correct under both Gradle 8 and 9.)
+   The zip is fully self-contained (`kuna_ghidra` needs no `.sla` files —
+   specs arrive over the wire), so it installs airgapped; it is version-locked
+   to the pinned Ghidra release, other 12.x installs go through the
+   installer's "Install Anyway" dialog. See
+   `integrations/ghidra/KunaDecompiler/README.md` for the install steps.
+5. **release** — `gh release create v<ver>` with all assets, tagging the built
    commit. This is what creates the git tag; no tags are pushed from anywhere
-   else.
+   else. (It downloads only `kuna-*` artifacts — the `ghidra-bin-*` binaries
+   are inter-job plumbing, not assets.)
 
 ## Using a released binary
 
@@ -102,3 +125,7 @@ export KUNA_SPECS=$PWD/specs
 
 (Inside a repo checkout none of this applies — binaries live in
 `decompiler/target/release/` and specs are found from the repo root.)
+
+The `kuna-v<ver>-KunaDecompiler-ghidra_<ghidra-version>.zip` asset is not an
+archive to extract — install it from inside Ghidra (**File → Install
+Extensions… → `+`**); see `integrations/ghidra/KunaDecompiler/README.md`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -89,7 +89,8 @@ and 18 tags**.
    extension, `kuna-v<ver>-KunaDecompiler-ghidra_<ghidra-version>.zip`. It
    downloads the pinned Ghidra release (version *and* full asset URL are
    pinned in the workflow's `env`, since the asset filename embeds a build
-   date; the zip is cached with `actions/cache`), stages the five
+   date; the zip is cached with `actions/cache` under a key derived from the
+   asset filename, so bumping the URL always invalidates it), stages the five
    `ghidra-bin-*` binaries into the extension's `os/<platform>/` dirs
    (restoring the exec bits that artifact upload drops), and runs Ghidra's own
    `support/buildExtension.gradle` via the runner's preinstalled Gradle under

--- a/integrations/ghidra/KunaDecompiler/README.md
+++ b/integrations/ghidra/KunaDecompiler/README.md
@@ -13,8 +13,9 @@ self-contained functions decompile cleanly; a function that references globals/t
 engine can't yet resolve shows placeholder names (`sub_…`/`DAT_…`) and default types —
 correct names/types at scale is Phase 3 (the lazy symbol scope). See
 [`docs/ghidra-integration.md`](../../../docs/ghidra-integration.md) for the design and
-phase plan. Target Ghidra version: **12.2** (the swap relies on the exact shape of
-`DecompileProcessFactory`; see *How it works* below).
+phase plan. Developed against Ghidra **12.2-DEV**; release zips are built against the
+latest stable release (currently **12.1.2**). The swap relies on the exact shape of
+`DecompileProcessFactory`, which is identical across both (see *How it works* below).
 
 ## Install from a GitHub Release (recommended; works airgapped)
 

--- a/integrations/ghidra/KunaDecompiler/README.md
+++ b/integrations/ghidra/KunaDecompiler/README.md
@@ -16,6 +16,33 @@ correct names/types at scale is Phase 3 (the lazy symbol scope). See
 phase plan. Target Ghidra version: **12.2** (the swap relies on the exact shape of
 `DecompileProcessFactory`; see *How it works* below).
 
+## Install from a GitHub Release (recommended; works airgapped)
+
+Every kuna release ships a ready-to-install extension zip —
+`kuna-v<ver>-KunaDecompiler-ghidra_<ghidra-version>.zip` on the
+[releases tab](https://github.com/Noelo-Lab/kuna/releases) — with prebuilt `kuna_ghidra`
+backends for **all platforms** already inside: Linux x86_64 and arm64, macOS x86_64 and
+arm64, Windows x86_64 (`kuna_ghidra.exe`). Ghidra picks the right one at runtime, and
+its built-in arm→x86 fallbacks cover the rest (Windows-on-ARM runs the x86_64 binary
+under emulation; an Apple-Silicon install missing `mac_arm_64` would fall back to
+`mac_x86_64` under Rosetta). No cargo, no network, no separate specs download —
+`kuna_ghidra` receives everything over the wire, so the zip plus a Ghidra release
+install are the only two files an airgapped machine needs.
+
+1. Download the `…KunaDecompiler-ghidra_<version>.zip` asset from the kuna releases tab.
+2. In Ghidra's project window: **File → Install Extensions… → `+` → select the zip**,
+   then restart Ghidra when prompted.
+3. Enable the plugin: open a program in the CodeBrowser, then **File → Configure →
+   Miscellaneous** and check **KunaDecompilerPlugin**.
+
+The zip is built against — and version-locked to — the Ghidra version in its filename
+(the extension installer compares versions). On another Ghidra 12.x, the installer shows
+an **Extension Version Mismatch** dialog; **Install Anyway** generally works because the
+factory seam the plugin relies on is stable across 12.x, but those pairings are
+unverified.
+
+The sections below are the from-source paths: building the backend and the zip yourself.
+
 ## How it works
 
 Every decompiler consumer in Ghidra funnels process creation through one static

--- a/integrations/ghidra/KunaDecompiler/build.gradle
+++ b/integrations/ghidra/KunaDecompiler/build.gradle
@@ -39,6 +39,23 @@ task distributeExtension {
 }
 //----------------------END "DO NOT MODIFY" SECTION-------------------------------
 
+// The env var wins over -P above, so a profile-exported GHIDRA_INSTALL_DIR silently
+// overrides the flag; print the resolved install to make a mis-pointed build visible.
+println "KunaDecompiler: building against Ghidra install " + ghidraInstallDir
+
+// Gradle 9 builds reproducible archives by default, normalizing every zip entry to
+// 0644 -- which strips the exec bit Ghidra's extension installer re-applies at
+// install time, shipping kuna_ghidra binaries that cannot spawn. Pin 0755 on them
+// regardless of Gradle version or staged file modes (the API exists since 8.3;
+// Gradle 8 preserved source modes anyway).
+tasks.named('buildExtension') {
+	eachFile { f ->
+		if (f.name == 'kuna_ghidra') {
+			f.permissions { unix('rwxr-xr-x') }
+		}
+	}
+}
+
 repositories {
 	// No external dependency repositories are needed: buildExtension.gradle puts the
 	// Ghidra installation's jars on the compile classpath.

--- a/integrations/ghidra/KunaDecompiler/build.sh
+++ b/integrations/ghidra/KunaDecompiler/build.sh
@@ -8,6 +8,11 @@
 #   ./build.sh                              # build + stage the binary only
 #   GHIDRA_INSTALL_DIR=/path ./build.sh     # also build the installable zip
 #
+# This script builds a HOST-ONLY zip from source. Release CI (the ghidra-ext job
+# in .github/workflows/release.yml) builds the multi-platform zip with prebuilt
+# binaries for all platforms -- grab that from the GitHub releases tab if you
+# just want to install (works airgapped, and it is the only Windows path).
+#
 # See README.md ("Run the kuna backend in a real Ghidra instance") for the full
 # runbook, including the dev-checkout (`-Dghidra.external.modules`) path.
 set -euo pipefail
@@ -25,9 +30,12 @@ case "$os/$arch" in
 	Darwin/x86_64)        PLATFORM=mac_x86_64;   EXE=kuna_ghidra ;;
 	Darwin/arm64)         PLATFORM=mac_arm_64;   EXE=kuna_ghidra ;;
 	*)
-		echo "error: unsupported host '$os/$arch'. Build kuna_ghidra manually" >&2
-		echo "       (cd decompiler && cargo build --release -p kuna-ghidra) and copy it" >&2
-		echo "       into os/<ghidra-platform-dir>/ yourself." >&2
+		echo "error: unsupported host '$os/$arch' (Windows and anything else non-Linux/mac)." >&2
+		echo "       Use the prebuilt extension zip from the kuna GitHub releases tab instead:" >&2
+		echo "       kuna-v<ver>-KunaDecompiler-ghidra_<version>.zip ships ready-to-install" >&2
+		echo "       binaries for all platforms (including win_x86_64/kuna_ghidra.exe)." >&2
+		echo "       Or build manually: (cd decompiler && cargo build --release -p kuna-ghidra)" >&2
+		echo "       and copy the binary into os/<ghidra-platform-dir>/ yourself." >&2
 		exit 1 ;;
 esac
 

--- a/integrations/ghidra/KunaDecompiler/os/linux_x86_64/README.md
+++ b/integrations/ghidra/KunaDecompiler/os/linux_x86_64/README.md
@@ -36,4 +36,7 @@ binary, with the same name, into the matching directory before zipping:
 
 Directory names are Ghidra's `Platform` enum names (`Ghidra/Framework/Generic/src/main/java/ghidra/framework/Platform.java`) — note the underscore before `64` on the arm variants (`linux_arm_64`, `mac_arm_64`).
 
-Phase 1 only targets `linux_x86_64`; the other directories may simply not exist.
+A local `build.sh` run only stages the host's platform; the other directories may
+simply not exist. Release CI (the `ghidra-ext` job in
+`.github/workflows/release.yml`) stages all five before zipping, so the published
+extension zip works on every platform.

--- a/integrations/ghidra/KunaDecompiler/settings.gradle
+++ b/integrations/ghidra/KunaDecompiler/settings.gradle
@@ -1,0 +1,4 @@
+// Pin the Gradle project name: buildExtension.gradle derives the zip's top-level
+// directory, the jar name, and the @extname@ substitution from project.name, which
+// otherwise falls back to the checkout directory's name (CI checkouts vary).
+rootProject.name = 'KunaDecompiler'

--- a/integrations/ghidra/KunaDecompiler/src/main/java/kuna/KunaCoreSwap.java
+++ b/integrations/ghidra/KunaDecompiler/src/main/java/kuna/KunaCoreSwap.java
@@ -139,7 +139,15 @@ public final class KunaCoreSwap {
 		}
 	}
 
+	/**
+	 * Verifies the binary is executable, first attempting to set the exec bit itself
+	 * (self-heal for zips unpacked by tools that drop unix modes); throws only if the
+	 * bit still cannot be gained.
+	 */
 	private static File checkExecutable(File file) throws FileNotFoundException {
+		if (!file.canExecute()) {
+			file.setExecutable(true, false);
+		}
 		if (!file.canExecute()) {
 			throw new FileNotFoundException("The kuna decompiler binary exists but is not " +
 				"executable: " + file.getAbsolutePath() + " (chmod +x it).");

--- a/integrations/ghidra/KunaDecompiler/src/main/java/kuna/KunaCoreSwap.java
+++ b/integrations/ghidra/KunaDecompiler/src/main/java/kuna/KunaCoreSwap.java
@@ -282,8 +282,9 @@ public final class KunaCoreSwap {
 	private static void showReflectionError(Object originator, Exception e) {
 		Msg.showError(originator, null, "Kuna Core Swap Failed",
 			"Could not access ghidra.app.decompiler.DecompileProcessFactory." + EXEPATH_FIELD +
-				" by reflection. This Ghidra version may have changed the factory's " +
-				"field layout; the " + MODULE_NAME + " extension targets Ghidra 12.2.",
+				" by reflection. This Ghidra version (" + Application.getApplicationVersion() +
+				") may have changed the factory's field layout the " + MODULE_NAME +
+				" extension relies on.",
 			e);
 	}
 }


### PR DESCRIPTION
## The user-facing story

Installing the KunaDecompiler Ghidra extension today requires running `build.sh`, which runs cargo (crates.io) at install time — the airgapped users who asked for this cannot install it at all, and there is no Windows path whatsoever. After this PR, the nightly GitHub Release carries a **ready-to-install, fully self-contained extension zip**:

```
kuna-v<ver>-KunaDecompiler-ghidra_12.1.2.zip
```

with prebuilt `kuna_ghidra` backends for **all five platforms** already inside — `os/linux_x86_64/`, `os/linux_arm_64/`, `os/mac_x86_64/`, `os/mac_arm_64/` (`kuna_ghidra`) and `os/win_x86_64/kuna_ghidra.exe`. Ghidra picks the right one at runtime (Windows-on-ARM falls back to the x86_64 binary via Ghidra's own emulation fallback). `kuna_ghidra` needs no `.sla` files — all specs arrive over the wire — so an airgapped machine needs exactly two files: the Ghidra release zip and this zip. Install = **File → Install Extensions… → `+` → pick the zip → restart**. The zip is version-locked to Ghidra 12.1.2 (the installer's version gate keys off the stamped `extension.properties`); other 12.x installs go through the **Install Anyway** dialog (seam is stable across 12.x, but those pairings are unverified — the release notes and README say so).

## CI design (release.yml)

- The `build` matrix now also builds `-p kuna-ghidra` on every row, and gains a **native linux-arm64 row** (`aarch64-unknown-linux-gnu` on `ubuntu-24.04-arm`, smoke-tested) — which upgrades the main kuna release with a `kuna-v<ver>-linux-arm64.tar.gz` archive for free. Each row uploads its `kuna_ghidra` as a `ghidra-bin-<platform>` artifact (deliberately *not* `kuna-*`: the `release` job now downloads `pattern: kuna-*` so the raw binaries never become release assets).
- New `ghidra-ext` job (ubuntu-latest): downloads the five binaries; downloads the pinned Ghidra release — both `GHIDRA_VERSION: 12.1.2` **and** the full asset URL are pinned in workflow `env` (the asset filename embeds a build date not derivable from the version), zip cached with first-party `actions/cache` under a key derived from the URL's basename so a URL bump always invalidates it; stages the binaries into `os/<platform>/`; builds with Ghidra's own `support/buildExtension.gradle` (preinstalled Gradle, `JAVA_HOME_21_X64`); then a **zipinfo gate** asserts all five `os/` binaries are present, the four unix ones carry mode 0755, the zip has a single `KunaDecompiler/` top dir, and `extension.properties` was stamped `version=12.1.2` — any miss fails the job. The verified zip is renamed to state both versions and flows into the existing release-asset path. No new third-party actions.

## Two real bugs the local verification caught

1. **Gradle 9 silently strips the exec bits.** Gradle 9 builds reproducible archives by default and normalizes every zip entry to 0644 — the staged 0755 binaries came out non-executable, which Ghidra's installer would faithfully reproduce (its unzip re-applies the zip's unix modes). Since the ubuntu-latest runner ships Gradle 9.7.0, the naïve port of the packaging recipe ships broken zips. Fixed in the extension's `build.gradle`: an `eachFile` rule pins `rwxr-xr-x` on the `kuna_ghidra` entries (API exists since Gradle 8.3; verified on 9.7.0 and 8.5). The zipinfo gate exists so this class of failure can never ship silently again.
2. **`GHIDRA_INSTALL_DIR` env outranks `-PGHIDRA_INSTALL_DIR`.** The skeleton-standard build.gradle prefers the env var, so a profile-exported install dir silently overrides the flag (locally this produced a zip stamped for the wrong Ghidra). CI now passes the env var explicitly, and `build.gradle` prints the resolved install dir so a mis-pointed build is visible.

## Other changes

- `settings.gradle` pins `rootProject.name = 'KunaDecompiler'` (zip top dir / jar / `@extname@` no longer depend on the checkout dir name).
- `KunaCoreSwap.checkExecutable` self-heals a missing exec bit (`setExecutable(true, false)`) before throwing — covers zips unpacked by tools that drop unix modes.
- `build.sh` keeps its behavior; the unsupported-host (Windows) error and the header now point at the release asset as the supported path.
- `KunaDecompiler/README.md` gains a top "Install from a GitHub Release (recommended; works airgapped)" section; `docs/release.md` documents the new job and asset.

## Local verification (real gradle build, no CI guessing)

Built with **Gradle 9.7.0** (the exact ubuntu-latest preinstalled version; also cross-checked with **Gradle 8.5**, Ghidra's minimum) against the real Ghidra 12.1.2 install, with the real linux_x86_64 `kuna_ghidra` staged plus correctly-named dummies for the other four platforms. The build also compile-checks the `KunaCoreSwap.java` change against real 12.1.2 jars. Output:

```
Created ghidra_12.1.2_PUBLIC_20260817_KunaDecompiler.zip

-rw-r--r--  2.0 unx      198 b- defN 80-Feb-01 00:00 KunaDecompiler/extension.properties
-rw-r--r--  2.0 unx     5933 b- defN 80-Feb-01 00:00 KunaDecompiler/lib/KunaDecompiler.jar
-rwxr-xr-x  2.0 unx       53 b- defN 80-Feb-01 00:00 KunaDecompiler/os/linux_arm_64/kuna_ghidra
-rwxr-xr-x  2.0 unx  8814368 b- defN 80-Feb-01 00:00 KunaDecompiler/os/linux_x86_64/kuna_ghidra
-rwxr-xr-x  2.0 unx       53 b- defN 80-Feb-01 00:00 KunaDecompiler/os/mac_arm_64/kuna_ghidra
-rwxr-xr-x  2.0 unx       53 b- defN 80-Feb-01 00:00 KunaDecompiler/os/mac_x86_64/kuna_ghidra
-rw-r--r--  2.0 unx       53 b- defN 80-Feb-01 00:00 KunaDecompiler/os/win_x86_64/kuna_ghidra.exe

$ unzip -p ...zip KunaDecompiler/extension.properties | grep version
version=12.1.2
```

(Listing elided to the load-bearing entries; the full zip has 22 entries, also carrying `Module.manifest` (required marker), `README.md`, `build.sh`, `ghidra_scripts/KunaCoreStatus.java`, `os/linux_x86_64/README.md`, and `lib/KunaDecompiler-src.zip` — all harmless.)

Single `KunaDecompiler/` top dir, `extension.properties` at depth 2 with `@extversion@` → `12.1.2`, `lib/KunaDecompiler.jar` present, all five `os/` entries, unix modes 0755 — the exact layout `ExtensionUtils` requires. The workflow's verification step was run verbatim against this zip: all assertions pass. Staged binaries cleaned up afterwards (they are gitignored).

## Gates

This diff touches no Rust, test, or spec-anchored files (`git diff --stat`: release.yml, docs/release.md, and `integrations/ghidra/KunaDecompiler/**` only), so the parity gates cannot be affected; they run on this PR as usual. `make check-spec` passes locally. The workspace suite is skipped on internal PRs, so the **`full-ci` label is added to this PR** to force it in CI anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfGYKwUWvPYYj1Aw7tcLhC
