### PR TITLE
[AUTOMATED] feat(ghidra): ghidra-sim differential test harness — pin the GUI-path quality gap

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,12 +139,17 @@ jobs:
       # The grep guards against the visible-skip trap: with specs missing these
       # tests print a skip notice and pass vacuously (same canary pattern as the
       # rust-test job).
+      # `tee` (not `out=$(…)`) so a FAILING run still prints its diagnostics:
+      # under `bash -e` a command substitution aborts the step before any
+      # `echo "$out"`, which would leave a red step with zero output exactly
+      # when the pins fire. pipefail (set by the explicit bash shell above)
+      # preserves cargo's exit code through the pipe.
       - name: ghidra-sim differential harness (kuna-ghidra, release)
         run: |
           cd decompiler
-          out=$(cargo test -p kuna-ghidra --release -- --include-ignored --nocapture 2>&1)
-          echo "$out"
-          if grep -qE 'skipping \(.*(\.sla|make specs|specs tree)' <<<"$out"; then
+          cargo test -p kuna-ghidra --release -- --include-ignored --nocapture 2>&1 \
+            | tee "$RUNNER_TEMP/ghidra-sim.log"
+          if grep -qE 'skipping \(.*(\.sla|make specs|specs tree)' "$RUNNER_TEMP/ghidra-sim.log"; then
             echo "::error::ghidra-sim tests skipped for missing/unusable SLEIGH specs -- the harness would be a false green"
             exit 1
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,6 +126,29 @@ jobs:
             exit 1
           fi
 
+      # The ghidra-mode differential harness (docs/ghidra-integration.md §11):
+      # drives the full decompile-process wire protocol in-process against real
+      # vendored ELFs, with the mock-Java end answered from kuna's own analysis,
+      # and pins the GUI-path quality numbers (placeholder rate, register/Unique
+      # leaks, ghidra-vs-CLI diff ratio, query traffic). Lives in the workspace
+      # suite too, but that job is skipped on internal PRs -- and a regression in
+      # the GUI path is exactly what these pins exist to catch pre-merge. Cheap:
+      # release profile over the deps `make binaries` already built (~2 min
+      # compile, seconds of runtime). `--include-ignored` picks up the heavier
+      # sort/grep breadth test that the dev-profile workspace run skips.
+      # The grep guards against the visible-skip trap: with specs missing these
+      # tests print a skip notice and pass vacuously (same canary pattern as the
+      # rust-test job).
+      - name: ghidra-sim differential harness (kuna-ghidra, release)
+        run: |
+          cd decompiler
+          out=$(cargo test -p kuna-ghidra --release -- --include-ignored --nocapture 2>&1)
+          echo "$out"
+          if grep -qE 'skipping \(.*(\.sla|make specs|specs tree)' <<<"$out"; then
+            echo "::error::ghidra-sim tests skipped for missing/unusable SLEIGH specs -- the harness would be a false green"
+            exit 1
+          fi
+
       - name: Assemble and test the browser Worker boundary
         run: |
           bash integrations/web/build.sh

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BINDIR  := $(ENGINE)/target/$(PROFILE)
 SLACOMP := $(BINDIR)/slacomp
 PYTHON  ?= python3
 
-.PHONY: all binaries specs test test-stages rust rust-test clean check-spec version
+.PHONY: all binaries specs test test-stages test-ghidra rust rust-test clean check-spec version
 
 all: binaries specs
 
@@ -53,6 +53,15 @@ test-stages: $(BINDIR)/kuna
 
 $(BINDIR)/kuna:
 	cd $(ENGINE) && cargo build --$(PROFILE) -p kuna-cli
+
+# The ghidra-mode differential harness (kuna-ghidra's ghidra-sim tests,
+# docs/ghidra-integration.md §11): drives the decompile-process wire protocol
+# in-process against real vendored ELFs and pins the GUI-path quality numbers.
+# Release profile (the dev profile costs minutes for the same answer);
+# --include-ignored picks up the heavier sort/grep breadth test.
+test-ghidra:
+	@test -n "$$(find $(SPECS) -name '*.sla' -print -quit)" || $(MAKE) specs
+	cd $(ENGINE) && cargo test --$(PROFILE) -p kuna-ghidra -- --include-ignored
 
 # Spec honesty gate: docs/spec/ anchors resolve, every phase folder is owned by
 # exactly one chapter, and (strict) every settable option is mentioned.

--- a/decompiler/Cargo.lock
+++ b/decompiler/Cargo.lock
@@ -184,7 +184,9 @@ dependencies = [
 name = "kuna-ghidra"
 version = "0.1.0"
 dependencies = [
+ "kuna-analysis",
  "kuna-base",
+ "kuna-console",
  "kuna-decomp",
  "kuna-num",
  "kuna-sleigh",

--- a/decompiler/crates/kuna-ghidra/Cargo.toml
+++ b/decompiler/crates/kuna-ghidra/Cargo.toml
@@ -30,6 +30,15 @@ kuna-sleigh.workspace = true
 # cycle: the ghidra translator is the downstream implementor of the trait.
 kuna-decomp.workspace = true
 
+[dev-dependencies]
+# The ghidra-sim test harness (tests/ghidra_sim/) answers the wire queries from
+# kuna's OWN analysis of real vendored ELFs: kuna-console provides the
+# in-process bootstrap/decompile drive (the CLI path — also the differential
+# ground truth), kuna-analysis rides in through it.  Dev-only and cycle-free:
+# nothing depends on kuna-ghidra, and dev-deps do not propagate.
+kuna-console.workspace = true
+kuna-analysis.workspace = true
+
 [lints]
 workspace = true
 

--- a/decompiler/crates/kuna-ghidra/tests/decompile_at_e2e.rs
+++ b/decompiler/crates/kuna-ghidra/tests/decompile_at_e2e.rs
@@ -1,19 +1,20 @@
 //! The decompileAt end-to-end proof (phase-2 step 6): drive a FULL ghidra-mode
 //! session — registerProgram → setAction("decompile","c") → decompileAt(entry)
-//! — for a TINY real function and prove C comes out.
+//! — for a TINY canned function and prove C comes out.
 //!
 //! Unlike the pre-canned byte streams of `protocol_e2e.rs`, this drives the LIVE
 //! decompiler: `decompileAt` runs `decompile_func`, whose flow-follow + pipeline
 //! issue getPcode/getCodeLabel/getRegister/... queries whose exact sequence
 //! depends on engine internals.  Pre-canning that sequence would be brittle, so
-//! the MockJava here is an **interactive single-threaded loopback**: the process
-//! writes queries into a shared buffer; the mock decodes each query's command
-//! element id and generates a response on demand (empty getUserOpName to end the
-//! probe, a name for getCodeLabel, a canned `<inst>` RETURN for getPcode at the
-//! entry, safe minimal answers for everything else).  This is sound because
-//! packed protocol payloads are 0x00-free (protocol.rs:21), so the 4-byte
-//! query-open marker `[0,0,1,4]` never occurs inside a payload and query frames
-//! are unambiguously delimited.
+//! the MockJava here is the **interactive single-threaded loopback** shared
+//! machinery in `tests/ghidra_sim/mod.rs` (extracted from this test): the
+//! process writes queries into a shared buffer; the mock decodes each query's
+//! command element id and generates a response on demand (empty getUserOpName
+//! to end the probe, a name for getCodeLabel, a canned `<inst>` RETURN for
+//! getPcode at the entry, safe minimal answers for everything else).
+//!
+//! The real-program twin of this test — the same machinery answering from
+//! kuna's own analysis of a vendored ELF — is `ghidra_sim_e2e.rs`.
 //!
 //! ## What this covers
 //!   * The whole wire lifecycle end to end over the real command loop.
@@ -35,26 +36,28 @@
 //!   * There is NO symbol scope (Phase 3): unresolved refs degrade to
 //!     placeholders, which is the accepted phase-2 quality.
 
+mod ghidra_sim;
+
 use std::cell::RefCell;
-use std::cmp::min;
-use std::collections::{BTreeMap, BTreeSet};
-use std::io::{Read, Write};
 use std::rc::Rc;
 
 use kuna_base::address::Address;
-use kuna_base::marshal::{
-    Decoder, ElementId, Encoder, PackedDecode, PackedEncode, ATTRIB_NAME, ATTRIB_SIZE,
-};
+use kuna_base::marshal::{Decoder, ElementId, Encoder, PackedDecode, PackedEncode, ATTRIB_SIZE};
 use kuna_base::space::AddrSpaceManager;
 use kuna_num::opcodes::{OpCode, OpcodeEncoder};
 use kuna_sleigh::translate::{ATTRIB_CODE, ELEM_OP};
 
 use kuna_ghidra::ids::{
     ELEM_COMMAND_GETBYTES, ELEM_COMMAND_GETCODELABEL, ELEM_COMMAND_GETPCODE,
-    ELEM_COMMAND_GETREGISTER, ELEM_COMMAND_GETREGISTERNAME, ELEM_COMMAND_GETUSEROPNAME, ELEM_DOC,
+    ELEM_COMMAND_GETREGISTER, ELEM_COMMAND_GETREGISTERNAME, ELEM_COMMAND_GETUSEROPNAME,
 };
 use kuna_ghidra::process::GhidraProcess;
 use kuna_ghidra::translate::{build_registry, TspecModel};
+
+use ghidra_sim::{
+    cmd_decompile_at, cmd_register_program, cmd_set_action, parse_decompile_doc, resp_empty,
+    resp_string, AnswerSource, MockReader, MockState, MockWriter,
+};
 
 // The four registerProgram documents — the same tiny valid specs
 // `protocol_e2e.rs` proves build a live `Architecture` (single init query, empty
@@ -75,119 +78,15 @@ const CORETYPES: &[u8] =
 const ENTRY: u64 = 0x1000;
 const FUNC_NAME: &[u8] = b"myfunc";
 
-// Marshaling attribute ids used only for decoding the response (raw numeric ids;
-// PackedDecode returns them straight from open_element / get_next_attribute_id).
-const ATTRIB_REF_ID: u32 = 18; // Varnode::getCreateIndex back-ref (marshal.rs)
-const ATTRIB_UNIQ_ID: u32 = 29; // <seqnum uniq> == PcodeOp::getTime (address.rs)
-const ATTRIB_OPREF_ID: u32 = 41; // EmitMarkup opref (prettyprint.rs)
-const ATTRIB_VARREF_ID: u32 = 42; // EmitMarkup varref (prettyprint.rs)
-const ELEM_FUNCTION_ID: u32 = 116; // <function> (funcdata_encode.rs)
-
-// ---------------------------------------------------------------------------
-// Interactive loopback MockJava
-// ---------------------------------------------------------------------------
-
-/// State shared between the process's `sin` ([`MockReader`]) and `sout`
-/// ([`MockWriter`]): the proactive command stream, the process's output buffer
-/// (scanned for query frames), and the response queue fed back to the process.
-struct MockState {
-    /// The proactive command frames (registerProgram/setAction/decompileAt).
-    commands: Vec<u8>,
-    /// Cursor into `commands`.
-    cmd_cursor: usize,
-    /// Everything the process has written (queries + command-response framing).
-    from_process: Vec<u8>,
-    /// How far `from_process` has been scanned for query frames.
-    parsed: usize,
-    /// Bytes queued to feed the process back (query responses).
-    to_process: Vec<u8>,
+/// The canned answer source: fixed constants over the tiny inline tspec (the
+/// original MockJava of this test, now behind the shared [`AnswerSource`]).
+struct CannedSource {
     /// The tspec address-space manager (decodes the getPcode `<addr>`, encodes
     /// the canned `<inst>` / register responses).
     manager: Rc<AddrSpaceManager>,
 }
 
-impl MockState {
-    /// Scan `from_process` for complete query frames `{4}{14}<doc>{15}{5}`,
-    /// generating a response for each into `to_process`.  Safe because packed
-    /// payloads are 0x00-free, so `[0,0,1,4]` marks only a query open.
-    fn pump(&mut self) {
-        loop {
-            let rest = &self.from_process[self.parsed..];
-            let start = match find_subseq(rest, &[0, 0, 1, 4]) {
-                Some(i) => self.parsed + i,
-                None => {
-                    // No query pending; keep the last 3 bytes in case a marker
-                    // straddles the next write.
-                    self.parsed = self.from_process.len().saturating_sub(3);
-                    return;
-                }
-            };
-            let after_qopen = start + 4;
-            // Expect the string-open marker {14}.
-            if self.from_process.len() < after_qopen + 4 {
-                self.parsed = start;
-                return; // incomplete — wait for more bytes
-            }
-            if self.from_process[after_qopen..after_qopen + 4] != [0, 0, 1, 14] {
-                // Not a well-formed query open; skip this marker.
-                self.parsed = start + 1;
-                continue;
-            }
-            let doc_start = after_qopen + 4;
-            // The packed doc is 0x00-free, so {15} delimits it unambiguously.
-            let close = match find_subseq(&self.from_process[doc_start..], &[0, 0, 1, 15]) {
-                Some(i) => doc_start + i,
-                None => {
-                    self.parsed = start;
-                    return; // incomplete — wait for the string close
-                }
-            };
-            let doc = self.from_process[doc_start..close].to_vec();
-            let after_sclose = close + 4; // past {15}
-            if self.from_process.len() < after_sclose + 4 {
-                self.parsed = start;
-                return; // the {5} query close has not arrived yet
-            }
-            let resp = self.generate_response(&doc);
-            self.to_process.extend_from_slice(&resp);
-            self.parsed = after_sclose + 4; // past the {5} query close
-        }
-    }
-
-    /// Decode a query's command element id and produce its response bytes.
-    fn generate_response(&self, doc: &[u8]) -> Vec<u8> {
-        let mut dec = PackedDecode::new(&self.manager);
-        dec.ingest_stream(doc).expect("query doc ingests");
-        let el = dec.open_element().expect("query has a command element");
-        if el == ELEM_COMMAND_GETUSEROPNAME.get_id() {
-            // Empty name at index 0 terminates the init-time user-op probe.
-            resp_string(b"")
-        } else if el == ELEM_COMMAND_GETCODELABEL.get_id() {
-            // The primary symbol name -> <function name>.
-            resp_string(FUNC_NAME)
-        } else if el == ELEM_COMMAND_GETPCODE.get_id() {
-            let addr = Address::decode(&mut dec).expect("getPcode carries an <addr>");
-            if addr.get_offset() == ENTRY {
-                resp_string(&self.return_inst_doc())
-            } else {
-                resp_empty() // BadData: flow should not ask past the RETURN
-            }
-        } else if el == ELEM_COMMAND_GETREGISTER.get_id() {
-            // A fixed valid register storage so a register lookup never errors
-            // (the register-free RETURN function should not reach here).
-            resp_string(&self.register_addr_doc())
-        } else if el == ELEM_COMMAND_GETREGISTERNAME.get_id() {
-            resp_string(b"") // no named register -> render by raw location
-        } else if el == ELEM_COMMAND_GETBYTES.get_id() {
-            resp_empty() // DataUnavail (no loadimage for a register/const-only fn)
-        } else {
-            // getComments / getMappedSymbols / getTrackedRegisters / getDataType
-            // / ... : an empty response (the decompile of this function issues
-            // none of them, but answer defensively so nothing desyncs).
-            resp_empty()
-        }
-    }
-
+impl CannedSource {
     /// The canned getPcode answer for the entry: `<inst offset=1>` + the pc
     /// `<addr>` + one `<op>` `RETURN #0x0:8` (output `<void/>`, one constant
     /// input).  A RETURN terminates flow, so this single instruction is the whole
@@ -228,210 +127,41 @@ impl MockState {
     }
 }
 
-/// The process's `sin`: serves query responses (from `to_process`) first, then
-/// the proactive command stream.
-struct MockReader {
-    shared: Rc<RefCell<MockState>>,
-}
-impl Read for MockReader {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let mut st = self.shared.borrow_mut();
-        st.pump(); // answer any pending query before serving
-        if !st.to_process.is_empty() {
-            let n = min(buf.len(), st.to_process.len());
-            buf[..n].copy_from_slice(&st.to_process[..n]);
-            st.to_process.drain(..n);
-            return Ok(n);
-        }
-        if st.cmd_cursor >= st.commands.len() {
-            return Ok(0); // EOF: the test stops driving before this is hit
-        }
-        let n = min(buf.len(), st.commands.len() - st.cmd_cursor);
-        let start = st.cmd_cursor;
-        buf[..n].copy_from_slice(&st.commands[start..start + n]);
-        st.cmd_cursor += n;
-        Ok(n)
-    }
-}
-
-/// The process's `sout`: accumulates output; flush triggers the query pump.
-struct MockWriter {
-    shared: Rc<RefCell<MockState>>,
-}
-impl Write for MockWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.shared.borrow_mut().from_process.extend_from_slice(buf);
-        Ok(buf.len())
-    }
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.shared.borrow_mut().pump();
-        Ok(())
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Wire builders (mirroring DecompileProcess.java's writer)
-// ---------------------------------------------------------------------------
-
-fn burst(v: &mut Vec<u8>, code: u8) {
-    v.extend_from_slice(&[0, 0, 1, code]);
-}
-
-/// `writeString`: {14} bytes {15}.
-fn wire_string(v: &mut Vec<u8>, s: &[u8]) {
-    burst(v, 14);
-    v.extend_from_slice(s);
-    burst(v, 15);
-}
-
-/// A query response wrapping a string stream: {8}{14}s{15}{9}.
-fn resp_string(s: &[u8]) -> Vec<u8> {
-    let mut r = Vec::new();
-    burst(&mut r, 8);
-    wire_string(&mut r, s);
-    burst(&mut r, 9);
-    r
-}
-
-/// An empty query response: {8}{9} (read_all -> false: BadData / DataUnavail /
-/// "not found", per the caller).
-fn resp_empty() -> Vec<u8> {
-    let mut r = Vec::new();
-    burst(&mut r, 8);
-    burst(&mut r, 9);
-    r
-}
-
-/// Build the proactive command stream: registerProgram + setAction + decompileAt.
-fn build_commands(addr_packed: &[u8]) -> Vec<u8> {
-    let mut v = Vec::new();
-    // registerProgram: {2}"registerProgram" + 4 string streams + {3}
-    burst(&mut v, 2);
-    wire_string(&mut v, b"registerProgram");
-    wire_string(&mut v, PSPEC);
-    wire_string(&mut v, CSPEC);
-    wire_string(&mut v, TSPEC);
-    wire_string(&mut v, CORETYPES);
-    burst(&mut v, 3);
-    // setAction: archid + "decompile" + "c"
-    burst(&mut v, 2);
-    wire_string(&mut v, b"setAction");
-    wire_string(&mut v, b"0");
-    wire_string(&mut v, b"decompile");
-    wire_string(&mut v, b"c");
-    burst(&mut v, 3);
-    // decompileAt: archid + packed <addr>
-    burst(&mut v, 2);
-    wire_string(&mut v, b"decompileAt");
-    wire_string(&mut v, b"0");
-    wire_string(&mut v, addr_packed);
-    burst(&mut v, 3);
-    v
-}
-
-// ---------------------------------------------------------------------------
-// Response-stream tokenizer + <doc> extractor
-// ---------------------------------------------------------------------------
-
-/// Find the first occurrence of `needle` in `hay`.
-fn find_subseq(hay: &[u8], needle: &[u8]) -> Option<usize> {
-    if needle.is_empty() || hay.len() < needle.len() {
-        return None;
-    }
-    (0..=hay.len() - needle.len()).find(|&i| &hay[i..i + needle.len()] == needle)
-}
-
-/// Split the process output into `(burst_code, payload)` tokens.  Payloads are
-/// 0x00-free, so each is exactly the bytes between one marker and the next.
-fn tokenize(stream: &[u8]) -> Vec<(u8, Vec<u8>)> {
-    let mut toks = Vec::new();
-    let mut i = 0usize;
-    while i < stream.len() {
-        // Skip any non-zero garbage, then the (1+) zero run, then 0x01.
-        while i < stream.len() && stream[i] != 0 {
-            i += 1;
-        }
-        while i < stream.len() && stream[i] == 0 {
-            i += 1;
-        }
-        if i >= stream.len() || stream[i] != 1 {
-            break;
-        }
-        i += 1;
-        if i >= stream.len() {
-            break;
-        }
-        let code = stream[i];
-        i += 1;
-        let start = i;
-        while i < stream.len() && stream[i] != 0 {
-            i += 1;
-        }
-        toks.push((code, stream[start..i].to_vec()));
-    }
-    toks
-}
-
-/// Extract the payload string-stream of the LAST command response (the
-/// decompileAt `<doc>`): within the last `{6}..{7}`, the `{14}` token that is NOT
-/// nested inside a `{4}..{5}` query.
-fn extract_last_response_payload(stream: &[u8]) -> Vec<u8> {
-    let toks = tokenize(stream);
-    let last6 = toks
-        .iter()
-        .rposition(|(c, _)| *c == 6)
-        .expect("a command-response open in the output");
-    let mut in_query = false;
-    for (code, payload) in &toks[last6..] {
-        match code {
-            4 => in_query = true,
-            5 => in_query = false,
-            14 if !in_query => return payload.clone(),
-            7 => break,
-            _ => {}
+impl AnswerSource for CannedSource {
+    /// Decode a query's command element id and produce its response bytes.
+    fn respond(&mut self, doc: &[u8]) -> Vec<u8> {
+        let mut dec = PackedDecode::new(&self.manager);
+        dec.ingest_stream(doc).expect("query doc ingests");
+        let el = dec.open_element().expect("query has a command element");
+        if el == ELEM_COMMAND_GETUSEROPNAME.get_id() {
+            // Empty name at index 0 terminates the init-time user-op probe.
+            resp_string(b"")
+        } else if el == ELEM_COMMAND_GETCODELABEL.get_id() {
+            // The primary symbol name -> <function name>.
+            resp_string(FUNC_NAME)
+        } else if el == ELEM_COMMAND_GETPCODE.get_id() {
+            let addr = Address::decode(&mut dec).expect("getPcode carries an <addr>");
+            if addr.get_offset() == ENTRY {
+                resp_string(&self.return_inst_doc())
+            } else {
+                resp_empty() // BadData: flow should not ask past the RETURN
+            }
+        } else if el == ELEM_COMMAND_GETREGISTER.get_id() {
+            // A fixed valid register storage so a register lookup never errors
+            // (the register-free RETURN function should not reach here).
+            resp_string(&self.register_addr_doc())
+        } else if el == ELEM_COMMAND_GETREGISTERNAME.get_id() {
+            resp_string(b"") // no named register -> render by raw location
+        } else if el == ELEM_COMMAND_GETBYTES.get_id() {
+            resp_empty() // DataUnavail (no loadimage for a register/const-only fn)
+        } else {
+            // getComments / getMappedSymbols / getTrackedRegisters / getDataType
+            // / ... : an empty response (the decompile of this function issues
+            // none of them, but answer defensively so nothing desyncs).
+            resp_empty()
         }
     }
-    Vec::new()
 }
-
-// ---------------------------------------------------------------------------
-// <doc> decoder
-// ---------------------------------------------------------------------------
-
-/// Recursively walk the current (already-opened) element, collecting the values
-/// of the `target` attribute ids into `out`, then recursing into children.
-fn walk(
-    dec: &mut PackedDecode,
-    targets: &[u32],
-    out: &mut BTreeMap<u32, BTreeSet<u64>>,
-) -> Result<(), kuna_base::error::KunaError> {
-    loop {
-        let aid = dec.get_next_attribute_id()?;
-        if aid == 0 {
-            break;
-        }
-        if targets.contains(&aid) {
-            let v = dec.read_unsigned_integer()?;
-            out.entry(aid).or_default().insert(v);
-        }
-        // Un-targeted attributes are left un-read; the next get_next_attribute_id
-        // auto-skips them (PackedDecode contract).
-    }
-    loop {
-        let c = dec.peek_element()?;
-        if c == 0 {
-            break;
-        }
-        let id = dec.open_element()?;
-        walk(dec, targets, out)?;
-        dec.close_element(id)?;
-    }
-    Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// The test
-// ---------------------------------------------------------------------------
 
 #[test]
 fn test_decompile_at_emits_c() {
@@ -451,14 +181,16 @@ fn test_decompile_at_emits_c() {
         v
     };
 
-    let shared = Rc::new(RefCell::new(MockState {
-        commands: build_commands(&addr_packed),
-        cmd_cursor: 0,
-        from_process: Vec::new(),
-        parsed: 0,
-        to_process: Vec::new(),
-        manager: Rc::clone(&manager),
-    }));
+    // The proactive command stream: registerProgram + setAction + decompileAt.
+    let mut commands = Vec::new();
+    cmd_register_program(&mut commands, PSPEC, CSPEC, TSPEC, CORETYPES);
+    cmd_set_action(&mut commands, "0", "decompile", "c");
+    cmd_decompile_at(&mut commands, "0", &addr_packed);
+
+    let shared = Rc::new(RefCell::new(MockState::new(
+        commands,
+        CannedSource { manager: Rc::clone(&manager) },
+    )));
 
     let reader = MockReader { shared: Rc::clone(&shared) };
     let writer = MockWriter { shared: Rc::clone(&shared) };
@@ -489,67 +221,64 @@ fn test_decompile_at_emits_c() {
         "decompileAt degraded to the incomplete-function shape: {text}"
     );
 
-    // Extract the decompileAt <doc> payload and decode it.
-    let doc = extract_last_response_payload(&out);
+    // Extract the decompileAt <doc> payload (the last command response) and
+    // decode it with the shared dual-<function> parser.
+    let trace = ghidra_sim::trace_session(&out);
+    let doc = trace
+        .responses
+        .last()
+        .and_then(|r| r.payload.clone())
+        .expect("decompileAt produced a response payload");
     assert!(!doc.is_empty(), "decompileAt emitted an EMPTY payload (no <doc>)");
 
-    let mut dec = PackedDecode::new(&manager);
-    dec.ingest_stream(&doc).expect("<doc> ingests");
-    let did = dec.open_element().expect("open <doc>");
-    assert_eq!(did, ELEM_DOC.get_id(), "root is not <doc>");
+    let parsed = parse_decompile_doc(&doc, &manager);
 
-    // --- the first <function>: the Funcdata::encode <function>/<ast> ---
-    let fid = dec.open_element().expect("open <function>");
-    assert_eq!(fid, ELEM_FUNCTION_ID, "first child of <doc> is not <function>");
-    let name = dec.read_string_id(&ATTRIB_NAME).expect("<function name>");
     assert_eq!(
-        name, FUNC_NAME,
+        parsed.name.as_bytes(),
+        FUNC_NAME,
         "<function name> must be the getCodeLabel name"
     );
-    // Collect the AST's op times (<seqnum uniq>) and varnode create-indices
-    // (<addr ref>).
-    let mut ast = BTreeMap::new();
-    walk(&mut dec, &[ATTRIB_REF_ID, ATTRIB_UNIQ_ID], &mut ast).expect("walk <function>");
-    dec.close_element(fid).expect("close <function>");
-
-    let op_times = ast.get(&ATTRIB_UNIQ_ID).cloned().unwrap_or_default();
-    let var_refs = ast.get(&ATTRIB_REF_ID).cloned().unwrap_or_default();
     assert!(
-        !op_times.is_empty(),
+        !parsed.ast_op_times.is_empty(),
         "the <ast> has no ops (empty function body) — expected the RETURN op"
     );
-
-    // --- the second <function>: the Clang token markup ---
-    let next = dec.peek_element().expect("peek after <function>");
-    assert_eq!(
-        next, ELEM_FUNCTION_ID,
+    assert!(
+        parsed.has_markup,
         "the C-code markup <function> is missing (send_c_code + decompile action)"
     );
-    let mid = dec.open_element().expect("open markup <function>");
-    let mut markup = BTreeMap::new();
-    walk(&mut dec, &[ATTRIB_OPREF_ID, ATTRIB_VARREF_ID], &mut markup)
-        .expect("walk markup <function>");
-    dec.close_element(mid).expect("close markup <function>");
-    dec.close_element(did).expect("close <doc>");
-
-    let oprefs = markup.get(&ATTRIB_OPREF_ID).cloned().unwrap_or_default();
-    let varrefs = markup.get(&ATTRIB_VARREF_ID).cloned().unwrap_or_default();
 
     // The click-to-address contract: every markup token ref resolves against the
     // AST it was emitted alongside.
     assert!(
-        oprefs.is_subset(&op_times),
-        "markup oprefs {oprefs:?} are not a subset of the AST op times {op_times:?}"
+        parsed.markup_oprefs.is_subset(&parsed.ast_op_times),
+        "markup oprefs {:?} are not a subset of the AST op times {:?}",
+        parsed.markup_oprefs,
+        parsed.ast_op_times
     );
     assert!(
-        varrefs.is_subset(&var_refs),
-        "markup varrefs {varrefs:?} are not a subset of the AST varnode refs {var_refs:?}"
+        parsed.markup_varrefs.is_subset(&parsed.ast_var_refs),
+        "markup varrefs {:?} are not a subset of the AST varnode refs {:?}",
+        parsed.markup_varrefs,
+        parsed.ast_var_refs
     );
     // The markup must actually reference the syntax tree (a bare `return;` still
     // tags its statement/op), proving the two documents are cross-linked rather
     // than trivially both empty.
     assert!(
-        !oprefs.is_empty() || !varrefs.is_empty(),
+        !parsed.markup_oprefs.is_empty() || !parsed.markup_varrefs.is_empty(),
         "the markup carried NO opref/varref — the dual <function> is not cross-linked to the <ast>"
+    );
+
+    // The flattened markup IS the C the GUI renders: it must name the function
+    // and carry a body.
+    assert!(
+        parsed.c_text.contains("myfunc"),
+        "flattened markup C does not name the function:\n{}",
+        parsed.c_text
+    );
+    assert!(
+        parsed.c_text.contains('{') && parsed.c_text.contains('}'),
+        "flattened markup C has no function body:\n{}",
+        parsed.c_text
     );
 }

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim/mod.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim/mod.rs
@@ -1,0 +1,770 @@
+//! Shared MockJava machinery for the ghidra-mode test harness.
+//!
+//! One end of the decompiler-process pipe, in-process: the interactive
+//! single-threaded loopback proven by `decompile_at_e2e.rs`, extracted so both
+//! the canned-answer e2e test and the real-program **ghidra-sim** harness
+//! (`ghidra_sim_e2e.rs`) drive the SAME machinery.  The process writes queries
+//! into a shared buffer; the mock decodes each query frame and asks a pluggable
+//! [`AnswerSource`] for the response.  This is sound because packed protocol
+//! payloads are 0x00-free (protocol.rs), so the 4-byte query-open marker
+//! `[0,0,1,4]` never occurs inside a payload and query frames are unambiguously
+//! delimited.
+//!
+//! Contents:
+//!   * the [`AnswerSource`] trait + [`MockState`]/[`MockReader`]/[`MockWriter`]
+//!     loopback (the process's `sin`/`sout`),
+//!   * wire builders mirroring `DecompileProcess.java`'s writer (command
+//!     frames, query responses),
+//!   * a session-output tracer ([`trace_session`]) splitting the raw output
+//!     stream into per-command responses with their nested queries + warnings,
+//!   * a `decompileAt` `<doc>` parser ([`parse_decompile_doc`]) that decodes
+//!     the dual `<function>` and **flattens the Clang markup to C text**, and
+//!   * the static badness scanners (register/Unique/placeholder leaks) and the
+//!     normalized line-diff ratio used by the differential-C pins.
+//!
+//! The real-program answer source lives in [`oracle`] (backed by
+//! `kuna_console::engine::bootstrap_from_object` — the same in-process load the
+//! CLI uses).
+
+#![allow(dead_code)] // shared by several test binaries; each uses a subset
+
+pub mod oracle;
+
+use std::cell::RefCell;
+use std::cmp::min;
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::{Read, Write};
+use std::rc::Rc;
+
+use kuna_base::address::{Address, ELEM_ADDR};
+use kuna_base::error::KunaError;
+use kuna_base::marshal::{Decoder, PackedDecode, ATTRIB_CONTENT, ATTRIB_NAME};
+use kuna_base::space::AddrSpaceManager;
+
+use kuna_ghidra::ids::ELEM_DOC;
+
+// ---------------------------------------------------------------------------
+// Raw numeric marshaling ids used only for decoding responses
+// ---------------------------------------------------------------------------
+
+/// Varnode::getCreateIndex back-ref (`<addr ref=…>`, marshal.rs).
+pub const ATTRIB_REF_ID: u32 = 18;
+/// `<seqnum uniq>` == PcodeOp::getTime (address.rs).
+pub const ATTRIB_UNIQ_ID: u32 = 29;
+/// EmitMarkup opref (prettyprint.rs).
+pub const ATTRIB_OPREF_ID: u32 = 41;
+/// EmitMarkup varref (prettyprint.rs).
+pub const ATTRIB_VARREF_ID: u32 = 42;
+/// EmitMarkup `<break indent=…>` (prettyprint.rs).
+pub const ATTRIB_INDENT_ID: u32 = 38;
+/// EmitMarkup `color` (prettyprint.rs) — the ClangToken syntax highlight.
+pub const ATTRIB_COLOR_ID: u32 = 37;
+/// `<function>` (funcdata_encode.rs).
+pub const ELEM_FUNCTION_ID: u32 = 116;
+/// `<break>` — the markup line break (prettyprint.rs).
+pub const ELEM_BREAK_ID: u32 = 17;
+/// `<funcname>` (prettyprint.rs) → Java ClangFuncNameToken.
+pub const ELEM_FUNCNAME_ID: u32 = 19;
+/// `<label>` (prettyprint.rs) → Java ClangLabelToken.
+pub const ELEM_LABEL_ID: u32 = 21;
+/// `<variable>` (prettyprint.rs) → Java ClangVariableToken.
+pub const ELEM_VARIABLE_ID: u32 = 26;
+/// `<field>` (type.cc vocabulary) → Java ClangFieldToken.
+pub const ELEM_FIELD_ID: u32 = 49;
+/// `<type>` (type.cc vocabulary) → Java ClangTypeToken.
+pub const ELEM_TYPE_ID: u32 = 60;
+/// `ClangToken.CONST_COLOR` (== `SyntaxHighlight::ConstColor`).
+pub const CONST_COLOR: u64 = 5;
+
+/// The 19 legal callback-query command element ids (ids.rs 239..=257).
+pub const QUERY_COMMAND_IDS: std::ops::RangeInclusive<u32> = 239..=257;
+
+// ---------------------------------------------------------------------------
+// Interactive loopback MockJava
+// ---------------------------------------------------------------------------
+
+/// The pluggable mock-Java answer half: given a decoded query *document* (the
+/// packed bytes between the `{14}`/`{15}` of a `{4}..{5}` query frame),
+/// produce the full response byte frame to feed back to the process.
+pub trait AnswerSource {
+    fn respond(&mut self, doc: &[u8]) -> Vec<u8>;
+}
+
+/// State shared between the process's `sin` ([`MockReader`]) and `sout`
+/// ([`MockWriter`]): the proactive command stream, the process's output buffer
+/// (scanned for query frames), and the response queue fed back to the process.
+pub struct MockState<S: AnswerSource> {
+    /// The proactive command frames (registerProgram/setAction/decompileAt/…).
+    pub commands: Vec<u8>,
+    /// Cursor into `commands`.
+    pub cmd_cursor: usize,
+    /// Everything the process has written (queries + command-response framing).
+    pub from_process: Vec<u8>,
+    /// How far `from_process` has been scanned for query frames.
+    pub parsed: usize,
+    /// Bytes queued to feed the process back (query responses).
+    pub to_process: Vec<u8>,
+    /// The answer generator.
+    pub source: S,
+}
+
+impl<S: AnswerSource> MockState<S> {
+    pub fn new(commands: Vec<u8>, source: S) -> Self {
+        MockState {
+            commands,
+            cmd_cursor: 0,
+            from_process: Vec::new(),
+            parsed: 0,
+            to_process: Vec::new(),
+            source,
+        }
+    }
+
+    /// Scan `from_process` for complete query frames `{4}{14}<doc>{15}{5}`,
+    /// generating a response for each into `to_process`.  Safe because packed
+    /// payloads are 0x00-free, so `[0,0,1,4]` marks only a query open.
+    fn pump(&mut self) {
+        loop {
+            let rest = &self.from_process[self.parsed..];
+            let start = match find_subseq(rest, &[0, 0, 1, 4]) {
+                Some(i) => self.parsed + i,
+                None => {
+                    // No query pending; keep the last 3 bytes in case a marker
+                    // straddles the next write.
+                    self.parsed = self.from_process.len().saturating_sub(3);
+                    return;
+                }
+            };
+            let after_qopen = start + 4;
+            // Expect the string-open marker {14}.
+            if self.from_process.len() < after_qopen + 4 {
+                self.parsed = start;
+                return; // incomplete — wait for more bytes
+            }
+            if self.from_process[after_qopen..after_qopen + 4] != [0, 0, 1, 14] {
+                // Not a well-formed query open; skip this marker.
+                self.parsed = start + 1;
+                continue;
+            }
+            let doc_start = after_qopen + 4;
+            // The packed doc is 0x00-free, so {15} delimits it unambiguously.
+            let close = match find_subseq(&self.from_process[doc_start..], &[0, 0, 1, 15]) {
+                Some(i) => doc_start + i,
+                None => {
+                    self.parsed = start;
+                    return; // incomplete — wait for the string close
+                }
+            };
+            let doc = self.from_process[doc_start..close].to_vec();
+            let after_sclose = close + 4; // past {15}
+            if self.from_process.len() < after_sclose + 4 {
+                self.parsed = start;
+                return; // the {5} query close has not arrived yet
+            }
+            let resp = self.source.respond(&doc);
+            self.to_process.extend_from_slice(&resp);
+            self.parsed = after_sclose + 4; // past the {5} query close
+        }
+    }
+}
+
+/// The process's `sin`: serves query responses (from `to_process`) first, then
+/// the proactive command stream.
+pub struct MockReader<S: AnswerSource> {
+    pub shared: Rc<RefCell<MockState<S>>>,
+}
+impl<S: AnswerSource> Read for MockReader<S> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let mut st = self.shared.borrow_mut();
+        st.pump(); // answer any pending query before serving
+        if !st.to_process.is_empty() {
+            let n = min(buf.len(), st.to_process.len());
+            buf[..n].copy_from_slice(&st.to_process[..n]);
+            st.to_process.drain(..n);
+            return Ok(n);
+        }
+        if st.cmd_cursor >= st.commands.len() {
+            return Ok(0); // EOF: the test stops driving before this is hit
+        }
+        let n = min(buf.len(), st.commands.len() - st.cmd_cursor);
+        let start = st.cmd_cursor;
+        buf[..n].copy_from_slice(&st.commands[start..start + n]);
+        st.cmd_cursor += n;
+        Ok(n)
+    }
+}
+
+/// The process's `sout`: accumulates output; flush triggers the query pump.
+pub struct MockWriter<S: AnswerSource> {
+    pub shared: Rc<RefCell<MockState<S>>>,
+}
+impl<S: AnswerSource> Write for MockWriter<S> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.shared.borrow_mut().from_process.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.shared.borrow_mut().pump();
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire builders (mirroring DecompileProcess.java's writer)
+// ---------------------------------------------------------------------------
+
+pub fn burst(v: &mut Vec<u8>, code: u8) {
+    v.extend_from_slice(&[0, 0, 1, code]);
+}
+
+/// `writeString`: {14} bytes {15}.
+pub fn wire_string(v: &mut Vec<u8>, s: &[u8]) {
+    burst(v, 14);
+    v.extend_from_slice(s);
+    burst(v, 15);
+}
+
+/// A query response wrapping a string stream: {8}{14}s{15}{9}.  Carries either
+/// raw text (getCodeLabel/getRegisterName/…) or a packed document.
+pub fn resp_string(s: &[u8]) -> Vec<u8> {
+    let mut r = Vec::new();
+    burst(&mut r, 8);
+    wire_string(&mut r, s);
+    burst(&mut r, 9);
+    r
+}
+
+/// An empty query response: {8}{9} (read_all -> false: BadData / DataUnavail /
+/// "not found", per the caller).
+pub fn resp_empty() -> Vec<u8> {
+    let mut r = Vec::new();
+    burst(&mut r, 8);
+    burst(&mut r, 9);
+    r
+}
+
+/// A byte-burst query response: {8}{12} raw {13}{9} (getBytes / getStringData;
+/// the payload is already nibble-doubled / header-prefixed by the caller).
+pub fn resp_bytes(raw: &[u8]) -> Vec<u8> {
+    let mut r = Vec::new();
+    burst(&mut r, 8);
+    burst(&mut r, 12);
+    r.extend_from_slice(raw);
+    burst(&mut r, 13);
+    burst(&mut r, 9);
+    r
+}
+
+/// registerProgram: {2}"registerProgram" + the four spec string streams + {3}.
+pub fn cmd_register_program(
+    v: &mut Vec<u8>,
+    pspec: &[u8],
+    cspec: &[u8],
+    tspec: &[u8],
+    coretypes: &[u8],
+) {
+    burst(v, 2);
+    wire_string(v, b"registerProgram");
+    wire_string(v, pspec);
+    wire_string(v, cspec);
+    wire_string(v, tspec);
+    wire_string(v, coretypes);
+    burst(v, 3);
+}
+
+/// setAction: archid + actionstring + printstring.
+pub fn cmd_set_action(v: &mut Vec<u8>, archid: &str, action: &str, print: &str) {
+    burst(v, 2);
+    wire_string(v, b"setAction");
+    wire_string(v, archid.as_bytes());
+    wire_string(v, action.as_bytes());
+    wire_string(v, print.as_bytes());
+    burst(v, 3);
+}
+
+/// decompileAt: archid + the packed `<addr>` of the entry.
+pub fn cmd_decompile_at(v: &mut Vec<u8>, archid: &str, addr_packed: &[u8]) {
+    burst(v, 2);
+    wire_string(v, b"decompileAt");
+    wire_string(v, archid.as_bytes());
+    wire_string(v, addr_packed);
+    burst(v, 3);
+}
+
+/// flushNative: archid only.
+pub fn cmd_flush_native(v: &mut Vec<u8>, archid: &str) {
+    burst(v, 2);
+    wire_string(v, b"flushNative");
+    wire_string(v, archid.as_bytes());
+    burst(v, 3);
+}
+
+/// deregisterProgram: archid only (terminates the process loop).
+pub fn cmd_deregister_program(v: &mut Vec<u8>, archid: &str) {
+    burst(v, 2);
+    wire_string(v, b"deregisterProgram");
+    wire_string(v, archid.as_bytes());
+    burst(v, 3);
+}
+
+// ---------------------------------------------------------------------------
+// Response-stream tokenizer + session tracer
+// ---------------------------------------------------------------------------
+
+/// Find the first occurrence of `needle` in `hay`.
+pub fn find_subseq(hay: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || hay.len() < needle.len() {
+        return None;
+    }
+    (0..=hay.len() - needle.len()).find(|&i| &hay[i..i + needle.len()] == needle)
+}
+
+/// Split the process output into `(burst_code, payload)` tokens.  Payloads are
+/// 0x00-free, so each is exactly the bytes between one marker and the next.
+pub fn tokenize(stream: &[u8]) -> Vec<(u8, Vec<u8>)> {
+    let mut toks = Vec::new();
+    let mut i = 0usize;
+    while i < stream.len() {
+        // Skip any non-zero garbage, then the (1+) zero run, then 0x01.
+        while i < stream.len() && stream[i] != 0 {
+            i += 1;
+        }
+        while i < stream.len() && stream[i] == 0 {
+            i += 1;
+        }
+        if i >= stream.len() || stream[i] != 1 {
+            break;
+        }
+        i += 1;
+        if i >= stream.len() {
+            break;
+        }
+        let code = stream[i];
+        i += 1;
+        let start = i;
+        while i < stream.len() && stream[i] != 0 {
+            i += 1;
+        }
+        toks.push((code, stream[start..i].to_vec()));
+    }
+    toks
+}
+
+/// One command's response span (`{6}..{7}`) in the process output.
+#[derive(Debug, Default)]
+pub struct ResponseTrace {
+    /// The response payload: the first `{14}` string stream NOT nested inside
+    /// a `{4}..{5}` query frame (`None` for a "Bad command" response).
+    pub payload: Option<Vec<u8>>,
+    /// The packed query documents this command issued, in wire order.
+    pub queries: Vec<Vec<u8>>,
+    /// The `{16}..{17}` warnings frame text (empty when the frame was empty
+    /// or — deregister — absent).
+    pub warnings: String,
+}
+
+/// The whole session output split per command response.
+#[derive(Debug, Default)]
+pub struct SessionTrace {
+    pub responses: Vec<ResponseTrace>,
+}
+
+/// Split the raw output stream into per-command [`ResponseTrace`]s: for each
+/// `{6}..{7}` span, the non-query-nested payload, the nested query docs, and
+/// the warnings text.
+pub fn trace_session(stream: &[u8]) -> SessionTrace {
+    let mut trace = SessionTrace::default();
+    let mut in_query = false;
+    for (code, payload) in tokenize(stream) {
+        match code {
+            6 => {
+                trace.responses.push(ResponseTrace::default());
+                in_query = false;
+            }
+            4 => in_query = true,
+            5 => in_query = false,
+            // The warnings text sits between the {16} marker and the {17}
+            // marker's leading 0x00, so tokenize() attaches it to the {16}
+            // token's payload.
+            16 => {
+                if let Some(cur) = trace.responses.last_mut() {
+                    cur.warnings = String::from_utf8_lossy(&payload).into_owned();
+                }
+            }
+            14 => {
+                if let Some(cur) = trace.responses.last_mut() {
+                    if in_query {
+                        cur.queries.push(payload);
+                    } else if cur.payload.is_none() {
+                        cur.payload = Some(payload);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    trace
+}
+
+/// The root element id of a packed query document (one of the 19 command ids).
+pub fn query_doc_id(doc: &[u8], manager: &AddrSpaceManager) -> u32 {
+    let mut dec = PackedDecode::new(manager);
+    dec.ingest_stream(doc).expect("query doc ingests");
+    dec.open_element().expect("query doc has a root element")
+}
+
+// ---------------------------------------------------------------------------
+// <doc> decoding: attribute walk, dual-<function> parse, markup flatten
+// ---------------------------------------------------------------------------
+
+/// Recursively walk the current (already-opened) element, collecting the values
+/// of the `target` attribute ids into `out`, then recursing into children.
+pub fn walk(
+    dec: &mut PackedDecode,
+    targets: &[u32],
+    out: &mut BTreeMap<u32, BTreeSet<u64>>,
+) -> Result<(), KunaError> {
+    loop {
+        let aid = dec.get_next_attribute_id()?;
+        if aid == 0 {
+            break;
+        }
+        if targets.contains(&aid) {
+            let v = dec.read_unsigned_integer()?;
+            out.entry(aid).or_default().insert(v);
+        }
+        // Un-targeted attributes are left un-read; the next get_next_attribute_id
+        // auto-skips them (PackedDecode contract).
+    }
+    loop {
+        let c = dec.peek_element()?;
+        if c == 0 {
+            break;
+        }
+        let id = dec.open_element()?;
+        walk(dec, targets, out)?;
+        dec.close_element(id)?;
+    }
+    Ok(())
+}
+
+/// A fully-decoded `decompileAt` response document.
+#[derive(Debug, Default)]
+pub struct ParsedDoc {
+    /// `<function name=…>` — must echo the name the mock served.
+    pub name: String,
+    /// The entry `<addr>` offset — must echo the requested address
+    /// (HighFunction.decode throws on mismatch).
+    pub entry_offset: Option<u64>,
+    /// `<ast>` op times (`<seqnum uniq=…>`).
+    pub ast_op_times: BTreeSet<u64>,
+    /// `<ast>` varnode create-indices (`<addr ref=…>`).
+    pub ast_var_refs: BTreeSet<u64>,
+    /// Markup `opref` values (must be ⊆ `ast_op_times`).
+    pub markup_oprefs: BTreeSet<u64>,
+    /// Markup `varref` values (must be ⊆ `ast_var_refs`).
+    pub markup_varrefs: BTreeSet<u64>,
+    /// Whether the second (markup) `<function>` was present.
+    pub has_markup: bool,
+    /// The C text flattened from the markup token stream (content strings +
+    /// `<break indent>` line breaks), with Java's `getC()` token cleaning
+    /// applied ([`illegal_char_cpp_transform`]) — what a script/export user
+    /// actually receives from `DecompileResults.getDecompiledFunction()`.
+    pub c_text: String,
+    /// Tokens whose text the Java-side `IllegalCharCppTransformer` CHANGED —
+    /// each is a token kuna emitted with non-identifier characters inside an
+    /// identifier-class token (e.g. the whole rendered declarator
+    /// `"unsigned long *"` as ONE `<type>` token, which `getC()` mangles to
+    /// `unsigned_long__`).  Zero once the markup emitter splits declarators
+    /// into base-type + syntax tokens (PR-C).
+    pub mangled_tokens: usize,
+}
+
+/// Decode a `decompileAt` `<doc>` payload: the first `<function>`'s name/entry
+/// echo + `<ast>` refs, and the second (markup) `<function>` flattened to C
+/// with its opref/varref sets.
+pub fn parse_decompile_doc(doc: &[u8], manager: &AddrSpaceManager) -> ParsedDoc {
+    let mut parsed = ParsedDoc::default();
+    let mut dec = PackedDecode::new(manager);
+    dec.ingest_stream(doc).expect("<doc> ingests");
+    let did = dec.open_element().expect("open <doc>");
+    assert_eq!(did, ELEM_DOC.get_id(), "root is not <doc>");
+
+    // --- the first <function>: the Funcdata::encode <function>/<ast> ---
+    let fid = dec.open_element().expect("open <function>");
+    assert_eq!(fid, ELEM_FUNCTION_ID, "first child of <doc> is not <function>");
+    parsed.name = String::from_utf8_lossy(
+        &dec.read_string_id(&ATTRIB_NAME).expect("<function name>"),
+    )
+    .into_owned();
+    // The base address is the first child element.
+    if dec.peek_element().expect("peek in <function>") == ELEM_ADDR.get_id() {
+        let addr = Address::decode(&mut dec).expect("<function> base <addr>");
+        parsed.entry_offset = Some(addr.get_offset());
+    }
+    let mut ast = BTreeMap::new();
+    walk(&mut dec, &[ATTRIB_REF_ID, ATTRIB_UNIQ_ID], &mut ast).expect("walk <function>");
+    dec.close_element(fid).expect("close <function>");
+    parsed.ast_op_times = ast.get(&ATTRIB_UNIQ_ID).cloned().unwrap_or_default();
+    parsed.ast_var_refs = ast.get(&ATTRIB_REF_ID).cloned().unwrap_or_default();
+
+    // --- the second <function>: the Clang token markup ---
+    if dec.peek_element().expect("peek after <function>") == ELEM_FUNCTION_ID {
+        parsed.has_markup = true;
+        let mid = dec.open_element().expect("open markup <function>");
+        let mut refs = BTreeMap::new();
+        let mut c = String::new();
+        let mut mangled = 0usize;
+        flatten_markup(&mut dec, mid, &mut c, &mut refs, &mut mangled)
+            .expect("flatten markup <function>");
+        dec.close_element(mid).expect("close markup <function>");
+        parsed.markup_oprefs = refs.get(&ATTRIB_OPREF_ID).cloned().unwrap_or_default();
+        parsed.markup_varrefs = refs.get(&ATTRIB_VARREF_ID).cloned().unwrap_or_default();
+        parsed.c_text = c;
+        parsed.mangled_tokens = mangled;
+    }
+    dec.close_element(did).expect("close <doc>");
+    parsed
+}
+
+/// Ordered flatten of the (already-opened) markup element: append every
+/// `content` attribute string, render `<break indent=N>` as `'\n' + N spaces`,
+/// and collect the `opref`/`varref` attributes on the way.
+///
+/// Identifier-class tokens (funcname/variable/type/field/label, except
+/// CONST_COLOR ones) are passed through [`illegal_char_cpp_transform`] first —
+/// exactly what Java's `DecompileResults.getDecompiledFunction()` does
+/// (`PrettyPrinter.getText` + `IllegalCharCppTransformer`), so the flattened C
+/// is what a script/export consumer actually receives, mangling included.
+fn flatten_markup(
+    dec: &mut PackedDecode,
+    elem_id: u32,
+    out: &mut String,
+    refs: &mut BTreeMap<u32, BTreeSet<u64>>,
+    mangled: &mut usize,
+) -> Result<(), KunaError> {
+    let mut indent: i64 = 0;
+    let mut color: Option<u64> = None;
+    let mut content: Option<String> = None;
+    loop {
+        let aid = dec.get_next_attribute_id()?;
+        if aid == 0 {
+            break;
+        }
+        if aid == ATTRIB_CONTENT.get_id() {
+            content = Some(String::from_utf8_lossy(&dec.read_string()?).into_owned());
+        } else if aid == ATTRIB_INDENT_ID {
+            indent = dec.read_signed_integer()?;
+        } else if aid == ATTRIB_COLOR_ID {
+            color = Some(dec.read_unsigned_integer()?);
+        } else if aid == ATTRIB_OPREF_ID || aid == ATTRIB_VARREF_ID {
+            let v = dec.read_unsigned_integer()?;
+            refs.entry(aid).or_default().insert(v);
+        }
+    }
+    if let Some(text) = content {
+        let is_token_to_clean = matches!(
+            elem_id,
+            ELEM_FUNCNAME_ID | ELEM_VARIABLE_ID | ELEM_TYPE_ID | ELEM_FIELD_ID | ELEM_LABEL_ID
+        ) && color != Some(CONST_COLOR);
+        if is_token_to_clean {
+            let cleaned = illegal_char_cpp_transform(&text);
+            if cleaned != text {
+                *mangled += 1;
+            }
+            out.push_str(&cleaned);
+        } else {
+            out.push_str(&text);
+        }
+    }
+    if elem_id == ELEM_BREAK_ID {
+        out.push('\n');
+        for _ in 0..indent.max(0) {
+            out.push(' ');
+        }
+    }
+    loop {
+        let c = dec.peek_element()?;
+        if c == 0 {
+            break;
+        }
+        let id = dec.open_element()?;
+        flatten_markup(dec, id, out, refs, mangled)?;
+        dec.close_element(id)?;
+    }
+    Ok(())
+}
+
+/// Java's `IllegalCharCppTransformer.simplify` (Features/Decompiler,
+/// `DecompileResults.getDecompiledFunction()`'s token cleaner), transcribed:
+/// any character illegal in a C++ identifier becomes `_`, with carve-outs for
+/// digits/`_` after the first character, template parameters inside `<…>`,
+/// `operator` punctuation at positions 8..=10, and a leading `~`.
+pub fn illegal_char_cpp_transform(input: &str) -> String {
+    const AFTER_FIRST: u8 = 1;
+    const TEMPLATE: u8 = 2;
+    const OPERATOR: u8 = 4;
+    const FIRST: u8 = 8;
+    fn legal(c: char) -> u8 {
+        match c {
+            '_' => AFTER_FIRST | TEMPLATE | OPERATOR | FIRST,
+            '0'..='9' => AFTER_FIRST | TEMPLATE | OPERATOR,
+            '*' | '(' | ')' | '[' | ']' | '&' => TEMPLATE | OPERATOR,
+            ':' | ',' => TEMPLATE,
+            '+' | '-' | '|' | '=' | '!' | '/' | '%' | '^' => OPERATOR,
+            '~' => TEMPLATE | OPERATOR | FIRST,
+            _ => 0,
+        }
+    }
+    let mut template_depth = 0i32;
+    let mut changed = false;
+    let mut outbuf: Vec<char> = input.chars().collect();
+    for (i, c) in input.chars().enumerate() {
+        if c.is_alphabetic() {
+            continue;
+        }
+        if c == '<' {
+            template_depth += 1;
+            continue;
+        }
+        if c == '>' {
+            template_depth = (template_depth - 1).max(0);
+            continue;
+        }
+        let val = legal(c);
+        if val != 0 {
+            if (val & AFTER_FIRST) != 0 && i > 0 {
+                continue;
+            }
+            if (val & FIRST) != 0 && i == 0 {
+                continue;
+            }
+            if (val & TEMPLATE) != 0 && template_depth > 0 {
+                continue;
+            }
+            if (val & OPERATOR) != 0 && (8..=10).contains(&i) && input.starts_with("operator") {
+                continue;
+            }
+        }
+        outbuf[i] = '_';
+        changed = true;
+    }
+    if changed {
+        outbuf.into_iter().collect()
+    } else {
+        input.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Static badness scanners (GUI-brokenness detectors) + differential metric
+// ---------------------------------------------------------------------------
+
+/// Split C text into identifier tokens (`[A-Za-z_][A-Za-z0-9_]*`).
+pub fn identifiers(text: &str) -> Vec<&str> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c.is_ascii_alphabetic() || c == b'_' {
+            let start = i;
+            while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                i += 1;
+            }
+            out.push(&text[start..i]);
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Raw-register-identifier leak: identifiers that exactly match a register
+/// name of the language (case-sensitive — the CLI's lowercase `// rax`
+/// location comments never collide).  Returns (occurrence count, distinct
+/// register names seen).
+pub fn register_leaks(c: &str, registers: &BTreeSet<String>) -> (usize, BTreeSet<String>) {
+    let mut count = 0usize;
+    let mut seen = BTreeSet::new();
+    for id in identifiers(c) {
+        if registers.contains(id) {
+            count += 1;
+            seen.insert(id.to_string());
+        }
+    }
+    (count, seen)
+}
+
+/// `Unique<hex>` token leak: identifiers of the un-named unique-storage
+/// rendering (`kuna_unnamed_location_name`), e.g. `Unique00023e00`.  Counts
+/// `Stack<hex>` tokens too — the same no-symbol print tail produces both.
+pub fn unique_leaks(c: &str) -> usize {
+    identifiers(c)
+        .into_iter()
+        .filter(|id| {
+            for prefix in ["Unique", "Stack"] {
+                if let Some(rest) = id.strip_prefix(prefix) {
+                    if !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_hexdigit()) {
+                        return true;
+                    }
+                }
+            }
+            false
+        })
+        .count()
+}
+
+/// Placeholder identifiers by kind: distinct addresses appearing as
+/// `sub_<hex>` / `FUN_<hex>` / `dat_<hex>` / `DAT_<hex>`.
+pub fn placeholder_addrs(c: &str) -> BTreeMap<&'static str, BTreeSet<u64>> {
+    let mut out: BTreeMap<&'static str, BTreeSet<u64>> = BTreeMap::new();
+    for id in identifiers(c) {
+        for kind in ["sub_", "FUN_", "dat_", "DAT_"] {
+            if let Some(rest) = id.strip_prefix(kind) {
+                if !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_hexdigit()) {
+                    if let Ok(addr) = u64::from_str_radix(rest, 16) {
+                        out.entry(kind).or_default().insert(addr);
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Normalize C text for the line diff: per-line trim, drop empty lines.
+pub fn normalized_lines(c: &str) -> Vec<String> {
+    c.lines()
+        .map(|l| l.split_whitespace().collect::<Vec<_>>().join(" "))
+        .filter(|l| !l.is_empty())
+        .collect()
+}
+
+/// Line-level diff ratio after whitespace normalization: `1 - 2*LCS/(|a|+|b|)`.
+/// 0.0 = identical, 1.0 = nothing in common.  This is the per-function gap the
+/// GUI user experiences between the ghidra-mode markup C and the CLI C.
+pub fn line_diff_ratio(a: &str, b: &str) -> f64 {
+    let la = normalized_lines(a);
+    let lb = normalized_lines(b);
+    if la.is_empty() && lb.is_empty() {
+        return 0.0;
+    }
+    // Classic O(n*m) LCS over lines — the fixtures are small functions.
+    let n = la.len();
+    let m = lb.len();
+    let mut prev = vec![0usize; m + 1];
+    let mut cur = vec![0usize; m + 1];
+    for i in 1..=n {
+        for j in 1..=m {
+            cur[j] = if la[i - 1] == lb[j - 1] {
+                prev[j - 1] + 1
+            } else {
+                prev[j].max(cur[j - 1])
+            };
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    let lcs = prev[m];
+    1.0 - (2.0 * lcs as f64) / ((n + m) as f64)
+}

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim/mod.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim/mod.rs
@@ -61,6 +61,10 @@ pub const ATTRIB_INDENT_ID: u32 = 38;
 pub const ATTRIB_COLOR_ID: u32 = 37;
 /// `<function>` (funcdata_encode.rs).
 pub const ELEM_FUNCTION_ID: u32 = 116;
+/// `<ast>` (funcdata_encode.rs).
+pub const ELEM_AST_ID: u32 = 115;
+/// `<varnodes>` — the mandatory first child of `<ast>` (funcdata_encode.rs).
+pub const ELEM_VARNODES_ID: u32 = 119;
 /// `<break>` — the markup line break (prettyprint.rs).
 pub const ELEM_BREAK_ID: u32 = 17;
 /// `<funcname>` (prettyprint.rs) → Java ClangFuncNameToken.
@@ -417,6 +421,16 @@ pub fn query_doc_id(doc: &[u8], manager: &AddrSpaceManager) -> u32 {
 // <doc> decoding: attribute walk, dual-<function> parse, markup flatten
 // ---------------------------------------------------------------------------
 
+/// Consume (skip) all attributes of the current open element, leaving the
+/// decoder positioned at its first child.
+pub fn skip_attributes(dec: &mut PackedDecode) -> Result<(), KunaError> {
+    loop {
+        if dec.get_next_attribute_id()? == 0 {
+            return Ok(());
+        }
+    }
+}
+
 /// Recursively walk the current (already-opened) element, collecting the values
 /// of the `target` attribute ids into `out`, then recursing into children.
 pub fn walk(
@@ -458,7 +472,11 @@ pub struct ParsedDoc {
     pub entry_offset: Option<u64>,
     /// `<ast>` op times (`<seqnum uniq=…>`).
     pub ast_op_times: BTreeSet<u64>,
-    /// `<ast>` varnode create-indices (`<addr ref=…>`).
+    /// `<ast>` varnode create-indices — collected from the `<varnodes>` child
+    /// ONLY, because that is all Java's `PcodeSyntaxTree.buildVarnodeRefs`
+    /// keys: an `<op>` operand `ref` that is not declared in `<varnodes>`
+    /// would silently resolve to null in the GUI, so it must not launder the
+    /// subset assertion.
     pub ast_var_refs: BTreeSet<u64>,
     /// Markup `opref` values (must be ⊆ `ast_op_times`).
     pub markup_oprefs: BTreeSet<u64>,
@@ -502,11 +520,45 @@ pub fn parse_decompile_doc(doc: &[u8], manager: &AddrSpaceManager) -> ParsedDoc 
         let addr = Address::decode(&mut dec).expect("<function> base <addr>");
         parsed.entry_offset = Some(addr.get_offset());
     }
-    let mut ast = BTreeMap::new();
-    walk(&mut dec, &[ATTRIB_REF_ID, ATTRIB_UNIQ_ID], &mut ast).expect("walk <function>");
+    // Walk the remaining children selectively: inside `<ast>`, varnode
+    // create-indices come from the `<varnodes>` declarations only (see the
+    // `ast_var_refs` field doc) while op times come from the `<block>` bodies.
+    loop {
+        let c = dec.peek_element().expect("peek <function> child");
+        if c == 0 {
+            break;
+        }
+        let cid = dec.open_element().expect("open <function> child");
+        if cid == ELEM_AST_ID {
+            skip_attributes(&mut dec).expect("<ast> attributes");
+            loop {
+                let a = dec.peek_element().expect("peek <ast> child");
+                if a == 0 {
+                    break;
+                }
+                let aid = dec.open_element().expect("open <ast> child");
+                let mut got = BTreeMap::new();
+                if aid == ELEM_VARNODES_ID {
+                    walk(&mut dec, &[ATTRIB_REF_ID], &mut got).expect("walk <varnodes>");
+                    parsed
+                        .ast_var_refs
+                        .extend(got.get(&ATTRIB_REF_ID).cloned().unwrap_or_default());
+                } else {
+                    walk(&mut dec, &[ATTRIB_UNIQ_ID], &mut got).expect("walk <ast> child");
+                    parsed
+                        .ast_op_times
+                        .extend(got.get(&ATTRIB_UNIQ_ID).cloned().unwrap_or_default());
+                }
+                dec.close_element(aid).expect("close <ast> child");
+            }
+        } else {
+            // Some other (future: localdb/prototype/…) child: skip through.
+            let mut sink = BTreeMap::new();
+            walk(&mut dec, &[], &mut sink).expect("walk <function> child");
+        }
+        dec.close_element(cid).expect("close <function> child");
+    }
     dec.close_element(fid).expect("close <function>");
-    parsed.ast_op_times = ast.get(&ATTRIB_UNIQ_ID).cloned().unwrap_or_default();
-    parsed.ast_var_refs = ast.get(&ATTRIB_REF_ID).cloned().unwrap_or_default();
 
     // --- the second <function>: the Clang token markup ---
     if dec.peek_element().expect("peek after <function>") == ELEM_FUNCTION_ID {

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim/oracle.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim/oracle.rs
@@ -1,0 +1,537 @@
+//! ghidra-sim v1: a mock-Java [`AnswerSource`] backed by kuna's OWN analysis
+//! of a real vendored ELF.
+//!
+//! The sim plays the Java host's role with real program facts:
+//!
+//! | query | answer source |
+//! |---|---|
+//! | getPcode | the oracle's real Sleigh (`one_instruction` re-encoded as the wire `<inst>`) |
+//! | getBytes | `ConsoleProgram::read_bytes` (the same `ObjectLoadImage` the CLI reads) |
+//! | getCodeLabel | `ConsoleProgram::function_named_at` (the committed symbol set) |
+//! | getRegister / getRegisterName | the real Sleigh's register table |
+//! | getUserOpName | the real Sleigh's userop table |
+//! | getComments | empty `<commentdb>` (always written, like Java) |
+//! | getTrackedRegisters | empty `<tracked_pointset>` (always written, like Java) |
+//! | getStringData | program bytes NUL-scanned + the biased size header |
+//! | isNameUsed | constant `f` |
+//! | **getMappedSymbols / getExternalRef** | **EMPTY — the Phase-2 reality this harness pins.** |
+//!
+//! ### PHASE-3 SEAM
+//! `getMappedSymbols`/`getExternalRef` answer empty in v1, which is exactly
+//! what makes today's `sub_ADDR`/`dat_ADDR`/raw-register output measurable.
+//! Phase 3 plugs a `<mapsym>` encoder into [`SimOracle::respond`] at the
+//! marked arms (building `<doc><mapsym><function|symbol…><addr><rangelist>`
+//! from `ConsoleProgram::function_named_at`/`global_data_symbols`), after
+//! which the pinned `getMappedSymbols == 0` / placeholder-rate numbers in
+//! `ghidra_sim_e2e.rs` FLIP.  `getDataType`/`getNamespacePath` are the same
+//! kind of seam (they need the Phase-3 `<type>` encoder / namespace model).
+//!
+//! The tspec is GENERATED from the loaded Sleigh's `AddrSpaceManager`
+//! ([`generate_tspec`]), so the sim's packed space indices and the process's
+//! tspec-derived indices agree **by construction** — the deepest interop
+//! invariant of the packed protocol.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use kuna_base::address::Address;
+use kuna_base::error::KunaError;
+use kuna_base::marshal::{
+    Decoder, ElementId, Encoder, PackedDecode, PackedEncode, ATTRIB_ID, ATTRIB_INDEX, ATTRIB_NAME,
+    ATTRIB_OFFSET, ATTRIB_SIZE, ATTRIB_TYPE, ELEM_VOID,
+};
+use kuna_base::space::{spacetype, AddrSpaceManager, RegisterLookup};
+use kuna_num::opcodes::{OpCode, OpcodeEncoder};
+use kuna_num::pcoderaw::{VarnodeData, ELEM_SPACEID};
+use kuna_sleigh::translate::{PcodeEmit, Translate, ATTRIB_CODE, ELEM_OP};
+
+use kuna_console::engine::{bootstrap_from_object, ConsoleProgram};
+use kuna_decomp::comment::ELEM_COMMENTDB;
+use kuna_decomp::decompile_drive::{decompile_func_full_with_override_dyn, print_c};
+use kuna_decomp::options::{OptionDatabase, KUNA_OPTION_NAMES};
+use kuna_ghidra::ids::{
+    ATTRIB_MAXSIZE, ELEM_COMMAND_GETBYTES, ELEM_COMMAND_GETCODELABEL, ELEM_COMMAND_GETCOMMENTS,
+    ELEM_COMMAND_GETCPOOLREF, ELEM_COMMAND_GETDATATYPE, ELEM_COMMAND_GETEXTERNALREF,
+    ELEM_COMMAND_GETMAPPEDSYMBOLS, ELEM_COMMAND_GETNAMESPACEPATH, ELEM_COMMAND_GETPCODE,
+    ELEM_COMMAND_GETREGISTER, ELEM_COMMAND_GETREGISTERNAME, ELEM_COMMAND_GETSTRINGDATA,
+    ELEM_COMMAND_GETTRACKEDREGISTERS, ELEM_COMMAND_GETUSEROPNAME, ELEM_COMMAND_ISNAMEUSED,
+    ELEM_UNIMPL,
+};
+use kuna_ghidra::protocol::{nibble_expand, string_data_size_header};
+use kuna_sleigh::globalcontext::ELEM_TRACKED_POINTSET;
+
+use super::{resp_bytes, resp_empty, resp_string, AnswerSource, QUERY_COMMAND_IDS};
+
+/// `<inst>` — the getPcode response root (ELEM_INST, kuna-decomp
+/// pcodeinject.rs; the numeric id is the wire contract).
+pub const ELEM_INST: ElementId = ElementId::new("inst", 98);
+
+/// The repository root (the tests run from the crate directory).
+pub fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .canonicalize()
+        .expect("repo root resolves")
+}
+
+/// A recording `PcodeEmit` capturing each op `one_instruction` produces.
+#[derive(Default)]
+pub struct RecordEmit {
+    pub ops: Vec<(OpCode, Option<VarnodeData>, Vec<VarnodeData>)>,
+}
+impl PcodeEmit for RecordEmit {
+    fn dump(
+        &mut self,
+        _addr: &Address,
+        opc: OpCode,
+        outvar: Option<&VarnodeData>,
+        vars: &[VarnodeData],
+    ) {
+        self.ops.push((opc, outvar.cloned(), vars.to_vec()));
+    }
+}
+
+/// Per-query traffic log (the behavioral-fingerprint pins).
+#[derive(Debug, Default)]
+pub struct QueryLog {
+    /// Total queries by command element id.
+    pub counts: BTreeMap<u32, u64>,
+    /// Every getPcode address, in wire order (repeat asks included).
+    pub pcode_addrs: Vec<u64>,
+    /// Distinct addresses the sim decoded successfully.
+    pub decoded_insts: BTreeSet<u64>,
+}
+
+/// The real-ELF mock-Java answer source (see the module docs).
+pub struct SimOracle {
+    pub prog: ConsoleProgram,
+    /// The oracle Sleigh's address-space manager — shared space identities
+    /// for every packed encode/decode the sim performs.
+    pub manager: Rc<AddrSpaceManager>,
+    pub big_endian: bool,
+    pub unique_base: u64,
+    /// The Sleigh's userop table, served index-by-index to the probe loop.
+    pub user_ops: Vec<String>,
+    /// Every register name of the language (the badness-scanner harvest).
+    pub register_names: BTreeSet<String>,
+    pub log: QueryLog,
+    /// PHASE-3 SEAM (flushNative semantics): a label override consulted before
+    /// the program lookup, letting a test change a "Java-side" symbol answer
+    /// between decompiles to prove cache clearing.
+    pub label_overrides: BTreeMap<u64, String>,
+}
+
+impl SimOracle {
+    /// Bootstrap the oracle over a vendored ELF, exactly as `kuna decompile`
+    /// does in-process: `load file` → the CLI's default options (`listing on` +
+    /// the size-resolved mode preset) → `read symbols`.
+    ///
+    /// Returns `None` (with the canonical skip message the CI canary greps
+    /// for) when the `.sla` specs are not built.
+    pub fn bootstrap(binary: &Path) -> Option<SimOracle> {
+        let root = repo_root();
+        let spec_roots = vec![root.join("specs").to_str().unwrap().to_string()];
+        let bin = binary.to_str()?.to_string();
+        let mut prog = match bootstrap_from_object(&bin, "", &spec_roots) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!(
+                    "ghidra_sim: skipping (bootstrap failed, build `.sla` with `make specs`): {}",
+                    e.explain()
+                );
+                return None;
+            }
+        };
+        let size = std::fs::metadata(&bin).map(|m| m.len()).unwrap_or(0);
+        apply_cli_default_options(&mut prog, size);
+        prog.commit_pending_analysis()
+            .expect("read symbols (analysis commit) must succeed");
+
+        let translate = prog.arch().translate();
+        let manager = translate.manager_rc();
+        let sleigh = translate.as_sleigh().expect("oracle engine is a Sleigh");
+        let big_endian = sleigh.is_big_endian();
+        let unique_base = sleigh.get_unique_base() as u64;
+        let mut user_ops = Vec::new();
+        sleigh.get_user_op_names(&mut user_ops);
+        #[allow(clippy::mutable_key_type)] // AddrSpace interior mutability does not affect Ord
+        let mut reglist: BTreeMap<VarnodeData, String> = BTreeMap::new();
+        sleigh.get_all_registers(&mut reglist);
+        let register_names: BTreeSet<String> = reglist.into_values().collect();
+
+        Some(SimOracle {
+            prog,
+            manager,
+            big_endian,
+            unique_base,
+            user_ops,
+            register_names,
+            log: QueryLog::default(),
+            label_overrides: BTreeMap::new(),
+        })
+    }
+
+    /// The primary label the "Java side" knows at an address (a function name
+    /// from the committed symbol set; the override map wins).
+    fn code_label(&self, offset: u64) -> Option<String> {
+        if let Some(over) = self.label_overrides.get(&offset) {
+            return Some(over.clone());
+        }
+        self.prog.function_named_at(offset)
+    }
+
+    /// Re-encode one really-translated instruction as the wire `<inst>`
+    /// document (`<inst offset=len><addr/><op>…</inst>` — the exact shape
+    /// `GhidraTranslate::one_instruction` decodes).
+    fn inst_doc(&self, addr: &Address, len: i32, emit: &RecordEmit) -> Vec<u8> {
+        let mut doc = Vec::new();
+        {
+            let mut e = PackedEncode::new(&mut doc);
+            e.open_element(&ELEM_INST);
+            e.write_signed_integer(&ATTRIB_OFFSET, len as i64);
+            addr.encode(&mut e).expect("pc addr encodes");
+            for (opc, out, ins) in &emit.ops {
+                e.open_element(&ELEM_OP);
+                e.write_signed_integer(&ATTRIB_SIZE, ins.len() as i64);
+                e.write_opcode(&ATTRIB_CODE, *opc);
+                match out {
+                    Some(v) => encode_varnode(&mut e, v),
+                    None => {
+                        e.open_element(&ELEM_VOID);
+                        e.close_element(&ELEM_VOID);
+                    }
+                }
+                for (slot, v) in ins.iter().enumerate() {
+                    // LOAD/STORE input 0 is the encoded space-id constant; the
+                    // wire form is `<spaceid name=…>` (PcodeOpRaw::decode maps
+                    // it back to the constant-space index form).
+                    let is_spaceid = slot == 0
+                        && matches!(opc, OpCode::CPUI_LOAD | OpCode::CPUI_STORE);
+                    if is_spaceid {
+                        let spc = v
+                            .get_space_from_const(&self.manager)
+                            .expect("spaceid constant resolves");
+                        e.open_element(&ELEM_SPACEID);
+                        e.write_space(&ATTRIB_NAME, &spc);
+                        e.close_element(&ELEM_SPACEID);
+                    } else {
+                        encode_varnode(&mut e, v);
+                    }
+                }
+                e.close_element(&ELEM_OP);
+            }
+            e.close_element(&ELEM_INST);
+        }
+        doc
+    }
+
+    /// getPcode: really translate the instruction at `addr` with the oracle
+    /// Sleigh and answer the re-encoded `<inst>`; `<unimpl>` on an unimplemented
+    /// instruction; empty (the caller's BadDataError) when decode fails.
+    fn answer_pcode(&mut self, dec: &mut PackedDecode) -> Vec<u8> {
+        let addr = Address::decode(dec).expect("getPcode carries an <addr>");
+        self.log.pcode_addrs.push(addr.get_offset());
+        let mut emit = RecordEmit::default();
+        let result = {
+            let sleigh = self
+                .prog
+                .arch()
+                .translate()
+                .as_sleigh()
+                .expect("oracle engine is a Sleigh");
+            sleigh.one_instruction(&mut emit, &addr)
+        };
+        match result {
+            Ok(len) => {
+                self.log.decoded_insts.insert(addr.get_offset());
+                resp_string(&self.inst_doc(&addr, len, &emit))
+            }
+            Err(KunaError::Unimpl {
+                instruction_length, ..
+            }) => {
+                let mut doc = Vec::new();
+                {
+                    let mut e = PackedEncode::new(&mut doc);
+                    e.open_element(&ELEM_UNIMPL);
+                    e.write_signed_integer(&ATTRIB_OFFSET, instruction_length as i64);
+                    e.close_element(&ELEM_UNIMPL);
+                }
+                resp_string(&doc)
+            }
+            Err(_) => resp_empty(),
+        }
+    }
+
+    /// getBytes: the oracle load image (the same bytes the CLI engine reads).
+    fn answer_bytes(&mut self, dec: &mut PackedDecode) -> Vec<u8> {
+        let (addr, size) = Address::decode_sized(dec).expect("getBytes carries a sized <addr>");
+        match self.prog.read_bytes(addr.get_offset(), size as usize) {
+            Some(bytes) => resp_bytes(&nibble_expand(&bytes)),
+            None => resp_empty(), // DataUnavail — same signal the CLI loader raises
+        }
+    }
+
+    /// getStringData: NUL-scan program bytes (the Java side would charset-decode;
+    /// the vendored fixtures are ASCII/UTF-8) and frame with the biased
+    /// 2-byte size header + truncation flag + nibble-doubled payload.
+    fn answer_string_data(&mut self, dec: &mut PackedDecode) -> Vec<u8> {
+        let max_bytes = dec
+            .read_signed_integer_id(&ATTRIB_MAXSIZE)
+            .expect("getStringData maxsize") as usize;
+        let _type_name = dec.read_string_id(&ATTRIB_TYPE).expect("type name");
+        let _type_id = dec.read_unsigned_integer_id(&ATTRIB_ID).expect("type id");
+        let addr = Address::decode(dec).expect("getStringData <addr>");
+        let mut collected: Vec<u8> = Vec::new();
+        let mut truncated = true;
+        for i in 0..max_bytes.max(1) as u64 {
+            match self.prog.read_bytes(addr.get_offset() + i, 1) {
+                Some(b) if b[0] != 0 => collected.push(b[0]),
+                Some(_) => {
+                    truncated = false;
+                    break;
+                }
+                None => break, // ran off the image: serve what we have
+            }
+        }
+        collected.push(0); // upstream ships the NUL terminator, doubled too
+        let mut raw = Vec::new();
+        raw.extend_from_slice(&string_data_size_header(collected.len() as u32));
+        raw.push(u8::from(truncated));
+        raw.extend_from_slice(&nibble_expand(&collected));
+        resp_bytes(&raw)
+    }
+}
+
+impl AnswerSource for SimOracle {
+    fn respond(&mut self, doc: &[u8]) -> Vec<u8> {
+        let manager = Rc::clone(&self.manager);
+        let mut dec = PackedDecode::new(&manager);
+        dec.ingest_stream(doc).expect("query doc ingests");
+        let el = dec.open_element().expect("query has a command element");
+        assert!(
+            QUERY_COMMAND_IDS.contains(&el),
+            "process issued a non-query element id {el} as a callback query"
+        );
+        *self.log.counts.entry(el).or_insert(0) += 1;
+
+        if el == ELEM_COMMAND_GETUSEROPNAME.get_id() {
+            let index = dec
+                .read_signed_integer_id(&ATTRIB_INDEX)
+                .expect("getUserOpName index");
+            let name = usize::try_from(index)
+                .ok()
+                .and_then(|i| self.user_ops.get(i))
+                .cloned()
+                .unwrap_or_default();
+            resp_string(name.as_bytes())
+        } else if el == ELEM_COMMAND_GETREGISTER.get_id() {
+            let name =
+                String::from_utf8_lossy(&dec.read_string_id(&ATTRIB_NAME).expect("register name"))
+                    .into_owned();
+            let lookup = {
+                let sleigh = self
+                    .prog
+                    .arch()
+                    .translate()
+                    .as_sleigh()
+                    .expect("oracle engine is a Sleigh");
+                RegisterLookup::get_register(sleigh, &name)
+            };
+            match lookup {
+                Ok(v) => {
+                    let spc = v.space.expect("register storage has a space");
+                    let mut doc = Vec::new();
+                    {
+                        let mut e = PackedEncode::new(&mut doc);
+                        Address::new(spc, v.offset)
+                            .encode_sized(&mut e, v.size as i32)
+                            .expect("register addr encodes");
+                    }
+                    resp_string(&doc)
+                }
+                Err(_) => resp_empty(),
+            }
+        } else if el == ELEM_COMMAND_GETREGISTERNAME.get_id() {
+            let (addr, size) =
+                Address::decode_sized(&mut dec).expect("getRegisterName sized <addr>");
+            let name = {
+                let sleigh = self
+                    .prog
+                    .arch()
+                    .translate()
+                    .as_sleigh()
+                    .expect("oracle engine is a Sleigh");
+                match addr.get_space() {
+                    Some(spc) => sleigh.get_register_name(spc, addr.get_offset(), size),
+                    None => String::new(),
+                }
+            };
+            resp_string(name.as_bytes())
+        } else if el == ELEM_COMMAND_GETPCODE.get_id() {
+            self.answer_pcode(&mut dec)
+        } else if el == ELEM_COMMAND_GETBYTES.get_id() {
+            self.answer_bytes(&mut dec)
+        } else if el == ELEM_COMMAND_GETCODELABEL.get_id() {
+            let addr = Address::decode(&mut dec).expect("getCodeLabel <addr>");
+            let label = self.code_label(addr.get_offset()).unwrap_or_default();
+            resp_string(label.as_bytes())
+        } else if el == ELEM_COMMAND_GETCOMMENTS.get_id() {
+            // Always written, possibly empty (like Java).  A Phase-3 sim can
+            // fill this from the analysis CommentFacts via the ported
+            // CommentDatabaseInternal encode (p9_emit/comment.rs).
+            let mut doc = Vec::new();
+            {
+                let mut e = PackedEncode::new(&mut doc);
+                e.open_element(&ELEM_COMMENTDB);
+                e.close_element(&ELEM_COMMENTDB);
+            }
+            resp_string(&doc)
+        } else if el == ELEM_COMMAND_GETTRACKEDREGISTERS.get_id() {
+            // Always written, possibly empty.  A Phase-3 sim can serve the real
+            // pspec tracked set via `encode_tracked` (kuna-sleigh/globalcontext.rs).
+            let mut doc = Vec::new();
+            {
+                let mut e = PackedEncode::new(&mut doc);
+                e.open_element(&ELEM_TRACKED_POINTSET);
+                e.close_element(&ELEM_TRACKED_POINTSET);
+            }
+            resp_string(&doc)
+        } else if el == ELEM_COMMAND_GETSTRINGDATA.get_id() {
+            self.answer_string_data(&mut dec)
+        } else if el == ELEM_COMMAND_ISNAMEUSED.get_id() {
+            resp_string(b"f")
+        } else if el == ELEM_COMMAND_GETMAPPEDSYMBOLS.get_id()
+            || el == ELEM_COMMAND_GETEXTERNALREF.get_id()
+        {
+            // ===================== PHASE-3 SEAM =====================
+            // Answer EMPTY: the Phase-2 engine never issues these, and the
+            // pinned `getMappedSymbols == 0` query-traffic number documents
+            // that.  Phase 3 plugs the `<mapsym>` encoder in HERE (build
+            // `<doc><mapsym><function|symbol…><addr><rangelist>` from
+            // `self.prog.function_named_at` / `self.prog.global_data_symbols`
+            // + `self.label_overrides`), and the harness pins flip.
+            // ========================================================
+            resp_empty()
+        } else if el == ELEM_COMMAND_GETDATATYPE.get_id()
+            || el == ELEM_COMMAND_GETNAMESPACEPATH.get_id()
+            || el == ELEM_COMMAND_GETCPOOLREF.get_id()
+        {
+            // PHASE-3 SEAM: needs the `<type>` encoder / namespace model /
+            // cpool records — empty is "not found", the lenient answer.
+            resp_empty()
+        } else {
+            // The four inject variants (241/242/243/252): the wire cspec's
+            // fixups are compiled engine-side, so these never fire today.
+            resp_empty()
+        }
+    }
+}
+
+/// Encode one recorded varnode as a sized `<addr>` (the wire varnode form).
+fn encode_varnode(e: &mut PackedEncode, v: &VarnodeData) {
+    let spc = v.space.as_ref().expect("recorded varnode has a space");
+    Address::new(Rc::clone(spc), v.offset)
+        .encode_sized(e, v.size as i32)
+        .expect("varnode encodes");
+}
+
+/// Generate the registerProgram tspec from the oracle Sleigh's space manager —
+/// the `SleighLanguage.encodeTranslator` shape (`<sleigh>` → `<spaces>` →
+/// one `<space|space_unique|space_other>` per language space).
+///
+/// The emitted `index` attributes are the oracle manager's REAL indices, so
+/// the process's tspec-derived manager assigns identical numbers (sparse
+/// `insert_space`); the engine-created special spaces (fspec/iop/join/stack)
+/// are appended by `Architecture` init in the same order on both sides.
+pub fn generate_tspec(manager: &AddrSpaceManager, big_endian: bool, unique_base: u64) -> Vec<u8> {
+    let default_name = manager
+        .get_default_code_space()
+        .expect("default code space")
+        .get_name()
+        .to_string();
+    let mut spaces = String::new();
+    for i in 0..manager.num_spaces() {
+        let Some(spc) = manager.get_space(i) else {
+            continue;
+        };
+        let elem = match spc.get_type() {
+            spacetype::IPTR_CONSTANT
+            | spacetype::IPTR_FSPEC
+            | spacetype::IPTR_IOP
+            | spacetype::IPTR_JOIN
+            | spacetype::IPTR_SPACEBASE => continue, // engine-created, never in a tspec
+            spacetype::IPTR_INTERNAL => "space_unique",
+            spacetype::IPTR_PROCESSOR if spc.get_name() == "OTHER" => "space_other",
+            spacetype::IPTR_PROCESSOR if spc.is_overlay() => continue,
+            spacetype::IPTR_PROCESSOR => "space",
+        };
+        spaces.push_str(&format!(
+            "<{elem} name=\"{}\" index=\"{}\" size=\"{}\" bigendian=\"{}\" delay=\"{}\" physical=\"{}\"",
+            spc.get_name(),
+            spc.get_index(),
+            spc.get_addr_size(),
+            spc.is_big_endian(),
+            spc.get_delay(),
+            spc.has_physical(),
+        ));
+        if spc.get_word_size() != 1 {
+            spaces.push_str(&format!(" wordsize=\"{}\"", spc.get_word_size()));
+        }
+        spaces.push_str("/>");
+    }
+    format!(
+        "<sleigh bigendian=\"{big_endian}\" uniqbase=\"0x{unique_base:x}\">\
+         <spaces defaultspace=\"{default_name}\">{spaces}</spaces></sleigh>"
+    )
+    .into_bytes()
+}
+
+/// Apply the options `kuna decompile` would inject for this binary size:
+/// `listing on` plus the `auto`-resolved mode preset (aggressive under
+/// 500 KiB) — the CLI-default ground truth the differential pins against.
+pub fn apply_cli_default_options(prog: &mut ConsoleProgram, size_bytes: u64) {
+    let mode = kuna_decomp::modes::resolve_mode_for_size(None, size_bytes)
+        .expect("auto mode resolves");
+    let mut options: Vec<(&str, &str)> = vec![("listing", "on")];
+    if let Some(overrides) = kuna_decomp::modes::mode_overrides(mode) {
+        options.extend(overrides.iter().copied());
+    }
+    for (name, value) in options {
+        if KUNA_OPTION_NAMES.contains(&name) {
+            prog.arch_mut()
+                .set_kuna_option(name, value)
+                .unwrap_or_else(|e| panic!("option {name}: {}", e.explain()));
+            continue;
+        }
+        let id = prog.registry().find_element(name, 0);
+        if id == 0 {
+            continue; // a load-time env gate — inert for the in-process oracle
+        }
+        let db = OptionDatabase::new();
+        db.set(prog.arch_mut(), id, value, "", "")
+            .unwrap_or_else(|e| panic!("option {name}: {}", e.explain()));
+    }
+}
+
+/// Decompile `name`@`addr` through the in-process CLI path — the same drive
+/// `kuna decompile` uses (`decompile_func_full_with_override_dyn` with the
+/// DWARF-local re-seed + `print_c`).  This is the differential ground truth.
+pub fn decompile_cli(prog: &mut ConsoleProgram, name: &str, addr: &Address) -> String {
+    let mapped = prog.dwarf_locals_for(addr.get_offset());
+    let fd = decompile_func_full_with_override_dyn(
+        prog.arch_mut(),
+        name,
+        addr.clone(),
+        0,
+        &mapped,
+        &[],
+        &[],
+        None,
+        &[],
+        &[],
+        &[],
+    )
+    .unwrap_or_else(|e| panic!("CLI-path decompile of {name} failed: {}", e.explain()));
+    print_c(prog.arch_mut(), &fd)
+}

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim/oracle.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim/oracle.rs
@@ -48,7 +48,7 @@ use kuna_sleigh::translate::{PcodeEmit, Translate, ATTRIB_CODE, ELEM_OP};
 
 use kuna_console::engine::{bootstrap_from_object, ConsoleProgram};
 use kuna_decomp::comment::ELEM_COMMENTDB;
-use kuna_decomp::decompile_drive::{decompile_func_full_with_override_dyn, print_c};
+use kuna_decomp::decompile_drive::print_c;
 use kuna_decomp::options::{OptionDatabase, KUNA_OPTION_NAMES};
 use kuna_ghidra::ids::{
     ATTRIB_MAXSIZE, ELEM_COMMAND_GETBYTES, ELEM_COMMAND_GETCODELABEL, ELEM_COMMAND_GETCOMMENTS,
@@ -173,8 +173,11 @@ impl SimOracle {
     }
 
     /// The primary label the "Java side" knows at an address (a function name
-    /// from the committed symbol set; the override map wins).
-    fn code_label(&self, offset: u64) -> Option<String> {
+    /// from the committed symbol set; the override map wins).  Public so the
+    /// harness asserts the name echo against exactly what the sim SERVED —
+    /// including a test-injected `label_overrides` entry — rather than against
+    /// the underlying program lookup.
+    pub fn code_label(&self, offset: u64) -> Option<String> {
         if let Some(over) = self.label_overrides.get(&offset) {
             return Some(over.clone());
         }
@@ -514,24 +517,38 @@ pub fn apply_cli_default_options(prog: &mut ConsoleProgram, size_bytes: u64) {
     }
 }
 
-/// Decompile `name`@`addr` through the in-process CLI path — the same drive
-/// `kuna decompile` uses (`decompile_func_full_with_override_dyn` with the
-/// DWARF-local re-seed + `print_c`).  This is the differential ground truth.
+/// Decompile `name`@`addr` through the in-process CLI path — the SAME shared
+/// per-function step the whole-binary surfaces run (`decompile_step::
+/// decompile_one`, DIV-66), seeded exactly as `kuna_console::project` seeds it:
+/// the DWARF stack-local re-seed plus the analysis's `call error(nonzero,…)`
+/// CALL_RETURN flow prunes (project.rs builds the same list from
+/// `arch.error_noreturn_callsites`; empty unless Listing + `noreturn_error`
+/// found such sites).  Then `print_c`.  This is the differential ground truth.
 pub fn decompile_cli(prog: &mut ConsoleProgram, name: &str, addr: &Address) -> String {
     let mapped = prog.dwarf_locals_for(addr.get_offset());
-    let fd = decompile_func_full_with_override_dyn(
+    let flow_ovr: Vec<(Address, u32)> = match addr.get_space() {
+        Some(space) if !prog.arch().error_noreturn_callsites.is_empty() => prog
+            .arch()
+            .error_noreturn_callsites
+            .iter()
+            .map(|&off| {
+                (
+                    Address::new(Rc::clone(space), off),
+                    kuna_decomp::overrides::flow_type::CALL_RETURN,
+                )
+            })
+            .collect(),
+        _ => Vec::new(),
+    };
+    let fd = kuna_console::decompile_step::decompile_one(
         prog.arch_mut(),
         name,
         addr.clone(),
         0,
-        &mapped,
-        &[],
-        &[],
-        None,
-        &[],
-        &[],
+        &kuna_console::decompile_step::DecompileSeed::plain(&mapped, &flow_ovr),
         &[],
     )
+    .result
     .unwrap_or_else(|e| panic!("CLI-path decompile of {name} failed: {}", e.explain()));
     print_c(prog.arch_mut(), &fd)
 }

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim_e2e.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim_e2e.rs
@@ -309,14 +309,14 @@ fn placeholder_total(c: &str) -> usize {
 const FAILLOG_TARGETS: &[&str] = &["sub_2620", "sub_3320", "sub_3ad0"];
 
 // ---- TODAY's measured Phase-2 pins (see "Pin discipline" above) -----------
-// Measured 2026-08-17 on main + this harness (empty getMappedSymbols, no
+// Measured 2026-08-17 on main @ 813ee131 (#316) + this harness (empty getMappedSymbols, no
 // options in ghidra mode).  These ARE the GUI-path quality gap, numerically.
 //
 // Raw-register identifier occurrences in the markup C, per target
 // (AL/EAX/RBP/R12/… rendered as C variables — r3 §8 defect c/d/e).
-const PIN_FAILLOG_REGISTER_LEAKS: [usize; 3] = [106, 64, 60];
+const PIN_FAILLOG_REGISTER_LEAKS: [usize; 3] = [108, 58, 60];
 // Unique<hex>/Stack<hex> token occurrences, per target (defect e).
-const PIN_FAILLOG_UNIQUE_TOKENS: [usize; 3] = [32, 2, 8];
+const PIN_FAILLOG_UNIQUE_TOKENS: [usize; 3] = [34, 4, 8];
 // Distinct placeholder addresses (sub_/FUN_/dat_/DAT_), per target
 // (defects a/b).
 const PIN_FAILLOG_PLACEHOLDERS: [usize; 3] = [49, 25, 17];
@@ -324,8 +324,8 @@ const PIN_FAILLOG_PLACEHOLDERS: [usize; 3] = [49, 25, 17];
 // getopt_long, dcgettext, …) that render as sub_ADDR only because
 // getMappedSymbols is unanswered.  Phase 3 drives these to 0.
 const PIN_FAILLOG_RESOLVABLE: [usize; 3] = [24, 18, 14];
-// The normalized line-diff ratio vs the CLI path, per target (measured 0.643 /
-// 0.898 / 0.811), banded from BOTH sides a few points off the measurement:
+// The normalized line-diff ratio vs the CLI path, per target (measured 0.646 /
+// 0.867 / 0.811), banded from BOTH sides a few points off the measurement:
 // the floor so a real Phase-3 improvement must flip the band downward
 // deliberately, the ceiling so a markup regression that makes the GUI text
 // even MORE alien (lost tokens, collapsed structure) fails instead of
@@ -345,13 +345,13 @@ const PIN_FAILLOG_DIFF_CEILING: [f64; 3] = [0.70, 0.95, 0.90];
 // structural size of what the GUI renders.  A `<break>`-token regression would
 // collapse this to ~1 while leaving every ratio-floor assertion green — this
 // pin is what catches it.
-const PIN_FAILLOG_C_LINES: [usize; 3] = [241, 174, 89];
+const PIN_FAILLOG_C_LINES: [usize; 3] = [243, 128, 89];
 // Tokens Java's `getC()` cleaner REWRITES (`IllegalCharCppTransformer`): kuna
 // emits whole rendered declarators (`"unsigned long *"`) as single `<type>`
 // tokens, which scripts/exports receive as `unsigned_long__` — the type-
 // spelling mangling of the live repro.  PR-C splits the declarator into
 // base-type + syntax tokens and drives these to 0.
-const PIN_FAILLOG_MANGLED_TOKENS: [usize; 3] = [21, 13, 7];
+const PIN_FAILLOG_MANGLED_TOKENS: [usize; 3] = [21, 6, 7];
 // Whole-session query traffic: total getPcode asks (repeat decompiles re-ask
 // everything — no p-code cache, faithful to upstream GhidraTranslate) vs
 // distinct instruction addresses actually decoded (the flow overruns

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim_e2e.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim_e2e.rs
@@ -1,0 +1,510 @@
+//! ghidra-sim: the real-program ghidra-mode differential harness.
+//!
+//! Drives the FULL wire lifecycle (registerProgram → setAction → decompileAt ×
+//! N → flushNative → decompileAt → deregisterProgram) against the in-process
+//! [`GhidraProcess`], with the mock-Java end answered from kuna's OWN analysis
+//! of real vendored ELFs (`tests/ghidra_sim/oracle.rs`): real Sleigh p-code,
+//! real bytes, real labels — and, deliberately, EMPTY `getMappedSymbols`/
+//! `getExternalRef`, because that is the Phase-2 reality of the GUI path.
+//!
+//! The harness turns "callees show as sub_ADDR, registers leak into the C"
+//! from a GUI anecdote into **pinned numbers**:
+//!
+//!   * structure asserts (r5 schema): dual-`<function>` decode, name + entry
+//!     echo, markup opref ⊆ ast op-times / varref ⊆ ast create-indices, the
+//!     19-query legality + query-legal-command placement, warnings clean;
+//!   * badness scanners on the markup-flattened C: raw-register identifier
+//!     leaks, `Unique<hex>`/`Stack<hex>` tokens, `sub_`/`FUN_`/`dat_`/`DAT_`
+//!     placeholder rate vs what the loader actually knows;
+//!   * query-traffic fingerprints: getPcode count vs decoded instructions,
+//!     getMappedSymbols == 0 (Phase 3 flips this to ≥ 1);
+//!   * the differential-C gap: the markup C vs the SAME function through the
+//!     in-process CLI path (`kuna decompile`'s drive) as a normalized
+//!     line-diff ratio — the number the GUI user experiences.
+//!
+//! ## Pin discipline
+//! The `PIN_*` constants record TODAY's measured reality (Phase 2, no symbol
+//! providers).  They only move together with the engine/provider change that
+//! earns the move — Phase 3 lands against this file by flipping the
+//! placeholder/mapped-symbols/diff pins downward.  NEVER re-pin to absorb an
+//! unexplained regression.
+//!
+//! ## Runtime
+//! `faillog` (23 KB, 3 functions + 1 repeat) is the fast default.  The
+//! `sort`/`grep` breadth test decompiles 3 mid-size functions each and runs in
+//! a few seconds in release; it is `#[ignore]`d under the default dev-profile
+//! workspace suite to keep `make rust-test` lean, and run explicitly (release)
+//! by the CI gates job and `make test-ghidra`.
+
+mod ghidra_sim;
+
+use std::cell::RefCell;
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::rc::Rc;
+
+use kuna_base::address::Address;
+use kuna_base::marshal::PackedEncode;
+
+use kuna_ghidra::ids::{ELEM_COMMAND_GETMAPPEDSYMBOLS, ELEM_COMMAND_GETPCODE};
+use kuna_ghidra::process::GhidraProcess;
+
+use ghidra_sim::oracle::{
+    decompile_cli, generate_tspec, repo_root, SimOracle,
+};
+use ghidra_sim::{
+    cmd_decompile_at, cmd_deregister_program, cmd_flush_native, cmd_register_program,
+    cmd_set_action, line_diff_ratio, parse_decompile_doc, placeholder_addrs, query_doc_id,
+    register_leaks, trace_session, unique_leaks, MockReader, MockState, MockWriter, ParsedDoc,
+    SessionTrace, QUERY_COMMAND_IDS,
+};
+
+/// One driven ghidra-mode session over a vendored ELF.
+struct SessionRun {
+    oracle: SimOracle,
+    trace: SessionTrace,
+    /// Parsed decompileAt docs, one per target (the flush-repeat doc is extra).
+    docs: Vec<ParsedDoc>,
+    /// The raw payloads of the target decompiles (index-aligned with `docs`).
+    payloads: Vec<Vec<u8>>,
+    /// The raw payload of the repeat decompile of target 0 after flushNative.
+    repeat_payload: Vec<u8>,
+    /// Resolved target entry addresses (index-aligned with `docs`).
+    addrs: Vec<Address>,
+}
+
+/// Bootstrap the oracle, drive the whole session, and split the output.
+/// Returns `None` when the `.sla` specs are not built (visible skip).
+fn run_session(binary: &Path, targets: &[&str]) -> Option<SessionRun> {
+    let oracle = SimOracle::bootstrap(binary)?;
+
+    let addrs: Vec<Address> = targets
+        .iter()
+        .map(|t| {
+            oracle
+                .prog
+                .find_entry_by_name(t)
+                .unwrap_or_else(|| panic!("{binary:?}: no function named {t}"))
+                .addr
+        })
+        .collect();
+
+    let tspec = generate_tspec(&oracle.manager, oracle.big_endian, oracle.unique_base);
+    let lang_dir = repo_root().join("specs/Ghidra/Processors/x86/data/languages");
+    let pspec = std::fs::read(lang_dir.join("x86-64.pspec")).expect("vendored x86-64.pspec");
+    let cspec = std::fs::read(lang_dir.join("x86-64-gcc.cspec")).expect("vendored x86-64-gcc.cspec");
+    // The wire corespec is ignored by the Phase-2 process (default core types).
+    let coretypes: &[u8] =
+        b"<coretypes><type name=\"int\" size=\"4\" metatype=\"int\" id=\"-1\"/></coretypes>";
+
+    let packed_addr = |a: &Address| -> Vec<u8> {
+        let mut v = Vec::new();
+        {
+            let mut e = PackedEncode::new(&mut v);
+            a.encode(&mut e).expect("entry addr encodes");
+        }
+        v
+    };
+
+    // registerProgram, setAction, decompileAt × N, flushNative, decompileAt
+    // (target 0 again), deregisterProgram.
+    let mut commands = Vec::new();
+    cmd_register_program(&mut commands, &pspec, &cspec, &tspec, coretypes);
+    cmd_set_action(&mut commands, "0", "decompile", "c");
+    for a in &addrs {
+        cmd_decompile_at(&mut commands, "0", &packed_addr(a));
+    }
+    cmd_flush_native(&mut commands, "0");
+    cmd_decompile_at(&mut commands, "0", &packed_addr(&addrs[0]));
+    cmd_deregister_program(&mut commands, "0");
+    let n_commands = 2 + addrs.len() + 2 + 1;
+
+    let shared = Rc::new(RefCell::new(MockState::new(commands, oracle)));
+    let reader = MockReader { shared: Rc::clone(&shared) };
+    let writer = MockWriter { shared: Rc::clone(&shared) };
+    let mut process = GhidraProcess::new(reader, writer);
+    for i in 0..n_commands {
+        let status = process
+            .read_command()
+            .unwrap_or_else(|e| panic!("command #{i} failed: {e:?}"));
+        let expected = if i == n_commands - 1 { 1 } else { 0 };
+        assert_eq!(status, expected, "command #{i} unexpected loop status");
+    }
+    let _ = process.into_inner();
+
+    let state = match Rc::try_unwrap(shared) {
+        Ok(cell) => cell.into_inner(),
+        Err(_) => panic!("mock state still shared after into_inner"),
+    };
+    let oracle = state.source;
+    let out = state.from_process;
+    let trace = trace_session(&out);
+    assert_eq!(
+        trace.responses.len(),
+        n_commands,
+        "one command response span per command"
+    );
+
+    // registerProgram answered archid 0 with an empty warnings frame.
+    let reg = &trace.responses[0];
+    assert_eq!(reg.payload.as_deref(), Some(b"0".as_slice()), "archid echo");
+    assert!(
+        !reg.warnings.contains("could not build the decompiler engine"),
+        "engine construction failed: {}",
+        reg.warnings
+    );
+    // setAction / flushNative / deregister accepted.
+    assert_eq!(trace.responses[1].payload.as_deref(), Some(b"t".as_slice()));
+    let flush_idx = 2 + addrs.len();
+    assert_eq!(
+        trace.responses[flush_idx].payload.as_deref(),
+        Some(b"0".as_slice()),
+        "flushNative result"
+    );
+    assert_eq!(
+        trace.responses[n_commands - 1].payload.as_deref(),
+        Some(b"1".as_slice()),
+        "deregister result"
+    );
+
+    let mut docs = Vec::new();
+    let mut payloads = Vec::new();
+    for (i, a) in addrs.iter().enumerate() {
+        let resp = &trace.responses[2 + i];
+        assert!(
+            !resp.warnings.contains("could not decompile the function"),
+            "decompileAt #{i} degraded: {}",
+            resp.warnings
+        );
+        let payload = resp.payload.clone().expect("decompileAt payload present");
+        assert!(
+            !payload.is_empty(),
+            "decompileAt #{i} emitted an EMPTY payload (warnings: {})",
+            resp.warnings
+        );
+        let parsed = parse_decompile_doc(&payload, &oracle.manager);
+        // Name + entry-address echo — the HighFunction.decode hard-throw traps.
+        assert_eq!(
+            Some(parsed.name.as_str()),
+            oracle.prog.function_named_at(a.get_offset()).as_deref(),
+            "decompileAt #{i}: <function name> must echo the getCodeLabel answer"
+        );
+        assert_eq!(
+            parsed.entry_offset,
+            Some(a.get_offset()),
+            "decompileAt #{i}: <function> base <addr> must echo the requested entry"
+        );
+        docs.push(parsed);
+        payloads.push(payload);
+    }
+    let repeat_payload = trace.responses[flush_idx + 1]
+        .payload
+        .clone()
+        .expect("repeat decompileAt payload present");
+
+    Some(SessionRun { oracle, trace, docs, payloads, repeat_payload, addrs })
+}
+
+/// The r5 wire/structure contract, per decompiled function.
+fn assert_structure(run: &SessionRun) {
+    for (i, parsed) in run.docs.iter().enumerate() {
+        assert!(
+            !parsed.ast_op_times.is_empty(),
+            "target #{i}: the <ast> has no ops"
+        );
+        assert!(parsed.has_markup, "target #{i}: markup <function> missing");
+        assert!(
+            parsed.markup_oprefs.is_subset(&parsed.ast_op_times),
+            "target #{i}: markup oprefs not a subset of ast op times"
+        );
+        assert!(
+            parsed.markup_varrefs.is_subset(&parsed.ast_var_refs),
+            "target #{i}: markup varrefs not a subset of ast varnode refs"
+        );
+        assert!(
+            !parsed.markup_oprefs.is_empty() || !parsed.markup_varrefs.is_empty(),
+            "target #{i}: markup not cross-linked to the ast"
+        );
+        assert!(
+            !parsed.c_text.trim().is_empty(),
+            "target #{i}: flattened markup C is empty"
+        );
+    }
+
+    // Query legality: every callback query is one of the 19 command elements,
+    // and queries appear ONLY inside query-legal command responses
+    // (registerProgram + decompileAt; never setAction / flushNative /
+    // deregisterProgram — Java nulls its callback decoder there).
+    let n = run.trace.responses.len();
+    let flush_idx = n - 3; // … decompileAt×N, flushNative, decompileAt, deregister
+    for (idx, resp) in run.trace.responses.iter().enumerate() {
+        let query_legal = idx == 0 || (idx >= 2 && idx != flush_idx && idx != n - 1);
+        if !query_legal {
+            assert!(
+                resp.queries.is_empty(),
+                "response #{idx}: {} callback queries during a query-illegal command",
+                resp.queries.len()
+            );
+        }
+        for q in &resp.queries {
+            let id = query_doc_id(q, &run.oracle.manager);
+            assert!(
+                QUERY_COMMAND_IDS.contains(&id),
+                "response #{idx}: query root element {id} is not one of the 19"
+            );
+        }
+    }
+}
+
+/// How many placeholder addresses the loader actually KNOWS a real name for —
+/// the symbol-resolution gap Phase 3 closes (each of these renders as
+/// `sub_`/`dat_` today but has a committed symbol in the oracle).
+fn resolvable_placeholders(oracle: &SimOracle, c: &str) -> usize {
+    let ph = placeholder_addrs(c);
+    let mut resolvable = 0usize;
+    let data_syms: BTreeSet<u64> = oracle
+        .prog
+        .global_data_symbols()
+        .into_iter()
+        .map(|(_, vma, _)| vma)
+        .collect();
+    for (kind, addrs) in &ph {
+        for a in addrs {
+            let known = match *kind {
+                "sub_" | "FUN_" => oracle
+                    .prog
+                    .function_named_at(*a)
+                    .is_some_and(|n| !n.starts_with("sub_") && !n.starts_with("FUN_")),
+                _ => data_syms.contains(a),
+            };
+            if known {
+                resolvable += 1;
+            }
+        }
+    }
+    resolvable
+}
+
+/// Total placeholder occurrences (distinct addresses across all four kinds).
+fn placeholder_total(c: &str) -> usize {
+    placeholder_addrs(c).values().map(|s| s.len()).sum()
+}
+
+// ===========================================================================
+// faillog — the fast default fixture (x86-64 PIE, stripped, 23 KB)
+// ===========================================================================
+
+/// The three fixed targets: `sub_2620` is `main` (call/global/switch-heavy),
+/// `sub_3320`/`sub_3ad0` are mid-size leaf-ish functions.
+const FAILLOG_TARGETS: &[&str] = &["sub_2620", "sub_3320", "sub_3ad0"];
+
+// ---- TODAY's measured Phase-2 pins (see "Pin discipline" above) -----------
+// Measured 2026-08-17 on main + this harness (empty getMappedSymbols, no
+// options in ghidra mode).  These ARE the GUI-path quality gap, numerically.
+//
+// Raw-register identifier occurrences in the markup C, per target
+// (AL/EAX/RBP/R12/… rendered as C variables — r3 §8 defect c/d/e).
+const PIN_FAILLOG_REGISTER_LEAKS: [usize; 3] = [106, 64, 60];
+// Unique<hex>/Stack<hex> token occurrences, per target (defect e).
+const PIN_FAILLOG_UNIQUE_TOKENS: [usize; 3] = [32, 2, 8];
+// Distinct placeholder addresses (sub_/FUN_/dat_/DAT_), per target
+// (defects a/b).
+const PIN_FAILLOG_PLACEHOLDERS: [usize; 3] = [49, 25, 17];
+// …of which the loader KNOWS a real name — the PLT imports (localtime,
+// getopt_long, dcgettext, …) that render as sub_ADDR only because
+// getMappedSymbols is unanswered.  Phase 3 drives these to 0.
+const PIN_FAILLOG_RESOLVABLE: [usize; 3] = [24, 18, 14];
+// The normalized line-diff ratio vs the CLI path, per target (measured 0.643 /
+// 0.898 / 0.811): today's gap must stay at least this bad — the floor is set a
+// few points under the measurement so unrelated CLI-side drift cannot trip it,
+// while any real Phase-3 improvement (target ≈ 0.1) MUST flip the assertion to
+// a ceiling.
+const PIN_FAILLOG_DIFF_FLOOR: [f64; 3] = [0.55, 0.80, 0.70];
+// Tokens Java's `getC()` cleaner REWRITES (`IllegalCharCppTransformer`): kuna
+// emits whole rendered declarators (`"unsigned long *"`) as single `<type>`
+// tokens, which scripts/exports receive as `unsigned_long__` — the type-
+// spelling mangling of the live repro.  PR-C splits the declarator into
+// base-type + syntax tokens and drives these to 0.
+const PIN_FAILLOG_MANGLED_TOKENS: [usize; 3] = [21, 13, 7];
+// Whole-session query traffic: total getPcode asks (repeat decompiles re-ask
+// everything — no p-code cache, faithful to upstream GhidraTranslate) vs
+// distinct instruction addresses actually decoded (the flow overruns
+// no-return calls into neighbours today — defect g — so this exceeds the real
+// function sizes).
+const PIN_FAILLOG_GETPCODE_TOTAL: u64 = 1477;
+const PIN_FAILLOG_DECODED_INSTS: usize = 1003;
+
+#[test]
+fn ghidra_sim_faillog_pins() {
+    let binary = repo_root().join("tests/bug-repro/faillog");
+    let Some(run) = run_session(&binary, FAILLOG_TARGETS) else {
+        return; // visible skip: specs not built
+    };
+    assert_structure(&run);
+
+    // ---- measure everything first (one run = every number), assert after ----
+    let mut reg_counts = Vec::new();
+    let mut reg_names_seen = Vec::new();
+    let mut uniq_counts = Vec::new();
+    let mut ph_totals = Vec::new();
+    let mut ph_resolvables = Vec::new();
+    let mut mangled_counts = Vec::new();
+    for parsed in &run.docs {
+        let c = &parsed.c_text;
+        let (reg_count, reg_names) = register_leaks(c, &run.oracle.register_names);
+        reg_counts.push(reg_count);
+        reg_names_seen.push(reg_names);
+        uniq_counts.push(unique_leaks(c));
+        ph_totals.push(placeholder_total(c));
+        ph_resolvables.push(resolvable_placeholders(&run.oracle, c));
+        mangled_counts.push(parsed.mangled_tokens);
+    }
+
+    // The differential-C gap vs the in-process CLI path.
+    let SessionRun { mut oracle, docs, addrs, .. } = run;
+    let mut ratios = Vec::new();
+    for (i, parsed) in docs.iter().enumerate() {
+        let cli_c = decompile_cli(&mut oracle.prog, &parsed.name.clone(), &addrs[i]);
+        ratios.push(line_diff_ratio(&parsed.c_text, &cli_c));
+    }
+
+    let mapped = oracle
+        .log
+        .counts
+        .get(&ELEM_COMMAND_GETMAPPEDSYMBOLS.get_id())
+        .copied()
+        .unwrap_or(0);
+    let pcode_total = oracle
+        .log
+        .counts
+        .get(&ELEM_COMMAND_GETPCODE.get_id())
+        .copied()
+        .unwrap_or(0);
+
+    let mut summary = String::new();
+    for (i, t) in FAILLOG_TARGETS.iter().enumerate() {
+        summary.push_str(&format!(
+            "{t}: registers={} {:?} unique={} placeholders={} resolvable={} mangled={} \
+             diff_ratio={:.3}\n",
+            reg_counts[i], reg_names_seen[i], uniq_counts[i], ph_totals[i], ph_resolvables[i],
+            mangled_counts[i], ratios[i]
+        ));
+    }
+    summary.push_str(&format!(
+        "getPcode total={pcode_total} distinct-decoded={} getMappedSymbols={mapped}\n",
+        oracle.log.decoded_insts.len()
+    ));
+    eprintln!("ghidra_sim faillog measurements:\n{summary}");
+
+    // ---- the pins ----
+    for (i, t) in FAILLOG_TARGETS.iter().enumerate() {
+        assert_eq!(
+            reg_counts[i], PIN_FAILLOG_REGISTER_LEAKS[i],
+            "{t}: raw-register leak count moved (found {:?})\n{}",
+            reg_names_seen[i], docs[i].c_text
+        );
+        assert_eq!(
+            uniq_counts[i], PIN_FAILLOG_UNIQUE_TOKENS[i],
+            "{t}: Unique/Stack token count moved\n{}",
+            docs[i].c_text
+        );
+        assert_eq!(
+            ph_totals[i], PIN_FAILLOG_PLACEHOLDERS[i],
+            "{t}: placeholder count moved\n{}",
+            docs[i].c_text
+        );
+        assert_eq!(
+            ph_resolvables[i], PIN_FAILLOG_RESOLVABLE[i],
+            "{t}: loader-resolvable placeholder count moved (Phase 3 drives this to 0)"
+        );
+        assert_eq!(
+            mangled_counts[i], PIN_FAILLOG_MANGLED_TOKENS[i],
+            "{t}: getC()-mangled token count moved (PR-C drives this to 0)"
+        );
+        assert!(
+            ratios[i] >= PIN_FAILLOG_DIFF_FLOOR[i],
+            "{t}: ghidra-vs-CLI diff ratio {:.3} fell below the pinned floor {} — \
+             the GUI-path gap shrank!  If a provider change earned this, flip the pin \
+             (and celebrate); otherwise investigate.",
+            ratios[i], PIN_FAILLOG_DIFF_FLOOR[i]
+        );
+        assert!(ratios[i] <= 1.0, "{t}: diff ratio out of range: {}", ratios[i]);
+    }
+
+    // ---- query-traffic fingerprints ----
+    assert_eq!(
+        mapped, 0,
+        "getMappedSymbols fired {mapped}× — Phase 2 never queries it.  If Phase 3 \
+         landed, flip this pin to an ≥1 assertion for the global-heavy target."
+    );
+    assert_eq!(
+        pcode_total as usize,
+        oracle.log.pcode_addrs.len(),
+        "internal log consistency"
+    );
+    assert_eq!(
+        pcode_total, PIN_FAILLOG_GETPCODE_TOTAL,
+        "whole-session getPcode traffic moved"
+    );
+    assert_eq!(
+        oracle.log.decoded_insts.len(),
+        PIN_FAILLOG_DECODED_INSTS,
+        "distinct decoded instruction count moved"
+    );
+}
+
+/// flushNative + repeat-decompile stability: TODAY flushNative clears nothing
+/// (no provider caches exist), and a repeat decompile of the same entry is
+/// byte-identical — the engine is deterministic across decompiles in one
+/// session.
+///
+/// PHASE-3 FLIP: once the lazy symbol/type caches exist, this test grows the
+/// cache-clearing semantics of r4 §3.4: change `oracle.label_overrides` for a
+/// symbol between the two decompiles — after flushNative the second doc MUST
+/// reflect the new answer.  (Today the label is re-queried per decompileAt, so
+/// only whole-doc stability is meaningful to pin.)
+#[test]
+fn ghidra_sim_faillog_flush_native_stability() {
+    let binary = repo_root().join("tests/bug-repro/faillog");
+    let Some(run) = run_session(&binary, &["sub_3ad0"]) else {
+        return; // visible skip: specs not built
+    };
+    assert_eq!(
+        run.payloads[0], run.repeat_payload,
+        "repeat decompileAt after flushNative is not byte-identical"
+    );
+}
+
+// ===========================================================================
+// sort + grep — the heavier breadth fixtures
+// ===========================================================================
+
+/// Mid-size functions picked once (deterministic names from the committed
+/// enumeration).  Structure + scanner sanity only — the exact pins live on the
+/// faillog fixture; here the harness proves breadth (bigger CFGs, jump tables,
+/// more PLT traffic) without pinning every number.
+#[test]
+#[ignore = "heavier fixtures (~10s release, minutes in dev profile); run explicitly: \
+            cargo test -p kuna-ghidra --release -- --ignored (the CI gates job and \
+            `make test-ghidra` do)"]
+fn ghidra_sim_sort_grep_breadth() {
+    for (fixture, targets) in [
+        ("tests/bug-repro/sort", &["sub_62f0", "sub_6370", "sub_63d0"][..]),
+        ("tests/bug-repro/grep", &["sub_e5c0", "sub_e640", "sub_e8f0"][..]),
+    ] {
+        let binary = repo_root().join(fixture);
+        let Some(run) = run_session(&binary, targets) else {
+            return; // visible skip: specs not built
+        };
+        assert_structure(&run);
+        for (i, parsed) in run.docs.iter().enumerate() {
+            let (reg_count, reg_names) = register_leaks(&parsed.c_text, &run.oracle.register_names);
+            eprintln!(
+                "{fixture} {}: registers={reg_count} {reg_names:?} unique={} placeholders={}",
+                targets[i],
+                unique_leaks(&parsed.c_text),
+                placeholder_total(&parsed.c_text),
+            );
+        }
+    }
+}

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim_e2e.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim_e2e.rs
@@ -54,9 +54,9 @@ use ghidra_sim::oracle::{
 };
 use ghidra_sim::{
     cmd_decompile_at, cmd_deregister_program, cmd_flush_native, cmd_register_program,
-    cmd_set_action, line_diff_ratio, parse_decompile_doc, placeholder_addrs, query_doc_id,
-    register_leaks, trace_session, unique_leaks, MockReader, MockState, MockWriter, ParsedDoc,
-    SessionTrace, QUERY_COMMAND_IDS,
+    cmd_set_action, line_diff_ratio, normalized_lines, parse_decompile_doc, placeholder_addrs,
+    query_doc_id, register_leaks, trace_session, unique_leaks, MockReader, MockState, MockWriter,
+    ParsedDoc, SessionTrace, QUERY_COMMAND_IDS,
 };
 
 /// One driven ghidra-mode session over a vendored ELF.
@@ -145,12 +145,13 @@ fn run_session(binary: &Path, targets: &[&str]) -> Option<SessionRun> {
         "one command response span per command"
     );
 
-    // registerProgram answered archid 0 with an empty warnings frame.
+    // registerProgram answered archid 0 with an EMPTY warnings frame (any text
+    // here — construction failure, marshaling error — is a defect).
     let reg = &trace.responses[0];
     assert_eq!(reg.payload.as_deref(), Some(b"0".as_slice()), "archid echo");
     assert!(
-        !reg.warnings.contains("could not build the decompiler engine"),
-        "engine construction failed: {}",
+        reg.warnings.trim().is_empty(),
+        "registerProgram shipped a non-empty warnings frame: {}",
         reg.warnings
     );
     // setAction / flushNative / deregister accepted.
@@ -172,8 +173,8 @@ fn run_session(binary: &Path, targets: &[&str]) -> Option<SessionRun> {
     for (i, a) in addrs.iter().enumerate() {
         let resp = &trace.responses[2 + i];
         assert!(
-            !resp.warnings.contains("could not decompile the function"),
-            "decompileAt #{i} degraded: {}",
+            resp.warnings.trim().is_empty(),
+            "decompileAt #{i} shipped a non-empty warnings frame (degradation): {}",
             resp.warnings
         );
         let payload = resp.payload.clone().expect("decompileAt payload present");
@@ -184,9 +185,11 @@ fn run_session(binary: &Path, targets: &[&str]) -> Option<SessionRun> {
         );
         let parsed = parse_decompile_doc(&payload, &oracle.manager);
         // Name + entry-address echo — the HighFunction.decode hard-throw traps.
+        // Compared against what the sim actually SERVED (`code_label` consults
+        // `label_overrides`), not the raw program lookup.
         assert_eq!(
             Some(parsed.name.as_str()),
-            oracle.prog.function_named_at(a.get_offset()).as_deref(),
+            oracle.code_label(a.get_offset()).as_deref(),
             "decompileAt #{i}: <function name> must echo the getCodeLabel answer"
         );
         assert_eq!(
@@ -221,9 +224,16 @@ fn assert_structure(run: &SessionRun) {
             parsed.markup_varrefs.is_subset(&parsed.ast_var_refs),
             "target #{i}: markup varrefs not a subset of ast varnode refs"
         );
+        // Both ref classes must be present PER CLASS (both are non-empty on
+        // every real function today): an either-or here would let one whole
+        // class of click-to-address links silently vanish.
         assert!(
-            !parsed.markup_oprefs.is_empty() || !parsed.markup_varrefs.is_empty(),
-            "target #{i}: markup not cross-linked to the ast"
+            !parsed.markup_oprefs.is_empty(),
+            "target #{i}: markup carries no oprefs — op tokens lost their ast links"
+        );
+        assert!(
+            !parsed.markup_varrefs.is_empty(),
+            "target #{i}: markup carries no varrefs — variable tokens lost their ast links"
         );
         assert!(
             !parsed.c_text.trim().is_empty(),
@@ -315,11 +325,27 @@ const PIN_FAILLOG_PLACEHOLDERS: [usize; 3] = [49, 25, 17];
 // getMappedSymbols is unanswered.  Phase 3 drives these to 0.
 const PIN_FAILLOG_RESOLVABLE: [usize; 3] = [24, 18, 14];
 // The normalized line-diff ratio vs the CLI path, per target (measured 0.643 /
-// 0.898 / 0.811): today's gap must stay at least this bad — the floor is set a
-// few points under the measurement so unrelated CLI-side drift cannot trip it,
-// while any real Phase-3 improvement (target ≈ 0.1) MUST flip the assertion to
-// a ceiling.
+// 0.898 / 0.811), banded from BOTH sides a few points off the measurement:
+// the floor so a real Phase-3 improvement must flip the band downward
+// deliberately, the ceiling so a markup regression that makes the GUI text
+// even MORE alien (lost tokens, collapsed structure) fails instead of
+// saturating unnoticed.  Unrelated CLI-side drift moves the ratio only a few
+// points, which the band absorbs.
+//
+// What the ratio is made of — so nobody chases an unreachable ≈0 with symbol
+// work alone: part is the Phase-3 symbol/type gap (sub_/dat_/register/Unique
+// rendering), and part is OPTION-PRESET SKEW — the CLI side runs the
+// aggressive-mode presets (`ctypes`, `stackalias`, `iteexpr`, …, applied by
+// `apply_cli_default_options`) that the ghidra-mode engine cannot receive
+// until setOptions is wired (Phase 3/4).  Expect Phase 3 to land in the
+// ~0.1–0.3 range, not 0; the residue is the setOptions work.
 const PIN_FAILLOG_DIFF_FLOOR: [f64; 3] = [0.55, 0.80, 0.70];
+const PIN_FAILLOG_DIFF_CEILING: [f64; 3] = [0.70, 0.95, 0.90];
+// Normalized non-empty line count of the flattened markup C, per target: the
+// structural size of what the GUI renders.  A `<break>`-token regression would
+// collapse this to ~1 while leaving every ratio-floor assertion green — this
+// pin is what catches it.
+const PIN_FAILLOG_C_LINES: [usize; 3] = [241, 174, 89];
 // Tokens Java's `getC()` cleaner REWRITES (`IllegalCharCppTransformer`): kuna
 // emits whole rendered declarators (`"unsigned long *"`) as single `<type>`
 // tokens, which scripts/exports receive as `unsigned_long__` — the type-
@@ -349,6 +375,7 @@ fn ghidra_sim_faillog_pins() {
     let mut ph_totals = Vec::new();
     let mut ph_resolvables = Vec::new();
     let mut mangled_counts = Vec::new();
+    let mut c_line_counts = Vec::new();
     for parsed in &run.docs {
         let c = &parsed.c_text;
         let (reg_count, reg_names) = register_leaks(c, &run.oracle.register_names);
@@ -358,6 +385,7 @@ fn ghidra_sim_faillog_pins() {
         ph_totals.push(placeholder_total(c));
         ph_resolvables.push(resolvable_placeholders(&run.oracle, c));
         mangled_counts.push(parsed.mangled_tokens);
+        c_line_counts.push(normalized_lines(c).len());
     }
 
     // The differential-C gap vs the in-process CLI path.
@@ -385,9 +413,9 @@ fn ghidra_sim_faillog_pins() {
     for (i, t) in FAILLOG_TARGETS.iter().enumerate() {
         summary.push_str(&format!(
             "{t}: registers={} {:?} unique={} placeholders={} resolvable={} mangled={} \
-             diff_ratio={:.3}\n",
+             c_lines={} diff_ratio={:.3}\n",
             reg_counts[i], reg_names_seen[i], uniq_counts[i], ph_totals[i], ph_resolvables[i],
-            mangled_counts[i], ratios[i]
+            mangled_counts[i], c_line_counts[i], ratios[i]
         ));
     }
     summary.push_str(&format!(
@@ -428,7 +456,17 @@ fn ghidra_sim_faillog_pins() {
              (and celebrate); otherwise investigate.",
             ratios[i], PIN_FAILLOG_DIFF_FLOOR[i]
         );
-        assert!(ratios[i] <= 1.0, "{t}: diff ratio out of range: {}", ratios[i]);
+        assert!(
+            ratios[i] <= PIN_FAILLOG_DIFF_CEILING[i],
+            "{t}: ghidra-vs-CLI diff ratio {:.3} rose above the pinned ceiling {} — \
+             the GUI path got WORSE (a markup/flatten regression?).",
+            ratios[i], PIN_FAILLOG_DIFF_CEILING[i]
+        );
+        assert_eq!(
+            c_line_counts[i], PIN_FAILLOG_C_LINES[i],
+            "{t}: flattened-C line count moved — the rendered structure changed \
+             (a <break>/token regression collapses this while ratios stay in band)"
+        );
     }
 
     // ---- query-traffic fingerprints ----

--- a/docs/ghidra-integration.md
+++ b/docs/ghidra-integration.md
@@ -372,25 +372,54 @@ What breaks when a partial core omits pieces — all failure modes are clean:
 
 ## 11. Testing strategy
 
-- **Phase 1 (now): in-crate mock-Java e2e.** A `MockJava` test double owns the other
-  end of the pipe: sends command bursts, answers queries from canned tables, asserts
-  the byte-exact response framing (including the response-open-before-params ordering,
-  the always-present 16/17 frame, and the self-alignment/exception paths). This is the
-  same differential discipline as the port — the upstream implementation
+- **In-crate mock-Java e2e (Phase 1, shipped).** A `MockJava` test double owns the
+  other end of the pipe: sends command bursts, answers queries from canned tables,
+  asserts the byte-exact response framing (including the response-open-before-params
+  ordering, the always-present 16/17 frame, and the self-alignment/exception paths) —
+  `kuna-ghidra/tests/protocol_e2e.rs` (canned streams) and `tests/decompile_at_e2e.rs`
+  (the interactive loopback, one canned RETURN function). This is the same
+  differential discipline as the port — the upstream implementation
   (`DecompileProcess.java`, `ghidra_arch.cc`) is the oracle.
-- **Phase 2+: DecompileDebug captures as fixtures.** Ghidra's "Debug Function
+- **ghidra-sim: the real-program differential harness (shipped with Phase 2).**
+  `kuna-ghidra/tests/ghidra_sim_e2e.rs` + the shared machinery in
+  `tests/ghidra_sim/` drive the FULL wire lifecycle in-process (registerProgram →
+  setAction → decompileAt×N → flushNative → deregister) against vendored ELFs
+  (`tests/bug-repro/faillog` fast; `sort`/`grep` breadth), with the mock-Java end
+  answered from **kuna's own analysis** (`ghidra_sim/oracle.rs`:
+  `bootstrap_from_object` for bytes/labels, the real Sleigh re-encoded as wire
+  `<inst>` documents for getPcode, a tspec *generated* from the Sleigh's space
+  manager so packed space indices agree by construction; getMappedSymbols answers
+  empty — the Phase-2 reality). It asserts the §6 response contracts (dual
+  `<function>` decode, name/entry echo, markup opref/varref ⊆ ast, the 19-query
+  legality and query-legal-command placement), flattens the Clang markup to C with
+  Java's `getC()` token cleaning applied (`IllegalCharCppTransformer` — the reason
+  over-wide type tokens read back as `unsigned_long__a1`), and **pins today's
+  GUI-path quality numbers**: raw-register identifier leaks, `Unique<hex>` tokens,
+  `sub_`/`dat_` placeholder rate vs what the loader knows, `getC()`-mangled token
+  counts, query traffic (getPcode totals, getMappedSymbols == 0), and the
+  normalized line-diff ratio against the SAME functions through the in-process CLI
+  path. The pins are inline consts in `ghidra_sim_e2e.rs`; they move only with the
+  provider/emitter change that earns the move — Phase 3/4 land by flipping them
+  downward. Run: `make test-ghidra` (release; also part of the CI `gates` job on
+  every PR, which matters because the workspace suite is skipped on internal PRs).
+- **Phase 3+: DecompileDebug captures as fixtures.** Ghidra's "Debug Function
   Decompilation" action (`DecompInterface.enableDebug`, `DebugDecompilerAction.java:38-73`)
   records every callback answer into an `<xml_savefile>` — exactly the document kuna's
   datatest corpus already consumes. Captures give us *recorded Java-side query answers*
-  to replay against `kuna-ghidra` without a live Ghidra, and `DecompileDebugXmlLoader`
-  (Features/Base) can import them as Programs for the reverse direction.
-- **Live smoke procedure** (manual, per phase): build the extension, install into a
-  Ghidra 12.2 release (or `-Dghidra.external.modules=` in a dev checkout), enable the
-  plugin, open a known binary, decompile; verify the spawned PID is `kuna_ghidra` and —
-  from Phase 2 — that the C, click-to-address, and rename round-trip behave.
-- **Regression floors**: the three standing gates (`make test`, `make test-stages`,
-  `make rust-test`) must stay green — `kuna-ghidra` is additive and must not perturb
-  the standalone engine.
+  to replay against `kuna-ghidra` without a live Ghidra (de-risking the sim's
+  synthesized `<mapsym>` shapes), and `DecompileDebugXmlLoader` (Features/Base) can
+  import them as Programs for the reverse direction.
+- **Live smoke** (manual, per phase): `integrations/ghidra/live-smoke/` — a
+  pyghidra rig that swaps `DecompileProcessFactory.exepath` to `kuna_ghidra` inside
+  a real Ghidra, decompiles the same functions with both cores, and writes a
+  side-by-side report with the same scanner counts the sim pins (see its README
+  for the offline-pyghidra setup). For the full extension path: build the
+  extension, install into a Ghidra 12.2 release (or `-Dghidra.external.modules=`
+  in a dev checkout), enable the plugin, verify the spawned PID is `kuna_ghidra`
+  and that the C, click-to-address, and rename round-trip behave.
+- **Regression floors**: the standing gates (`make test`, `make test-stages`,
+  `make rust-test`, now plus the `gates`-job ghidra-sim step) must stay green —
+  `kuna-ghidra` is additive and must not perturb the standalone engine.
 
 ## 12. Phase breakdown
 

--- a/integrations/ghidra/live-smoke/README.md
+++ b/integrations/ghidra/live-smoke/README.md
@@ -27,8 +27,13 @@ the native process. No extension install is needed for the smoke.
        "$GHIDRA_INSTALL_DIR/Ghidra/Features/PyGhidra/pypkg/dist" pyghidra
    ```
 
-3. The kuna binaries: `make binaries` at the repo root (produces
-   `decompiler/target/release/kuna_ghidra`).
+3. The `kuna_ghidra` binary — NOT part of `make binaries`; build it directly:
+
+   ```bash
+   cd decompiler && cargo build --release -p kuna-ghidra
+   ```
+
+   (produces `decompiler/target/release/kuna_ghidra`).
 
 ## Run
 

--- a/integrations/ghidra/live-smoke/README.md
+++ b/integrations/ghidra/live-smoke/README.md
@@ -1,0 +1,73 @@
+# Live-smoke: kuna_ghidra inside a real Ghidra
+
+A **manual/dev** rig (not CI) that runs the one thing the in-tree ghidra-sim
+harness (`make test-ghidra`, see `docs/ghidra-integration.md` §11) cannot: a
+REAL Ghidra as the other end of the decompile-process pipe. It decompiles the
+same functions twice — once with the stock native core, once with
+`kuna_ghidra` swapped in — and writes a side-by-side report carrying the same
+badness-scanner counts the sim pins (raw-register leaks, `Unique<hex>` tokens,
+`sub_`/`dat_` placeholder rate, the `unsigned_long__`-style `getC()` mangling
+signature, and a kuna-vs-stock line-diff ratio).
+
+The core swap uses the same seam as the `KunaDecompiler` extension
+(`integrations/ghidra/KunaDecompiler/`): a reflection write of
+`DecompileProcessFactory.exepath`, which the factory consults before spawning
+the native process. No extension install is needed for the smoke.
+
+## Setup
+
+1. A Ghidra release (12.x), e.g. `~/tools/ghidra_12.1.2_PUBLIC`.
+2. A venv with **pyghidra**. Ghidra bundles the wheels, so this works fully
+   offline (the PyPI `pyghidra` also works when you have network):
+
+   ```bash
+   python3 -m venv ~/.virtualenvs/kuna-ghidra
+   source ~/.virtualenvs/kuna-ghidra/bin/activate
+   pip install --no-index --find-links \
+       "$GHIDRA_INSTALL_DIR/Ghidra/Features/PyGhidra/pypkg/dist" pyghidra
+   ```
+
+3. The kuna binaries: `make binaries` at the repo root (produces
+   `decompiler/target/release/kuna_ghidra`).
+
+## Run
+
+```bash
+source ~/.virtualenvs/kuna-ghidra/bin/activate
+export GHIDRA_INSTALL_DIR=~/tools/ghidra_12.1.2_PUBLIC
+export KUNA_SMOKE_BINARY=$PWD/tests/bug-repro/faillog   # any program
+# optional:
+#   export KUNA_GHIDRA_EXE=…/decompiler/target/release/kuna_ghidra  (default)
+#   export KUNA_SMOKE_FUNCTIONS=main,usage    (default: main + 2 largest)
+#   export KUNA_SMOKE_OUT=./live-smoke-out    (default)
+python3 integrations/ghidra/live-smoke/kuna_vs_stock.py
+```
+
+Outputs, under `KUNA_SMOKE_OUT`:
+
+- `stock_<fn>.c` / `kuna_<fn>.c` — the `getC()` text per core, per function;
+- `REPORT.md` — completion status, per-function scanner counts, and the
+  kuna-vs-stock diff ratio.
+
+A working local example (the machine this rig was built on):
+`GHIDRA_INSTALL_DIR=/home/mahaloz/ctf/tools/ghidra_12.1.2_PUBLIC` with the venv
+`/home/mahaloz/.virtualenvs/kuna-ghidra`.
+
+## Notes / learnings baked in
+
+- **`analyze=True` matters**: the stock analyzers create the `FUN_…` function
+  symbols and types that Java answers queries from; an unanalyzed program
+  makes both cores look artificially bad.
+- **`getC()` is not the GUI panel**: `DecompileResults.getDecompiledFunction()`
+  runs every funcname/variable/type/field/label token through Java's
+  `IllegalCharCppTransformer`, so a token kuna emits with spaces/stars inside
+  (`"unsigned long *"` as ONE `<type>` token) reads back as
+  `unsigned_long__…`. The GUI panel renders token text verbatim. The sim
+  harness replicates the `getC()` behavior, so its numbers and this rig's line
+  up.
+- The python scanners here are a small re-implementation of the rust ones
+  (`decompiler/crates/kuna-ghidra/tests/ghidra_sim/mod.rs`) with a fixed
+  x86-64 register set; the rust harness (which harvests the register list from
+  the live Sleigh) is authoritative for pinned numbers.
+- Decompile timeouts are process murder (Java disposes the child); if the kuna
+  pass hangs, look for the spawned `kuna_ghidra` PID and its stderr.

--- a/integrations/ghidra/live-smoke/kuna_vs_stock.py
+++ b/integrations/ghidra/live-smoke/kuna_vs_stock.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Live-smoke: decompile the same functions with the stock Ghidra core and the
+kuna_ghidra core inside a REAL Ghidra, and write a side-by-side report with the
+same badness-scanner counts the in-tree ghidra-sim harness pins.
+
+This is the manual/dev complement to `make test-ghidra` (which needs no Ghidra
+at all): it validates the pieces the sim cannot — the extension/exepath spawn,
+Java's real query answers, and Java-side rendering (`getC()` runs the token
+stream through IllegalCharCppTransformer, which is where kuna's over-wide type
+tokens become `unsigned_long__a1`).
+
+Environment:
+  GHIDRA_INSTALL_DIR    Ghidra release root (required; pyghidra needs it)
+  KUNA_GHIDRA_EXE       path to the kuna_ghidra binary
+                        (default: <repo>/decompiler/target/release/kuna_ghidra)
+  KUNA_SMOKE_BINARY     the program to analyze (required)
+  KUNA_SMOKE_FUNCTIONS  comma-separated function names (default: main plus the
+                        two largest non-thunk functions)
+  KUNA_SMOKE_OUT        output directory (default: ./live-smoke-out)
+
+Run it inside a venv with pyghidra installed (see README.md):
+  python3 kuna_vs_stock.py
+"""
+
+import os
+import re
+import sys
+import difflib
+import traceback
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+KUNA_GHIDRA = os.environ.get(
+    "KUNA_GHIDRA_EXE",
+    os.path.join(REPO, "decompiler", "target", "release", "kuna_ghidra"),
+)
+BINARY = os.environ.get("KUNA_SMOKE_BINARY")
+FUNCTIONS = [f for f in os.environ.get("KUNA_SMOKE_FUNCTIONS", "").split(",") if f]
+OUT = os.path.abspath(os.environ.get("KUNA_SMOKE_OUT", "live-smoke-out"))
+
+# ---------------------------------------------------------------------------
+# Badness scanners — a small python re-implementation of the rust harness's
+# (tests/ghidra_sim/mod.rs). The rust harness harvests the register list from
+# the live Sleigh; here a fixed x86-64 set suffices for a smoke report.
+# ---------------------------------------------------------------------------
+
+_GPR = []
+for base in "AX BX CX DX SI DI BP SP".split():
+    _GPR += [f"R{base}", f"E{base}", base]
+_GPR += [b[0] + suf for b in ("AX", "BX", "CX", "DX") for suf in ("L", "H")]
+_GPR += ["SIL", "DIL", "BPL", "SPL"]
+for n in range(8, 16):
+    _GPR += [f"R{n}", f"R{n}D", f"R{n}W", f"R{n}B"]
+REGISTERS = set(_GPR) | {
+    "CF", "PF", "AF", "ZF", "SF", "TF", "IF", "DF", "OF",
+    "FS_OFFSET", "GS_OFFSET", "RIP", "EIP",
+} | {f"XMM{n}" for n in range(16)} | {f"YMM{n}" for n in range(16)} \
+  | {f"ST{n}" for n in range(8)}
+
+IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+HEX = re.compile(r"[0-9a-fA-F]+$")
+
+
+def identifiers(text):
+    return IDENT.findall(text)
+
+
+def register_leaks(text):
+    seen = [i for i in identifiers(text) if i in REGISTERS]
+    return len(seen), sorted(set(seen))
+
+
+def unique_leaks(text):
+    count = 0
+    for i in identifiers(text):
+        for prefix in ("Unique", "Stack"):
+            rest = i[len(prefix):] if i.startswith(prefix) else None
+            if rest and HEX.match(rest):
+                count += 1
+                break
+    return count
+
+
+def placeholder_addrs(text):
+    out = {}
+    for i in identifiers(text):
+        for kind in ("sub_", "FUN_", "dat_", "DAT_"):
+            rest = i[len(kind):] if i.startswith(kind) else None
+            if rest and HEX.match(rest):
+                out.setdefault(kind, set()).add(rest.lower())
+    return out
+
+
+def mangled_tokens(text):
+    """Identifiers showing the getC() type-mangling signature (double
+    underscore from a cleaned ``<space>*`` inside a type token)."""
+    return len(re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*__[A-Za-z0-9_]*\b", text))
+
+
+def diff_ratio(a, b):
+    la = [" ".join(l.split()) for l in a.splitlines() if l.split()]
+    lb = [" ".join(l.split()) for l in b.splitlines() if l.split()]
+    return 1.0 - difflib.SequenceMatcher(a=la, b=lb).ratio()
+
+
+def scan(text):
+    regs, reg_names = register_leaks(text)
+    ph = placeholder_addrs(text)
+    return {
+        "registers": regs,
+        "register_names": reg_names,
+        "unique": unique_leaks(text),
+        "placeholders": sum(len(v) for v in ph.values()),
+        "placeholders_by_kind": {k: len(v) for k, v in ph.items()},
+        "mangled_like": mangled_tokens(text),
+    }
+
+
+# ---------------------------------------------------------------------------
+# The exepath reflection swap (the same seam the KunaDecompiler extension uses)
+# ---------------------------------------------------------------------------
+
+
+def get_exepath_field():
+    from ghidra.app.decompiler import DecompileProcessFactory
+    cls = DecompileProcessFactory.class_
+    try:
+        f = cls.getDeclaredField("exepath")
+        f.setAccessible(True)
+        return f
+    except Exception as e:
+        print(f"FATAL: DecompileProcessFactory has no 'exepath' field here: {e}")
+        print("Declared fields:")
+        for fld in cls.getDeclaredFields():
+            print(f"  {fld}")
+        sys.exit(2)
+
+
+def decompile_one(ifc, func, out_path, timeout=120):
+    from ghidra.util.task import ConsoleTaskMonitor
+    diag = {"function": str(func.getName()), "entry": str(func.getEntryPoint())}
+    code = None
+    try:
+        res = ifc.decompileFunction(func, timeout, ConsoleTaskMonitor())
+        diag["decompileCompleted"] = bool(res.decompileCompleted())
+        diag["errorMessage"] = str(res.getErrorMessage())
+        dfunc = res.getDecompiledFunction()
+        code = str(dfunc.getC()) if dfunc is not None else None
+    except Exception:
+        diag["exception"] = traceback.format_exc()
+    diag["lastMessage"] = str(ifc.getLastMessage())
+    with open(out_path, "w") as fh:
+        fh.write(code if code else "/* NO OUTPUT */\n")
+    return code or "", diag
+
+
+def main():
+    if not BINARY:
+        print("usage: KUNA_SMOKE_BINARY=/path/to/prog [KUNA_SMOKE_FUNCTIONS=a,b] "
+              "python3 kuna_vs_stock.py")
+        sys.exit(1)
+    if not os.path.exists(KUNA_GHIDRA):
+        print(f"FATAL: kuna_ghidra not built at {KUNA_GHIDRA} (make binaries)")
+        sys.exit(1)
+    os.makedirs(OUT, exist_ok=True)
+
+    import pyghidra
+    pyghidra.start()
+    from ghidra.app.decompiler import DecompInterface
+
+    field = get_exepath_field()
+    report = []
+
+    with pyghidra.open_program(
+        BINARY,
+        project_location=os.path.join(OUT, "ghidra_project"),
+        project_name="kuna_live_smoke",
+        analyze=True,
+    ) as flat:
+        program = flat.getCurrentProgram()
+        fm = program.getFunctionManager()
+        print(f"[+] {program.getName()}: {fm.getFunctionCount()} functions, "
+              f"lang={program.getLanguageID()}")
+
+        def find(name):
+            for f in fm.getFunctions(True):
+                if str(f.getName()) == name:
+                    return f
+            return None
+
+        targets = []
+        if FUNCTIONS:
+            for name in FUNCTIONS:
+                f = find(name)
+                if f is None:
+                    print(f"WARNING: no function named {name}")
+                else:
+                    targets.append(f)
+        else:
+            main_f = find("main")
+            if main_f is not None:
+                targets.append(main_f)
+            rest = [f for f in fm.getFunctions(True)
+                    if not f.isThunk() and not f.isExternal() and f not in targets]
+            rest.sort(key=lambda f: -f.getBody().getNumAddresses())
+            targets += rest[:2]
+        if not targets:
+            print("FATAL: no target functions")
+            sys.exit(1)
+
+        for core, exe in (("stock", None), ("kuna", KUNA_GHIDRA)):
+            field.set(None, exe)
+            print(f"[+] {core} pass (exepath override: {field.get(None)})")
+            ifc = DecompInterface()
+            ifc.openProgram(program)
+            for f in targets:
+                name = str(f.getName())
+                out_path = os.path.join(OUT, f"{core}_{name}.c")
+                code, diag = decompile_one(ifc, f, out_path)
+                counts = scan(code)
+                report.append((core, name, diag, counts))
+                print(f"    {name}: completed={diag.get('decompileCompleted')} "
+                      f"err={diag.get('errorMessage')!r} scan={counts}")
+            ifc.dispose()
+        field.set(None, None)
+
+    # Side-by-side report with the per-function gap.
+    lines = ["# kuna_ghidra vs stock core — live smoke report", ""]
+    names = []
+    for core, name, _, _ in report:
+        if name not in names:
+            names.append(name)
+    for name in names:
+        stock_c = kuna_c = ""
+        for core, n, diag, counts in report:
+            if n != name:
+                continue
+            lines.append(f"## {core} / {name}")
+            lines.append(f"    completed={diag.get('decompileCompleted')} "
+                         f"error={diag.get('errorMessage')!r}")
+            lines.append(f"    scan: {counts}")
+            path = os.path.join(OUT, f"{core}_{name}.c")
+            text = open(path).read()
+            if core == "stock":
+                stock_c = text
+            else:
+                kuna_c = text
+        if stock_c and kuna_c:
+            lines.append(f"## diff_ratio({name}) = "
+                         f"{diff_ratio(kuna_c, stock_c):.3f} (kuna vs stock)")
+        lines.append("")
+    report_path = os.path.join(OUT, "REPORT.md")
+    with open(report_path, "w") as fh:
+        fh.write("\n".join(lines))
+    print(f"[+] report: {report_path}")
+    print(f"[+] per-function C: {OUT}/<core>_<function>.c")
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/ghidra/live-smoke/kuna_vs_stock.py
+++ b/integrations/ghidra/live-smoke/kuna_vs_stock.py
@@ -159,7 +159,8 @@ def main():
               "python3 kuna_vs_stock.py")
         sys.exit(1)
     if not os.path.exists(KUNA_GHIDRA):
-        print(f"FATAL: kuna_ghidra not built at {KUNA_GHIDRA} (make binaries)")
+        print(f"FATAL: kuna_ghidra not built at {KUNA_GHIDRA} "
+              "(cd decompiler && cargo build --release -p kuna-ghidra)")
         sys.exit(1)
     os.makedirs(OUT, exist_ok=True)
 


### PR DESCRIPTION
Test harness for the Ghidra integration: make GUI-path regressions and the Phase-2 quality gap **measurable numbers in CI, without a live Ghidra**. This is PR-A of the ghidra-mode series; the Phase-3 (lazy symbol/type providers) and Phase-4 PRs land against this harness by flipping its pins.

## What the harness is

- **Shared MockJava loopback** (`decompiler/crates/kuna-ghidra/tests/ghidra_sim/mod.rs`): the interactive single-threaded pipe double proven by `decompile_at_e2e.rs`, extracted behind a pluggable `AnswerSource` — wire builders, query pump, session tracer, a dual-`<function>` doc parser, a **markup→C flattener** that replicates Java's `getC()` token cleaning (`IllegalCharCppTransformer`), badness scanners, and a normalized line-diff metric. `decompile_at_e2e.rs` is refactored onto it (still green).
- **ghidra-sim v1** (`tests/ghidra_sim/oracle.rs`): a mock-Java answer source backed by **kuna's own analysis of real vendored ELFs** — `bootstrap_from_object` for bytes/labels/facts, the real Sleigh re-encoded as wire `<inst>` docs for `getPcode`, register/userop tables from the same Sleigh, and a tspec **generated from the loaded Sleigh's `AddrSpaceManager`** so packed space indices agree by construction. `getMappedSymbols`/`getExternalRef` answer **empty** — the Phase-2 reality — at a clearly marked `PHASE-3 SEAM` where the `<mapsym>` encoder plugs in.
- **The differential harness** (`tests/ghidra_sim_e2e.rs`): drives registerProgram → setAction → decompileAt×3 → flushNative → repeat decompileAt → deregister over `tests/bug-repro/faillog` (plus a `sort`/`grep` breadth test), asserts the response-document schema (name/entry echo, markup opref/varref ⊆ ast, 19-query legality + query-legal-command placement, clean warnings), and decompiles the SAME functions through the in-process CLI drive to pin the gap the GUI user experiences.

## Today's pinned numbers (faillog, x86-64, stripped)

| target | register leaks | Unique/Stack tokens | placeholders | loader-resolvable | getC()-mangled tokens | C lines | diff ratio vs CLI (band) |
|---|---|---|---|---|---|---|---|
| `sub_2620` (main) | 108 | 34 | 49 | 24 | 21 | 243 | 0.646 [0.55, 0.70] |
| `sub_3320` | 58 | 4 | 25 | 18 | 6 | 128 | 0.867 [0.80, 0.95] |
| `sub_3ad0` | 60 | 8 | 17 | 14 | 7 | 89 | 0.811 [0.70, 0.90] |

*(Re-measured on main @ `813ee131` after rebasing — the engine PRs #303–#316 shift the ghidra-path output slightly; determinism verified over three identical runs.)*

Session query traffic (unchanged by the rebase): `getPcode` total **1477** vs **1003** distinct decoded instructions (no p-code cache + no-return flow overrun into neighbours); `getMappedSymbols` **= 0** (pinned; Phase 3 flips this to ≥ 1). flushNative + repeat decompile is pinned **byte-identical** (deterministic engine; Phase 3 turns this into the cache-clearing semantics test via the oracle's `label_overrides` seam).

How the next PRs flip them:
- **Phase 3** (lazy `ScopeGhidra`/`TypeFactoryGhidra`): `resolvable → 0` (the 24/18/14 are PLT imports the loader already names — `localtime`, `getopt_long`, `dcgettext`, … rendering as `sub_ADDR` only because `getMappedSymbols` is unanswered), `getMappedSymbols ≥ 1`, diff-ratio floors flip to ceilings, register/Unique leak counts collapse (r3 §8 defects a–e, g).
- **PR-C** (markup emitter): `mangled tokens → 0` (see root cause below).

## Root cause found (reported, NOT fixed here — PR-C's job)

The live-repro type mangling (`unsigned_long__a1`, `(char__)`) is **two-sided**:
1. kuna's markup path emits the whole rendered declarator as ONE `<type>` token — `tag_type(ty/decl_type/ret_type, …)` at `decompiler/crates/kuna-decomp/src/p9_emit/printc.rs:1428,1451,2190,2679` receives strings like `"unsigned long *"` (the code at :2683 even tests `decl_type.ends_with('*')`). Upstream `PrintC::pushTypeStart` pushes only the base type NAME as the type token; stars/spaces travel as separate syntax/op tokens.
2. Java's `DecompileResults.getDecompiledFunction()` (`DecompileResults.java:211`) runs every funcname/variable/type/field/label token through `IllegalCharCppTransformer.simplify`, rewriting every non-identifier char to `_` — so `"unsigned long *"` + `"a1"` reads back as `unsigned_long__a1`. The GUI *panel* renders token text verbatim; scripts/exports/`getC()` consumers see the mangling.

The harness flattener replicates (2) exactly, so (1) is pinned as the `mangled tokens` column and PR-C's fix is measurable. Fixing (1) is a multi-site token-granularity change (> 10 lines), out of scope here per the brief.

## CI + tooling

- `.github/workflows/tests.yml` `gates` job (runs on every PR): one new step — `cargo test -p kuna-ghidra --release -- --include-ignored` with the standard skip-canary grep. Cost: ~1–2 min compile over the already-built release deps + **~2 s** of test runtime.
- `make test-ghidra`: the same run locally.
- `make rust-test` (dev profile) runs the faillog tests too (~12 s; the sort/grep breadth test is `#[ignore]`d there and picked up by the release contexts).
- **Live-smoke rig** (`integrations/ghidra/live-smoke/`, manual/dev, not CI): a parameterized pyghidra script that swaps `DecompileProcessFactory.exepath` to `kuna_ghidra` inside a real Ghidra, decompiles the same functions with both cores, and writes a side-by-side report with the same scanner counts (README covers the offline-pyghidra setup).
- `docs/ghidra-integration.md` §11 rewritten around the harness.

## Gates

`make test` 675/675 PARITY OK · `make test-stages` PARITY OK · `make rust-test` green (the new tests run inside it) · `make check-spec` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfGYKwUWvPYYj1Aw7tcLhC


---

**Review hardening (`aa67ad57`)**: diff-ratio pins are now a band (floors + ceilings `[0.70, 0.95, 0.90]`) and the flattened-C normalized **line count is pinned per target (241 / 174 / 89)** — the assert that catches a `<break>`-token collapse the ratio floors alone could not; the vacuous `<= 1.0` assert is gone. `decompile_cli` now routes through the shared `decompile_step::decompile_one` with the error-noreturn CALL_RETURN flow overrides exactly as `kuna_console::project` builds them (latent fix — every faillog pin re-measured identical). Assert strength: warnings frames pinned trim-empty, markup oprefs AND varrefs non-empty per class, ast varnode refs collected from `<varnodes>` only (all Java's `buildVarnodeRefs` keys), name echo vs the sim's served `code_label`. The CI step now `tee`s its log so a failing pin prints diagnostics under `bash -e`. Live-smoke docs point at `cargo build --release -p kuna-ghidra` (not `make binaries`). **No pinned value moved.**

