### PR TITLE
[AUTOMATED] feat(ghidra): Phase 4 — full response encode (rename/retype, switch recovery, real signatures in the GUI)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ PROFILE ?= release
 BINDIR  := $(ENGINE)/target/$(PROFILE)
 SLACOMP := $(BINDIR)/slacomp
 PYTHON  ?= python3
+# Where `test-ghidra` tees its output for the two false-green canaries below
+# (inside target/, which is gitignored, so a failed run leaves no repo litter).
+GHIDRA_SIM_LOG := $(ENGINE)/target/ghidra-sim.log
 
 .PHONY: all binaries specs test test-stages test-ghidra rust rust-test clean check-spec version
 
@@ -59,9 +62,34 @@ $(BINDIR)/kuna:
 # in-process against real vendored ELFs and pins the GUI-path quality numbers.
 # Release profile (the dev profile costs minutes for the same answer);
 # --include-ignored picks up the heavier sort/grep breadth test.
+#
+# TWO canaries, because this target has twice been a FALSE GREEN while CI's
+# equivalent step was red:
+#   * the skip canary (the same grep CI runs): with the `.sla` specs missing or
+#     unusable every ghidra-sim test prints a skip notice and returns early --
+#     by design, so a specs-less checkout is a visible skip rather than a false
+#     failure.  A green `make test-ghidra` that skipped everything proves
+#     nothing.  Worktrees hit this constantly: `KUNA_SPECS`/`SLEIGHHOME` do not
+#     reach the cargo suites (AGENTS.md), so the harness resolves <repo>/specs
+#     relative to its own crate and finds nothing.
+#   * the breadth canary: `ghidra_sim_sort_grep_breadth` is `#[ignore]`d (it is
+#     the heavy one), so ANY run that loses `--include-ignored` reports it
+#     "ignored" and still exits 0 -- which is exactly how a broken
+#     `<vardecl symref>` on the sort/grep fixtures reached CI green-locally.
+#     Demand the line that proves it actually ran.
 test-ghidra:
 	@test -n "$$(find $(SPECS) -name '*.sla' -print -quit)" || $(MAKE) specs
-	cd $(ENGINE) && cargo test --$(PROFILE) -p kuna-ghidra -- --include-ignored
+	@bash -c 'set -o pipefail; cd $(ENGINE) && \
+	  cargo test --$(PROFILE) -p kuna-ghidra -- --include-ignored --nocapture \
+	    2>&1 | tee $(GHIDRA_SIM_LOG)'
+	@if grep -qE 'skipping \(.*(\.sla|make specs|specs tree)' $(GHIDRA_SIM_LOG); then \
+	  echo "ERROR: ghidra-sim tests skipped for missing/unusable SLEIGH specs -- false green"; \
+	  exit 1; \
+	fi
+	@grep -q 'test ghidra_sim_sort_grep_breadth \.\.\. ok' $(GHIDRA_SIM_LOG) || { \
+	  echo "ERROR: the sort/grep breadth test did not RUN (needs --include-ignored) -- false green"; \
+	  exit 1; \
+	}
 
 # Spec honesty gate: docs/spec/ anchors resolve, every phase folder is owned by
 # exactly one chapter, and (strict) every settable option is mentioned.

--- a/decompiler/crates/kuna-decomp/src/infra/architecture.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/architecture.rs
@@ -718,6 +718,17 @@ pub struct Architecture {
     /// rather than Symbols.  Always empty outside ghidra mode, so the
     /// standalone pipeline is structurally unaffected.
     pub kuna_pending_name_recs: Vec<(String, Address, Address, int4)>,
+    /// (ghidra-mode, Phase 4) The DYNAMIC (hash-storage) half of the same
+    /// staging — `(name, first-use address, hash)`; see
+    /// [`Self::kuna_pending_name_recs`].  Always empty outside ghidra mode.
+    pub kuna_pending_dyn_recs: Vec<(String, Address, u64)>,
+    /// (ghidra-mode, Phase 4) The prototype MODEL the host declared for the
+    /// next decompiled function (`<prototype model=…>`), staged the same way.
+    /// The host assigned its committed parameter storage under this
+    /// convention, so re-deriving storage from kuna's default model would
+    /// disagree with the database and make Java's `checkFullCommit` rewrite
+    /// the user's signature on any rename.  `None` outside ghidra mode.
+    pub kuna_pending_proto_model: Option<Rc<crate::fspec::ProtoModel>>,
 
     // --- kuna analysis-pass gates (per-run `--option <id> on|off`) ----------
     // One boolean per `kuna_analysis::passes` pass id; the console's
@@ -1410,6 +1421,8 @@ impl Architecture {
             kuna_fn_budget: None,   // (kuna) decompile-all watchdog: no budget by default
             kuna_fn_deadline: None, // (kuna) set per drive from kuna_fn_budget
             kuna_pending_name_recs: Vec::new(), // (ghidra Phase 4) staged per drive
+            kuna_pending_dyn_recs: Vec::new(),  // (ghidra Phase 4) staged per drive
+            kuna_pending_proto_model: None,     // (ghidra Phase 4) staged per drive
 
             // Analysis-pass gates: placeholder values -- `Architecture::new` calls
             // `reset_defaults_internal()` below, the SINGLE source of every

--- a/decompiler/crates/kuna-decomp/src/infra/architecture.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/architecture.rs
@@ -709,6 +709,15 @@ pub struct Architecture {
     /// ([`ActionContext::deadline`](crate::action::ActionContext)).  Always
     /// `None` when no budget is set.
     pub kuna_fn_deadline: Option<std::time::Instant>,
+    /// (ghidra-mode, Phase 4) Name recommendations staged for the NEXT
+    /// decompile drive — `(name, storage addr, usepoint, size)`, taken (and
+    /// cleared) by `decompile_func_full_with_override_dyn` and seeded into the
+    /// fresh `Funcdata`'s local scope.  The carrier for the host `<localdb>`'s
+    /// namelocked-but-not-typelocked locals (GUI renames of untyped
+    /// variables), which C++ keeps as `ScopeLocal::nameRecommend` entries
+    /// rather than Symbols.  Always empty outside ghidra mode, so the
+    /// standalone pipeline is structurally unaffected.
+    pub kuna_pending_name_recs: Vec<(String, Address, Address, int4)>,
 
     // --- kuna analysis-pass gates (per-run `--option <id> on|off`) ----------
     // One boolean per `kuna_analysis::passes` pass id; the console's
@@ -1400,6 +1409,7 @@ impl Architecture {
             preserve_thumb_funcptr: false,
             kuna_fn_budget: None,   // (kuna) decompile-all watchdog: no budget by default
             kuna_fn_deadline: None, // (kuna) set per drive from kuna_fn_budget
+            kuna_pending_name_recs: Vec::new(), // (ghidra Phase 4) staged per drive
 
             // Analysis-pass gates: placeholder values -- `Architecture::new` calls
             // `reset_defaults_internal()` below, the SINGLE source of every

--- a/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
@@ -818,6 +818,8 @@ pub fn decompile_func_full_with_override_dyn(
     // (ghidra-mode, Phase 4) Take the staged name recommendations UP FRONT so
     // an early flow failure can never leak them into a later drive.
     let staged_name_recs = std::mem::take(&mut arch.kuna_pending_name_recs);
+    let staged_dyn_recs = std::mem::take(&mut arch.kuna_pending_dyn_recs);
+    let staged_proto_model = arch.kuna_pending_proto_model.take();
     let result = (|| {
         // Kept for the parked-prototype lookup below (the flow build consumes the
         // address).
@@ -872,7 +874,12 @@ pub fn decompile_func_full_with_override_dyn(
         // recovery SEED): after this the inputs/output are type-locked, so
         // ActionPrototypeTypes forces the typed Varnodes.
         if let Some(pieces) = pending_proto.or(recovered_proto.as_ref()) {
-            fd.apply_locked_prototype(pieces)?;
+            // (ghidra-mode, Phase 4) A host-declared model rides with the
+            // pieces so parameter storage is assigned under the SAME
+            // convention the database committed (see
+            // `Architecture::kuna_pending_proto_model`); `None` everywhere
+            // else keeps the architecture default.
+            fd.apply_locked_prototype_with_model(pieces, staged_proto_model.clone())?;
         }
         // Re-seed any console `map param <i> <addr> <typedecl>` storage locks (lost
         // when the IR is rebuilt, like `pending_proto`/`mapped_symbols`).  This makes
@@ -892,6 +899,9 @@ pub fn decompile_func_full_with_override_dyn(
         // entries); empty everywhere outside ghidra mode.
         if !staged_name_recs.is_empty() {
             fd.seed_name_recommendations(&staged_name_recs);
+        }
+        if !staged_dyn_recs.is_empty() {
+            fd.seed_dynamic_recommendations(&staged_dyn_recs);
         }
         // With the single-manager unification (LOSS-132) the universalAction passes
         // now reach the *real* lifted varnodes, so the pipeline genuinely executes

--- a/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
@@ -815,6 +815,9 @@ pub fn decompile_func_full_with_override_dyn(
     // and the action pipeline — and is consulted cooperatively at the action /
     // rule-pool / heritage loop boundaries.
     arch.kuna_fn_deadline = arch.kuna_fn_budget.map(|b| std::time::Instant::now() + b);
+    // (ghidra-mode, Phase 4) Take the staged name recommendations UP FRONT so
+    // an early flow failure can never leak them into a later drive.
+    let staged_name_recs = std::mem::take(&mut arch.kuna_pending_name_recs);
     let result = (|| {
         // Kept for the parked-prototype lookup below (the flow build consumes the
         // address).
@@ -884,6 +887,12 @@ pub fn decompile_func_full_with_override_dyn(
         fd.seed_usepoint_symbols(usepoint_symbols);
         // Re-seed the console-added dynamic (`map hash`) symbols (likewise lost).
         fd.seed_dynamic_symbols(dynamic_symbols);
+        // (ghidra-mode, Phase 4) Seed the staged name recommendations (the
+        // host `<localdb>`'s rename-only locals — C++ `nameRecommend`
+        // entries); empty everywhere outside ghidra mode.
+        if !staged_name_recs.is_empty() {
+            fd.seed_name_recommendations(&staged_name_recs);
+        }
         // With the single-manager unification (LOSS-132) the universalAction passes
         // now reach the *real* lifted varnodes, so the pipeline genuinely executes
         // heritage / simplification / merge / … on live IR.  Some pass BODIES are

--- a/decompiler/crates/kuna-decomp/src/infra/paramid.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/paramid.rs
@@ -16,25 +16,22 @@
 //! op's parent block `isLoopIn` (the same edge the C++ reads through
 //! `op->getParent()->isLoopIn(slot)`).
 //!
-//! # Stubs
+//! # Completeness
 //!
-//! * The `justproto` constructor path needs the recovered [`FuncProto`] from
-//!   `Funcdata::getFuncProto()` (`numParams`/`getParam`/`getOutput`).  In the
-//!   merged tree `Funcdata::funcp` is still the W3/W4 placeholder
-//!   (`crate::context::FuncProto`), not the real `fspec::FuncProto`, so the
-//!   prototype-driven measure collection cannot run yet — [`ParamIDAnalysis::new`]
-//!   returns a `STUB(W4)` error for `justproto = true`.  The non-prototype path
-//!   (input Varnodes outside the model, via `beginDef(input)`) is fully ported.
-//! * `ParamMeasure::encode` needs `Datatype::encodeRef` and the W8 marshal of the
-//!   `<rank>`/`<addr>` children; the address-space attribute encode exists, the
-//!   type-ref does not, so [`ParamMeasure::encode`] stubs out.  `savePretty` is fully
-//!   ported (it prints only the `VarnodeData` fields).
+//! Fully ported (Phase 4 unstubbed the marshal): both constructor paths — the
+//! `justproto` prototype walk over the real [`crate::fspec::FuncProto`] on
+//! `Funcdata::funcp` and the input-Varnode listing — plus
+//! [`ParamMeasure::encode`] / [`ParamIDAnalysis::encode`] over
+//! `Datatype::encode_ref`, producing the `<parammeasures>` document the
+//! `paramid` action answers (Java `HighParamID.decode`; the `<rank>` child is
+//! REQUIRED by `ParamMeasure.decode`, so `moredetail` should stay `true` on
+//! the wire path, matching both upstream ghidra_process call sites).
 
 use std::rc::Rc;
 
 use kuna_base::address::Address;
-use kuna_base::error::{KunaError, KunaResult};
-use kuna_base::marshal::{AttributeId, ElementId};
+use kuna_base::error::KunaResult;
+use kuna_base::marshal::ElementId;
 use kuna_num::opcodes::OpCode;
 use kuna_num::pcoderaw::VarnodeData;
 
@@ -364,18 +361,37 @@ impl ParamMeasure {
         s.push_str(&format!("  Rank: {}\n", self.rank));
     }
 
-    /// Encode the measure (C++ `ParamMeasure::encode`, paramid.cc:161-175).
-    ///
-    /// The C++ writes `<addr>` (the space attributes), then `vntype->encodeRef`,
-    /// then (if `moredetail`) the `<rank>` child.  The `vntype->encodeRef` is the
-    /// W8 type-marshal surface (`Datatype::encodeRef`), which is not yet ported,
-    /// so the whole encode stubs out.
-    pub fn encode(&self, _moredetail: bool) -> KunaResult<()> {
-        // The encode genuinely consumes `vntype` (the `<addr>` type-ref child).
-        let _has_type = self.vntype.is_some();
-        Err(KunaError::lowlevel(
-            "kuna rust port: ParamMeasure::encode needs Datatype::encodeRef (W8 type marshal)",
-        ))
+    /// Encode the measure under `tag` (C++ `ParamMeasure::encode`,
+    /// paramid.cc:161-175): the sized `<addr>`, the type reference, and — when
+    /// `moredetail` — the REQUIRED `<rank val>` child (both upstream
+    /// ghidra_process call sites pass `moredetail=true`; Java's
+    /// `ParamMeasure.decode` throws without it).
+    pub fn encode(
+        &self,
+        encoder: &mut dyn kuna_base::marshal::Encoder,
+        tag: &ElementId,
+        moredetail: bool,
+    ) -> KunaResult<()> {
+        encoder.open_element(tag);
+        encoder.open_element(&kuna_base::address::ELEM_ADDR);
+        if let Some(spc) = &self.vndata.space {
+            spc.encode_attributes_sized(encoder, self.vndata.offset, self.vndata.size as i32)?;
+        }
+        encoder.close_element(&kuna_base::address::ELEM_ADDR);
+        match &self.vntype {
+            Some(t) => t.encode_ref(encoder)?,
+            None => {
+                encoder.open_element(&kuna_base::marshal::ELEM_VOID);
+                encoder.close_element(&kuna_base::marshal::ELEM_VOID);
+            }
+        }
+        if moredetail {
+            encoder.open_element(&ELEM_RANK);
+            encoder.write_signed_integer(&kuna_base::marshal::ATTRIB_VAL, self.rank as i64);
+            encoder.close_element(&ELEM_RANK);
+        }
+        encoder.close_element(tag);
+        Ok(())
     }
 }
 
@@ -391,6 +407,12 @@ impl ParamMeasure {
 pub struct ParamIDAnalysis {
     /// The function's display name (cached for `savePretty`/`encode`).
     fdname: String,
+    /// The function's entry address (C++ `fd->getAddress()`, for `encode`).
+    fdaddr: Address,
+    /// The recovered prototype's model name (C++ `getFuncProto().getModelName()`).
+    model_name: String,
+    /// The recovered prototype's extrapop (C++ `getFuncProto().getExtraPop()`).
+    extrapop: i32,
     /// Measures for input locations (C++ `InputParamMeasures`).
     input_param_measures: Vec<ParamMeasure>,
     /// Measures for output locations (C++ `OutputParamMeasures`).
@@ -401,27 +423,70 @@ impl ParamIDAnalysis {
     /// Build the analysis for a function (C++ `ParamIDAnalysis::ParamIDAnalysis`,
     /// paramid.cc:186-235).
     ///
-    /// `justproto = true` restricts collection to the recovered prototype; that
-    /// path needs the real [`FuncProto`](crate::fspec::FuncProto) from
-    /// `Funcdata::getFuncProto`, which is still the W3/W4 placeholder in the
-    /// merged tree, so it stubs out.  `justproto = false` lists the input Varnodes
-    /// outside the model (the `beginDef(input)` range) and is fully ported.
+    /// `justproto = true` restricts collection to the recovered prototype
+    /// (`numParams`/`getParam(i)`/`getOutput` + `findVarnodeInput` + the
+    /// RETURN-op output scan); `justproto = false` lists the input Varnodes
+    /// outside the model (the `beginDef(input)` range).
     pub fn new(fd: &Funcdata, justproto: bool) -> KunaResult<ParamIDAnalysis> {
+        let proto = fd.get_func_proto();
+        // C++ always has a model + store by analysis end; hand-built fixtures
+        // may not — degrade to the "default" model spelling / no measures
+        // rather than panic.
+        let model_name =
+            if proto.has_model() { proto.get_model_name().to_string() } else { "default".into() };
         let mut analysis = ParamIDAnalysis {
             fdname: fd.get_name().to_string(),
+            fdaddr: fd.get_address().clone(),
+            model_name,
+            extrapop: proto.get_extra_pop(),
             input_param_measures: Vec::new(),
             output_param_measures: Vec::new(),
         };
         if justproto {
-            // const FuncProto &fproto( fd->getFuncProto() );
-            //   numParams()/getParam(i)/getOutput() + findVarnodeInput + the
-            //   RETURN-op output scan.  STUB(W4): Funcdata::funcp is still the
-            //   placeholder (crate::context::FuncProto), not fspec::FuncProto, so
-            //   the recovered prototype is unavailable here.
-            return Err(KunaError::lowlevel(
-                "kuna rust port: ParamIDAnalysis(justproto=true) needs the recovered \
-                 FuncProto from Funcdata::getFuncProto (W4 — funcp is still the placeholder)",
-            ));
+            // We only provide info on the recovered prototype.
+            let num = if proto.has_store() { proto.num_params() } else { 0 };
+            for i in 0..num {
+                let param = match proto.get_param(i) {
+                    Some(p) => p,
+                    None => continue,
+                };
+                let addr = param.get_address();
+                let size = param.get_size();
+                let ty = param.get_type().cloned();
+                let mut pm = ParamMeasure::new(&addr, size, ty, ParamIDIO::Input);
+                if let Some(vn) = fd.find_varnode_input(size, &addr) {
+                    pm.calculate_rank(fd, true, vn, None);
+                }
+                analysis.input_param_measures.push(pm);
+            }
+            if !proto.has_store() {
+                return Ok(analysis);
+            }
+            let outparam = proto.get_output();
+            let out_addr = outparam.get_address();
+            if !out_addr.is_invalid() {
+                // If we don't have a void type.
+                let mut pm = ParamMeasure::new(
+                    &out_addr,
+                    outparam.get_size(),
+                    outparam.get_type().cloned(),
+                    ParamIDIO::Output,
+                );
+                // For a RETURN op, input1 (if present) is the returned Varnode.
+                for rtn_op in fd.obank().iter_code(OpCode::CPUI_RETURN) {
+                    let o = match fd.obank().get(rtn_op) {
+                        Some(o) => o,
+                        None => continue,
+                    };
+                    if o.num_input() == 2 {
+                        if let Some(ovn) = o.get_in(1) {
+                            pm.calculate_rank(fd, true, ovn, Some(rtn_op));
+                            break;
+                        }
+                    }
+                }
+                analysis.output_param_measures.push(pm);
+            }
         } else {
             // Need to list input varnodes that are outside of the model.
             let inputs: Vec<VarnodeId> = fd.vbank().iter_def_flag(varnode_flags::input).collect();
@@ -474,19 +539,36 @@ impl ParamIDAnalysis {
         s.push('\n');
     }
 
-    /// Encode the analysis (C++ `ParamIDAnalysis::encode`, paramid.cc:237-262).
-    ///
-    /// Needs the recovered `FuncProto` (model/extrapop) and
-    /// `ParamMeasure::encode` (`Datatype::encodeRef`); both STUB.
-    pub fn encode(&self) -> KunaResult<()> {
-        // Reference the element ids so they stay live until the marshal surface
-        // (W4 FuncProto + W8 type-ref) is threaded.
-        let _ = (&ELEM_PARAMMEASURES, &ELEM_PROTO, &ELEM_RANK);
-        let _ = (&AttributeId::new("model", 13), &AttributeId::new("extrapop", 6));
-        Err(KunaError::lowlevel(
-            "kuna rust port: ParamIDAnalysis::encode needs FuncProto (model/extrapop, W4) \
-             + ParamMeasure::encode (Datatype::encodeRef, W8)",
-        ))
+    /// Encode the analysis as a `<parammeasures>` element (C++
+    /// `ParamIDAnalysis::encode`, paramid.cc:237-262): the function name +
+    /// entry address, the `<proto model extrapop>` child, then each
+    /// input/output measure.
+    pub fn encode(
+        &self,
+        encoder: &mut dyn kuna_base::marshal::Encoder,
+        moredetail: bool,
+    ) -> KunaResult<()> {
+        use kuna_base::marshal::{ATTRIB_MODEL, ATTRIB_NAME};
+        encoder.open_element(&ELEM_PARAMMEASURES);
+        encoder.write_string(&ATTRIB_NAME, self.fdname.as_bytes());
+        self.fdaddr.encode(encoder)?;
+        encoder.open_element(&ELEM_PROTO);
+        encoder.write_string(&ATTRIB_MODEL, self.model_name.as_bytes());
+        if self.extrapop == crate::fspec::EXTRAPOP_UNKNOWN {
+            encoder.write_string(&crate::remote_provider::ATTRIB_EXTRAPOP, b"unknown");
+        } else {
+            encoder
+                .write_signed_integer(&crate::remote_provider::ATTRIB_EXTRAPOP, self.extrapop as i64);
+        }
+        encoder.close_element(&ELEM_PROTO);
+        for pm in &self.input_param_measures {
+            pm.encode(encoder, &kuna_base::marshal::ELEM_INPUT, moredetail)?;
+        }
+        for pm in &self.output_param_measures {
+            pm.encode(encoder, &kuna_base::marshal::ELEM_OUTPUT, moredetail)?;
+        }
+        encoder.close_element(&ELEM_PARAMMEASURES);
+        Ok(())
     }
 }
 
@@ -645,10 +727,76 @@ mod tests {
         assert!(s.contains("Rank: 2"), "got: {s}");
     }
 
-    /// The justproto path stubs out (prototype unavailable in the merged tree).
+    /// The justproto path on a store-less fixture proto degrades to an empty
+    /// measure set (a real pipeline Funcdata always carries a store).
     #[test]
-    fn justproto_is_stub() {
+    fn justproto_storeless_yields_empty() {
         let fd = build_fd();
-        assert!(ParamIDAnalysis::new(&fd, true).is_err());
+        let analysis = ParamIDAnalysis::new(&fd, true).unwrap();
+        assert_eq!(analysis.num_input_measures(), 0);
+        assert_eq!(analysis.num_output_measures(), 0);
+    }
+
+    /// The encode emits `<parammeasures name><addr/><proto model extrapop/>` +
+    /// one measure per input, each with the REQUIRED `<rank val>` child
+    /// (paramid.cc:161-175 moredetail=true — the shape both upstream
+    /// ghidra_process call sites produce).
+    #[test]
+    fn encode_roundtrip_shape() {
+        use kuna_base::marshal::{Decoder, PackedDecode, PackedEncode};
+        let mut fd = build_fd();
+        let rs = ramspace(&fd);
+        let root = fd.bblocks_root_pub();
+        let bl = fd.bblocks_mut().new_block_basic(root);
+        fd.bblocks_mut().set_start_block(root, bl);
+        let a = fd.new_varnode(4, &Address::new(Rc::clone(&rs), 0x100), None);
+        let a = fd.set_input_varnode(a).unwrap();
+        let add = add_op(&mut fd, bl, OpCode::CPUI_INT_ADD, 2, Address::new(Rc::clone(&rs), 0x1000));
+        let _out = fd.new_varnode_out(4, &Address::new(Rc::clone(&rs), 0x200), add).unwrap();
+        fd.op_set_input(add, a, 0).unwrap();
+        fd.op_set_input(add, a, 1).unwrap();
+        fd.structure_reset();
+
+        let analysis = ParamIDAnalysis::new(&fd, false).unwrap();
+        assert_eq!(analysis.num_input_measures(), 1);
+        let mut bytes: Vec<u8> = Vec::new();
+        {
+            let mut enc = PackedEncode::new(&mut bytes);
+            analysis.encode(&mut enc, true).unwrap();
+        }
+        let mut dec = PackedDecode::new(fd.get_arch().manage());
+        dec.ingest_stream(&bytes).unwrap();
+        let pm = dec.open_element().unwrap();
+        assert_eq!(pm, ELEM_PARAMMEASURES.get_id());
+        let name = dec.read_string_id(&kuna_base::marshal::ATTRIB_NAME).unwrap();
+        assert_eq!(name, b"func");
+        // <addr/> child.
+        let ad = dec.open_element().unwrap();
+        assert_eq!(ad, kuna_base::address::ELEM_ADDR.get_id());
+        dec.close_element_skipping(ad).unwrap();
+        // <proto model extrapop/>.
+        let pr = dec.open_element().unwrap();
+        assert_eq!(pr, ELEM_PROTO.get_id());
+        dec.close_element_skipping(pr).unwrap();
+        // <input> with a <rank val> child.
+        let inp = dec.open_element().unwrap();
+        assert_eq!(inp, kuna_base::marshal::ELEM_INPUT.get_id());
+        let mut saw_rank = false;
+        loop {
+            let c = dec.peek_element().unwrap();
+            if c == 0 {
+                break;
+            }
+            let id = dec.open_element().unwrap();
+            if id == ELEM_RANK.get_id() {
+                let val = dec.read_signed_integer_id(&kuna_base::marshal::ATTRIB_VAL).unwrap();
+                assert_eq!(val, param_rank::DIRECTREAD as i64);
+                saw_rank = true;
+            }
+            dec.close_element_skipping(id).unwrap();
+        }
+        assert!(saw_rank, "<rank> child is REQUIRED (ParamMeasure.decode throws)");
+        dec.close_element(inp).unwrap();
+        dec.close_element(pm).unwrap();
     }
 }

--- a/decompiler/crates/kuna-decomp/src/infra/remote_provider.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/remote_provider.rs
@@ -1387,14 +1387,26 @@ impl RemoteScope {
                             if !p.model.is_empty() {
                                 model_name = Some(p.model.clone());
                             }
+                            // SLOT BASIS: the storage overrides address the
+                            // slots of the prototype `to_pieces` builds, which
+                            // COMPACTS OUT any parameter with no decodable type
+                            // — so count in that same compacted basis, never
+                            // `rp.index`.  A host cat-0 parameter whose type
+                            // failed to decode would otherwise shift every
+                            // later `pieces` slot while these overrides stayed
+                            // absolute, and the resulting index/count disagreement
+                            // is exactly what Java's `checkFullCommit` reacts to
+                            // by force-rewriting the user's signature.
+                            let mut slot: int4 = 0;
                             for rp in &p.params {
-                                let (Some(dt), false) =
-                                    (rp.dtype.clone(), rp.storage.is_invalid())
-                                else {
+                                let Some(dt) = rp.dtype.clone() else { continue };
+                                let this_slot = slot;
+                                slot += 1;
+                                if rp.storage.is_invalid() {
                                     continue;
-                                };
+                                }
                                 param_storage.push((
-                                    rp.index as int4,
+                                    this_slot,
                                     rp.name.clone(),
                                     crate::fspec::ParameterPieces {
                                         addr: rp.storage.clone(),

--- a/decompiler/crates/kuna-decomp/src/infra/remote_provider.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/remote_provider.rs
@@ -261,6 +261,9 @@ pub struct RemoteFunction {
     pub inline: bool,
     /// The decoded `<prototype>` (+ `<localdb>` cat-0 params), when present.
     pub proto: Option<RemoteProto>,
+    /// Non-parameter `<localdb>` symbols (host-committed locals; see
+    /// [`RemoteLocalVar`]).
+    pub locals: Vec<RemoteLocalVar>,
 }
 
 /// A decoded `<prototype>` plus the `<localdb>` category-0 parameters.
@@ -295,6 +298,31 @@ pub struct RemoteParam {
     pub dtype: Option<Rc<Datatype>>,
     /// The symbol's typelock bit.
     pub typelock: bool,
+}
+
+/// One non-parameter local symbol delivered in the current function's
+/// `<localdb>` (a user-named/typed variable committed to the host database —
+/// e.g. by a prior GUI rename/retype through `HighFunctionDBUtil`).  The
+/// upstream native core decodes these straight into the function's `ScopeLocal`
+/// (`Funcdata::decode` → localmap restore), which is what makes a GUI rename
+/// SURVIVE the event-driven re-decompile; kuna seeds them through the same
+/// per-function seeding path the console's `map addr`/`type varnode` symbols
+/// use ([`crate::funcdata::Funcdata::seed_mapped_symbols`] /
+/// [`crate::funcdata::Funcdata::seed_usepoint_symbols`]).
+#[derive(Clone)]
+pub struct RemoteLocalVar {
+    /// Symbol name.
+    pub name: String,
+    /// Symbol data-type.
+    pub dtype: Rc<Datatype>,
+    /// Storage address of the first mapped entry.
+    pub addr: Address,
+    /// The symbol's flag bits (namelock/typelock/readonly/volatile — the
+    /// subset `decode_symbol_header` reads).
+    pub flags: kuna_base::types::uint4,
+    /// The first-use address (the first `<rangelist>` range start); invalid =
+    /// an empty uselimit = an address-tied (whole-function) local.
+    pub usepoint: Address,
 }
 
 impl RemoteProto {
@@ -573,6 +601,7 @@ fn decode_wire_function(
         no_return: false,
         inline: false,
         proto: None,
+        locals: Vec::new(),
     };
     loop {
         let aid = decoder.get_next_attribute_id()?;
@@ -606,7 +635,13 @@ fn decode_wire_function(
     while decoder.peek_element()? != 0 {
         let sub = decoder.peek_element()?;
         if sub == ELEM_LOCALDB.get_id() {
-            decode_localdb_params(decoder, types, &mut params, &mut params_locked)?;
+            decode_localdb_params(
+                decoder,
+                types,
+                &mut params,
+                &mut params_locked,
+                &mut func.locals,
+            )?;
         } else if sub == ELEM_PROTOTYPE.get_id() {
             proto = Some(decode_prototype(decoder, types)?);
         } else {
@@ -626,13 +661,14 @@ fn decode_wire_function(
 
 /// Walk `<localdb><scope>…<symbollist>` collecting the category-0 (parameter)
 /// symbols (Java `LocalSymbolMap.encodeLocalDb`; C++ params come from the
-/// scope's category vector, database.cc:1831-1840).  Non-parameter locals are
-/// structurally consumed and dropped (Phase-4 seeds them).
+/// scope's category vector, database.cc:1831-1840) plus the non-parameter
+/// locals ([`RemoteLocalVar`] — the Phase-4 rename/retype persistence seed).
 fn decode_localdb_params(
     decoder: &mut dyn Decoder,
     types: &TypeFactoryImpl,
     params: &mut Vec<RemoteParam>,
     params_locked: &mut bool,
+    locals: &mut Vec<RemoteLocalVar>,
 ) -> KunaResult<()> {
     let localdb_id = decoder.open_element_id(&ELEM_LOCALDB)?;
     // lock/main attributes: not consumed.
@@ -665,6 +701,28 @@ fn decode_localdb_params(
                             dtype: rec.dtype,
                             typelock: (rec.flags & varnode_flags::typelock) != 0,
                         });
+                    } else if rec.category < 0 {
+                        // A plain local committed to the host database: keep
+                        // its first mapped entry + first-use address so the
+                        // decompile can seed it (rename/retype persistence).
+                        let entry = rec.entries.iter().find(|e| !e.addr.is_invalid());
+                        if let (Some(e), Some(dt)) = (entry, rec.dtype.clone()) {
+                            if dt.get_size() > 0 && !rec.display_name.is_empty() {
+                                let usepoint = e
+                                    .uselimit
+                                    .iter()
+                                    .next()
+                                    .map(|r| Address::new(r.get_space().clone(), r.get_first()))
+                                    .unwrap_or_else(Address::new_invalid);
+                                locals.push(RemoteLocalVar {
+                                    name: rec.display_name,
+                                    dtype: dt,
+                                    addr: e.addr.clone(),
+                                    flags: rec.flags,
+                                    usepoint,
+                                });
+                            }
+                        }
                     }
                 }
                 decoder.close_element(list_el)?;
@@ -835,6 +893,10 @@ pub struct RemoteFunctionFacts {
     pub no_return: bool,
     /// The locked prototype pieces, when the host signature was locked.
     pub pieces: Option<PrototypePieces>,
+    /// Host-committed non-parameter locals from the function's `<localdb>`
+    /// (see [`RemoteLocalVar`]) — seeded into the fresh `Funcdata`'s local
+    /// scope so GUI renames/retypes survive the event-driven re-decompile.
+    pub locals: Vec<RemoteLocalVar>,
 }
 
 /// The ghidra-mode lazy symbol provider (see the module docs).  Installed on
@@ -1256,6 +1318,7 @@ impl RemoteScope {
                             display_name: fname,
                             no_return: func_no_return,
                             pieces,
+                            locals: func.locals.clone(),
                         },
                     );
                 }
@@ -1286,6 +1349,7 @@ impl RemoteScope {
                 symbol_name: display.clone(),
                 symbol_offset: 0,
                 symbol_type: symbol_type.clone(),
+                symbol_id: rec.symbol_id,
                 scope_path: scope_path.clone(),
                 is_function,
                 func_inject_id: -1,

--- a/decompiler/crates/kuna-decomp/src/infra/remote_provider.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/remote_provider.rs
@@ -206,10 +206,15 @@ pub enum RemoteMapAnswer {
 
 /// One mapped storage of a decoded symbol.
 pub struct RemoteEntry {
-    /// Starting address of the storage.
+    /// Starting address of the storage; invalid for a DYNAMIC (`<hash>`)
+    /// entry, whose identity is [`Self::hash`] plus the uselimit's first-use
+    /// address.
     pub addr: Address,
     /// Byte size of the storage.
     pub size: int4,
+    /// The data-flow hash of a DYNAMIC entry (C++ `DynamicEntry::hash`), 0 for
+    /// ordinary mapped storage.
+    pub hash: u64,
     /// Code-address ranges where the storage is in use (empty = address-tied).
     pub uselimit: RangeList,
 }
@@ -298,6 +303,13 @@ pub struct RemoteParam {
     pub dtype: Option<Rc<Datatype>>,
     /// The symbol's typelock bit.
     pub typelock: bool,
+    /// The parameter's EXACT committed storage (the cat-0 mapsym's `<addr>`).
+    /// Java's `checkFullCommit` compares kuna's echoed storage against the
+    /// database's; re-deriving it from a default model instead (the Phase-4
+    /// behavior before this) makes every rename of a nonstandard-convention
+    /// function force-commit a kuna-rederived signature over the user's.
+    /// Invalid when the host sent a dynamic/hash entry.
+    pub storage: Address,
 }
 
 /// One non-parameter local symbol delivered in the current function's
@@ -315,8 +327,16 @@ pub struct RemoteLocalVar {
     pub name: String,
     /// Symbol data-type.
     pub dtype: Rc<Datatype>,
-    /// Storage address of the first mapped entry.
+    /// Storage address of the first mapped entry — or, for a DYNAMIC
+    /// (`<hash>`) entry, the hash's first-use address (`DynamicEntry`'s
+    /// `getAddress()`), which is what `DynamicHash::findVarnode` keys on.
     pub addr: Address,
+    /// The data-flow hash of a DYNAMIC entry, or 0 for ordinary mapped
+    /// storage.  Java writes hash storage for every variable that
+    /// `requiresDynamicStorage` — unique-space representatives and
+    /// `splitOutMergeGroup` products — so this is not an exotic case but the
+    /// normal shape for renames of register/temporary variables.
+    pub hash: u64,
     /// The symbol's flag bits (namelock/typelock/readonly/volatile — the
     /// subset `decode_symbol_header` reads).
     pub flags: kuna_base::types::uint4,
@@ -499,19 +519,24 @@ pub fn decode_mapsym(
     // The SymbolEntry list: <hash val=…>|<addr…> then a <rangelist> each
     // (SymbolEntry::decode, database.cc:206-221).
     while decoder.peek_element()? != 0 {
-        let (addr, size) = if decoder.peek_element()? == ELEM_HASH.get_id() {
+        // A DYNAMIC entry carries the data-flow hash INSTEAD of an address
+        // (`DynamicEntry::decode`, database.cc:69-74); keeping it is what lets
+        // a rename of a unique-space / split-merge-group variable round-trip.
+        let (addr, size, hash) = if decoder.peek_element()? == ELEM_HASH.get_id() {
             let hid = decoder.open_element()?;
-            let _hash = decoder.read_unsigned_integer_id(&ATTRIB_VAL)?;
+            let hash = decoder.read_unsigned_integer_id(&ATTRIB_VAL)?;
             decoder.close_element(hid)?;
-            (Address::new_invalid(), 0)
+            (Address::new_invalid(), 0, hash)
         } else {
-            Address::decode_sized(decoder)?
+            let (a, sz) = Address::decode_sized(decoder)?;
+            (a, sz, 0)
         };
         let mut uselimit = RangeList::default();
         uselimit.decode(decoder)?;
         rec.entries.push(RemoteEntry {
             addr,
             size: size as int4,
+            hash,
             uselimit,
         });
     }
@@ -695,31 +720,60 @@ fn decode_localdb_params(
                         if (rec.flags & varnode_flags::typelock) == 0 {
                             *params_locked = false;
                         }
+                        let storage = rec
+                            .entries
+                            .iter()
+                            .find(|e| !e.addr.is_invalid())
+                            .map(|e| e.addr.clone())
+                            .unwrap_or_else(Address::new_invalid);
                         params.push(RemoteParam {
                             index: rec.cat_index,
                             name: rec.display_name,
                             dtype: rec.dtype,
                             typelock: (rec.flags & varnode_flags::typelock) != 0,
+                            storage,
                         });
                     } else if rec.category < 0 {
                         // A plain local committed to the host database: keep
-                        // its first mapped entry + first-use address so the
-                        // decompile can seed it (rename/retype persistence).
-                        let entry = rec.entries.iter().find(|e| !e.addr.is_invalid());
+                        // its first entry so the decompile can seed it
+                        // (rename/retype persistence).  BOTH storage classes
+                        // matter: a mapped `<addr>` entry (stack/register) and
+                        // a DYNAMIC `<hash>` entry — the latter is what Java
+                        // writes for every `requiresDynamicStorage` variable
+                        // (unique-space representatives, split merge groups),
+                        // so dropping it silently reverted those renames.
+                        let mapped = rec.entries.iter().find(|e| !e.addr.is_invalid());
+                        let dynamic = rec
+                            .entries
+                            .iter()
+                            .find(|e| e.addr.is_invalid() && e.hash != 0);
+                        let entry = mapped.or(dynamic);
                         if let (Some(e), Some(dt)) = (entry, rec.dtype.clone()) {
                             if dt.get_size() > 0 && !rec.display_name.is_empty() {
-                                let usepoint = e
+                                let first_use = e
                                     .uselimit
                                     .iter()
                                     .next()
                                     .map(|r| Address::new(r.get_space().clone(), r.get_first()))
                                     .unwrap_or_else(Address::new_invalid);
+                                let is_dynamic = e.addr.is_invalid();
                                 locals.push(RemoteLocalVar {
                                     name: rec.display_name,
                                     dtype: dt,
-                                    addr: e.addr.clone(),
+                                    // A dynamic entry has no storage address;
+                                    // its identity is (hash, first-use addr).
+                                    addr: if is_dynamic {
+                                        first_use.clone()
+                                    } else {
+                                        e.addr.clone()
+                                    },
+                                    hash: if is_dynamic { e.hash } else { 0 },
                                     flags: rec.flags,
-                                    usepoint,
+                                    usepoint: if is_dynamic {
+                                        Address::new_invalid()
+                                    } else {
+                                        first_use
+                                    },
                                 });
                             }
                         }
@@ -897,6 +951,15 @@ pub struct RemoteFunctionFacts {
     /// (see [`RemoteLocalVar`]) — seeded into the fresh `Funcdata`'s local
     /// scope so GUI renames/retypes survive the event-driven re-decompile.
     pub locals: Vec<RemoteLocalVar>,
+    /// The host's declared prototype MODEL name (`<prototype model=…>`) when
+    /// the signature is locked — the convention its committed parameter
+    /// storage was assigned under.
+    pub model: Option<String>,
+    /// The host's EXACT committed parameter storage, slot-ordered:
+    /// `(slot, name, pieces)` ready for `Funcdata::apply_mapped_params`.
+    /// Empty when the signature is unlocked (kuna then recovers parameters
+    /// itself) or when the host sent no storage.
+    pub param_storage: Vec<(int4, String, crate::fspec::ParameterPieces)>,
 }
 
 /// The ghidra-mode lazy symbol provider (see the module docs).  Installed on
@@ -1311,6 +1374,38 @@ impl RemoteScope {
                             pieces = Some(pc);
                         }
                     }
+                    // The host's committed parameter storage + convention,
+                    // carried verbatim so the echoed `<localdb>`/`<prototype>`
+                    // match the database (Java's `checkFullCommit`).  Only
+                    // meaningful for a locked signature — an unlocked one is
+                    // kuna's to recover.
+                    let mut param_storage: Vec<(int4, String, crate::fspec::ParameterPieces)> =
+                        Vec::new();
+                    let mut model_name: Option<String> = None;
+                    if let Some(p) = &func.proto {
+                        if p.is_input_locked() {
+                            if !p.model.is_empty() {
+                                model_name = Some(p.model.clone());
+                            }
+                            for rp in &p.params {
+                                let (Some(dt), false) =
+                                    (rp.dtype.clone(), rp.storage.is_invalid())
+                                else {
+                                    continue;
+                                };
+                                param_storage.push((
+                                    rp.index as int4,
+                                    rp.name.clone(),
+                                    crate::fspec::ParameterPieces {
+                                        addr: rp.storage.clone(),
+                                        type_: Some(dt),
+                                        flags: varnode_flags::typelock
+                                            | varnode_flags::namelock,
+                                    },
+                                ));
+                            }
+                        }
+                    }
                     st.functions.insert(
                         key,
                         RemoteFunctionFacts {
@@ -1319,6 +1414,8 @@ impl RemoteScope {
                             no_return: func_no_return,
                             pieces,
                             locals: func.locals.clone(),
+                            model: model_name,
+                            param_storage,
                         },
                     );
                 }

--- a/decompiler/crates/kuna-decomp/src/infra/remote_provider/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/remote_provider/tests.rs
@@ -682,3 +682,106 @@ fn tracked_caches_and_failures_negative_cache() {
     let warnings = scope.drain_warnings();
     assert_eq!(warnings.len(), 1, "post-clear re-query fired again");
 }
+
+/// Phase-4 differential: the `ScopeLocal::encode` `<localdb>` document decodes
+/// through the SAME decoder Java shapes decode through (`decode_localdb_params`
+/// / `decode_mapsym`): the cat-0 parameter round-trips with its slot index and
+/// typelock, the plain local does not become a parameter, and every `<symbol>`
+/// carries a NONZERO internal-range id (`HighSymbol.decodeHeader` throws
+/// "missing unique symbol id" on 0 — the r5 §3 trap).
+#[test]
+fn phase4_localdb_encode_decodes_as_params() {
+    let m = manager();
+    let types = types_with_core();
+    let int4_t = crate::dtype::TypeFactory::find_by_name(types.as_ref(), "int4")
+        .unwrap()
+        .unwrap();
+    let mut lm =
+        crate::varmap::ScopeLocal::new(0x1234, ram(&m), "testfn", m.num_spaces()).unwrap();
+    // A register-style cat-0 parameter (exact storage + slot index 0).
+    let param_addr = Address::new(ram(&m), 0x38);
+    let usepoint = Address::new(ram(&m), 0x100f);
+    let sid = lm
+        .add_param_symbol(0, "argc", Rc::clone(&int4_t), &param_addr, &usepoint)
+        .unwrap()
+        .expect("param created");
+    // Lock it (the Java write path needs cat/index/storage; locks ride along).
+    let _ = sid;
+    // A plain mapped local (no category).
+    lm.add_symbol("local_10", Rc::clone(&int4_t), &Address::new(ram(&m), 0x2000), &Address::new_invalid())
+        .unwrap();
+
+    let mut doc = Vec::new();
+    {
+        let mut e = PackedEncode::new(&mut doc);
+        lm.encode(&mut e).unwrap();
+    }
+
+    // Decode through the wire-shape consumer.
+    let mut dec = kuna_base::marshal::PackedDecode::new(&m);
+    kuna_base::marshal::Decoder::ingest_stream(&mut dec, &doc).unwrap();
+    let mut params: Vec<RemoteParam> = Vec::new();
+    let mut locals: Vec<RemoteLocalVar> = Vec::new();
+    let mut locked = true;
+    decode_localdb_params(&mut dec, types.as_ref(), &mut params, &mut locked, &mut locals)
+        .unwrap();
+    assert_eq!(params.len(), 1, "exactly the cat-0 symbol is a parameter");
+    assert_eq!(params[0].index, 0);
+    assert_eq!(params[0].name, "argc");
+    assert!(params[0].dtype.as_ref().is_some_and(|t| t.get_size() == 4));
+    // The non-parameter local rides the Phase-4 seeding channel: name + first
+    // mapped entry + (empty uselimit ⇒ invalid) usepoint.
+    assert_eq!(locals.len(), 1, "the plain local is captured for seeding");
+    assert_eq!(locals[0].name, "local_10");
+    assert_eq!(locals[0].addr.get_offset(), 0x2000);
+    assert!(locals[0].usepoint.is_invalid(), "empty uselimit ⇒ addr-tied seed");
+
+    // Structural walk: every <symbol> has a nonzero internal-range id, and every
+    // <mapsym> carries at least one entry (addr|hash) + rangelist pair.
+    let mut dec = kuna_base::marshal::PackedDecode::new(&m);
+    kuna_base::marshal::Decoder::ingest_stream(&mut dec, &doc).unwrap();
+    let localdb = dec.open_element().unwrap();
+    assert_eq!(localdb, ELEM_LOCALDB.get_id());
+    let scope_el = dec.open_element().unwrap();
+    assert_eq!(scope_el, ELEM_SCOPE.get_id());
+    // Positional contract: <parent> then <rangelist> BEFORE <symbollist>
+    // (LocalSymbolMap.decodeScope skips the first two children blind).
+    let parent_el = dec.open_element().unwrap();
+    assert_eq!(parent_el, ELEM_PARENT.get_id(), "first scope child must be <parent>");
+    dec.close_element_skipping(parent_el).unwrap();
+    let rl_el = dec.open_element().unwrap();
+    assert_eq!(rl_el, ELEM_RANGELIST.get_id(), "second scope child must be <rangelist>");
+    dec.close_element_skipping(rl_el).unwrap();
+    let list_el = dec.open_element().unwrap();
+    assert_eq!(list_el, ELEM_SYMBOLLIST.get_id());
+    let mut mapsym_count = 0;
+    while dec.peek_element().unwrap() != 0 {
+        let ms = dec.open_element().unwrap();
+        assert_eq!(ms, ELEM_MAPSYM.get_id());
+        mapsym_count += 1;
+        // <symbol id=NONZERO ...>
+        let sym_el = dec.open_element().unwrap();
+        assert_eq!(sym_el, ELEM_SYMBOL.get_id());
+        let id = kuna_base::marshal::Decoder::read_unsigned_integer_id(&mut dec, &ATTRIB_ID)
+            .unwrap();
+        assert_ne!(id, 0, "symbol id must be nonzero (Java hard-throw)");
+        assert_eq!(id >> 56, 0x40, "invented symbols carry internal-range ids");
+        dec.close_element_skipping(sym_el).unwrap();
+        // >=1 SymbolEntry: (addr|hash) + rangelist.
+        let entry_el = dec.open_element().unwrap();
+        assert!(
+            entry_el == kuna_base::address::ELEM_ADDR.get_id()
+                || entry_el == ELEM_HASH.get_id(),
+            "mapsym entry must open with <addr> or <hash>"
+        );
+        dec.close_element_skipping(entry_el).unwrap();
+        let ul_el = dec.open_element().unwrap();
+        assert_eq!(ul_el, ELEM_RANGELIST.get_id(), "entry uselimit rangelist required");
+        dec.close_element_skipping(ul_el).unwrap();
+        dec.close_element_skipping(ms).unwrap();
+    }
+    assert_eq!(mapsym_count, 2);
+    dec.close_element(list_el).unwrap();
+    dec.close_element(scope_el).unwrap();
+    dec.close_element(localdb).unwrap();
+}

--- a/decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs
+++ b/decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs
@@ -3167,6 +3167,7 @@ impl Database {
                         symbol_name: sym.get_display_name().to_string(),
                         symbol_offset: entry.get_offset(),
                         symbol_type: sym.dtype.clone(),
+                        symbol_id: sym.symbol_id,
                         scope_path: scope_path.clone(),
                         is_function: matches!(sym.kind, SymbolKind::Function { .. }),
                         func_inject_id: match sym.kind {
@@ -4113,6 +4114,200 @@ impl Database {
             let nm = self.build_default_name(scope, sid, base, None, arch)?;
             self.rename_symbol(sid, &nm)?;
         }
+        Ok(())
+    }
+}
+
+// ===========================================================================
+// Wire <scope>/<mapsym>/<symbol> encode (C++ ScopeInternal::encode
+// database.cc:2620-2660, Symbol::encode{,Header,Body} database.cc:363-475,
+// SymbolEntry::encode database.cc:187-199, EquateSymbol::encode) — the
+// Phase-4 <localdb> marshal-out consumed by Java's LocalSymbolMap.decodeScope
+// / HighSymbol.decodeMapSym.
+// ===========================================================================
+
+impl SymbolEntry {
+    /// Encode this entry as a (`<addr>` | `<hash>`) + uselimit `<rangelist>`
+    /// pair (C++ `SymbolEntry::encode`, database.cc:187-199).  A piece entry
+    /// encodes nothing.
+    pub fn encode(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
+        if self.is_piece() {
+            return Ok(()); // Don't save a piece
+        }
+        if self.addr.is_invalid() {
+            encoder.open_element(&crate::remote_provider::ELEM_HASH);
+            encoder.write_unsigned_integer(&kuna_base::marshal::ATTRIB_VAL, self.hash);
+            encoder.close_element(&crate::remote_provider::ELEM_HASH);
+        } else {
+            self.addr.encode(encoder)?;
+        }
+        self.uselimit.encode(encoder);
+        Ok(())
+    }
+}
+
+impl Symbol {
+    /// Encode the symbol attributes (C++ `Symbol::encodeHeader`,
+    /// database.cc:363-391).  The id is written UNCONDITIONALLY — Java's
+    /// `HighSymbol.decodeHeader` throws "missing unique symbol id" without it.
+    pub fn encode_header(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
+        use kuna_base::marshal::{
+            ATTRIB_FORMAT, ATTRIB_HIDDENRETPARM, ATTRIB_ID, ATTRIB_INDEX, ATTRIB_INDIRECTSTORAGE,
+            ATTRIB_NAME, ATTRIB_NAMELOCK, ATTRIB_READONLY, ATTRIB_THISPTR, ATTRIB_TYPELOCK,
+        };
+        encoder.write_string(&ATTRIB_NAME, self.name.as_bytes());
+        encoder.write_unsigned_integer(&ATTRIB_ID, self.symbol_id);
+        if (self.flags & varnode_flags::namelock) != 0 {
+            encoder.write_bool(&ATTRIB_NAMELOCK, true);
+        }
+        if (self.flags & varnode_flags::typelock) != 0 {
+            encoder.write_bool(&ATTRIB_TYPELOCK, true);
+        }
+        if (self.flags & varnode_flags::readonly) != 0 {
+            encoder.write_bool(&ATTRIB_READONLY, true);
+        }
+        if (self.flags & varnode_flags::volatil) != 0 {
+            encoder.write_bool(&crate::funcdata_encode::ATTRIB_VOLATILE, true);
+        }
+        if (self.flags & varnode_flags::indirectstorage) != 0 {
+            encoder.write_bool(&ATTRIB_INDIRECTSTORAGE, true);
+        }
+        if (self.flags & varnode_flags::hiddenretparm) != 0 {
+            encoder.write_bool(&ATTRIB_HIDDENRETPARM, true);
+        }
+        if (self.dispflags & symbol_dispflags::ISOLATE) != 0 {
+            encoder.write_bool(&crate::remote_provider::ATTRIB_MERGE, false);
+        }
+        if (self.dispflags & symbol_dispflags::IS_THIS_PTR) != 0 {
+            encoder.write_bool(&ATTRIB_THISPTR, true);
+        }
+        let format = self.get_display_format();
+        if format != 0 {
+            encoder.write_string(
+                &ATTRIB_FORMAT,
+                Datatype::decode_integer_format(format)?.as_bytes(),
+            );
+        }
+        encoder.write_signed_integer(&crate::remote_provider::ATTRIB_CAT, self.category as i64);
+        if self.category >= 0 {
+            encoder.write_unsigned_integer(&ATTRIB_INDEX, self.catindex as u64);
+        }
+        Ok(())
+    }
+
+    /// Encode the symbol description body (C++ `Symbol::encodeBody`,
+    /// database.cc:466-470): the data-type reference.
+    pub fn encode_body(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
+        match &self.dtype {
+            Some(t) => t.encode_ref(encoder),
+            None => Err(KunaError::lowlevel("Symbol::encode: symbol has no data-type")),
+        }
+    }
+
+    /// Encode this symbol (C++ `Symbol::encode` database.cc:473-479 for the
+    /// plain kind; `EquateSymbol::encode` for equates).  The remaining
+    /// subclasses never appear in a function-local scope; they degrade to the
+    /// plain `<symbol>` form (Java's `decodeMapSym` dispatches only on
+    /// `<equatesymbol>` vs everything-else).
+    pub fn encode(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
+        if let SymbolKind::Equate { value } = &self.kind {
+            encoder.open_element(&crate::remote_provider::ELEM_EQUATESYMBOL);
+            self.encode_header(encoder)?;
+            encoder.open_element(&kuna_base::marshal::ELEM_VALUE);
+            encoder.write_unsigned_integer(&kuna_base::marshal::ATTRIB_CONTENT, *value);
+            encoder.close_element(&kuna_base::marshal::ELEM_VALUE);
+            encoder.close_element(&crate::remote_provider::ELEM_EQUATESYMBOL);
+        } else {
+            encoder.open_element(&kuna_base::marshal::ELEM_SYMBOL);
+            self.encode_header(encoder)?;
+            self.encode_body(encoder)?;
+            encoder.close_element(&kuna_base::marshal::ELEM_SYMBOL);
+        }
+        Ok(())
+    }
+}
+
+impl Database {
+    /// Encode one scope as a `<scope>` element (C++ `ScopeInternal::encode`,
+    /// database.cc:2620-2660): name + id attributes, the positional `<parent>`
+    /// and `<rangelist>` children (Java's `LocalSymbolMap.decodeScope` skips
+    /// the first two children BLIND, so both are always emitted — a parentless
+    /// scope writes its own id), then the `<symbollist>` of `<mapsym>`s in
+    /// nametree order.
+    ///
+    /// Symbols with NO storage entry are skipped (kuna divergence): Java's
+    /// `LocalSymbolMap.insertSymbol` dereferences `entryList[0]`, so an
+    /// entry-less mapsym would NPE the whole decode.  Upstream never encodes
+    /// one because every C++ Symbol acquires an entry at creation.
+    pub fn encode_scope(
+        &self,
+        scope: ScopeId,
+        encoder: &mut dyn kuna_base::marshal::Encoder,
+    ) -> KunaResult<()> {
+        use crate::remote_provider::{ELEM_MAPSYM, ELEM_PARENT, ELEM_SCOPE, ELEM_SYMBOLLIST};
+        use kuna_base::marshal::{ATTRIB_ID, ATTRIB_NAME, ATTRIB_TYPE};
+        let sc = &self.scopes[scope];
+        encoder.open_element(&ELEM_SCOPE);
+        encoder.write_string(&ATTRIB_NAME, sc.name.as_bytes());
+        encoder.write_unsigned_integer(&ATTRIB_ID, sc.unique_id);
+        // C++ emits <parent> only when a parent exists, but the Java consumer
+        // skips two positional children unconditionally — upstream scopes on
+        // the decompileAt path always have a parent (the global scope).  A
+        // kuna ScopeLocal's private Database is parentless; write the scope's
+        // own id so the positional contract holds.
+        {
+            let pid = match sc.parent {
+                Some(p) => self.scopes[p].unique_id,
+                None => sc.unique_id,
+            };
+            encoder.open_element(&ELEM_PARENT);
+            encoder.write_unsigned_integer(&ATTRIB_ID, pid);
+            encoder.close_element(&ELEM_PARENT);
+        }
+        sc.rangetree.encode(encoder);
+        if !sc.nametree.is_empty() {
+            encoder.open_element(&ELEM_SYMBOLLIST);
+            for (_, &sid) in sc.nametree.iter() {
+                let sym = &self.symbols[sid];
+                if sym.mapentry.is_empty() {
+                    continue; // no SymbolEntry — Java would NPE (see doc).
+                }
+                // (kuna divergence, defensive) Java-side hard throws: a symbol
+                // with no id ("missing unique symbol id"), and a mapped entry
+                // whose data-type has size 0 (MappedEntry.decode).  Neither
+                // occurs through the kuna creation paths (add_symbol_internal
+                // always assigns an internal id; local symbols carry sized
+                // types) — but one bad symbol must not kill the whole result.
+                if sym.symbol_id == 0 {
+                    continue;
+                }
+                match &sym.dtype {
+                    Some(t) if t.get_size() > 0 => {}
+                    _ => continue,
+                }
+                let mut symbol_type = 0;
+                let first = self.entry(scope, sym.mapentry[0]);
+                if first.is_dynamic() {
+                    if sym.category == symbol_category::UNION_FACET {
+                        continue; // Don't save override
+                    }
+                    symbol_type = if sym.category == symbol_category::EQUATE { 2 } else { 1 };
+                }
+                encoder.open_element(&ELEM_MAPSYM);
+                if symbol_type == 1 {
+                    encoder.write_string(&ATTRIB_TYPE, b"dynamic");
+                } else if symbol_type == 2 {
+                    encoder.write_string(&ATTRIB_TYPE, b"equate");
+                }
+                sym.encode(encoder)?;
+                for eref in &sym.mapentry {
+                    self.entry(scope, *eref).encode(encoder)?;
+                }
+                encoder.close_element(&ELEM_MAPSYM);
+            }
+            encoder.close_element(&ELEM_SYMBOLLIST);
+        }
+        encoder.close_element(&ELEM_SCOPE);
         Ok(())
     }
 }

--- a/decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs
+++ b/decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs
@@ -4161,6 +4161,18 @@ pub struct WireSymbol {
 }
 
 impl WireSymbol {
+    /// The wire-symbol analogue of [`Database::symbol_is_encodable`]: a MAPPED
+    /// entry whose data-type has size 0 makes Java's `MappedEntry.decode` throw
+    /// "Invalid symbol 0-sized data-type" and DISCARD the whole decompile
+    /// result.  (`DynamicEntry.decode` has no such check, so a hashed symbol is
+    /// always encodable.)  `kuna_link_high_symbols` steers a 0-size high to the
+    /// hashed shape, so this is the same defensive backstop the scope symbols
+    /// have — and, like theirs, it also withholds the id from
+    /// `<high symref>`/`<vardecl symref>` so a skip cannot orphan a reference.
+    pub fn is_encodable(&self) -> bool {
+        self.hash != 0 || self.dtype.get_size() > 0
+    }
+
     /// Encode as a `<mapsym>` — the same shape `Symbol::encode` +
     /// `SymbolEntry::encode` produce for a scope symbol.
     fn encode(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
@@ -4341,6 +4353,13 @@ impl Database {
         out
     }
 
+    /// [`Database::symbol_is_encodable`] for one already-known symbol (the
+    /// markup's per-declaration `<vardecl symref>` check — see
+    /// [`ScopeLocal::symbol_is_encodable`](crate::varmap::ScopeLocal::symbol_is_encodable)).
+    pub fn symbol_encodable(&self, sym: SymbolId) -> bool {
+        Self::symbol_is_encodable(&self.symbols[sym])
+    }
+
     /// The per-symbol filter shared by [`Database::encode_scope`] and
     /// [`Database::encodable_symbol_ids`] so the two can never disagree.
     fn symbol_is_encodable(sym: &Symbol) -> bool {
@@ -4435,6 +4454,9 @@ impl Database {
             // not load-bearing to any Java consumer: LocalSymbolMap indexes by
             // id and sorts parameters by their cat index).
             for ws in wire_symbols {
+                if !ws.is_encodable() {
+                    continue;
+                }
                 ws.encode(encoder)?;
             }
             encoder.close_element(&ELEM_SYMBOLLIST);

--- a/decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs
+++ b/decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs
@@ -4126,6 +4126,77 @@ impl Database {
 // / HighSymbol.decodeMapSym.
 // ===========================================================================
 
+/// A WIRE-ONLY symbol: one the ghidra-mode `<localdb>` encodes so Java has a
+/// `HighSymbol` (and therefore a rename/retype target) for a variable, without
+/// the symbol ever entering the analysis scope.
+///
+/// The distinction is load-bearing.  kuna's naming pass leaves some named
+/// variables symbol-less on purpose — a register/unique temp with no covering
+/// entry, or a high the conflict scan deliberately separated from the
+/// parameter whose storage it overlaps.  Java still needs an id for them, but
+/// creating real `Symbol`s would feed the printer's own scope queries and
+/// change the emitted C, i.e. the wire encode would perturb decompilation.
+/// A `WireSymbol` carries exactly what `Symbol::encode` + `SymbolEntry::encode`
+/// would have written, and nothing else.
+#[derive(Debug, Clone)]
+pub struct WireSymbol {
+    /// The internal-range id (reserved via
+    /// [`Database::reserve_internal_symbol_id`], so it can never collide with
+    /// a real scope symbol's).
+    pub id: uint8,
+    /// Display name — the name the markup already printed for the variable.
+    pub name: String,
+    /// The variable's data-type.
+    pub dtype: Rc<Datatype>,
+    /// Storage address for a MAPPED symbol; invalid when `hash != 0`.
+    pub addr: Address,
+    /// Data-flow hash for a DYNAMIC symbol (0 = mapped storage).  This is the
+    /// `buildDynamicSymbol` shape: the variable is identified by its position
+    /// in the data flow, not by a storage location it shares with something
+    /// else.
+    pub hash: uint8,
+    /// First-use address: the `<rangelist>`'s single range (invalid = an
+    /// empty rangelist = address-tied / whole-function).
+    pub usepoint: Address,
+}
+
+impl WireSymbol {
+    /// Encode as a `<mapsym>` — the same shape `Symbol::encode` +
+    /// `SymbolEntry::encode` produce for a scope symbol.
+    fn encode(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
+        use crate::remote_provider::{ATTRIB_CAT, ELEM_HASH, ELEM_MAPSYM};
+        use kuna_base::marshal::{ATTRIB_ID, ATTRIB_NAME, ATTRIB_TYPE, ATTRIB_VAL};
+        encoder.open_element(&ELEM_MAPSYM);
+        if self.hash != 0 {
+            encoder.write_string(&ATTRIB_TYPE, b"dynamic");
+        }
+        encoder.open_element(&kuna_base::marshal::ELEM_SYMBOL);
+        encoder.write_string(&ATTRIB_NAME, self.name.as_bytes());
+        encoder.write_unsigned_integer(&ATTRIB_ID, self.id);
+        encoder.write_signed_integer(&ATTRIB_CAT, -1);
+        self.dtype.encode_ref(encoder)?;
+        encoder.close_element(&kuna_base::marshal::ELEM_SYMBOL);
+        if self.hash != 0 {
+            encoder.open_element(&ELEM_HASH);
+            encoder.write_unsigned_integer(&ATTRIB_VAL, self.hash);
+            encoder.close_element(&ELEM_HASH);
+        } else {
+            self.addr.encode(encoder)?;
+        }
+        // The uselimit rangelist (REQUIRED; may be empty).
+        let mut uselimit = RangeList::default();
+        if !self.usepoint.is_invalid() {
+            if let Some(spc) = self.usepoint.get_space() {
+                let off = self.usepoint.get_offset();
+                uselimit.insert_range(Rc::clone(spc), off, off);
+            }
+        }
+        uselimit.encode(encoder);
+        encoder.close_element(&ELEM_MAPSYM);
+        Ok(())
+    }
+}
+
 impl SymbolEntry {
     /// Encode this entry as a (`<addr>` | `<hash>`) + uselimit `<rangelist>`
     /// pair (C++ `SymbolEntry::encode`, database.cc:187-199).  A piece entry
@@ -4239,9 +4310,68 @@ impl Database {
     /// `LocalSymbolMap.insertSymbol` dereferences `entryList[0]`, so an
     /// entry-less mapsym would NPE the whole decode.  Upstream never encodes
     /// one because every C++ Symbol acquires an entry at creation.
+    /// Reserve a fresh internal-range symbol id in `scope` WITHOUT creating a
+    /// Symbol (the id formula of [`Database::add_symbol_internal`],
+    /// database.cc:1818).  The ghidra-mode encode uses it for the wire-only
+    /// symbols of [`WireSymbol`]: a variable that needs an id Java can key a
+    /// rename on, but that must not enter the analysis scope — adding it there
+    /// would feed the printer's scope queries and change the emitted C.
+    pub fn reserve_internal_symbol_id(&mut self, scope: ScopeId) -> uint8 {
+        let unique_id = self.scopes[scope].unique_id;
+        let next = self.scopes[scope].next_unique_id;
+        self.scopes[scope].next_unique_id += 1;
+        SYMBOL_ID_BASE + ((unique_id & 0xffff) << 40) + next
+    }
+
+    /// Which symbol ids [`Database::encode_scope`] would actually emit — the
+    /// set a `<high symref>` may safely reference.  A symbol the encode skips
+    /// (see the defensive filters there) MUST NOT be referenced: Java's
+    /// `HighLocal.decode` hard-throws on an unresolvable local/param symref
+    /// and discards the whole decompile result, so the guard would create the
+    /// very crash it guards against.
+    pub fn encodable_symbol_ids(&self, scope: ScopeId) -> std::collections::BTreeSet<u64> {
+        let mut out = std::collections::BTreeSet::new();
+        let sc = &self.scopes[scope];
+        for (_, &sid) in sc.nametree.iter() {
+            let sym = &self.symbols[sid];
+            if Self::symbol_is_encodable(sym) {
+                out.insert(sym.symbol_id);
+            }
+        }
+        out
+    }
+
+    /// The per-symbol filter shared by [`Database::encode_scope`] and
+    /// [`Database::encodable_symbol_ids`] so the two can never disagree.
+    fn symbol_is_encodable(sym: &Symbol) -> bool {
+        if sym.mapentry.is_empty() {
+            return false; // no SymbolEntry — Java's insertSymbol NPEs
+        }
+        if sym.symbol_id == 0 {
+            return false; // "missing unique symbol id" hard-throw
+        }
+        match &sym.dtype {
+            // MappedEntry.decode throws on a 0-sized data-type.
+            Some(t) if t.get_size() > 0 => true,
+            _ => false,
+        }
+    }
+
     pub fn encode_scope(
         &self,
         scope: ScopeId,
+        encoder: &mut dyn kuna_base::marshal::Encoder,
+    ) -> KunaResult<()> {
+        self.encode_scope_with_wire_symbols(scope, &[], encoder)
+    }
+
+    /// [`Database::encode_scope`] plus a list of WIRE-ONLY symbols
+    /// ([`WireSymbol`]) appended to the same `<symbollist>` — variables the
+    /// analysis deliberately left symbol-less that Java still needs an id for.
+    pub fn encode_scope_with_wire_symbols(
+        &self,
+        scope: ScopeId,
+        wire_symbols: &[WireSymbol],
         encoder: &mut dyn kuna_base::marshal::Encoder,
     ) -> KunaResult<()> {
         use crate::remote_provider::{ELEM_MAPSYM, ELEM_PARENT, ELEM_SCOPE, ELEM_SYMBOLLIST};
@@ -4265,25 +4395,21 @@ impl Database {
             encoder.close_element(&ELEM_PARENT);
         }
         sc.rangetree.encode(encoder);
-        if !sc.nametree.is_empty() {
+        if !sc.nametree.is_empty() || !wire_symbols.is_empty() {
             encoder.open_element(&ELEM_SYMBOLLIST);
             for (_, &sid) in sc.nametree.iter() {
                 let sym = &self.symbols[sid];
-                if sym.mapentry.is_empty() {
-                    continue; // no SymbolEntry — Java would NPE (see doc).
-                }
                 // (kuna divergence, defensive) Java-side hard throws: a symbol
                 // with no id ("missing unique symbol id"), and a mapped entry
                 // whose data-type has size 0 (MappedEntry.decode).  Neither
                 // occurs through the kuna creation paths (add_symbol_internal
                 // always assigns an internal id; local symbols carry sized
                 // types) — but one bad symbol must not kill the whole result.
-                if sym.symbol_id == 0 {
+                // A skipped symbol is ALSO withheld from `<high symref>` (see
+                // `encodable_symbol_ids`), so the skip cannot orphan a
+                // reference and trip the throw it is guarding against.
+                if !Self::symbol_is_encodable(sym) {
                     continue;
-                }
-                match &sym.dtype {
-                    Some(t) if t.get_size() > 0 => {}
-                    _ => continue,
                 }
                 let mut symbol_type = 0;
                 let first = self.entry(scope, sym.mapentry[0]);
@@ -4304,6 +4430,12 @@ impl Database {
                     self.entry(scope, *eref).encode(encoder)?;
                 }
                 encoder.close_element(&ELEM_MAPSYM);
+            }
+            // The wire-only symbols, after the scope's own (nametree order is
+            // not load-bearing to any Java consumer: LocalSymbolMap indexes by
+            // id and sorts parameters by their cat index).
+            for ws in wire_symbols {
+                ws.encode(encoder)?;
             }
             encoder.close_element(&ELEM_SYMBOLLIST);
         }

--- a/decompiler/crates/kuna-decomp/src/p4_calls/fspec.rs
+++ b/decompiler/crates/kuna-decomp/src/p4_calls/fspec.rs
@@ -84,6 +84,25 @@ use kuna_num::pcoderaw::VarnodeData;
 
 use crate::dtype::{metatype2typeclass, type_class, type_metatype, Datatype, TypeFactory};
 
+// -----------------------------------------------------------------------------
+// Wire marshaling ids owned by fspec (upstream numbers, fspec.cc:40-51;
+// DECOMPILER scope — written by number, never registered on the SLEIGH
+// registry; see the note in `substrate/funcdata_encode.rs`).
+// -----------------------------------------------------------------------------
+
+/// Marshaling element `<killedbycall>` (C++ `ELEM_KILLEDBYCALL`, fspec.cc:40).
+pub const ELEM_KILLEDBYCALL: kuna_base::marshal::ElementId =
+    kuna_base::marshal::ElementId::new("killedbycall", 162);
+/// Marshaling element `<likelytrash>` (C++ `ELEM_LIKELYTRASH`, fspec.cc:41).
+pub const ELEM_LIKELYTRASH: kuna_base::marshal::ElementId =
+    kuna_base::marshal::ElementId::new("likelytrash", 163);
+/// Marshaling element `<unaffected>` (C++ `ELEM_UNAFFECTED`, fspec.cc:51).
+pub const ELEM_UNAFFECTED: kuna_base::marshal::ElementId =
+    kuna_base::marshal::ElementId::new("unaffected", 173);
+/// Marshaling element `<returnaddress>` re-export (defined in kuna-base,
+/// upstream marshal.cc id 5).
+pub use kuna_base::marshal::ELEM_RETURNADDRESS;
+
 // =============================================================================
 // AssignAction response codes (modelrules.hh:264-270)  // STUB(w6-modelrules)
 // =============================================================================
@@ -1719,6 +1738,21 @@ impl EffectRecord {
         let s1 = op1.range.get_addr();
         let s2 = op2.range.get_addr();
         s1.cmp(&s2)
+    }
+
+    /// Encode this record as a sized `<addr>` element (C++
+    /// `EffectRecord::encode`, fspec.cc:3560-3568).  Only the three named
+    /// effect types are encodable.
+    pub fn encode(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
+        let addr = self.range.get_addr();
+        if self.type_ == effect_type::UNAFFECTED
+            || self.type_ == effect_type::KILLEDBYCALL
+            || self.type_ == effect_type::RETURN_ADDRESS
+        {
+            addr.encode_sized(encoder, self.range.size as int4)
+        } else {
+            Err(KunaError::lowlevel("Bad EffectRecord type"))
+        }
     }
 }
 
@@ -6078,6 +6112,165 @@ impl FuncProto {
         Err(KunaError::lowlevel(
             "STUB(w6-fspec-2) FuncProto::decode: needs marshaling + Architecture registry",
         ))
+    }
+
+    /// Encode this to a `<prototype>` element (C++ `FuncProto::encode`,
+    /// fspec.cc:4625-4668): the model + extrapop + boolean flags, the
+    /// `<returnsym>` (storage + type of the output parameter), the effect /
+    /// likely-trash overrides, and the call-fixup `<inject>` when
+    /// `inject_name` supplies the resolved fixup name (the C++ reads it
+    /// through `glb->pcodeinjectlib`, which the kuna `FuncProto` cannot
+    /// reach — the caller resolves it).
+    ///
+    /// The C++ tail calls `store->encode` — `ProtoStoreSymbol::encode`
+    /// (fspec.cc:3293) writes NOTHING, and upstream's decompileAt path always
+    /// has the symbol-backed store, so the wire shape omits `<internallist>`;
+    /// kuna's internal store follows the wire shape (input parameters travel
+    /// as `<localdb>` category-0 symbols, `LocalSymbolMap.decodeSymbolList`).
+    pub fn encode(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
+        use kuna_base::marshal::{
+            ATTRIB_CONSTRUCTOR, ATTRIB_DESTRUCTOR, ATTRIB_MODEL, ATTRIB_TYPELOCK,
+        };
+        use crate::remote_provider::{
+            ATTRIB_CUSTOM, ATTRIB_DOTDOTDOT, ATTRIB_EXTRAPOP, ATTRIB_INLINE, ATTRIB_MODELLOCK,
+            ATTRIB_NORETURN, ATTRIB_VOIDLOCK, ELEM_PROTOTYPE, ELEM_RETURNSYM,
+        };
+        encoder.open_element(&ELEM_PROTOTYPE);
+        // C++ `model->getName()` (a null model never encodes upstream); an
+        // un-modeled kuna proto degrades to the "default" spelling, which the
+        // Java side maps onto the program's default model.
+        let model_name = self.model.as_ref().map(|m| m.get_name()).unwrap_or("default");
+        encoder.write_string(&ATTRIB_MODEL, model_name.as_bytes());
+        if self.extrapop == EXTRAPOP_UNKNOWN {
+            encoder.write_string(&ATTRIB_EXTRAPOP, b"unknown");
+        } else {
+            encoder.write_signed_integer(&ATTRIB_EXTRAPOP, self.extrapop as i64);
+        }
+        if self.is_dotdotdot() {
+            encoder.write_bool(&ATTRIB_DOTDOTDOT, true);
+        }
+        if self.is_model_locked() {
+            encoder.write_bool(&ATTRIB_MODELLOCK, true);
+        }
+        if (self.flags & func_proto_flags::VOIDINPUTLOCK) != 0 {
+            encoder.write_bool(&ATTRIB_VOIDLOCK, true);
+        }
+        if self.is_inline() {
+            encoder.write_bool(&ATTRIB_INLINE, true);
+        }
+        if self.is_no_return() {
+            encoder.write_bool(&ATTRIB_NORETURN, true);
+        }
+        if self.has_custom_storage() {
+            encoder.write_bool(&ATTRIB_CUSTOM, true);
+        }
+        if self.is_constructor() {
+            encoder.write_bool(&ATTRIB_CONSTRUCTOR, true);
+        }
+        if self.is_destructor() {
+            encoder.write_bool(&ATTRIB_DESTRUCTOR, true);
+        }
+        // <returnsym>: outparam storage (sized <addr>) + type.  Java requires
+        // the pair (FunctionPrototype.decodePrototype).
+        let store = self
+            .store
+            .as_ref()
+            .ok_or_else(|| KunaError::lowlevel("FuncProto::encode: no parameter store"))?;
+        let outparam = store.get_output();
+        encoder.open_element(&ELEM_RETURNSYM);
+        if outparam.is_type_locked() {
+            encoder.write_bool(&ATTRIB_TYPELOCK, true);
+        }
+        outparam.get_address().encode_sized(encoder, outparam.get_size())?;
+        match outparam.get_type() {
+            Some(t) => t.encode_ref(encoder)?,
+            None => {
+                // A type-less output is the void state (C++ outparam type is
+                // never null; ParameterBasic seeds TYPE_VOID).
+                encoder.open_element(&kuna_base::marshal::ELEM_VOID);
+                encoder.close_element(&kuna_base::marshal::ELEM_VOID);
+            }
+        }
+        encoder.close_element(&ELEM_RETURNSYM);
+        self.encode_effect(encoder)?;
+        self.encode_likely_trash(encoder)?;
+        // <inject>: only when the caller resolved the fixup name (injectid>=0).
+        // Without the resolver the id is silently dropped, matching a fixup-less
+        // proto (Java skips the element anyway).
+        encoder.close_element(&ELEM_PROTOTYPE);
+        Ok(())
+    }
+
+    /// Encode the effect-record overrides (C++ `FuncProto::encodeEffect`,
+    /// fspec.cc:3589-3627): only records differing from the underlying
+    /// `ProtoModel`, grouped as `<unaffected>` / `<killedbycall>` /
+    /// `<returnaddress>`.
+    fn encode_effect(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
+        if self.effectlist.is_empty() {
+            return Ok(());
+        }
+        let mut unaffected: Vec<&EffectRecord> = Vec::new();
+        let mut killed: Vec<&EffectRecord> = Vec::new();
+        let mut ret_addr: Option<&EffectRecord> = None;
+        for cur in &self.effectlist {
+            let tp = match &self.model {
+                Some(m) => m.has_effect(&cur.get_address(), cur.get_size()),
+                None => effect_type::UNKNOWN_EFFECT,
+            };
+            if tp == cur.get_type() {
+                continue;
+            }
+            if cur.get_type() == effect_type::UNAFFECTED {
+                unaffected.push(cur);
+            } else if cur.get_type() == effect_type::KILLEDBYCALL {
+                killed.push(cur);
+            } else if cur.get_type() == effect_type::RETURN_ADDRESS {
+                ret_addr = Some(cur);
+            }
+        }
+        if !unaffected.is_empty() {
+            encoder.open_element(&ELEM_UNAFFECTED);
+            for r in unaffected {
+                r.encode(encoder)?;
+            }
+            encoder.close_element(&ELEM_UNAFFECTED);
+        }
+        if !killed.is_empty() {
+            encoder.open_element(&ELEM_KILLEDBYCALL);
+            for r in killed {
+                r.encode(encoder)?;
+            }
+            encoder.close_element(&ELEM_KILLEDBYCALL);
+        }
+        if let Some(r) = ret_addr {
+            encoder.open_element(&ELEM_RETURNADDRESS);
+            r.encode(encoder)?;
+            encoder.close_element(&ELEM_RETURNADDRESS);
+        }
+        Ok(())
+    }
+
+    /// Encode the likely-trash overrides (C++ `FuncProto::encodeLikelyTrash`,
+    /// fspec.cc:3631-3648): the entries not already in the `ProtoModel`'s list.
+    fn encode_likely_trash(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
+        if self.likelytrash.is_empty() {
+            return Ok(());
+        }
+        let model_trash: &[VarnodeData] =
+            self.model.as_ref().map(|m| m.trash_list()).unwrap_or(&[]);
+        encoder.open_element(&ELEM_LIKELYTRASH);
+        for cur in &self.likelytrash {
+            if model_trash.binary_search_by(|p| p.cmp(cur)).is_ok() {
+                continue; // Already exists in ProtoModel
+            }
+            encoder.open_element(&kuna_base::address::ELEM_ADDR);
+            if let Some(spc) = &cur.space {
+                spc.encode_attributes_sized(encoder, cur.offset, cur.size as int4)?;
+            }
+            encoder.close_element(&kuna_base::address::ELEM_ADDR);
+        }
+        encoder.close_element(&ELEM_LIKELYTRASH);
+        Ok(())
     }
 
     // -- test/tooling builder hooks -----------------------------------------

--- a/decompiler/crates/kuna-decomp/src/p6_variables/coreaction_cleanup.rs
+++ b/decompiler/crates/kuna-decomp/src/p6_variables/coreaction_cleanup.rs
@@ -2350,6 +2350,7 @@ fn kuna_default_local_name(
 /// defining-write address.
 fn recommended_name_for(
     data: &Funcdata,
+    high: crate::context::HighVariableId,
     name_rep: crate::context::VarnodeId,
     v_addr: &kuna_base::address::Address,
     v_size: i32,
@@ -2360,14 +2361,53 @@ fn recommended_name_for(
     if lm.name_recommendations().is_empty() {
         return None;
     }
+    // C++ `!sym->isNameUndefined()` guard (varmap.cc:1541): a recommendation
+    // never paints over a variable that already resolved to a real Symbol
+    // (a parameter, a locked/mapped local) — otherwise the markup token and
+    // the encoded `<localdb>`/`<prototype>` would disagree about the name.
+    if data
+        .high_bank()
+        .get(high)
+        .map(|h| {
+            h.kuna_dynamic_symbol().is_some()
+                || h.kuna_equate_symbol().is_some()
+                || h.kuna_link_symbol().is_some()
+        })
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    if lm.category_for_varnode(v_addr, v_size)
+        == Some(crate::database::symbol_category::FUNCTION_PARAMETER)
+    {
+        return None; // a cat-0 parameter's name comes from the prototype
+    }
     let param_usepoint = &data.get_address().clone() + -1;
-    let def_addr = data
-        .vbank()
-        .get(name_rep)
-        .filter(|v| v.is_written())
-        .and_then(|v| v.get_def())
-        .and_then(|op| data.obank().get(op))
-        .map(|o| o.get_addr().clone());
+    // Every def address across the high's INSTANCES, not just the name
+    // representative's: upstream's `findVarnodeWritten(size,addr,usepoint)`
+    // searches the whole function for a varnode of this storage written at
+    // the usepoint, then resolves `vn->getHigh()`.  A multi-instance high
+    // (one register written at several ops) records the rename at whichever
+    // instance the user clicked — usually NOT the representative.
+    let mut def_addrs: Vec<kuna_base::address::Address> = Vec::new();
+    let insts: Vec<crate::context::VarnodeId> = match data.high_bank().get(high) {
+        Some(h) => (0..h.num_instances()).map(|i| h.get_instance(i)).collect(),
+        None => vec![name_rep],
+    };
+    for ivn in insts {
+        let Some(v) = data.vbank().get(ivn) else { continue };
+        // Only instances at the recommendation's storage can match.
+        if v.get_size() != v_size || v.get_addr() != v_addr {
+            continue;
+        }
+        if !v.is_written() {
+            continue;
+        }
+        if let Some(a) = v.get_def().and_then(|op| data.obank().get(op)).map(|o| o.get_addr().clone())
+        {
+            def_addrs.push(a);
+        }
+    }
     for rec in lm.name_recommendations() {
         if rec.size != v_size || rec.addr != *v_addr {
             continue;
@@ -2377,7 +2417,7 @@ fn recommended_name_for(
         } else if rec.useaddr == param_usepoint {
             v_input
         } else {
-            def_addr.as_ref() == Some(&rec.useaddr)
+            def_addrs.iter().any(|a| *a == rec.useaddr)
         };
         if hit {
             return Some(rec.name.clone());
@@ -2425,6 +2465,15 @@ fn name_local_highs_angr(data: &mut Funcdata) {
     // (C++ `ProtoStoreSymbol::setInput` did this at recovery time; the kuna
     // `ProtoStoreInternal` does not, so it is done here before the walk).
     data.link_proto_params();
+
+    // C++ `ActionNameVars::apply` (coreaction.cc:3065) opens with
+    // `getScopeLocal()->recoverNameRecommendationsForSymbols()`.  Its
+    // hash-addressed half runs here, before any high is named, so a
+    // GUI-renamed dynamic-storage variable (unique-space temp, split merge
+    // group) keeps the user's name instead of consuming a fresh `vN`; the
+    // address-keyed half is applied per-high inside the walk
+    // (`recommended_name_for`).  Both are no-ops without recommendations.
+    data.kuna_apply_dynamic_recommendations();
 
     // C++ `ActionNameVars::apply` (coreaction.cc:3084) calls
     // `lookForFuncParamNames(data,namerec)` AFTER `linkSymbols` but BEFORE the
@@ -2537,10 +2586,15 @@ fn name_local_highs_angr(data: &mut Funcdata) {
         // `clearUnlockedCategory(-1)`) — wins over both the container bind and
         // the `vN` allocator for the variable at its recorded storage.  The
         // three matching arms mirror the C++: invalid usepoint = an
-        // address-tied whole; entry-1 = a function input; otherwise the
-        // defining-write address.  Empty outside ghidra mode.
+        // address-tied whole; entry-1 = a function input; otherwise ANY
+        // instance of this high written at that address (the C++
+        // `findVarnodeWritten(size,addr,usepoint)` searches the whole
+        // function, so a recommendation recorded at a NON-representative
+        // instance's def address must still match).  Empty outside ghidra
+        // mode.
         if let Some(rec_name) = recommended_name_for(
             data,
+            high,
             name_rep.unwrap(),
             &v_addr,
             v_size,
@@ -2704,11 +2758,25 @@ fn name_local_highs_angr(data: &mut Funcdata) {
                     Some(t) => t,
                     None => (info.display_name, info.sym_off, info.sym_type),
                 };
+                // (kuna, ghidra Phase 4) Record WHICH Symbol this bind resolved
+                // to — the same `findContainer` query the name came from.  The
+                // wire encode reads this decision instead of re-deriving a
+                // container binding, so the conflict fall-through below (which
+                // deliberately leaves the high symbol-less) can never be
+                // mistaken for a bind: re-deriving there would hand the
+                // conflict-separated high the PARAMETER's symbol id.
+                let bound_sid = data
+                    .get_scope_local()
+                    .and_then(|lm| lm.container_symbol_link(&v_addr, &usepoint))
+                    .map(|(sid, _, _, _)| sid);
                 if let Some(h) = data.high_bank_mut().get_mut(high) {
                     h.set_kuna_name(sym_name);
                     h.set_symbol_offset(sym_off);
                     if let Some(t) = sym_type {
                         h.set_symbol_type(t);
+                    }
+                    if let Some(sid) = bound_sid {
+                        h.set_kuna_link_symbol(sid);
                     }
                 }
                 continue;

--- a/decompiler/crates/kuna-decomp/src/p6_variables/coreaction_cleanup.rs
+++ b/decompiler/crates/kuna-decomp/src/p6_variables/coreaction_cleanup.rs
@@ -2342,6 +2342,50 @@ fn kuna_default_local_name(
     }
 }
 
+/// The stored-name recommendation matching a high's name representative (C++
+/// `ScopeLocal::recoverNameRecommendationsForSymbols`, varmap.cc:1050-1090):
+/// storage address + size must match, and the recommendation's use address
+/// selects the arm — invalid = an address-tied whole-function location,
+/// `entry - 1` = a function input, anything else = the representative's
+/// defining-write address.
+fn recommended_name_for(
+    data: &Funcdata,
+    name_rep: crate::context::VarnodeId,
+    v_addr: &kuna_base::address::Address,
+    v_size: i32,
+    v_input: bool,
+    v_addrtied: bool,
+) -> Option<String> {
+    let lm = data.get_scope_local()?;
+    if lm.name_recommendations().is_empty() {
+        return None;
+    }
+    let param_usepoint = &data.get_address().clone() + -1;
+    let def_addr = data
+        .vbank()
+        .get(name_rep)
+        .filter(|v| v.is_written())
+        .and_then(|v| v.get_def())
+        .and_then(|op| data.obank().get(op))
+        .map(|o| o.get_addr().clone());
+    for rec in lm.name_recommendations() {
+        if rec.size != v_size || rec.addr != *v_addr {
+            continue;
+        }
+        let hit = if rec.useaddr.is_invalid() {
+            v_addrtied
+        } else if rec.useaddr == param_usepoint {
+            v_input
+        } else {
+            def_addr.as_ref() == Some(&rec.useaddr)
+        };
+        if hit {
+            return Some(rec.name.clone());
+        }
+    }
+    None
+}
+
 /// The callee-parameter name recommendation for `high`, if the
 /// `ActionNameVars::lookForFuncParamNames` apply-gates (coreaction.cc:2981-2993)
 /// admit it: the representative is not free / not an input, the high has a single
@@ -2485,6 +2529,33 @@ fn name_local_highs_angr(data: &mut Funcdata) {
                 ),
                 None => continue,
             };
+        // C++ `ScopeLocal::recoverNameRecommendationsForSymbols` (varmap.cc:
+        // 1050-1090, run at the top of `ActionNameVars::apply`,
+        // coreaction.cc:3065): a name recommendation — the surviving identity
+        // of a namelocked-but-NOT-typelocked Symbol (a GUI rename of an
+        // untyped local; such Symbols never survive restructure's
+        // `clearUnlockedCategory(-1)`) — wins over both the container bind and
+        // the `vN` allocator for the variable at its recorded storage.  The
+        // three matching arms mirror the C++: invalid usepoint = an
+        // address-tied whole; entry-1 = a function input; otherwise the
+        // defining-write address.  Empty outside ghidra mode.
+        if let Some(rec_name) = recommended_name_for(
+            data,
+            name_rep.unwrap(),
+            &v_addr,
+            v_size,
+            v_input,
+            v_addrtied,
+        ) {
+            let unique = data
+                .get_scope_local()
+                .map(|lm| lm.make_local_name_unique(&rec_name))
+                .unwrap_or(rec_name);
+            if let Some(h) = data.high_bank_mut().get_mut(high) {
+                h.set_kuna_name(unique);
+            }
+            continue;
+        }
         // C++ `Funcdata::linkSymbol` (`funcdata_varnode.cc:1177`): query the local
         // map for the SMALLEST CONTAINING SymbolEntry of the representative's BASE
         // BYTE (`queryProperties(vn->getAddr(), 1, usepoint)` — size 1, the

--- a/decompiler/crates/kuna-decomp/src/p6_variables/dynamic.rs
+++ b/decompiler/crates/kuna-decomp/src/p6_variables/dynamic.rs
@@ -857,7 +857,12 @@ impl DynamicHash {
         if total != vnlist2.len() as uint4 {
             return None;
         }
-        Some(vnlist2[pos as usize])
+        // C++ indexes `vnlist2[pos]` bare: `total == vnlist2.size()` and a
+        // well-formed hash keeps `pos < total`.  The hash is HOST-supplied on
+        // the ghidra-mode path (a Java `DynamicEntry`), so a corrupt/hand-edited
+        // one could carry `pos >= total` and panic the whole process instead of
+        // failing the one lookup.
+        vnlist2.get(pos as usize).copied()
     }
 
     /// Given an address and hash, find the unique matching PcodeOp

--- a/decompiler/crates/kuna-decomp/src/p6_variables/variable.rs
+++ b/decompiler/crates/kuna-decomp/src/p6_variables/variable.rs
@@ -390,6 +390,22 @@ pub struct HighVariable {
     /// would let the encode path perturb decompilation.  Nothing outside the
     /// encode/markup reads this one.
     kuna_link_symbol: Option<crate::database::SymbolId>,
+    /// (kuna, ghidra Phase 4) The local Symbol a `&symbol` REFERENCE high
+    /// points at — C++ `Varnode::setSymbolReference` →
+    /// `HighVariable::setSymbolReference(entry->getSymbol(), off)`
+    /// (`varnode.cc:465`, `variable.cc:283`), the identity half of the bind
+    /// `link_symbol_reference` already performs for the name/type/offset.
+    ///
+    /// Its high is the CONSTANT `PTRSUB` offset operand, not the variable's own
+    /// storage, so this is deliberately NOT [`Self::kuna_link_symbol`]: that
+    /// field feeds `<high symref>`, and such a high encodes `class="constant"`,
+    /// where Java's `HighConstant.decode` does nothing at all with a mapped
+    /// local symref.  Only the DECLARATION needs it: a stack array/struct
+    /// materialized solely through `&sym` (`char v1 [16]` used as `memcmp(v1,…)`)
+    /// is declared off this reference high, and its `<vardecl symref>` must
+    /// carry the `<localdb>` id or `ClangVariableDecl.decode` logs "Invalid
+    /// symbol reference" and leaves rename/retype dead on that line.
+    kuna_ref_symbol: Option<crate::database::SymbolId>,
 }
 
 impl HighVariable {
@@ -419,6 +435,7 @@ impl HighVariable {
             kuna_equate_symbol: None,
             kuna_global: false,
             kuna_link_symbol: None,
+            kuna_ref_symbol: None,
         }
     }
 
@@ -469,6 +486,20 @@ impl HighVariable {
     /// deliberately left symbol-less.
     pub fn kuna_link_symbol(&self) -> Option<crate::database::SymbolId> {
         self.kuna_link_symbol
+    }
+
+    /// (kuna, ghidra Phase 4) Record the local Symbol this `&symbol` reference
+    /// high points at — see [`Self::kuna_ref_symbol`].
+    pub fn set_kuna_ref_symbol(&mut self, sym: crate::database::SymbolId) {
+        self.kuna_ref_symbol = Some(sym);
+    }
+
+    /// (kuna, ghidra Phase 4) The local Symbol this `&symbol` reference high
+    /// points at, or `None` when the high is not such a reference (or the
+    /// reference resolved through the GLOBAL scope, whose ids are not
+    /// `LocalSymbolMap` ids).
+    pub fn kuna_ref_symbol(&self) -> Option<crate::database::SymbolId> {
+        self.kuna_ref_symbol
     }
 
     /// (kuna) Bind the mapped Symbol's data-type (for array/struct rendering).

--- a/decompiler/crates/kuna-decomp/src/p6_variables/variable.rs
+++ b/decompiler/crates/kuna-decomp/src/p6_variables/variable.rs
@@ -373,6 +373,23 @@ pub struct HighVariable {
     /// global Symbol is rendered by name in the body but never carries a local
     /// declaration.  `false` == a local-scope (or unscoped) high (declarable).
     kuna_global: bool,
+    /// (kuna, ghidra Phase 4) The local-scope Symbol this high's NAME actually
+    /// resolved to — the bind decision `ActionNameVars` made, recorded at the
+    /// moment it made it (the C++ `high->getSymbol()` that `linkSymbol`'s
+    /// `handleSymbolConflict` arm establishes).  `None` means the naming pass
+    /// deliberately left the high symbol-less: either no Symbol covers its
+    /// storage, or the covering entry was a storage CONFLICT and the high was
+    /// routed to a fresh `vN` (upstream: `buildDynamicSymbol`).  The wire
+    /// encode reads it for `<high symref>` / `<vardecl symref>` and NEVER
+    /// re-derives a container binding itself — re-deriving would hand a
+    /// conflict-separated high the conflicting parameter's symbol id, so a
+    /// rename from that variable's token would rename the parameter.
+    ///
+    /// Deliberately a separate field from [`Self::kuna_dynamic_symbol`]: that
+    /// one is an analysis-time input the merge reads, and writing it here
+    /// would let the encode path perturb decompilation.  Nothing outside the
+    /// encode/markup reads this one.
+    kuna_link_symbol: Option<crate::database::SymbolId>,
 }
 
 impl HighVariable {
@@ -401,6 +418,7 @@ impl HighVariable {
             kuna_symbol_type: None,
             kuna_equate_symbol: None,
             kuna_global: false,
+            kuna_link_symbol: None,
         }
     }
 
@@ -438,6 +456,19 @@ impl HighVariable {
     /// (kuna LOSS-229) The dynamic-mapping Symbol id bound to this high, or `None`.
     pub fn kuna_dynamic_symbol(&self) -> Option<crate::database::SymbolId> {
         self.symbol
+    }
+
+    /// (kuna, ghidra Phase 4) Record the Symbol the naming pass bound this
+    /// high's name to — see [`Self::kuna_link_symbol`].
+    pub fn set_kuna_link_symbol(&mut self, sym: crate::database::SymbolId) {
+        self.kuna_link_symbol = Some(sym);
+    }
+
+    /// (kuna, ghidra Phase 4) The Symbol bound by the naming pass (or
+    /// materialized by the encode-time link pass), or `None` when the high was
+    /// deliberately left symbol-less.
+    pub fn kuna_link_symbol(&self) -> Option<crate::database::SymbolId> {
+        self.kuna_link_symbol
     }
 
     /// (kuna) Bind the mapped Symbol's data-type (for array/struct rendering).

--- a/decompiler/crates/kuna-decomp/src/p6_variables/variable.rs
+++ b/decompiler/crates/kuna-decomp/src/p6_variables/variable.rs
@@ -54,6 +54,25 @@ use crate::dtype::{type_metatype, Datatype};
 use crate::context::{HighVariableId, VarnodeId};
 
 // =============================================================================
+// Wire marshaling ids owned by variable.cc (upstream numbers, variable.cc:23-27;
+// DECOMPILER scope — written by numeric id, never registered on the SLEIGH
+// registry; see the note in `substrate/funcdata_encode.rs`).
+// =============================================================================
+
+/// Marshaling attribute "class" (C++ `ATTRIB_CLASS`, variable.cc:23, id 66).
+pub const ATTRIB_CLASS: kuna_base::marshal::AttributeId =
+    kuna_base::marshal::AttributeId::new("class", 66);
+/// Marshaling attribute "repref" (C++ `ATTRIB_REPREF`, variable.cc:24, id 67).
+pub const ATTRIB_REPREF: kuna_base::marshal::AttributeId =
+    kuna_base::marshal::AttributeId::new("repref", 67);
+/// Marshaling attribute "symref" (C++ `ATTRIB_SYMREF`, variable.cc:25, id 68).
+pub const ATTRIB_SYMREF: kuna_base::marshal::AttributeId =
+    kuna_base::marshal::AttributeId::new("symref", 68);
+/// Marshaling element `<high>` (C++ `ELEM_HIGH`, variable.cc:27, id 82).
+pub const ELEM_HIGH: kuna_base::marshal::ElementId =
+    kuna_base::marshal::ElementId::new("high", 82);
+
+// =============================================================================
 // Arena keys for the VariableGroup / VariablePiece overlap model
 // =============================================================================
 

--- a/decompiler/crates/kuna-decomp/src/p6_variables/varmap.rs
+++ b/decompiler/crates/kuna-decomp/src/p6_variables/varmap.rs
@@ -914,6 +914,14 @@ pub struct ScopeLocal {
     /// Storage-address -> data-type recommendations for input Varnodes (C++
     /// `list<TypeRecommend> typeRecommend`, `varmap.hh:218`).
     type_recommend: Vec<TypeRecommend>,
+    /// Storage-location -> name recommendations (C++ `list<NameRecommend>
+    /// nameRecommend`, `varmap.hh:216`): the names of namelocked-but-NOT-
+    /// typelocked Symbols, which do not survive `clearUnlockedCategory(-1)` at
+    /// restructure — C++ collects them (`collectNameRecs`) and re-applies at
+    /// naming time (`recoverNameRecommendationsForSymbols`, the mechanism that
+    /// makes a GUI rename of an untyped local persist).  kuna's ghidra-mode
+    /// seeds these directly from the host `<localdb>` answer.
+    name_recommend: Vec<NameRecommend>,
 }
 
 impl ScopeLocal {
@@ -940,6 +948,7 @@ impl ScopeLocal {
             stack_grows_negative: true,
             overlap_problems: false,
             type_recommend: Vec::new(),
+            name_recommend: Vec::new(),
         })
     }
 
@@ -1041,6 +1050,33 @@ impl ScopeLocal {
         !self.type_recommend.is_empty()
     }
 
+    /// C++ `ScopeLocal::addRecommendName` (`varmap.cc:1583`): record a name
+    /// recommendation for a storage location.  ghidra-mode seeds these from
+    /// the host `<localdb>`'s namelocked-but-not-typelocked locals (the shape
+    /// a GUI rename produces), the same identities C++ `collectNameRecs`
+    /// would harvest before restructure clears the unlocked symbols.
+    pub fn add_recommend_name(
+        &mut self,
+        addr: Address,
+        usepoint: Address,
+        size: int4,
+        name: &str,
+    ) {
+        self.name_recommend.push(NameRecommend::new(
+            addr,
+            usepoint,
+            size,
+            name.to_string(),
+            0,
+        ));
+    }
+
+    /// The pending name recommendations (C++ `nameRecommend` list), applied by
+    /// the `ActionNameVars` port (`recoverNameRecommendationsForSymbols`).
+    pub fn name_recommendations(&self) -> &[NameRecommend] {
+        &self.name_recommend
+    }
+
     /// The pending `(address, type)` recommendations (C++ `typeRecommend` list),
     /// consumed by [`Funcdata::apply_type_recommendations`] (which owns
     /// `findVarnodeInput`).
@@ -1061,6 +1097,21 @@ impl ScopeLocal {
     /// The local scope id within the owned database.
     pub fn scope_id(&self) -> crate::database::ScopeId {
         self.scope
+    }
+
+    /// Encode this scope as a `<localdb>` element (C++ `ScopeLocal::encode`,
+    /// varmap.cc:462-470): the `main=` space + `lock=` attributes, then the
+    /// inner `<scope>` document.  Also stands in for the C++
+    /// `encodeRecursive(encoder,false)` call site (`Funcdata::encode`) — a
+    /// `ScopeLocal`'s private database has no child scopes to recurse into.
+    pub fn encode(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
+        use crate::remote_provider::{ATTRIB_LOCK, ATTRIB_MAIN, ELEM_LOCALDB};
+        encoder.open_element(&ELEM_LOCALDB);
+        encoder.write_space(&ATTRIB_MAIN, &self.space);
+        encoder.write_bool(&ATTRIB_LOCK, self.range_locked);
+        self.db.encode_scope(self.scope, encoder)?;
+        encoder.close_element(&ELEM_LOCALDB);
+        Ok(())
     }
 
     /// C++ `ScopeInternal::assignDefaultNames(base)` (`database.cc:2880`) on this
@@ -1692,6 +1743,28 @@ impl ScopeLocal {
         self.db.symbol(sym).is_isolated()
     }
 
+    /// The identity of the smallest containing SymbolEntry for the Phase-4
+    /// encode-time symbol link (the same `findContainer` query as
+    /// [`Self::query_container_for_link`], but returning the [`SymbolId`] plus
+    /// the entry geometry the `HighVariable::setSymbol` offset rule needs):
+    /// `(symbol, entry_addr, entry_size, entry_offset)`.
+    pub fn container_symbol_link(
+        &self,
+        addr: &Address,
+        usepoint: &Address,
+    ) -> Option<(crate::database::SymbolId, Address, int4, int4)> {
+        let eref = self.db.find_container(self.scope, addr, 1, usepoint)?;
+        let entry = self.db.entry(self.scope, eref);
+        Some((entry.symbol, entry.get_addr().clone(), entry.get_size(), entry.get_offset()))
+    }
+
+    /// Read a symbol's `(id, category)` pair for the `<high>` encode (C++
+    /// `symbol->getId()` / `symbol->getCategory()`).
+    pub fn symbol_id_and_category(&self, sym: crate::database::SymbolId) -> (u64, int4) {
+        let s = self.db.symbol(sym);
+        (s.get_id(), s.get_category())
+    }
+
     /// C++ `Funcdata::linkSymbol(nameRep)` (`funcdata_varnode.cc:1177`) for the
     /// on-demand naming of a CONCAT-tree ROOT in `linkProtoPartial`
     /// (`funcdata_varnode.cc:1164-1166`).  The root's name representative is an
@@ -2217,6 +2290,7 @@ impl TypeRecommend {
         TypeRecommend { addr, data_type }
     }
 }
+
 
 // ===========================================================================
 // MapState (varmap.hh:174-203, varmap.cc:864-1249)

--- a/decompiler/crates/kuna-decomp/src/p6_variables/varmap.rs
+++ b/decompiler/crates/kuna-decomp/src/p6_variables/varmap.rs
@@ -821,6 +821,9 @@ pub struct SyncOverlap {
 /// scan.  Produced by [`ScopeLocal::query_container_for_link`].
 #[derive(Debug, Clone)]
 pub struct LinkEntryInfo {
+    /// `entry->getSymbol()` — the containing Symbol's identity in THIS scope
+    /// (the id `<localdb>` encodes, via [`ScopeLocal::symbol_id_and_category`]).
+    pub symbol: crate::database::SymbolId,
     /// `entry->getSymbol()->getDisplayName()` (the name the high renders if the
     /// entry is reused — e.g. the recovered parameter `a`).
     pub display_name: String,
@@ -1242,8 +1245,9 @@ impl ScopeLocal {
     /// bind to the parameter names (`ptr`/`a`/`b`) instead of the raw registers.
     ///
     /// Idempotent: if a Symbol already overlaps the parameter's storage (a console
-    /// `map addr`, a seeded host local, a promoted local, or a prior call) it is
-    /// not re-created — but it IS categorized as this parameter slot (see below).
+    /// `map addr`, a seeded host local, or a prior call) it is not re-created; it
+    /// is categorized as this parameter slot only when its storage matches the
+    /// parameter's EXACTLY (see below).
     /// Returns the new `SymbolId`, or `None` when an existing symbol was reused.
     pub fn add_param_symbol(
         &mut self,
@@ -1260,24 +1264,41 @@ impl ScopeLocal {
         // entry; only create when none exists (the `entry == 0` arm of
         // `setInput`/`linkSymbol`).
         if let Some(eref) = self.db.find_overlap(self.scope, addr, ct.get_size()) {
-            // (kuna, ghidra Phase 4) The overlapping symbol IS this parameter's
-            // storage — e.g. a host local seeded at the same register.  C++
-            // `ProtoStoreSymbol::setInput` categorizes whatever symbol occupies
-            // the slot (`scope->setCategory(sym, function_parameter, i)`).
-            // Leaving it uncategorized would drop the parameter from the encoded
-            // cat-0 list, shrinking `<localdb>`'s parameter set below the
-            // database's — which makes Java's `checkFullCommit` force-rewrite
-            // the user's signature on the next rename.
-            let sym = self.db.entry(self.scope, eref).symbol;
-            if self.db.symbol(sym).get_category()
-                != crate::database::symbol_category::FUNCTION_PARAMETER
-            {
-                self.db.set_category(
-                    self.scope,
-                    sym,
-                    crate::database::symbol_category::FUNCTION_PARAMETER,
-                    i,
-                );
+            // (kuna, ghidra Phase 4) An EXACT-storage match is this parameter's
+            // own symbol under another guise — a host local seeded at the very
+            // same address and width, or a prior call's creation — so it carries
+            // the slot.  Upstream reaches the same state from the other end
+            // (`ProtoStoreSymbol::setInput`, fspec.cc:3150-3183): it looks the
+            // symbol up BY SLOT (`getCategorySymbol(function_parameter,i)`) and,
+            // when that symbol's `getFirstWholeMap()` entry disagrees on addr OR
+            // size, REMOVES it and adds a fresh one — it never promotes an
+            // unrelated overlapping local.  So the exactness test is the whole
+            // guard: an 8-byte local merely OVERLAPPING a 4-byte parameter must
+            // stay `no_category`, or (a) `<localdb>` would advertise the local's
+            // name/type/storage as cat-0 slot `i`, whose storage compare in
+            // Java's `checkFullCommit` fails and force-rewrites the user's
+            // signature, and (b) `HighFunctionDBUtil.getDatabaseParameter` keys
+            // the DB slot off `getCategoryIndex()`, so renaming that LOCAL in
+            // the GUI would rewrite DB parameter `i`.  This runs in the main
+            // loop (`ActionRestructureVarnode`), standalone included, and
+            // `clear_unlocked_category_negative` only clears `cat < 0` — a
+            // wrongly promoted symbol would be permanent.
+            let (entry_addr, entry_size) = {
+                let e = self.db.entry(self.scope, eref);
+                (e.get_addr().clone(), e.get_size())
+            };
+            if entry_addr == *addr && entry_size == ct.get_size() {
+                let sym = self.db.entry(self.scope, eref).symbol;
+                if self.db.symbol(sym).get_category()
+                    != crate::database::symbol_category::FUNCTION_PARAMETER
+                {
+                    self.db.set_category(
+                        self.scope,
+                        sym,
+                        crate::database::symbol_category::FUNCTION_PARAMETER,
+                        i,
+                    );
+                }
             }
             return Ok(None);
         }
@@ -1783,6 +1804,7 @@ impl ScopeLocal {
         let sym_off =
             (addr.get_offset().wrapping_sub(entry_addr_off) as int4).wrapping_add(entry_off);
         Some(LinkEntryInfo {
+            symbol: sym,
             display_name: symbol.get_display_name().to_string(),
             sym_off,
             sym_type: symbol.dtype.clone(),
@@ -1821,6 +1843,14 @@ impl ScopeLocal {
     pub fn symbol_id_and_category(&self, sym: crate::database::SymbolId) -> (u64, int4) {
         let s = self.db.symbol(sym);
         (s.get_id(), s.get_category())
+    }
+
+    /// Whether [`Self::encode`] will actually emit this symbol — the O(1)
+    /// single-symbol form of [`Self::encodable_symbol_ids`], for the markup's
+    /// `<vardecl symref>` (which is computed per declaration on every
+    /// decompile, so it must not pay for building the whole id set).
+    pub fn symbol_is_encodable(&self, sym: crate::database::SymbolId) -> bool {
+        self.db.symbol_encodable(sym)
     }
 
     /// The symbol ids [`ScopeLocal::encode`] actually emits — the set a

--- a/decompiler/crates/kuna-decomp/src/p6_variables/varmap.rs
+++ b/decompiler/crates/kuna-decomp/src/p6_variables/varmap.rs
@@ -922,6 +922,15 @@ pub struct ScopeLocal {
     /// makes a GUI rename of an untyped local persist).  kuna's ghidra-mode
     /// seeds these directly from the host `<localdb>` answer.
     name_recommend: Vec<NameRecommend>,
+    /// Dynamic-storage name recommendations (C++ `list<DynamicRecommend>
+    /// dynRecommend`, `varmap.hh:217`): the same identity carrier as
+    /// [`Self::name_recommend`] for a variable whose storage is a data-flow
+    /// HASH rather than an address — what the Ghidra GUI writes for any
+    /// variable that `requiresDynamicStorage` (a unique-space representative,
+    /// a `splitOutMergeGroup` product).  Applied through
+    /// `DynamicHash::find_varnode` (`recoverNameRecommendationsForSymbols`,
+    /// varmap.cc:1557-1573).
+    dyn_recommend: Vec<DynamicRecommend>,
 }
 
 impl ScopeLocal {
@@ -949,6 +958,7 @@ impl ScopeLocal {
             overlap_problems: false,
             type_recommend: Vec::new(),
             name_recommend: Vec::new(),
+            dyn_recommend: Vec::new(),
         })
     }
 
@@ -1077,6 +1087,18 @@ impl ScopeLocal {
         &self.name_recommend
     }
 
+    /// C++ `ScopeLocal::addRecommendDynamic` (`varmap.cc:1595`): record a
+    /// name recommendation for a DYNAMIC (hash-addressed) storage location.
+    pub fn add_recommend_dynamic(&mut self, use_point: Address, hash: u64, name: &str) {
+        self.dyn_recommend
+            .push(DynamicRecommend::new(use_point, hash, name.to_string(), 0));
+    }
+
+    /// The pending dynamic name recommendations (C++ `dynRecommend`).
+    pub fn dynamic_recommendations(&self) -> &[DynamicRecommend] {
+        &self.dyn_recommend
+    }
+
     /// The pending `(address, type)` recommendations (C++ `typeRecommend` list),
     /// consumed by [`Funcdata::apply_type_recommendations`] (which owns
     /// `findVarnodeInput`).
@@ -1105,13 +1127,29 @@ impl ScopeLocal {
     /// `encodeRecursive(encoder,false)` call site (`Funcdata::encode`) — a
     /// `ScopeLocal`'s private database has no child scopes to recurse into.
     pub fn encode(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
+        self.encode_with_wire_symbols(&[], encoder)
+    }
+
+    /// [`ScopeLocal::encode`] with WIRE-ONLY symbols appended to the
+    /// `<symbollist>` (see [`crate::database::WireSymbol`]).
+    pub fn encode_with_wire_symbols(
+        &self,
+        wire_symbols: &[crate::database::WireSymbol],
+        encoder: &mut dyn kuna_base::marshal::Encoder,
+    ) -> KunaResult<()> {
         use crate::remote_provider::{ATTRIB_LOCK, ATTRIB_MAIN, ELEM_LOCALDB};
         encoder.open_element(&ELEM_LOCALDB);
         encoder.write_space(&ATTRIB_MAIN, &self.space);
         encoder.write_bool(&ATTRIB_LOCK, self.range_locked);
-        self.db.encode_scope(self.scope, encoder)?;
+        self.db.encode_scope_with_wire_symbols(self.scope, wire_symbols, encoder)?;
         encoder.close_element(&ELEM_LOCALDB);
         Ok(())
+    }
+
+    /// Reserve a fresh internal-range symbol id without creating a Symbol —
+    /// the id source for [`crate::database::WireSymbol`]s.
+    pub fn reserve_internal_symbol_id(&mut self) -> u64 {
+        self.db.reserve_internal_symbol_id(self.scope)
     }
 
     /// C++ `ScopeInternal::assignDefaultNames(base)` (`database.cc:2880`) on this
@@ -1204,8 +1242,9 @@ impl ScopeLocal {
     /// bind to the parameter names (`ptr`/`a`/`b`) instead of the raw registers.
     ///
     /// Idempotent: if a Symbol already overlaps the parameter's storage (a console
-    /// `map addr`, a promoted local, or a prior call) it is left untouched and
-    /// `None` is returned.  Returns the new `SymbolId` otherwise.
+    /// `map addr`, a seeded host local, a promoted local, or a prior call) it is
+    /// not re-created — but it IS categorized as this parameter slot (see below).
+    /// Returns the new `SymbolId`, or `None` when an existing symbol was reused.
     pub fn add_param_symbol(
         &mut self,
         i: int4,
@@ -1220,7 +1259,26 @@ impl ScopeLocal {
         // C++ `linkSymbol`/`queryProperties` would find any existing overlapping
         // entry; only create when none exists (the `entry == 0` arm of
         // `setInput`/`linkSymbol`).
-        if self.db.find_overlap(self.scope, addr, ct.get_size()).is_some() {
+        if let Some(eref) = self.db.find_overlap(self.scope, addr, ct.get_size()) {
+            // (kuna, ghidra Phase 4) The overlapping symbol IS this parameter's
+            // storage — e.g. a host local seeded at the same register.  C++
+            // `ProtoStoreSymbol::setInput` categorizes whatever symbol occupies
+            // the slot (`scope->setCategory(sym, function_parameter, i)`).
+            // Leaving it uncategorized would drop the parameter from the encoded
+            // cat-0 list, shrinking `<localdb>`'s parameter set below the
+            // database's — which makes Java's `checkFullCommit` force-rewrite
+            // the user's signature on the next rename.
+            let sym = self.db.entry(self.scope, eref).symbol;
+            if self.db.symbol(sym).get_category()
+                != crate::database::symbol_category::FUNCTION_PARAMETER
+            {
+                self.db.set_category(
+                    self.scope,
+                    sym,
+                    crate::database::symbol_category::FUNCTION_PARAMETER,
+                    i,
+                );
+            }
             return Ok(None);
         }
         // C++ `ProtoStoreSymbol::setInput` (fspec.cc:3170-3171): the usepoint is
@@ -1763,6 +1821,13 @@ impl ScopeLocal {
     pub fn symbol_id_and_category(&self, sym: crate::database::SymbolId) -> (u64, int4) {
         let s = self.db.symbol(sym);
         (s.get_id(), s.get_category())
+    }
+
+    /// The symbol ids [`ScopeLocal::encode`] actually emits — the set a
+    /// `<high symref>` may reference (see
+    /// [`Database::encodable_symbol_ids`](crate::database::Database::encodable_symbol_ids)).
+    pub fn encodable_symbol_ids(&self) -> std::collections::BTreeSet<u64> {
+        self.db.encodable_symbol_ids(self.scope)
     }
 
     /// C++ `Funcdata::linkSymbol(nameRep)` (`funcdata_varnode.cc:1177`) for the

--- a/decompiler/crates/kuna-decomp/src/p9_emit/prettyprint.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/prettyprint.rs
@@ -128,8 +128,9 @@ pub mod ids {
     pub const ELEM_FIELD: ElementId = ElementId::new("field", 49);
     /// Marshaling element `<bitfield>` (type.cc:74, id 289, cross-file).
     pub const ELEM_BITFIELD: ElementId = ElementId::new("bitfield", 289);
-    /// Marshaling attribute "symref" (variable.cc:25, id 68, cross-file).
-    pub const ATTRIB_SYMREF: AttributeId = AttributeId::new("symref", 68);
+    /// Marshaling attribute "symref" (variable.cc:25, id 68), re-exported from
+    /// the `HighVariable::encode` port (same numeric id).
+    pub use crate::variable::ATTRIB_SYMREF;
 }
 
 /// An empty string (C++ `Emit::EMPTY_STRING`).
@@ -862,6 +863,45 @@ impl EmitMarkup {
         let mut enc = PackedEncode::new(&mut self.out);
         f(&mut enc);
     }
+
+    /// Write ONE `<type>` token (the pre-split body of `tag_type`; C++
+    /// `EmitMarkup::tagType`, prettyprint.cc).
+    fn tag_type_single(&mut self, name: &str, hl: SyntaxHighlight, markup: &MarkupRef) {
+        let tid = markup.type_id;
+        self.with_encoder(|e| {
+            e.open_element(&ids::ELEM_TYPE);
+            if hl != SyntaxHighlight::NoColor {
+                e.write_unsigned_integer(&ids::ATTRIB_COLOR, hl.value());
+            }
+            if let Some(id) = tid {
+                if id != 0 {
+                    e.write_unsigned_integer(&ids::ATTRIB_ID, id);
+                }
+            }
+            e.write_string(&ids::ATTRIB_CONTENT, name.as_bytes());
+            e.close_element(&ids::ELEM_TYPE);
+        });
+    }
+}
+
+/// Does a `<type>` token's text contain a template-depth-0 character outside
+/// the C identifier alphabet — i.e. would Java's `IllegalCharCppTransformer`
+/// rewrite it in `getC()`?  (`<…>` template payloads are accepted verbatim by
+/// the transformer, so they never force a split.)
+fn markup_type_token_needs_split(name: &str) -> bool {
+    let mut depth = 0i32;
+    for c in name.chars() {
+        match c {
+            '<' => depth += 1,
+            '>' => depth = (depth - 1).max(0),
+            _ => {
+                if depth == 0 && !(c.is_ascii_alphanumeric() || c == '_') {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 impl Emit for EmitMarkup {
@@ -1016,20 +1056,53 @@ impl Emit for EmitMarkup {
         });
     }
     fn tag_type(&mut self, name: &str, hl: SyntaxHighlight, markup: &MarkupRef) {
-        let tid = markup.type_id;
-        self.with_encoder(|e| {
-            e.open_element(&ids::ELEM_TYPE);
-            if hl != SyntaxHighlight::NoColor {
-                e.write_unsigned_integer(&ids::ATTRIB_COLOR, hl.value());
-            }
-            if let Some(id) = tid {
-                if id != 0 {
-                    e.write_unsigned_integer(&ids::ATTRIB_ID, id);
+        // (kuna, Phase 4) Declarator-token fidelity: kuna's declarator builder
+        // hands the WHOLE rendered front ("unsigned long *") to one tag_type
+        // call, where upstream pushes only the base type name as the <type>
+        // token and the stars/spaces as separate syntax tokens.  A multi-word
+        // single token per-token-breaks the GUI's type semantics and — worse —
+        // Java's getC() path (PrettyPrinter + IllegalCharCppTransformer)
+        // rewrites every non-identifier character in a type token to '_', so
+        // scripts/exports receive `unsigned_long__a1`.  Split here, at the
+        // markup emitter (the flattened byte stream is unchanged, and the
+        // EmitNoMarkup/EmitPrettyPrint standalone paths never enter this
+        // code): identifier words stay <type> tokens, separator runs become
+        // <syntax> tokens.  Template payloads (`<…>`) stay inside their word
+        // (the Java transformer accepts them verbatim).
+        if markup_type_token_needs_split(name) {
+            let mut chunk = String::new();
+            let mut syn = String::new();
+            let mut depth = 0i32;
+            for c in name.chars() {
+                let ident = c.is_ascii_alphanumeric() || c == '_';
+                if ident || c == '<' || c == '>' || depth > 0 {
+                    if c == '<' {
+                        depth += 1;
+                    } else if c == '>' {
+                        depth = (depth - 1).max(0);
+                    }
+                    if !syn.is_empty() {
+                        self.print(&syn, SyntaxHighlight::NoColor);
+                        syn.clear();
+                    }
+                    chunk.push(c);
+                } else {
+                    if !chunk.is_empty() {
+                        self.tag_type_single(&chunk, hl, markup);
+                        chunk.clear();
+                    }
+                    syn.push(c);
                 }
             }
-            e.write_string(&ids::ATTRIB_CONTENT, name.as_bytes());
-            e.close_element(&ids::ELEM_TYPE);
-        });
+            if !chunk.is_empty() {
+                self.tag_type_single(&chunk, hl, markup);
+            }
+            if !syn.is_empty() {
+                self.print(&syn, SyntaxHighlight::NoColor);
+            }
+            return;
+        }
+        self.tag_type_single(name, hl, markup);
     }
     fn tag_field(&mut self, name: &str, hl: SyntaxHighlight, off: int4, markup: &MarkupRef) {
         self.record_association(markup);

--- a/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
@@ -2719,14 +2719,19 @@ impl PrintC {
             // once per declaration per decompile AND leave declaration-token
             // rename/retype dead.  The create index survives only as the
             // fallback for a high the naming pass deliberately left
-            // symbol-less.  The representative's `varref` rides along too, so
-            // the declaration's name token resolves to a Varnode (and through
-            // it a HighVariable) exactly like a usage token — the standalone
-            // printer ignores both fields (EmitNoMarkup), so the rendered C is
-            // unchanged either way.
+            // symbol-less.
+            //
+            // NO `varref`: upstream's `emitVarDecl` pushes an explicitly null
+            // Varnode (`pushSymbol(sym,(Varnode *)0,(PcodeOp *)0)`,
+            // printc.cc:2629-2640), and the omission is load-bearing —
+            // `ClangVariableToken.getHighVariable` returns `inst.getHigh()`
+            // from INSIDE its `inst != null` block, so a declaration carrying a
+            // varref whose Varnode has no `<high>` yields a NULL HighVariable
+            // where the (unconditional) parent-declaration fallback would have
+            // supplied the symbol's own.
             let mut markup = MarkupRef::none();
             let decl_rep = decl_rep_varnode(fd, *high);
-            markup.varref = decl_rep
+            let decl_rep_index = decl_rep
                 .and_then(|vn| fd.vbank().get(vn))
                 .map(|v| v.get_create_index() as uintb);
             // The declaration may be keyed on a GROUP MEMBER high while the
@@ -2741,7 +2746,7 @@ impl PrintC {
                         .and_then(|v| v.get_high())
                         .and_then(|h| fd.kuna_high_symbol_wire_id(h))
                 })
-                .or(markup.varref);
+                .or(decl_rep_index);
             let (mut decl_type, mut array_count, comment) =
                 self.rendered_local_decl(fd, arch, *high);
             // (kuna) The Symbol-keyed collapse arbitrated a type disagreement between

--- a/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
@@ -2706,17 +2706,42 @@ impl PrintC {
             // and Ghidra's `ClangVariableDecl.decode` does a REQUIRED read of `symref`:
             // an ABSENT attribute aborts the whole markup decode with "Attribute symref
             // is not present", so the Decompiler window shows nothing for any function
-            // that declares a local.  Phase 2 does not yet encode `<localdb>`
-            // (funcdata_encode.rs), so no HighSymbol reaches Java to resolve against —
-            // but the attribute must still be PRESENT (Java only *logs* an unresolvable
-            // ref, non-fatally, and still renders the declaration tokens).  Use the
-            // declaration representative Varnode's create index — the same id the
-            // `<ast>` and the token `varref` already carry — as the placeholder symref
-            // until the lazy scope encoding (Phase 3/4) supplies real symbol ids.
+            // that declares a local.
+            //
+            // (kuna, ghidra Phase 4) The id must be the LocalSymbolMap id the
+            // `<localdb>` encodes — Java resolves `symref` through that map
+            // (`ClangVariableDecl.decode` → `pfactory.getSymbol(symref)`), and
+            // right-click rename/retype ON THE DECLARATION LINE resolves the
+            // HighSymbol exclusively through it.  Phase 2 wrote the
+            // declaration representative's varnode create index here as a
+            // stand-in (no symbols existed yet); now that real symbols do, an
+            // unresolvable create index would log "Invalid symbol reference"
+            // once per declaration per decompile AND leave declaration-token
+            // rename/retype dead.  The create index survives only as the
+            // fallback for a high the naming pass deliberately left
+            // symbol-less.  The representative's `varref` rides along too, so
+            // the declaration's name token resolves to a Varnode (and through
+            // it a HighVariable) exactly like a usage token — the standalone
+            // printer ignores both fields (EmitNoMarkup), so the rendered C is
+            // unchanged either way.
             let mut markup = MarkupRef::none();
-            markup.symref = decl_rep_varnode(fd, *high)
+            let decl_rep = decl_rep_varnode(fd, *high);
+            markup.varref = decl_rep
                 .and_then(|vn| fd.vbank().get(vn))
                 .map(|v| v.get_create_index() as uintb);
+            // The declaration may be keyed on a GROUP MEMBER high while the
+            // name (and therefore the Symbol) resolved on the group's naming
+            // high — resolve through the declaration representative's own
+            // high as well before falling back.
+            markup.symref = fd
+                .kuna_high_symbol_wire_id(*high)
+                .or_else(|| {
+                    decl_rep
+                        .and_then(|vn| fd.vbank().get(vn))
+                        .and_then(|v| v.get_high())
+                        .and_then(|h| fd.kuna_high_symbol_wire_id(h))
+                })
+                .or(markup.varref);
             let (mut decl_type, mut array_count, comment) =
                 self.rendered_local_decl(fd, arch, *high);
             // (kuna) The Symbol-keyed collapse arbitrated a type disagreement between

--- a/decompiler/crates/kuna-decomp/src/substrate/context.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/context.rs
@@ -172,6 +172,13 @@ pub struct GlobalEntry {
     /// CALLIND to a no-return callee never schedules the restart that re-flows the
     /// now-direct CALL with an artificial halt.
     pub func_no_return: bool,
+    /// The owning Symbol's id (C++ `SymbolEntry::getSymbol()->getId()`), for the
+    /// Phase-4 `<high symref>` echo: ghidra-mode carries the REAL host database
+    /// id delivered by getMappedSymbols (0 when the host sent none — the encode
+    /// then omits `symref` rather than fabricate an id); the standalone console
+    /// snapshot carries the internal `SYMBOL_ID_BASE`-range id, which is legal
+    /// on the wire in the native-to-Java direction.
+    pub symbol_id: u64,
 }
 
 /// A read-only snapshot of the global [`Scope`](crate::database::Scope)
@@ -1491,6 +1498,7 @@ impl ArchContext {
             entry_addr: Address::new(Rc::clone(space), e.first),
             all_flags: e.all_flags,
             symbol_offset: e.symbol_offset,
+            symbol_id: e.symbol_id,
         })
     }
 
@@ -1642,6 +1650,8 @@ pub struct GlobalContainer {
     /// owning Symbol, for the `TypeSpacebase::getSubType` residual-offset
     /// computation (`funcdata.cc` / `type.cc:3431`).
     pub symbol_offset: int4,
+    /// `entry->getSymbol()->getId()` — see [`GlobalEntry::symbol_id`].
+    pub symbol_id: u64,
 }
 
 impl GlobalContainer {

--- a/decompiler/crates/kuna-decomp/src/substrate/context_tests.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/context_tests.rs
@@ -48,6 +48,7 @@ fn entry(
         is_function: false,
         func_inject_id: -1,
         func_no_return: false,
+        symbol_id: 0,
     }
 }
 

--- a/decompiler/crates/kuna-decomp/src/substrate/dtype.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/dtype.rs
@@ -1135,15 +1135,12 @@ impl Datatype {
     /// Get the type id, without variable length size adjustment (C++
     /// `getUnsizedId`, the inline at type.hh:968).
     ///
-    /// STUB(W6): the variable-length branch needs `Datatype::hashSize`
-    /// (reversible size hashing in type.cc); the non-variable-length case is
-    /// implemented (returns the plain id).
+    /// For a variable-length type the stored id is the size-specific instance
+    /// id; feeding it back through the reversible [`Datatype::hash_size`]
+    /// recovers the size-independent base id.
     pub fn get_unsized_id(&self) -> KunaResult<uint8> {
         if (self.flags & flags::variable_length) != 0 {
-            // C++: return hashSize(id, size);  // STUB(W6)
-            Err(KunaError::lowlevel(
-                "STUB(W6): Datatype::getUnsizedId hashSize not yet ported",
-            ))
+            Ok(Datatype::hash_size(self.id, self.size))
         } else {
             Ok(self.id)
         }
@@ -1191,11 +1188,9 @@ impl Datatype {
 
     // -- Variable-length identity (type.cc:127-135) -------------------------
 
-    /// Are these the same variable length data-type (C++ `hasSameVariableBase`).
-    ///
-    /// STUB(W6): the non-trivial path needs `Datatype::hashSize`; the
-    /// short-circuits (`!isVariableLength()`) are implemented and cover the
-    /// common case (returns `false`).
+    /// Are these the same variable length data-type (C++ `hasSameVariableBase`,
+    /// type.cc:127-135): both variable-length and the size-independent
+    /// [`Datatype::hash_size`] base ids agree.
     pub fn has_same_variable_base(&self, ct: &Datatype) -> KunaResult<bool> {
         if !self.is_variable_length() {
             return Ok(false);
@@ -1203,10 +1198,9 @@ impl Datatype {
         if !ct.is_variable_length() {
             return Ok(false);
         }
-        // C++: uint8 thisId = hashSize(id, size); ... return thisId == themId;
-        Err(KunaError::lowlevel(
-            "STUB(W6): Datatype::hasSameVariableBase hashSize not yet ported",
-        ))
+        let this_id = Datatype::hash_size(self.id, self.size);
+        let them_id = Datatype::hash_size(ct.id, ct.size);
+        Ok(this_id == them_id)
     }
 
     // -- Component / pointer structure (type.hh:252-300) --------------------
@@ -4176,6 +4170,330 @@ pub fn register_type_wire_ids(reg: &mut kuna_base::marshal::IdRegistry) {
     reg.register_attribute(&ATTRIB_OPAQUESTRING);
     reg.register_attribute(&ATTRIB_UTF);
     reg.register_attribute(&ATTRIB_VARLENGTH);
+}
+
+// ===========================================================================
+// Wire <type>/<typeref>/<def> encode — Datatype::encodeRef and the per-subclass
+// encode overrides (type.cc:462-560 + the subclass sites), the W8 type
+// marshal-out.  The consumer is Java's PcodeDataTypeManager.decodeDataType,
+// which resolves a <typeref>/named <type> by (name,id) via findBaseType — for
+// wire-delivered types the (name,id) pair originally came from Java, so the
+// echo is sufficient; only kuna-invented types need the full <type> body.
+// ===========================================================================
+
+impl Datatype {
+    /// Decode a display-format code into its attribute string (C++
+    /// `Datatype::decodeIntegerFormat`, type.cc:773-787): 1-5 map to
+    /// "hex"/"dec"/"oct"/"bin"/"char".
+    pub fn decode_integer_format(val: uint4) -> KunaResult<&'static str> {
+        match val {
+            1 => Ok("hex"),
+            2 => Ok("dec"),
+            3 => Ok("oct"),
+            4 => Ok("bin"),
+            5 => Ok("char"),
+            _ => Err(KunaError::lowlevel("Unrecognized integer format encoding")),
+        }
+    }
+
+    /// Encode basic data-type properties (name/id/size/metatype/…) as
+    /// attributes (C++ `Datatype::encodeBasic`, type.cc:474-498).  Presumes the
+    /// element is already open.  `meta` is the metatype attribute to write
+    /// (subclasses override it), `align` the alignment (`-1` = do not encode).
+    fn encode_basic(
+        &self,
+        meta: type_metatype,
+        align: int4,
+        encoder: &mut dyn kuna_base::marshal::Encoder,
+    ) -> KunaResult<()> {
+        use kuna_base::marshal::{ATTRIB_ID, ATTRIB_METATYPE, ATTRIB_NAME, ATTRIB_SIZE};
+        encoder.write_string(&ATTRIB_NAME, self.name.as_bytes());
+        let save_id = self.get_unsized_id()?;
+        if save_id != 0 {
+            encoder.write_unsigned_integer(&ATTRIB_ID, save_id);
+        }
+        encoder.write_signed_integer(&ATTRIB_SIZE, self.size as i64);
+        let metastring = metatype2string(meta)?;
+        encoder.write_string(&ATTRIB_METATYPE, metastring.as_bytes());
+        if align > 0 {
+            encoder.write_signed_integer(&ATTRIB_ALIGNMENT, align as i64);
+        }
+        if (self.flags & flags::coretype) != 0 {
+            encoder.write_bool(&ATTRIB_CORE, true);
+        }
+        if self.is_variable_length() {
+            encoder.write_bool(&ATTRIB_VARLENGTH, true);
+        }
+        if (self.flags & flags::opaque_string) != 0 {
+            encoder.write_bool(&ATTRIB_OPAQUESTRING, true);
+        }
+        let format = self.get_display_format();
+        if format != 0 {
+            encoder.write_string(
+                &kuna_base::marshal::ATTRIB_FORMAT,
+                Datatype::decode_integer_format(format)?.as_bytes(),
+            );
+        }
+        Ok(())
+    }
+
+    /// Encode this data-type to the stream as a simple `<def>` typedef element
+    /// (C++ `Datatype::encodeTypedef`, type.cc:543-556).  Called only when
+    /// `typedef_imm` is set.
+    fn encode_typedef(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
+        use kuna_base::marshal::{ATTRIB_ID, ATTRIB_NAME};
+        let imm = self
+            .typedef_imm
+            .as_ref()
+            .expect("encode_typedef called without typedefImm");
+        encoder.open_element(&ELEM_DEF);
+        encoder.write_string(&ATTRIB_NAME, self.name.as_bytes());
+        encoder.write_unsigned_integer(&ATTRIB_ID, self.id);
+        let format = self.get_display_format();
+        if format != 0 {
+            encoder.write_string(
+                &kuna_base::marshal::ATTRIB_FORMAT,
+                Datatype::decode_integer_format(format)?.as_bytes(),
+            );
+        }
+        imm.encode_ref(encoder)?;
+        encoder.close_element(&ELEM_DEF);
+        Ok(())
+    }
+
+    /// Encode a simple reference to this data-type as a `<typeref>` element
+    /// including only name and id (C++ `Datatype::encodeRef`, type.cc:503-521).
+    /// Falls back to the full [`Datatype::encode`] for id-less or void types.
+    pub fn encode_ref(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
+        use kuna_base::marshal::{ATTRIB_ID, ATTRIB_NAME, ATTRIB_SIZE};
+        if self.id != 0 && self.metatype != type_metatype::TYPE_VOID {
+            encoder.open_element(&ELEM_TYPEREF);
+            encoder.write_string(&ATTRIB_NAME, self.name.as_bytes());
+            if self.is_variable_length() {
+                // For a variable-length base: the size-independent id plus the
+                // size of this instance.
+                encoder
+                    .write_unsigned_integer(&ATTRIB_ID, Datatype::hash_size(self.id, self.size));
+                encoder.write_signed_integer(&ATTRIB_SIZE, self.size as i64);
+            } else {
+                encoder.write_unsigned_integer(&ATTRIB_ID, self.id);
+            }
+            encoder.close_element(&ELEM_TYPEREF);
+            Ok(())
+        } else {
+            self.encode(encoder)
+        }
+    }
+
+    /// Encode a formal description of this data-type as a `<type>` element
+    /// (C++ `Datatype::encode` + every subclass override, type.cc).  Composite
+    /// data-types descend one level, describing components by reference.
+    pub fn encode(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
+        use kuna_base::marshal::{
+            ATTRIB_CONTENT, ATTRIB_NAME, ATTRIB_SPACE, ATTRIB_VALUE, ATTRIB_WORDSIZE, ELEM_OFF,
+            ELEM_VAL, ELEM_VOID,
+        };
+        use kuna_base::marshal::ATTRIB_OFFSET;
+        let elem_type = &crate::prettyprint::ids::ELEM_TYPE;
+        // The typedef indirection (every C++ subclass override's first check,
+        // except the partial/relative kinds which never typedef).
+        if self.typedef_imm.is_some()
+            && !matches!(
+                self.kind,
+                DatatypeKind::PartialStruct { .. }
+                    | DatatypeKind::PartialUnion { .. }
+                    | DatatypeKind::PartialEnum { .. }
+                    | DatatypeKind::PointerRel { .. }
+            )
+        {
+            return self.encode_typedef(encoder);
+        }
+        match &self.kind {
+            // TypeVoid::encode (type.cc:1060): the bare <void/> element.
+            DatatypeKind::Void => {
+                encoder.open_element(&ELEM_VOID);
+                encoder.close_element(&ELEM_VOID);
+            }
+            // TypeBase / TypeUnknown / TypeChar / TypeUnicode (type.cc:462,983,
+            // 1030): the basic form; the char/unicode subclasses are flag bits
+            // in kuna and add their marker attribute.
+            DatatypeKind::Base | DatatypeKind::Unknown => {
+                encoder.open_element(elem_type);
+                self.encode_basic(self.metatype, -1, encoder)?;
+                if self.is_ascii() {
+                    encoder.write_bool(&ATTRIB_CHAR, true);
+                } else if self.is_utf16() || self.is_utf32() {
+                    encoder.write_bool(&ATTRIB_UTF, true);
+                }
+                encoder.close_element(elem_type);
+            }
+            // TypeEnum::encode (type.cc:1639): metatype re-spelled as
+            // enum_int/enum_uint, one <val> child per name.
+            DatatypeKind::Enum { namemap } => {
+                encoder.open_element(elem_type);
+                let meta = if self.metatype == type_metatype::TYPE_INT {
+                    type_metatype::TYPE_ENUM_INT
+                } else {
+                    type_metatype::TYPE_ENUM_UINT
+                };
+                self.encode_basic(meta, -1, encoder)?;
+                for (val, nm) in namemap.iter() {
+                    encoder.open_element(&ELEM_VAL);
+                    encoder.write_string(&ATTRIB_NAME, nm.as_bytes());
+                    encoder.write_unsigned_integer(&ATTRIB_VALUE, *val);
+                    encoder.close_element(&ELEM_VAL);
+                }
+                encoder.close_element(elem_type);
+            }
+            // TypePointer::encode (type.cc:1130).
+            DatatypeKind::Pointer { ptrto, spaceid, wordsize, .. } => {
+                encoder.open_element(elem_type);
+                self.encode_basic(self.metatype, -1, encoder)?;
+                if *wordsize != 1 {
+                    encoder.write_unsigned_integer(&ATTRIB_WORDSIZE, *wordsize as u64);
+                }
+                if let Some(spc) = spaceid {
+                    encoder.write_space(&ATTRIB_SPACE, spc);
+                }
+                ptrto.encode_ref(encoder)?;
+                encoder.close_element(elem_type);
+            }
+            // TypeArray::encode (type.cc:1461).
+            DatatypeKind::Array { arrayof, arraysize } => {
+                encoder.open_element(elem_type);
+                self.encode_basic(self.metatype, -1, encoder)?;
+                encoder.write_signed_integer(&ATTRIB_ARRAYSIZE, *arraysize as i64);
+                arrayof.encode_ref(encoder)?;
+                encoder.close_element(elem_type);
+            }
+            // TypeStruct::encode (type.cc:2085): fields and bitfields
+            // interleaved by byte offset.
+            DatatypeKind::Struct { field, bitfield } => {
+                encoder.open_element(elem_type);
+                self.encode_basic(self.metatype, self.alignment, encoder)?;
+                let mut i1 = field.iter().peekable();
+                let mut i2 = bitfield.iter().peekable();
+                while let (Some(f), Some(b)) = (i1.peek(), i2.peek()) {
+                    if f.offset < b.byte_offset {
+                        i1.next().unwrap().encode(encoder)?;
+                    } else {
+                        i2.next().unwrap().encode(encoder)?;
+                    }
+                }
+                for f in i1 {
+                    f.encode(encoder)?;
+                }
+                for b in i2 {
+                    b.encode(encoder)?;
+                }
+                encoder.close_element(elem_type);
+            }
+            // TypeUnion::encode (type.cc:2545).
+            DatatypeKind::Union { field } => {
+                encoder.open_element(elem_type);
+                self.encode_basic(self.metatype, self.alignment, encoder)?;
+                for f in field {
+                    f.encode(encoder)?;
+                }
+                encoder.close_element(elem_type);
+            }
+            // TypeCode::encode (type.cc:3372): the prototype child when known.
+            DatatypeKind::Code { proto } => {
+                encoder.open_element(elem_type);
+                self.encode_basic(self.metatype, -1, encoder)?;
+                if let Some(p) = proto {
+                    p.encode(encoder)?;
+                }
+                encoder.close_element(elem_type);
+            }
+            // TypeSpacebase::encode (type.cc:3552).
+            DatatypeKind::Spacebase { spaceid, localframe } => {
+                encoder.open_element(elem_type);
+                self.encode_basic(self.metatype, -1, encoder)?;
+                if let Some(spc) = spaceid {
+                    encoder.write_space(&ATTRIB_SPACE, spc);
+                }
+                localframe.encode(encoder)?;
+                encoder.close_element(elem_type);
+            }
+            // TypePartialStruct: no C++ override — the base Datatype::encode
+            // basic form (type.cc:462).
+            DatatypeKind::PartialStruct { .. } => {
+                encoder.open_element(elem_type);
+                self.encode_basic(self.metatype, -1, encoder)?;
+                encoder.close_element(elem_type);
+            }
+            // TypePartialUnion::encode (type.cc:2948).
+            DatatypeKind::PartialUnion { container, offset, .. } => {
+                encoder.open_element(elem_type);
+                self.encode_basic(self.metatype, -1, encoder)?;
+                encoder.write_signed_integer(&ATTRIB_OFFSET, *offset as i64);
+                container.encode_ref(encoder)?;
+                encoder.close_element(elem_type);
+            }
+            // TypePartialEnum::encode (type.cc:2761).
+            DatatypeKind::PartialEnum { parent, offset, .. } => {
+                encoder.open_element(elem_type);
+                self.encode_basic(type_metatype::TYPE_PARTIALENUM, -1, encoder)?;
+                encoder.write_signed_integer(&ATTRIB_OFFSET, *offset as i64);
+                parent.encode_ref(encoder)?;
+                encoder.close_element(elem_type);
+            }
+            // TypePointerRel::encode (type.cc:3125): metatype re-spelled as
+            // ptrrel, the pointed-to type in FULL form, the parent by ref, and
+            // the byte offset as an <off> child.
+            DatatypeKind::PointerRel { ptrto, wordsize, parent, offset, .. } => {
+                encoder.open_element(elem_type);
+                self.encode_basic(type_metatype::TYPE_PTRREL, -1, encoder)?;
+                if *wordsize != 1 {
+                    encoder.write_unsigned_integer(&ATTRIB_WORDSIZE, *wordsize as u64);
+                }
+                ptrto.encode(encoder)?;
+                parent.encode_ref(encoder)?;
+                encoder.open_element(&ELEM_OFF);
+                encoder.write_signed_integer(&ATTRIB_CONTENT, *offset as i64);
+                encoder.close_element(&ELEM_OFF);
+                encoder.close_element(elem_type);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl TypeField {
+    /// Encode a formal description of this field as a `<field>` element (C++
+    /// `TypeField::encode`, type.cc:852-862).
+    pub fn encode(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
+        use kuna_base::marshal::{ATTRIB_ID, ATTRIB_NAME, ATTRIB_OFFSET};
+        let elem_field = &crate::prettyprint::ids::ELEM_FIELD;
+        encoder.open_element(elem_field);
+        encoder.write_string(&ATTRIB_NAME, self.name.as_bytes());
+        encoder.write_signed_integer(&ATTRIB_OFFSET, self.offset as i64);
+        if self.ident != self.offset {
+            encoder.write_signed_integer(&ATTRIB_ID, self.ident as i64);
+        }
+        self.field_type.encode_ref(encoder)?;
+        encoder.close_element(elem_field);
+        Ok(())
+    }
+}
+
+impl TypeBitField {
+    /// Encode a formal description of this bit-field as a `<bitfield>` element
+    /// (C++ `TypeBitField::encode`, type.cc:940-950).
+    pub fn encode(&self, encoder: &mut dyn kuna_base::marshal::Encoder) -> KunaResult<()> {
+        use kuna_base::marshal::{ATTRIB_NAME, ATTRIB_OFFSET, ATTRIB_SIZE};
+        let elem_bitfield = &crate::prettyprint::ids::ELEM_BITFIELD;
+        encoder.open_element(elem_bitfield);
+        encoder.write_string(&ATTRIB_NAME, self.name.as_bytes());
+        encoder.write_signed_integer(&ATTRIB_OFFSET, self.byte_offset as i64);
+        encoder.write_signed_integer(&ATTRIB_SIZE, self.num_bits as i64);
+        encoder
+            .write_signed_integer(&kuna_base::address::ATTRIB_FIRST, self.least_sig_bit as i64);
+        self.field_type.encode_ref(encoder)?;
+        encoder.close_element(elem_bitfield);
+        Ok(())
+    }
 }
 
 /// The ghidra-mode remote type source (C++ `TypeFactoryGhidra`'s `glb`
@@ -7511,6 +7829,66 @@ mod tests {
         assert!(pr.is_ptrsub_matching(0, 12, 1).unwrap()); // 16 in [0,16]
         assert!(!pr.is_ptrsub_matching(0, 13, 1).unwrap()); // 17 > 16
         assert!(!pr.is_ptrsub_matching(-5, 0, 1).unwrap()); // -1 < 0
+    }
+
+    // ----------------------------------------------------------------------
+    // Wire encode (Datatype::encodeRef / encode) — differential against the
+    // already-shipped decode side: what `encode_ref` writes, `decode_type`
+    // must resolve back to the SAME interned object.
+    // ----------------------------------------------------------------------
+
+    /// encode_ref of a named (id-carrying) core type emits `<typeref name id>`
+    /// and the wire decoder resolves it to the identical interned Rc; an
+    /// id-less derived type (pointer/array) emits the full `<type>` form with
+    /// a one-level `<typeref>` descent, and decode re-interns to the same Rc.
+    #[test]
+    fn wire_encode_roundtrips_through_decode_type() {
+        use kuna_base::marshal::{Decoder, PackedDecode, PackedEncode};
+        let f = factory();
+        f.set_core_type("int", 4, type_metatype::TYPE_INT, false).unwrap();
+        f.set_core_type("undefined", 1, type_metatype::TYPE_UNKNOWN, false).unwrap();
+        f.cache_core_types().unwrap();
+        let m = kuna_base::space::AddrSpaceManager::new();
+        let roundtrip = |t: &Rc<Datatype>, full: bool| -> Rc<Datatype> {
+            let mut bytes: Vec<u8> = Vec::new();
+            {
+                let mut e = PackedEncode::new(&mut bytes);
+                if full {
+                    t.encode(&mut e).unwrap();
+                } else {
+                    t.encode_ref(&mut e).unwrap();
+                }
+            }
+            let mut d = PackedDecode::new(&m);
+            d.ingest_stream(&bytes).unwrap();
+            f.decode_type(&mut d).unwrap()
+        };
+
+        let i4 = crate::dtype::TypeFactory::find_by_name(&f, "int").unwrap().unwrap();
+        assert_ne!(i4.get_id(), 0, "core types carry hashed ids");
+        let back = roundtrip(&i4, false);
+        assert!(Rc::ptr_eq(&back, &i4), "<typeref> resolves to the same interned type");
+
+        let p = crate::dtype::TypeFactory::get_type_pointer(&f, 8, Rc::clone(&i4), 1).unwrap();
+        assert_eq!(p.get_id(), 0, "derived pointer has no id -> full <type> form");
+        let back = roundtrip(&p, false);
+        assert!(Rc::ptr_eq(&back, &p), "full <type ptr> re-interns to the same object");
+
+        let a = crate::dtype::TypeFactory::get_type_array(&f, 5, Rc::clone(&i4)).unwrap();
+        let back = roundtrip(&a, true);
+        assert!(Rc::ptr_eq(&back, &a), "full <type array> re-interns to the same object");
+    }
+
+    /// `decode_integer_format` is the inverse of the wire format vocabulary
+    /// (`wire_integer_format`), and errors on out-of-range codes.
+    #[test]
+    fn decode_integer_format_vocabulary() {
+        for (code, s) in [(1u32, "hex"), (2, "dec"), (3, "oct"), (4, "bin"), (5, "char")] {
+            assert_eq!(Datatype::decode_integer_format(code).unwrap(), s);
+            assert_eq!(wire_integer_format(s), code);
+        }
+        assert!(Datatype::decode_integer_format(0).is_err());
+        assert!(Datatype::decode_integer_format(6).is_err());
     }
 
     // ----------------------------------------------------------------------

--- a/decompiler/crates/kuna-decomp/src/substrate/funcdata.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/funcdata.rs
@@ -1200,6 +1200,20 @@ impl Funcdata {
         }
     }
 
+    /// Seed name recommendations into the local scope (the ghidra-mode
+    /// carrier for C++ `ScopeLocal::collectNameRecs` results: the host
+    /// `<localdb>`'s namelocked-but-not-typelocked locals, i.e. GUI renames of
+    /// untyped variables).  `(name, storage addr, usepoint, size)`; an invalid
+    /// usepoint = address-tied.  Applied by the `ActionNameVars` port
+    /// (`recoverNameRecommendationsForSymbols`).
+    pub fn seed_name_recommendations(&mut self, specs: &[(String, Address, Address, int4)]) {
+        if let Some(lm) = self.localmap.as_mut() {
+            for (name, addr, usepoint, size) in specs {
+                lm.add_recommend_name(addr.clone(), usepoint.clone(), *size, name);
+            }
+        }
+    }
+
     /// C++ `localmap->resetLocalWindow()` — reset the local-variable discovery
     /// window from the function prototype's stack ranges.  Faithful to the C++
     /// `Funcdata` constructor / `clear()` call cadence, but deferred until a

--- a/decompiler/crates/kuna-decomp/src/substrate/funcdata.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/funcdata.rs
@@ -335,6 +335,16 @@ pub struct Funcdata {
     /// ([`Self::set_kuna_pipeline_failure`]) so the printer says the pipeline
     /// failed, and why, instead of blaming structuring (`PrintC::emit_function_document`).
     kuna_pipeline_failure: Option<String>,
+    /// (kuna, ghidra Phase 4) WIRE-ONLY symbols the encode-time link pass
+    /// synthesized for named HighVariables the analysis deliberately left
+    /// symbol-less — see [`crate::database::WireSymbol`].  They are encoded
+    /// into `<localdb>` and referenced by `<high symref>` / `<vardecl symref>`
+    /// but never enter the analysis scope, so the wire encode cannot perturb
+    /// the emitted C.  Empty outside the ghidra-mode encode.
+    pub(crate) kuna_wire_symbols: Vec<crate::database::WireSymbol>,
+    /// Index into [`Self::kuna_wire_symbols`] per HighVariable.
+    pub(crate) kuna_wire_symbol_for_high:
+        std::collections::BTreeMap<crate::context::HighVariableId, usize>,
 }
 
 /// Opaque handle for a jump-table (C++ `JumpTable *` slot in `jumpvec`).
@@ -433,6 +443,8 @@ impl Funcdata {
             union_map: std::collections::BTreeMap::new(),
             pending_comments: Vec::new(),
             kuna_pipeline_failure: None,
+            kuna_wire_symbols: Vec::new(),
+            kuna_wire_symbol_for_high: std::collections::BTreeMap::new(),
         })
     }
 
@@ -629,8 +641,22 @@ impl Funcdata {
         &mut self,
         pieces: &crate::fspec::PrototypePieces,
     ) -> KunaResult<()> {
-        let defaultfp = match self.glb.default_fp() {
-            Some(m) => Rc::clone(m),
+        self.apply_locked_prototype_with_model(pieces, None)
+    }
+
+    /// [`Self::apply_locked_prototype`] with an explicit prototype MODEL (the
+    /// ghidra-mode path: the host's `<prototype model=…>` names the convention
+    /// its committed parameter storage was assigned under, so re-deriving
+    /// storage from kuna's default model would disagree with the database and
+    /// force Java's `checkFullCommit` to rewrite the user's signature).
+    /// `None` keeps the architecture default.
+    pub fn apply_locked_prototype_with_model(
+        &mut self,
+        pieces: &crate::fspec::PrototypePieces,
+        model: Option<Rc<crate::fspec::ProtoModel>>,
+    ) -> KunaResult<()> {
+        let defaultfp = match model.or_else(|| self.glb.default_fp().cloned()) {
+            Some(m) => m,
             None => return Ok(()),
         };
         let void_type =
@@ -1200,6 +1226,63 @@ impl Funcdata {
         }
     }
 
+    /// (kuna, ghidra Phase 4) The local-scope Symbol **id** a HighVariable's
+    /// name resolves to — the naming pass's recorded bind, an analysis-time
+    /// dynamic/equate symbol, or a symbol the encode-time link pass
+    /// materialized.  `None` when the high is deliberately symbol-less.
+    ///
+    /// This is what the markup's `<vardecl symref>` must carry: Java resolves
+    /// it through `LocalSymbolMap`, whose ids are exactly the ones
+    /// `<localdb>` encodes.  (Before Phase 4 the markup wrote a varnode
+    /// create index here — a placeholder that can never resolve, which left
+    /// rename/retype dead on declaration-line tokens.)
+    pub fn kuna_high_symbol_wire_id(
+        &self,
+        high: crate::context::HighVariableId,
+    ) -> Option<uint8> {
+        // A wire-only symbol first (the encode-time link pass synthesized it
+        // for a high the analysis left symbol-less), then the real scope
+        // symbol the naming pass / analysis bound.
+        if let Some(idx) = self.kuna_wire_symbol_for_high.get(&high) {
+            if let Some(w) = self.kuna_wire_symbols.get(*idx) {
+                return Some(w.id);
+            }
+        }
+        let h = self.high_bank.get(high)?;
+        if let Some(sid) = h
+            .kuna_link_symbol()
+            .or_else(|| h.kuna_dynamic_symbol())
+            .or_else(|| h.kuna_equate_symbol())
+        {
+            let lm = self.localmap.as_ref()?;
+            return Some(lm.symbol_id_and_category(sid).0);
+        }
+        // A declaration can be keyed on a GROUP MEMBER high (the printer
+        // collapses the several highs of one mapped Symbol into a single
+        // declaration) whose own symbol link lives on the sibling that carried
+        // the name.  Resolve the covering local Symbol through the high's
+        // addr-tied instances — the very query the declaration's name and type
+        // came from (`kuna_mapped_symbol_entry`).  A conflict-separated high
+        // never reaches here: the link pass already gave it a wire symbol of
+        // its own, which the branch above returns.
+        let lm = self.localmap.as_ref()?;
+        let invalid = Address::new_invalid();
+        let n = h.num_instances();
+        for i in 0..n {
+            let vn = h.get_instance(i);
+            let Some(v) = self.vbank.get(vn) else { continue };
+            if v.is_free() || !v.is_addr_tied() {
+                continue;
+            }
+            if let Some((sid, _, _, _)) =
+                lm.container_symbol_link(v.get_addr(), &invalid)
+            {
+                return Some(lm.symbol_id_and_category(sid).0);
+            }
+        }
+        None
+    }
+
     /// Seed name recommendations into the local scope (the ghidra-mode
     /// carrier for C++ `ScopeLocal::collectNameRecs` results: the host
     /// `<localdb>`'s namelocked-but-not-typelocked locals, i.e. GUI renames of
@@ -1210,6 +1293,94 @@ impl Funcdata {
         if let Some(lm) = self.localmap.as_mut() {
             for (name, addr, usepoint, size) in specs {
                 lm.add_recommend_name(addr.clone(), usepoint.clone(), *size, name);
+            }
+        }
+    }
+
+    /// Seed DYNAMIC name recommendations (the hash-storage half of the
+    /// ghidra-mode carrier — C++ `ScopeLocal::dynRecommend`).  `(name,
+    /// first-use address, hash)`: the Ghidra GUI writes hash storage for any
+    /// variable that `requiresDynamicStorage` (unique-space representatives,
+    /// `splitOutMergeGroup` products), so this is the channel a rename of such
+    /// a variable comes back through.  Applied by
+    /// [`Funcdata::kuna_apply_dynamic_recommendations`].
+    pub fn seed_dynamic_recommendations(&mut self, specs: &[(String, Address, u64)]) {
+        if let Some(lm) = self.localmap.as_mut() {
+            for (name, addr, hash) in specs {
+                lm.add_recommend_dynamic(addr.clone(), *hash, name);
+            }
+        }
+    }
+
+    /// Apply the dynamic name recommendations (C++
+    /// `ScopeLocal::recoverNameRecommendationsForSymbols`'s `dynRecommend`
+    /// loop, varmap.cc:1557-1573): resolve each recorded hash back to its
+    /// Varnode with `DynamicHash::findVarnode`, and — when that Varnode's
+    /// HighVariable is still unnamed — bind the recommended name AND a real
+    /// dynamic Symbol carrying the SAME hash, so the wire `<localdb>` echoes
+    /// a `<mapsym type="dynamic"><hash>` Java resolves to the very variable
+    /// the user renamed.
+    ///
+    /// Runs at the top of the naming pass (upstream runs it at the top of
+    /// `ActionNameVars::apply`); a no-op with no recommendations, so the
+    /// standalone pipeline is structurally unaffected.
+    pub fn kuna_apply_dynamic_recommendations(&mut self) {
+        let recs: Vec<(String, Address, u64)> = match self.localmap.as_ref() {
+            Some(lm) => lm
+                .dynamic_recommendations()
+                .iter()
+                .map(|r| (r.name.clone(), r.use_point.clone(), r.hash))
+                .collect(),
+            None => return,
+        };
+        if recs.is_empty() {
+            return;
+        }
+        for (name, addr, hash) in recs {
+            // Java computes the same hash with a hardcoded budget of 8
+            // (`DynamicHash.java:440`); use it so both sides agree.
+            let mut dh = crate::dynamic::DynamicHash::new();
+            let Some(vn) = dh.find_varnode(self, &addr, hash) else {
+                continue;
+            };
+
+            let Some(high) = self.vbank().get(vn).and_then(|v| v.get_high()) else {
+                continue;
+            };
+            if self.vbank().get(vn).map(|v| v.is_annotation()).unwrap_or(true) {
+                continue;
+            }
+            // C++ `!sym->isNameUndefined()` — never paint over a resolved name.
+            let already = self
+                .high_bank()
+                .get(high)
+                .map(|h| {
+                    h.kuna_name().is_some()
+                        || h.kuna_dynamic_symbol().is_some()
+                        || h.kuna_equate_symbol().is_some()
+                        || h.kuna_link_symbol().is_some()
+                })
+                .unwrap_or(true);
+            if already {
+                continue;
+            }
+            let dtype = self.with_high_split(|hb, ctx| {
+                hb.get_mut(high).expect("dyn rec: stale high").get_type(ctx, None)
+            });
+            let unique = self
+                .localmap
+                .as_ref()
+                .map(|lm| lm.make_local_name_unique(&name))
+                .unwrap_or_else(|| name.clone());
+            let sid = self
+                .localmap
+                .as_mut()
+                .and_then(|lm| lm.add_dynamic_symbol(&unique, dtype, &addr, hash).ok());
+            if let Some(h) = self.high_bank_mut().get_mut(high) {
+                h.set_kuna_name(unique);
+                if let Some(sid) = sid {
+                    h.set_kuna_link_symbol(sid);
+                }
             }
         }
     }
@@ -4093,6 +4264,88 @@ mod tests {
             .build_dynamic_symbol(c, 8, unk)
             .expect_err("must reject a type-locked varnode");
         assert!(err.explain().contains("locked varnode"));
+    }
+
+    /// (ghidra Phase 4, review round C2) The DYNAMIC name-recommendation
+    /// channel — upstream `ScopeLocal::dynRecommend` +
+    /// `recoverNameRecommendationsForSymbols`'s hash loop (varmap.cc:1557).
+    ///
+    /// This is the mechanism a GUI rename of a variable with hash storage
+    /// (anything `requiresDynamicStorage`: a unique-space representative, a
+    /// `splitOutMergeGroup` product) comes back through.  Seed a
+    /// recommendation keyed on the SAME hash `DynamicHash` computes for a
+    /// varnode, apply it, and the varnode's HighVariable must take the
+    /// recommended name AND acquire a dynamic Symbol carrying that hash — so
+    /// the re-encoded `<localdb>` hands Java a `<mapsym type="dynamic">` it
+    /// resolves to the very variable the user renamed.
+    #[test]
+    fn dynamic_name_recommendation_renames_the_hashed_variable() {
+        // A manager WITH a stack space so the Funcdata gets a real ScopeLocal
+        // (the recommendation lists live on it).
+        let mut m = build_manager();
+        let regspc = Rc::new(kuna_base::space::AddrSpace::new(
+            spacetype::IPTR_PROCESSOR,
+            "register",
+            false,
+            8,
+            1,
+            5,
+            kuna_base::space::addrspace_flags::hasphysical,
+            1,
+            1,
+        ));
+        m.insert_space(Rc::clone(&regspc)).unwrap();
+        m.insert_space(Rc::new(kuna_base::space::SpacebaseSpace::new(
+            "stack", 6, 8, &regspc, 1, true, false,
+        )))
+        .unwrap();
+        let glb = Rc::new(ArchContext::new(m));
+        let ram = Rc::clone(glb.manage().get_space_by_name("ram").unwrap());
+        let entry = Address::new(ram, 0x1000);
+        let mut fd = Funcdata::new("func", "func", glb, entry, 0x10000000, 0x40).unwrap();
+        assert!(fd.get_scope_local().is_some(), "fixture must have a local scope");
+        let rs = Rc::clone(fd.get_arch().manage().get_space_by_name("ram").unwrap());
+        let root = fd.bblocks_root_pub();
+        let bl = fd.bblocks_mut().new_block_basic(root);
+        fd.bblocks_mut().set_start_block(root, bl);
+        // out = in + in, so `out` is a written varnode the hasher can key on.
+        let a = fd.new_varnode(4, &Address::new(Rc::clone(&rs), 0x100), None);
+        let a = fd.set_input_varnode(a).unwrap();
+        let op = fd.new_op(2, Address::new(Rc::clone(&rs), 0x1000));
+        fd.op_set_opcode(op, crate::context::TypeOp::new(OpCode::CPUI_INT_ADD, 0, "ADD"));
+        let out = fd.new_varnode_out(4, &Address::new(Rc::clone(&rs), 0x200), op).unwrap();
+        fd.op_set_input(op, a, 0).unwrap();
+        fd.op_set_input(op, a, 1).unwrap();
+        fd.op_insert(op, bl, None);
+        fd.structure_reset();
+        fd.set_high_level();
+
+        // The hash Java would compute for this variable (same algorithm, same
+        // hardcoded budget of 8 — DynamicHash.java:440).
+        let (hash, hash_addr) =
+            crate::dynamic::dynamic_unique_hash(out, 8, &mut fd).expect("hash");
+        assert_ne!(hash, 0, "the fixture varnode must hash uniquely");
+
+        fd.seed_dynamic_recommendations(&[("user_renamed".to_string(), hash_addr, hash)]);
+        fd.kuna_apply_dynamic_recommendations();
+
+        let high = fd.vbank().get(out).and_then(|v| v.get_high()).expect("high");
+        let h = fd.high_bank().get(high).expect("high present");
+        assert_eq!(
+            h.kuna_name(),
+            Some("user_renamed"),
+            "the dynamic recommendation did not name the hashed variable"
+        );
+        assert!(
+            h.kuna_link_symbol().is_some(),
+            "the recommendation must also bind a Symbol so the wire carries an id"
+        );
+        // A second apply is idempotent (the name is already resolved).
+        fd.kuna_apply_dynamic_recommendations();
+        assert_eq!(
+            fd.high_bank().get(high).unwrap().kuna_name(),
+            Some("user_renamed")
+        );
     }
 
     /// Adversarial (Convert B2): binding a dynamic SymbolEntry to a Varnode marks

--- a/decompiler/crates/kuna-decomp/src/substrate/funcdata.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/funcdata.rs
@@ -1240,22 +1240,42 @@ impl Funcdata {
         &self,
         high: crate::context::HighVariableId,
     ) -> Option<uint8> {
+        // Every branch below returns only an id the `<localdb>` encode ACTUALLY
+        // WRITES: `encode_scope`'s defensive per-symbol skips (and the wire
+        // symbols' `is_encodable`) would otherwise leave the declaration
+        // pointing at a symbol that is not in the document — "Invalid symbol
+        // reference" in Java's log and a dead rename on that line, exactly what
+        // this attribute exists to prevent.  The caller falls back to the
+        // varnode create index, which is no worse.
+        //
         // A wire-only symbol first (the encode-time link pass synthesized it
         // for a high the analysis left symbol-less), then the real scope
         // symbol the naming pass / analysis bound.
         if let Some(idx) = self.kuna_wire_symbol_for_high.get(&high) {
             if let Some(w) = self.kuna_wire_symbols.get(*idx) {
-                return Some(w.id);
+                if w.is_encodable() {
+                    return Some(w.id);
+                }
             }
         }
         let h = self.high_bank.get(high)?;
+        // `kuna_ref_symbol` last of the recorded binds: it is the Symbol a
+        // `&symbol` REFERENCE high points at (C++ `setSymbolReference`), which a
+        // high that also owns storage would already have answered above.  It is
+        // the only bind a stack aggregate reached solely through `&sym` has —
+        // its entire high is the constant PTRSUB operand, so the addr-tied
+        // re-derivation below cannot see it.
         if let Some(sid) = h
             .kuna_link_symbol()
             .or_else(|| h.kuna_dynamic_symbol())
             .or_else(|| h.kuna_equate_symbol())
+            .or_else(|| h.kuna_ref_symbol())
         {
             let lm = self.localmap.as_ref()?;
-            return Some(lm.symbol_id_and_category(sid).0);
+            if lm.symbol_is_encodable(sid) {
+                return Some(lm.symbol_id_and_category(sid).0);
+            }
+            return None;
         }
         // A declaration can be keyed on a GROUP MEMBER high (the printer
         // collapses the several highs of one mapped Symbol into a single
@@ -1277,6 +1297,9 @@ impl Funcdata {
             if let Some((sid, _, _, _)) =
                 lm.container_symbol_link(v.get_addr(), &invalid)
             {
+                if !lm.symbol_is_encodable(sid) {
+                    continue;
+                }
                 return Some(lm.symbol_id_and_category(sid).0);
             }
         }
@@ -1324,6 +1347,22 @@ impl Funcdata {
     /// Runs at the top of the naming pass (upstream runs it at the top of
     /// `ActionNameVars::apply`); a no-op with no recommendations, so the
     /// standalone pipeline is structurally unaffected.
+    ///
+    /// PLACEMENT (a real divergence, guarded rather than reordered): upstream
+    /// runs this loop AFTER `linkSymbols`, so `vn->getHigh()->getSymbol()` is
+    /// already populated and its guards — `sym == 0`, `sym->getScope() != this`,
+    /// `!sym->isNameUndefined()` — are live, and it only ever RENAMES an
+    /// existing Symbol.  kuna's naming pass fuses linkSymbols with the `vN`
+    /// default assignment into one location-ordered walk, so there is no point
+    /// "after linking, before defaults" to run at; the loop therefore runs
+    /// first and CREATES a dynamic Symbol.  The per-high guard below is then
+    /// vacuous (no high is named yet), so the equivalent guard is applied
+    /// against the SCOPE instead: a hash that lands on storage the naming walk
+    /// would bind to a real Symbol — a cat-0 parameter, or any Symbol that
+    /// already has a defined name — is skipped, which is what upstream's
+    /// `sym != 0 && !isNameUndefined` pair achieves.  Without it a stale or
+    /// shape-shifted host hash could take a parameter's variable, and that
+    /// high's `<high symref>` would stop pointing at the parameter.
     pub fn kuna_apply_dynamic_recommendations(&mut self) {
         let recs: Vec<(String, Address, u64)> = match self.localmap.as_ref() {
             Some(lm) => lm
@@ -1363,6 +1402,28 @@ impl Funcdata {
                 .unwrap_or(true);
             if already {
                 continue;
+            }
+            // The scope-side stand-in for upstream's `sym == 0` /
+            // `!sym->isNameUndefined()` pair (see the placement note above):
+            // never take a Varnode whose storage the naming walk is going to
+            // bind to a real Symbol.
+            {
+                let usepoint = self.vn_use_point(vn);
+                let Some(v_addr) = self.vbank().get(vn).map(|v| v.get_addr().clone()) else {
+                    continue;
+                };
+                let blocked = self
+                    .localmap
+                    .as_ref()
+                    .and_then(|lm| lm.query_container_for_link(&v_addr, &usepoint))
+                    .map(|info| {
+                        info.category == crate::database::symbol_category::FUNCTION_PARAMETER
+                            || !info.is_name_undefined
+                    })
+                    .unwrap_or(false);
+                if blocked {
+                    continue;
+                }
             }
             let dtype = self.with_high_split(|hb, ctx| {
                 hb.get_mut(high).expect("dyn rec: stale high").get_type(ctx, None)
@@ -2261,6 +2322,12 @@ impl Funcdata {
         // `new HighVariable`s are freed); the W7 high bank is cleared here to
         // mirror that lifecycle.
         self.high_bank.clear();
+        // (kuna, ghidra Phase 4) The wire symbols are keyed by HighVariableId,
+        // so they MUST die with the arena that issued those ids — a restart
+        // would otherwise let a rebuilt high inherit another variable's symbol
+        // id and hand the GUI the wrong rename target.
+        self.kuna_wire_symbols.clear();
+        self.kuna_wire_symbol_for_high.clear();
     }
 
     /// Set a delay/flag bit directly (test/seam helper; not a C++ method).

--- a/decompiler/crates/kuna-decomp/src/substrate/funcdata_encode.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/funcdata_encode.rs
@@ -134,7 +134,15 @@ impl Funcdata {
             if let Some(lm) = self.get_scope_local() {
                 lm.encode_with_wire_symbols(&wire_symbols, enc)?;
                 encodable = lm.encodable_symbol_ids();
-                encodable.extend(wire_symbols.iter().map(|w| w.id));
+                // Only the wire symbols the encode above actually WROTE (the
+                // `is_encodable` filter): a reference to a skipped one is the
+                // orphan-symref hard-throw the filter exists to avoid.  And
+                // when `has_no_code()` this whole block is skipped, so
+                // `encodable` stays EMPTY and every symref — wire ids included
+                // — is withheld: there is no `<localdb>` to resolve against.
+                encodable.extend(
+                    wire_symbols.iter().filter(|w| w.is_encodable()).map(|w| w.id),
+                );
             }
             self.kuna_wire_symbols = wire_symbols;
         }
@@ -252,7 +260,15 @@ impl Funcdata {
                 .and_then(|i| self.kuna_wire_symbols.get(*i))
                 .map(|w| w.id);
             let (local_symref, category) = match (attached, wire, self.get_scope_local()) {
-                (None, Some(id), _) => (Some(id), crate::database::symbol_category::NO_CATEGORY),
+                // The wire arm takes the SAME encodable gate as the attached
+                // one: an id that was filtered out of `<localdb>` (or a whole
+                // `<localdb>` that a `has_no_code()` function never emitted) is
+                // the "HighLocal is missing symbol" hard-throw, which discards
+                // the entire result.  Withholding it drops the class to
+                // `"other"`, which Java decodes happily.
+                (None, Some(id), _) if encodable_symbols.contains(&id) => {
+                    (Some(id), crate::database::symbol_category::NO_CATEGORY)
+                }
                 (Some(sid), _, Some(lm)) => {
                     let (id, cat) = lm.symbol_id_and_category(sid);
                     // Only reference a symbol the `<localdb>` actually
@@ -474,11 +490,20 @@ impl Funcdata {
                 .and_then(|h| h.kuna_name())
                 .expect("named checked above")
                 .to_string();
-            let hash = if covered {
+            // A 0-sized (void/undefined-empty) data-type takes the hashed shape
+            // too, whatever the coverage: Java's `MappedEntry.decode` throws
+            // "Invalid symbol 0-sized data-type" and discards the whole result,
+            // while `DynamicEntry.decode` has no size check at all.  (The
+            // `is_encodable` filter on the encode is the backstop if the hash
+            // also fails.)
+            let hash = if covered || dtype.get_size() < 1 {
                 // The collision budget is pinned at the UPSTREAM 8 on the wire
                 // path: Java computes its own hash for the same variable with a
                 // hardcoded `maxduplicates = 8` (`DynamicHash.java:440`), and a
                 // hash the two sides disagree on cannot round-trip a rename.
+                // Deliberately NOT kuna's `dynamichashmax` option: the wire
+                // value must match what Java recomputes, not what kuna's own
+                // analysis is configured for.
                 match crate::dynamic::dynamic_unique_hash(rep, 8, self) {
                     Ok((h, _)) if h != 0 => h,
                     _ => continue, // no unique hash: stay symbol-less

--- a/decompiler/crates/kuna-decomp/src/substrate/funcdata_encode.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/funcdata_encode.rs
@@ -65,6 +65,11 @@ use crate::context::{OpId, VarnodeId};
 pub const ELEM_IOP: ElementId = ElementId::new("iop", 113);
 /// Marshaling element `<ast>` (C++ `ELEM_AST`, `funcdata.cc`, id 115).
 pub const ELEM_AST: ElementId = ElementId::new("ast", 115);
+/// Marshaling element `<highlist>` (C++ `ELEM_HIGHLIST`, `funcdata.cc`, id 117).
+pub const ELEM_HIGHLIST: ElementId = ElementId::new("highlist", 117);
+/// Marshaling element `<jumptablelist>` (C++ `ELEM_JUMPTABLELIST`,
+/// `funcdata.cc`, id 118).
+pub const ELEM_JUMPTABLELIST: ElementId = ElementId::new("jumptablelist", 118);
 /// Marshaling element `<function>` (C++ `ELEM_FUNCTION`, `funcdata.cc`, id 116).
 ///
 /// Re-exported by `p9_emit/prettyprint.rs`'s `ids` module (the markup
@@ -92,10 +97,16 @@ pub const ATTRIB_NOCODE: AttributeId = AttributeId::new("nocode", 84);
 impl Funcdata {
     /// C++ `Funcdata::encode(Encoder&,uint8 id,bool savetree)` (`funcdata.cc:734`).
     ///
-    /// Emits the `<function>` document consumed by Ghidra's `HighFunction.decode`.
-    /// v1 covers `<function>` + baseaddr `<addr>` + (when `savetree`) the `<ast>`;
-    /// the secondary encoders are deferred (see the `// v1.1:` skip sites).
-    pub fn encode(&self, enc: &mut dyn Encoder, id: u64, savetree: bool) -> KunaResult<()> {
+    /// Emits the `<function>` document consumed by Ghidra's `HighFunction.decode`,
+    /// in the upstream child order: baseaddr `<addr>` → `<localdb>` → (savetree)
+    /// `<ast>` → (savetree + high-level on) `<highlist>` → `<jumptablelist>` →
+    /// `<prototype>`.  `<override>` (Java-skipped) stays deferred.
+    ///
+    /// Takes `&mut self` (the C++ method is const): the Phase-4 encode runs the
+    /// [`Funcdata::kuna_link_high_symbols`] linking pass — the encode-time
+    /// stand-in for C++ `ActionNameVars::linkSymbols`, which upstream ran during
+    /// analysis — and the HighVariable reads re-derive dirty state.
+    pub fn encode(&mut self, enc: &mut dyn Encoder, id: u64, savetree: bool) -> KunaResult<()> {
         enc.open_element(&ELEM_FUNCTION);
         if id != 0 {
             enc.write_unsigned_integer(&ATTRIB_ID, id);
@@ -106,19 +117,342 @@ impl Funcdata {
             enc.write_bool(&ATTRIB_NOCODE, true);
         }
         self.get_address().encode(enc)?;
-        // v1.1: localmap->encodeRecursive(encoder,false)  (<localdb>) — deferred.
+        // The symbol-link pass must run BEFORE <localdb> so linked-in symbols
+        // are part of the encoded scope (the ids <highlist> symrefs resolve
+        // against — Java throws "HighLocal is missing symbol" otherwise).
+        let offsets = if savetree && self.is_high_on() {
+            self.kuna_link_high_symbols()
+        } else {
+            std::collections::BTreeMap::new()
+        };
+        // localmap->encodeRecursive(encoder,false): the <localdb> scope.  The
+        // kuna ScopeLocal owns a private single-scope database — no child
+        // scopes to recurse into.
+        if !self.has_no_code() {
+            if let Some(lm) = self.get_scope_local() {
+                lm.encode(enc)?;
+            }
+        }
         if savetree {
             self.encode_tree(enc)?;
-            // v1.1 (Phase 4): encodeHigh(encoder)  (<highlist>) — deferred.
+            self.encode_high(enc, &offsets)?;
         }
-        // v1.1 (Phase 4): encodeJumpTable(encoder)  (<jumptablelist>) — deferred.
-        // v1.1: funcp.encode(encoder)  (<prototype>, FuncProto::encode) — deferred.
-        //       A large independent encoder (ProtoStore/ProtoParameter/
-        //       Datatype::encodeRef/effect lists); `HighFunction.decode` treats
-        //       `<prototype>` as optional, so it does not block v1.
-        // v1.1: localoverride.encode(encoder,name)  (<override>) — deferred.
+        self.encode_jump_table(enc)?;
+        // funcp.encode: "Must be saved after database" (funcdata.cc:758).  A
+        // store-less proto (a partial/jump-table-recovery clone) has nothing
+        // encodable; `<prototype>` is optional to HighFunction.decode.
+        if self.get_func_proto().has_store() {
+            self.get_func_proto().encode(enc)?;
+        }
+        // v1.1: localoverride.encode(encoder,name)  (<override>) — Java skips it.
         enc.close_element(&ELEM_FUNCTION);
         Ok(())
+    }
+
+    /// C++ `Funcdata::encodeJumpTable(Encoder&)` (`funcdata.cc:625-635`): the
+    /// `<jumptablelist>` of recovered `JumpTable`s, omitted when there are none.
+    /// Emitted independently of `savetree` — the switch analyzer requests
+    /// `notree`+`noc`+`jumpload` and consumes ONLY this list.
+    fn encode_jump_table(&self, enc: &mut dyn Encoder) -> KunaResult<()> {
+        let tables = self.jumpvec_slice();
+        if tables.is_empty() {
+            return Ok(());
+        }
+        enc.open_element(&ELEM_JUMPTABLELIST);
+        for jt in tables {
+            // C++ JumpTable::encode throws on an unrecovered table; a table
+            // that survived to the encode without recovery must not kill the
+            // whole response (kuna divergence: skip it — Java drops empty
+            // tables anyway via isEmpty()).
+            if !jt.is_recovered() {
+                continue;
+            }
+            jt.encode(enc)?;
+        }
+        enc.close_element(&ELEM_JUMPTABLELIST);
+        Ok(())
+    }
+
+    /// C++ `Funcdata::encodeHigh(Encoder&)` (`funcdata.cc:658-683`): one
+    /// `<high>` per distinct HighVariable of any non-annotation Varnode, in
+    /// varnode-loc first-appearance order.  Emitted only when the high-level
+    /// (HighVariable) analysis ran.  `offsets` is the per-high wire
+    /// `offset` attribute computed by [`Funcdata::kuna_link_high_symbols`]
+    /// (C++ `HighVariable::symboloffset`; absent = -1 = whole symbol).
+    fn encode_high(
+        &mut self,
+        enc: &mut dyn Encoder,
+        offsets: &std::collections::BTreeMap<crate::context::HighVariableId, i32>,
+    ) -> KunaResult<()> {
+        use crate::variable::{ATTRIB_CLASS, ATTRIB_REPREF, ATTRIB_SYMREF, ELEM_HIGH};
+        if !self.is_high_on() {
+            return Ok(());
+        }
+        // Distinct highs in first-appearance loc order (the C++ mark/clearMark
+        // dedup, realized as an ordered set — no second clearing pass needed).
+        let vns: Vec<VarnodeId> = self.vbank().iter_loc().collect();
+        let mut seen: std::collections::BTreeSet<crate::context::HighVariableId> =
+            std::collections::BTreeSet::new();
+        let mut order: Vec<crate::context::HighVariableId> = Vec::new();
+        for vn in &vns {
+            let v = self.vbank().get(*vn).expect("encode_high: stale vn");
+            if v.is_annotation() {
+                continue;
+            }
+            if let Some(h) = v.get_high() {
+                if seen.insert(h) {
+                    order.push(h);
+                }
+            }
+        }
+        enc.open_element(&ELEM_HIGHLIST);
+        for high in order {
+            // Phase 1: the &mut HighVariable reads (predicates / type / name
+            // representative / instances) under the field-split borrow.
+            let (rep, spacebase, implied, persist, addrtied, constant, typelock, dtype, insts) =
+                self.with_high_split(|hb, ctx| {
+                    let h = hb.get_mut(high).expect("encode_high: stale high");
+                    let rep = h.get_name_representative(ctx);
+                    let spacebase = h.is_spacebase(ctx);
+                    let implied = h.is_implied(ctx);
+                    let persist = h.is_persist(ctx);
+                    let addrtied = h.is_addr_tied(ctx);
+                    let constant = h.is_constant(ctx);
+                    let typelock = h.is_type_lock(ctx, None);
+                    let dtype = h.get_type(ctx, None);
+                    let n = h.num_instances();
+                    let insts: Vec<VarnodeId> = (0..n).map(|i| h.get_instance(i)).collect();
+                    (rep, spacebase, implied, persist, addrtied, constant, typelock, dtype, insts)
+                });
+            let rep_index = self
+                .vbank()
+                .get(rep)
+                .expect("encode_high: stale representative")
+                .get_create_index() as u64;
+            // Phase 2: the symbol linkage (the C++ `symbol`/`symboloffset`
+            // members).  Locals/params resolve through the attached local
+            // SymbolId; globals resolve their REAL id through the global-scope
+            // snapshot (ghidra-mode: the host DB id delivered with the mapped
+            // symbol; 0 = unknown ⇒ symref is omitted, never fabricated).
+            let attached = self
+                .high_bank()
+                .get(high)
+                .and_then(|h| h.kuna_dynamic_symbol().or_else(|| h.kuna_equate_symbol()));
+            let (local_symref, category) = match (attached, self.get_scope_local()) {
+                (Some(sid), Some(lm)) => {
+                    let (id, cat) = lm.symbol_id_and_category(sid);
+                    (Some(id), cat)
+                }
+                _ => (None, crate::database::symbol_category::NO_CATEGORY),
+            };
+            let is_global_class = persist && addrtied;
+            // class per variable.cc:839-855 (order load-bearing).
+            let class: &str = if spacebase || implied {
+                "other"
+            } else if is_global_class {
+                "global"
+            } else if constant {
+                "constant"
+            } else if !persist && local_symref.is_some() {
+                if category == crate::database::symbol_category::FUNCTION_PARAMETER {
+                    "param"
+                } else {
+                    "local"
+                }
+            } else {
+                "other"
+            };
+            enc.open_element(&ELEM_HIGH);
+            enc.write_unsigned_integer(&ATTRIB_REPREF, rep_index);
+            enc.write_string(&ATTRIB_CLASS, class.as_bytes());
+            if typelock {
+                enc.write_bool(&kuna_base::marshal::ATTRIB_TYPELOCK, true);
+            }
+            let mut symbol_offset: i64 = -1;
+            let symref: Option<u64> = if is_global_class {
+                // The global-scope symbol id + partial-offset resolution.
+                let rep_vn = self.vbank().get(rep).expect("encode_high: stale rep");
+                let rep_addr = rep_vn.get_addr().clone();
+                let rep_size = rep_vn.get_size();
+                match self.get_arch().query_container_global(
+                    &rep_addr,
+                    1,
+                    &kuna_base::address::Address::new_invalid(),
+                ) {
+                    Some(gc) if gc.symbol_id != 0 => {
+                        let delta = rep_addr.get_offset().wrapping_sub(
+                            gc.entry_addr.get_offset(),
+                        ) as i64;
+                        if delta != 0 || gc.symbol_offset != 0 {
+                            symbol_offset = delta + gc.symbol_offset as i64;
+                        }
+                        let _ = rep_size;
+                        Some(gc.symbol_id)
+                    }
+                    _ => None,
+                }
+            } else {
+                if let Some(&off) = offsets.get(&high) {
+                    symbol_offset = off as i64;
+                }
+                local_symref
+            };
+            if let Some(id) = symref {
+                enc.write_unsigned_integer(&ATTRIB_SYMREF, id);
+                if symbol_offset >= 0 {
+                    enc.write_signed_integer(&kuna_base::marshal::ATTRIB_OFFSET, symbol_offset);
+                }
+            }
+            dtype.encode_ref(enc)?;
+            for ivn in insts {
+                let create = self
+                    .vbank()
+                    .get(ivn)
+                    .expect("encode_high: stale instance")
+                    .get_create_index();
+                self.encode_bare_ref(enc, create);
+            }
+            enc.close_element(&ELEM_HIGH);
+        }
+        enc.close_element(&ELEM_HIGHLIST);
+        Ok(())
+    }
+
+    /// The Phase-4 encode-time symbol-link pass: the kuna stand-in for C++
+    /// `ActionNameVars::linkSymbols` → `Funcdata::linkSymbol`
+    /// (`funcdata_varnode.cc:1189-1216`), which upstream runs during analysis so
+    /// every named HighVariable carries a localmap `Symbol` by encode time.
+    /// kuna's naming pass binds plain name strings (`kuna_name`) instead, so the
+    /// `Symbol` objects the `<localdb>`/`<highlist>` wire contract needs are
+    /// materialized here, on demand, just before encoding:
+    ///
+    ///   * a named, non-persist, non-constant high whose name-representative
+    ///     storage is covered by an existing localmap entry (a parameter from
+    ///     `link_proto_params`, a restructured stack local) is ATTACHED to that
+    ///     entry's Symbol;
+    ///   * a named high with no covering entry gets a fresh mapped Symbol at its
+    ///     representative storage (the C++ `localmap->addSymbol("",...)` branch,
+    ///     with the high's name instead of a `$$undef` placeholder);
+    ///   * equate/dynamic symbols attached during analysis are kept.
+    ///
+    /// Returns the per-high wire `offset` attribute (C++
+    /// `HighVariable::symboloffset`; the map carries only offsets >= 0).  The
+    /// pass never touches `HighVariable::symbol_offset` (a printer input) — the
+    /// encode is not allowed to perturb the rendered C.
+    pub(crate) fn kuna_link_high_symbols(
+        &mut self,
+    ) -> std::collections::BTreeMap<crate::context::HighVariableId, i32> {
+        use kuna_base::address::Address;
+        let mut offsets: std::collections::BTreeMap<crate::context::HighVariableId, i32> =
+            std::collections::BTreeMap::new();
+        if !self.is_high_on() || self.get_scope_local().is_none() {
+            return offsets;
+        }
+        let vns: Vec<VarnodeId> = self.vbank().iter_loc().collect();
+        let mut seen: std::collections::BTreeSet<crate::context::HighVariableId> =
+            std::collections::BTreeSet::new();
+        for vn in vns {
+            let v = match self.vbank().get(vn) {
+                Some(v) => v,
+                None => continue,
+            };
+            if v.is_annotation() {
+                continue;
+            }
+            let high = match v.get_high() {
+                Some(h) => h,
+                None => continue,
+            };
+            if !seen.insert(high) {
+                continue;
+            }
+            // Symbol already attached during analysis (equate / dynamic).
+            let (has_symbol, named) = match self.high_bank().get(high) {
+                Some(h) => (
+                    h.kuna_dynamic_symbol().or_else(|| h.kuna_equate_symbol()).is_some(),
+                    h.kuna_name().is_some(),
+                ),
+                None => continue,
+            };
+            if has_symbol || !named {
+                continue;
+            }
+            let (rep, spacebase, implied, persist, constant, dtype) =
+                self.with_high_split(|hb, ctx| {
+                    let h = hb.get_mut(high).expect("link_high_symbols: stale high");
+                    let rep = h.get_name_representative(ctx);
+                    (
+                        rep,
+                        h.is_spacebase(ctx),
+                        h.is_implied(ctx),
+                        h.is_persist(ctx),
+                        h.is_constant(ctx),
+                        h.get_type(ctx, None),
+                    )
+                });
+            // Only local (non-persist) nameable storage acquires a Symbol —
+            // the C++ `if (!vn->isPersist())` create guard; constants take the
+            // equate path, spacebase/implied never carry symbols.
+            if persist || constant || spacebase || implied {
+                continue;
+            }
+            let rep_vn = match self.vbank().get(rep) {
+                Some(v) => v,
+                None => continue,
+            };
+            if rep_vn.get_space().get_type() == spacetype::IPTR_CONSTANT
+                || rep_vn.get_space().get_type() == spacetype::IPTR_IOP
+            {
+                continue;
+            }
+            let rep_addr = rep_vn.get_addr().clone();
+            let rep_size = rep_vn.get_size();
+            let rep_addrtied = rep_vn.is_addr_tied();
+            let usepoint = self.vn_use_point(rep);
+            // Find any entry overlapping the base address (linkSymbol's
+            // queryProperties → findContainer).
+            let found = self
+                .get_scope_local()
+                .and_then(|lm| lm.container_symbol_link(&rep_addr, &usepoint));
+            match found {
+                Some((sid, entry_addr, entry_size, entry_off)) => {
+                    if entry_size != rep_size || entry_addr != rep_addr {
+                        // Partial match: the wire offset (HighVariable::setSymbol).
+                        let off = (rep_addr
+                            .get_offset()
+                            .wrapping_sub(entry_addr.get_offset())
+                            as i32)
+                            .wrapping_add(entry_off);
+                        offsets.insert(high, off);
+                    }
+                    if let Some(h) = self.high_bank_mut().get_mut(high) {
+                        h.set_kuna_dynamic_symbol(sid);
+                    }
+                }
+                None => {
+                    // Create the local symbol (linkSymbol's addSymbol branch);
+                    // an addr-tied storage maps usepoint-free.
+                    let name = self
+                        .high_bank()
+                        .get(high)
+                        .and_then(|h| h.kuna_name())
+                        .expect("named checked above")
+                        .to_string();
+                    let create_usepoint =
+                        if rep_addrtied { Address::new_invalid() } else { usepoint };
+                    let res = self
+                        .get_scope_local_mut()
+                        .expect("scope checked above")
+                        .add_symbol(&name, dtype, &rep_addr, &create_usepoint);
+                    if let Ok(sid) = res {
+                        if let Some(h) = self.high_bank_mut().get_mut(high) {
+                            h.set_kuna_dynamic_symbol(sid);
+                        }
+                    }
+                }
+            }
+        }
+        offsets
     }
 
     /// C++ `Funcdata::encodeTree(Encoder&)` (`funcdata.cc:686`).

--- a/decompiler/crates/kuna-decomp/src/substrate/funcdata_encode.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/funcdata_encode.rs
@@ -120,22 +120,27 @@ impl Funcdata {
         // The symbol-link pass must run BEFORE <localdb> so linked-in symbols
         // are part of the encoded scope (the ids <highlist> symrefs resolve
         // against — Java throws "HighLocal is missing symbol" otherwise).
-        let offsets = if savetree && self.is_high_on() {
-            self.kuna_link_high_symbols()
-        } else {
-            std::collections::BTreeMap::new()
-        };
+        // It is idempotent: the ghidra-mode driver runs it earlier still, so
+        // the printed markup's `<vardecl symref>` can carry the same real ids.
+        if savetree && self.is_high_on() {
+            self.kuna_link_high_symbols();
+        }
         // localmap->encodeRecursive(encoder,false): the <localdb> scope.  The
         // kuna ScopeLocal owns a private single-scope database — no child
         // scopes to recurse into.
+        let mut encodable: std::collections::BTreeSet<u64> = std::collections::BTreeSet::new();
         if !self.has_no_code() {
+            let wire_symbols = std::mem::take(&mut self.kuna_wire_symbols);
             if let Some(lm) = self.get_scope_local() {
-                lm.encode(enc)?;
+                lm.encode_with_wire_symbols(&wire_symbols, enc)?;
+                encodable = lm.encodable_symbol_ids();
+                encodable.extend(wire_symbols.iter().map(|w| w.id));
             }
+            self.kuna_wire_symbols = wire_symbols;
         }
         if savetree {
             self.encode_tree(enc)?;
-            self.encode_high(enc, &offsets)?;
+            self.encode_high(enc, &encodable)?;
         }
         self.encode_jump_table(enc)?;
         // funcp.encode: "Must be saved after database" (funcdata.cc:758).  A
@@ -182,7 +187,7 @@ impl Funcdata {
     fn encode_high(
         &mut self,
         enc: &mut dyn Encoder,
-        offsets: &std::collections::BTreeMap<crate::context::HighVariableId, i32>,
+        encodable_symbols: &std::collections::BTreeSet<u64>,
     ) -> KunaResult<()> {
         use crate::variable::{ATTRIB_CLASS, ATTRIB_REPREF, ATTRIB_SYMREF, ELEM_HIGH};
         if !self.is_high_on() {
@@ -234,14 +239,30 @@ impl Funcdata {
             // SymbolId; globals resolve their REAL id through the global-scope
             // snapshot (ghidra-mode: the host DB id delivered with the mapped
             // symbol; 0 = unknown ⇒ symref is omitted, never fabricated).
-            let attached = self
-                .high_bank()
-                .get(high)
-                .and_then(|h| h.kuna_dynamic_symbol().or_else(|| h.kuna_equate_symbol()));
-            let (local_symref, category) = match (attached, self.get_scope_local()) {
-                (Some(sid), Some(lm)) => {
+            let attached = self.high_bank().get(high).and_then(|h| {
+                h.kuna_link_symbol()
+                    .or_else(|| h.kuna_dynamic_symbol())
+                    .or_else(|| h.kuna_equate_symbol())
+            });
+            // A wire-only symbol (the analysis left the high symbol-less) is
+            // referenced by its reserved id and is never a parameter.
+            let wire = self
+                .kuna_wire_symbol_for_high
+                .get(&high)
+                .and_then(|i| self.kuna_wire_symbols.get(*i))
+                .map(|w| w.id);
+            let (local_symref, category) = match (attached, wire, self.get_scope_local()) {
+                (None, Some(id), _) => (Some(id), crate::database::symbol_category::NO_CATEGORY),
+                (Some(sid), _, Some(lm)) => {
                     let (id, cat) = lm.symbol_id_and_category(sid);
-                    (Some(id), cat)
+                    // Only reference a symbol the `<localdb>` actually
+                    // encoded: an orphan `<high class=local|param symref>` is
+                    // a Java hard-throw that discards the entire result.
+                    if encodable_symbols.contains(&id) {
+                        (Some(id), cat)
+                    } else {
+                        (None, crate::database::symbol_category::NO_CATEGORY)
+                    }
                 }
                 _ => (None, crate::database::symbol_category::NO_CATEGORY),
             };
@@ -292,7 +313,15 @@ impl Funcdata {
                     _ => None,
                 }
             } else {
-                if let Some(&off) = offsets.get(&high) {
+                // C++ `HighVariable::symboloffset` — written only when >= 0
+                // (a PARTIAL symbol match).  The naming pass records it when
+                // it binds a high into a composite/parameter entry.
+                let off = self
+                    .high_bank()
+                    .get(high)
+                    .map(|h| h.get_symbol_offset())
+                    .unwrap_or(-1);
+                if off >= 0 {
                     symbol_offset = off as i64;
                 }
                 local_symref
@@ -339,14 +368,10 @@ impl Funcdata {
     /// `HighVariable::symboloffset`; the map carries only offsets >= 0).  The
     /// pass never touches `HighVariable::symbol_offset` (a printer input) — the
     /// encode is not allowed to perturb the rendered C.
-    pub(crate) fn kuna_link_high_symbols(
-        &mut self,
-    ) -> std::collections::BTreeMap<crate::context::HighVariableId, i32> {
+    pub fn kuna_link_high_symbols(&mut self) {
         use kuna_base::address::Address;
-        let mut offsets: std::collections::BTreeMap<crate::context::HighVariableId, i32> =
-            std::collections::BTreeMap::new();
         if !self.is_high_on() || self.get_scope_local().is_none() {
-            return offsets;
+            return;
         }
         let vns: Vec<VarnodeId> = self.vbank().iter_loc().collect();
         let mut seen: std::collections::BTreeSet<crate::context::HighVariableId> =
@@ -366,15 +391,24 @@ impl Funcdata {
             if !seen.insert(high) {
                 continue;
             }
-            // Symbol already attached during analysis (equate / dynamic).
+            // Symbol already attached — during analysis (equate / dynamic) or
+            // by the naming pass's recorded bind decision
+            // (`kuna_link_symbol`), which INCLUDES a previous run of this
+            // idempotent pass.
             let (has_symbol, named) = match self.high_bank().get(high) {
                 Some(h) => (
-                    h.kuna_dynamic_symbol().or_else(|| h.kuna_equate_symbol()).is_some(),
+                    h.kuna_dynamic_symbol()
+                        .or_else(|| h.kuna_equate_symbol())
+                        .or_else(|| h.kuna_link_symbol())
+                        .is_some(),
                     h.kuna_name().is_some(),
                 ),
                 None => continue,
             };
-            if has_symbol || !named {
+            // Idempotent: a previous run of this pass already gave the high a
+            // wire symbol (the ghidra driver runs it before the markup, the
+            // encode runs it again).
+            if has_symbol || !named || self.kuna_wire_symbol_for_high.contains_key(&high) {
                 continue;
             }
             let (rep, spacebase, implied, persist, constant, dtype) =
@@ -406,53 +440,76 @@ impl Funcdata {
                 continue;
             }
             let rep_addr = rep_vn.get_addr().clone();
-            let rep_size = rep_vn.get_size();
             let rep_addrtied = rep_vn.is_addr_tied();
             let usepoint = self.vn_use_point(rep);
-            // Find any entry overlapping the base address (linkSymbol's
-            // queryProperties → findContainer).
-            let found = self
+            // The naming pass left this high symbol-less.  There are exactly
+            // two reasons, and they need OPPOSITE treatment:
+            //
+            //  * no Symbol covers the storage at all — the C++ `linkSymbol`
+            //    `addSymbol("",...)` branch: a register/unique/stack temp the
+            //    naming pass named `vN`.  Give it a MAPPED wire symbol at that
+            //    storage.
+            //  * a Symbol DOES cover it but the naming pass rejected the bind
+            //    as a storage CONFLICT (the narrower addr-tied return over a
+            //    wider scalar parameter, the float8 lane over a float4 param —
+            //    `coreaction_cleanup.rs`'s conflict scan).  C++ answers with
+            //    `buildDynamicSymbol` — a data-flow-HASHED symbol of its own.
+            //    Re-deriving the container binding here would hand the high
+            //    the PARAMETER's symbol id, so a rename from this variable's
+            //    token would rename the parameter.  Never do that: hash it, or
+            //    (no unique hash) leave it symbol-less — it then encodes as
+            //    `<high class="other">` with no `symref`, which Java tolerates.
+            //
+            // Both produce a WIRE-ONLY symbol ([`WireSymbol`]): the analysis
+            // scope is never touched, so this pass cannot change the emitted C
+            // no matter when it runs (the ghidra driver runs it BEFORE the
+            // markup so `<vardecl symref>` can carry the real ids).
+            let covered = self
                 .get_scope_local()
-                .and_then(|lm| lm.container_symbol_link(&rep_addr, &usepoint));
-            match found {
-                Some((sid, entry_addr, entry_size, entry_off)) => {
-                    if entry_size != rep_size || entry_addr != rep_addr {
-                        // Partial match: the wire offset (HighVariable::setSymbol).
-                        let off = (rep_addr
-                            .get_offset()
-                            .wrapping_sub(entry_addr.get_offset())
-                            as i32)
-                            .wrapping_add(entry_off);
-                        offsets.insert(high, off);
-                    }
-                    if let Some(h) = self.high_bank_mut().get_mut(high) {
-                        h.set_kuna_dynamic_symbol(sid);
-                    }
+                .and_then(|lm| lm.container_symbol_link(&rep_addr, &usepoint))
+                .is_some();
+            let name = self
+                .high_bank()
+                .get(high)
+                .and_then(|h| h.kuna_name())
+                .expect("named checked above")
+                .to_string();
+            let hash = if covered {
+                // The collision budget is pinned at the UPSTREAM 8 on the wire
+                // path: Java computes its own hash for the same variable with a
+                // hardcoded `maxduplicates = 8` (`DynamicHash.java:440`), and a
+                // hash the two sides disagree on cannot round-trip a rename.
+                match crate::dynamic::dynamic_unique_hash(rep, 8, self) {
+                    Ok((h, _)) if h != 0 => h,
+                    _ => continue, // no unique hash: stay symbol-less
                 }
-                None => {
-                    // Create the local symbol (linkSymbol's addSymbol branch);
-                    // an addr-tied storage maps usepoint-free.
-                    let name = self
-                        .high_bank()
-                        .get(high)
-                        .and_then(|h| h.kuna_name())
-                        .expect("named checked above")
-                        .to_string();
-                    let create_usepoint =
-                        if rep_addrtied { Address::new_invalid() } else { usepoint };
-                    let res = self
-                        .get_scope_local_mut()
-                        .expect("scope checked above")
-                        .add_symbol(&name, dtype, &rep_addr, &create_usepoint);
-                    if let Ok(sid) = res {
-                        if let Some(h) = self.high_bank_mut().get_mut(high) {
-                            h.set_kuna_dynamic_symbol(sid);
-                        }
-                    }
-                }
-            }
+            } else {
+                0
+            };
+            let Some(id) = self
+                .get_scope_local_mut()
+                .map(|lm| lm.reserve_internal_symbol_id())
+            else {
+                continue;
+            };
+            let idx = self.kuna_wire_symbols.len();
+            self.kuna_wire_symbols.push(crate::database::WireSymbol {
+                id,
+                name,
+                dtype,
+                addr: if hash != 0 { Address::new_invalid() } else { rep_addr },
+                hash,
+                // A mapped addr-tied storage is valid function-wide (empty
+                // uselimit); everything else is scoped to its use point, which
+                // is also the address a DYNAMIC entry hashes at.
+                usepoint: if hash == 0 && rep_addrtied {
+                    Address::new_invalid()
+                } else {
+                    usepoint
+                },
+            });
+            self.kuna_wire_symbol_for_high.insert(high, idx);
         }
-        offsets
     }
 
     /// C++ `Funcdata::encodeTree(Encoder&)` (`funcdata.cc:686`).

--- a/decompiler/crates/kuna-decomp/src/substrate/funcdata_varnode.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/funcdata_varnode.rs
@@ -1247,6 +1247,7 @@ impl Funcdata {
             .get_scope_local()
             .and_then(|lm| lm.query_container_for_link(&addr, &sb_usepoint));
         let info_is_global = local_hit.is_none();
+        let local_sid = local_hit.as_ref().map(|i| i.symbol);
         let resolved: Option<(String, int4, Option<Rc<Datatype>>, bool)> = match local_hit {
             Some(i) => Some((i.display_name, i.sym_off, i.sym_type, i.is_name_undefined)),
             None => {
@@ -1295,6 +1296,18 @@ impl Funcdata {
             // A reference resolved through the global scope is not a local symbol;
             // mark it so the printer's local decl loop renders it by name only.
             h.set_kuna_global(info_is_global);
+            // C++ `Varnode::setSymbolReference` (varnode.cc:465) →
+            // `HighVariable::setSymbolReference(entry->getSymbol(), off)`: the
+            // SYMBOL IDENTITY travels with the name/offset/type this bind just
+            // copied.  kuna dropped it, which left the `<vardecl symref>` of a
+            // stack aggregate materialized only through `&sym` — its whole high
+            // is the constant PTRSUB operand, so no addr-tied instance exists to
+            // re-derive a container from — with no resolvable id.  Local scope
+            // only: a global reference's Symbol is not in the `LocalSymbolMap`
+            // the wire id must key into.
+            if let Some(sid) = local_sid {
+                h.set_kuna_ref_symbol(sid);
+            }
         }
         true
     }

--- a/decompiler/crates/kuna-decomp/tests/funcdata_encode_e2e.rs
+++ b/decompiler/crates/kuna-decomp/tests/funcdata_encode_e2e.rs
@@ -378,7 +378,7 @@ fn expected_uniqs(fd: &Funcdata) -> BTreeSet<u64> {
 
 /// Encode `fd`, round-trip, and assert the structure + the load-bearing
 /// invariant.  Returns the `Observed` for the aggregate coverage report.
-fn encode_and_verify(fd: &Funcdata) -> Observed {
+fn encode_and_verify(fd: &mut Funcdata) -> Observed {
     let mut bytes: Vec<u8> = Vec::new();
     {
         let mut enc = PackedEncode::new(&mut bytes);
@@ -441,8 +441,8 @@ fn corpus_functions_encode_and_roundtrip() {
             };
             let entry = Address::new(space, sym.offset);
             match decompile_func(base, &sym.name, entry, 0) {
-                Ok(fd) => {
-                    let obs = encode_and_verify(&fd);
+                Ok(mut fd) => {
+                    let obs = encode_and_verify(&mut fd);
                     verified += 1;
                     agg.saw_iop |= obs.saw_iop;
                     agg.saw_spaceid |= obs.saw_spaceid;

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_global_persist_adversarial.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_global_persist_adversarial.rs
@@ -72,6 +72,7 @@ fn tied_entry(space: &Rc<AddrSpace>, first: u64, last: u64, all_flags: u32) -> G
         is_function: false,
         func_inject_id: -1,
         func_no_return: false,
+        symbol_id: 0,
     }
 }
 
@@ -239,6 +240,7 @@ fn av4_smallest_in_use_entry_wins() {
         is_function: false,
         func_inject_id: -1,
         func_no_return: false,
+        symbol_id: 0,
     };
     let gq2 = GlobalQuery::new(
         vec![big.clone(), limited.clone()],

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_symbol_consolidate.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_symbol_consolidate.rs
@@ -90,6 +90,7 @@ fn typed_entry(
         is_function: false,
         func_inject_id: -1,
         func_no_return: false,
+        symbol_id: 0,
     }
 }
 

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_symbol_consolidate_adversarial.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_symbol_consolidate_adversarial.rs
@@ -91,6 +91,7 @@ fn named_entry(
         is_function: false,
         func_inject_id: -1,
         func_no_return: false,
+        symbol_id: 0,
     }
 }
 

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_symbol_consolidate_verifier2.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_symbol_consolidate_verifier2.rs
@@ -80,6 +80,7 @@ fn entry(
         is_function: false,
         func_inject_id: -1,
         func_no_return: false,
+        symbol_id: 0,
     }
 }
 

--- a/decompiler/crates/kuna-ghidra/src/process.rs
+++ b/decompiler/crates/kuna-ghidra/src/process.rs
@@ -614,20 +614,31 @@ impl<R: Read + 'static, W: Write + 'static> GhidraProcess<R, W> {
                 // HighFunction.decode name echo compares against it); the
                 // label, when the host sent one (TemplateSimplifier), is only
                 // the display form the printed signature uses.
-                let (name, display_name, pending_pieces, host_locals) = match facts {
-                    Some(f) => (f.name, f.display_name, f.pieces, f.locals),
+                let (
+                    name,
+                    display_name,
+                    pending_pieces,
+                    host_locals,
+                    host_model,
+                    host_param_storage,
+                ) = match facts {
+                    Some(f) => (
+                        f.name,
+                        f.display_name,
+                        f.pieces,
+                        f.locals,
+                        f.model,
+                        f.param_storage,
+                    ),
                     None => {
                         let label = self.client.borrow_mut().get_code_label(&addr);
-                        match label {
+                        let n = match label {
                             Ok(l) if !l.is_empty() => {
-                                let n = String::from_utf8_lossy(&l).into_owned();
-                                (n.clone(), n, None, Vec::new())
+                                String::from_utf8_lossy(&l).into_owned()
                             }
-                            _ => {
-                                let n = format!("FUN_{:08x}", addr.get_offset());
-                                (n.clone(), n, None, Vec::new())
-                            }
-                        }
+                            _ => format!("FUN_{:08x}", addr.get_offset()),
+                        };
+                        (n.clone(), n, None, Vec::new(), None, Vec::new())
                     }
                 };
 
@@ -781,10 +792,36 @@ impl<R: Read + 'static, W: Write + 'static> GhidraProcess<R, W> {
                         bool,
                     )> = Vec::new();
                     let mut name_recs: Vec<(String, Address, Address, i32)> = Vec::new();
+                    let mut dyn_recs: Vec<(String, Address, u64)> = Vec::new();
+                    let mut seed_dynamic: Vec<kuna_decomp::database::DynamicSymbolSpec> =
+                        Vec::new();
                     for l in &host_locals {
                         let typelocked = (l.flags
                             & kuna_decomp::varnode::varnode_flags::typelock)
                             != 0;
+                        // A DYNAMIC (hash) local addresses a VALUE, not a
+                        // storage location — the class Java writes for every
+                        // `requiresDynamicStorage` variable (unique-space
+                        // representatives, `splitOutMergeGroup` products).  It
+                        // travels through the dynamic channels: a rename as a
+                        // `dynRecommend`, a retype as a dynamic Symbol seed.
+                        if l.hash != 0 {
+                            if typelocked {
+                                seed_dynamic.push(kuna_decomp::database::DynamicSymbolSpec {
+                                    name: l.name.clone(),
+                                    dtype: std::rc::Rc::clone(&l.dtype),
+                                    addr: l.addr.clone(),
+                                    hash: l.hash,
+                                    category: -1,
+                                    dispflags: 0,
+                                    equate_value: None,
+                                    union_facet: None,
+                                });
+                            } else {
+                                dyn_recs.push((l.name.clone(), l.addr.clone(), l.hash));
+                            }
+                            continue;
+                        }
                         if !typelocked {
                             name_recs.push((
                                 l.name.clone(),
@@ -811,6 +848,14 @@ impl<R: Read + 'static, W: Write + 'static> GhidraProcess<R, W> {
                         }
                     }
                     arch.kuna_pending_name_recs = name_recs;
+                    arch.kuna_pending_dyn_recs = dyn_recs;
+                    // The host's declared convention: parameter storage must be
+                    // assigned under the SAME model the database committed, or
+                    // Java's checkFullCommit rewrites the user's signature on
+                    // the first rename.
+                    arch.kuna_pending_proto_model = host_model
+                        .as_deref()
+                        .and_then(|m| arch.get_model(m).cloned());
                     match kuna_decomp::decompile_drive::decompile_func_full_with_override_dyn(
                         arch,
                         &name,
@@ -818,11 +863,13 @@ impl<R: Read + 'static, W: Write + 'static> GhidraProcess<R, W> {
                         0,
                         &seed_mapped,
                         &seed_usepoint,
-                        &[],
+                        &seed_dynamic,
                         pending_pieces.as_ref(),
                         &[],
                         &[],
-                        &[],
+                        // The host's EXACT committed parameter storage (empty
+                        // for an unlocked signature — kuna recovers those).
+                        &host_param_storage,
                     ) {
                         Ok(mut fd) => {
                             // The printed signature/tokens use the display
@@ -1211,10 +1258,18 @@ fn parse_arch_id(payload: &[u8]) -> i32 {
 /// appending the markup bytes then writing `</doc>` from a fresh encoder is
 /// byte-identical to C++ writing both to one `sout` — exactly the same splice.
 ///
-/// The markup is rendered BEFORE `fd.encode`: the encode runs the Phase-4
-/// symbol-link pass (`kuna_link_high_symbols`), and the printed C must be what
-/// the analysis produced, not what the link pass touched.  Both documents are
-/// spliced into the upstream order (`<function>` #1 first) regardless.
+/// The Phase-4 symbol-link pass (`kuna_link_high_symbols`) runs FIRST — before
+/// the markup is printed — because the markup's `<vardecl symref>` must carry
+/// the same LocalSymbolMap ids `<localdb>` encodes: Java resolves the
+/// declaration line's HighSymbol exclusively through that attribute, so a
+/// declaration printed before the symbols exist leaves rename/retype dead on
+/// declaration tokens (and logs "Invalid symbol reference" once per
+/// declaration per decompile).  The pass is idempotent and does not change the
+/// printed C — it only attaches Symbols to highs the naming pass already
+/// named, writing a field (`kuna_link_symbol`) nothing in the printer's text
+/// path reads; the harness asserts the C text is byte-identical across the
+/// reorder.  Both documents are then spliced in the upstream order
+/// (`<function>` #1 first).
 ///
 /// kuna divergence (documented): under action `paramid` the C++ ran the reduced
 /// `paramid` action set; kuna's `decompile_func_full` runs the full decompile,
@@ -1229,6 +1284,11 @@ fn build_decompile_at_doc(
     current_action: &str,
 ) -> KunaResult<Vec<u8>> {
     let mut buf: Vec<u8> = Vec::new();
+    // The symbol-link pass, ahead of everything that reads its results (the
+    // markup's `<vardecl symref>` and the `<localdb>`/`<highlist>` encode).
+    if send_syntax_tree {
+        fd.kuna_link_high_symbols();
+    }
     {
         let mut enc = PackedEncode::new(&mut buf);
         enc.open_element(&ELEM_DOC);

--- a/decompiler/crates/kuna-ghidra/src/process.rs
+++ b/decompiler/crates/kuna-ghidra/src/process.rs
@@ -55,7 +55,6 @@ use kuna_base::marshal::{Decoder, Encoder, PackedDecode, PackedEncode};
 use kuna_base::space::AddrSpaceManager;
 
 use kuna_decomp::architecture::Architecture;
-use kuna_decomp::decompile_drive::decompile_func_full;
 use kuna_decomp::funcdata::Funcdata;
 use kuna_decomp::options::OptionDatabase;
 
@@ -615,18 +614,18 @@ impl<R: Read + 'static, W: Write + 'static> GhidraProcess<R, W> {
                 // HighFunction.decode name echo compares against it); the
                 // label, when the host sent one (TemplateSimplifier), is only
                 // the display form the printed signature uses.
-                let (name, display_name, pending_pieces) = match facts {
-                    Some(f) => (f.name, f.display_name, f.pieces),
+                let (name, display_name, pending_pieces, host_locals) = match facts {
+                    Some(f) => (f.name, f.display_name, f.pieces, f.locals),
                     None => {
                         let label = self.client.borrow_mut().get_code_label(&addr);
                         match label {
                             Ok(l) if !l.is_empty() => {
                                 let n = String::from_utf8_lossy(&l).into_owned();
-                                (n.clone(), n, None)
+                                (n.clone(), n, None, Vec::new())
                             }
                             _ => {
                                 let n = format!("FUN_{:08x}", addr.get_offset());
-                                (n.clone(), n, None)
+                                (n.clone(), n, None, Vec::new())
                             }
                         }
                     }
@@ -712,11 +711,12 @@ impl<R: Read + 'static, W: Write + 'static> GhidraProcess<R, W> {
                 }
 
                 // Snapshot the render flags before taking `&mut Architecture`.
-                let (send_syntax_tree, send_c_code, current_action) = {
+                let (send_syntax_tree, send_c_code, send_param_measures, current_action) = {
                     let session = self.archlist[slot].as_ref().expect("bound session");
                     (
                         session.send_syntax_tree,
                         session.send_c_code,
+                        session.send_param_measures,
                         session.current_action.clone(),
                     )
                 };
@@ -734,19 +734,95 @@ impl<R: Read + 'static, W: Write + 'static> GhidraProcess<R, W> {
                         .architecture
                         .as_mut()
                         .expect("addr decoded ⇒ engine present");
+                    // Phase 4: the session's jumpload toggle reaches the
+                    // flow-following engine as the upstream flowoptions bit
+                    // (SetAction "jumpload" → `ghidra->flowoptions |=
+                    // FlowInfo::record_jumploads`, ghidra_process.cc:398-401).
+                    // Applied per-decompile so the setOptions reset-then-apply
+                    // baseline restore can never strand the toggle.
+                    if session.record_jumploads {
+                        arch.flowoptions |= kuna_decomp::flow::flow_flags::record_jumploads;
+                    } else {
+                        arch.flowoptions &= !kuna_decomp::flow::flow_flags::record_jumploads;
+                    }
                     // Phase 3: a LOCKED host signature (typelocked params /
                     // locked-void input) seeds the fresh Funcdata's prototype —
                     // the C++ queryFunction handing DecompileAt the decoded
                     // `<prototype>`+`<localdb>`.  An unlocked signature stays
                     // None and kuna recovers parameters itself (the CLI-path
                     // behavior for undeclared functions).
-                    match decompile_func_full(
+                    //
+                    // Phase 4: the host-committed LOCALS from the function's
+                    // `<localdb>` seed the fresh local scope through the same
+                    // per-function seeding path the console symbols use — the
+                    // upstream `Funcdata::decode` localmap restore.  This is
+                    // what makes a GUI rename/retype (a DB write followed by
+                    // an event-driven re-decompile) SURVIVE the re-decompile.
+                    // An entry with a first-use address seeds usepoint-scoped
+                    // (register locals); an empty uselimit seeds addr-tied
+                    // (stack locals).  A namelocked-but-NOT-typelocked local
+                    // (a GUI rename of an untyped variable) is NOT a symbol
+                    // seed — such symbols never survive restructure's
+                    // clearUnlockedCategory(-1) — it stages as a NAME
+                    // RECOMMENDATION, exactly the C++ ScopeLocal::nameRecommend
+                    // identity `recoverNameRecommendationsForSymbols` applies.
+                    let mut seed_mapped: Vec<(
+                        String,
+                        std::rc::Rc<kuna_decomp::dtype::Datatype>,
+                        Address,
+                        u32,
+                    )> = Vec::new();
+                    let mut seed_usepoint: Vec<(
+                        String,
+                        std::rc::Rc<kuna_decomp::dtype::Datatype>,
+                        Address,
+                        u32,
+                        Address,
+                        bool,
+                    )> = Vec::new();
+                    let mut name_recs: Vec<(String, Address, Address, i32)> = Vec::new();
+                    for l in &host_locals {
+                        let typelocked = (l.flags
+                            & kuna_decomp::varnode::varnode_flags::typelock)
+                            != 0;
+                        if !typelocked {
+                            name_recs.push((
+                                l.name.clone(),
+                                l.addr.clone(),
+                                l.usepoint.clone(),
+                                l.dtype.get_size(),
+                            ));
+                        } else if l.usepoint.is_invalid() {
+                            seed_mapped.push((
+                                l.name.clone(),
+                                std::rc::Rc::clone(&l.dtype),
+                                l.addr.clone(),
+                                l.flags,
+                            ));
+                        } else {
+                            seed_usepoint.push((
+                                l.name.clone(),
+                                std::rc::Rc::clone(&l.dtype),
+                                l.addr.clone(),
+                                l.flags,
+                                l.usepoint.clone(),
+                                false,
+                            ));
+                        }
+                    }
+                    arch.kuna_pending_name_recs = name_recs;
+                    match kuna_decomp::decompile_drive::decompile_func_full_with_override_dyn(
                         arch,
                         &name,
                         addr.clone(),
                         0,
+                        &seed_mapped,
+                        &seed_usepoint,
                         &[],
                         pending_pieces.as_ref(),
+                        &[],
+                        &[],
+                        &[],
                     ) {
                         Ok(mut fd) => {
                             // The printed signature/tokens use the display
@@ -757,9 +833,10 @@ impl<R: Read + 'static, W: Write + 'static> GhidraProcess<R, W> {
                             }
                             build_decompile_at_doc(
                                 arch,
-                                &fd,
+                                &mut fd,
                                 send_syntax_tree,
                                 send_c_code,
+                                send_param_measures,
                                 &current_action,
                             )
                         }
@@ -1110,15 +1187,18 @@ fn parse_arch_id(payload: &[u8]) -> i32 {
 }
 
 /// Assemble the decompileAt response document (C++ `DecompileAt::rawAction`
-/// isProcComplete branch, `decompiler/cpp/ghidra_process.cc:317-333`):
+/// isProcComplete branch, `decompiler/cpp/ghidra_process.cc:293-335`):
 ///
 /// ```text
-///   XmlEncode encoder(sout);        // kuna: PackedEncode over a buffer
 ///   encoder.openElement(ELEM_DOC);
-///   fd->encode(encoder,0,ghidra->getSendSyntaxTree());   // <function>/<ast>
-///   if (ghidra->getSendCCode() && (actionname == "decompile")) {
-///     ghidra->print->setOutputStream(&sout);
-///     ghidra->print->docFunction(fd);   // the Clang-markup <function>
+///   if (getSendParamMeasures() && actionname == "paramid")
+///     ParamIDAnalysis(fd,true).encode(encoder,true);      // the ONLY child
+///   else {
+///     if (getSendParamMeasures())
+///       ParamIDAnalysis(fd,false).encode(encoder,true);
+///     fd->encode(encoder,0,getSendSyntaxTree());          // <function>/<ast>
+///     if (getSendCCode() && actionname == "decompile")
+///       ghidra->print->docFunction(fd);                   // markup <function>
 ///   }
 ///   encoder.closeElement(ELEM_DOC);
 /// ```
@@ -1130,28 +1210,60 @@ fn parse_arch_id(payload: &[u8]) -> i32 {
 /// its 0x00-free bytes straight to the buffer with no open-element stack, so
 /// appending the markup bytes then writing `</doc>` from a fresh encoder is
 /// byte-identical to C++ writing both to one `sout` — exactly the same splice.
+///
+/// The markup is rendered BEFORE `fd.encode`: the encode runs the Phase-4
+/// symbol-link pass (`kuna_link_high_symbols`), and the printed C must be what
+/// the analysis produced, not what the link pass touched.  Both documents are
+/// spliced into the upstream order (`<function>` #1 first) regardless.
+///
+/// kuna divergence (documented): under action `paramid` the C++ ran the reduced
+/// `paramid` action set; kuna's `decompile_func_full` runs the full decompile,
+/// so the measured prototype is the fully-recovered one — a superset of what
+/// the reduced pipeline exposes.
 fn build_decompile_at_doc(
     arch: &mut Architecture,
-    fd: &Funcdata,
+    fd: &mut Funcdata,
     send_syntax_tree: bool,
     send_c_code: bool,
+    send_param_measures: bool,
     current_action: &str,
 ) -> KunaResult<Vec<u8>> {
     let mut buf: Vec<u8> = Vec::new();
-    // <doc> open + fd.encode (the <function>/<ast> syntax tree).
     {
         let mut enc = PackedEncode::new(&mut buf);
         enc.open_element(&ELEM_DOC);
-        fd.encode(&mut enc, 0, send_syntax_tree)?;
     }
-    // The dual <function>: the Clang token-markup document.  `doc_function_markup`
-    // needs `&mut PrintC` + `&Architecture`; move the printer out (the
-    // `print_c` split-borrow precedent), render, put it back, splice the bytes.
-    if send_c_code && current_action == "decompile" {
-        let mut printer = arch.take_print();
-        let markup = printer.doc_function_markup(fd, arch);
-        arch.put_print(printer);
-        buf.extend_from_slice(&markup);
+    if send_param_measures && current_action == "paramid" {
+        // The parammeasures-only doc (DecompilerParameterIdCmd /
+        // ConventionAnalysisDecompileConfigurer).
+        let analysis = kuna_decomp::paramid::ParamIDAnalysis::new(fd, true)?;
+        let mut enc = PackedEncode::new(&mut buf);
+        analysis.encode(&mut enc, true)?;
+    } else {
+        if send_param_measures {
+            let analysis = kuna_decomp::paramid::ParamIDAnalysis::new(fd, false)?;
+            let mut enc = PackedEncode::new(&mut buf);
+            analysis.encode(&mut enc, true)?;
+        }
+        // The dual <function>: the Clang token-markup document, rendered first
+        // (see above), spliced after the syntax tree.  `doc_function_markup`
+        // needs `&mut PrintC` + `&Architecture`; move the printer out (the
+        // `print_c` split-borrow precedent), render, put it back.
+        let markup: Option<Vec<u8>> = if send_c_code && current_action == "decompile" {
+            let mut printer = arch.take_print();
+            let m = printer.doc_function_markup(fd, arch);
+            arch.put_print(printer);
+            Some(m)
+        } else {
+            None
+        };
+        {
+            let mut enc = PackedEncode::new(&mut buf);
+            fd.encode(&mut enc, 0, send_syntax_tree)?;
+        }
+        if let Some(m) = markup {
+            buf.extend_from_slice(&m);
+        }
     }
     {
         let mut enc = PackedEncode::new(&mut buf);

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim/mod.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim/mod.rs
@@ -80,6 +80,131 @@ pub const ELEM_TYPE_ID: u32 = 60;
 /// `ClangToken.CONST_COLOR` (== `SyntaxHighlight::ConstColor`).
 pub const CONST_COLOR: u64 = 5;
 
+// --- Phase-4 first-`<function>` vocabulary (upstream numbers) --------------
+/// `<addr>` (address.rs).
+pub const ELEM_ADDR_ID: u32 = 11;
+/// `<localdb>` (database.cc vocabulary).
+pub const ELEM_LOCALDB_ID: u32 = 228;
+/// `<scope>`.
+pub const ELEM_SCOPE_ID: u32 = 80;
+/// `<parent>`.
+pub const ELEM_PARENT_ID: u32 = 77;
+/// `<rangelist>`.
+pub const ELEM_RANGELIST_ID: u32 = 13;
+/// `<symbollist>`.
+pub const ELEM_SYMBOLLIST_ID: u32 = 81;
+/// `<mapsym>`.
+pub const ELEM_MAPSYM_ID: u32 = 76;
+/// `<symbol>`.
+pub const ELEM_SYMBOL_ID: u32 = 6;
+/// `<equatesymbol>`.
+pub const ELEM_EQUATESYMBOL_ID: u32 = 69;
+/// `<hash>` (a dynamic SymbolEntry).
+pub const ELEM_HASH_ID: u32 = 73;
+/// `<highlist>` (funcdata.cc vocabulary).
+pub const ELEM_HIGHLIST_ID: u32 = 117;
+/// `<high>` (variable.cc vocabulary).
+pub const ELEM_HIGH_ID: u32 = 82;
+/// `<jumptablelist>`.
+pub const ELEM_JUMPTABLELIST_ID: u32 = 118;
+/// `<jumptable>`.
+pub const ELEM_JUMPTABLE_ID: u32 = 213;
+/// `<dest>` (one switch case target).
+pub const ELEM_DEST_ID: u32 = 212;
+/// `<loadtable>` (jumpload-collected memory reads).
+pub const ELEM_LOADTABLE_ID: u32 = 214;
+/// `<prototype>` (fspec.cc vocabulary).
+pub const ELEM_PROTOTYPE_ID: u32 = 169;
+/// `<returnsym>`.
+pub const ELEM_RETURNSYM_ID: u32 = 172;
+/// `<typeref>` (type.cc vocabulary).
+pub const ELEM_TYPEREF_ID: u32 = 63;
+/// `<def>` (a typedef).
+pub const ELEM_DEF_ID: u32 = 43;
+/// `<void>`.
+pub const ELEM_VOID_ID: u32 = 10;
+/// `<override>` (Java-skipped).
+pub const ELEM_OVERRIDE_ID: u32 = 223;
+/// `<parammeasures>` (paramid.cc vocabulary).
+pub const ELEM_PARAMMEASURES_ID: u32 = 106;
+/// `<rank>` — REQUIRED per measure (ParamMeasure.decode throws).
+pub const ELEM_RANK_ID: u32 = 108;
+/// `<input>` / `<output>` measure wrappers.
+pub const ELEM_INPUT_ID: u32 = 2;
+pub const ELEM_OUTPUT_ID: u32 = 4;
+/// symbol/scope `id` attribute.
+pub const ATTRIB_ID_ID: u32 = 9;
+/// symbol `cat` (signed; -1 none, 0 parameter).
+pub const ATTRIB_CAT_ID: u32 = 61;
+/// symbol `index` (the parameter slot).
+pub const ATTRIB_INDEX_ID: u32 = 10;
+/// high `class`.
+pub const ATTRIB_CLASS_ID: u32 = 66;
+/// high `repref`.
+pub const ATTRIB_REPREF_ID: u32 = 67;
+/// high/vardecl `symref`.
+pub const ATTRIB_SYMREF_ID: u32 = 68;
+/// prototype `model`.
+pub const ATTRIB_MODEL_ID: u32 = 13;
+/// prototype `extrapop`.
+pub const ATTRIB_EXTRAPOP_ID: u32 = 6;
+/// `Symbol::ID_BASE` — the internal symbol-id range marker (top byte 0x40).
+pub const SYMBOL_ID_BASE_TOP: u64 = 0x40;
+/// range `first` attribute (address.rs).
+pub const ATTRIB_FIRST_ID: u32 = 27;
+
+/// One decoded `<localdb>` `<mapsym>` (what `HighSymbol.decodeMapSym` sees).
+#[derive(Debug)]
+pub struct SimSymbol {
+    /// `<symbol id>` — MUST be nonzero (`HighSymbol.decodeHeader` throws).
+    pub id: u64,
+    /// `cat` (-1 none, 0 parameter).
+    pub cat: i64,
+    /// `index` when cat >= 0.
+    pub index: Option<u64>,
+    /// The symbol's name.
+    pub name: String,
+    /// Number of SymbolEntry pairs — MUST be >= 1 (`insertSymbol` NPEs on 0).
+    pub entries: usize,
+    /// Whether every entry carried its uselimit `<rangelist>`.
+    pub entries_have_rangelists: bool,
+    /// The `<symbol>` body carried a type child (`<type>`/`<typeref>`/`<def>`).
+    pub has_type: bool,
+    /// The type child's `size` attribute (Java derives the SymbolEntry size
+    /// from the data-type; the `<addr>` itself is unsized, database.cc:196).
+    /// A `<typeref>` carries no size unless variable-length — see `type_name`.
+    pub type_size: Option<i64>,
+    /// The type child's `name` attribute.
+    pub type_name: Option<String>,
+    /// The first mapped entry's storage `(space name, offset)`.
+    pub entry_storage: Option<(String, u64)>,
+    /// The first entry's uselimit start (`<range first>`), when non-empty.
+    pub first_use: Option<u64>,
+}
+
+/// One decoded `<high>` (what `HighFunction.decodeHigh` sees).
+#[derive(Debug)]
+pub struct SimHigh {
+    /// `class` — REQUIRED, one of other/global/constant/param/local.
+    pub class: String,
+    /// `repref` — must resolve in the `<ast>` (decodeInstances throws).
+    pub repref: Option<u64>,
+    /// `symref` — REQUIRED for local/param (HighLocal.decode throws).
+    pub symref: Option<u64>,
+}
+
+/// The decoded `<prototype>` header (what `FunctionPrototype.decodePrototype`
+/// requires).
+#[derive(Debug)]
+pub struct SimProto {
+    /// `model` attribute value.
+    pub model: String,
+    /// `extrapop` attribute present (int or "unknown").
+    pub has_extrapop: bool,
+    /// `<returnsym>` with an `<addr>` first child then a data-type child.
+    pub returnsym_ok: bool,
+}
+
 /// The 19 legal callback-query command element ids (ids.rs 239..=257).
 pub const QUERY_COMMAND_IDS: std::ops::RangeInclusive<u32> = 239..=257;
 
@@ -529,11 +654,33 @@ pub struct ParsedDoc {
     /// `unsigned_long__`).  Zero once the markup emitter splits declarators
     /// into base-type + syntax tokens (PR-C).
     pub mangled_tokens: usize,
+    // --- Phase-4 first-<function> children ---------------------------------
+    /// The `<function>` child element ids in stream order (the Java decode is
+    /// order-sensitive: localdb before highlist, ast before highlist).
+    pub function_child_ids: Vec<u32>,
+    /// `<localdb>` present, with the decoded `<mapsym>` symbols.
+    pub localdb: Option<Vec<SimSymbol>>,
+    /// The `<scope>`'s first two child element ids (POSITIONALLY parent +
+    /// rangelist — `LocalSymbolMap.decodeScope` skips them blind).
+    pub scope_prefix: Vec<u32>,
+    /// `<highlist>` present, with the decoded `<high>` headers.
+    pub highlist: Option<Vec<SimHigh>>,
+    /// `<prototype>` header when present.
+    pub prototype: Option<SimProto>,
+    /// Per `<jumptable>`: (dest count, loadtable count).
+    pub jumptables: Vec<(usize, usize)>,
+    /// `<parammeasures>` when present: per-measure (is_input, has_rank).
+    pub parammeasures: Option<Vec<(bool, bool)>>,
+    /// Whether the first `<function>` was present at all (a parammeasures-only
+    /// paramid doc has none).
+    pub has_function: bool,
 }
 
-/// Decode a `decompileAt` `<doc>` payload: the first `<function>`'s name/entry
-/// echo + `<ast>` refs, and the second (markup) `<function>` flattened to C
-/// with its opref/varref sets.
+/// Decode a `decompileAt` `<doc>` payload: an optional `<parammeasures>`, the
+/// first `<function>` (name/entry echo, `<ast>` refs, and the Phase-4
+/// `<localdb>`/`<highlist>`/`<prototype>`/`<jumptablelist>` children), and the
+/// second (markup) `<function>` flattened to C with its opref/varref sets —
+/// dispatching exactly like `DecompileResults.decodeStream`.
 pub fn parse_decompile_doc(doc: &[u8], manager: &AddrSpaceManager) -> ParsedDoc {
     let mut parsed = ParsedDoc::default();
     let mut dec = PackedDecode::new(manager);
@@ -541,16 +688,52 @@ pub fn parse_decompile_doc(doc: &[u8], manager: &AddrSpaceManager) -> ParsedDoc 
     let did = dec.open_element().expect("open <doc>");
     assert_eq!(did, ELEM_DOC.get_id(), "root is not <doc>");
 
-    // --- the first <function>: the Funcdata::encode <function>/<ast> ---
-    let fid = dec.open_element().expect("open <function>");
-    assert_eq!(fid, ELEM_FUNCTION_ID, "first child of <doc> is not <function>");
+    loop {
+        let c = dec.peek_element().expect("peek <doc> child");
+        if c == 0 {
+            break;
+        }
+        if c == ELEM_PARAMMEASURES_ID {
+            let pid = dec.open_element().expect("open <parammeasures>");
+            parse_parammeasures(&mut dec, &mut parsed);
+            dec.close_element(pid).expect("close <parammeasures>");
+        } else if c == ELEM_FUNCTION_ID && !parsed.has_function {
+            let fid = dec.open_element().expect("open <function>");
+            parsed.has_function = true;
+            parse_first_function(&mut dec, &mut parsed);
+            dec.close_element(fid).expect("close <function>");
+        } else if c == ELEM_FUNCTION_ID {
+            // --- the second <function>: the Clang token markup ---
+            parsed.has_markup = true;
+            let mid = dec.open_element().expect("open markup <function>");
+            let mut refs = BTreeMap::new();
+            let mut ctext = String::new();
+            let mut mangled = 0usize;
+            flatten_markup(&mut dec, mid, &mut ctext, &mut refs, &mut mangled)
+                .expect("flatten markup <function>");
+            dec.close_element(mid).expect("close markup <function>");
+            parsed.markup_oprefs = refs.get(&ATTRIB_OPREF_ID).cloned().unwrap_or_default();
+            parsed.markup_varrefs = refs.get(&ATTRIB_VARREF_ID).cloned().unwrap_or_default();
+            parsed.c_text = ctext;
+            parsed.mangled_tokens = mangled;
+        } else {
+            // Java: "Unknown decompiler tag" — the whole result is discarded.
+            panic!("unknown <doc> child element id {c}");
+        }
+    }
+    dec.close_element(did).expect("close <doc>");
+    parsed
+}
+
+/// The first `<function>`: name/entry + the child walk (opened by the caller).
+fn parse_first_function(dec: &mut PackedDecode, parsed: &mut ParsedDoc) {
     parsed.name = String::from_utf8_lossy(
         &dec.read_string_id(&ATTRIB_NAME).expect("<function name>"),
     )
     .into_owned();
     // The base address is the first child element.
     if dec.peek_element().expect("peek in <function>") == ELEM_ADDR.get_id() {
-        let addr = Address::decode(&mut dec).expect("<function> base <addr>");
+        let addr = Address::decode(dec).expect("<function> base <addr>");
         parsed.entry_offset = Some(addr.get_offset());
     }
     // Walk the remaining children selectively: inside `<ast>`, varnode
@@ -562,8 +745,9 @@ pub fn parse_decompile_doc(doc: &[u8], manager: &AddrSpaceManager) -> ParsedDoc 
             break;
         }
         let cid = dec.open_element().expect("open <function> child");
+        parsed.function_child_ids.push(cid);
         if cid == ELEM_AST_ID {
-            skip_attributes(&mut dec).expect("<ast> attributes");
+            skip_attributes(dec).expect("<ast> attributes");
             loop {
                 let a = dec.peek_element().expect("peek <ast> child");
                 if a == 0 {
@@ -572,44 +756,438 @@ pub fn parse_decompile_doc(doc: &[u8], manager: &AddrSpaceManager) -> ParsedDoc 
                 let aid = dec.open_element().expect("open <ast> child");
                 let mut got = BTreeMap::new();
                 if aid == ELEM_VARNODES_ID {
-                    walk(&mut dec, &[ATTRIB_REF_ID], &mut got).expect("walk <varnodes>");
+                    walk(dec, &[ATTRIB_REF_ID], &mut got).expect("walk <varnodes>");
                     parsed
                         .ast_var_refs
                         .extend(got.get(&ATTRIB_REF_ID).cloned().unwrap_or_default());
                 } else {
-                    walk(&mut dec, &[ATTRIB_UNIQ_ID], &mut got).expect("walk <ast> child");
+                    walk(dec, &[ATTRIB_UNIQ_ID], &mut got).expect("walk <ast> child");
                     parsed
                         .ast_op_times
                         .extend(got.get(&ATTRIB_UNIQ_ID).cloned().unwrap_or_default());
                 }
                 dec.close_element(aid).expect("close <ast> child");
             }
-        } else {
-            // Some other (future: localdb/prototype/…) child: skip through.
+        } else if cid == ELEM_LOCALDB_ID {
+            parse_localdb(dec, parsed);
+        } else if cid == ELEM_HIGHLIST_ID {
+            parse_highlist(dec, parsed);
+        } else if cid == ELEM_PROTOTYPE_ID {
+            parse_prototype(dec, parsed);
+        } else if cid == ELEM_JUMPTABLELIST_ID {
+            parse_jumptablelist(dec, parsed);
+        } else if cid == ELEM_OVERRIDE_ID || cid == ELEM_SCOPE_ID {
+            // Java skips both.
             let mut sink = BTreeMap::new();
-            walk(&mut dec, &[], &mut sink).expect("walk <function> child");
+            walk(dec, &[], &mut sink).expect("walk skipped <function> child");
+        } else {
+            // HighFunction.decode: "Unknown element in function" — hard throw.
+            panic!("unknown <function> child element id {cid}");
         }
         dec.close_element(cid).expect("close <function> child");
     }
-    dec.close_element(fid).expect("close <function>");
+}
 
-    // --- the second <function>: the Clang token markup ---
-    if dec.peek_element().expect("peek after <function>") == ELEM_FUNCTION_ID {
-        parsed.has_markup = true;
-        let mid = dec.open_element().expect("open markup <function>");
-        let mut refs = BTreeMap::new();
-        let mut c = String::new();
-        let mut mangled = 0usize;
-        flatten_markup(&mut dec, mid, &mut c, &mut refs, &mut mangled)
-            .expect("flatten markup <function>");
-        dec.close_element(mid).expect("close markup <function>");
-        parsed.markup_oprefs = refs.get(&ATTRIB_OPREF_ID).cloned().unwrap_or_default();
-        parsed.markup_varrefs = refs.get(&ATTRIB_VARREF_ID).cloned().unwrap_or_default();
-        parsed.c_text = c;
-        parsed.mangled_tokens = mangled;
+/// `<localdb>` (opened): `<scope>` whose first two children are positionally
+/// `<parent>` + `<rangelist>`, then `<symbollist>` of `<mapsym>`s.
+fn parse_localdb(dec: &mut PackedDecode, parsed: &mut ParsedDoc) {
+    skip_attributes(dec).expect("<localdb> attributes");
+    let mut symbols: Vec<SimSymbol> = Vec::new();
+    while dec.peek_element().expect("peek <localdb> child") != 0 {
+        let sid = dec.open_element().expect("open <localdb> child");
+        if sid != ELEM_SCOPE_ID {
+            let mut sink = BTreeMap::new();
+            walk(dec, &[], &mut sink).expect("walk non-scope localdb child");
+            dec.close_element(sid).expect("close non-scope localdb child");
+            continue;
+        }
+        skip_attributes(dec).expect("<scope> attributes");
+        // Record the first two child element ids (the blind positional skip).
+        let mut child_pos = 0usize;
+        while dec.peek_element().expect("peek <scope> child") != 0 {
+            let cid = dec.open_element().expect("open <scope> child");
+            if child_pos < 2 {
+                parsed.scope_prefix.push(cid);
+            }
+            child_pos += 1;
+            if cid == ELEM_SYMBOLLIST_ID {
+                while dec.peek_element().expect("peek <symbollist> child") != 0 {
+                    let ms = dec.open_element().expect("open <mapsym>");
+                    assert_eq!(ms, ELEM_MAPSYM_ID, "<symbollist> child is not <mapsym>");
+                    symbols.push(parse_mapsym(dec));
+                    dec.close_element(ms).expect("close <mapsym>");
+                }
+            } else {
+                let mut sink = BTreeMap::new();
+                walk(dec, &[], &mut sink).expect("walk <scope> child");
+            }
+            dec.close_element(cid).expect("close <scope> child");
+        }
+        dec.close_element(sid).expect("close <scope>");
     }
-    dec.close_element(did).expect("close <doc>");
-    parsed
+    parsed.localdb = Some(symbols);
+}
+
+/// One `<mapsym>` (opened): the `<symbol>`/`<equatesymbol>` header + the
+/// SymbolEntry pairs ((`<addr>`|`<hash>`) + `<rangelist>`).
+fn parse_mapsym(dec: &mut PackedDecode) -> SimSymbol {
+    skip_attributes(dec).expect("<mapsym> attributes");
+    let mut sym = SimSymbol {
+        id: 0,
+        cat: -1,
+        index: None,
+        name: String::new(),
+        entries: 0,
+        entries_have_rangelists: true,
+        has_type: false,
+        type_size: None,
+        type_name: None,
+        entry_storage: None,
+        first_use: None,
+    };
+    let mut pending_entry_needs_rangelist = false;
+    while dec.peek_element().expect("peek <mapsym> child") != 0 {
+        let cid = dec.open_element().expect("open <mapsym> child");
+        if cid == ELEM_SYMBOL_ID || cid == ELEM_EQUATESYMBOL_ID {
+            loop {
+                let aid = dec.get_next_attribute_id().expect("symbol attr");
+                if aid == 0 {
+                    break;
+                }
+                if aid == ATTRIB_ID_ID {
+                    sym.id = dec.read_unsigned_integer().expect("symbol id");
+                } else if aid == ATTRIB_CAT_ID {
+                    sym.cat = dec.read_signed_integer().expect("symbol cat");
+                } else if aid == ATTRIB_INDEX_ID {
+                    sym.index = Some(dec.read_unsigned_integer().expect("symbol index"));
+                } else if aid == ATTRIB_NAME.get_id() {
+                    sym.name = String::from_utf8_lossy(
+                        &dec.read_string().expect("symbol name"),
+                    )
+                    .into_owned();
+                }
+            }
+            // Body: the data-type child (plus <value> for an equate).
+            while dec.peek_element().expect("peek <symbol> child") != 0 {
+                let b = dec.open_element().expect("open <symbol> body child");
+                if b == ELEM_TYPE_ID || b == ELEM_TYPEREF_ID || b == ELEM_DEF_ID
+                    || b == ELEM_VOID_ID
+                {
+                    sym.has_type = true;
+                    if b == ELEM_TYPE_ID || b == ELEM_TYPEREF_ID {
+                        loop {
+                            let aid = dec.get_next_attribute_id().expect("type attr");
+                            if aid == 0 {
+                                break;
+                            }
+                            if aid == kuna_base::marshal::ATTRIB_SIZE.get_id() {
+                                sym.type_size =
+                                    Some(dec.read_signed_integer().expect("type size"));
+                            } else if aid == ATTRIB_NAME.get_id() {
+                                sym.type_name = Some(
+                                    String::from_utf8_lossy(
+                                        &dec.read_string().expect("type name"),
+                                    )
+                                    .into_owned(),
+                                );
+                            }
+                        }
+                    }
+                }
+                let mut sink = BTreeMap::new();
+                walk(dec, &[], &mut sink).expect("walk <symbol> body child");
+                dec.close_element(b).expect("close <symbol> body child");
+            }
+        } else if cid == ELEM_ADDR_ID || cid == ELEM_HASH_ID {
+            sym.entries += 1;
+            if pending_entry_needs_rangelist {
+                sym.entries_have_rangelists = false; // previous entry had none
+            }
+            pending_entry_needs_rangelist = true;
+            if cid == ELEM_ADDR_ID && sym.entry_storage.is_none() {
+                // Capture (space, offset) of the first mapped entry (the
+                // <addr> is unsized; the size comes from the type child).
+                let (mut spc, mut off) = (None, 0u64);
+                loop {
+                    let aid = dec.get_next_attribute_id().expect("entry attr");
+                    if aid == 0 {
+                        break;
+                    }
+                    if aid == kuna_base::marshal::ATTRIB_SPACE.get_id() {
+                        spc = dec.read_space().ok();
+                    } else if aid == kuna_base::marshal::ATTRIB_OFFSET.get_id() {
+                        off = dec.read_unsigned_integer().expect("entry offset");
+                    }
+                }
+                if let Some(s) = spc {
+                    sym.entry_storage = Some((s.get_name().to_string(), off));
+                }
+            }
+            let mut sink = BTreeMap::new();
+            walk(dec, &[], &mut sink).expect("walk entry");
+        } else if cid == ELEM_RANGELIST_ID {
+            pending_entry_needs_rangelist = false;
+            if sym.first_use.is_none() {
+                let mut got = BTreeMap::new();
+                walk(dec, &[ATTRIB_FIRST_ID], &mut got).expect("walk entry rangelist");
+                sym.first_use =
+                    got.get(&ATTRIB_FIRST_ID).and_then(|s| s.iter().next().copied());
+            } else {
+                let mut sink = BTreeMap::new();
+                walk(dec, &[], &mut sink).expect("walk entry rangelist");
+            }
+        } else {
+            let mut sink = BTreeMap::new();
+            walk(dec, &[], &mut sink).expect("walk unknown mapsym child");
+        }
+        dec.close_element(cid).expect("close <mapsym> child");
+    }
+    if pending_entry_needs_rangelist {
+        sym.entries_have_rangelists = false;
+    }
+    sym
+}
+
+/// `<highlist>` (opened): the `<high>` headers.
+fn parse_highlist(dec: &mut PackedDecode, parsed: &mut ParsedDoc) {
+    skip_attributes(dec).expect("<highlist> attributes");
+    let mut highs: Vec<SimHigh> = Vec::new();
+    while dec.peek_element().expect("peek <highlist> child") != 0 {
+        let hid = dec.open_element().expect("open <high>");
+        assert_eq!(hid, ELEM_HIGH_ID, "<highlist> child is not <high>");
+        let mut h = SimHigh { class: String::new(), repref: None, symref: None };
+        loop {
+            let aid = dec.get_next_attribute_id().expect("high attr");
+            if aid == 0 {
+                break;
+            }
+            if aid == ATTRIB_CLASS_ID {
+                h.class = String::from_utf8_lossy(&dec.read_string().expect("high class"))
+                    .into_owned();
+            } else if aid == ATTRIB_REPREF_ID {
+                h.repref = Some(dec.read_unsigned_integer().expect("high repref"));
+            } else if aid == ATTRIB_SYMREF_ID {
+                h.symref = Some(dec.read_unsigned_integer().expect("high symref"));
+            }
+        }
+        let mut sink = BTreeMap::new();
+        walk(dec, &[], &mut sink).expect("walk <high> children");
+        dec.close_element(hid).expect("close <high>");
+        highs.push(h);
+    }
+    parsed.highlist = Some(highs);
+}
+
+/// `<prototype>` (opened): the model/extrapop header + the `<returnsym>`.
+fn parse_prototype(dec: &mut PackedDecode, parsed: &mut ParsedDoc) {
+    let mut proto = SimProto { model: String::new(), has_extrapop: false, returnsym_ok: false };
+    loop {
+        let aid = dec.get_next_attribute_id().expect("prototype attr");
+        if aid == 0 {
+            break;
+        }
+        if aid == ATTRIB_MODEL_ID {
+            proto.model =
+                String::from_utf8_lossy(&dec.read_string().expect("prototype model")).into_owned();
+        } else if aid == ATTRIB_EXTRAPOP_ID {
+            proto.has_extrapop = true;
+        }
+    }
+    while dec.peek_element().expect("peek <prototype> child") != 0 {
+        let cid = dec.open_element().expect("open <prototype> child");
+        if cid == ELEM_RETURNSYM_ID {
+            // FunctionPrototype.decodePrototype: <addr> first child, then a
+            // data-type child.
+            skip_attributes(dec).expect("<returnsym> attributes");
+            let mut saw_addr = false;
+            let mut saw_type = false;
+            let mut first = true;
+            while dec.peek_element().expect("peek <returnsym> child") != 0 {
+                let b = dec.open_element().expect("open <returnsym> child");
+                if first {
+                    saw_addr = b == ELEM_ADDR_ID;
+                    first = false;
+                } else if b == ELEM_TYPE_ID
+                    || b == ELEM_TYPEREF_ID
+                    || b == ELEM_DEF_ID
+                    || b == ELEM_VOID_ID
+                {
+                    saw_type = true;
+                }
+                let mut sink = BTreeMap::new();
+                walk(dec, &[], &mut sink).expect("walk <returnsym> child");
+                dec.close_element(b).expect("close <returnsym> child");
+            }
+            proto.returnsym_ok = saw_addr && saw_type;
+        } else {
+            // Effect lists / likelytrash / inject / internallist: Java skips.
+            let mut sink = BTreeMap::new();
+            walk(dec, &[], &mut sink).expect("walk <prototype> child");
+        }
+        dec.close_element(cid).expect("close <prototype> child");
+    }
+    parsed.prototype = Some(proto);
+}
+
+/// `<jumptablelist>` (opened): per `<jumptable>` the dest/loadtable counts.
+fn parse_jumptablelist(dec: &mut PackedDecode, parsed: &mut ParsedDoc) {
+    skip_attributes(dec).expect("<jumptablelist> attributes");
+    while dec.peek_element().expect("peek <jumptablelist> child") != 0 {
+        let jid = dec.open_element().expect("open <jumptable>");
+        assert_eq!(jid, ELEM_JUMPTABLE_ID, "<jumptablelist> child is not <jumptable>");
+        skip_attributes(dec).expect("<jumptable> attributes");
+        let mut dests = 0usize;
+        let mut loads = 0usize;
+        while dec.peek_element().expect("peek <jumptable> child") != 0 {
+            let cid = dec.open_element().expect("open <jumptable> child");
+            if cid == ELEM_DEST_ID {
+                dests += 1;
+            } else if cid == ELEM_LOADTABLE_ID {
+                loads += 1;
+            }
+            let mut sink = BTreeMap::new();
+            walk(dec, &[], &mut sink).expect("walk <jumptable> child");
+            dec.close_element(cid).expect("close <jumptable> child");
+        }
+        parsed.jumptables.push((dests, loads));
+        dec.close_element(jid).expect("close <jumptable>");
+    }
+}
+
+/// `<parammeasures>` (opened): per input/output measure, whether the REQUIRED
+/// `<rank>` child is present.
+fn parse_parammeasures(dec: &mut PackedDecode, parsed: &mut ParsedDoc) {
+    skip_attributes(dec).expect("<parammeasures> attributes");
+    let mut measures: Vec<(bool, bool)> = Vec::new();
+    while dec.peek_element().expect("peek <parammeasures> child") != 0 {
+        let cid = dec.open_element().expect("open <parammeasures> child");
+        if cid == ELEM_INPUT_ID || cid == ELEM_OUTPUT_ID {
+            let is_input = cid == ELEM_INPUT_ID;
+            skip_attributes(dec).expect("measure attributes");
+            let mut has_rank = false;
+            while dec.peek_element().expect("peek measure child") != 0 {
+                let b = dec.open_element().expect("open measure child");
+                if b == ELEM_RANK_ID {
+                    has_rank = true;
+                }
+                let mut sink = BTreeMap::new();
+                walk(dec, &[], &mut sink).expect("walk measure child");
+                dec.close_element(b).expect("close measure child");
+            }
+            measures.push((is_input, has_rank));
+        } else {
+            // <addr> / <proto>.
+            let mut sink = BTreeMap::new();
+            walk(dec, &[], &mut sink).expect("walk <parammeasures> child");
+        }
+        dec.close_element(cid).expect("close <parammeasures> child");
+    }
+    parsed.parammeasures = Some(measures);
+}
+
+/// The Phase-4 Java hard-throw traps (r5 §3), asserted the way the Java
+/// consumers would fail: one violation would discard the WHOLE decompile
+/// result in the GUI.
+pub fn assert_phase4_traps(parsed: &ParsedDoc, label: &str) {
+    // Child order: localdb before highlist, ast before highlist.
+    let pos = |id: u32| parsed.function_child_ids.iter().position(|&c| c == id);
+    if let Some(hpos) = pos(ELEM_HIGHLIST_ID) {
+        let lpos = pos(ELEM_LOCALDB_ID)
+            .unwrap_or_else(|| panic!("{label}: <highlist> present without <localdb>"));
+        assert!(lpos < hpos, "{label}: <localdb> must precede <highlist>");
+        let apos = pos(ELEM_AST_ID)
+            .unwrap_or_else(|| panic!("{label}: <highlist> present without <ast>"));
+        assert!(apos < hpos, "{label}: <ast> must precede <highlist>");
+    }
+    // The scope's first two children are positionally <parent> + <rangelist>.
+    if parsed.localdb.is_some() {
+        assert_eq!(
+            parsed.scope_prefix,
+            vec![ELEM_PARENT_ID, ELEM_RANGELIST_ID],
+            "{label}: <scope> must open with <parent> then <rangelist> \
+             (LocalSymbolMap.decodeScope skips both blind)"
+        );
+    }
+    // Symbols: nonzero ids, >=1 entry with rangelists, cat-0 carries an index,
+    // every symbol has a type child.
+    let mut localdb_ids: BTreeSet<u64> = BTreeSet::new();
+    if let Some(symbols) = &parsed.localdb {
+        for s in symbols {
+            assert_ne!(
+                s.id, 0,
+                "{label}: <symbol {}> id 0 — HighSymbol.decodeHeader throws",
+                s.name
+            );
+            assert!(
+                s.entries >= 1,
+                "{label}: <mapsym {}> has no SymbolEntry — insertSymbol NPEs",
+                s.name
+            );
+            assert!(
+                s.entries_have_rangelists,
+                "{label}: <mapsym {}> entry missing its uselimit <rangelist>",
+                s.name
+            );
+            assert!(s.has_type, "{label}: <symbol {}> carries no data-type child", s.name);
+            if s.cat == 0 {
+                assert!(
+                    s.index.is_some(),
+                    "{label}: cat-0 <symbol {}> without an index — the param slot \
+                     sort (and the rename full-commit guard) needs it",
+                    s.name
+                );
+            }
+            localdb_ids.insert(s.id);
+        }
+    }
+    // Highs: legal class vocabulary; local/param symrefs resolve in the
+    // just-decoded localdb; reprefs resolve in the just-decoded ast.
+    if let Some(highs) = &parsed.highlist {
+        for h in highs {
+            assert!(
+                matches!(h.class.as_str(), "other" | "global" | "constant" | "param" | "local"),
+                "{label}: unknown <high> class '{}'",
+                h.class
+            );
+            let repref = h
+                .repref
+                .unwrap_or_else(|| panic!("{label}: <high> without repref"));
+            assert!(
+                parsed.ast_var_refs.contains(&repref),
+                "{label}: <high repref={repref}> not declared in <ast> varnodes \
+                 (decodeInstances throws)"
+            );
+            if h.class == "local" || h.class == "param" {
+                let symref = h.symref.unwrap_or_else(|| {
+                    panic!("{label}: <high class={}> without symref (HighLocal throws)", h.class)
+                });
+                assert!(
+                    localdb_ids.contains(&symref),
+                    "{label}: <high class={} symref={symref}> not present in <localdb> \
+                     — 'HighLocal is missing symbol'",
+                    h.class
+                );
+            }
+        }
+    }
+    // Prototype: model + extrapop + returnsym(addr+type).
+    if let Some(p) = &parsed.prototype {
+        assert!(!p.model.is_empty(), "{label}: <prototype> without model");
+        assert!(p.has_extrapop, "{label}: <prototype> without extrapop");
+        assert!(
+            p.returnsym_ok,
+            "{label}: <returnsym> must carry <addr> first then a data-type child"
+        );
+    }
+    // Parammeasures: the <rank> child is REQUIRED per measure.
+    if let Some(measures) = &parsed.parammeasures {
+        for (i, (_is_input, has_rank)) in measures.iter().enumerate() {
+            assert!(
+                has_rank,
+                "{label}: parammeasures measure #{i} without <rank> (ParamMeasure.decode throws)"
+            );
+        }
+    }
 }
 
 /// Ordered flatten of the (already-opened) markup element: append every

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim/mod.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim/mod.rs
@@ -77,6 +77,10 @@ pub const ELEM_VARIABLE_ID: u32 = 26;
 pub const ELEM_FIELD_ID: u32 = 49;
 /// `<type>` (type.cc vocabulary) → Java ClangTypeToken.
 pub const ELEM_TYPE_ID: u32 = 60;
+/// `<vardecl>` (prettyprint.rs) → Java ClangVariableDecl, whose `symref` MUST
+/// resolve in the decoded LocalSymbolMap or declaration-line rename/retype is
+/// dead (and Java logs "Invalid symbol reference" per declaration).
+pub const ELEM_VARDECL_ID: u32 = 25;
 /// `ClangToken.CONST_COLOR` (== `SyntaxHighlight::ConstColor`).
 pub const CONST_COLOR: u64 = 5;
 
@@ -176,10 +180,15 @@ pub struct SimSymbol {
     pub type_size: Option<i64>,
     /// The type child's `name` attribute.
     pub type_name: Option<String>,
+    /// The symbol's data-type body was `<void/>` — a 0-sized type, which
+    /// `MappedEntry.decode` rejects.
+    pub type_is_void: bool,
     /// The first mapped entry's storage `(space name, offset)`.
     pub entry_storage: Option<(String, u64)>,
     /// The first entry's uselimit start (`<range first>`), when non-empty.
     pub first_use: Option<u64>,
+    /// The `<hash val>` of a DYNAMIC entry (0 = mapped storage).
+    pub hash: u64,
 }
 
 /// One decoded `<high>` (what `HighFunction.decodeHigh` sees).
@@ -674,6 +683,15 @@ pub struct ParsedDoc {
     /// Whether the first `<function>` was present at all (a parammeasures-only
     /// paramid doc has none).
     pub has_function: bool,
+    /// Every `<vardecl symref>` in the markup — each SHOULD resolve against
+    /// the `<localdb>` ids (Java `ClangVariableDecl.decode` →
+    /// `pfactory.getSymbol(symref)`); an unresolvable one leaves
+    /// rename/retype dead on that declaration line and logs once per
+    /// decompile.
+    pub vardecl_symrefs: BTreeSet<u64>,
+    /// How many of them do NOT resolve (the create-index fallback) — pinned,
+    /// so the systemic case stays fixed and the residue can only shrink.
+    pub vardecl_symref_unresolved: usize,
 }
 
 /// Decode a `decompileAt` `<doc>` payload: an optional `<parammeasures>`, the
@@ -714,6 +732,7 @@ pub fn parse_decompile_doc(doc: &[u8], manager: &AddrSpaceManager) -> ParsedDoc 
             dec.close_element(mid).expect("close markup <function>");
             parsed.markup_oprefs = refs.get(&ATTRIB_OPREF_ID).cloned().unwrap_or_default();
             parsed.markup_varrefs = refs.get(&ATTRIB_VARREF_ID).cloned().unwrap_or_default();
+            parsed.vardecl_symrefs = refs.get(&ATTRIB_SYMREF_ID).cloned().unwrap_or_default();
             parsed.c_text = ctext;
             parsed.mangled_tokens = mangled;
         } else {
@@ -842,8 +861,10 @@ fn parse_mapsym(dec: &mut PackedDecode) -> SimSymbol {
         has_type: false,
         type_size: None,
         type_name: None,
+        type_is_void: false,
         entry_storage: None,
         first_use: None,
+        hash: 0,
     };
     let mut pending_entry_needs_rangelist = false;
     while dec.peek_element().expect("peek <mapsym> child") != 0 {
@@ -874,6 +895,9 @@ fn parse_mapsym(dec: &mut PackedDecode) -> SimSymbol {
                     || b == ELEM_VOID_ID
                 {
                     sym.has_type = true;
+                    if b == ELEM_VOID_ID {
+                        sym.type_is_void = true;
+                    }
                     if b == ELEM_TYPE_ID || b == ELEM_TYPEREF_ID {
                         loop {
                             let aid = dec.get_next_attribute_id().expect("type attr");
@@ -900,6 +924,11 @@ fn parse_mapsym(dec: &mut PackedDecode) -> SimSymbol {
             }
         } else if cid == ELEM_ADDR_ID || cid == ELEM_HASH_ID {
             sym.entries += 1;
+            if cid == ELEM_HASH_ID && sym.hash == 0 {
+                sym.hash = dec
+                    .read_unsigned_integer_id(&kuna_base::marshal::ATTRIB_VAL)
+                    .unwrap_or(0);
+            }
             if pending_entry_needs_rangelist {
                 sym.entries_have_rangelists = false; // previous entry had none
             }
@@ -1085,10 +1114,27 @@ fn parse_parammeasures(dec: &mut PackedDecode, parsed: &mut ParsedDoc) {
     parsed.parammeasures = Some(measures);
 }
 
+/// Count `<vardecl symref>`s that do NOT resolve against the document's own
+/// `<localdb>` ids (the create-index fallback for a declaration whose high the
+/// analysis left symbol-less).
+pub fn vardecl_unresolved(parsed: &ParsedDoc) -> usize {
+    let ids: BTreeSet<u64> = parsed
+        .localdb
+        .as_ref()
+        .map(|syms| syms.iter().map(|s| s.id).collect())
+        .unwrap_or_default();
+    parsed
+        .vardecl_symrefs
+        .iter()
+        .filter(|sr| !ids.contains(*sr))
+        .count()
+}
+
 /// The Phase-4 Java hard-throw traps (r5 §3), asserted the way the Java
 /// consumers would fail: one violation would discard the WHOLE decompile
 /// result in the GUI.
 pub fn assert_phase4_traps(parsed: &ParsedDoc, label: &str) {
+    let _ = &parsed.vardecl_symref_unresolved;
     // Child order: localdb before highlist, ast before highlist.
     let pos = |id: u32| parsed.function_child_ids.iter().position(|&c| c == id);
     if let Some(hpos) = pos(ELEM_HIGHLIST_ID) {
@@ -1129,6 +1175,14 @@ pub fn assert_phase4_traps(parsed: &ParsedDoc, label: &str) {
                 s.name
             );
             assert!(s.has_type, "{label}: <symbol {}> carries no data-type child", s.name);
+            // r5 §3 trap 4: `MappedEntry.decode` throws
+            // "Invalid symbol 0-sized data-type" — a `<void/>` body or an
+            // explicit size 0 is exactly that shape.
+            assert!(
+                s.type_size.map(|sz| sz > 0).unwrap_or(true) && !s.type_is_void,
+                "{label}: <symbol {}> has a 0-sized data-type (MappedEntry.decode throws)",
+                s.name
+            );
             if s.cat == 0 {
                 assert!(
                     s.index.is_some(),
@@ -1169,6 +1223,25 @@ pub fn assert_phase4_traps(parsed: &ParsedDoc, label: &str) {
                 );
             }
         }
+    }
+    // Every `<vardecl symref>` must resolve in the just-decoded `<localdb>`:
+    // an unresolvable one leaves declaration-line rename/retype dead and logs
+    // once per declaration per decompile.
+    if !parsed.vardecl_symrefs.is_empty() {
+        assert!(
+            !localdb_ids.is_empty(),
+            "{label}: declarations carry symrefs but the <localdb> has no symbols"
+        );
+        let resolved = parsed
+            .vardecl_symrefs
+            .iter()
+            .filter(|sr| localdb_ids.contains(*sr))
+            .count();
+        assert!(
+            resolved > 0,
+            "{label}: NO <vardecl symref> resolves against <localdb> — the \
+             declaration-line rename/retype contract is broken wholesale"
+        );
     }
     // Prototype: model + extrapop + returnsym(addr+type).
     if let Some(p) = &parsed.prototype {
@@ -1213,6 +1286,11 @@ fn flatten_markup(
         let aid = dec.get_next_attribute_id()?;
         if aid == 0 {
             break;
+        }
+        if aid == ATTRIB_SYMREF_ID && elem_id == ELEM_VARDECL_ID {
+            let v = dec.read_unsigned_integer()?;
+            refs.entry(ATTRIB_SYMREF_ID).or_default().insert(v);
+            continue;
         }
         if aid == ATTRIB_CONTENT.get_id() {
             content = Some(String::from_utf8_lossy(&dec.read_string()?).into_owned());

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim/oracle.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim/oracle.rs
@@ -146,6 +146,35 @@ pub struct SimOracle {
     /// served by the getTrackedRegisters answer — lets a test prove a
     /// host-side context fact changes the output.
     pub tracked_overrides: Vec<kuna_sleigh::globalcontext::TrackedContext>,
+    /// PHASE-4 SEAM (rename/retype persistence): host-committed non-parameter
+    /// locals served in the function's `<localdb>` (keyed by entry offset) —
+    /// the shape Java's `LocalSymbolMap.grabFromFunction` produces after
+    /// `HighFunctionDBUtil.updateDBVariable` wrote a user rename/retype to
+    /// the database.  Lets a test prove the GUI rename SURVIVES the
+    /// event-driven re-decompile.
+    pub local_var_overrides: BTreeMap<u64, Vec<HostLocalVar>>,
+}
+
+/// One host-committed local for [`SimOracle::local_var_overrides`].
+#[derive(Clone)]
+pub struct HostLocalVar {
+    /// The (user-chosen) name; served namelocked.
+    pub name: String,
+    /// Storage space name.
+    pub space: String,
+    /// Storage offset.
+    pub offset: u64,
+    /// Storage size in bytes.
+    pub size: i64,
+    /// First-use code offset (the uselimit rangelist start); `None` = an
+    /// address-tied (whole-function) local, served with an empty rangelist.
+    pub first_use: Option<u64>,
+    /// Served typelocked?  Java's `grabFromFunction` sends `typelock=false`
+    /// for an `Undefined`-typed DB local — the shape a plain GUI RENAME
+    /// produces (`updateDBVariable(name, null)`), which kuna must keep as a
+    /// name RECOMMENDATION; `true` is the retype shape (a real type), which
+    /// survives as a seeded Symbol.
+    pub typelock: bool,
 }
 
 impl SimOracle {
@@ -222,6 +251,7 @@ impl SimOracle {
             callee_pieces,
             readonly_ranges,
             tracked_overrides: Vec::new(),
+            local_var_overrides: BTreeMap::new(),
         })
     }
 
@@ -381,8 +411,15 @@ impl SimOracle {
                 e.write_bool(&ATTRIB_NORETURN, true);
             }
             entry.encode(&mut e).expect("entry addr encodes");
+            let locals = self
+                .local_var_overrides
+                .get(&entry.get_offset())
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]);
+            if pieces.is_some() || !locals.is_empty() {
+                self.encode_localdb(&mut e, name, pieces, locals);
+            }
             if let Some(p) = pieces {
-                self.encode_localdb(&mut e, name, p);
                 self.encode_prototype(&mut e, p);
             }
             e.close_element(&ELEM_FUNCTION);
@@ -398,8 +435,15 @@ impl SimOracle {
 
     /// `<localdb lock main><scope><parent id=0/><rangelist/><symbollist>` with
     /// one cat-0 `<mapsym><symbol>` per declared parameter (Java
-    /// `LocalSymbolMap.encodeLocalDb`).
-    fn encode_localdb(&self, e: &mut PackedEncode, fname: &str, pieces: &PrototypePieces) {
+    /// `LocalSymbolMap.encodeLocalDb`) plus one plain `<mapsym>` per
+    /// host-committed local override ([`HostLocalVar`]).
+    fn encode_localdb(
+        &self,
+        e: &mut PackedEncode,
+        fname: &str,
+        pieces: Option<&PrototypePieces>,
+        locals: &[HostLocalVar],
+    ) {
         let ram = self
             .manager
             .get_default_code_space()
@@ -416,6 +460,50 @@ impl SimOracle {
         e.open_element(&ELEM_RANGELIST);
         e.close_element(&ELEM_RANGELIST);
         e.open_element(&ELEM_SYMBOLLIST);
+        for l in locals {
+            let spc = self
+                .manager
+                .get_space_by_name(&l.space)
+                .unwrap_or_else(|| panic!("override space {}", l.space))
+                .clone();
+            e.open_element(&ELEM_MAPSYM);
+            e.open_element(&ELEM_SYMBOL);
+            // A stable fake host-database id (never internal-range).
+            e.write_unsigned_integer(&ATTRIB_ID, l.offset | 0x2_0000_0000);
+            e.write_string(&ATTRIB_NAME, l.name.as_bytes());
+            e.write_bool(&ATTRIB_TYPELOCK, l.typelock);
+            e.write_bool(&ATTRIB_NAMELOCK, true);
+            e.write_signed_integer(&ATTRIB_CAT, -1);
+            // A sized base type (metatype uint) — what grabFromFunction sends
+            // for a typed DB local.
+            e.open_element(&kuna_decomp::prettyprint::ids::ELEM_TYPE);
+            e.write_string(&ATTRIB_NAME, b"");
+            e.write_string(&kuna_base::marshal::ATTRIB_METATYPE, b"uint");
+            e.write_signed_integer(&ATTRIB_SIZE, l.size);
+            e.close_element(&kuna_decomp::prettyprint::ids::ELEM_TYPE);
+            e.close_element(&ELEM_SYMBOL);
+            // Storage entry: <addr space offset size/> + the uselimit.
+            e.open_element(&kuna_base::address::ELEM_ADDR);
+            spc.encode_attributes_sized(e, l.offset, l.size as i32)
+                .expect("override storage encodes");
+            e.close_element(&kuna_base::address::ELEM_ADDR);
+            e.open_element(&ELEM_RANGELIST);
+            if let Some(first) = l.first_use {
+                e.open_element(&kuna_base::address::ELEM_RANGE);
+                e.write_space(&kuna_base::marshal::ATTRIB_SPACE, &ram);
+                e.write_unsigned_integer(&kuna_base::address::ATTRIB_FIRST, first);
+                e.write_unsigned_integer(&kuna_base::address::ATTRIB_LAST, first);
+                e.close_element(&kuna_base::address::ELEM_RANGE);
+            }
+            e.close_element(&ELEM_RANGELIST);
+            e.close_element(&ELEM_MAPSYM);
+        }
+        let Some(pieces) = pieces else {
+            e.close_element(&ELEM_SYMBOLLIST);
+            e.close_element(&ELEM_SCOPE);
+            e.close_element(&ELEM_LOCALDB);
+            return;
+        };
         for (i, ct) in pieces.intypes.iter().enumerate() {
             e.open_element(&ELEM_MAPSYM);
             e.open_element(&ELEM_SYMBOL);

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim/oracle.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim/oracle.rs
@@ -169,6 +169,10 @@ pub struct HostLocalVar {
     /// First-use code offset (the uselimit rangelist start); `None` = an
     /// address-tied (whole-function) local, served with an empty rangelist.
     pub first_use: Option<u64>,
+    /// A DYNAMIC (hash) entry instead of `<addr>` storage — what Java writes
+    /// for every `requiresDynamicStorage` variable (unique-space
+    /// representatives, `splitOutMergeGroup` products).  0 = mapped storage.
+    pub hash: u64,
     /// Served typelocked?  Java's `grabFromFunction` sends `typelock=false`
     /// for an `Undefined`-typed DB local — the shape a plain GUI RENAME
     /// produces (`updateDBVariable(name, null)`), which kuna must keep as a
@@ -467,6 +471,9 @@ impl SimOracle {
                 .unwrap_or_else(|| panic!("override space {}", l.space))
                 .clone();
             e.open_element(&ELEM_MAPSYM);
+            if l.hash != 0 {
+                e.write_string(&kuna_base::marshal::ATTRIB_TYPE, b"dynamic");
+            }
             e.open_element(&ELEM_SYMBOL);
             // A stable fake host-database id (never internal-range).
             e.write_unsigned_integer(&ATTRIB_ID, l.offset | 0x2_0000_0000);
@@ -482,11 +489,18 @@ impl SimOracle {
             e.write_signed_integer(&ATTRIB_SIZE, l.size);
             e.close_element(&kuna_decomp::prettyprint::ids::ELEM_TYPE);
             e.close_element(&ELEM_SYMBOL);
-            // Storage entry: <addr space offset size/> + the uselimit.
-            e.open_element(&kuna_base::address::ELEM_ADDR);
-            spc.encode_attributes_sized(e, l.offset, l.size as i32)
-                .expect("override storage encodes");
-            e.close_element(&kuna_base::address::ELEM_ADDR);
+            // Storage entry: a DYNAMIC <hash val> or <addr space offset size/>,
+            // then the uselimit.
+            if l.hash != 0 {
+                e.open_element(&ELEM_HASH);
+                e.write_unsigned_integer(&ATTRIB_VAL, l.hash);
+                e.close_element(&ELEM_HASH);
+            } else {
+                e.open_element(&kuna_base::address::ELEM_ADDR);
+                spc.encode_attributes_sized(e, l.offset, l.size as i32)
+                    .expect("override storage encodes");
+                e.close_element(&kuna_base::address::ELEM_ADDR);
+            }
             e.open_element(&ELEM_RANGELIST);
             if let Some(first) = l.first_use {
                 e.open_element(&kuna_base::address::ELEM_RANGE);

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim_e2e.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim_e2e.rs
@@ -73,6 +73,8 @@ struct SessionRun {
     repeat_payload: Vec<u8>,
     /// Resolved target entry addresses (index-aligned with `docs`).
     addrs: Vec<Address>,
+    /// The response index of the first decompileAt (1 + the setAction count).
+    first_decompile: usize,
 }
 
 /// Bootstrap the oracle, drive the whole session, and split the output.
@@ -86,6 +88,19 @@ fn run_session(binary: &Path, targets: &[&str]) -> Option<SessionRun> {
 fn run_session_with(
     binary: &Path,
     targets: &[&str],
+    mutate: impl FnOnce(&mut SimOracle),
+) -> Option<SessionRun> {
+    run_session_config(binary, targets, &[("decompile", "c")], mutate)
+}
+
+/// [`run_session_with`] with an explicit setAction replay — the analyzer
+/// configurations replay several `(actionstring, printstring)` pairs
+/// (`DecompInterface.initializeProcess`), e.g. the switch analyzer's
+/// `("decompile","")+("","noc")+("","notree")+("","jumpload")`.
+fn run_session_config(
+    binary: &Path,
+    targets: &[&str],
+    actions: &[(&str, &str)],
     mutate: impl FnOnce(&mut SimOracle),
 ) -> Option<SessionRun> {
     let mut oracle = SimOracle::bootstrap(binary)?;
@@ -119,18 +134,20 @@ fn run_session_with(
         v
     };
 
-    // registerProgram, setAction, decompileAt × N, flushNative, decompileAt
-    // (target 0 again), deregisterProgram.
+    // registerProgram, setAction × A, decompileAt × N, flushNative,
+    // decompileAt (target 0 again), deregisterProgram.
     let mut commands = Vec::new();
     cmd_register_program(&mut commands, &pspec, &cspec, &tspec, coretypes);
-    cmd_set_action(&mut commands, "0", "decompile", "c");
+    for (action, printstring) in actions {
+        cmd_set_action(&mut commands, "0", action, printstring);
+    }
     for a in &addrs {
         cmd_decompile_at(&mut commands, "0", &packed_addr(a));
     }
     cmd_flush_native(&mut commands, "0");
     cmd_decompile_at(&mut commands, "0", &packed_addr(&addrs[0]));
     cmd_deregister_program(&mut commands, "0");
-    let n_commands = 2 + addrs.len() + 2 + 1;
+    let n_commands = 1 + actions.len() + addrs.len() + 2 + 1;
 
     let shared = Rc::new(RefCell::new(MockState::new(commands, oracle)));
     let reader = MockReader { shared: Rc::clone(&shared) };
@@ -168,8 +185,15 @@ fn run_session_with(
         reg.warnings
     );
     // setAction / flushNative / deregister accepted.
-    assert_eq!(trace.responses[1].payload.as_deref(), Some(b"t".as_slice()));
-    let flush_idx = 2 + addrs.len();
+    for i in 0..actions.len() {
+        assert_eq!(
+            trace.responses[1 + i].payload.as_deref(),
+            Some(b"t".as_slice()),
+            "setAction #{i} not accepted"
+        );
+    }
+    let first_decompile = 1 + actions.len();
+    let flush_idx = first_decompile + addrs.len();
     assert_eq!(
         trace.responses[flush_idx].payload.as_deref(),
         Some(b"0".as_slice()),
@@ -184,7 +208,7 @@ fn run_session_with(
     let mut docs = Vec::new();
     let mut payloads = Vec::new();
     for (i, a) in addrs.iter().enumerate() {
-        let resp = &trace.responses[2 + i];
+        let resp = &trace.responses[first_decompile + i];
         assert!(
             resp.warnings.trim().is_empty(),
             "decompileAt #{i} shipped a non-empty warnings frame (degradation): {}",
@@ -199,17 +223,20 @@ fn run_session_with(
         let parsed = parse_decompile_doc(&payload, &oracle.manager);
         // Name + entry-address echo — the HighFunction.decode hard-throw traps.
         // Compared against what the sim actually SERVED (`code_label` consults
-        // `label_overrides`), not the raw program lookup.
-        assert_eq!(
-            Some(parsed.name.as_str()),
-            oracle.code_label(a.get_offset()).as_deref(),
-            "decompileAt #{i}: <function name> must echo the getCodeLabel answer"
-        );
-        assert_eq!(
-            parsed.entry_offset,
-            Some(a.get_offset()),
-            "decompileAt #{i}: <function> base <addr> must echo the requested entry"
-        );
+        // `label_overrides`), not the raw program lookup.  (A
+        // parammeasures-only paramid doc carries no <function> to echo.)
+        if parsed.has_function {
+            assert_eq!(
+                Some(parsed.name.as_str()),
+                oracle.code_label(a.get_offset()).as_deref(),
+                "decompileAt #{i}: <function name> must echo the getCodeLabel answer"
+            );
+            assert_eq!(
+                parsed.entry_offset,
+                Some(a.get_offset()),
+                "decompileAt #{i}: <function> base <addr> must echo the requested entry"
+            );
+        }
         docs.push(parsed);
         payloads.push(payload);
     }
@@ -218,7 +245,7 @@ fn run_session_with(
         .clone()
         .expect("repeat decompileAt payload present");
 
-    Some(SessionRun { oracle, trace, docs, payloads, repeat_payload, addrs })
+    Some(SessionRun { oracle, trace, docs, payloads, repeat_payload, addrs, first_decompile })
 }
 
 /// The r5 wire/structure contract, per decompiled function.
@@ -260,6 +287,32 @@ fn assert_structure(run: &SessionRun) {
             "target #{i}: the ghidra-mode `Kuna v…` banner comment is missing\n{}",
             parsed.c_text
         );
+        // ---- Phase 4: the full-response children + the Java hard-throw traps.
+        ghidra_sim::assert_phase4_traps(parsed, &format!("target #{i}"));
+        let symbols = parsed
+            .localdb
+            .as_ref()
+            .unwrap_or_else(|| panic!("target #{i}: <localdb> missing"));
+        assert!(
+            !symbols.is_empty(),
+            "target #{i}: <localdb> carries no symbols (params/locals lost)"
+        );
+        let highs = parsed
+            .highlist
+            .as_ref()
+            .unwrap_or_else(|| panic!("target #{i}: <highlist> missing"));
+        assert!(
+            highs.iter().any(|h| h.class == "local" || h.class == "param"),
+            "target #{i}: no local/param <high> — rename/retype has no target"
+        );
+        let proto = parsed
+            .prototype
+            .as_ref()
+            .unwrap_or_else(|| panic!("target #{i}: <prototype> missing"));
+        assert!(
+            !proto.model.is_empty() && proto.has_extrapop && proto.returnsym_ok,
+            "target #{i}: <prototype> header incomplete"
+        );
     }
 
     // Query legality: every callback query is one of the 19 command elements,
@@ -269,7 +322,8 @@ fn assert_structure(run: &SessionRun) {
     let n = run.trace.responses.len();
     let flush_idx = n - 3; // … decompileAt×N, flushNative, decompileAt, deregister
     for (idx, resp) in run.trace.responses.iter().enumerate() {
-        let query_legal = idx == 0 || (idx >= 2 && idx != flush_idx && idx != n - 1);
+        let query_legal =
+            idx == 0 || (idx >= run.first_decompile && idx != flush_idx && idx != n - 1);
         if !query_legal {
             assert!(
                 resp.queries.is_empty(),
@@ -403,19 +457,19 @@ const PIN_FAILLOG_PLACEHOLDERS: [usize; 3] = [27, 4, 3];
 // …of which the loader KNOWS a real name — ZERO: every PLT import
 // (localtime, getopt_long, dcgettext, …) resolves through getMappedSymbols.
 const PIN_FAILLOG_RESOLVABLE: [usize; 3] = [0, 0, 0];
-// The normalized line-diff ratio vs the CLI path, per target (measured 0.170 /
-// 0.184 / 0.264 after style normalization — see `style_normalize`), banded
+// The normalized line-diff ratio vs the CLI path, per target (measured 0.050 /
+// 0.079 / 0.099 after style normalization — see `style_normalize`), banded
 // from BOTH sides a few points off the measurement: the floor so a further
 // improvement must flip the band downward deliberately, the ceiling so a
 // markup regression fails instead of saturating unnoticed.
 //
-// The residue is NOT symbol resolution any more: it is per-function analysis
-// skew (the ghidra path decompiles one function against wire-fed facts while
-// the CLI path runs after whole-binary analysis commits — jumptable label
-// choices, readonly-driven const folds) plus the getC() type-token mangling
-// PR-C removes.
-const PIN_FAILLOG_DIFF_FLOOR: [f64; 3] = [0.10, 0.15, 0.19];
-const PIN_FAILLOG_DIFF_CEILING: [f64; 3] = [0.25, 0.29, 0.34];
+// Phase 4 collapsed the Phase-3 band (0.170/0.184/0.264): the getC()
+// type-token mangling is gone (the EmitMarkup declarator-token split).  The
+// residue is per-function analysis skew — the ghidra path decompiles one
+// function against wire-fed facts while the CLI path runs after whole-binary
+// analysis commits (jumptable label choices, readonly-driven const folds).
+const PIN_FAILLOG_DIFF_FLOOR: [f64; 3] = [0.02, 0.04, 0.06];
+const PIN_FAILLOG_DIFF_CEILING: [f64; 3] = [0.09, 0.12, 0.15];
 // Normalized non-empty line count of the flattened markup C, per target: the
 // structural size of what the GUI renders.  A `<break>`-token regression would
 // collapse this to ~1 while leaving every ratio-floor assertion green — this
@@ -423,14 +477,13 @@ const PIN_FAILLOG_DIFF_CEILING: [f64; 3] = [0.25, 0.29, 0.34];
 // truncate the flow overrun that used to decode neighbouring functions into
 // it — defect g; the +1 everywhere is the `Kuna v…` banner line.)
 const PIN_FAILLOG_C_LINES: [usize; 3] = [283, 39, 92];
-// Tokens Java's `getC()` cleaner REWRITES (`IllegalCharCppTransformer`): kuna
-// emits whole rendered declarators (`"unsigned long *"`) as single `<type>`
-// tokens, which scripts/exports receive as `unsigned_long__` — the type-
-// spelling mangling of the live repro.  Phase 3 moved these UP (the
-// aggressive preset's `ctypes` spells multi-word C types everywhere, and the
-// resolved output simply renders more typed expressions); PR-C splits the
-// declarator into base-type + syntax tokens and drives these to 0.
-const PIN_FAILLOG_MANGLED_TOKENS: [usize; 3] = [57, 10, 24];
+// Tokens Java's `getC()` cleaner REWRITES (`IllegalCharCppTransformer`).
+// Phase 3 measured 57/10/24 (whole rendered declarators like
+// `"unsigned long *"` as single `<type>` tokens, received by scripts/exports
+// as `unsigned_long__` — the type-spelling mangling of the live repro).
+// Phase 4's EmitMarkup declarator-token split (word `<type>` tokens +
+// `<syntax>` separators) drives these to ZERO and must keep them there.
+const PIN_FAILLOG_MANGLED_TOKENS: [usize; 3] = [0, 0, 0];
 // Whole-session query traffic: total getPcode asks (repeat decompiles re-ask
 // everything — no p-code cache, faithful to upstream GhidraTranslate) vs
 // distinct instruction addresses actually decoded.  Phase 3 REDUCED both
@@ -580,6 +633,182 @@ fn ghidra_sim_faillog_pins() {
         oracle.log.decoded_insts.len(),
         PIN_FAILLOG_DECODED_INSTS,
         "distinct decoded instruction count moved"
+    );
+}
+
+/// The SWITCH-ANALYZER configuration (SwitchAnalysisDecompileConfigurer:
+/// `noc` + `jumpload` + `notree`, action `decompile`): the response must be a
+/// first-`<function>`-only doc — no markup, no `<ast>`, no `<highlist>` — that
+/// still carries `<localdb>`, `<prototype>`, and the `<jumptablelist>` with
+/// the recovered `<dest>` targets plus the jumpload-collected `<loadtable>`s
+/// (`DecompilerSwitchAnalysisCmd` consumes exactly this).
+#[test]
+fn ghidra_sim_faillog_switch_analyzer_shape() {
+    let binary = repo_root().join("tests/bug-repro/faillog");
+    // sub_2620 (main) is the switch-heavy target.
+    let Some(run) = run_session_config(
+        &binary,
+        &["sub_2620"],
+        &[("decompile", ""), ("", "noc"), ("", "notree"), ("", "jumpload")],
+        |_| {},
+    ) else {
+        return; // visible skip: specs not built
+    };
+    let parsed = &run.docs[0];
+    ghidra_sim::assert_phase4_traps(parsed, "switch-analyzer");
+    assert!(!parsed.has_markup, "noc: the markup <function> must be absent");
+    assert!(
+        !parsed.function_child_ids.contains(&ghidra_sim::ELEM_AST_ID),
+        "notree: the <ast> must be absent"
+    );
+    assert!(
+        !parsed.function_child_ids.contains(&ghidra_sim::ELEM_HIGHLIST_ID),
+        "notree: the <highlist> must be absent"
+    );
+    assert!(parsed.localdb.is_some(), "the <localdb> still travels under notree");
+    assert!(parsed.prototype.is_some(), "the <prototype> still travels under notree");
+    assert!(
+        !parsed.jumptables.is_empty(),
+        "no <jumptablelist> — the switch analyzer gets nothing (children: {:?})",
+        parsed.function_child_ids
+    );
+    let (dests, loads) = parsed.jumptables[0];
+    assert!(dests >= 2, "a recovered switch needs >= 2 <dest> targets, got {dests}");
+    assert!(
+        loads >= 1,
+        "jumpload was toggled but no <loadtable> was collected — \
+         FlowInfo::record_jumploads is not reaching the recovery"
+    );
+}
+
+/// The PARAM-ID ANALYZER configuration (DecompilerParameterIdCmd /
+/// ConventionAnalysisDecompileConfigurer: `noc` + `notree` + `parammeasures`,
+/// action `paramid`): the response is a `<parammeasures>`-ONLY doc — no
+/// `<function>` at all — with the REQUIRED `<rank>` per measure.
+#[test]
+fn ghidra_sim_faillog_paramid_shape() {
+    let binary = repo_root().join("tests/bug-repro/faillog");
+    let Some(run) = run_session_config(
+        &binary,
+        &["sub_3320"],
+        &[("paramid", ""), ("", "noc"), ("", "notree"), ("", "parammeasures")],
+        |_| {},
+    ) else {
+        return; // visible skip: specs not built
+    };
+    let parsed = &run.docs[0];
+    ghidra_sim::assert_phase4_traps(parsed, "paramid");
+    assert!(
+        !parsed.has_function,
+        "paramid + parammeasures: the doc must contain ONLY <parammeasures> \
+         (ghidra_process.cc:318-321), children: {:?}",
+        parsed.function_child_ids
+    );
+    assert!(!parsed.has_markup, "paramid: no markup <function>");
+    let measures = parsed
+        .parammeasures
+        .as_ref()
+        .expect("the <parammeasures> document");
+    assert!(
+        !measures.is_empty(),
+        "paramid produced no measures — the param-ID analyzer gets nothing"
+    );
+    assert!(
+        measures.iter().any(|(is_input, _)| *is_input),
+        "paramid produced no <input> measures"
+    );
+}
+
+/// The byte size of an encoded localdb symbol: the `<type size>` when present
+/// (the full form), else the trailing digits of a core `<typeref name>`
+/// (`uint8` → 8; Java derives entry sizes from the type, so the harness does
+/// too).
+fn sim_symbol_size(s: &ghidra_sim::SimSymbol) -> Option<i64> {
+    if let Some(sz) = s.type_size {
+        if sz > 0 {
+            return Some(sz);
+        }
+    }
+    let name = s.type_name.as_deref()?;
+    let digits: String =
+        name.chars().rev().take_while(|c| c.is_ascii_digit()).collect::<Vec<_>>()
+            .into_iter().rev().collect();
+    if digits.is_empty() {
+        return matches!(name, "bool" | "char" | "byte").then_some(1);
+    }
+    digits.parse::<i64>().ok().filter(|v| *v > 0 && *v <= 16)
+}
+
+/// The RENAME-PERSISTENCE loop (the GUI keystone): a user rename is a DB write
+/// (`HighFunctionDBUtil.updateDBVariable`) followed by an event-driven
+/// re-decompile whose getMappedSymbols answer now carries the renamed local in
+/// the function's `<localdb>` (Java `LocalSymbolMap.grabFromFunction`).  kuna
+/// must SEED that local into the fresh Funcdata so the new name — not a fresh
+/// `vN` — renders.  Echo-back differential: run once, take a local kuna itself
+/// encoded (storage + first-use), serve it back RENAMED, assert the C shows
+/// the new name.
+#[test]
+fn ghidra_sim_faillog_rename_persistence() {
+    let binary = repo_root().join("tests/bug-repro/faillog");
+    let Some(run1) = run_session(&binary, &["sub_3ad0"]) else {
+        return; // visible skip: specs not built
+    };
+    let parsed = &run1.docs[0];
+    let cand = parsed
+        .localdb
+        .as_ref()
+        .expect("<localdb> present")
+        .iter()
+        .find(|s| {
+            s.cat < 0
+                && s.entry_storage.as_ref().is_some_and(|(spc, _)| spc != "unique")
+                && sim_symbol_size(s).is_some()
+                && parsed.c_text.contains(s.name.as_str())
+        })
+        .expect("a non-unique-storage local kuna named");
+    let (spc, off) = cand.entry_storage.clone().expect("mapped storage");
+    let size = sim_symbol_size(cand).expect("sized type");
+    let first_use = cand.first_use;
+    let old_name = cand.name.clone();
+    let entry_off = run1.addrs[0].get_offset();
+
+    // typelock=false: the exact shape a plain GUI rename produces (verified
+    // against a live Ghidra 12.1.2 DecompileDebug capture — `<symbol
+    // typelock="false" namelock="true" cat="-1"><typeref name="undefined8">`)
+    // — which kuna must carry as a NAME RECOMMENDATION, the C++
+    // `ScopeLocal::nameRecommend` path.
+    let renamed = "host_renamed_probe";
+    let Some(run2) = run_session_with(&binary, &["sub_3ad0"], move |o| {
+        o.local_var_overrides.insert(
+            entry_off,
+            vec![ghidra_sim::oracle::HostLocalVar {
+                name: renamed.to_string(),
+                space: spc,
+                offset: off,
+                size,
+                first_use,
+                typelock: false,
+            }],
+        );
+    }) else {
+        return;
+    };
+    let parsed2 = &run2.docs[0];
+    assert!(
+        parsed2.c_text.contains(renamed),
+        "the host-committed rename ({old_name} -> {renamed}) did not survive \
+         the re-decompile:\n{}",
+        parsed2.c_text
+    );
+    // The re-encoded localdb carries the seeded symbol back to Java.
+    assert!(
+        parsed2
+            .localdb
+            .as_ref()
+            .expect("<localdb> present")
+            .iter()
+            .any(|s| s.name == renamed),
+        "the seeded local is missing from the re-encoded <localdb>"
     );
 }
 

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim_e2e.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim_e2e.rs
@@ -484,6 +484,15 @@ const PIN_FAILLOG_C_LINES: [usize; 3] = [283, 39, 92];
 // Phase 4's EmitMarkup declarator-token split (word `<type>` tokens +
 // `<syntax>` separators) drives these to ZERO and must keep them there.
 const PIN_FAILLOG_MANGLED_TOKENS: [usize; 3] = [0, 0, 0];
+// `<vardecl symref>`s that do NOT resolve against the document's own
+// `<localdb>` (the create-index fallback).  Phase 4 originally emitted the
+// fallback for EVERY declaration — Java logged "Invalid symbol reference" per
+// declaration and rename/retype was dead on declaration lines.  The review
+// round drives these to ~0; the single survivor on sub_3320 is a declaration
+// the printer keys on a group-member high whose covering Symbol the analysis
+// never bound (documented follow-up).  Pinned so the systemic case cannot
+// come back and the residue can only shrink.
+const PIN_FAILLOG_VARDECL_UNRESOLVED: [usize; 3] = [0, 1, 0];
 // Whole-session query traffic: total getPcode asks (repeat decompiles re-ask
 // everything — no p-code cache, faithful to upstream GhidraTranslate) vs
 // distinct instruction addresses actually decoded.  Phase 3 REDUCED both
@@ -512,6 +521,7 @@ fn ghidra_sim_faillog_pins() {
     let mut ph_totals = Vec::new();
     let mut ph_resolvables = Vec::new();
     let mut mangled_counts = Vec::new();
+    let mut vardecl_unresolved_counts = Vec::new();
     let mut c_line_counts = Vec::new();
     for parsed in &run.docs {
         let c = &parsed.c_text;
@@ -522,6 +532,7 @@ fn ghidra_sim_faillog_pins() {
         ph_totals.push(placeholder_total(c));
         ph_resolvables.push(resolvable_placeholders(&run.oracle, c));
         mangled_counts.push(parsed.mangled_tokens);
+        vardecl_unresolved_counts.push(ghidra_sim::vardecl_unresolved(parsed));
         c_line_counts.push(normalized_lines(c).len());
     }
 
@@ -555,9 +566,9 @@ fn ghidra_sim_faillog_pins() {
     for (i, t) in FAILLOG_TARGETS.iter().enumerate() {
         summary.push_str(&format!(
             "{t}: registers={} {:?} unique={} placeholders={} resolvable={} mangled={} \
-             c_lines={} diff_ratio={:.3}\n",
+             vardecl_unresolved={} c_lines={} diff_ratio={:.3}\n",
             reg_counts[i], reg_names_seen[i], uniq_counts[i], ph_totals[i], ph_resolvables[i],
-            mangled_counts[i], c_line_counts[i], ratios[i]
+            mangled_counts[i], vardecl_unresolved_counts[i], c_line_counts[i], ratios[i]
         ));
     }
     summary.push_str(&format!(
@@ -590,6 +601,11 @@ fn ghidra_sim_faillog_pins() {
         assert_eq!(
             mangled_counts[i], PIN_FAILLOG_MANGLED_TOKENS[i],
             "{t}: getC()-mangled token count moved (PR-C drives this to 0)"
+        );
+        assert_eq!(
+            vardecl_unresolved_counts[i], PIN_FAILLOG_VARDECL_UNRESOLVED[i],
+            "{t}: unresolvable <vardecl symref> count moved — declaration-line \
+             rename/retype resolution changed"
         );
         assert!(
             ratios[i] >= PIN_FAILLOG_DIFF_FLOOR[i],
@@ -788,6 +804,7 @@ fn ghidra_sim_faillog_rename_persistence() {
                 size,
                 first_use,
                 typelock: false,
+                hash: 0,
             }],
         );
     }) else {
@@ -810,6 +827,103 @@ fn ghidra_sim_faillog_rename_persistence() {
             .any(|s| s.name == renamed),
         "the seeded local is missing from the re-encoded <localdb>"
     );
+}
+
+
+/// C2 (review round): a host-committed local whose only SymbolEntry is a
+/// DYNAMIC `<hash>` — the storage class Java writes for every
+/// `requiresDynamicStorage` variable (unique-space representatives,
+/// `splitOutMergeGroup` products) — must survive the re-decompile.  Before the
+/// fix the decoder dropped hash-entry locals outright, so a rename of such a
+/// variable silently reverted in front of the user.
+///
+/// Echo-back differential: take a hash kuna itself encoded for a wire symbol
+/// (the link pass hashes conflict-separated / uncovered variables with the
+/// upstream budget Java also uses), serve it back as a renamed dynamic local,
+/// and assert the name comes back in the C.
+#[test]
+fn ghidra_sim_faillog_dynamic_rename_persistence() {
+    let binary = repo_root().join("tests/bug-repro/faillog");
+    let Some(run1) = run_session(&binary, &["sub_3ad0"]) else {
+        return; // visible skip: specs not built
+    };
+    let parsed = &run1.docs[0];
+    // A wire symbol kuna encoded with a `<hash>` entry (type="dynamic").
+    let cand = parsed
+        .localdb
+        .as_ref()
+        .expect("<localdb> present")
+        .iter()
+        .find(|s| s.cat < 0 && s.hash != 0 && parsed.c_text.contains(s.name.as_str()));
+    let Some(cand) = cand else {
+        // No dynamic wire symbol on this target: nothing to assert (the
+        // shape is target-dependent; the decode-side unit test covers the
+        // wire contract unconditionally).
+        return;
+    };
+    let hash = cand.hash;
+    let first_use = cand.first_use;
+    let old_name = cand.name.clone();
+    let entry_off = run1.addrs[0].get_offset();
+    let renamed = "host_dyn_renamed";
+    let Some(run2) = run_session_with(&binary, &["sub_3ad0"], move |o| {
+        o.local_var_overrides.insert(
+            entry_off,
+            vec![ghidra_sim::oracle::HostLocalVar {
+                name: renamed.to_string(),
+                space: "ram".to_string(),
+                offset: first_use.unwrap_or(entry_off),
+                size: 8,
+                first_use,
+                typelock: false,
+                hash,
+            }],
+        );
+    }) else {
+        return;
+    };
+    assert!(
+        run2.docs[0].c_text.contains(renamed),
+        "a host rename of a DYNAMIC (hash-storage) local ({old_name} -> {renamed}) \
+         did not survive the re-decompile:\n{}",
+        run2.docs[0].c_text
+    );
+}
+
+/// C4 (review round): no `<high>` may borrow another variable's symbol id.
+/// The encode-time link pass must never re-derive a container binding — a high
+/// the naming pass deliberately separated from the parameter whose storage it
+/// overlaps would otherwise inherit the PARAMETER's id, and renaming that
+/// variable in the GUI would rename the parameter.
+///
+/// Invariant asserted on every decompiled function: each `<high symref>` is
+/// claimed by at most ONE high (bar the deliberate group sharing of a composite
+/// symbol, where the highs also share a `<localdb>` symbol whose type is
+/// composite), and every param-class high's symref is a cat-0 symbol.
+#[test]
+fn ghidra_sim_faillog_high_symrefs_are_not_shared_with_params() {
+    let binary = repo_root().join("tests/bug-repro/faillog");
+    let Some(run) = run_session(&binary, FAILLOG_TARGETS) else {
+        return; // visible skip: specs not built
+    };
+    for (i, parsed) in run.docs.iter().enumerate() {
+        let symbols = parsed.localdb.as_ref().expect("<localdb> present");
+        let param_ids: BTreeSet<u64> =
+            symbols.iter().filter(|s| s.cat == 0).map(|s| s.id).collect();
+        let highs = parsed.highlist.as_ref().expect("<highlist> present");
+        for h in highs {
+            let Some(sr) = h.symref else { continue };
+            if param_ids.contains(&sr) {
+                assert_eq!(
+                    h.class, "param",
+                    "target #{i}: a non-param <high class={}> references the \
+                     cat-0 parameter symbol {sr} — renaming that variable in the \
+                     GUI would rename the PARAMETER",
+                    h.class
+                );
+            }
+        }
+    }
 }
 
 /// flushNative + repeat-decompile stability: with unchanged host answers a

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim_e2e.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim_e2e.rs
@@ -488,11 +488,13 @@ const PIN_FAILLOG_MANGLED_TOKENS: [usize; 3] = [0, 0, 0];
 // `<localdb>` (the create-index fallback).  Phase 4 originally emitted the
 // fallback for EVERY declaration — Java logged "Invalid symbol reference" per
 // declaration and rename/retype was dead on declaration lines.  The review
-// round drives these to ~0; the single survivor on sub_3320 is a declaration
-// the printer keys on a group-member high whose covering Symbol the analysis
-// never bound (documented follow-up).  Pinned so the systemic case cannot
-// come back and the residue can only shrink.
-const PIN_FAILLOG_VARDECL_UNRESOLVED: [usize; 3] = [0, 1, 0];
+// round drove these to 0/1/0; carrying the Symbol identity through the
+// `&symbol` reference bind (C++ `Varnode::setSymbolReference`) closed the last
+// one on sub_3320 too, so every declaration in the corpus now resolves.  ZERO
+// is the contract, not a high-water mark: a new residue must be justified
+// against `ClangVariableDecl.decode` (a log line + a dead rename on that one
+// declaration, never a decode throw) before this pin moves up.
+const PIN_FAILLOG_VARDECL_UNRESOLVED: [usize; 3] = [0, 0, 0];
 // Whole-session query traffic: total getPcode asks (repeat decompiles re-ask
 // everything — no p-code cache, faithful to upstream GhidraTranslate) vs
 // distinct instruction addresses actually decoded.  Phase 3 REDUCED both
@@ -1229,11 +1231,33 @@ fn ghidra_sim_sort_grep_breadth() {
         assert_structure(&run);
         for (i, parsed) in run.docs.iter().enumerate() {
             let (reg_count, reg_names) = register_leaks(&parsed.c_text, &run.oracle.register_names);
+            let unresolved = ghidra_sim::vardecl_unresolved(parsed);
             eprintln!(
-                "{fixture} {}: registers={reg_count} {reg_names:?} unique={} placeholders={}",
+                "{fixture} {}: registers={reg_count} {reg_names:?} unique={} placeholders={} \
+                 vardecl_unresolved={unresolved} vardecls={}",
                 targets[i],
                 unique_leaks(&parsed.c_text),
                 placeholder_total(&parsed.c_text),
+                parsed.vardecl_symrefs.len(),
+            );
+            // The structural assertion above only demands that SOME declaration
+            // resolves; on breadth it must be ALL of them.  `assert_structure`'s
+            // wholesale check went red here (100% unresolved on sort/sub_6370)
+            // while the faillog fixture measured healthy, because a stack
+            // aggregate reached only through `&sym` is declared off the constant
+            // PTRSUB high, which carried no Symbol identity at all.  Pin the
+            // count at 0: a genuine residue must be recorded per target with the
+            // Java degradation spelled out (`ClangVariableDecl.decode` logs
+            // "Invalid symbol reference" and returns -- a dead rename on that one
+            // line, never a decode throw), not absorbed silently.
+            assert_eq!(
+                unresolved, 0,
+                "{fixture} {}: {unresolved} of {} <vardecl symref>s do not resolve \
+                 against <localdb> — declaration-line rename/retype is dead on \
+                 those lines\n{}",
+                targets[i],
+                parsed.vardecl_symrefs.len(),
+                parsed.c_text,
             );
         }
     }

--- a/docs/ghidra-integration.md
+++ b/docs/ghidra-integration.md
@@ -388,14 +388,15 @@ The engine-seam inventory, with honest difficulty:
 | `LoadImage` | trait ready | **trivial** — `GhidraLoadImage::load_fill` = `getBytes` | 2 |
 | `ContextDatabase` | trait ready | **trivial** — `ContextGhidra` implements `getTrackedSet` only (upstream throws on the rest, `ghidra_context.hh:36-47`) | 2 |
 | `Translate` | trait exists; `Architecture.translate: Sleigh` concrete (`architecture.rs:836`) | **enum seam** `{Sleigh, GhidraTranslate}` + the Sleigh-only call surface audit | 2 |
-| `Funcdata::encode` | **missing** (no encode on `substrate/funcdata*.rs`) | port from upstream `funcdata.cc` — minimal `<function>` first | 2 |
+| `Funcdata::encode` | **DONE (Phase 4)** — the FULL `<function>` in upstream child order: `<addr>` + `<localdb>` + `<ast>` + `<highlist>` + `<jumptablelist>` + `<prototype>` (`substrate/funcdata_encode.rs`), over the `Datatype::encodeRef` / `FuncProto::encode` / `Symbol`/`SymbolEntry`/scope encode ports and the encode-time symbol-link pass | `<override>`/child-`<scope>` statics deferred (Java skips both) | 4 ✔ |
 | PrintC → `EmitMarkup` | back-end ported, front-end hardwired (`printc.rs:1015`) | generalize PrintC's `emit` field; wire `doc_function` (`printc.rs:1102`) to the markup path | 2 |
-| Scope / symbol table | **DONE (Phase 3)** — `RemoteScope` (`infra/remote_provider.rs`): query-through + `<hole>` negatives + property paints + namespace paths, at the GlobalQuery/flow seams | — | 3 ✔ |
-| `TypeFactory` | **DONE (Phase 3)** — wire `<coretypes>` decode + `decode_type`/`<typeref>` + `find_by_id_or_remote` getDataType miss-hook + `clear_noncore` (`substrate/dtype.rs`) | function-definition `<prototype>` bodies inside `<type metatype="code">` are skipped (FuncProto::decode unported) | 3 ✔ |
+| Scope / symbol table | **DONE (Phase 3)** — `RemoteScope` (`infra/remote_provider.rs`): query-through + `<hole>` negatives + property paints + namespace paths, at the GlobalQuery/flow seams; **Phase 4** echoes the delivered DB symbol ids back (`GlobalEntry::symbol_id` → `<high symref>`) | — | 3 ✔ / 4 ✔ |
+| `TypeFactory` | **DONE (Phase 3)** — wire `<coretypes>` decode + `decode_type`/`<typeref>` + `find_by_id_or_remote` getDataType miss-hook + `clear_noncore` (`substrate/dtype.rs`); **Phase 4** adds the marshal-OUT (`Datatype::encode_ref`/`encode`) | function-definition `<prototype>` bodies inside `<type metatype="code">` are skipped (FuncProto::decode unported) | 3 ✔ / 4 ✔ |
 | `CommentDatabase` | **DONE (Phase 3)** — `RemoteScope::fill_comments` (getComments, printer-filtered, fill-once-per-flush) into the `Architecture.commentdb` sink | the printer renders PRE/warning + header comments; EOL/POST placement is a printer gap, not a wire gap | 3 ✔ |
-| `StringManager` | concrete, no trait (`stringmanage.rs:83`); cleared by flushNative | one-method extraction for Java-side charset-faithful decode | 4 |
-| Inject library | traits exist; owner concrete; SLEIGH inject engine compiles the **wire-fed cspec** snippets (shipped in Phase 2) | dynamic getPcodeInject query fallback | 4 |
-| `ConstantPool` | trait ready (`infra/cpool.rs:470`) but **unwired** into `Architecture` | wiring + `CPOOLREF` path; JVM/Dalvik only | 4 |
+| `ParamIDAnalysis` | **DONE (Phase 4)** — `<parammeasures>` encode + the paramid-action doc shape (`infra/paramid.rs`; the justproto constructor reads the real recovered `FuncProto`) | — | 4 ✔ |
+| `StringManager` | concrete, no trait (`stringmanage.rs:83`); cleared by flushNative | one-method extraction for Java-side charset-faithful decode | deferred |
+| Inject library | traits exist; owner concrete; SLEIGH inject engine compiles the **wire-fed cspec** snippets (shipped in Phase 2) | dynamic getPcodeInject query fallback | deferred |
+| `ConstantPool` | trait ready (`infra/cpool.rs:470`) but **unwired** into `Architecture` | wiring + `CPOOLREF` path; JVM/Dalvik only | deferred |
 | ArchSeam snapshot | **DONE (Phase 3)** — the three frozen tables read through live seams when a `RemoteScope` is installed (`ArchContext::effective_global_query`/`callee_proto_pieces`; tracked sets decode from the wire pspec `<tracked_set>`) | — | 3 ✔ |
 
 ## 10. Graceful degradation
@@ -530,10 +531,57 @@ pins now hold the Phase-3 level.
       `FUN_`/`DAT_`/`LAB_` fallback naming (DIV-77); `setOptions` decodes and applies
       for real with per-element skip-unknown (DIV-76).
 
-**Phase 4 — parity.**
-- [ ] `<highlist>`/`<jumptablelist>` fidelity incl. DB symbol-id echo for
-      rename/retype; `structureGraph`; `<parammeasures>`.
+**Phase 4 — the full response encode (branch `feat/ghidra-phase4-encode`).**
+- [x] `Datatype::encodeRef` port (`substrate/dtype.rs` `encode_ref`/`encode`/
+      `encode_basic`/`encode_typedef` + `TypeField`/`TypeBitField` encode) —
+      the cross-cutting type marshal-out every other element needed.
+- [x] `<prototype>` (`FuncProto::encode`, `p4_calls/fspec.rs`): model +
+      extrapop (+"unknown"), the boolean flags, `<returnsym>` (sized storage +
+      type), effect/likely-trash model-diffs.  Input params travel as localdb
+      cat-0 symbols (the upstream symbol-backed store shape).
+- [x] `<localdb>` (`ScopeLocal::encode`, `varmap.rs` →
+      `Database::encode_scope`/`Symbol::encode`/`SymbolEntry::encode`,
+      `p0_knowledge/database.rs`): nonzero ids everywhere, ≥1 entry per
+      mapsym, positional `<parent>`+`<rangelist>`, params cat=0+index+exact
+      storage.
+- [x] `<highlist>` (`Funcdata::encode_high`, `substrate/funcdata_encode.rs`)
+      + the encode-time symbol-link pass (`kuna_link_high_symbols` — the
+      C++ `ActionNameVars::linkSymbols` stand-in) attaching/creating localmap
+      symbols for named highs so `<high symref>` resolves in the just-encoded
+      `<localdb>`; global `<high>`s echo the REAL host DB id
+      (`GlobalEntry::symbol_id` from the getMappedSymbols record) and omit
+      `symref` rather than fabricate one.
+- [x] `<jumptablelist>` (the ported `JumpTable::encode` wired into
+      `Funcdata::encode`, emitted independently of savetree) + the jumpload
+      toggle plumbed to `FlowInfo::record_jumploads` per decompile — the
+      switch-analyzer contract (noc+notree+jumpload), loadtables included.
+- [x] `<parammeasures>` (`ParamIDAnalysis::encode`, `infra/paramid.rs`,
+      `<rank>` always on) + the `paramid`-action doc shape (parammeasures is
+      the ONLY doc child) — the param-ID / convention analyzers.
+- [x] Markup type-token fidelity: `EmitMarkup::tag_type` splits a rendered
+      declarator into base-word `<type>` tokens + `<syntax>` separators, so
+      Java's `getC()` (`IllegalCharCppTransformer`) no longer mangles
+      `unsigned long *` to `unsigned_long__` (ghidra-sim mangled pins → 0).
+- [x] The rename/retype PERSISTENCE loop: the function `<localdb>` answer's
+      non-parameter locals (what Java sends after
+      `HighFunctionDBUtil.updateDBVariable` committed a user edit) seed the
+      fresh Funcdata — typelocked locals as mapped/usepoint symbols, plain
+      renames (typelock=false) as `ScopeLocal::nameRecommend` records (the
+      C++ mechanism; applied by the `ActionNameVars` port) — so a GUI
+      rename/retype SURVIVES the event-driven re-decompile.
+- [x] Harness: the ghidra-sim decode now validates every Java hard-throw trap
+      (r5 §3 — nonzero symbol ids, entry pairs, positional scope children,
+      localdb/ast-before-highlist order, symref/repref resolution, prototype
+      completeness, `<rank>` presence) plus switch-analyzer- and
+      paramid-shaped configuration tests.
+
+**Phase-4 deferred (follow-ups, graceful degradation per §10):**
+- [ ] `structureGraph` (FunctionGraph nested layout only).
 - [ ] The four signature commands (engine already ported) for BSim.
 - [ ] Overlay spaces (Java swaps in overlay codecs transparently —
       `DecompInterface.java:84-127,896-909`); `getStringData` charset fidelity
       (Java-side decode instead of `GhidraLoadImage` bytes).
+- [ ] `<hash>` dynamic-storage symbols for unique-space locals in the link
+      pass (rename of a unique-storage temp falls back to Java's
+      address-keyed `DynamicEntry.build` path meanwhile); `<override>` /
+      child-`<scope>` statics (Java skips both).

--- a/docs/ghidra-integration.md
+++ b/docs/ghidra-integration.md
@@ -581,7 +581,11 @@ pins now hold the Phase-3 level.
 - [ ] Overlay spaces (Java swaps in overlay codecs transparently —
       `DecompInterface.java:84-127,896-909`); `getStringData` charset fidelity
       (Java-side decode instead of `GhidraLoadImage` bytes).
-- [ ] `<hash>` dynamic-storage symbols for unique-space locals in the link
-      pass (rename of a unique-storage temp falls back to Java's
-      address-keyed `DynamicEntry.build` path meanwhile); `<override>` /
-      child-`<scope>` statics (Java skips both).
+- [ ] `<override>` / child-`<scope>` statics (Java skips both); the C++
+      `collectNameRecs` harvest (standalone symbols → recommendations).
+- [ ] One residual `<vardecl symref>` per corpus function can still fall back
+      to the create-index placeholder: a declaration the printer keys on a
+      group-member high whose covering Symbol the analysis never bound
+      (pinned at 0/1/0 by `PIN_FAILLOG_VARDECL_UNRESOLVED`, so it can only
+      shrink).  Java logs that one reference; rename works from the
+      variable's usage tokens meanwhile.

--- a/docs/ghidra-integration.md
+++ b/docs/ghidra-integration.md
@@ -569,6 +569,13 @@ pins now hold the Phase-3 level.
       renames (typelock=false) as `ScopeLocal::nameRecommend` records (the
       C++ mechanism; applied by the `ActionNameVars` port) — so a GUI
       rename/retype SURVIVES the event-driven re-decompile.
+- [x] Every `<vardecl symref>` in the corpus resolves against its own
+      `<localdb>` — `PIN_FAILLOG_VARDECL_UNRESOLVED = [0,0,0]`, plus a
+      per-target 0 on the sort/grep breadth fixtures, so declaration-line
+      rename/retype is live everywhere.  The last residue was a stack aggregate
+      reached only through `&sym`, whose whole HighVariable is the constant
+      `PTRSUB` operand: `link_symbol_reference` now records the referenced
+      Symbol's identity (C++ `Varnode::setSymbolReference`).
 - [x] Harness: the ghidra-sim decode now validates every Java hard-throw trap
       (r5 §3 — nonzero symbol ids, entry pairs, positional scope children,
       localdb/ast-before-highlist order, symref/repref resolution, prototype
@@ -583,9 +590,8 @@ pins now hold the Phase-3 level.
       (Java-side decode instead of `GhidraLoadImage` bytes).
 - [ ] `<override>` / child-`<scope>` statics (Java skips both); the C++
       `collectNameRecs` harvest (standalone symbols → recommendations).
-- [ ] One residual `<vardecl symref>` per corpus function can still fall back
-      to the create-index placeholder: a declaration the printer keys on a
-      group-member high whose covering Symbol the analysis never bound
-      (pinned at 0/1/0 by `PIN_FAILLOG_VARDECL_UNRESOLVED`, so it can only
-      shrink).  Java logs that one reference; rename works from the
-      variable's usage tokens meanwhile.
+- [ ] `kuna_apply_dynamic_recommendations` runs BEFORE the naming walk rather
+      than after linking (kuna fuses the two upstream stages into one pass), so
+      it creates a dynamic Symbol where upstream renames an existing one.  The
+      upstream guards are reproduced against the scope instead of the high —
+      see `docs/spec/06-variables-and-merge.md` §6.4.

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -314,16 +314,31 @@ Four front-ends drive one engine assembly:
   database), and the `<scope>` opens positionally with `<parent>` +
   `<rangelist>` because `LocalSymbolMap.decodeScope` skips both blind.
   Because kuna's naming pass binds plain strings (`kuna_name`) instead of the
-  C++ `ActionNameVars::linkSymbols` Symbol objects, the encode runs an
-  encode-time link pass (`Funcdata::kuna_link_high_symbols`): a named,
-  non-persist, non-constant high resolves its name-representative storage to a
-  covering localmap entry (parameters from `link_proto_params`, restructured
-  stack locals) or materializes a fresh mapped Symbol there, and the SymbolId
-  lands on the high — so the `<highlist>` (`Funcdata::encode_high`, the
+  C++ `ActionNameVars::linkSymbols` Symbol objects, two mechanisms supply the
+  ids the wire needs. First, the naming pass RECORDS the bind it actually made
+  (`HighVariable::kuna_link_symbol`,
+  `decompiler/crates/kuna-decomp/src/p6_variables/coreaction_cleanup.rs`) when
+  a high resolves to a covering localmap entry. Second, an encode-time link
+  pass (`Funcdata::kuna_link_high_symbols`) gives every REMAINING named high a
+  **wire-only symbol**
+  (`decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs (WireSymbol)`):
+  a mapped one at its storage when nothing covers it, or — when a Symbol does
+  cover the storage yet the naming pass declined the bind as a CONFLICT (the
+  narrower addr-tied return over a wider scalar parameter; the float8 lane over
+  a float4 param) — a data-flow-HASHED one, upstream's `buildDynamicSymbol`
+  answer. The encode never re-derives a container binding itself: doing so
+  would hand a conflict-separated high the parameter's id, and a rename from
+  that variable's token would rename the parameter. Wire symbols are encoded
+  into `<localdb>` and referenced by `<high symref>`, but never enter the
+  analysis scope — which is what lets the pass run BEFORE the markup is
+  printed (so `<vardecl symref>` carries the same ids) without changing a byte
+  of the emitted C. The `<highlist>` (`Funcdata::encode_high`, the
   `HighVariable::encode` port: `repref` = name-representative create-index,
   the five-way `class` rule, `symref` + partial `offset`, the type reference,
-  one instance `<addr ref>` per member) points at ids the just-encoded
-  `<localdb>` resolves.  Globals echo the REAL host database id delivered by
+  one instance `<addr ref>` per member) therefore points only at ids the
+  just-encoded `<localdb>` resolves — a symbol the encode skipped defensively
+  is withheld from `symref` too (`Database::encodable_symbol_ids`), because an
+  orphan reference is the Java hard-throw the skip exists to avoid.  Globals echo the REAL host database id delivered by
   getMappedSymbols (`GlobalEntry::symbol_id`,
   `decompiler/crates/kuna-decomp/src/substrate/context.rs`) and NEVER a
   fabricated one — an unknown id omits `symref` (Java warns and falls back to
@@ -350,17 +365,33 @@ Four front-ends drive one engine assembly:
   the function's `<localdb>` (Java `LocalSymbolMap.grabFromFunction`).  kuna
   decodes those non-parameter locals
   (`decompiler/crates/kuna-decomp/src/infra/remote_provider.rs
-  (RemoteLocalVar)`) and seeds them into the fresh `Funcdata`: a TYPELOCKED
-  local (a retype — Java sends `typelock=false` only for `Undefined` types)
-  seeds as a real mapped/usepoint symbol (`Funcdata::seed_mapped_symbols` /
-  `Funcdata::seed_usepoint_symbols`, surviving restructure's typelock-keep
-  rule), while a namelocked-but-NOT-typelocked local (a plain rename) — which
-  C++ itself never keeps as a Symbol — stages as a NAME RECOMMENDATION
-  (`Architecture::kuna_pending_name_recs` →
-  `decompiler/crates/kuna-decomp/src/substrate/funcdata.rs
-  (Funcdata::seed_name_recommendations)`), the
-  `ScopeLocal::nameRecommend` mechanism of chapter
-  [06](06-variables-and-merge.md) §6.4.
+  (RemoteLocalVar)`) and seeds them into the fresh `Funcdata` along FOUR
+  channels, chosen by the two bits Java sets — the storage class and the
+  typelock:
+  a mapped, TYPELOCKED local (a retype — Java sends `typelock=false` only for
+  `Undefined` types) seeds as a real mapped/usepoint symbol
+  (`Funcdata::seed_mapped_symbols` / `Funcdata::seed_usepoint_symbols`,
+  surviving restructure's typelock-keep rule); a mapped, namelocked-only local
+  (a plain rename) — which C++ itself never keeps as a Symbol — stages as a
+  NAME RECOMMENDATION (`Architecture::kuna_pending_name_recs` →
+  `Funcdata::seed_name_recommendations`), the `ScopeLocal::nameRecommend`
+  mechanism of chapter [06](06-variables-and-merge.md) §6.4; and the same two
+  cases in DYNAMIC (`<hash>`) storage — the class Java writes for every
+  variable that `requiresDynamicStorage`, i.e. unique-space representatives and
+  `splitOutMergeGroup` products — seed as a dynamic Symbol
+  (`Funcdata::seed_dynamic_symbols`) or a DYNAMIC name recommendation
+  (`Architecture::kuna_pending_dyn_recs` →
+  `Funcdata::seed_dynamic_recommendations`, applied through
+  `DynamicHash::find_varnode` by
+  `Funcdata::kuna_apply_dynamic_recommendations`).  Dropping the hash-storage
+  half would silently revert renames of exactly the register/temporary
+  variables users rename most.  The host's declared prototype MODEL and its
+  EXACT committed parameter storage ride along too
+  (`Architecture::kuna_pending_proto_model`,
+  `Funcdata::apply_locked_prototype_with_model`, and the decoded cat-0
+  storage threaded into `Funcdata::apply_mapped_params`): re-deriving either
+  from kuna's default model makes Java's `checkFullCommit` see a mismatch and
+  force-rewrite the user's signature on the next rename.
 
 (kuna) **Surfacing a failed function.** A per-function pipeline abort is
 *recoverable*: the drive catches the unwind and returns the reason as an error

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -318,7 +318,17 @@ Four front-ends drive one engine assembly:
   ids the wire needs. First, the naming pass RECORDS the bind it actually made
   (`HighVariable::kuna_link_symbol`,
   `decompiler/crates/kuna-decomp/src/p6_variables/coreaction_cleanup.rs`) when
-  a high resolves to a covering localmap entry. Second, an encode-time link
+  a high resolves to a covering localmap entry — and, for a `&symbol`
+  REFERENCE, the identity of the Symbol referred to
+  (`HighVariable::kuna_ref_symbol`, set by `Funcdata::link_symbol_reference`,
+  the port of C++ `Varnode::setSymbolReference` →
+  `HighVariable::setSymbolReference`). That second record is what a stack
+  aggregate reached ONLY through `&sym` — a `char v [16]` passed to `memcmp`,
+  whose entire HighVariable is the constant `PTRSUB` offset operand and which
+  therefore owns no storage to re-derive a Symbol from — is declared off; it is
+  read for the declaration only, because such a high encodes
+  `class="constant"`, where Java's `HighConstant.decode` does nothing with a
+  mapped local symref. Second, an encode-time link
   pass (`Funcdata::kuna_link_high_symbols`) gives every REMAINING named high a
   **wire-only symbol**
   (`decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs (WireSymbol)`):
@@ -337,8 +347,15 @@ Four front-ends drive one engine assembly:
   the five-way `class` rule, `symref` + partial `offset`, the type reference,
   one instance `<addr ref>` per member) therefore points only at ids the
   just-encoded `<localdb>` resolves — a symbol the encode skipped defensively
-  is withheld from `symref` too (`Database::encodable_symbol_ids`), because an
-  orphan reference is the Java hard-throw the skip exists to avoid.  Globals echo the REAL host database id delivered by
+  is withheld from `symref` too (`Database::encodable_symbol_ids`, and
+  `WireSymbol::is_encodable` for the wire ones: a 0-sized data-type at MAPPED
+  storage is the `MappedEntry.decode` throw, so such a high takes the hashed
+  shape instead), because an orphan reference is the Java hard-throw the skip
+  exists to avoid.  The markup's `<vardecl symref>` passes the SAME filter and
+  falls back to the create index when it fails — an unresolvable declaration
+  reference is not a throw (`ClangVariableDecl.decode` logs and returns) but it
+  is a dead rename on that line, which is the whole point of the attribute.
+  Globals echo the REAL host database id delivered by
   getMappedSymbols (`GlobalEntry::symbol_id`,
   `decompiler/crates/kuna-decomp/src/substrate/context.rs`) and NEVER a
   fabricated one — an unknown id omits `symref` (Java warns and falls back to
@@ -389,9 +406,13 @@ Four front-ends drive one engine assembly:
   EXACT committed parameter storage ride along too
   (`Architecture::kuna_pending_proto_model`,
   `Funcdata::apply_locked_prototype_with_model`, and the decoded cat-0
-  storage threaded into `Funcdata::apply_mapped_params`): re-deriving either
-  from kuna's default model makes Java's `checkFullCommit` see a mismatch and
-  force-rewrite the user's signature on the next rename.
+  storage threaded into `Funcdata::apply_mapped_params`, whose slots are
+  counted in the SAME compacted basis `RemoteProto::to_pieces` builds).  The
+  storage echo is the load-bearing half: Java's `checkFullCommit` compares the
+  parameter COUNT, each `categoryIndex`, and each storage — never the model
+  name — so a kuna-rederived storage or a slot skew force-rewrites the user's
+  signature on the next rename.  The model rides along because the storage kuna
+  would otherwise derive comes from it, not because Java inspects it.
 
 (kuna) **Surfacing a failed function.** A per-function pipeline abort is
 *recoverable*: the drive catches the unwind and returns the reason as an error

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -295,6 +295,73 @@ Four front-ends drive one engine assembly:
   None of this touches the standalone path: no provider installed means every
   seam takes its frozen-snapshot branch, byte-identically.
 
+  (kuna) **The Phase-4 full response encode** makes the `decompileAt` answer
+  carry everything the native GUI features consume, in the upstream child
+  order (`Funcdata::encode`,
+  `decompiler/crates/kuna-decomp/src/substrate/funcdata_encode.rs`): the base
+  `<addr>`, the `<localdb>` symbol scope, the `<ast>` (savetree), the
+  `<highlist>` (savetree + high-level on), the `<jumptablelist>`, and the
+  `<prototype>`.  `<localdb>` is `ScopeLocal::encode`
+  (`decompiler/crates/kuna-decomp/src/p6_variables/varmap.rs`) over the
+  function's private symbol database
+  (`decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs
+  (Database::encode_scope, Symbol::encode_header, SymbolEntry::encode)`):
+  every `<symbol>` carries its NONZERO id (internal `SYMBOL_ID_BASE`-range for
+  kuna-invented symbols; Java's `HighSymbol.decodeHeader` throws on 0), every
+  `<mapsym>` at least one storage entry (`<addr>`/`<hash>` + its uselimit
+  `<rangelist>`), parameters their `cat=0` + slot `index` + exact storage (the
+  Java rename path re-commits the whole signature when these disagree with the
+  database), and the `<scope>` opens positionally with `<parent>` +
+  `<rangelist>` because `LocalSymbolMap.decodeScope` skips both blind.
+  Because kuna's naming pass binds plain strings (`kuna_name`) instead of the
+  C++ `ActionNameVars::linkSymbols` Symbol objects, the encode runs an
+  encode-time link pass (`Funcdata::kuna_link_high_symbols`): a named,
+  non-persist, non-constant high resolves its name-representative storage to a
+  covering localmap entry (parameters from `link_proto_params`, restructured
+  stack locals) or materializes a fresh mapped Symbol there, and the SymbolId
+  lands on the high — so the `<highlist>` (`Funcdata::encode_high`, the
+  `HighVariable::encode` port: `repref` = name-representative create-index,
+  the five-way `class` rule, `symref` + partial `offset`, the type reference,
+  one instance `<addr ref>` per member) points at ids the just-encoded
+  `<localdb>` resolves.  Globals echo the REAL host database id delivered by
+  getMappedSymbols (`GlobalEntry::symbol_id`,
+  `decompiler/crates/kuna-decomp/src/substrate/context.rs`) and NEVER a
+  fabricated one — an unknown id omits `symref` (Java warns and falls back to
+  address-keyed rename) rather than silently renaming the wrong symbol.  Type
+  references marshal through the `Datatype::encode_ref` port (chapter
+  [05](05-types.md)); the prototype through `FuncProto::encode` (chapter
+  [04](04-calls-and-prototypes.md)).  The `<jumptablelist>` re-uses the ported
+  `JumpTable::encode` and is emitted INDEPENDENTLY of savetree — the switch
+  analyzer asks `noc`+`notree`+`jumpload` and consumes only this list; the
+  session's jumpload toggle reaches recovery as the upstream
+  `FlowInfo::record_jumploads` flowoptions bit, applied per-decompile in
+  `decompiler/crates/kuna-ghidra/src/process.rs` so the setOptions baseline
+  reset can never strand it.  Under action `paramid` with parammeasures on,
+  the doc contains ONLY `<parammeasures>`
+  (`decompiler/crates/kuna-decomp/src/infra/paramid.rs
+  (ParamIDAnalysis::encode)`, the `<rank>` child always on — Java throws
+  without it); otherwise an optional `<parammeasures>` precedes the function
+  pair.  The markup `<function>` is rendered BEFORE `fd.encode` runs (the
+  link pass must not perturb the printed C) and spliced after the syntax tree,
+  keeping the upstream document order.
+  The rename/retype PERSISTENCE loop closes the circle: a GUI edit is a DB
+  write (`HighFunctionDBUtil.updateDBVariable`) followed by an event-driven
+  re-decompile whose getMappedSymbols answer now carries the edited local in
+  the function's `<localdb>` (Java `LocalSymbolMap.grabFromFunction`).  kuna
+  decodes those non-parameter locals
+  (`decompiler/crates/kuna-decomp/src/infra/remote_provider.rs
+  (RemoteLocalVar)`) and seeds them into the fresh `Funcdata`: a TYPELOCKED
+  local (a retype — Java sends `typelock=false` only for `Undefined` types)
+  seeds as a real mapped/usepoint symbol (`Funcdata::seed_mapped_symbols` /
+  `Funcdata::seed_usepoint_symbols`, surviving restructure's typelock-keep
+  rule), while a namelocked-but-NOT-typelocked local (a plain rename) — which
+  C++ itself never keeps as a Symbol — stages as a NAME RECOMMENDATION
+  (`Architecture::kuna_pending_name_recs` →
+  `decompiler/crates/kuna-decomp/src/substrate/funcdata.rs
+  (Funcdata::seed_name_recommendations)`), the
+  `ScopeLocal::nameRecommend` mechanism of chapter
+  [06](06-variables-and-merge.md) §6.4.
+
 (kuna) **Surfacing a failed function.** A per-function pipeline abort is
 *recoverable*: the drive catches the unwind and returns the reason as an error
 (`decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs (panic_message)`

--- a/docs/spec/04-calls-and-prototypes.md
+++ b/docs/spec/04-calls-and-prototypes.md
@@ -629,6 +629,22 @@ the CALLIND after type recovery starts) is not wired; such a site today keeps
 its model-recovered argument list. Restarts triggered here are refused during
 jump-table sub-decompilation like every other feedback edge (00 §0.7).
 
+**The prototype wire encode.** The recovered prototype marshals out for the
+ghidra-mode `decompileAt` response through the `FuncProto::encode` port
+(`decompiler/crates/kuna-decomp/src/p4_calls/fspec.rs (FuncProto::encode)`):
+the model name (a model-less fixture degrades to the `"default"` spelling
+Java maps onto the program default), the extrapop (the reserved
+`EXTRAPOP_UNKNOWN` spells the string `"unknown"`), the eight boolean flag
+attributes, and the REQUIRED `<returnsym>` — the output parameter's sized
+storage `<addr>` (blank for void) followed by its type reference.  Effect and
+likely-trash overrides encode as model-diffs only
+(`encode_effect`/`encode_likely_trash` + `EffectRecord::encode`, the
+fspec.cc:3589/3631 ports); Java's `FunctionPrototype.decodePrototype` skips
+them, so they matter only to a native decoder.  Input parameters are
+deliberately NOT here: on the wire they travel as `<localdb>` category-0
+symbols (chapter [06](06-variables-and-merge.md) §6.2), matching upstream's
+symbol-backed `ProtoStoreSymbol::encode`, which writes nothing.
+
 ## 4.4 kuna extensions
 
 ### (kuna) `returnpair` — the register-pair return split

--- a/docs/spec/05-types.md
+++ b/docs/spec/05-types.md
@@ -151,6 +151,34 @@ vendored cspecs carry no `<data_organization>` element whatsoever — every
 PowerPC 32-bit one among them — so the fallbacks are the common case, not the
 exception.
 
+**The wire marshal.** Types cross the ghidra-mode wire in both directions.
+Inbound, registerProgram's `<coretypes>` and per-miss getDataType answers
+decode through `decompiler/crates/kuna-decomp/src/substrate/dtype.rs
+(decode_core_types, decode_type, find_by_id_or_remote)`. Outbound — the
+Phase-4 `decompileAt` response — every type reference marshals through the
+`Datatype::encodeRef` port (`decompiler/crates/kuna-decomp/src/substrate/dtype.rs
+(Datatype::encode_ref)`): a type with a nonzero id (and non-void metatype)
+travels as the compact `<typeref name id>` — a variable-length base emits the
+size-independent id (`Datatype::hash_size` is reversible, and both
+`get_unsized_id` and `has_same_variable_base` now complete through it) plus
+the instance size — and Java's `PcodeDataTypeManager.decodeDataType` resolves
+the (name,id) pair, which for wire-delivered types originally CAME from Java,
+so the echo is exact by construction. An id-less type (a derived
+pointer/array, an invented unknown) travels as the full `<type>` form
+(`Datatype::encode`): `encode_basic` writes name/unsized-id/size/metatype
+plus the alignment (composites), core/varlength/opaquestring flags and the
+display format, and each `DatatypeKind` arm reproduces its C++ subclass
+override — pointer/array descend ONE level by reference, struct interleaves
+`TypeField::encode`/`TypeBitField::encode` by byte offset, enum re-spells its
+metatype `enum_int`/`enum_uint` with one `<val>` child per name, a typedef
+collapses to `<def name id>` + the referent's reference, and `PointerRel`
+encodes its pointed-to type in FULL (the one place the C++ does) plus the
+parent by reference and the `<off>` child. The differential guard is the
+decode side itself: `wire_encode_roundtrips_through_decode_type` (same file's
+tests) asserts that whatever `encode_ref` emits, `decode_type` resolves back
+to the *identical interned `Rc`* — the same intern-equality contract §5.1's
+factory provides in-process.
+
 ## 5.2 Inference
 
 Type recovery is **off** for the entire first `fullloop` iteration — early

--- a/docs/spec/06-variables-and-merge.md
+++ b/docs/spec/06-variables-and-merge.md
@@ -463,15 +463,27 @@ list: C++ keeps `dynRecommend` and re-applies it through
 `DynamicHash::findVarnode` (varmap.cc:1557-1573).  kuna ports that too
 (`ScopeLocal::add_recommend_dynamic` /
 `decompiler/crates/kuna-decomp/src/substrate/funcdata.rs
-(Funcdata::kuna_apply_dynamic_recommendations)`, run at the top of the naming
-pass exactly as upstream runs it at the top of `ActionNameVars::apply`): the
-recorded hash resolves back to its Varnode, and when that Varnode's high is
-still unnamed it takes the recommended name AND a dynamic Symbol carrying the
-same hash — so the re-encoded `<localdb>` hands Java a `<mapsym
-type="dynamic">` it resolves to the very variable the user renamed.  The hash
-is computed with the upstream budget of 8 because Java hardcodes the same
-(`DynamicHash.java:440`) and a hash the two sides disagree on cannot
-round-trip.
+(Funcdata::kuna_apply_dynamic_recommendations)`): the recorded hash resolves
+back to its Varnode, and when that Varnode's high is still unnamed it takes the
+recommended name AND a dynamic Symbol carrying the same hash — so the
+re-encoded `<localdb>` hands Java a `<mapsym type="dynamic">` it resolves to
+the very variable the user renamed.  The hash is computed with the upstream
+budget of 8 because Java hardcodes the same (`DynamicHash.java:440`) and a hash
+the two sides disagree on cannot round-trip — deliberately NOT kuna's
+`dynamichashmax` option, whose value only has to satisfy kuna's own analysis.
+
+PLACEMENT is a real divergence.  Upstream runs the `dynRecommend` loop AFTER
+`linkSymbols`, so every high already carries `getSymbol()` and the loop merely
+RENAMES an existing Symbol under three guards (`sym == 0`, wrong scope,
+`!isNameUndefined`).  kuna's naming pass fuses linking with the `vN` default
+assignment into one location-ordered walk, leaving no "after linking, before
+defaults" point; the loop therefore runs FIRST and CREATES the dynamic Symbol.
+Because no high is named at that moment, the ported per-high guard is vacuous,
+so the equivalent guard is applied against the SCOPE instead: a hash landing on
+storage the walk is about to bind to a real Symbol — a `function_parameter`, or
+any Symbol that already has a defined name — is skipped.  Without it a stale or
+shape-shifted host hash could take a parameter's variable, and that high's
+`<high symref>` would stop pointing at the parameter.
 
 The lists' only producer today is ghidra-mode's host-`<localdb>` seeding (the
 GUI rename persistence loop, chapter [00](00-overview.md)); the standalone

--- a/docs/spec/06-variables-and-merge.md
+++ b/docs/spec/06-variables-and-merge.md
@@ -458,11 +458,26 @@ applies it in the `ActionNameVars` port
 storage + size wins the recommended name — the use-address selects the arm
 (invalid = address-tied whole, `entry-1` = a function input, else the defining
 write's address) — before both the container bind and the `vN` allocator.
-The list's only producer today is ghidra-mode's host-`<localdb>` seeding (the
+A variable whose storage is a HASH rather than an address needs the parallel
+list: C++ keeps `dynRecommend` and re-applies it through
+`DynamicHash::findVarnode` (varmap.cc:1557-1573).  kuna ports that too
+(`ScopeLocal::add_recommend_dynamic` /
+`decompiler/crates/kuna-decomp/src/substrate/funcdata.rs
+(Funcdata::kuna_apply_dynamic_recommendations)`, run at the top of the naming
+pass exactly as upstream runs it at the top of `ActionNameVars::apply`): the
+recorded hash resolves back to its Varnode, and when that Varnode's high is
+still unnamed it takes the recommended name AND a dynamic Symbol carrying the
+same hash — so the re-encoded `<localdb>` hands Java a `<mapsym
+type="dynamic">` it resolves to the very variable the user renamed.  The hash
+is computed with the upstream budget of 8 because Java hardcodes the same
+(`DynamicHash.java:440`) and a hash the two sides disagree on cannot
+round-trip.
+
+The lists' only producer today is ghidra-mode's host-`<localdb>` seeding (the
 GUI rename persistence loop, chapter [00](00-overview.md)); the standalone
-pipeline never adds a record, so the pass is structurally inert there.  The
-C++ `collectNameRecs` harvest (standalone symbols → records) and the
-dynamic-hash record list remain unported follow-ups.
+pipeline never adds a record, so both passes are structurally inert there.
+The C++ `collectNameRecs` harvest (standalone symbols → records) remains an
+unported follow-up.
 
 **The scope wire encode.** The whole local scope marshals out for the
 ghidra-mode `decompileAt` response as the `<localdb>` element

--- a/docs/spec/06-variables-and-merge.md
+++ b/docs/spec/06-variables-and-merge.md
@@ -443,6 +443,49 @@ stack pointer gets a `PTRSUB(sp, #0)` spliced in so the type system renders
 `&local` instead of the bare register (`funcdata_spacebase.rs
 (Funcdata::annotate_raw_stack_ptr)`).
 
+**Name recommendations.** A namelocked-but-NOT-typelocked local never
+survives restructure — `clearUnlockedCategory(-1)` removes every non-typelocked
+category-less symbol at the pass head — so its *name* survives separately: C++
+harvests such symbols into `ScopeLocal::nameRecommend` records and re-applies
+them at naming time (`recoverNameRecommendationsForSymbols`, varmap.cc:1050 —
+run at the top of `ActionNameVars::apply`).  The kuna port carries the record
+type (`decompiler/crates/kuna-decomp/src/p6_variables/varmap.rs
+(NameRecommend)`) with a list on the scope
+(`ScopeLocal::add_recommend_name`/`ScopeLocal::name_recommendations`) and
+applies it in the `ActionNameVars` port
+(`decompiler/crates/kuna-decomp/src/p6_variables/coreaction_cleanup.rs
+(recommended_name_for)`): a high whose name representative matches a record's
+storage + size wins the recommended name — the use-address selects the arm
+(invalid = address-tied whole, `entry-1` = a function input, else the defining
+write's address) — before both the container bind and the `vN` allocator.
+The list's only producer today is ghidra-mode's host-`<localdb>` seeding (the
+GUI rename persistence loop, chapter [00](00-overview.md)); the standalone
+pipeline never adds a record, so the pass is structurally inert there.  The
+C++ `collectNameRecs` harvest (standalone symbols → records) and the
+dynamic-hash record list remain unported follow-ups.
+
+**The scope wire encode.** The whole local scope marshals out for the
+ghidra-mode `decompileAt` response as the `<localdb>` element
+(`decompiler/crates/kuna-decomp/src/p6_variables/varmap.rs
+(ScopeLocal::encode)`, the varmap.cc:462 port): the `main=` stack space and
+`lock=` attributes, then the `<scope>` document
+(`decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs
+(Database::encode_scope)`) — the positional `<parent>` + `<rangelist>` pair
+(Java's `LocalSymbolMap.decodeScope` skips its first two scope children
+blind, so both are always written; the parentless private database writes its
+own id), then the `<symbollist>` of `<mapsym>`s in nametree order.  Each
+mapsym is `Symbol::encode` (header: name, the UNCONDITIONAL nonzero id, the
+lock/storage flag attributes, `cat` and — for a parameter — the slot `index`;
+body: the data-type reference) followed by its storage entries
+(`SymbolEntry::encode`: a `<hash>` for a dynamic entry, a plain `<addr>`
+otherwise, each with its uselimit `<rangelist>`; piece entries are skipped).
+Category-0 symbols with exact parameter storage are what the Java rename path
+compares against the database (`checkFullCommit`) — a mismatch would turn
+every rename into a whole-signature rewrite.  Symbols with no entry, no id,
+or a zero-sized type are skipped defensively (each is a Java-side hard throw
+that would discard the entire decompile result); none arises through the kuna
+creation paths.
+
 ## 6.3 Dynamic hashes
 
 A stack local is addressed by its offset, a register by its storage — but a

--- a/integrations/ghidra/live-smoke/phase4_features.py
+++ b/integrations/ghidra/live-smoke/phase4_features.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Live Phase-4 feature verification: drive the NATIVE Ghidra GUI features the
+full `decompileAt` response encode lights up, against a REAL Ghidra with
+`kuna_ghidra` swapped in as the decompiler core.
+
+What it proves (each section prints PASS/FAIL and lands in PHASE4_REPORT.md):
+
+  1. signature   — the recovered prototype renders (model + return type +
+                   parameters from the `<prototype>` + `<localdb>` cat-0
+                   symbols), and `getC()` carries CLEAN type spellings (no
+                   `unsigned_long__`-style `IllegalCharCppTransformer` mangle).
+  2. symbols     — the HighFunction's LocalSymbolMap decoded params + locals
+                   (ids, storage) from kuna's `<localdb>`/`<highlist>`.
+  3. rename      — the KEYSTONE: `HighFunctionDBUtil.updateDBVariable` renames
+                   a kuna-delivered local HighSymbol; verified against the DB
+                   variable AT THE SAME STORAGE (a wrong symbol id silently
+                   renames the wrong thing), then re-decompiled to show the
+                   new name in the C.
+  4. retype      — `updateDBVariable(sym, None, dtype)` on the same symbol.
+  5. param rename— rename a parameter (cat-0 + index + exact storage: a
+                   mismatch forces a whole-signature commit — r2 §4).
+  6. jumptables  — `toggleJumpLoads` + `toggleSyntaxTree(false)` +
+                   `toggleCCode(false)` (the switch-analyzer configuration):
+                   `HighFunction.getJumpTables()` decodes kuna's
+                   `<jumptablelist>` (cases + loadtables), and
+                   `DecompilerSwitchAnalysisCmd` re-creates the jump
+                   references from it after they are deleted.
+  7. paramid     — the `paramid` action + parammeasures toggle:
+                   `DecompileResults.getHighParamID()` decodes kuna's
+                   `<parammeasures>`.
+
+Environment: as kuna_vs_stock.py (GHIDRA_INSTALL_DIR, KUNA_GHIDRA_EXE,
+KUNA_SMOKE_BINARY, KUNA_SMOKE_OUT), plus KUNA_SMOKE_FUNCTION (default: main).
+"""
+
+import os
+import re
+import sys
+import traceback
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+KUNA_GHIDRA = os.environ.get(
+    "KUNA_GHIDRA_EXE",
+    os.path.join(REPO, "decompiler", "target", "release", "kuna_ghidra"),
+)
+BINARY = os.environ.get("KUNA_SMOKE_BINARY")
+FUNCTION = os.environ.get("KUNA_SMOKE_FUNCTION", "main")
+OUT = os.path.abspath(os.environ.get("KUNA_SMOKE_OUT", "live-phase4-out"))
+
+REPORT = []
+
+
+def log(line=""):
+    print(line)
+    REPORT.append(line)
+
+
+def check(name, ok, detail=""):
+    log(f"[{'PASS' if ok else 'FAIL'}] {name}" + (f" — {detail}" if detail else ""))
+    return ok
+
+
+def main():
+    if not BINARY:
+        print("usage: KUNA_SMOKE_BINARY=/path/to/prog python3 phase4_features.py")
+        sys.exit(1)
+    if not os.path.exists(KUNA_GHIDRA):
+        print(f"FATAL: kuna_ghidra not built at {KUNA_GHIDRA}")
+        sys.exit(1)
+    os.makedirs(OUT, exist_ok=True)
+    # The probe MUTATES the program database (renames/retypes/reference
+    # edits); a reused project would accumulate them and skew every check.
+    # Always analyze into a fresh project.
+    import shutil
+    shutil.rmtree(os.path.join(OUT, "ghidra_project"), ignore_errors=True)
+
+    import pyghidra
+    pyghidra.start()
+    from ghidra.app.decompiler import DecompInterface, DecompileProcessFactory
+    from ghidra.program.model.pcode import HighFunctionDBUtil
+    from ghidra.program.model.symbol import SourceType
+    from ghidra.program.model.data import AbstractIntegerDataType
+    from ghidra.util.task import ConsoleTaskMonitor
+
+    field = DecompileProcessFactory.class_.getDeclaredField("exepath")
+    field.setAccessible(True)
+
+    failures = 0
+    with pyghidra.open_program(
+        BINARY,
+        project_location=os.path.join(OUT, "ghidra_project"),
+        project_name="kuna_phase4",
+        analyze=True,
+    ) as flat:
+        program = flat.getCurrentProgram()
+        monitor = ConsoleTaskMonitor()
+        fm = program.getFunctionManager()
+        func = None
+        for f in fm.getFunctions(True):
+            if str(f.getName()) == FUNCTION:
+                func = f
+                break
+        if func is None:
+            print(f"FATAL: no function named {FUNCTION}")
+            sys.exit(1)
+
+        field.set(None, KUNA_GHIDRA)
+        log(f"# Phase-4 live feature report — {os.path.basename(BINARY)}::{FUNCTION}")
+        log(f"core: {KUNA_GHIDRA}")
+        log()
+
+        # ---- 1+2: full decompile: signature, symbols, clean spellings ------
+        from ghidra.app.decompiler import DecompileOptions
+        ifc = DecompInterface()
+        ifc.setOptions(DecompileOptions())  # the GUI always sends options
+        assert ifc.openProgram(program), ifc.getLastMessage()
+        res = ifc.decompileFunction(func, 120, monitor)
+        if not check("decompileCompleted", res.decompileCompleted(),
+                     str(res.getErrorMessage())):
+            failures += 1
+        hf = res.getHighFunction()
+        dfunc = res.getDecompiledFunction()
+        c = str(dfunc.getC()) if dfunc else ""
+        with open(os.path.join(OUT, f"kuna_{FUNCTION}.c"), "w") as fh:
+            fh.write(c)
+        sig = str(dfunc.getSignature()) if dfunc else ""
+        proto = hf.getFunctionPrototype()
+        log(f"signature: {sig}")
+        log(f"prototype: model={proto.getModelName()} extrapop={proto.getExtraPop()} "
+            f"ret={proto.getReturnType()} nparams={proto.getNumParams()}")
+        if not check("signature renders with parameters",
+                     bool(sig) and proto.getNumParams() >= 1, sig):
+            failures += 1
+        # The type-token mangle signature specifically ("unsigned long *" as
+        # ONE <type> token reads back as `unsigned_long__…`) — NOT the
+        # legitimate double underscores of Ghidra's string-literal symbols.
+        mangles = re.findall(
+            r"\b(?:unsigned|signed)_\w+"
+            r"|\b(?:u?long|u?int|u?short|u?char|byte|bool|float|double"
+            r"|void|code|undefined\d*)__\w*",
+            c,
+        )
+        if not check("getC() carries no IllegalChar-mangled type tokens",
+                     not mangles, f"{mangles[:5]}"):
+            failures += 1
+
+        lsm = hf.getLocalSymbolMap()
+        params = [lsm.getParamSymbol(i) for i in range(lsm.getNumParams())]
+        locals_ = [s for s in lsm.getSymbols() if not s.isParameter()]
+        log(f"localdb: {lsm.getNumParams()} params, {len(locals_)} locals")
+        for p in params:
+            log(f"  param {p.getCategoryIndex()}: {p.getName()} @ {p.getStorage()} "
+                f"id={p.getId():#x} type={p.getDataType()}")
+        for s in locals_[:8]:
+            log(f"  local: {s.getName()} @ {s.getStorage()} id={s.getId():#x} "
+                f"type={s.getDataType()}")
+        if not check("locals decoded as HighSymbols", len(locals_) >= 1):
+            failures += 1
+
+        # ---- 3: the rename keystone ----------------------------------------
+        # Prefer stack storage, then a >=2-byte register (a 1-byte flag local
+        # is renameable but a poor retype target), then anything sane.
+        def storage_rank(s):
+            st = s.getStorage()
+            if st is None or st.isBadStorage() or not str(s.getName()):
+                return None
+            if st.isStackStorage():
+                return 0
+            if st.isRegisterStorage() and st.size() >= 2:
+                return 1
+            return 2
+
+        ranked = sorted(
+            (s for s in locals_ if storage_rank(s) is not None),
+            key=storage_rank,
+        )
+        target = ranked[0] if ranked else None
+        if target is None:
+            failures += 1
+            check("rename: a renameable local exists", False)
+        else:
+            old_name = str(target.getName())
+            storage = target.getStorage()
+            pcaddr = target.getPCAddress()
+            new_name = "kuna_ren_probe"
+            before = {str(v.getName()) for v in func.getAllVariables()}
+            tid = program.startTransaction("phase4 rename")
+            err = None
+            try:
+                HighFunctionDBUtil.updateDBVariable(
+                    target, new_name, None, SourceType.USER_DEFINED)
+            except Exception:
+                err = traceback.format_exc()
+            finally:
+                program.endTransaction(tid, err is None)
+            if err:
+                log(err)
+            hit = [v for v in func.getAllVariables()
+                   if str(v.getName()) == new_name]
+            same_storage = bool(hit) and str(hit[0].getVariableStorage()) == str(storage)
+            after = {str(v.getName()) for v in func.getAllVariables()}
+            collateral = (before - {old_name}) - after
+            if not check(
+                "rename round-trip writes the RIGHT DB variable",
+                err is None and same_storage and not collateral,
+                f"{old_name} @ {storage} (pc {pcaddr}) -> {new_name}; "
+                f"db-hit={[str(v.getVariableStorage()) for v in hit]}; "
+                f"collateral-renames={sorted(collateral)}",
+            ):
+                failures += 1
+            # Optional deep-debug: capture the full wire session (query answers
+            # included) around the re-decompile via DecompInterface.enableDebug.
+            if os.environ.get("KUNA_SMOKE_DEBUGXML"):
+                from java.io import File as JFile
+                dbg_path = os.path.join(OUT, "post_rename_session.xml")
+                ifc.enableDebug(JFile(dbg_path))
+            # Event-driven re-decompile: the new name must come back in the C.
+            res2 = ifc.decompileFunction(func, 120, monitor)
+            c2 = str(res2.getDecompiledFunction().getC())
+            with open(os.path.join(OUT, f"kuna_{FUNCTION}_renamed.c"), "w") as fh:
+                fh.write(c2)
+            lsm2 = res2.getHighFunction().getLocalSymbolMap()
+            names2 = sorted(str(s.getName()) for s in lsm2.getSymbols())
+            log(f"post-rename localdb: {names2}")
+            if not check("re-decompile shows the new name", new_name in c2):
+                failures += 1
+
+            # ---- 4: retype the same symbol ---------------------------------
+            res3 = ifc.decompileFunction(func, 120, monitor)
+            lsm3 = res3.getHighFunction().getLocalSymbolMap()
+            tgt3 = None
+            for s in lsm3.getSymbols():
+                if str(s.getName()) == new_name:
+                    tgt3 = s
+                    break
+            if tgt3 is None:
+                failures += 1
+                check("retype: renamed symbol resolvable after re-decompile", False)
+            else:
+                # Retype to the same-size unsigned integer (a size-changing
+                # retype of register storage is a GUI error case, not a wire
+                # test).
+                new_dt = AbstractIntegerDataType.getUnsignedDataType(
+                    tgt3.getSize(), program.getDataTypeManager())
+                tid = program.startTransaction("phase4 retype")
+                err = None
+                try:
+                    HighFunctionDBUtil.updateDBVariable(
+                        tgt3, None, new_dt, SourceType.USER_DEFINED)
+                except Exception:
+                    err = traceback.format_exc()
+                finally:
+                    program.endTransaction(tid, err is None)
+                if err:
+                    log(err)
+                res4 = ifc.decompileFunction(func, 120, monitor)
+                c4 = str(res4.getDecompiledFunction().getC())
+                retyped = [str(s.getDataType())
+                           for s in res4.getHighFunction().getLocalSymbolMap().getSymbols()
+                           if str(s.getName()) == new_name]
+                if not check("retype round-trip",
+                             err is None and retyped == [str(new_dt.getName())],
+                             f"wanted {new_dt.getName()}, got {retyped}"):
+                    failures += 1
+                with open(os.path.join(OUT, f"kuna_{FUNCTION}_retyped.c"), "w") as fh:
+                    fh.write(c4)
+
+        # ---- 5: parameter rename (cat-0 + index + exact storage) -----------
+        if params:
+            p0 = params[0]
+            old_p = str(p0.getName())
+            tid = program.startTransaction("phase4 param rename")
+            err = None
+            try:
+                HighFunctionDBUtil.updateDBVariable(
+                    p0, "kuna_param_probe", None, SourceType.USER_DEFINED)
+            except Exception:
+                err = traceback.format_exc()
+            finally:
+                program.endTransaction(tid, err is None)
+            if err:
+                log(err)
+            db_params = [str(p.getName()) for p in func.getParameters()]
+            if not check("param rename lands on the DB parameter",
+                         err is None and "kuna_param_probe" in db_params,
+                         f"{old_p} -> DB params now {db_params}"):
+                failures += 1
+        ifc.dispose()
+
+        # ---- 6: the switch-analyzer configuration --------------------------
+        ifc_sw = DecompInterface()
+        ifc_sw.toggleCCode(False)
+        ifc_sw.toggleSyntaxTree(False)
+        ifc_sw.toggleJumpLoads(True)
+        assert ifc_sw.openProgram(program), ifc_sw.getLastMessage()
+        res_sw = ifc_sw.decompileFunction(func, 120, monitor)
+        hf_sw = res_sw.getHighFunction()
+        jts = list(hf_sw.getJumpTables()) if hf_sw else []
+        detail = "; ".join(
+            f"@{jt.getSwitchAddress()} cases={len(list(jt.getCases()))} "
+            f"labels={len(list(jt.getLabelValues()))} "
+            f"loadtables={len(list(jt.getLoadTables()))}"
+            for jt in jts)
+        if not check("HighFunction.getJumpTables decodes <jumptablelist>",
+                     bool(jts), detail):
+            failures += 1
+        # loadtables are model-dependent (collected only when table recovery
+        # emulates the memory walk) — report, don't gate; the in-tree sim
+        # gate (ghidra_sim_faillog_switch_analyzer_shape) covers the jumpload
+        # plumbing.
+        log(f"loadtables per table: "
+            f"{[len(list(jt.getLoadTables())) for jt in jts]}")
+
+        # DecompilerSwitchAnalysisCmd end-to-end: delete the computed jump's
+        # references, then let the analyzer command rebuild them from the
+        # DecompileResults kuna produced under the analyzer's configuration.
+        if jts:
+            from ghidra.app.cmd.function import DecompilerSwitchAnalysisCmd
+            sw_addr = jts[0].getSwitchAddress()
+            instr = program.getListing().getInstructionAt(sw_addr)
+            refmgr = program.getReferenceManager()
+            if instr is None:
+                failures += 1
+                check("switch instruction exists at the jumptable address", False,
+                      str(sw_addr))
+            else:
+                tid = program.startTransaction("phase4 clear switch refs")
+                try:
+                    for ref in list(refmgr.getReferencesFrom(sw_addr)):
+                        refmgr.delete(ref)
+                finally:
+                    program.endTransaction(tid, True)
+                cleared = len(list(refmgr.getReferencesFrom(sw_addr)))
+                # 12.1.2 vintage: the Cmd consumes the DecompileResults from
+                # the analyzer-configured interface (noc/notree/jumpload).
+                cmd = DecompilerSwitchAnalysisCmd(res_sw)
+                _ = instr
+                tid = program.startTransaction("phase4 switch analysis")
+                ok = False
+                try:
+                    ok = cmd.applyTo(program, monitor)
+                finally:
+                    program.endTransaction(tid, True)
+                rebuilt = len(list(refmgr.getReferencesFrom(sw_addr)))
+                if not check(
+                    "DecompilerSwitchAnalysisCmd rebuilds the case references",
+                    ok and rebuilt >= 2,
+                    f"cleared to {cleared}, rebuilt {rebuilt} refs "
+                    f"(status: {cmd.getStatusMsg()})",
+                ):
+                    failures += 1
+        ifc_sw.dispose()
+
+        # ---- 7: the paramid action -----------------------------------------
+        ifc_pid = DecompInterface()
+        ifc_pid.setSimplificationStyle("paramid")
+        ifc_pid.toggleCCode(False)
+        ifc_pid.toggleSyntaxTree(False)
+        ifc_pid.toggleParamMeasures(True)
+        assert ifc_pid.openProgram(program), ifc_pid.getLastMessage()
+        res_pid = ifc_pid.decompileFunction(func, 120, monitor)
+        hpid = res_pid.getHighParamID()
+        if not check("getHighParamID decodes <parammeasures>",
+                     hpid is not None and hpid.getNumInputs() >= 1,
+                     f"inputs={hpid.getNumInputs() if hpid else 'n/a'} "
+                     f"outputs={hpid.getNumOutputs() if hpid else 'n/a'}"):
+            failures += 1
+        ifc_pid.dispose()
+
+        field.set(None, None)
+
+    with open(os.path.join(OUT, "PHASE4_REPORT.md"), "w") as fh:
+        fh.write("\n".join(REPORT) + "\n")
+    print(f"\n[+] report: {os.path.join(OUT, 'PHASE4_REPORT.md')}")
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/ghidra/live-smoke/phase4_features.py
+++ b/integrations/ghidra/live-smoke/phase4_features.py
@@ -196,9 +196,17 @@ def main():
             finally:
                 program.endTransaction(tid0, True)
             before = {str(v.getName()) for v in func.getAllVariables()}
+            # Gate on the COMMIT having produced something, not on an arbitrary
+            # count: a function with a single local is a legitimate target and
+            # must not fail the rig.  With 0 committed variables the collateral
+            # check below is vacuous, which IS a failure of this rig's premise;
+            # with 1 it is weak, so say so and carry on.
             if not check("DB carries committed locals to detect collateral renames",
-                         len(before) >= 2, f"{len(before)} DB variables"):
+                         len(before) >= 1, f"{len(before)} DB variables"):
                 failures += 1
+            elif len(before) < 2:
+                log("NOTE: only 1 committed DB variable — the collateral-rename "
+                    "check cannot discriminate on this function")
             tid = program.startTransaction("phase4 rename")
             err = None
             try:
@@ -283,7 +291,6 @@ def main():
         # ---- 5: parameter rename (cat-0 + index + exact storage) -----------
         if params:
             p0 = params[0]
-            old_p = str(p0.getName())
             # An in-place rename is only meaningful if the decoded prototype
             # ALREADY agrees with the database — otherwise getDatabaseParameter
             # force-commits kuna's whole signature and the rename "lands"
@@ -315,7 +322,13 @@ def main():
                 f"db={[(p.getName(), str(p.getVariableStorage())) for p in db_params]}",
             ):
                 failures += 1
-            p0 = decoded[0] if decoded else p0
+            # Rename through the POST-COMMIT result (a GUI edit always acts on
+            # the HighSymbol of the result currently on screen), and take the
+            # "old name" from that same result — reading it from the pre-commit
+            # `params` would report a name the rename never targeted.
+            if decoded:
+                p0 = decoded[0]
+            old_p = str(p0.getName())
             tid = program.startTransaction("phase4 param rename")
             err = None
             try:

--- a/integrations/ghidra/live-smoke/phase4_features.py
+++ b/integrations/ghidra/live-smoke/phase4_features.py
@@ -183,7 +183,22 @@ def main():
             storage = target.getStorage()
             pcaddr = target.getPCAddress()
             new_name = "kuna_ren_probe"
+            # The collateral set must be non-trivial to mean anything: on a
+            # fresh analysis the DB has no committed locals, so ALSO commit the
+            # decoded locals first (HighFunctionDBUtil.commitLocalNamesToDatabase
+            # is what the GUI does on any local edit) — then a stray rename has
+            # something to collide with.
+            tid0 = program.startTransaction("phase4 commit locals")
+            try:
+                HighFunctionDBUtil.commitLocalNamesToDatabase(hf, SourceType.ANALYSIS)
+            except Exception:
+                log(traceback.format_exc())
+            finally:
+                program.endTransaction(tid0, True)
             before = {str(v.getName()) for v in func.getAllVariables()}
+            if not check("DB carries committed locals to detect collateral renames",
+                         len(before) >= 2, f"{len(before)} DB variables"):
+                failures += 1
             tid = program.startTransaction("phase4 rename")
             err = None
             try:
@@ -269,6 +284,38 @@ def main():
         if params:
             p0 = params[0]
             old_p = str(p0.getName())
+            # An in-place rename is only meaningful if the decoded prototype
+            # ALREADY agrees with the database — otherwise getDatabaseParameter
+            # force-commits kuna's whole signature and the rename "lands"
+            # regardless (the vacuous PASS this check used to be).  Commit the
+            # signature first, then assert storage+ordinal equality decoded-vs-DB
+            # BEFORE renaming.
+            tidp = program.startTransaction("phase4 commit params")
+            try:
+                HighFunctionDBUtil.commitParamsToDatabase(
+                    hf, True, HighFunctionDBUtil.ReturnCommitOption.NO_COMMIT,
+                    SourceType.ANALYSIS)
+            except Exception:
+                log(traceback.format_exc())
+            finally:
+                program.endTransaction(tidp, True)
+            res_p = ifc.decompileFunction(func, 120, monitor)
+            lsm_p = res_p.getHighFunction().getLocalSymbolMap()
+            decoded = [lsm_p.getParamSymbol(i) for i in range(lsm_p.getNumParams())]
+            db_params = list(func.getParameters())
+            storage_ok = len(decoded) == len(db_params) and all(
+                str(d.getStorage()) == str(db.getVariableStorage())
+                and d.getCategoryIndex() == i
+                for i, (d, db) in enumerate(zip(decoded, db_params))
+            )
+            if not check(
+                "encoded param storage/ordinals match the DB (no forced full commit)",
+                storage_ok,
+                f"decoded={[(s.getName(), str(s.getStorage()), s.getCategoryIndex()) for s in decoded]} "
+                f"db={[(p.getName(), str(p.getVariableStorage())) for p in db_params]}",
+            ):
+                failures += 1
+            p0 = decoded[0] if decoded else p0
             tid = program.startTransaction("phase4 param rename")
             err = None
             try:


### PR DESCRIPTION
Phase 4 of the Ghidra integration (`docs/ghidra-integration.md` §12; Phases 1–3 = #135/#317/#318): the `decompileAt` response now carries the FULL first-`<function>` document — `<localdb>`, `<highlist>`, `<jumptablelist>`, `<prototype>`, `<parammeasures>` — plus the markup type-token fix, which is what lights up the native GUI features on a kuna core: real signature display, variable rename/retype that persists, switch recovery through the stock analyzer, and the param-ID analyzer.

## What lights up (live-verified on stock Ghidra 12.1.2, `fmt::main`, pyghidra rig)

Every line below is a `[PASS]` from `integrations/ghidra/live-smoke/phase4_features.py` (new, committed) — the full report is reproduced at the end.

| feature | before (Phase 3) | after (this PR) |
|---|---|---|
| Signature | prototype absent from the response; GUI showed the DB stub state | `int main(int argc,char **argv)` — model `__stdcall`, extrapop 8, ret `int`, 2 params, from `<prototype>` + localdb cat-0 symbols |
| HighSymbols | `<localdb>` absent — no rename/retype targets at all | 2 params + 19 locals decode as HighSymbols with nonzero ids + storage |
| **Rename (the keystone)** | dead (no symbols) | `HighFunctionDBUtil.updateDBVariable` renames `v11 @ RSI:8` → the DB variable **at the same storage** changes, zero collateral renames, and the new name **survives the event-driven re-decompile** (`kuna_ren_probe` in the next getC()) |
| Retype | dead | retype to `ulong` persists across re-decompile (typelocked localdb seed) |
| Param rename | dead | `argc → kuna_param_probe` lands on the DB Parameter (cat-0 + slot index + exact storage — no forced full-signature commit) |
| Switch analyzer | `<jumptablelist>` absent — analyzer no-op | `HighFunction.getJumpTables()` = 10 cases + 10 labels; after deleting all references from the BRANCHIND, `DecompilerSwitchAnalysisCmd` rebuilds all 10 case references from kuna's tables |
| Param-ID analyzer | `<parammeasures>` stubbed | action `paramid` + parammeasures → `getHighParamID()` decodes 2 inputs + 1 output (ranked) |
| getC() type spelling | `unsigned_long__a1` (the IllegalCharCppTransformer mangle) | `unsigned long *a1` — zero mangled tokens |

## The encode (kuna-decomp)

Upstream child order `addr → localdb → ast → highlist → jumptablelist → prototype` (`Funcdata::encode`, funcdata.cc:734):

- **`Datatype::encodeRef`/`encode`** (`substrate/dtype.rs`) — the cross-cutting type marshal-out: `<typeref name id>` for id-carrying types (variable-length emits the size-independent `hash_size` id + instance size; `get_unsized_id`/`has_same_variable_base` completed), full `<type>` per C++ subclass override otherwise (pointer/array one-level descent, struct field/bitfield interleave, enum `<val>`s, `<def>` typedefs, PTRREL's full-ptrto + `<off>`). Differential-tested against kuna's own shipped decode: what `encode_ref` writes, `decode_type` resolves to the identical interned `Rc`.
- **`FuncProto::encode`** (`p4_calls/fspec.rs`) + `EffectRecord::encode` + model-diff effect/likelytrash lists. Params deliberately travel as localdb cat-0 symbols (upstream's symbol-backed store shape).
- **`<localdb>`** — `ScopeLocal::encode` (`p6_variables/varmap.rs`) → `Database::encode_scope`/`Symbol::encode{_header,_body}`/`SymbolEntry::encode` (`p0_knowledge/database.rs`), nametree order, equate symbols included.
- **`<highlist>`** — `Funcdata::encode_high` + the encode-time symbol-link pass `kuna_link_high_symbols` (the C++ `ActionNameVars::linkSymbols` stand-in: kuna names highs with strings, so the Symbols the wire needs are attached/materialized just before encoding; runs only from `Funcdata::encode`, so the standalone path is untouched). Five-way class rule verbatim (variable.cc:839).
- **`<jumptablelist>`** — the already-ported `JumpTable::encode` wired in, emitted independently of savetree; the session `jumpload` toggle now reaches `FlowInfo::record_jumploads` per decompile (loadtables collected).
- **`<parammeasures>`** — `ParamIDAnalysis` unstubbed (the justproto arm now reads the real recovered `FuncProto`), `<rank>` always on; under action `paramid` it is the ONLY doc child (ghidra_process.cc:318).
- **Markup type tokens** — `EmitMarkup::tag_type` splits a rendered declarator into word `<type>` tokens + `<syntax>` separators (template payloads stay intact). Markup-emitter-only, so standalone output is byte-identical by construction.

## Symbol-id discipline (r5 §5)

- Invented locals/params carry kuna's internal `SYMBOL_ID_BASE`-range ids (legal on the wire native→Java; Java's decode already zeroes received internal-range ids — `remote_provider.rs:522`).
- Globals echo the REAL host DB id: `GlobalEntry`/`GlobalContainer` gained `symbol_id`, filled from the getMappedSymbols record; `<high class="global" symref>` is emitted **only when a real id is known** — never fabricated (a wrong non-internal id silently renames the wrong DB symbol).

## The rename/retype persistence loop

A GUI edit is a DB write + event-driven re-decompile; Java's next getMappedSymbols answer carries the edited local in the function `<localdb>` (`LocalSymbolMap.grabFromFunction`). kuna now decodes those non-param locals (`RemoteLocalVar`) and seeds the fresh Funcdata:
- typelocked (a retype; Java sends `typelock=false` only for Undefined types) → real mapped/usepoint symbol seeds (survive restructure's typelock-keep rule);
- namelocked-only (a plain rename) → **name recommendations** — the C++ `ScopeLocal::nameRecommend` mechanism (such symbols never survive `clearUnlockedCategory(-1)` upstream either), applied by the `ActionNameVars` port (`recommended_name_for`, three-arm use-address match per varmap.cc:1050).

Root-caused live: the first implementation seeded renames as symbols and they vanished at restructure — exactly why upstream keeps them as recommendations. Verified against a live DecompileDebug capture (`<symbol typelock="false" namelock="true" cat="-1"><typeref name="undefined8">`).

## Harness (ghidra-sim)

`parse_decompile_doc` now decode-validates the whole response the way Java would, and `assert_phase4_traps` asserts every r5 §3 hard-throw on every decompiled function:
nonzero symbol ids; ≥1 SymbolEntry (+ uselimit rangelist) per mapsym; positional `<parent>`+`<rangelist>` before `<symbollist>`; localdb-before-highlist and ast-before-highlist order; legal high class vocabulary; local/param `symref` resolves in the just-decoded localdb; `repref` resolves in the just-decoded ast; prototype model+extrapop+returnsym(addr+type); `<rank>` per measure; cat-0 symbols carry the slot index; unknown `<function>`/`<doc>` children are a test failure (Java discards the whole result).

New configuration tests: the switch-analyzer shape (`noc`+`notree`+`jumpload` → function-only doc, no ast/highlist/markup, jumptablelist with ≥2 dests and ≥1 loadtable), the paramid shape (parammeasures-ONLY doc), and the rename-persistence echo-back (serve a kuna-encoded local back renamed with `typelock=false` → the new name renders and re-encodes).

## Pin table (`ghidra_sim_e2e.rs`, faillog)

| pin | Phase 3 | now |
|---|---|---|
| `PIN_FAILLOG_MANGLED_TOKENS` | [57, 10, 24] | **[0, 0, 0]** |
| `PIN_FAILLOG_DIFF_FLOOR` (measured) | [0.10, 0.15, 0.19] (0.170/0.184/0.264) | **[0.02, 0.04, 0.06]** (0.050/0.079/0.099) |
| `PIN_FAILLOG_DIFF_CEILING` | [0.25, 0.29, 0.34] | **[0.09, 0.12, 0.15]** |
| `PIN_FAILLOG_C_LINES` | [283, 39, 92] | unchanged (the split moves tokens, not text) |
| register/unique/placeholder/query pins | — | unchanged |

The ghidra-vs-CLI gap collapsed to pure per-function analysis skew — the getC() mangling half of the residue is gone.

## Gates

`make test` 675/675 PARITY OK · `make test-stages` PARITY OK · `make rust-test` green (full workspace) · `make check-spec` OK · `make test-ghidra` green (incl. the release breadth test). No baselines re-pinned; no options added; no ghidra-mode default changed (no new DIV rows). Spec prose updated in the same PR (00-overview, 04, 05, 06) + `docs/ghidra-integration.md` Phase-4 checkboxes and §9 seam table.

## Deliberately deferred (documented in ghidra-integration.md)

- `structureGraph` (FunctionGraph nested layout only), the four signature commands (BSim), overlay spaces, `getStringData` charset fidelity — all with clean §10 degradation.
- `<hash>` dynamic-storage symbols for unique-space locals in the link pass (renames of unique-storage temps fall back to Java's address-keyed `DynamicEntry.build` path meanwhile); `<override>`/child-`<scope>` statics (Java skips both); the standalone `collectNameRecs` harvest + dynamic-hash recommendation list.
- Live observation (not a defect): fmt/main's jumptable reports 0 loadtables (model-dependent collection); the sim gate pins loadtables ≥1 on faillog where the emulated table walk collects them.

## Live rig

`integrations/ghidra/live-smoke/phase4_features.py` (committed; same env as `kuna_vs_stock.py`). Full run on fmt::main:

```
[PASS] decompileCompleted
signature: int main(int argc,char **argv);
prototype: model=__stdcall extrapop=8 ret=int nparams=2
[PASS] signature renders with parameters
[PASS] getC() carries no IllegalChar-mangled type tokens
[PASS] locals decoded as HighSymbols (2 params, 19 locals)
[PASS] rename round-trip writes the RIGHT DB variable — v11 @ RSI:8 (pc 00101c77) -> kuna_ren_probe; db-hit=['RSI:8']; collateral-renames=[]
[PASS] re-decompile shows the new name
[PASS] retype round-trip — wanted ulong, got ['ulong']
[PASS] param rename lands on the DB parameter — argc -> DB params now ['kuna_param_probe', 'argv']
[PASS] HighFunction.getJumpTables decodes <jumptablelist> — @001019fb cases=10 labels=10
[PASS] DecompilerSwitchAnalysisCmd rebuilds the case references — cleared to 0, rebuilt 10 refs
[PASS] getHighParamID decodes <parammeasures> — inputs=2 outputs=1
```

---

## Review revisions (adversarial review round — 6 confirmed findings, all fixed)

Commits `49e1b84f` (code+tests) and `e6b85c1b` (docs).

| # | finding | fix |
|---|---|---|
| **C1≡C5** (MED) | `<vardecl symref>` still emitted the Phase-2 varnode-create-index placeholder — unresolvable now that every real id is `SYMBOL_ID_BASE`-range, so Java logged *"Invalid symbol reference"* per declaration per decompile and rename/retype was **dead on declaration-line tokens** | The link pass now runs **before** the markup, and the declaration carries the real LocalSymbolMap id + the representative's `varref`; create-index survives only as the fallback for a high the analysis left symbol-less. Making that reorder safe required the pass to stop mutating the analysis scope — see the design note below. |
| **C2** (HIGH) | host locals whose only entry was a `<hash>` DynamicEntry were **dropped on decode** — the storage class Java writes for every `requiresDynamicStorage` variable (unique-space representatives, `splitOutMergeGroup` products), so renaming one silently reverted | Hash entries kept (`RemoteEntry::hash`, `RemoteLocalVar::hash`) and applied through the **full upstream mechanism**: `ScopeLocal::dynRecommend` + `recoverNameRecommendationsForSymbols`'s hash loop (`kuna_apply_dynamic_recommendations` over `DynamicHash::find_varnode`, at the top of the naming pass); typelocked ones seed as dynamic Symbols. Hash budget pinned to upstream's 8 — Java hardcodes the same (`DynamicHash.java:440`) and a disagreeing hash cannot round-trip. |
| **C3** (MED) | recommendations matched only the high's **name representative**'s def address; upstream's `findVarnodeWritten` matches any varnode of (size,addr) written at the usepoint, so renames recorded at another instance reverted | Matched across **every instance**, plus upstream's `!sym->isNameUndefined()` guard and a cat-0 guard (a parameter's name comes from the prototype). |
| **C4** (MED) | the encode-time link pass bound any unattached high to the smallest containing entry with **none of the naming pass's conflict logic** — a high deliberately routed to `vN` inherited the **parameter's** id, so renaming it renamed the parameter | The naming pass now **records its bind decisions** (`HighVariable::kuna_link_symbol`); the encode materializes symbols only for highs left unbound, and a covered-but-unbound (conflict) high gets a data-flow-**hashed** wire symbol — upstream's `buildDynamicSymbol` — never the conflicting entry's id. |
| **C6** (MED) | decoded cat-0 **parameter storage** and the `<prototype model>` were parsed then discarded; kuna echoed model-rederived storage, so Java's `checkFullCommit` force-committed a kuna-rederived signature over the user's on any param rename | Both carried through (`RemoteParam::storage`, `RemoteFunctionFacts::{model,param_storage}` → `apply_locked_prototype_with_model` + `apply_mapped_params`); `add_param_symbol` categorizes an existing overlapping entry as the parameter slot instead of skipping it. |
| **LOWs** | (a) defensive `encode_scope` skips could orphan a `<high symref>` — the Java hard-throw the skip guards against; (b) two vacuous live-rig PASS criteria; (c) missing r5 §3 0-sized-datatype trap | (a) skipped ids are withheld from `symref` too (`Database::encodable_symbol_ids`); (b) collateral detection now commits the decoded locals first (**21** DB variables on fmt/main) and the param check asserts decoded-vs-DB storage/ordinal equality **before** renaming, so a forced full commit can no longer masquerade as an in-place edit; (c) trap added. |

### Design note: wire-only symbols (why the C text is provably unchanged)

The reviewers' C1 fix (link pass before the markup) was re-derived as text-neutral. It was **not** — the harness caught it: mutating the local scope before printing moved faillog `sub_2620` from 283 → 284 lines. The pass therefore no longer touches the analysis scope at all: it emits **`database::WireSymbol`** records — encoded into `<localdb>` and referenced by `<high symref>`/`<vardecl symref>`, never entering the scope — so it cannot perturb decompilation wherever it runs. `c_lines` is back to **283/39/92**, i.e. byte-identical C, and that pin is the standing proof.

### Pins (this round)

| pin | before | after |
|---|---|---|
| `PIN_FAILLOG_C_LINES` | [283, 39, 92] | unchanged (the invariant) |
| `PIN_FAILLOG_MANGLED_TOKENS` | [0, 0, 0] | unchanged |
| diff floors / ceilings | [0.02…] / [0.09…] | unchanged (0.050/0.079/0.099) |
| `PIN_FAILLOG_VARDECL_UNRESOLVED` | *(new)* | **[0, 1, 0]** — was effectively "every declaration"; one group-member residue documented as a follow-up |
| query traffic (getPcode/getMappedSymbols) | 1314 / 1448 | unchanged |

### New tests

- **unit** `dynamic_name_recommendation_renames_the_hashed_variable` — hashes a real varnode, seeds the recommendation, applies it, asserts the name **and** a Symbol land on that variable (the C2 mechanism, non-vacuously).
- **sim** `ghidra_sim_faillog_high_symrefs_are_not_shared_with_params` — no non-param `<high>` may reference a cat-0 parameter symbol (the C4 regression).
- **sim** `ghidra_sim_faillog_dynamic_rename_persistence` — hash-storage rename round-trip through the oracle's new dynamic-entry serving.
- **harness** `<vardecl symref>` resolution + the 0-sized-datatype trap; the oracle serves `<hash>` locals and typelock=false/true shapes.

### Live re-verification (stock Ghidra 12.1.2, fmt::main)

**13/13 PASS**, including the strengthened criteria:

```
[PASS] DB carries committed locals to detect collateral renames — 21 DB variables
[PASS] rename round-trip writes the RIGHT DB variable — v9 @ RAX:8 -> kuna_ren_probe; db-hit=['RAX:8']; collateral-renames=[]
[PASS] re-decompile shows the new name
[PASS] retype round-trip — wanted ulong, got ['ulong']
[PASS] encoded param storage/ordinals match the DB (no forced full commit) — decoded=[('argc','EDI:4',0),('argv','RSI:8',1)] db=[('argc','EDI:4'),('argv','RSI:8')]
[PASS] param rename lands on the DB parameter
[PASS] DecompilerSwitchAnalysisCmd rebuilds the case references — rebuilt 10 refs
[PASS] getHighParamID decodes <parammeasures> — inputs=2 outputs=1
```

### Gates (post-fix)

`make test` 675/675 PARITY OK · `make test-stages` PARITY OK · `make rust-test` exit 0 (316 suites) · `make check-spec` OK · `make test-ghidra` green. No baseline re-pins, no options, no DIV rows.

---

## Review round 2 (delta review of `e6b85c1b` + the red CI gate) — 10 findings

The branch was **red on its own gate**: `ghidra_sim_sort_grep_breadth` (the `#[ignore]`d sort/grep breadth test that `make test-ghidra` and the CI gates job run with `--include-ignored`) failed on `tests/bug-repro/sort` / `sub_6370` with *"NO `<vardecl symref>` resolves against `<localdb>`"*. Fixed, plus the nine other findings from the delta review.

### The CI failure — root cause

`sub_6370` declares two stack aggregates, `char v1 [16]` and `char v2 [24]`, that are *only ever* used as `memcmp(v1,v2,0x10)` — i.e. reached **exclusively** through a `&sym` reference. The whole HighVariable of such a variable is the **constant `PTRSUB` offset operand** (dumped: one instance, `const` space, `is_constant=true`, `is_addr_tied=false`), and `kuna_link_high_symbols` skips constants by design (upstream's `if (!vn->isPersist())` create guard never fires for one), while `kuna_high_symbol_wire_id`'s re-derivation loop only scans **addr-tied** instances. Both declarations therefore fell back to the varnode create index — 2 of 2, hence "wholesale". The Symbols themselves were in `<localdb>` all along (`v1`/`v2`, cat −1, real ids).

The missing link was an actual **port gap**, not a heuristic: `Funcdata::link_symbol_reference` copies the referenced Symbol's *name*, *offset* and *type* onto that high but dropped its **identity**, where upstream `Varnode::setSymbolReference` (varnode.cc:465) → `HighVariable::setSymbolReference(entry->getSymbol(), off)` (variable.cc:283) carries the Symbol itself. The identity is now recorded (`HighVariable::kuna_ref_symbol`) and read by the declaration's `symref`.

It is deliberately a **separate field** from `kuna_link_symbol`: the latter feeds `<high symref>`, and such a high encodes `class="constant"`, where Java's `HighConstant.decode` does nothing at all with a mapped local symref — so nothing is gained there, and keeping it out preserves the one-owner invariant `ghidra_sim_faillog_high_symrefs_are_not_shared_with_params` asserts.

**This also closed the pinned residual**: `PIN_FAILLOG_VARDECL_UNRESOLVED` moves **[0,1,0] → [0,0,0]** — the sub_3320 survivor was the same class. Every declaration in the corpus now resolves, and the pin doc says ZERO is the contract, not a high-water mark.

### Test hygiene — why a green local run shipped a red CI

The previous round's recorded verification run (`scratchpad/ghidra_sim_run.log`) reads:

```
test ghidra_sim_sort_grep_breadth ... ignored, heavier fixtures (…)
test result: ok. 8 passed; 0 failed; 1 ignored
```

— i.e. `cargo test -p kuna-ghidra --release` **without** `--include-ignored`. The breadth test was never executed locally, and nothing said so.

That is a harness bug, and `make test-ghidra` is now **two canaries** instead of a bare `cargo test`:

1. the CI skip canary (`skipping (… .sla …)`) — with specs missing or unusable every ghidra-sim test prints a skip notice and returns early *by design*, so a green run proves nothing. CI greps for it; the Makefile did not. Worktrees hit this constantly (`KUNA_SPECS`/`SLEIGHHOME` do not reach the cargo suites).
2. a **breadth canary** — the target now demands the literal `test ghidra_sim_sort_grep_breadth ... ok` line, so any invocation that loses `--include-ignored` fails loudly instead of exiting 0.

The breadth test itself was also strengthened per the reviewer's note that the generic `resolved > 0` gate only catches *wholesale* breakage: it now asserts **0 unresolved per target** (and prints `vardecl_unresolved`/`vardecls`), so a 20/20 → 1/20 regression can no longer pass.

### The other nine

| # | sev | finding | disposition |
|---|---|---|---|
| 2 | HIGH | `add_param_symbol` promoted **any storage-overlapping** symbol into parameter slot `i`; the cited `ProtoStoreSymbol::setInput` does the opposite (looks up **by slot**, and removes+recreates on an addr/size mismatch). Not ghidra-gated — it runs in `ActionRestructureVarnode`, and `clear_unlocked_category_negative` only clears `cat < 0`, so a wrong promotion is permanent | **Fixed**: categorize only on an **exact** `(addr, size)` match; comment rewritten to the real upstream mechanism and to both failure modes (`checkFullCommit` storage compare; `getDatabaseParameter` keying the DB slot off `getCategoryIndex`) |
| 3 | MED | `WireSymbol::encode` bypassed the 0-size-type filter added for scope symbols → `MappedEntry.decode` hard-throw discards the whole result | **Fixed** two ways: `kuna_link_high_symbols` routes a 0-sized dtype to the **hashed** shape (`DynamicEntry.decode` has no size check), and `WireSymbol::is_encodable` is the backstop in both the encode and the id set |
| 4 | MED | `<vardecl symref>` was not filtered through the encodable predicate → a defensively-skipped symbol yields an unresolvable declaration ref | **Fixed**: every branch of `kuna_high_symbol_wire_id` now passes `ScopeLocal::symbol_is_encodable` (new O(1) single-symbol form — the set build would be per-declaration on every decompile) and falls back to the create index |
| 5 | MED | `kuna_apply_dynamic_recommendations` runs at the **top** of the naming pass, where the ported `isNameUndefined` guard is vacuous, and it *creates* a Symbol where upstream *renames* one | **Guarded, not moved** (kuna fuses linkSymbols + `vN` assignment into one walk, so there is no "after linking, before defaults" point): the equivalent guard is applied against the **scope** — a hash landing on storage the walk will bind to a `function_parameter`, or to any Symbol with a defined name, is skipped. Divergence documented in `docs/spec/06` and the ghidra-integration deferred list. Also: `find_varnode`'s `vnlist2[pos]` is now a checked `.get()` (the hash is host-supplied), and the hardcoded 8 carries the "not `dynamichashmax`" note |
| 6 | MED | the **wire arm** of `encode_high` skipped the `encodable_symbols` guard; `encodable` is empty for a `has_no_code()` function → `class="local"` + symref against a `<localdb>` never written → `HighLocal.decode` hard-throw | **Fixed**: the wire arm takes the same gate (falls to `class="other"`) |
| 7 | LOW | `Funcdata::clear()` left `kuna_wire_symbols` / `kuna_wire_symbol_for_high` behind — `HighVariableId`-keyed maps outliving the arena that issued the ids | **Fixed**: both cleared with `high_bank` |
| 8 | LOW | declaration tokens carried `varref`; upstream `emitVarDecl` pushes an explicitly **null** Varnode, and the omission is load-bearing (`ClangVariableToken.getHighVariable` returns `inst.getHigh()` from inside its `inst != null` block, never reaching the parent-decl fallback) | **Dropped** the `varref` — upstream shape restored; the create index remains the `symref` fallback |
| 9 | LOW | slot skew: `to_pieces` **compacts out** params with no dtype while `param_storage` carried absolute `rp.index` → count/index disagreement → `checkFullCommit` fires | **Fixed**: `param_storage` slots are counted in the same compacted basis |
| 10 | LOW | live rig: `len(before) >= 2` hard-fails on a function with one DB local; `p0 = decoded[0] if decoded else p0` swapped the rename target mid-section | **Fixed**: gate on `>= 1` (0 committed = the rig's premise failed) with a NOTE at 1; the rename target and its recorded old name now both come from the post-commit result |

**Doc correction** (reviewer-verified): `checkFullCommit` inspects the parameter count, each `categoryIndex` and each storage — **never the model name**. The C6 prose in `docs/spec/00-overview.md` said otherwise; corrected to "the storage echo is the load-bearing half; the model rides along because the storage kuna would otherwise derive comes from it".

### Pins (this round)

| pin | before | after |
|---|---|---|
| `PIN_FAILLOG_VARDECL_UNRESOLVED` | [0, **1**, 0] | **[0, 0, 0]** — the residual was the same `&sym`-reference class; ZERO is now the contract |
| breadth `vardecl_unresolved` | *(unasserted)* | **0 per target**, 6/6 targets (sort + grep) |
| `PIN_FAILLOG_C_LINES` | [283, 39, 92] | unchanged — the standing byte-identical-C proof |
| `PIN_FAILLOG_MANGLED_TOKENS` / placeholders / registers / uniques | — | unchanged |
| diff floors / ceilings (measured) | 0.050 / 0.079 / 0.099 | unchanged |
| query traffic (getPcode 1314, distinct 801, getMappedSymbols 1448) | — | unchanged |

### Gates (round 2)

`make test` **675/675 PARITY OK** · `make test-stages` **484/484 PARITY OK** · `make rust-test` green · `make check-spec` OK · `make test-ghidra` green **with the breadth test proven to have run** (`ghidra_sim_sort_grep_breadth ... ok`, 11 sim tests, both canaries armed). No baseline re-pins, no options added, no DIV rows.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfGYKwUWvPYYj1Aw7tcLhC
