### PR TITLE
[AUTOMATED] refactor(p9): the output-language seam — LangProfile, LangCaps, TypeSpeller (C only, byte-identical)

### DIFF
--- a/decompiler/crates/kuna-decomp/src/p9_emit/kuna_lang.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/kuna_lang.rs
@@ -1,0 +1,212 @@
+//! (kuna) The output-language plane: which surface language P9 renders into.
+//!
+//! # Why this exists
+//!
+//! The C++ tree kuna was ported from had a three-level printer hierarchy —
+//! `PrintLanguage` (the RPN driver and the mod/scope stacks) → `PrintC` →
+//! `PrintJava : public PrintC` — selected through a `PrintLanguageCapability`
+//! registry. The port flattened all of it into one concrete `PrintC`
+//! (`p9_emit/printc.rs`), and `p9_emit/printjava.rs` is the stub that records
+//! the loss. This module re-erects the seam, in the shape kuna actually needs.
+//!
+//! # The shape, and why it is not a trait object over the whole printer
+//!
+//! `PrintC` (`p9_emit/printc.rs`) is **parameterized**, not subclassed: it
+//! carries one [`OutLang`] field and every language-varying site reads a
+//! `&'static` policy object instead of a `keywords::`/`tokens::` constant. The
+//! RPN driver, `op_push_ir`, `push_vn`, `emit_atom`, `parentheses_top`, the
+//! `CastStrategy` plumbing, the `CommentSorter` and the markup emitter are
+//! shared verbatim — there is no second printer and no duplicated emitter.
+//!
+//! A `Box<dyn PrintLanguage>` over the whole printer (the C++ shape) would put
+//! vtable dispatch in the RPN inner loop and make byte-identity unprovable by
+//! inspection; a second `PrintRust` struct would fork ~4000 lines, which is the
+//! choice the reference implementation (SEFCOM Oxidizer, merged into angr as
+//! `structured_codegen/rust.py`) made and then drifted from inside one release
+//! cycle. Parameterization keeps exactly one implementation of "emit an if".
+//!
+//! # The byte-identity invariant
+//!
+//! Every [`LANG_C`] field **is** the `keywords::`/`tokens::` constant it
+//! replaces, asserted field-by-field in this module's tests. Reading the C
+//! profile at a call site therefore produces the identical token, so the
+//! migration is a provably byte-identical rewrite and `docs/baseline.json` is
+//! never re-pinned.
+
+use crate::printc::{keywords, tokens};
+use crate::printlanguage::OpToken;
+
+/// The surface language P9 renders the recovered function into.
+///
+/// `C` is the corpus-pinned default: only its rendering is asserted by
+/// `docs/baseline.json`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum OutLang {
+    /// The c-language back-end (`printc.cc`'s successor).
+    #[default]
+    C,
+}
+
+impl OutLang {
+    /// The `option setlanguage` name this language answers to.
+    pub fn print_name(self) -> &'static str {
+        match self {
+            OutLang::C => "c-language",
+        }
+    }
+
+    /// The surface vocabulary and capability record.
+    pub fn profile(self) -> &'static LangProfile {
+        match self {
+            OutLang::C => &LANG_C,
+        }
+    }
+}
+
+/// What the emitter is **allowed** to produce in this language.
+///
+/// These gate the decision sites of kuna's default-ON C rendering options, so a
+/// language that cannot express a construct never sees it — rather than the
+/// operator being told to flip four options. `switch_captures_break` is the
+/// load-bearing one: a C `switch` captures a bare `break`, so
+/// `kuna_scope_break` (`p8_structure/kuna_loopbreak_recovery.rs`) legitimately retags a
+/// goto-to-switch-exit as `f_break_goto`; a language whose switch does not
+/// capture `break` must re-resolve that scope or emit a jump to the wrong place.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LangCaps {
+    /// `goto <label>;` to an arbitrary label in the function body.
+    pub goto: bool,
+    /// A bare `break;` inside a switch terminates the switch.
+    pub switch_captures_break: bool,
+    /// A case falls into the next when it does not break.
+    pub switch_falls_through: bool,
+    /// One arm may carry several labels (`case A: case B:` / `A | B =>`).
+    pub switch_multi_label: bool,
+    /// A switch with no default is legal.
+    pub switch_default_optional: bool,
+    /// `break 'l` / `continue 'l` naming an enclosing loop.
+    pub labeled_loop_break: bool,
+    /// `break 'l` out of an arbitrary labeled block.
+    pub labeled_block_break: bool,
+    /// Bottom-tested `do { } while (c);`.
+    pub do_while: bool,
+    /// C-style `for (init; cond; iter)`.
+    pub c_for: bool,
+    /// `cond ? a : b` as an expression.
+    pub ternary: bool,
+    /// `(a, b)` usable as an operand — what `option condfold` requires.
+    pub comma_expression: bool,
+    /// A non-boolean scalar is usable directly as a condition — what
+    /// `option truthycond` (DIV-37) produces.
+    pub implicit_bool_conditions: bool,
+    /// A single-statement block body may drop its braces — what
+    /// `option braceelide` (DIV-38) produces.
+    pub brace_elision: bool,
+    /// `p->f` is spelled as such (rather than requiring an explicit deref).
+    pub arrow_member: bool,
+}
+
+/// The per-language surface vocabulary.
+///
+/// The `kw_*` and punctuation fields are the spellings; the `tok_*` fields are
+/// the [`OpToken`]s whose *spelling* varies. The other ~40 operator tokens —
+/// arithmetic, comparison, shifts, the ten `op=` forms — are identical across
+/// every language kuna targets and stay in `printc::tokens`, un-churned.
+pub struct LangProfile {
+    /// The `option setlanguage` name.
+    pub name: &'static str,
+    /// The source-file extension for project export.
+    pub file_ext: &'static str,
+
+    pub kw_open_curly: &'static str,
+    pub kw_close_curly: &'static str,
+    pub kw_semicolon: &'static str,
+    pub kw_colon: &'static str,
+    pub kw_comma: &'static str,
+    pub kw_dotdotdot: &'static str,
+    pub kw_void: &'static str,
+    pub kw_true: &'static str,
+    pub kw_false: &'static str,
+    pub kw_if: &'static str,
+    pub kw_else: &'static str,
+    pub kw_do: &'static str,
+    pub kw_while: &'static str,
+    pub kw_for: &'static str,
+    pub kw_goto: &'static str,
+    pub kw_break: &'static str,
+    pub kw_continue: &'static str,
+    pub kw_case: &'static str,
+    pub kw_switch: &'static str,
+    pub kw_default: &'static str,
+    pub kw_return: &'static str,
+    /// The `TypePointerRel` display macro (C++ `typePointerRelToken`).
+    pub kw_type_pointer_rel: &'static str,
+
+    pub tok_bitwise_not: &'static OpToken,
+    pub tok_boolean_and: &'static OpToken,
+    pub tok_boolean_or: &'static OpToken,
+    pub tok_boolean_xor: &'static OpToken,
+    pub tok_addressof: &'static OpToken,
+    pub tok_dereference: &'static OpToken,
+    pub tok_typecast: &'static OpToken,
+
+    pub caps: LangCaps,
+}
+
+/// The c-language profile. Every field is the `keywords::`/`tokens::` constant
+/// it replaces — see this module's byte-identity invariant.
+pub static LANG_C: LangProfile = LangProfile {
+    name: "c-language",
+    file_ext: "c",
+
+    kw_open_curly: keywords::OPEN_CURLY,
+    kw_close_curly: keywords::CLOSE_CURLY,
+    kw_semicolon: keywords::SEMICOLON,
+    kw_colon: keywords::COLON,
+    kw_comma: keywords::COMMA,
+    kw_dotdotdot: keywords::DOTDOTDOT,
+    kw_void: keywords::KEYWORD_VOID,
+    kw_true: keywords::KEYWORD_TRUE,
+    kw_false: keywords::KEYWORD_FALSE,
+    kw_if: keywords::KEYWORD_IF,
+    kw_else: keywords::KEYWORD_ELSE,
+    kw_do: keywords::KEYWORD_DO,
+    kw_while: keywords::KEYWORD_WHILE,
+    kw_for: keywords::KEYWORD_FOR,
+    kw_goto: keywords::KEYWORD_GOTO,
+    kw_break: keywords::KEYWORD_BREAK,
+    kw_continue: keywords::KEYWORD_CONTINUE,
+    kw_case: keywords::KEYWORD_CASE,
+    kw_switch: keywords::KEYWORD_SWITCH,
+    kw_default: keywords::KEYWORD_DEFAULT,
+    kw_return: keywords::KEYWORD_RETURN,
+    kw_type_pointer_rel: keywords::TYPE_POINTER_REL_TOKEN,
+
+    tok_bitwise_not: &tokens::BITWISE_NOT,
+    tok_boolean_and: &tokens::BOOLEAN_AND,
+    tok_boolean_or: &tokens::BOOLEAN_OR,
+    tok_boolean_xor: &tokens::BOOLEAN_XOR,
+    tok_addressof: &tokens::ADDRESSOF,
+    tok_dereference: &tokens::DEREFERENCE,
+    tok_typecast: &tokens::TYPECAST,
+
+    caps: LangCaps {
+        goto: true,
+        switch_captures_break: true,
+        switch_falls_through: true,
+        switch_multi_label: true,
+        switch_default_optional: true,
+        labeled_loop_break: false,
+        labeled_block_break: false,
+        do_while: true,
+        c_for: true,
+        ternary: true,
+        comma_expression: true,
+        implicit_bool_conditions: true,
+        brace_elision: true,
+        arrow_member: true,
+    },
+};
+
+#[cfg(test)]
+mod tests;

--- a/decompiler/crates/kuna-decomp/src/p9_emit/kuna_lang.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/kuna_lang.rs
@@ -61,6 +61,13 @@ impl OutLang {
             OutLang::C => &LANG_C,
         }
     }
+
+    /// How this language spells a recovered type.
+    pub fn speller(self) -> &'static dyn crate::kuna_langtypes::TypeSpeller {
+        match self {
+            OutLang::C => &crate::kuna_langc::C_SPELLER,
+        }
+    }
 }
 
 /// What the emitter is **allowed** to produce in this language.

--- a/decompiler/crates/kuna-decomp/src/p9_emit/kuna_lang/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/kuna_lang/tests.rs
@@ -1,0 +1,80 @@
+//! Tests for the output-language profile.
+//!
+//! The load-bearing one is [`profile_matches_legacy_constants`]: it is what makes
+//! "read the C profile instead of the constant" a provably byte-identical
+//! rewrite, and therefore what lets the migration touch `printc.rs` without
+//! re-pinning `docs/baseline.json`.
+
+use super::*;
+
+#[test]
+fn profile_matches_legacy_constants() {
+    let p = OutLang::C.profile();
+
+    assert_eq!(p.name, "c-language");
+    assert_eq!(p.file_ext, "c");
+
+    assert_eq!(p.kw_open_curly, keywords::OPEN_CURLY);
+    assert_eq!(p.kw_close_curly, keywords::CLOSE_CURLY);
+    assert_eq!(p.kw_semicolon, keywords::SEMICOLON);
+    assert_eq!(p.kw_colon, keywords::COLON);
+    assert_eq!(p.kw_comma, keywords::COMMA);
+    assert_eq!(p.kw_dotdotdot, keywords::DOTDOTDOT);
+    assert_eq!(p.kw_void, keywords::KEYWORD_VOID);
+    assert_eq!(p.kw_true, keywords::KEYWORD_TRUE);
+    assert_eq!(p.kw_false, keywords::KEYWORD_FALSE);
+    assert_eq!(p.kw_if, keywords::KEYWORD_IF);
+    assert_eq!(p.kw_else, keywords::KEYWORD_ELSE);
+    assert_eq!(p.kw_do, keywords::KEYWORD_DO);
+    assert_eq!(p.kw_while, keywords::KEYWORD_WHILE);
+    assert_eq!(p.kw_for, keywords::KEYWORD_FOR);
+    assert_eq!(p.kw_goto, keywords::KEYWORD_GOTO);
+    assert_eq!(p.kw_break, keywords::KEYWORD_BREAK);
+    assert_eq!(p.kw_continue, keywords::KEYWORD_CONTINUE);
+    assert_eq!(p.kw_case, keywords::KEYWORD_CASE);
+    assert_eq!(p.kw_switch, keywords::KEYWORD_SWITCH);
+    assert_eq!(p.kw_default, keywords::KEYWORD_DEFAULT);
+    assert_eq!(p.kw_return, keywords::KEYWORD_RETURN);
+    assert_eq!(p.kw_type_pointer_rel, keywords::TYPE_POINTER_REL_TOKEN);
+}
+
+/// `printlanguage::parentheses` decides parenthesization by `std::ptr::eq` on the
+/// token, so a profile that merely *spells* a token the same is not enough — the
+/// C profile must hand back the very same static.
+#[test]
+fn profile_tokens_are_the_legacy_statics() {
+    let p = OutLang::C.profile();
+    assert!(std::ptr::eq(p.tok_bitwise_not, &tokens::BITWISE_NOT));
+    assert!(std::ptr::eq(p.tok_boolean_and, &tokens::BOOLEAN_AND));
+    assert!(std::ptr::eq(p.tok_boolean_or, &tokens::BOOLEAN_OR));
+    assert!(std::ptr::eq(p.tok_boolean_xor, &tokens::BOOLEAN_XOR));
+    assert!(std::ptr::eq(p.tok_addressof, &tokens::ADDRESSOF));
+    assert!(std::ptr::eq(p.tok_dereference, &tokens::DEREFERENCE));
+    assert!(std::ptr::eq(p.tok_typecast, &tokens::TYPECAST));
+}
+
+#[test]
+fn c_is_the_default_language() {
+    assert_eq!(OutLang::default(), OutLang::C);
+    assert_eq!(OutLang::C.print_name(), OutLang::C.profile().name);
+}
+
+/// The C capability record must describe C, or every gate built on it is wrong
+/// in the direction that silently changes C output.
+#[test]
+fn c_caps_describe_c() {
+    let c = OutLang::C.profile().caps;
+    assert!(c.goto);
+    assert!(c.switch_captures_break);
+    assert!(c.switch_falls_through);
+    assert!(c.switch_default_optional);
+    assert!(c.do_while);
+    assert!(c.c_for);
+    assert!(c.ternary);
+    assert!(c.comma_expression);
+    assert!(c.implicit_bool_conditions);
+    assert!(c.brace_elision);
+    assert!(c.arrow_member);
+    assert!(!c.labeled_loop_break);
+    assert!(!c.labeled_block_break);
+}

--- a/decompiler/crates/kuna-decomp/src/p9_emit/kuna_langc.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/kuna_langc.rs
@@ -1,0 +1,191 @@
+//! (kuna) The c-language policy objects: the concrete half of the output-language
+//! seam for C.
+//!
+//! [`CSpeller`] carries the declarator algorithm transcribed from
+//! `PrintC::pushTypeStart` / `pushTypeEnd` (printc.cc:265/314) plus
+//! `buildTypeStack` (printc.cc:143), together with the kuna `realtypes`/`ctypes`
+//! relabelling (DIV-5/DIV-6). The bodies are moved verbatim out of `printc.rs`,
+//! which now keeps only thin dispatchers so its existing free-function callers
+//! and their tests are unchanged.
+
+use std::borrow::Cow;
+use std::rc::Rc;
+
+use kuna_base::types::int4;
+
+use crate::dtype::{type_metatype, Datatype};
+use crate::kuna_langtypes::{SpellCtx, TypeSpeller};
+
+/// The c-language type speller.
+pub struct CSpeller;
+
+/// The singleton reached through `OutLang::C.speller()`.
+pub static C_SPELLER: CSpeller = CSpeller;
+
+impl TypeSpeller for CSpeller {
+    /// Real C name for a residual `TYPE_UNKNOWN` base, or `None` when the gate is
+    /// off / the type is not unknown. Conservative on sign (multi-byte unknowns
+    /// are unsigned, since the real sign is genuinely unknown); a pointer-to-
+    /// unknown base relabels through the same size table as a scalar, so the
+    /// pointee keeps its width and `void` is only the residual fallback.
+    fn relabel(
+        &self,
+        cx: &SpellCtx,
+        dt: &Rc<Datatype>,
+        under_pointer: bool,
+    ) -> Option<Cow<'static, str>> {
+        if dt.get_metatype() == type_metatype::TYPE_UNKNOWN {
+            if !cx.enabled {
+                return None;
+            }
+            return self.unknown_base(dt.get_size(), under_pointer, cx.long_is_8);
+        }
+        // (kuna `ctypes`) Every OTHER core type -- the named `int4`/`uint1`/
+        // `float8`/`code` vocabulary -- spells as the target's own C type.
+        // Restricted to core types so a user-defined or DWARF-recovered type keeps
+        // the name it was declared with; that name is already C.
+        if !cx.ctypes || !dt.is_core_type() {
+            return None;
+        }
+        crate::kuna_ctypes::core_type_spelling(
+            &cx.model,
+            dt.get_metatype(),
+            dt.get_size(),
+            dt.is_char_print(),
+        )
+        .map(Cow::Borrowed)
+    }
+
+    fn anonymous(&self, dt: &Rc<Datatype>) -> String {
+        match dt.get_metatype() {
+            type_metatype::TYPE_VOID => "void".to_string(),
+            _ => format!("undefined{}", dt.get_size()),
+        }
+    }
+
+    /// The stack is built base-up exactly as `buildTypeStack`; pointer modifiers
+    /// go on the front (`*`), array/function modifiers on the tail (`[N]`/`(...)`),
+    /// and a `*` front nested inside an array/function tail is parenthesised --
+    /// the precedence the RPN `ptr_expr`/`array_expr` tokens encode.
+    fn declarator(&self, cx: &SpellCtx, ct: &Rc<Datatype>) -> (String, String) {
+        // buildTypeStack: walk to the base (named) type, recording the modifiers.
+        let mut stack: Vec<Rc<Datatype>> = Vec::new();
+        let mut cur = Rc::clone(ct);
+        loop {
+            stack.push(Rc::clone(&cur));
+            if !cur.get_name().is_empty() {
+                break; // base type
+            }
+            let next = match cur.get_metatype() {
+                type_metatype::TYPE_PTR => cur.get_ptr_to(),
+                type_metatype::TYPE_ARRAY => cur.get_array_base(),
+                _ => None, // other anonymous type: stop
+            };
+            match next {
+                Some(n) => cur = n,
+                None => break,
+            }
+        }
+        // The base type's display name (anonymous -> `undefined<N>` / `void`).
+        let base = stack.last().expect("declarator: non-empty stack");
+        // (kuna) realtypes: relabel a residual TYPE_UNKNOWN base as a real C type
+        // by size. Under a pointer modifier the same size table applies, so the
+        // pointee width survives into the declaration; only a residual size with
+        // no natural C type degrades to `void` there (the `*` chain is laid out by
+        // the walk below).
+        let under_pointer = stack[..stack.len() - 1]
+            .iter()
+            .any(|m| matches!(m.get_metatype(), type_metatype::TYPE_PTR));
+        let base_name = if let Some(n) = self.relabel(cx, base, under_pointer) {
+            n.into_owned()
+        } else if base.get_name().is_empty() {
+            self.anonymous(base)
+        } else {
+            base.get_display_name().to_string()
+        };
+
+        // Walk the modifiers from base toward the outermost (stack[len-2]..stack[0]),
+        // accumulating front (`*`) and back (`[N]`) declarator pieces. An array/
+        // function tail wraps any pending pointer front in parentheses.
+        let mut front = String::new();
+        let mut back = String::new();
+        let mut pending_ptr = false; // a `*` not yet absorbed by a tail
+        for ct_mod in stack.iter().rev().skip(1) {
+            match ct_mod.get_metatype() {
+                type_metatype::TYPE_PTR => {
+                    front.push('*');
+                    pending_ptr = true;
+                }
+                type_metatype::TYPE_ARRAY => {
+                    let n = ct_mod.num_elements().unwrap_or_else(|| {
+                        let base =
+                            ct_mod.get_array_base().map(|b| b.get_size()).unwrap_or(1).max(1);
+                        ct_mod.get_size() / base
+                    });
+                    if pending_ptr {
+                        front.insert(0, '(');
+                        back = format!("){}", back);
+                        pending_ptr = false;
+                    }
+                    back = format!("{}[{}]", back, n);
+                }
+                _ => {}
+            }
+        }
+        // `<base> <front>` with a single separating space before any `*` modifiers
+        // (the `type_expr_space` token); a bare base type has no trailing space
+        // here (the caller adds the space before the identifier).
+        let front_full =
+            if front.is_empty() { base_name } else { format!("{base_name} {front}") };
+        (front_full, back)
+    }
+
+    fn type_name(&self, cx: &SpellCtx, t: &Rc<Datatype>) -> String {
+        // (kuna) realtypes: a scalar residual TYPE_UNKNOWN (the named `xunknownN`
+        // core type or an anonymous `undefined<N>`) becomes its real C type by size.
+        if let Some(n) = self.relabel(cx, t, false) {
+            return n.into_owned();
+        }
+        let name = t.get_name();
+        if !name.is_empty() {
+            return name.to_string();
+        }
+        match t.get_metatype() {
+            // An anonymous pointer renders as `<pointee> *` (recursively), exactly
+            // as `push_cast_type` does for a `(char *)` cast. `declarator` walks
+            // the modifier chain to the named base and lays out the `*` front.
+            type_metatype::TYPE_PTR => self.declarator(cx, t).0,
+            _ => self.anonymous(t),
+        }
+    }
+
+    /// Size -> standard-C name for an unknown value. `None` for sizes with no
+    /// natural single C type (3/5/6/7/10/16...), which keep the `undefined<N>`
+    /// form; under a pointer those residual sizes fall back to `void` (the
+    /// modifier walk adds the `*` chain), since `void *` is the only spelling that
+    /// carries no width claim. A pointee whose size *does* have a natural type
+    /// keeps it, so the declaration agrees with the stride the index/cast
+    /// expressions were built from.
+    fn unknown_base(
+        &self,
+        size: int4,
+        under_pointer: bool,
+        long_is_8: bool,
+    ) -> Option<Cow<'static, str>> {
+        Some(Cow::Borrowed(match size {
+            1 => "char",
+            2 => "unsigned short",
+            4 => "unsigned int",
+            8 => {
+                if long_is_8 {
+                    "unsigned long"
+                } else {
+                    "unsigned long long"
+                }
+            }
+            _ => {
+                return if under_pointer { Some(Cow::Borrowed("void")) } else { None };
+            }
+        }))
+    }
+}

--- a/decompiler/crates/kuna-decomp/src/p9_emit/kuna_langtypes.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/kuna_langtypes.rs
@@ -1,0 +1,112 @@
+//! (kuna) The type-spelling seam: how a recovered [`Datatype`] is *named* in the
+//! output language.
+//!
+//! # Recovery is language-independent; only spelling is not
+//!
+//! P5 recovers a `Datatype`; this module decides whether that shows up as
+//! `uint4`, `unsigned int`, or `u32`. Spelling deliberately lives in the printer
+//! rather than in the type factory, for the reason `kuna_ctypes.rs` already
+//! records: [`Datatype::hash_name`] makes the registered name determine the type
+//! id, identifier generation derives from the first character of the type name
+//! (`float8` → `fVar1`), and the console's C-type parser resolves base types by
+//! `TypeFactory::find_by_name` — so renaming the interned core types would break
+//! the Ghidra wire protocol.
+//!
+//! # Why the language rides on [`SpellCtx`]
+//!
+//! `SpellCtx` (the former `printc::RealTypeCtx`) is `Copy` and is already
+//! threaded through every declarator chokepoint. Carrying [`OutLang`] on it means
+//! the free-function declarator family learns the language with no new threading
+//! and no new parameter: `rt.speller()` is available wherever `rt` already was.
+//!
+//! # The C declarator's `(front, back)` is a C-ism
+//!
+//! C declarators wrap the identifier (`int4 (*a)[1]`), so the C speller returns a
+//! front/back pair. Rust's `[T; N]` and Go's `[N]T` are prefixes and would have
+//! to fake the split, which is why [`TypeSpeller::declarator`] is documented in
+//! terms of `<front><name><back>` rather than promising a meaningful `back`.
+//!
+//! [`Datatype`]: crate::dtype::Datatype
+//! [`Datatype::hash_name`]: crate::dtype::Datatype
+
+use std::borrow::Cow;
+use std::rc::Rc;
+
+use kuna_base::types::int4;
+
+use crate::dtype::Datatype;
+use crate::kuna_lang::OutLang;
+
+/// The per-document type-rendering context (C++ has no analogue: the `realtypes`
+/// and `ctypes` gates are kuna divergences).
+///
+/// `Copy`, so it threads cheaply through the declarator chokepoints.
+#[derive(Clone, Copy)]
+pub struct SpellCtx {
+    /// The output language, which selects the [`TypeSpeller`].
+    pub(crate) lang: OutLang,
+    /// (kuna `realtypes`) Relabel residual `TYPE_UNKNOWN` bases as real types.
+    pub(crate) enabled: bool,
+    /// The data-model fact that `long` is 8 bytes, so an 8-byte unknown reads
+    /// `unsigned long` on LP64 and `unsigned long long` on LLP64.
+    pub(crate) long_is_8: bool,
+    /// (kuna `ctypes`) Spell the NAMED core types (`int4`/`uint1`/`float8`/`code`)
+    /// as the target's own type names too, not just the residual unknowns.
+    pub(crate) ctypes: bool,
+    /// (kuna `ctypes`) The target's declared C scalar widths, which is what makes
+    /// the spelling per-architecture rather than a guess.
+    pub(crate) model: crate::kuna_ctypes::CDataModel,
+}
+
+impl SpellCtx {
+    /// The disabled context — never relabels (preserves the upstream
+    /// `xunknownN`/`undefined<N>` rendering).
+    pub const OFF: SpellCtx = SpellCtx {
+        lang: OutLang::C,
+        enabled: false,
+        long_is_8: true,
+        ctypes: false,
+        model: crate::kuna_ctypes::CDataModel::LP64,
+    };
+
+    /// The speller for this context's output language.
+    #[inline]
+    pub fn speller(&self) -> &'static dyn TypeSpeller {
+        self.lang.speller()
+    }
+}
+
+/// Per-language spelling of a recovered type.
+///
+/// Implementations are zero-sized policy objects reached through
+/// [`OutLang::speller`]; the C one delegates to the ported declarator algorithm
+/// verbatim, so routing through this trait is byte-identical for C.
+pub trait TypeSpeller {
+    /// The base-type name to use for `dt`, or `None` to keep the type's own
+    /// declared name. `under_pointer` is true when a pointer modifier sits
+    /// between `dt` and the declared object, which C uses to decide whether a
+    /// width-less residual size may degrade to `void`.
+    fn relabel(
+        &self,
+        cx: &SpellCtx,
+        dt: &Rc<Datatype>,
+        under_pointer: bool,
+    ) -> Option<Cow<'static, str>>;
+
+    /// The name for an anonymous (unnamed) base type — C's `undefined<N>`/`void`
+    /// fallback.
+    fn anonymous(&self, dt: &Rc<Datatype>) -> String;
+
+    /// `(front, back)` such that `<front><name><back>` declares an object named
+    /// `name` of type `ct`. A language whose types are pure prefixes returns an
+    /// empty `back`.
+    fn declarator(&self, cx: &SpellCtx, ct: &Rc<Datatype>) -> (String, String);
+
+    /// The type token to render in a declaration's type position.
+    fn type_name(&self, cx: &SpellCtx, t: &Rc<Datatype>) -> String;
+
+    /// Real name for a residual unknown of `size` bytes, or `None` when the
+    /// language has no natural single type of that width.
+    fn unknown_base(&self, size: int4, under_pointer: bool, long_is_8: bool)
+        -> Option<Cow<'static, str>>;
+}

--- a/decompiler/crates/kuna-decomp/src/p9_emit/mod.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/mod.rs
@@ -18,5 +18,7 @@ pub mod kuna_truthycond;
 pub mod kuna_braceelide;
 pub mod kuna_warnstyle;
 pub mod kuna_lang; // (kuna) the output-language plane: profile + capabilities
+pub mod kuna_langtypes; // (kuna) the type-spelling seam (TypeSpeller + SpellCtx)
+pub mod kuna_langc; // (kuna) the c-language policy objects (CSpeller)
 pub mod kuna_ctypes; // (kuna) valid per-architecture C spelling of the core types
 pub mod coreaction_render;

--- a/decompiler/crates/kuna-decomp/src/p9_emit/mod.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/mod.rs
@@ -17,5 +17,6 @@ pub mod kuna_dedupvardecls;
 pub mod kuna_truthycond;
 pub mod kuna_braceelide;
 pub mod kuna_warnstyle;
+pub mod kuna_lang; // (kuna) the output-language plane: profile + capabilities
 pub mod kuna_ctypes; // (kuna) valid per-architecture C spelling of the core types
 pub mod coreaction_render;

--- a/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
@@ -1333,6 +1333,11 @@ pub struct PrintC {
     /// types as real C types.  Refreshed at the top of [`doc_function_full`] from
     /// the live `arch`; `OFF` until then (so an out-of-band print never relabels).
     rt_ctx: RealTypeCtx,
+    /// (kuna outlang) The output language this document renders into.  Selects
+    /// the surface vocabulary and capability record every language-varying site
+    /// reads (`crate::kuna_lang`).  Refreshed per document alongside `rt_ctx`;
+    /// `OutLang::C` until then, so an out-of-band print is never non-C.
+    out_lang: crate::kuna_lang::OutLang,
     /// (kuna warnstyle, DIV-39) Warning slugs collected under `warn_inline` by
     /// [`emit_comment_group`](PrintC::emit_comment_group) /
     /// [`emit_comment_func_header`](PrintC::emit_comment_func_header), flushed
@@ -1364,8 +1369,19 @@ impl PrintC {
             pending: 0,
             commsorter: crate::comment::CommentSorter::new(),
             rt_ctx: RealTypeCtx::OFF,
+            out_lang: crate::kuna_lang::OutLang::C,
             eol_warns: Vec::new(),
         }
+    }
+
+    /// The active output language's surface vocabulary and capability record.
+    ///
+    /// Every language-varying emit site reads through here rather than naming a
+    /// `keywords::`/`tokens::` constant directly, so a second language is a new
+    /// profile rather than a second emitter.
+    #[inline]
+    pub fn lang(&self) -> &'static crate::kuna_lang::LangProfile {
+        self.out_lang.profile()
     }
 
     /// The printer name (C++ `PrintLanguage::getName`, `"c-language"`).
@@ -3227,7 +3243,7 @@ impl PrintC {
         }
         self.emit.tag_line_indent(0);
         self.emit.print(&self.block_label_name(fd, bl), SyntaxHighlight::NoColor);
-        self.emit.print(keywords::COLON, SyntaxHighlight::NoColor);
+        self.emit.print(self.lang().kw_colon, SyntaxHighlight::NoColor);
     }
 
     /// C++ `PrintC::emitAnyLabelStatement` (printc.cc:3354): find the entry basic
@@ -3557,7 +3573,7 @@ impl PrintC {
         );
 
         // ... then `if ` + the branch condition (only_branch).
-        self.emit.tag_op(keywords::KEYWORD_IF, SyntaxHighlight::KeywordColor, &MarkupRef::none());
+        self.emit.tag_op(self.lang().kw_if, SyntaxHighlight::KeywordColor, &MarkupRef::none());
         self.emit.spaces(1, 0);
         self.context.push_mod();
         self.context.set_mod(modifiers::ONLY_BRANCH);
@@ -3592,7 +3608,7 @@ impl PrintC {
             self.emit.stop_indent(id);
             if size == 3 {
                 self.emit.tag_line();
-                self.emit.print(keywords::KEYWORD_ELSE, SyntaxHighlight::KeywordColor);
+                self.emit.print(self.lang().kw_else, SyntaxHighlight::KeywordColor);
                 let else_block = fd.sblocks_ref().block(blk).get_block(2);
                 let else_is_if = fd.sblocks_ref().block(else_block).get_type()
                     == crate::block::BlockType::If;
@@ -3604,11 +3620,11 @@ impl PrintC {
                 } else {
                     let id2 = self
                         .emit
-                        .open_brace_indent(keywords::OPEN_CURLY, to_emit_brace(self.options.brace_ifelse));
+                        .open_brace_indent(self.lang().kw_open_curly, to_emit_brace(self.options.brace_ifelse));
                     let id3 = self.emit.begin_block(0);
                     self.emit_block(fd, arch, else_block);
                     self.emit.end_block(id3);
-                    self.emit.close_brace_indent(keywords::CLOSE_CURLY, id2);
+                    self.emit.close_brace_indent(self.lang().kw_close_curly, id2);
                 }
             }
         } else {
@@ -3616,19 +3632,19 @@ impl PrintC {
             self.context.set_mod(modifiers::NO_BRANCH);
             let id = self
                 .emit
-                .open_brace_indent(keywords::OPEN_CURLY, to_emit_brace(self.options.brace_ifelse));
+                .open_brace_indent(self.lang().kw_open_curly, to_emit_brace(self.options.brace_ifelse));
             // (kuna warnstyle, DIV-39) condition-attached warnings land after
             // the `if (cond) {` header brace.
             self.flush_eol_warnings();
             let id1 = self.emit.begin_block(0);
             self.emit_block(fd, arch, fd.sblocks_ref().block(blk).get_block(1));
             self.emit.end_block(id1);
-            self.emit.close_brace_indent(keywords::CLOSE_CURLY, id);
+            self.emit.close_brace_indent(self.lang().kw_close_curly, id);
 
             // Optional else.
             if size == 3 {
                 self.emit.tag_line();
-                self.emit.print(keywords::KEYWORD_ELSE, SyntaxHighlight::KeywordColor);
+                self.emit.print(self.lang().kw_else, SyntaxHighlight::KeywordColor);
                 let else_block = fd.sblocks_ref().block(blk).get_block(2);
                 let else_is_if = fd.sblocks_ref().block(else_block).get_type()
                     == crate::block::BlockType::If;
@@ -3642,11 +3658,11 @@ impl PrintC {
                 } else {
                     let id2 = self
                         .emit
-                        .open_brace_indent(keywords::OPEN_CURLY, to_emit_brace(self.options.brace_ifelse));
+                        .open_brace_indent(self.lang().kw_open_curly, to_emit_brace(self.options.brace_ifelse));
                     let id3 = self.emit.begin_block(0);
                     self.emit_block(fd, arch, else_block);
                     self.emit.end_block(id3);
-                    self.emit.close_brace_indent(keywords::CLOSE_CURLY, id2);
+                    self.emit.close_brace_indent(self.lang().kw_close_curly, id2);
                 }
             }
         }
@@ -3656,7 +3672,7 @@ impl PrintC {
         // statements before its `if`, so it rendered `else { ... if`), close
         // that brace.
         if my_pending_indent >= 0 {
-            self.emit.close_brace_indent(keywords::CLOSE_CURLY, my_pending_indent);
+            self.emit.close_brace_indent(self.lang().kw_close_curly, my_pending_indent);
         }
     }
 
@@ -3852,13 +3868,13 @@ impl PrintC {
         self.emit_block(fd, arch, m.cond_block);
         self.context.pop_mod();
         self.emit.end_statement(sid);
-        self.emit.print(keywords::SEMICOLON, SyntaxHighlight::NoColor);
+        self.emit.print(self.lang().kw_semicolon, SyntaxHighlight::NoColor);
         // (kuna warnstyle, DIV-39) condition-attached warnings land at the end of
         // the assignment line.
         self.flush_eol_warnings();
 
         if my_pending_indent >= 0 {
-            self.emit.close_brace_indent(keywords::CLOSE_CURLY, my_pending_indent);
+            self.emit.close_brace_indent(self.lang().kw_close_curly, my_pending_indent);
         }
         self.context.pop_mod();
     }
@@ -3942,14 +3958,14 @@ impl PrintC {
         self.emit.spaces(1, 0);
         self.op_push_ir(fd, arch, m.else_op, None);
         self.emit.end_statement(sid);
-        self.emit.print(keywords::SEMICOLON, SyntaxHighlight::NoColor);
+        self.emit.print(self.lang().kw_semicolon, SyntaxHighlight::NoColor);
         // (kuna warnstyle, DIV-39) condition-attached warnings land at the end
         // of the ternary statement line.
         self.flush_eol_warnings();
 
         // Close the pending brace if it fired (the else-clause `{ ... }`).
         if my_pending_indent >= 0 {
-            self.emit.close_brace_indent(keywords::CLOSE_CURLY, my_pending_indent);
+            self.emit.close_brace_indent(self.lang().kw_close_curly, my_pending_indent);
         }
         self.context.pop_mod();
     }
@@ -3975,7 +3991,7 @@ impl PrintC {
         self.emit_block(fd, arch, switch_block);
         self.context.pop_mod();
         let brace_id =
-            self.emit.open_brace_indent(keywords::OPEN_CURLY, to_emit_brace(self.options.brace_switch));
+            self.emit.open_brace_indent(self.lang().kw_open_curly, to_emit_brace(self.options.brace_switch));
         // (kuna warnstyle, DIV-39) warnings pending from the switch block land
         // after the `switch (v) {` header brace.
         self.flush_eol_warnings();
@@ -4005,7 +4021,7 @@ impl PrintC {
             self.emit.stop_indent(id);
         }
         self.emit.tag_line();
-        self.emit.close_brace_indent(keywords::CLOSE_CURLY, brace_id);
+        self.emit.close_brace_indent(self.lang().kw_close_curly, brace_id);
         self.context.pop_mod();
     }
 
@@ -4026,12 +4042,12 @@ impl PrintC {
             };
             self.emit.tag_line();
             self.emit.tag_case_label(
-                keywords::KEYWORD_DEFAULT,
+                self.lang().kw_default,
                 SyntaxHighlight::KeywordColor,
                 &case_markup,
                 case.label,
             );
-            self.emit.print(keywords::COLON, SyntaxHighlight::NoColor);
+            self.emit.print(self.lang().kw_colon, SyntaxHighlight::NoColor);
         } else {
             // case <label>: — one line per index targeting this case.
             let jt_index = fd.sblocks_ref().block(blk).switch_jt_index();
@@ -4053,7 +4069,7 @@ impl PrintC {
                     _ => case.label,
                 };
                 self.emit.tag_line();
-                self.emit.print(keywords::KEYWORD_CASE, SyntaxHighlight::KeywordColor);
+                self.emit.print(self.lang().kw_case, SyntaxHighlight::KeywordColor);
                 self.emit.spaces(1, 0);
                 let sz = self.switch_var_size(fd, blk);
                 // (kuna) Render the label signed when the recovered switch variable
@@ -4070,7 +4086,7 @@ impl PrintC {
                     }
                 }
                 self.recurse();
-                self.emit.print(keywords::COLON, SyntaxHighlight::NoColor);
+                self.emit.print(self.lang().kw_colon, SyntaxHighlight::NoColor);
             }
         }
         let _ = arch;
@@ -4147,7 +4163,7 @@ impl PrintC {
         let cond_block = fd.sblocks_ref().block(blk).get_block(0);
         self.emit_comment_block_tree(fd, cond_block);
         self.emit.tag_line();
-        self.emit.tag_op(keywords::KEYWORD_FOR, SyntaxHighlight::KeywordColor, &MarkupRef::none());
+        self.emit.tag_op(self.lang().kw_for, SyntaxHighlight::KeywordColor, &MarkupRef::none());
         self.emit.spaces(1, 0);
         let id1 = self.emit.open_paren(crate::printlanguage::OPEN_PAREN, 0);
         self.context.push_mod();
@@ -4158,11 +4174,11 @@ impl PrintC {
             self.emit_expression_ir(fd, arch, op);
             self.emit.end_statement(id3);
         }
-        self.emit.print(keywords::SEMICOLON, SyntaxHighlight::NoColor);
+        self.emit.print(self.lang().kw_semicolon, SyntaxHighlight::NoColor);
         self.emit.spaces(1, 0);
         // Emit the conditional statement (the condition block, comma-separated).
         self.emit_block(fd, arch, cond_block);
-        self.emit.print(keywords::SEMICOLON, SyntaxHighlight::NoColor);
+        self.emit.print(self.lang().kw_semicolon, SyntaxHighlight::NoColor);
         self.emit.spaces(1, 0);
         // Emit the iterator statement.
         if let Some(op) = fd.sblocks_ref().block(blk).get_iterate_op() {
@@ -4173,7 +4189,7 @@ impl PrintC {
         self.context.pop_mod();
         self.emit.close_paren(crate::printlanguage::CLOSE_PAREN, id1);
         let indent =
-            self.emit.open_brace_indent(keywords::OPEN_CURLY, to_emit_brace(self.options.brace_loop));
+            self.emit.open_brace_indent(self.lang().kw_open_curly, to_emit_brace(self.options.brace_loop));
         // (kuna warnstyle, DIV-39) condition-attached warnings land after the
         // `for (...) {` header brace.
         self.flush_eol_warnings();
@@ -4181,7 +4197,7 @@ impl PrintC {
         let id2 = self.emit.begin_block(0);
         self.emit_block(fd, arch, fd.sblocks_ref().block(blk).get_block(1));
         self.emit.end_block(id2);
-        self.emit.close_brace_indent(keywords::CLOSE_CURLY, indent);
+        self.emit.close_brace_indent(self.lang().kw_close_curly, indent);
         self.context.pop_mod();
     }
 
@@ -4205,19 +4221,19 @@ impl PrintC {
         if fd.sblocks_ref().block(blk).has_overflow_syntax() {
             // Renders: while( true ) { conditionbody...; break-on-branch }
             self.emit.tag_line();
-            self.emit.tag_op(keywords::KEYWORD_WHILE, SyntaxHighlight::KeywordColor, &MarkupRef::none());
+            self.emit.tag_op(self.lang().kw_while, SyntaxHighlight::KeywordColor, &MarkupRef::none());
             let id1 = self.emit.open_paren(crate::printlanguage::OPEN_PAREN, 0);
             self.emit.spaces(1, 0);
-            self.emit.print(keywords::KEYWORD_TRUE, SyntaxHighlight::ConstColor);
+            self.emit.print(self.lang().kw_true, SyntaxHighlight::ConstColor);
             self.emit.spaces(1, 0);
             self.emit.close_paren(crate::printlanguage::CLOSE_PAREN, id1);
-            indent = self.emit.open_brace_indent(keywords::OPEN_CURLY, to_emit_brace(self.options.brace_loop));
+            indent = self.emit.open_brace_indent(self.lang().kw_open_curly, to_emit_brace(self.options.brace_loop));
             self.context.push_mod();
             self.context.set_mod(modifiers::NO_BRANCH);
             self.emit_block(fd, arch, cond_block);
             self.context.pop_mod();
             self.emit.tag_line();
-            self.emit.tag_op(keywords::KEYWORD_IF, SyntaxHighlight::KeywordColor, &MarkupRef::none());
+            self.emit.tag_op(self.lang().kw_if, SyntaxHighlight::KeywordColor, &MarkupRef::none());
             self.emit.spaces(1, 0);
             self.context.push_mod();
             self.context.set_mod(modifiers::ONLY_BRANCH);
@@ -4229,7 +4245,7 @@ impl PrintC {
             // Renders: while(condition) { ... }
             self.emit_comment_block_tree(fd, cond_block);
             self.emit.tag_line();
-            self.emit.tag_op(keywords::KEYWORD_WHILE, SyntaxHighlight::KeywordColor, &MarkupRef::none());
+            self.emit.tag_op(self.lang().kw_while, SyntaxHighlight::KeywordColor, &MarkupRef::none());
             self.emit.spaces(1, 0);
             let id1 = self.emit.open_paren(crate::printlanguage::OPEN_PAREN, 0);
             self.context.push_mod();
@@ -4237,7 +4253,7 @@ impl PrintC {
             self.emit_block(fd, arch, cond_block);
             self.context.pop_mod();
             self.emit.close_paren(crate::printlanguage::CLOSE_PAREN, id1);
-            indent = self.emit.open_brace_indent(keywords::OPEN_CURLY, to_emit_brace(self.options.brace_loop));
+            indent = self.emit.open_brace_indent(self.lang().kw_open_curly, to_emit_brace(self.options.brace_loop));
             // (kuna warnstyle, DIV-39) condition-attached warnings land after
             // the `while (cond) {` header brace.
             self.flush_eol_warnings();
@@ -4246,7 +4262,7 @@ impl PrintC {
         let id2 = self.emit.begin_block(0);
         self.emit_block(fd, arch, fd.sblocks_ref().block(blk).get_block(1));
         self.emit.end_block(id2);
-        self.emit.close_brace_indent(keywords::CLOSE_CURLY, indent);
+        self.emit.close_brace_indent(self.lang().kw_close_curly, indent);
         self.context.pop_mod();
     }
 
@@ -4260,8 +4276,8 @@ impl PrintC {
         // above the `do` (suppressed inline via f_label_bumpup).
         self.emit_any_label_statement(fd, blk);
         self.emit.tag_line();
-        self.emit.print(keywords::KEYWORD_DO, SyntaxHighlight::KeywordColor);
-        let id = self.emit.open_brace_indent(keywords::OPEN_CURLY, to_emit_brace(self.options.brace_loop));
+        self.emit.print(self.lang().kw_do, SyntaxHighlight::KeywordColor);
+        let id = self.emit.open_brace_indent(self.lang().kw_open_curly, to_emit_brace(self.options.brace_loop));
         let body = fd.sblocks_ref().block(blk).get_block(0);
         self.context.push_mod();
         let id2 = self.emit.begin_block(0);
@@ -4269,13 +4285,13 @@ impl PrintC {
         self.emit_block(fd, arch, body);
         self.emit.end_block(id2);
         self.context.pop_mod();
-        self.emit.close_brace_indent(keywords::CLOSE_CURLY, id);
+        self.emit.close_brace_indent(self.lang().kw_close_curly, id);
         self.emit.spaces(1, 0);
-        self.emit.tag_op(keywords::KEYWORD_WHILE, SyntaxHighlight::KeywordColor, &MarkupRef::none());
+        self.emit.tag_op(self.lang().kw_while, SyntaxHighlight::KeywordColor, &MarkupRef::none());
         self.emit.spaces(1, 0);
         self.context.set_mod(modifiers::ONLY_BRANCH);
         self.emit_block(fd, arch, body);
-        self.emit.print(keywords::SEMICOLON, SyntaxHighlight::NoColor);
+        self.emit.print(self.lang().kw_semicolon, SyntaxHighlight::NoColor);
         // (kuna warnstyle, DIV-39) body/condition warnings still pending land
         // at the end of the `} while (cond);` line.
         self.flush_eol_warnings();
@@ -4291,21 +4307,21 @@ impl PrintC {
         // above the `do` (suppressed inline via f_label_bumpup).
         self.emit_any_label_statement(fd, blk);
         self.emit.tag_line();
-        self.emit.print(keywords::KEYWORD_DO, SyntaxHighlight::KeywordColor);
-        let id = self.emit.open_brace_indent(keywords::OPEN_CURLY, to_emit_brace(self.options.brace_loop));
+        self.emit.print(self.lang().kw_do, SyntaxHighlight::KeywordColor);
+        let id = self.emit.open_brace_indent(self.lang().kw_open_curly, to_emit_brace(self.options.brace_loop));
         let body = fd.sblocks_ref().block(blk).get_block(0);
         let id1 = self.emit.begin_block(0);
         self.emit_block(fd, arch, body);
         self.emit.end_block(id1);
-        self.emit.close_brace_indent(keywords::CLOSE_CURLY, id);
+        self.emit.close_brace_indent(self.lang().kw_close_curly, id);
         self.emit.spaces(1, 0);
-        self.emit.tag_op(keywords::KEYWORD_WHILE, SyntaxHighlight::KeywordColor, &MarkupRef::none());
+        self.emit.tag_op(self.lang().kw_while, SyntaxHighlight::KeywordColor, &MarkupRef::none());
         let id2 = self.emit.open_paren(crate::printlanguage::OPEN_PAREN, 0);
         self.emit.spaces(1, 0);
-        self.emit.print(keywords::KEYWORD_TRUE, SyntaxHighlight::ConstColor);
+        self.emit.print(self.lang().kw_true, SyntaxHighlight::ConstColor);
         self.emit.spaces(1, 0);
         self.emit.close_paren(crate::printlanguage::CLOSE_PAREN, id2);
-        self.emit.print(keywords::SEMICOLON, SyntaxHighlight::NoColor);
+        self.emit.print(self.lang().kw_semicolon, SyntaxHighlight::NoColor);
         // (kuna warnstyle, DIV-39) pending body warnings land at the end of
         // the `} while ( true );` line.
         self.flush_eol_warnings();
@@ -4327,18 +4343,18 @@ impl PrintC {
         let id = self.emit.begin_statement(&MarkupRef::none());
         match gototype {
             x if x == block_flags::f_break_goto => {
-                self.emit.print(keywords::KEYWORD_BREAK, SyntaxHighlight::KeywordColor);
+                self.emit.print(self.lang().kw_break, SyntaxHighlight::KeywordColor);
             }
             x if x == block_flags::f_continue_goto => {
-                self.emit.print(keywords::KEYWORD_CONTINUE, SyntaxHighlight::KeywordColor);
+                self.emit.print(self.lang().kw_continue, SyntaxHighlight::KeywordColor);
             }
             _ => {
-                self.emit.print(keywords::KEYWORD_GOTO, SyntaxHighlight::KeywordColor);
+                self.emit.print(self.lang().kw_goto, SyntaxHighlight::KeywordColor);
                 self.emit.spaces(1, 0);
                 self.emit.print(&self.block_label_name(fd, target), SyntaxHighlight::NoColor);
             }
         }
-        self.emit.print(keywords::SEMICOLON, SyntaxHighlight::NoColor);
+        self.emit.print(self.lang().kw_semicolon, SyntaxHighlight::NoColor);
         self.emit.end_statement(id);
     }
 
@@ -4398,7 +4414,7 @@ impl PrintC {
             }
             if separator {
                 if self.context.is_set(modifiers::COMMA_SEPARATE) {
-                    self.emit.print(keywords::COMMA, SyntaxHighlight::NoColor);
+                    self.emit.print(self.lang().kw_comma, SyntaxHighlight::NoColor);
                     self.emit.spaces(1, 0);
                 } else {
                     self.emit_comment_group(fd, Some(inst));
@@ -4438,7 +4454,7 @@ impl PrintC {
         self.emit_expression_ir(fd, arch, inst);
         self.emit.end_statement(id);
         if !self.context.is_set(modifiers::COMMA_SEPARATE) {
-            self.emit.print(keywords::SEMICOLON, SyntaxHighlight::NoColor);
+            self.emit.print(self.lang().kw_semicolon, SyntaxHighlight::NoColor);
         }
     }
 
@@ -4672,7 +4688,7 @@ impl PrintC {
             // `emit_block_switch`; here only the `switch(in0)` expression prints.
             OpCode::CPUI_BRANCHIND => {
                 let kw_markup = self.op_markup(fd, op);
-                self.emit.tag_op(keywords::KEYWORD_SWITCH, SyntaxHighlight::KeywordColor, &kw_markup);
+                self.emit.tag_op(self.lang().kw_switch, SyntaxHighlight::KeywordColor, &kw_markup);
                 let id = self.emit.open_paren(crate::printlanguage::OPEN_PAREN, 0);
                 if let Some(vn) = fd.obank().get(op).and_then(|o| o.get_in(0)) {
                     self.push_vn_ir(fd, arch, vn, op);
@@ -4682,7 +4698,7 @@ impl PrintC {
             // RETURN (printc.cc:774 opReturn, the plain-return case).
             OpCode::CPUI_RETURN => {
                 let kw_markup = self.op_markup(fd, op);
-                self.emit.tag_op(keywords::KEYWORD_RETURN, SyntaxHighlight::KeywordColor, &kw_markup);
+                self.emit.tag_op(self.lang().kw_return, SyntaxHighlight::KeywordColor, &kw_markup);
                 let nin = fd.obank().get(op).map(|o| o.num_input()).unwrap_or(0);
                 if nin > 1 {
                     self.emit.spaces(1, 0);
@@ -7112,7 +7128,7 @@ impl PrintC {
         // funcname_color (matching the C++ Atom(typePointerRelToken,optoken,
         // funcname_color,op)).
         self.push_atom(&Atom::with_op(
-            keywords::TYPE_POINTER_REL_TOKEN.to_string(),
+            self.lang().kw_type_pointer_rel.to_string(),
             TagType::OpToken,
             crate::printlanguage::SyntaxHighlight::funcname_color,
             op_key(op),

--- a/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
@@ -8027,102 +8027,23 @@ fn array_decl_parts(
     Some((type_name_for_decl(&base, rt), count))
 }
 
-/// The type name to render in a declaration (C++ `Datatype::getName`), with the
-/// Ghidra fallback for an unnamed type: a `TYPE_UNKNOWN` of size N (the W8
-/// un-inferred base, no real name) renders as `undefined<N>` (or `undefined` for
-/// size 1's anonymous form), and a `TYPE_VOID` renders as `void`.  The oracle's
-/// inferred names (e.g. `uint1`) need the W8 `ActionInferTypes`; this is the
-/// faithful unnamed-type rendering until then.
-/// Build the C-declarator front/back text bracketing an identifier for `ct`,
-/// transcribing the declarator algorithm of `PrintC::pushTypeStart` /
-/// `pushTypeEnd` (printc.cc:265/314) plus `buildTypeStack` (printc.cc:143).
+/// Build the declarator front/back text bracketing an identifier for `ct`.
 ///
-/// Returns `(front, back)` such that `<front><name><back>` is the full C
-/// declaration of an object named `name` of type `ct` — e.g.
-///   * `int8`              → `("int8", "")`             → `int8 a`
-///   * `twostruct *`       → `("twostruct *", "")`      → `twostruct *ptr`
-///   * `int4 (*)[1]`       → `("int4 (*", ")[1]")`      → `int4 (*a)[1]`
-///   * `char *`            → `("char *", "")`           → `char *pchar`
+/// Returns `(front, back)` such that `<front><name><back>` is the full
+/// declaration of an object named `name` of type `ct` -- e.g. in C
+///   * `int8`              -> `("int8", "")`             -> `int8 a`
+///   * `twostruct *`       -> `("twostruct *", "")`      -> `twostruct *ptr`
+///   * `int4 (*)[1]`       -> `("int4 (*", ")[1]")`      -> `int4 (*a)[1]`
 ///
-/// The stack is built base-up exactly as `buildTypeStack`; pointer modifiers go
-/// on the front (`*`), array/function modifiers on the tail (`[N]`/`(...)`), and
-/// a `*` front nested inside an array/function tail is parenthesised — the
-/// precedence the RPN `ptr_expr`/`array_expr` tokens encode.
+/// The C body -- the transcription of `PrintC::pushTypeStart`/`pushTypeEnd`
+/// (printc.cc:265/314) plus `buildTypeStack` (printc.cc:143) -- moved to
+/// `CSpeller::declarator` (`p9_emit/kuna_langc.rs`) when the output-language seam
+/// landed. A language whose types are pure prefixes returns an empty `back`.
 pub(crate) fn declarator_parts(
     ct: &std::rc::Rc<crate::dtype::Datatype>,
     rt: RealTypeCtx,
 ) -> (String, String) {
-    use crate::dtype::type_metatype;
-    // buildTypeStack: walk to the base (named) type, recording the modifier chain.
-    let mut stack: Vec<std::rc::Rc<crate::dtype::Datatype>> = Vec::new();
-    let mut cur = std::rc::Rc::clone(ct);
-    loop {
-        stack.push(std::rc::Rc::clone(&cur));
-        if !cur.get_name().is_empty() {
-            break; // base type
-        }
-        let next = match cur.get_metatype() {
-            type_metatype::TYPE_PTR => cur.get_ptr_to(),
-            type_metatype::TYPE_ARRAY => cur.get_array_base(),
-            _ => None, // other anonymous type: stop
-        };
-        match next {
-            Some(n) => cur = n,
-            None => break,
-        }
-    }
-    // The base type's display name (anonymous → `undefined<N>` / `void`).
-    let base = stack.last().expect("declarator: non-empty stack");
-    // (kuna) realtypes: relabel a residual TYPE_UNKNOWN base as a real C type by
-    // size.  Under a pointer modifier the same size table applies, so the pointee
-    // width survives into the declaration; only a residual size with no natural C
-    // type degrades to `void` there (the `*` chain is laid out by the walk below).
-    let under_pointer = stack[..stack.len() - 1]
-        .iter()
-        .any(|m| matches!(m.get_metatype(), type_metatype::TYPE_PTR));
-    let base_name = if let Some(n) = realtype_relabel(&rt, base, under_pointer) {
-        n.to_string()
-    } else if base.get_name().is_empty() {
-        match base.get_metatype() {
-            type_metatype::TYPE_VOID => "void".to_string(),
-            _ => format!("undefined{}", base.get_size()),
-        }
-    } else {
-        base.get_display_name().to_string()
-    };
-
-    // Walk the modifiers from base toward the outermost (stack[len-2]..stack[0]),
-    // accumulating front (`*`) and back (`[N]`) declarator pieces.  An array/
-    // function tail wraps any pending pointer front in parentheses.
-    let mut front = String::new();
-    let mut back = String::new();
-    let mut pending_ptr = false; // a `*` not yet absorbed by a tail
-    for ct_mod in stack.iter().rev().skip(1) {
-        match ct_mod.get_metatype() {
-            type_metatype::TYPE_PTR => {
-                front.push('*');
-                pending_ptr = true;
-            }
-            type_metatype::TYPE_ARRAY => {
-                let n = ct_mod.num_elements().unwrap_or_else(|| {
-                    let base = ct_mod.get_array_base().map(|b| b.get_size()).unwrap_or(1).max(1);
-                    ct_mod.get_size() / base
-                });
-                if pending_ptr {
-                    front.insert(0, '(');
-                    back = format!("){}", back);
-                    pending_ptr = false;
-                }
-                back = format!("{}[{}]", back, n);
-            }
-            _ => {}
-        }
-    }
-    // `<base> <front>` with a single separating space before any `*` modifiers
-    // (the `type_expr_space` token); a bare base type has no trailing space here
-    // (the caller adds the space before the identifier).
-    let front_full = if front.is_empty() { base_name } else { format!("{base_name} {front}") };
-    (front_full, back)
+    rt.speller().declarator(&rt, ct)
 }
 
 /// (kuna) The full C type string for `ct` with no identifier, rendered exactly as
@@ -8426,126 +8347,33 @@ fn render_type_definitions(
     out
 }
 
-/// The type-token text for a local declaration.  Mirrors C++ `pushTypeStart`
-/// (printc.cc:265): a named/base type prints its name; an *anonymous pointer*
-/// (e.g. `char *`) prints the full declarator front via `declarator_parts` so a
-/// `char *pchar` local is not flattened to `undefined8`.  The trailing `*` is
-/// kept on the type token — the emit loop suppresses the separating space before
-/// the identifier when the front ends in `*` (the C++ `ptr_expr` glues `*` to the
-/// identifier with no space).
+/// The type token to render in a declaration's type position.
+///
+/// The C body moved to `CSpeller::type_name` (`p9_emit/kuna_langc.rs`) when the
+/// output-language seam landed.
 fn type_name_for_decl(t: &std::rc::Rc<crate::dtype::Datatype>, rt: RealTypeCtx) -> String {
-    use crate::dtype::type_metatype;
-    // (kuna) realtypes: a scalar residual TYPE_UNKNOWN (the named `xunknownN` core
-    // type or an anonymous `undefined<N>`) becomes its real C type by size.
-    if let Some(n) = realtype_relabel(&rt, t, false) {
-        return n.to_string();
-    }
-    let name = t.get_name();
-    if !name.is_empty() {
-        return name.to_string();
-    }
-    match t.get_metatype() {
-        type_metatype::TYPE_VOID => "void".to_string(),
-        // An anonymous pointer renders as `<pointee> *` (recursively), exactly as
-        // `push_cast_type` does for a `(char *)` cast.  `declarator_parts` walks
-        // the modifier chain to the named base and lays out the `*` front.
-        type_metatype::TYPE_PTR => {
-            let (front, _back) = declarator_parts(t, rt);
-            front
-        }
-        _ => format!("undefined{}", t.get_size()),
-    }
+    rt.speller().type_name(&rt, t)
 }
 
-/// (kuna) The `realtypes` rendering context: the `Architecture::realtypes` gate
-/// plus the data-model fact that `long` is 8 bytes (so an 8-byte unknown reads
-/// `unsigned long` on LP64, `unsigned long long` on LLP64).  `Copy` so it threads
-/// cheaply through the declarator chokepoints.
-#[derive(Clone, Copy)]
-pub(crate) struct RealTypeCtx {
-    enabled: bool,
-    long_is_8: bool,
-    /// (kuna `ctypes`) Spell the NAMED core types (`int4`/`uint1`/`float8`/`code`)
-    /// as the target's own C type names too, not just the residual unknowns.
-    ctypes: bool,
-    /// (kuna `ctypes`) The target's declared C scalar widths, which is what makes
-    /// the spelling per-architecture rather than a guess.
-    model: crate::kuna_ctypes::CDataModel,
-}
+/// (kuna) The per-document type-rendering context.
+///
+/// An alias for [`crate::kuna_langtypes::SpellCtx`], which is where it moved when
+/// the output-language seam landed: it now also carries the output language, so
+/// the free-function declarator family reaches its speller with no new threading.
+pub(crate) type RealTypeCtx = crate::kuna_langtypes::SpellCtx;
 
 impl RealTypeCtx {
-    /// The disabled context — never relabels (preserves the upstream
-    /// `xunknownN`/`undefined<N>` rendering).
-    pub(crate) const OFF: RealTypeCtx = RealTypeCtx {
-        enabled: false,
-        long_is_8: true,
-        ctypes: false,
-        model: crate::kuna_ctypes::CDataModel::LP64,
-    };
-
-    /// Resolve the context from the live architecture: the `realtypes` /`ctypes`
-    /// gates and the target's decoded data organization.
+    /// Resolve the context from the live architecture: the `realtypes`/`ctypes`
+    /// gates, the target's decoded data organization, and the output language.
     fn from_arch(arch: &Architecture) -> RealTypeCtx {
         RealTypeCtx {
+            lang: crate::kuna_lang::OutLang::C,
             enabled: arch.realtypes,
             long_is_8: arch.types().get_size_of_long() == 8,
             ctypes: arch.ctypes,
             model: crate::kuna_ctypes::CDataModel::from_types(&*arch.types()),
         }
     }
-}
-
-/// (kuna) Real C name for a residual `TYPE_UNKNOWN` base, or `None` when the gate
-/// is off / the type is not unknown.  Conservative on sign (multi-byte unknowns
-/// are unsigned, since the real sign is genuinely unknown); a pointer-to-unknown
-/// base relabels through the same size table as a scalar, so the pointee keeps its
-/// width and `void` is only the residual fallback.
-fn realtype_relabel(
-    rt: &RealTypeCtx,
-    dt: &std::rc::Rc<crate::dtype::Datatype>,
-    under_pointer: bool,
-) -> Option<&'static str> {
-    if dt.get_metatype() == crate::dtype::type_metatype::TYPE_UNKNOWN {
-        if !rt.enabled {
-            return None;
-        }
-        return realtype_unknown_base(dt.get_size(), under_pointer, rt.long_is_8);
-    }
-    // (kuna `ctypes`) Every OTHER core type — the named `int4`/`uint1`/`float8`/
-    // `code` vocabulary — spells as the target's own C type.  Restricted to core
-    // types so a user-defined or DWARF-recovered type keeps the name it was
-    // declared with; that name is already C.
-    if !rt.ctypes || !dt.is_core_type() {
-        return None;
-    }
-    crate::kuna_ctypes::core_type_spelling(
-        &rt.model,
-        dt.get_metatype(),
-        dt.get_size(),
-        dt.is_char_print(),
-    )
-}
-
-/// (kuna) Size → standard-C name for an unknown value.  `None` for sizes with no
-/// natural single C type (3/5/6/7/10/16…), which keep the `undefined<N>` form;
-/// under a pointer those residual sizes fall back to `void` (the modifier walk
-/// adds the `*` chain), since `void *` is the only spelling that carries no width
-/// claim.  A pointee whose size *does* have a natural type keeps it, so the
-/// declaration agrees with the stride the index/cast expressions were built from.
-fn realtype_unknown_base(size: int4, under_pointer: bool, long_is_8: bool) -> Option<&'static str> {
-    Some(match size {
-        1 => "char",
-        2 => "unsigned short",
-        4 => "unsigned int",
-        8 => {
-            if long_is_8 {
-                "unsigned long"
-            } else {
-                "unsigned long long"
-            }
-        }
-        _ => return if under_pointer { Some("void") } else { None },
-    })
 }
 
 /// STUB A helper — the kuna stand-in for C++ `Symbol::getFirstWholeMap() != entry`

--- a/docs/spec/09-emission.md
+++ b/docs/spec/09-emission.md
@@ -642,6 +642,56 @@ presentation.
 
 ## 9.6 Alternate languages
 
+**(kuna) The output-language plane.** The C++ tree kuna was ported from selected a
+back-end through a `PrintLanguageCapability` registry over a three-level hierarchy
+(`PrintLanguage` → `PrintC` → `PrintJava : public PrintC`); the port flattened
+that into one concrete `PrintC`. kuna re-erects the seam by **parameterizing** the
+single emitter rather than growing a second one: `PrintC` carries one `out_lang`
+field, and every language-varying site reads a `&'static` policy object through
+`printc.rs (PrintC::lang)` instead of naming a `keywords::`/`tokens::` constant.
+The RPN driver, the op emitters, `parentheses`, the cast plumbing, the comment
+sorter and the markup back-end are shared verbatim — there is no duplicated
+emitter, which is what keeps one implementation of "emit an `if`" as languages are
+added.
+
+Three artifacts make up the plane, all in
+`decompiler/crates/kuna-decomp/src/p9_emit/`:
+
+- **`kuna_lang.rs`** — `OutLang` (the selector), `LangProfile` (the surface
+  vocabulary: the keyword and punctuation spellings the emitters use, plus the
+  `OpToken`s whose *spelling* varies; the ~40 arithmetic/comparison/shift tokens
+  are identical in every language kuna targets and stay in `printc.rs (tokens)`),
+  and `LangCaps` — **what the emitter is allowed to produce**. `LangCaps` is what
+  lets a language that cannot express a construct never be handed one, instead of
+  the operator being asked to flip the kuna rendering defaults that would produce
+  it (`truthycond`'s implicit-bool condition, `braceelide`'s braceless body,
+  `condfold`'s comma operand, `nullprinting`'s `NULL`). Its load-bearing member is
+  `switch_captures_break`: a C `switch` captures a bare `break`, which is why
+  `p8_structure/kuna_loopbreak_recovery.rs` legitimately retags a
+  goto-to-switch-exit as `f_break_goto` (§8.3); a language whose switch does *not*
+  capture `break` must re-resolve that scope or emit a jump to the wrong place.
+- **`kuna_langtypes.rs`** — `TypeSpeller` and `SpellCtx`. Type *recovery* (P5) is
+  language-independent; only the spelling differs, and it lives in the printer for
+  the reason `kuna_ctypes.rs` records: `Datatype::hash_name` makes the registered
+  name determine the type id, so renaming the interned core types would break the
+  Ghidra wire protocol. `SpellCtx` is the former `RealTypeCtx` — `Copy`, already
+  threaded through every declarator chokepoint — now also carrying the language, so
+  the free-function declarator family reaches its speller with no new parameter.
+  `TypeSpeller::declarator` is documented as `<front><name><back>` rather than
+  promising a meaningful `back`, because the front/back split is a C-ism: C
+  declarators wrap the identifier (`int4 (*a)[1]`) where other languages' types are
+  pure prefixes.
+- **`kuna_langc.rs`** — `CSpeller`, the c-language policy object. It carries the
+  declarator algorithm transcribed from `pushTypeStart`/`pushTypeEnd`/
+  `buildTypeStack` and the `realtypes`/`ctypes` relabelling (DIV-5/DIV-6), moved
+  verbatim out of `printc.rs`, which keeps thin dispatchers.
+
+The invariant that makes the seam free: every `LANG_C` field **is** the constant
+it replaces, asserted field-by-field — and by pointer identity for the tokens,
+since `printlanguage.rs (parentheses)` decides parenthesization with `ptr::eq`.
+Reading the C profile therefore produces the identical token, so introducing the
+plane is a byte-identical rewrite and `docs/baseline.json` is never re-pinned.
+
 The Java back-end is deliberately not ported:
 `decompiler/crates/kuna-decomp/src/p9_emit/printjava.rs (PrintJava)` is a
 recorded LOSS whose constructor returns an error — upstream `PrintJava` is a


### PR DESCRIPTION
## What

First PR of the non-C output-language work. It re-erects the printer seam the Rust port flattened, **with zero change to emitted C**.

The C++ tree kuna was ported from selected a back-end through a `PrintLanguageCapability` registry over `PrintLanguage` → `PrintC` → `PrintJava : public PrintC`. The port flattened all of it into one concrete 8,995-line `PrintC`, and `p9_emit/printjava.rs` is the 47-line `Err("printjava deferred — LOSS")` stub that records the loss. `option setlanguage` is registered, reaches `Architecture::set_print_language`, and assigns a `String` to nothing — `infra/architecture/tests.rs:415` literally pins that the name flips and the emitter does not.

## The shape, and why it is not a second printer

`PrintC` is **parameterized**, not subclassed: one `out_lang` field, and every language-varying site reads a `&'static` policy object through `PrintC::lang()` instead of naming a `keywords::`/`tokens::` constant. The RPN driver, the op emitters, `parentheses`, the cast plumbing, the comment sorter and the markup back-end are shared verbatim.

The alternative — forking `printc.rs` — is what the reference implementation did: SEFCOM's Oxidizer (merged into angr as `structured_codegen/rust.py`, 4,499 lines vs `c.py`'s 4,403, ~68% identical after `s/Rust/C/`). Inside one release cycle that fork drifted into four concrete bugs: `RustStructuredCodeGenerator.__init__` omits three kwargs `c.py` accepts, so `flavor="rust"` plus any of those display options is a `TypeError`; four accepted params are never assigned; and the method-call `receiver` plumbing reads a tag nothing in the tree ever sets. With a 675-assertion byte-exact corpus, a C copy that can rot silently is not an option.

## Contents

Three new files in `p9_emit/`:

- **`kuna_lang.rs`** — `OutLang` (the selector, one variant today), `LangProfile` (the surface vocabulary: the 19 keyword/punctuation spellings the emitters actually use, plus the 7 `OpToken`s whose spelling varies; the ~40 arithmetic/comparison/shift tokens are identical in every language kuna targets and are deliberately left in `printc::tokens`), and `LangCaps` — what the emitter is *allowed* to produce.
- **`kuna_langtypes.rs`** — `TypeSpeller` + `SpellCtx`.
- **`kuna_langc.rs`** — `CSpeller`, carrying the declarator algorithm and the `realtypes`/`ctypes` relabelling moved verbatim out of `printc.rs`.

`printc.rs` drops 222 lines to thin dispatchers; `docs/spec/09-emission.md` §9.6 describes the plane.

### `LangCaps` is the part that matters later

It is what lets a language that cannot express a construct never be handed one, instead of the operator being asked to flip the kuna rendering defaults that would produce it — `truthycond` (DIV-37) renders `x != 0` as `x`, `braceelide` (DIV-38) drops braces on a single-statement body, `nullprinting` (DIV-35) emits `NULL`; all three are **default-ON** and all three are invalid in a language like Rust.

Its load-bearing member is `switch_captures_break`. A C `switch` captures a bare `break`, which is why `kuna_scope_break` (`p8_structure/kuna_loopbreak_recovery.rs:171-194`, DIV-10 default-ON) legitimately retags a goto-to-switch-exit as `f_break_goto`. A language whose switch does **not** capture `break` — Rust's `match` — would take that same flag and emit a jump to the wrong place, silently, wherever a switch sits inside a loop. Recording the capability now is what makes that a correctness gate later rather than a bug report.

### `SpellCtx` rides the language, so nothing new is threaded

`SpellCtx` is the former `printc::RealTypeCtx`: already `Copy`, already threaded through every declarator chokepoint. Adding `OutLang` to it means the free-function declarator family reaches its speller with no new parameter. `printc::RealTypeCtx` stays as an alias, so its ~45 existing uses — 25 of them in `printc/tests.rs` — are untouched.

`TypeSpeller::declarator` is specified as `<front><name><back>` rather than promising a meaningful `back`: the front/back split is a C-ism (C declarators wrap the identifier, `int4 (*a)[1]`) and a language whose types are pure prefixes would have to fake it.

## Why this is byte-identical, and the proof

Every `LANG_C` field **is** the constant it replaces — asserted field-by-field, and by `ptr::eq` for the tokens, since `printlanguage::parentheses` decides parenthesization by pointer identity, so a profile that merely *spells* a token the same would not be enough. Reading the C profile therefore produces the identical token.

| Gate | Result |
|---|---|
| `make test` | **675/675, PARITY OK** — `docs/baseline.json` untouched |
| `make test-stages` | **484/484, PARITY OK** — `docs/baseline-stages.json` untouched |
| `make rust-test` | green — 316 test groups, 0 failures |
| `make check-spec` | OK, **strict** mode |

Plus the check the assertion corpus cannot give — a whole-binary render diff over `tests/bug-repro/{faillog,grep,sort,libselinux.so.1}` and `tests/fixtures/fid/prog`, ~25 MB of emitted C:

```
faillog: IDENTICAL   grep: IDENTICAL   sort: IDENTICAL
libselinux.so.1: IDENTICAL   prog: IDENTICAL
```

## New tests

`p9_emit/kuna_lang/tests.rs` — `profile_matches_legacy_constants` (the byte-identity invariant, ~22 field asserts), `profile_tokens_are_the_legacy_statics` (the `ptr::eq` identity), `c_is_the_default_language`, `c_caps_describe_c`.

## Not in this PR

No option, no catalog-count bump, no `phases.toml` row: `setlanguage` is an upstream option, not a `[[settable]]`, so language selection costs nothing from the 111-settable ledger. No structuring change. `OutLang` has one variant — adding the second is what makes the compiler enumerate every dispatch site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WUuE4zdiEqZFWLL2YEUk9