### PR TITLE
[AUTOMATED] feat(p4): kuna_langabi — the ABI seam, with one decision that is real

### DIFF
--- a/decompiler/crates/kuna-decomp/src/p4_calls/kuna_langabi.rs
+++ b/decompiler/crates/kuna-decomp/src/p4_calls/kuna_langabi.rs
@@ -1,0 +1,89 @@
+//! (kuna) The ABI seam: what a function's recovered calling convention looks like
+//! in the output language.
+//!
+//! # Why this axis is thin, deliberately
+//!
+//! The other two output-language axes are thick because they have to be: every
+//! statement has a shape ([`crate::kuna_lang::LangForms`]) and every value has a
+//! type ([`crate::kuna_langtypes::TypeSpeller`]). The ABI axis is thin because
+//! `extern "Rust"` is **unspecified** and, for the scalar arguments a decompiler
+//! actually recovers, System-V-shaped -- the same convention the cspec already
+//! describes. A `build_param_list("rust")` strategy would encode a guess as an
+//! engine fact, which is exactly what `fspec.rs`'s allowlist (`""`/`"standard"`/
+//! `"register"`, error otherwise) exists to prevent.
+//!
+//! Rust's genuinely distinct ABI surface -- a niche-optimized `Option<&T>` that
+//! is a nullable pointer, a `Result<T, E>` tagged across `rax:rdx`, a slice
+//! passed as a `(ptr, len)` register pair -- is an **enum and discriminant
+//! inference** problem living in P5, not a convention problem living here.
+//! Modelling it as a convention would be modelling the wrong thing.
+//!
+//! So this trait carries exactly one decision, and that decision is real: which
+//! `extern` the signature must declare. It is load-bearing rather than
+//! decorative -- rustc rejects a C-variadic on anything but an
+//! `unsafe extern "C" fn`, so the output does not compile without it.
+//!
+//! # What a third language adds, and where
+//!
+//! Go is the case that justifies the seam existing at all, because its ABI
+//! genuinely differs rather than merely being spelled differently: a register ABI
+//! since 1.17, multi-value returns, and a two-word representation for interfaces
+//! and slices. Those need two more members -- a preferred prototype model
+//! consulted where `ActionPrototypeTypes` picks one, and a multi-return form
+//! consulted where the `RETURN` op is emitted. Neither is added here, because a
+//! trait method with no consumer is a wish list rather than an interface: the
+//! `ArchContext` the P4 action reads carries only `defaultfp`/`evalfp_current`
+//! and no named-model registry, so a `preferred_model` hook would be plumbing in
+//! service of a function that returns `None` for both languages kuna emits.
+
+/// Per-language rendering of a recovered calling convention.
+pub trait LangAbi {
+    /// The `extern "..."` marker this function's signature must declare, or
+    /// `None` to declare none.
+    ///
+    /// `model_name` is the recovered prototype model (`__stdcall`, `__fastcall`,
+    /// …); `is_variadic` is whether the recovered prototype takes `...`.
+    fn extern_marker(&self, model_name: &str, is_variadic: bool) -> Option<&'static str>;
+}
+
+/// C declares no `extern` in a definition -- the convention, when it is shown at
+/// all, is the `option conventionprinting` keyword (`__cdecl`), which is a
+/// different token in a different position.
+pub struct CAbi;
+
+/// The singleton reached through `OutLang::C.abi()`.
+pub static C_ABI: CAbi = CAbi;
+
+impl LangAbi for CAbi {
+    fn extern_marker(&self, _model_name: &str, _is_variadic: bool) -> Option<&'static str> {
+        None
+    }
+}
+
+/// Rust's rule.
+pub struct RustAbi;
+
+/// The singleton reached through `OutLang::Rust.abi()`.
+pub static RUST_ABI: RustAbi = RustAbi;
+
+impl LangAbi for RustAbi {
+    /// `extern "C"` exactly when the prototype is variadic, and otherwise
+    /// nothing.
+    ///
+    /// The variadic case is forced: a C-variadic parameter is only legal on an
+    /// `unsafe extern "C" fn`, and rustc rejects it anywhere else (a semantic
+    /// rule, so a token-level parser accepts the shorter form and the compiler
+    /// does not).
+    ///
+    /// Every other function declares nothing, which means `extern "Rust"` -- the
+    /// default, and unspellable. That is the honest answer rather than a
+    /// conservative one: marking every recovered function `extern "C"` would
+    /// assert a convention the recovery cannot support, and a Rust binary's own
+    /// functions are precisely the ones that are NOT `extern "C"`.
+    fn extern_marker(&self, _model_name: &str, is_variadic: bool) -> Option<&'static str> {
+        is_variadic.then_some("extern \"C\" ")
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/decompiler/crates/kuna-decomp/src/p4_calls/kuna_langabi/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/p4_calls/kuna_langabi/tests.rs
@@ -1,0 +1,28 @@
+//! Tests for the ABI seam.
+
+use super::*;
+use crate::kuna_lang::OutLang;
+
+/// The rule that makes this seam load-bearing rather than decorative: rustc
+/// rejects a C-variadic on anything but an `unsafe extern "C" fn`.
+#[test]
+fn rust_declares_extern_c_exactly_for_variadics() {
+    let abi = OutLang::Rust.abi();
+    assert_eq!(abi.extern_marker("__stdcall", true), Some("extern \"C\" "));
+    assert_eq!(abi.extern_marker("__cdecl", true), Some("extern \"C\" "));
+    // Everything else declares nothing, which means `extern "Rust"` -- the
+    // default, and unspellable. A Rust binary's own functions are exactly the
+    // ones that are NOT `extern "C"`, so claiming otherwise would be a lie about
+    // the recovery.
+    assert_eq!(abi.extern_marker("__stdcall", false), None);
+    assert_eq!(abi.extern_marker("__cdecl", false), None);
+}
+
+/// C shows a convention through `option conventionprinting`'s keyword, in a
+/// different position; it never declares an `extern`.
+#[test]
+fn c_declares_no_extern() {
+    let abi = OutLang::C.abi();
+    assert_eq!(abi.extern_marker("__cdecl", false), None);
+    assert_eq!(abi.extern_marker("__cdecl", true), None);
+}

--- a/decompiler/crates/kuna-decomp/src/p4_calls/mod.rs
+++ b/decompiler/crates/kuna-decomp/src/p4_calls/mod.rs
@@ -12,3 +12,4 @@ pub mod kuna_dfunaffected;
 pub mod kuna_returnpair;
 pub mod kuna_returnuncomputed;
 pub mod kuna_spillargtrial;
+pub mod kuna_langabi; // (kuna) the ABI seam: per-language `extern` rendering

--- a/decompiler/crates/kuna-decomp/src/p9_emit/kuna_lang.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/kuna_lang.rs
@@ -81,6 +81,14 @@ impl OutLang {
         }
     }
 
+    /// How this language renders a recovered calling convention.
+    pub fn abi(self) -> &'static dyn crate::kuna_langabi::LangAbi {
+        match self {
+            OutLang::C => &crate::kuna_langabi::C_ABI,
+            OutLang::Rust => &crate::kuna_langabi::RUST_ABI,
+        }
+    }
+
     /// How this language spells a recovered type.
     pub fn speller(self) -> &'static dyn crate::kuna_langtypes::TypeSpeller {
         match self {

--- a/decompiler/crates/kuna-decomp/src/p9_emit/kuna_langrust.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/kuna_langrust.rs
@@ -320,15 +320,15 @@ impl PrintC {
         }
 
         let idp = self.emit.begin_func_proto();
-        // A C-variadic parameter is only legal on an `unsafe extern "C" fn`;
-        // rustc rejects it on a plain `unsafe fn` (a semantic rule, so a
-        // token-level parser accepts the shorter form and rustc does not).
-        let kw = if fd.get_func_proto().is_dotdotdot() {
-            "unsafe extern \"C\" fn"
-        } else {
-            "unsafe fn"
-        };
-        self.emit.print(kw, SyntaxHighlight::KeywordColor);
+        // Which `extern` the signature declares is the ABI seam's one decision
+        // (`p4_calls/kuna_langabi.rs`); for Rust it is forced by the grammar --
+        // a C-variadic is only legal on an `unsafe extern "C" fn`.
+        let model = fd.get_func_proto().get_model_name().to_string();
+        let ext = self
+            .lang_abi()
+            .extern_marker(&model, fd.get_func_proto().is_dotdotdot())
+            .unwrap_or("");
+        self.emit.print(&format!("unsafe {ext}fn"), SyntaxHighlight::KeywordColor);
         self.emit.spaces(1, 0);
         let id1g = self.emit.open_group();
         self.emit.tag_func_name(&display, SyntaxHighlight::FuncnameColor, markup);

--- a/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
@@ -1423,6 +1423,12 @@ impl PrintC {
         }
     }
 
+    /// How the active output language renders a recovered calling convention.
+    #[inline]
+    pub fn lang_abi(&self) -> &'static dyn crate::kuna_langabi::LangAbi {
+        self.out_lang.abi()
+    }
+
     /// The active output language's surface vocabulary and capability record.
     ///
     /// Every language-varying emit site reads through here rather than naming a

--- a/docs/spec/04-calls-and-prototypes.md
+++ b/docs/spec/04-calls-and-prototypes.md
@@ -715,3 +715,47 @@ function's output storage still agrees across every RETURN.
 This subsumes `returnpair` on the GH-6990 case it was written for (`tests/stages/
 gh6990-returnpair.xml` now records both passes agreeing); the flag remains as the
 blunt per-function instrument for a pair this rule judges genuine.
+
+### The ABI seam (`kuna_langabi.rs`)
+
+**(kuna, output languages)** How a recovered calling convention *appears* is a
+property of the output language, so it is a seam rather than a constant:
+`p4_calls/kuna_langabi.rs` defines `LangAbi`, reached through
+`OutLang::abi()`, with one method — the `extern "..."` marker a function's
+signature must declare.
+
+The axis is thin on purpose. The other two output-language axes are thick
+because they have to be (every statement has a shape, every value has a type);
+this one is thin because **`extern "Rust"` is unspecified**, and for the scalar
+arguments a decompiler actually recovers it is System-V-shaped — the same
+convention the cspec already describes. A `build_param_list("rust")` strategy
+would encode a guess as an engine fact, which is precisely what `fspec.rs`'s
+strategy allowlist (`""`/`"standard"`/`"register"`, error otherwise) exists to
+prevent. Rust's genuinely distinct ABI surface — a niche-optimized
+`Option<&T>` that is a nullable pointer, a `Result<T, E>` tagged across
+`rax:rdx`, a slice passed as a `(ptr, len)` register pair — is an **enum and
+discriminant inference** problem belonging to chapter [05](05-types.md), not a
+convention problem belonging here. Modelling it as a convention would be
+modelling the wrong thing.
+
+The one decision the seam does own is load-bearing rather than decorative: Rust
+declares `extern "C"` exactly when the recovered prototype is variadic, because
+a C-variadic parameter is only legal on an `unsafe extern "C" fn` and rustc
+rejects it anywhere else. Every other function declares nothing, which means
+`extern "Rust"` — the default, and unspellable. That is the honest answer rather
+than a conservative one: marking every recovered function `extern "C"` would
+assert a convention the recovery cannot support, and a Rust binary's own
+functions are exactly the ones that are *not* `extern "C"`. C declares no
+`extern` at all; its convention, when shown, is the `option conventionprinting`
+keyword (`__cdecl`), a different token in a different position.
+
+Nothing in this phase's recovery changes: the seam is consulted by the P9
+prototype emitter (chapter [09](09-emission.md) §9.6), and no pass here reads it.
+A third language is what would make it thicker — Go's ABI genuinely differs
+(a register ABI since 1.17, multi-value returns, a two-word interface and slice
+representation), and would add a preferred prototype model consulted where
+`ActionPrototypeTypes` picks one, plus a multi-return form consulted where the
+`RETURN` op is emitted. Neither is added ahead of a consumer: the `ArchContext`
+that P4 action reads carries only `defaultfp`/`evalfp_current` and no named-model
+registry, so a `preferred_model` hook today would be plumbing in service of a
+function that returns `None` for both languages kuna emits.

--- a/docs/spec/09-emission.md
+++ b/docs/spec/09-emission.md
@@ -681,6 +681,12 @@ Three artifacts make up the plane, all in
   promising a meaningful `back`, because the front/back split is a C-ism: C
   declarators wrap the identifier (`int4 (*a)[1]`) where other languages' types are
   pure prefixes.
+- **`p4_calls/kuna_langabi.rs`** — `LangAbi`, the ABI seam. It owns one decision,
+  consulted by the Rust prototype emitter: which `extern` a signature declares.
+  Rust declares `extern "C"` exactly when the prototype is variadic (rustc admits
+  a C-variadic on nothing else) and otherwise nothing, which means the
+  unspellable default `extern "Rust"`. Chapter [04](04-calls-and-prototypes.md)
+  explains why the axis is thin and what a third language would add.
 - **`kuna_langc.rs`** — `CSpeller`, the c-language policy object. It carries the
   declarator algorithm transcribed from `pushTypeStart`/`pushTypeEnd`/
   `buildTypeStack` and the `realtypes`/`ctypes` relabelling (DIV-5/DIV-6), moved


### PR DESCRIPTION
## What

The third output-language axis, completing the set the language plane was meant to have: **syntax** (`LangForms`), **types** (`TypeSpeller`), and now **ABI** (`LangAbi`).

`LangAbi::extern_marker` answers which `extern "..."` a function's signature declares. It is reached through `OutLang::abi()` and consulted by the Rust prototype emitter, which previously hard-coded the rule inline.

## Why the axis is thin, stated rather than left implicit

The other two axes are thick because they have to be — every statement has a shape, every value has a type. This one is thin because **`extern "Rust"` is unspecified**, and for the scalar arguments a decompiler actually recovers it is System-V-shaped: the same convention the cspec already describes. A `build_param_list("rust")` strategy would encode a guess as an engine fact, which is precisely what `fspec.rs`'s strategy allowlist (`""`/`"standard"`/`"register"`, error otherwise) exists to prevent.

Rust's genuinely distinct ABI surface — a niche-optimized `Option<&T>` that is a nullable pointer, a `Result<T, E>` tagged across `rax:rdx`, a slice passed as a `(ptr, len)` register pair — is an **enum and discriminant inference** problem living in P5. Modelling it as a *convention* would be modelling the wrong thing.

## The one decision it owns is load-bearing

rustc admits a C-variadic on nothing but an `unsafe extern "C" fn`, so the output does not compile without it — and `syn` accepts the shorter form, so a parser gate cannot catch it either.

Every other function declares nothing, which means `extern "Rust"`: the default, and unspellable. That is the honest answer rather than the conservative one — marking every recovered function `extern "C"` would assert a convention the recovery cannot support, and **a Rust binary's own functions are precisely the ones that are not `extern "C"`.**

## No speculative members

Go is what would make the seam thicker; its ABI genuinely differs (register ABI since 1.17, multi-value returns, a two-word interface and slice representation) and would add a preferred prototype model plus a multi-return form. Neither is added ahead of a consumer: the `ArchContext` the P4 action reads carries only `defaultfp`/`evalfp_current` and no named-model registry, so a `preferred_model` hook today would be plumbing in service of a method that returns `None` for both languages kuna emits. A trait with four unused methods is a wish list, not an interface — the module doc says exactly that, and where each future member would plug in.

## Effect on output: none

The Rust prototype emits the same tokens through the seam that it emitted inline:

```
unsafe extern "C" fn __printf_chk(mut a0: i32, mut a1: *mut u8, ...) -> i32
unsafe fn sub_3050(mut a0: i32)
```

## Gates

| Gate | Result |
|---|---|
| `make test` | **675/675, PARITY OK** |
| `make test-stages` | **PARITY OK** |
| `make rust-test` | green — 317 groups, 0 failures |
| `make check-spec` | OK, strict mode |

Whole-binary C render over the five vendored fixtures, compared field-by-field: identical.

`docs/spec/04-calls-and-prototypes.md` gains the section (the concept belongs to P4 even though today's only consumer is P9, which is stated); `docs/spec/09-emission.md` §9.6 points at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WUuE4zdiEqZFWLL2YEUk9