### PR TITLE
[AUTOMATED] fix(p9): spell recovered generic types as Rust, not as identifiers

### DIFF
--- a/decompiler/crates/kuna-decomp/src/p9_emit/kuna_rusttypes.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/kuna_rusttypes.rs
@@ -113,7 +113,7 @@ impl RustSpeller {
                     if name.is_empty() {
                         self.anonymous(ct)
                     } else {
-                        sanitize(ct.get_display_name())
+                        type_path(ct.get_display_name())
                     }
                 }
             },
@@ -148,6 +148,53 @@ pub(crate) fn sanitize_path(name: &str) -> String {
 pub(crate) fn path_tail(name: &str) -> String {
     let tail = name.rsplit("::").find(|c| !c.trim().is_empty()).unwrap_or(name);
     sanitize(tail)
+}
+
+/// A recovered **type** name, spelled as Rust rather than flattened to an
+/// identifier.
+///
+/// A recovered composite carries the source spelling the debug info recorded --
+/// `Result<u8, u32>`, `Vec<u8, alloc::alloc::Global>`, `(u8, u32)`. Every
+/// character in those is legal in Rust *type* position, so running them through
+/// the identifier sanitizer turns `Result<u8, u32>` into `Result_u8__u32_` and
+/// throws away the one thing a reader wanted. Type position is not identifier
+/// position, and this is the spelling for it.
+///
+/// Anything outside the type grammar (a DWARF `{closure#0}`, a codegen-unit
+/// suffix) still collapses to `_`, and a name whose brackets do not balance
+/// falls back to [`sanitize`] whole -- an unbalanced `<` would swallow the rest
+/// of the declaration.
+pub(crate) fn type_path(name: &str) -> String {
+    let keep = |c: char| {
+        c.is_ascii_alphanumeric()
+            || matches!(c, '_' | '<' | '>' | ',' | ':' | '&' | '[' | ']' | ';' | '*' | '(' | ')' | '\'' | '+' | ' ')
+    };
+    let (mut out, mut angle, mut square, mut round) = (String::new(), 0i32, 0i32, 0i32);
+    let mut it = name.chars().peekable();
+    while let Some(c) = it.next() {
+        if c == '-' && it.peek() == Some(&'>') {
+            it.next();
+            out.push_str("->");
+            continue;
+        }
+        match c {
+            '<' => angle += 1,
+            '>' => angle -= 1,
+            '[' => square += 1,
+            ']' => square -= 1,
+            '(' => round += 1,
+            ')' => round -= 1,
+            _ => {}
+        }
+        out.push(if keep(c) { c } else { '_' });
+    }
+    if angle != 0 || square != 0 || round != 0 {
+        return sanitize(name);
+    }
+    if out.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        out.insert(0, '_');
+    }
+    out
 }
 
 /// Rust identifiers admit only `[A-Za-z0-9_]`.

--- a/decompiler/crates/kuna-decomp/src/p9_emit/kuna_rusttypes/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/kuna_rusttypes/tests.rs
@@ -118,11 +118,14 @@ fn code_is_an_opaque_pointer() {
     assert_eq!(spell(&base(1, type_metatype::TYPE_CODE)), "*const ()");
 }
 
-/// A recovered aggregate name can carry C spellings Rust identifiers forbid.
+/// A recovered aggregate name is spelled in *type* position, so a generic
+/// argument list survives; only what Rust's type grammar cannot accept collapses.
 #[test]
-fn aggregate_names_are_sanitized() {
+fn aggregate_names_are_spelled_as_types() {
     let s = named(8, type_metatype::TYPE_STRUCT, "std::pair<int,int>");
-    assert_eq!(spell(&s), "std__pair_int_int_");
+    assert_eq!(spell(&s), "std::pair<int,int>");
+    let closure = named(8, type_metatype::TYPE_STRUCT, "{closure#0}");
+    assert_eq!(spell(&closure), "_closure_0_");
     let leading_digit = named(4, type_metatype::TYPE_STRUCT, "2big");
     assert_eq!(spell(&leading_digit), "_2big");
 }
@@ -152,4 +155,34 @@ fn rust_ignores_the_realtypes_gates() {
         RUST_SPELLER.declarator(&off, &t).0,
         RUST_SPELLER.declarator(&on, &t).0
     );
+}
+
+/// Type position is not identifier position: a recovered generic keeps the
+/// spelling the debug info recorded, because every character in it is legal
+/// Rust *type* syntax.
+#[test]
+fn type_path_keeps_rust_generic_syntax() {
+    for (raw, want) in [
+        ("Result<u8, u32>", "Result<u8, u32>"),
+        ("Vec<u8, alloc::alloc::Global>", "Vec<u8, alloc::alloc::Global>"),
+        ("(u8, u32)", "(u8, u32)"),
+        ("[u8; 4]", "[u8; 4]"),
+        ("&mut Box<dyn Error + 'static>", "&mut Box<dyn Error + 'static>"),
+        ("fn(u8) -> u32", "fn(u8) -> u32"),
+        ("core::option::Option<&str>", "core::option::Option<&str>"),
+    ] {
+        assert_eq!(super::type_path(raw), want, "raw: {raw}");
+    }
+}
+
+/// Anything outside the type grammar still collapses, and an unbalanced bracket
+/// falls back to the identifier sanitizer whole -- a stray `<` would otherwise
+/// swallow the rest of the declaration.
+#[test]
+fn type_path_rejects_what_rust_cannot_parse() {
+    assert_eq!(super::type_path("{closure#0}"), "_closure_0_");
+    assert_eq!(super::type_path("std.9778ba8b-cgu.0"), "std_9778ba8b_cgu_0");
+    assert_eq!(super::type_path("Result<u8"), super::sanitize("Result<u8"));
+    assert_eq!(super::type_path("a>b"), super::sanitize("a>b"));
+    assert_eq!(super::type_path("4tuple<u8>"), "_4tuple<u8>");
 }

--- a/docs/spec/09-emission.md
+++ b/docs/spec/09-emission.md
@@ -723,6 +723,15 @@ What differs, and why each is a language fact rather than a preference:
   not carry. A width Rust cannot name (3/5/6/7, x87's 10) spells `[u8; N]`, which
   is *more* faithful than C's `undefined3`: it names the storage exactly and does
   not claim to be a scalar.
+- **Recovered composite names** are spelled in *type* position rather than
+  flattened to an identifier. A composite carries whatever spelling the debug
+  info recorded — `Result<u8, u32>`, `Vec<u8, alloc::alloc::Global>`,
+  `(u8, u32)` — and every character in those is legal Rust type syntax, so the
+  identifier sanitiser would turn `Result<u8, u32>` into `Result_u8__u32_` and
+  discard the one thing the reader wanted. What falls outside the type grammar
+  (a DWARF `{closure#0}`, a codegen-unit suffix) still collapses to `_`, and a
+  name whose brackets do not balance falls back to the identifier sanitiser
+  whole, because a stray `<` would swallow the rest of the declaration.
 - **Names** are rendered as Rust *paths*, not flattened into identifiers. `::` is
   legal wherever a name is used — a call, a static — because that position takes a
   path; only a `fn` *definition* needs a bare identifier, so it takes the last


### PR DESCRIPTION
## The defect

A recovered composite type carries whatever spelling the debug info recorded — `Result<u8, u32>`, `Vec<u8, alloc::alloc::Global>`, `(u8, u32)`. Every character in those is legal Rust **type** syntax, but the Rust speller ran them through the **identifier** sanitiser.

Witness — a `rustc -g` binary whose DWARF has the type right there:

```rust
// before
unsafe fn read_first(mut rethidden: *mut Result_u8__u32_, mut data: u64) -> *mut Result_u8__u32_

// after
unsafe fn read_first(mut rethidden: *mut Result<u8, u32>, mut data: u64) -> *mut Result<u8, u32>
```

Type position is not identifier position. `sanitize` is still exactly right for a `fn` definition's name; it is wrong for a type.

## What `type_path` does

Keeps what Rust's type grammar accepts (`< > , : & [ ] ; * ( ) ' +` and space), collapses everything else to `_`, so a DWARF `{closure#0}` still becomes `_closure_0_` and a codegen-unit suffix still collapses. Two guards:

- a name whose brackets do not balance falls back to `sanitize` **whole** — a stray `<` would otherwise swallow the rest of the declaration;
- `->` is carried through as a unit, so `fn(u8) -> u32` does not read as an unbalanced `>`.

## C cannot reach this

`type_path` has exactly one call site, inside `RustSpeller::type_expr` — an inherent method of `RustSpeller`. C output goes through `CSpeller` and never calls it. The 675-assertion C corpus is the corroborating evidence, not the argument.

One existing test (`aggregate_names_are_sanitized`) pinned the old behaviour on `std::pair<int,int>`; it is updated to pin the new contract and extended with the `{closure#0}` case, since that is the branch that keeps the collapse honest.

## Gates

| Gate | Result |
|---|---|
| `make test` | **PARITY OK** 675/675 |
| `make test-stages` | **PARITY OK** |
| `make rust-test` | green — 317 groups, exit 0 |
| `make check-spec` | OK lenient **and** strict |
| `syn::parse_file` validity gate | 9/9 |

Spec prose added to `docs/spec/09-emission.md` (§ Rust emission, alongside the existing **Names**/**Types** bullets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WUuE4zdiEqZFWLL2YEUk9