### PR TITLE
[AUTOMATED] fix(analysis): Rust v0 detection requires the leading underscore

### DIFF
--- a/decompiler/crates/kuna-analysis/src/analyzers/sourcelang/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/sourcelang/mod.rs
@@ -403,9 +403,12 @@ fn symbols_indicate_rust(file: &object::File) -> bool {
 ///   trailing 16-hex-digit `17h…` hash component, which distinguishes it from a
 ///   plain C++ `_ZN…` symbol.
 pub fn is_rust_mangled(name: &str) -> bool {
-    // v0: leading `_R` (allow one extra platform underscore: `__R`).
-    let v0 = name.strip_prefix('_').unwrap_or(name);
-    if v0.starts_with('R') && v0.len() > 1 {
+    // v0: leading `_R` (allow one extra platform underscore: `__R`). The
+    // underscore is load-bearing: `strip_prefix('_').unwrap_or(name)` KEEPS the
+    // original name when there is none, which degrades the test to "starts with
+    // `R`" and claims every OpenSSL `RSA_new`/`RAND_bytes` importer is Rust.
+    let v0 = name.strip_prefix("__R").or_else(|| name.strip_prefix("_R"));
+    if v0.is_some_and(|rest| !rest.is_empty()) {
         return true;
     }
     // legacy: a `17h<16 hex>E` hash tail anywhere after a `_ZN` prefix.
@@ -678,6 +681,19 @@ mod tests {
         assert!(!is_rust_mangled("puts"));
         // a wrong-length hash tail is rejected
         assert!(!is_rust_mangled("_ZN4core5panic17hdeadE"));
+        // v0 requires the LEADING UNDERSCORE. Without it the prefix test
+        // degrades to "starts with `R`", and an ordinary C program that imports
+        // OpenSSL is claimed to be Rust -- which made `--language auto` render
+        // /usr/bin/ncat as Rust.
+        assert!(!is_rust_mangled("RAND_bytes"));
+        assert!(!is_rust_mangled("RSA_new"));
+        assert!(!is_rust_mangled("RAND_bytes@OPENSSL_3.0.0"));
+        assert!(!is_rust_mangled("Rmake"));
+        assert!(!is_rust_mangled("R"));
+        // the platform double underscore still counts
+        assert!(is_rust_mangled("__RNvCs1234_4core5panic"));
+        // a bare `_R` with nothing after it is not a symbol
+        assert!(!is_rust_mangled("_R"));
     }
 
     #[test]

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -605,6 +605,17 @@ The always-on core, in pass order (`passes.rs (passes_for)`):
   so a symbol carrying either goes to `rustc_demangle` first. A C symbol carries
   neither, so the arm is unreachable for one.
 
+  The v0 arm requires the **leading underscore**, and that requirement is
+  load-bearing rather than cosmetic. A prefix test written as
+  `strip_prefix('_').unwrap_or(name)` keeps the *original* name when there is no
+  underscore to strip, which quietly reduces "begins with `_R`" to "begins with
+  `R`" -- and since one matching symbol is enough to classify the whole image,
+  any C program importing OpenSSL's `RAND_bytes` or `RSA_new` was reported as
+  `Compiler::Rustc`. That misclassification is invisible to both parity corpora,
+  whose fixtures are `<bytechunk>` images with no symbol table at all, and it
+  reaches the reader through the `--language auto` policy of DIV-80: an ordinary
+  C binary rendered as `unsafe fn`.
+
   A Rust demangling is a *type expression*, not a path: it carries generic
   arguments (`drop_in_place<Vec<u8>>`) and trait qualifiers
   (`<aes::Aes256 as crypto_common::KeyInit>::new`). `normalize_rust_name`


### PR DESCRIPTION
## The defect

`is_rust_mangled`'s v0 arm intends to match Rust v0 mangling (`_R…`):

```rust
let v0 = name.strip_prefix('_').unwrap_or(name);
if v0.starts_with('R') && v0.len() > 1 { return true; }
```

`strip_prefix` returns `None` when there is no leading underscore, and `.unwrap_or(name)` then hands back the **original** name — so the test silently degenerates from "begins with `_R`" to "begins with `R`".

`symbols_indicate_rust` is an `.any()`, so **one** matching symbol classifies the whole image. OpenSSL's `RAND_bytes`, `RSA_new`, `RAND_add` all match.

## What it costs the reader

Via DIV-80's `--language auto` policy, ordinary C programs render as Rust:

```
$ readelf -p .comment /usr/bin/ncat | grep GCC
  GCC: (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0

$ kuna decompile /usr/bin/ncat --addr 0x1e640          # before
unsafe fn sub_1e640(mut a0: u64, mut a1: u32) -> *mut u64

$ kuna decompile /usr/bin/ncat --addr 0x1e640          # after
unsigned long * sub_1e640(unsigned long a0,unsigned int a1)
```

A real Rust binary is unaffected — `private/FakeCrypt` still detects as Rust and renders `unsafe fn encrypt_file(…)`.

The misclassification also reaches anything else gated on `Compiler::Rustc` (the Rust no-return list, `noreturn_propagate`'s widening).

## Why no test caught it

Every fixture in **both** parity corpora is a `<bytechunk>` image with no symbol table, so `symbols_indicate_rust` is never reached. The corpora are structurally blind to this predicate. The new regression test pins the OpenSSL names directly.

## Provenance, stated plainly

Found by an adversarial verifier reviewing the `rustabi` gate (PR #331), not by the implementer. The implementer's C-collateral sweep — `grep`, `sort`, `faillog`, `libselinux.so.1`, `fauxware` — reported zero differences and was *correct*: all five carry zero `R`-prefixed symbols. Sample bias, not carelessness. PR #331 is held until this lands, because its Rust gate is only sound afterwards.

## Gates

| Gate | Result |
|---|---|
| `make test` | **PARITY OK** 675/675 |
| `make test-stages` | **PARITY OK** |
| `make rust-test` | exit 0, 319 groups |
| `make check-spec` | OK lenient **and** `--strict` |
| `kuna catalog --check` | OK |

No option, no catalog change, no baseline re-pin — this is a strict bug fix that only corrects wrong output. Spec prose added to `docs/spec/01-program-prep.md` beside the demangler-routing paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WUuE4zdiEqZFWLL2YEUk9