### PR TITLE
fix(ghidra): apply the host's typelocked parameter types (wrong flag namespace)

### DIFF
--- a/decompiler/crates/kuna-decomp/src/infra/remote_provider.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/remote_provider.rs
@@ -1411,8 +1411,8 @@ impl RemoteScope {
                                     crate::fspec::ParameterPieces {
                                         addr: rp.storage.clone(),
                                         type_: Some(dt),
-                                        flags: varnode_flags::typelock
-                                            | varnode_flags::namelock,
+                                        flags: crate::fspec::parameter_pieces_flags::TYPELOCK
+                                            | crate::fspec::parameter_pieces_flags::NAMELOCK,
                                     },
                                 ));
                             }

--- a/decompiler/crates/kuna-decomp/src/infra/remote_provider/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/remote_provider/tests.rs
@@ -387,10 +387,9 @@ const CAPTURED_MAIN_MAPSYM: &str = r#"<doc id="0x0"><mapsym>
   <rangelist/>
 </mapsym></doc>"#;
 
-/// Decode the vendored REAL Java answer (XML form; the packed wire form
-/// differs only in the marshaling layer behind `dyn Decoder`).
-#[test]
-fn captured_java_function_mapsym_decodes() {
+/// The capture's parameters carry `register` storage, so its manager needs the
+/// space the plain [`manager`] omits.
+fn manager_with_registers() -> Rc<AddrSpaceManager> {
     let mut m = AddrSpaceManager::new();
     m.insert_space(Rc::new(AddrSpace::new(
         spacetype::IPTR_PROCESSOR,
@@ -416,9 +415,13 @@ fn captured_java_function_mapsym_decodes() {
         0,
     )))
     .unwrap();
-    let m = Rc::new(m);
-    let types = types_with_core();
+    Rc::new(m)
+}
 
+fn decode_captured_main(
+    m: &Rc<AddrSpaceManager>,
+    types: &TypeFactoryImpl,
+) -> Box<RemoteSymbolRecord> {
     let mut registry = IdRegistry::with_base_ids();
     register_remote_provider_ids(&mut registry);
     crate::dtype::register_type_wire_ids(&mut registry);
@@ -428,11 +431,20 @@ fn captured_java_function_mapsym_decodes() {
 
     let store = kuna_base::xml::xml_tree(CAPTURED_MAIN_MAPSYM.as_bytes()).unwrap();
     let root = store.get_root().clone();
-    let mut dec = XmlDecode::new_with_root(&m, &registry, &root, 0);
-    let rec = match decode_mapped_answer(&mut dec, &types).unwrap() {
+    let mut dec = XmlDecode::new_with_root(m, &registry, &root, 0);
+    match decode_mapped_answer(&mut dec, types).unwrap() {
         RemoteMapAnswer::Symbol(rec) => rec,
         _ => panic!("expected a symbol"),
-    };
+    }
+}
+
+/// Decode the vendored REAL Java answer (XML form; the packed wire form
+/// differs only in the marshaling layer behind `dyn Decoder`).
+#[test]
+fn captured_java_function_mapsym_decodes() {
+    let m = manager_with_registers();
+    let types = types_with_core();
+    let rec = decode_captured_main(&m, &types);
     assert_eq!(rec.symbol_id, 0x18b);
     let func = rec.func.as_ref().expect("function record");
     assert_eq!(func.name, "main");
@@ -460,6 +472,40 @@ fn captured_java_function_mapsym_decodes() {
     // The mapping entry (the outer <addr size=1> at the function entry).
     assert_eq!(rec.entries.len(), 1);
     assert_eq!(rec.entries[0].addr.get_offset(), 0x101900);
+}
+
+/// The host's typelocked parameters must reach [`RemoteFunctionFacts::param_storage`]
+/// carrying the **`ParameterPieces`** lock bits.  `varnode_flags::typelock|namelock`
+/// (0x300) shares no bit with `parameter_pieces_flags::TYPELOCK|NAMELOCK` (0x18), and
+/// `Funcdata::apply_mapped_params` re-`set_param`s every slot wholesale AFTER
+/// `apply_locked_prototype_with_model`, so unlocked pieces here CLOBBER the lock the
+/// prototype channel just set: `FuncProto::is_input_locked` reads slot 0's typelock,
+/// so the whole signature reads unlocked and the host's declared types and names are
+/// re-derived instead of applied.
+#[test]
+fn captured_java_locked_params_materialize_with_pieces_locks() {
+    let m = manager_with_registers();
+    let types = types_with_core();
+    let scope = scope_over(&m, Rc::clone(&types), MockFetch::default());
+    scope.materialize(*decode_captured_main(&m, &types));
+
+    let facts =
+        scope.function_at(&Address::new(ram(&m), 0x101900)).expect("the captured function");
+    let locks = crate::fspec::parameter_pieces_flags::TYPELOCK
+        | crate::fspec::parameter_pieces_flags::NAMELOCK;
+    let want = [(0, "argc", 0x38u64), (1, "argv", 0x30)];
+    assert_eq!(facts.param_storage.len(), want.len(), "both host params carried storage");
+    for ((slot, name, piece), (wslot, wname, woff)) in facts.param_storage.iter().zip(&want) {
+        assert_eq!(slot, wslot, "{wname}: compacted slot basis");
+        assert_eq!(name, wname);
+        assert_eq!(piece.addr.get_offset(), *woff, "{wname}: host storage verbatim");
+        assert_eq!(
+            piece.flags & locks,
+            locks,
+            "{wname}: locks must be parameter_pieces_flags bits, got {:#x}",
+            piece.flags
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -438,7 +438,14 @@ Four front-ends drive one engine assembly:
   parameter COUNT, each `categoryIndex`, and each storage — never the model
   name — so a kuna-rederived storage or a slot skew force-rewrites the user's
   signature on the next rename.  The model rides along because the storage kuna
-  would otherwise derive comes from it, not because Java inspects it.
+  would otherwise derive comes from it, not because Java inspects it.  Those
+  echoed pieces carry the `ParameterPieces` lock bits (`TYPELOCK|NAMELOCK`),
+  never the same-named `varnode_flags` ones — the two namespaces share no bit,
+  and `apply_mapped_params` re-`setParam`s each slot WHOLESALE after the
+  prototype channel has already locked it, so unlocked pieces here silently
+  unlock the whole signature (`FuncProto::isInputLocked` reads slot 0's
+  typelock) and the host's declared types and names get re-derived instead of
+  applied.
 
 (kuna) **Surfacing a failed function.** A per-function pipeline abort is
 *recoverable*: the drive catches the unwind and returns the reason as an error


### PR DESCRIPTION
## The bug

`RemoteScope::materialize` built every `ParameterPieces.flags` from the **`varnode_flags`** namespace instead of **`parameter_pieces_flags`**:

| constant | value | |
|---|---|---|
| `varnode_flags::typelock` / `namelock` | `0x100` / `0x200` | what was written |
| `parameter_pieces_flags::TYPELOCK` / `NAMELOCK` | `0x10` / `0x08` | what is read |

`0x300 & 0x10 == 0`, so every parameter materialised from Ghidra's `<localdb>` was stored type- and name-unlocked no matter what the host sent. This was the only site in the workspace constructing a `ParameterPieces.flags` from `varnode_flags`; the analogous console `map param` path (`kuna-console/src/ifacedecomp.rs`) already used the correct namespace.

## Causal chain

1. `apply_locked_prototype_with_model` seeds the prototype correctly, then `apply_mapped_params` overwrites it with the mis-flagged pieces (`infra/decompile_drive.rs`).
2. `ProtoStoreInternal::set_input` stores `pieces.flags` verbatim (`p4_calls/fspec.rs`).
3. `FuncProto::is_input_locked()` masks with `parameter_pieces_flags::TYPELOCK` → false.
4. `ActionPrototypeTypes` is therefore skipped, so `update_type_locked` never forces the declared type onto the input varnode (`p4_calls/coreaction_protos.rs`), and `clear_unlocked_input` drops the host's names, leaving `kuna_arg_name` to re-derive `a0`/`a1`.

**The wire decode was never at fault.** `decode_symbol_header` reads `ATTRIB_TYPELOCK` off the `<symbol>` child exactly where Ghidra's `HighSymbol.encodeHeader` writes it, and `RemoteProto::is_input_locked()` is true off the wire.

## Evidence

Ghidra 12.1.2, aarch64 ELF with DWARF, `main`. Measured on the Ghidra side via `LocalSymbolMap.grabFromFunction`: `argv` = `char **`, storage `x1:8`, `typeLocked=true`, `nameLocked=true`. A tee shim on the decompiler pipe confirms the packed mapped-symbol record reaching `kuna_ghidra` is byte-identical to the one the stock C++ `decompile` receives — and stock renders `argv[1]` correctly from it.

```
before:  int main(int a0,long a1)
           int argc;   // w0
           long argv;  // x1
         file = *(char **)(argv + (long)argc * 8 + -8);

after:   int main(int argc,char **argv)
         file = argv[(long)argc + -1];
```

With `argv` typed, the machine's `* 8` is absorbed by the pointee size and all 27 `argv` accesses in that function recover array notation. No structural transform changed: branchflip 54, no-return 29, ternary 1, before and after.

Retyping from the GUI could not work around this — neither `Parameter.setDataType(..., USER_DEFINED)` nor `HighFunctionDBUtil.updateDBVariable` (the Decompiler window's *Retype Variable*) changed the output, because the type was already arriving correctly and being discarded after decode.

## Scope

Not register-specific, despite how it presents. The locals path (`seed_mapped_symbols`) legitimately masks with `varnode_flags` — `Symbol` attributes really do live in that namespace — and only the params path crosses into `ParameterPieces`. aarch64 makes it look like a register-parameter bug because all of `main`'s params are register-mapped; a stack-passed parameter (arg 7+ on aarch64, any x86-32 `__cdecl` param) was broken identically.

## Gates

| Gate | Result |
|---|---|
| `make test` | **PARITY OK** — 675/675 |
| `make test-stages` | **PARITY OK** — 568/568 |
| `make check-spec` | green |
| `make rust-test` | green except one pre-existing failure (below) |

`kuna-cli::decompile_project_cli::header_syntax_checks_with_cc` fails **identically on an unmodified tree at the base commit** (`3f98c70`): the generated `fauxware.h` declares `void main(void);` and clang rejects it with `'main' must return 'int'`. Unrelated to this change and probably deserves its own issue. Happy to add the `full-ci` label if you want CI's verdict on `rust-test` on the record.

No option gate, no `docs/spec` change, no baseline re-pin: this is a strict bug fix that only corrects wrong output, and both parity corpora passed unchanged.

## Not included: a regression test

There isn't one, deliberately rather than by omission. The right test targets `RemoteScope::materialize` — feed a typelocked register param, assert the materialised `ParameterPieces.flags` carries `parameter_pieces_flags::TYPELOCK` — which fails before this change and passes after. Say the word and I'll add it as a second commit.
