### PR TITLE
fix(pipeline): four latent defects in the headless fleet

### DIFF
--- a/scripts/pipeline/state.py
+++ b/scripts/pipeline/state.py
@@ -13,6 +13,7 @@ CLI (called by the driver shell and by workers to heartbeat):
     python -m scripts.pipeline.state done      --worker ID --opportunity O --pr URL
     python -m scripts.pipeline.state remove    --worker ID
     python -m scripts.pipeline.state list [--json] [--proposals]
+    python -m scripts.pipeline.state reap [--stale-seconds 1800]   # free a dead worker's claim
 
 Large-feature proposal flow (requirement #5: confirm big features before implementing):
     python -m scripts.pipeline.state proposal       --worker ID --opportunity O --pr URL --branch B
@@ -96,13 +97,22 @@ def _save(data):
 # --- worker inventory -------------------------------------------------------
 
 def register(worker, slug, branch, opportunity, pid=None):
+    """Record a worker. ``pid`` MUST be the long-lived driver's pid, not this process's.
+
+    Recording ``os.getpid()`` here is a trap: this runs as an ephemeral
+    ``python -m scripts.pipeline.state register`` invocation that exits immediately, so the
+    stored pid is dead a moment later and :func:`reap` would then fail every LIVE worker and
+    release its claim. ``worker.sh`` passes ``--pid $$``; with no usable pid the worker is
+    marked ``pid_source: none`` and reap() falls back to a long staleness timeout instead of
+    a liveness check.
+    """
     now = time.time()
     with _locked():
         data = _load()
         data["workers"][worker] = {
             "worker": worker, "slug": slug, "branch": branch,
             "opportunity": opportunity, "phase": "setup", "status": "running",
-            "pr_url": None, "pid": pid or os.getpid(),
+            "pr_url": None, "pid": pid, "pid_source": "caller" if pid else "none",
             "started_at": now, "updated_at": now,
         }
         _save(data)
@@ -234,6 +244,64 @@ def claim_approved(worker, opportunity):
         return appr.get("branch")
 
 
+# --- reap (a dead worker must not hold its claim forever) -------------------
+#
+# Nothing ever cleared `claims` when a worker died, so a killed or timed-out worker blocked
+# its opportunity permanently: `select` skips anything in `claims`, so the backlog quietly
+# shrank by one every time a worker was lost.
+
+# How stale a worker with no trustworthy pid must be before reap() will fail it. Longer than
+# any single feature run, because with no liveness signal staleness is all we have and a
+# heartbeat gap is not proof of death.
+UNTRUSTED_STALE_SECONDS = int(os.environ.get("KUNA_PIPELINE_UNTRUSTED_STALE", "14400"))
+
+
+def _pid_alive(pid):
+    if not pid:
+        return False
+    try:
+        os.kill(int(pid), 0)
+    except (ProcessLookupError, ValueError):
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def reap(stale_seconds=1800):
+    """Fail every running worker whose pid is provably gone, and release what it held.
+
+    Liveness is only consulted when the caller vouched for the pid (``pid_source ==
+    "caller"``). A worker whose pid came from an ephemeral CLI process -- or from an
+    inventory written before that field existed -- is judged by staleness alone, because
+    reaping on a bogus "pid is gone" would fail LIVE workers and hand their claims away.
+    """
+    now = time.time()
+    reaped = {"workers": []}
+    with _locked():
+        data = _load()
+        for wid, w in list(data["workers"].items()):
+            if w.get("status") != "running":
+                continue
+            if now - w.get("updated_at", now) <= stale_seconds:
+                continue
+            if w.get("pid_source") == "caller" and w.get("pid"):
+                if _pid_alive(w.get("pid")):
+                    continue
+            elif now - w.get("updated_at", now) <= max(stale_seconds, UNTRUSTED_STALE_SECONDS):
+                continue
+            w["status"] = "failed"
+            w["note"] = "reaped (pid %s gone, stale %ds)" % (
+                w.get("pid"), int(now - w.get("updated_at", now)))
+            w["updated_at"] = now
+            for oid, held in list(data["claims"].items()):
+                if held.get("worker") == wid:
+                    data["claims"].pop(oid, None)
+            reaped["workers"].append(wid)
+        _save(data)
+    return reaped
+
+
 def snapshot():
     with _locked():
         return _load()
@@ -264,6 +332,8 @@ def main(argv=None):
     sp.add_argument("--slug", required=True)
     sp.add_argument("--branch", required=True)
     sp.add_argument("--opportunity", required=True)
+    sp.add_argument("--pid", type=int, default=None,
+                    help="the DRIVER's pid ($$), not this process's -- see register()")
 
     sp = sub.add_parser("update")
     sp.add_argument("--worker", required=True)
@@ -299,6 +369,10 @@ def main(argv=None):
     sp.add_argument("--worker", required=True)
     sp.add_argument("--opportunity", required=True)
 
+    sp = sub.add_parser("reap")
+    sp.add_argument("--stale-seconds", type=int, default=1800)
+    sp.add_argument("--json", action="store_true")
+
     sp = sub.add_parser("list")
     sp.add_argument("--json", action="store_true")
     sp.add_argument("--proposals", action="store_true",
@@ -307,7 +381,7 @@ def main(argv=None):
     args = p.parse_args(argv)
 
     if args.cmd == "register":
-        register(args.worker, args.slug, args.branch, args.opportunity)
+        register(args.worker, args.slug, args.branch, args.opportunity, pid=args.pid)
     elif args.cmd == "update":
         update(args.worker, phase=args.phase, status=args.status,
                pr_url=args.pr, note=args.note)
@@ -331,6 +405,13 @@ def main(argv=None):
             return 1
         print(branch)
         return 0
+    elif args.cmd == "reap":
+        out = reap(args.stale_seconds)
+        if args.json:
+            print(json.dumps(out))
+        else:
+            for wid in out["workers"]:
+                print("reaped worker %s" % wid)
     elif args.cmd == "list":
         data = snapshot()
         if args.json:

--- a/scripts/pipeline/status.py
+++ b/scripts/pipeline/status.py
@@ -8,16 +8,58 @@ Aggregates three sources into one live view:
     python -m scripts.pipeline.status            # one-shot table + "N workers active"
     python -m scripts.pipeline.status --watch    # refresh every 2s
     python -m scripts.pipeline.status --json      # machine-readable
+
+The two subprocess sources (`git worktree list`, `gh api`) sit behind a TTL cache. Without it
+`--watch` spawned a GitHub request per redraw at its 2 s interval -- a cold `collect()` was
+measured at 10.65 s on this repo, so the watch loop could not even keep its own cadence.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 import time
 
 from . import config, state
+
+
+# --- TTL cache in front of the subprocess sources ---------------------------
+#
+# collect() shells out to `git worktree list` AND `gh api`. At --watch's 2 s interval that is
+# a request per redraw; a failed fetch is cached as None with a stale marker rather than
+# retried in a hot loop.
+
+WORKTREE_TTL = float(os.environ.get("KUNA_PIPELINE_WORKTREE_TTL", "20"))
+PR_TTL = float(os.environ.get("KUNA_PIPELINE_PR_TTL", "60"))
+
+_CACHE = {}
+
+
+def _cached(key, ttl, fetch):
+    now = time.time()
+    ent = _CACHE.get(key)
+    if ent is not None and now - ent["ts"] < ttl:
+        return ent["value"]
+    try:
+        value = fetch()
+    except Exception:
+        value = None
+    # A failed fetch keeps the last good value visible, but marks it stale.
+    if value is None and ent is not None and ent.get("value") is not None:
+        ent["stale_since"] = ent.get("stale_since") or now
+        ent["ts"] = now
+        return ent["value"]
+    _CACHE[key] = {"value": value, "ts": now, "stale_since": None}
+    return value
+
+
+def cache_ages():
+    """{key: seconds since the last successful fetch} -- for a caller's stale markers."""
+    now = time.time()
+    return {k: {"age_s": round(now - v["ts"], 1), "stale_since": v.get("stale_since")}
+            for k, v in _CACHE.items()}
 
 
 def _git_worktrees():
@@ -76,8 +118,9 @@ def collect():
         "done": data["done"],
         "proposals": data.get("proposals", {}),
         "approved": data.get("approved", {}),
-        "worktrees": _git_worktrees(),
-        "prs": _open_prs(),
+        "worktrees": _cached("worktrees", WORKTREE_TTL, _git_worktrees) or [],
+        "prs": _cached("prs", PR_TTL, _open_prs),
+        "cache": cache_ages(),
         "ts": now,
     }
 

--- a/tools/pipeline/run.sh
+++ b/tools/pipeline/run.sh
@@ -23,7 +23,10 @@ export KUNA_REPO="$REPO" KUNA_PY="$KUNA_PY"
 export PYTHONPATH="$REPO${PYTHONPATH:+:$PYTHONPATH}"
 STATE_DIR="$REPO/.kuna-pipeline"
 STOP_FILE="$STATE_DIR/STOP"
-mkdir -p "$STATE_DIR"
+# logs/ must exist BEFORE spawn_worker, whose `>>"$STATE_DIR/logs/..."` redirect is set up by
+# THIS shell -- worker.sh's own mkdir runs in the child, too late. Without this the very first
+# spawn into a fresh state dir fails.
+mkdir -p "$STATE_DIR/logs" "$STATE_DIR/worktrees"
 rm -f "$STOP_FILE"
 
 START=$(date +%s)
@@ -89,6 +92,9 @@ while :; do
   [ "$DEADLINE" != "0" ] && [ "$(date +%s)" -ge "$DEADLINE" ] && { log "time budget reached"; break; }
 
   gc_merged_worktrees
+  # Free the claims of workers that died without saying so; otherwise their opportunities are
+  # blocked forever and the backlog silently shrinks.
+  "$KUNA_PY" -m scripts.pipeline.state reap >/dev/null 2>&1
   n="$(active_count)"
   if [ "$n" -lt "$WORKERS" ]; then
     if spawn_worker; then

--- a/tools/pipeline/worker.sh
+++ b/tools/pipeline/worker.sh
@@ -72,15 +72,46 @@ else
   }
 fi
 
+# --pid $$ is THIS driver's pid, which lives as long as the worker does. Without it the
+# inventory records the ephemeral `state register` process and reap() cannot tell a live
+# worker from a dead one.
 "$KUNA_PY" -m scripts.pipeline.state register --worker "$WORKER_ID" --slug "$SLUG" \
-  --branch "$BRANCH" --opportunity "$OPP_ID" >>"$LOG" 2>&1
+  --branch "$BRANCH" --opportunity "$OPP_ID" --pid $$ >>"$LOG" 2>&1
 
 # --- 2. env: kuna tooling targets THIS worktree; specs reuse the main .sla --
 export KUNA_ROOT="$WT"
 export KUNA_DECOMP_DBG="$WT/decompiler/target/release/decomp_dbg"
 export KUNA_DECOMP_TEST="$WT/decompiler/target/release/decomp_test_dbg"
 export KUNA_SPECS="$REPO/specs"          # reuse the main tree's already-compiled .sla
+export SLEIGHHOME="$REPO/specs"
 export KUNA_PIPELINE_ANGR_PYTHON="${KUNA_PIPELINE_ANGR_PYTHON:-$HOME/.virtualenvs/decbench/bin/python}"
+
+# docs/agents.md's worktree hygiene, enforced here rather than left to the prompt -- the
+# prompt did not carry it, and both failures below have actually happened on this machine.
+#
+# 1. The default debug profile costs 20-30 GB per worktree and has filled the disk mid-run,
+#    so debug info is off and target/debug is removed on EVERY exit path (success, timeout,
+#    crash) via the trap -- not only on the happy path.
+export CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0
+cleanup_target() { rm -rf "$WT/decompiler/target/debug" 2>/dev/null; }
+trap cleanup_target EXIT
+# 2. KUNA_SPECS/SLEIGHHOME do NOT reach the cargo workspace suite: ~22 targets resolve
+#    <repo>/specs relative to their own crate and fail with "Could not find .sla file". The
+#    .sla are gitignored artifacts inside the TRACKED specs/Ghidra tree, so they are linked
+#    file by file -- symlinking the directory just nests a dead link inside it, and
+#    `make specs` must never run in a worktree.
+link_specs() {
+  local n=0 rel
+  while IFS= read -r sla; do
+    rel="${sla#$REPO/specs/}"
+    mkdir -p "$WT/specs/$(dirname "$rel")"
+    ln -sf "$sla" "$WT/specs/$rel" && n=$((n+1))
+  done < <(find "$REPO/specs" -name '*.sla' -type f 2>/dev/null)
+  echo "$n"
+}
+SLA_N="$(link_specs)"
+log "linked $SLA_N compiled .sla into the worktree"
+[ "$SLA_N" = "0" ] && log "WARNING: no .sla in $REPO/specs -- run \`make specs\` in the MAIN tree first"
 
 # --- 3. initial build so the worker's analyze phase has working binaries ----
 log "building binaries in worktree (initial)"


### PR DESCRIPTION
Four defects in the headless fleet, each found while building a second pipeline on top of it. They only bite an unattended run, which is why they survived — and the first means the fleet is **broken on a clean checkout today**.

### 1. `run.sh` never creates `$STATE_DIR/logs` — the first spawn always fails

`run.sh:26` does `mkdir -p "$STATE_DIR"`; `run.sh:80` redirects into `>>"$STATE_DIR/logs/driver-$wid.log"`. That redirect is set up by the **parent** shell, so `worker.sh:52`'s `mkdir -p "$LOG_DIR"` runs in the child — too late. `.kuna-pipeline/` is gitignored, so any fresh checkout hits this on its very first worker.

### 2. `status.py --watch` sent a GitHub request per redraw

`_open_prs()` is unconditional in `collect()` and `--interval` defaults to `2.0`. Measured cold `collect()` on this repo: **10.65 s** — the watch loop could not keep its own cadence, and each additional viewer was another `gh` request.

Both subprocess sources now sit behind a TTL cache (worktrees 20 s, PRs 60 s, both overridable):

```
cold 10.92s -> cached 0.0011s
```

A failed fetch keeps the last good value and marks it `stale_since`, which is what `render()` already expected.

### 3. `worker.sh` violated all three of `docs/agents.md`'s worktree rules

It set none of `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0`, never linked the compiled specs, and never removed `target/debug`. Those are the direct causes of both recorded failures: 20–30 GB per worktree filling the disk mid-run, and the ~22 `Could not find .sla file` targets in `make rust-test` (`KUNA_SPECS`/`SLEIGHHOME` do not reach the workspace suite).

Cleanup now runs from a `trap`, so it fires on timeout and crash too — not just the happy path.

The specs are linked **file by file**, which matters: `specs/Ghidra` is a *tracked* directory that already exists in the worktree, so symlinking the directory just nests a dead link inside itself. Verified in a real worktree:

```
linked 148; x86-64.sla readable in worktree: yes
```

### 4. `state.py` had no `reap` — a dead worker held its claim forever

`select` skips anything in `claims`, and nothing ever cleared one, so the backlog silently shrank by one every time a worker was killed or timed out. `run.sh` now reaps each tick.

Liveness needs a pid you can trust, and `register()` was storing `os.getpid()` — the pid of the ephemeral `state register` process, dead the moment it returns. Reaping on that would have failed every **live** worker and handed its claim to someone else. So the driver passes `--pid $$`, and a worker with no vouched pid is judged by staleness alone (`KUNA_PIPELINE_UNTRUSTED_STALE`, default 4 h).

```
reap -> {"workers": ["wdead"]}   claim freed: rc=0
reap -> {"workers": []}          live worker's claim held: rc=1
```

## Gates

```
make test        PARITY OK 675/675
make test-stages PARITY OK 574/574
make check-spec  OK (lenient)
kuna catalog --check  catalog OK
```

No Rust is touched, so `make rust-test` is unaffected — verified green anyway on a superset of this change: **4,900 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
