### PR TITLE
feat(repipe): the RE-friction loop — agents reverse-engineer with kuna and close what it lacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ __pycache__/
 # The durable backlog (docs/improvement-pipeline/*.json, matrix.md) IS committed; live state is not.
 .kuna-pipeline/
 
+# RE-friction loop runtime state: inventory, rounds, tester arenas, per-run CODEX_HOMEs,
+# worktrees, logs. The durable backlog (docs/re-needs/) and the promoted regression probes
+# (tests/cli/) ARE committed; nothing under here is.
+.kuna-repipe/
+
 # Rewritten patch left by tools/sync_upstream.py (dry runs / failed applies)
 .kuna_sync.patch
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -23,6 +23,7 @@ is not needed for day-to-day work.
 | `tests/golden/` | Differential golden vectors for the workspace suite (`make rust-test`). |
 | `specs/Ghidra/Processors/` | Vendored SLEIGH specs. `.sla` files are built artifacts (gitignored), produced by `slacomp`. |
 | `scripts/` + `tools/pipeline/` | Python helpers (`decompile.py` library shim, `paths.py`, `pipeline/`, `decbench/`) + driver for the improvement pipeline (`docs/improvement-pipeline.md`) and the decbench campaign (`docs/decbench-loop.md`). |
+| `scripts/repipe/` + `tools/repipe/` | The RE-friction loop (`docs/re-pipeline.md`): codex testers reverse-engineer crackmes with kuna and record where it fails them; claude builders close those gaps and self-merge. Durable backlog in `docs/re-needs/`; promoted regression probes in `tests/cli/`. |
 | `integrations/` | Front-ends embedding the engine: `ghidra/` (kuna as stock Ghidra's decompiler core), `web/` (the project site + in-browser decompiler at `kuna.noelo.org`). |
 
 ## Build & test
@@ -158,6 +159,7 @@ phases are **settable assertions/options** (`--option NAME VALUE`, discovered vi
 | `docs/options.md` | The generated option catalog (tiers, symptoms, flip guidance). |
 | `docs/cli.md` | The full `kuna` CLI reference. |
 | `docs/improvement-pipeline.md` | The autonomous improvement pipeline + standing requirements for feature PRs. |
+| `docs/re-pipeline.md` | The RE-friction loop: agents solve crackmes with kuna, record where it fails them, and close those gaps. The second, self-merging lane. |
 | `docs/decbench-loop.md` | The decbench benchmark / improvement campaign. |
 | `docs/modes.md` | `--mode auto\|reliable\|aggressive\|fast` option presets and size thresholds. |
 | `docs/missing-ghidra-analyses.md` | The `kuna-analysis` tier: the analyzer gap vs Ghidra, pass contract, commit gating. |

--- a/docs/improvement-pipeline.md
+++ b/docs/improvement-pipeline.md
@@ -4,8 +4,18 @@
 decbench corpus, or a report), root-cause it to one phase decision, and ship ONE
 option-gated feature that closes it — verified, measured, and reviewable. This file is the
 runbook: an agent (interactive session or headless worker) should be able to execute the
-whole loop from what's written here. Nothing ever lands on `main` without a
-human-reviewed PR.
+whole loop from what's written here. **In this lane, nothing ever lands on `main` without a
+human-reviewed PR.**
+
+There is a second, fully autonomous lane. `docs/re-pipeline.md` — the RE-friction loop —
+asks the other question about the same engine: not "is the emitted C worse than angr's" but
+"can an agent USE kuna to reverse-engineer a binary". Its builders **self-merge**, gated on
+the four gates plus `kuna catalog --check`, a re-derivation of every shared counter on the
+rebased tree, green CI with the `full-ci` label forced on, and an executable acceptance
+predicate that must flip from FAIL to PASS. Its large features still stop at a draft
+`[PROPOSAL]` PR; the captain, not a human, approves them. The two lanes share this
+repository's standing requirements below, and share the scheduler, claim registry and PR
+opener in `tools/pipeline/` and `scripts/pipeline/`.
 
 One iteration:
 

--- a/docs/re-needs/decompile-no-json.md
+++ b/docs/re-needs/decompile-no-json.md
@@ -1,0 +1,252 @@
+---
+need_id: decompile-no-json
+title: kuna decompile has no --json: the one-function call is text-only and exits 2 on the flag
+track: tooling
+status: open
+severity: major
+probe_id: p-e9cc6a296ca5
+acceptance_id: a-f618026c4005
+hypothesis_status: inconclusive
+credibility: 1.0
+instances: 4
+challenges: [6609e458cddae72ae250bf40, 67bd52114e1a16f76a1ad5bc, 61ffb07c33c5d46c8bcbfc1d]
+rounds: [0]
+first_seen_round: 0
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-cli/src, tests/cli, docs/cli.md]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+`kuna decompile <bin> <func>` is the call an agent makes most, and it is the
+only one of kuna's four decompile commands with no machine-readable mode.
+Passing `--json` does not degrade gracefully -- it is a hard argument error:
+
+```
+$ kuna decompile <fixture> _DT_INIT --json
+error: unknown option --json
+$ echo $?
+2
+```
+
+`decompile-all --json` exists and emits everything an agent wants (`name`,
+`address`, `size`, `code`, `error`, `line_mappings`, `variables`), but it
+decompiles the **whole binary** to answer a question about one function. On the
+dataset's mid-size ELFs that is the difference between one function and two
+hundred.
+
+So the agent's options today are: scrape C out of a text stream with no
+delimiters and no error channel, or pay a whole-binary decompile per function.
+Both are bad, and the second is the one that makes kuna feel slow -- the cost is
+not kuna's decompiler, it is the missing flag.
+
+The text mode also has no error channel: a function that fails to decompile is
+reported in prose on a stream an agent is simultaneously trying to parse as C.
+`decompile-all --json` has a per-record `error` field for exactly this.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "probe_id": "p-e9cc6a296ca5",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "_DT_INIT",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "binary_sha256": "1a592a85f424cc2db8953d5a38c86676bcee5e37b242b6fb6244a2c9fccfeeef",
+    "binary_size": 14408,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "selector": "_DT_INIT",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 2
+    },
+    "stdout_bytes": {
+      "eq": 0
+    },
+    "stderr_matches": [
+      "error: unknown option --json"
+    ]
+  },
+  "notes": "Current bad behaviour: the single-function decompile has no machine-readable mode at all; --json is rejected by the argument parser before any work happens."
+}
+```
+
+Replayed on the release build at `de9177fc` -- **PASS**, and identically on
+three dataset binaries (see `## Instances`):
+
+```
+$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64 _DT_INIT --json
+error: unknown option --json          # stderr
+                                      # stdout: 0 bytes
+exit=2
+```
+
+`stdout_bytes: {"eq": 0}` is in the probe deliberately: it asserts the flag is
+rejected *before* any output, which is what distinguishes "unsupported flag"
+from "flag ignored". A build that started ignoring `--json` and printing text
+anyway would flip this probe to FAIL, and the need would be re-gated instead of
+silently surviving on a stale assertion.
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-f618026c4005",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "_DT_INIT",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "binary_sha256": "1a592a85f424cc2db8953d5a38c86676bcee5e37b242b6fb6244a2c9fccfeeef",
+    "binary_size": 14408,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "selector": "_DT_INIT",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "functions[0].name",
+        "op": "eq",
+        "value": "_DT_INIT"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "exists"
+      }
+    ]
+  },
+  "notes": "Desired: decompile --json emits the decompile-all record shape for the one selected function. Same shape, one element -- not a second, incompatible JSON dialect."
+}
+```
+
+Replayed on the same build -- **FAIL**: exit is 2 and stdout is empty, so
+neither `exit_code.eq 0` nor `stdout_is_json` holds.
+
+The acceptance pins the **record shape to `decompile-all --json`'s** -- a
+`functions` array whose element carries `name` and `code` -- rather than
+inventing a flat single-function object. That is a deliberate constraint on the
+builder, and the reason for it is the promoted regression test: `tests/cli/`
+will hold both this and any future `decompile-all` probe, and two shapes for the
+same record is how a tool surface starts drifting. One element in the array is
+the honest representation of "you asked for one function".
+
+Verified today that the target shape is real -- `decompile-all --json` on this
+fixture emits `functions[0].name == "_DT_INIT"` with a `code` string. So the
+acceptance asks for something kuna already knows how to build.
+
+## Hypothesis
+
+ADVISORY, not binding. `decompile` predates the JSON surface and renders
+straight to stdout, while `decompile-all` was written later around a serializable
+record; the single-function path never got retrofitted onto that record.
+
+The builder is not bound to this. Questions worth settling first:
+1. whether `decompile --addr 0x...` and the `--slice`/`--language` variants all
+   route through the same emit point, because a `--json` that works for one
+   selector kind and not the others is worse than none;
+2. what `--json` should do about the `--kassert` output, which is a second
+   stream of information the text mode interleaves;
+3. whether a one-function `--json` can reuse `decompile-all`'s serializer
+   without also inheriting its per-function `decomp_dbg` spawn -- the cost
+   question is real but belongs to a `perf` need, not to this one.
+
+## Refutation
+
+Not yet refuted. `kind: cli`, so absence-skip does not apply.
+
+The claim a refuter should attack hardest: that `decompile-all --functions <one>`
+is not already an adequate substitute. If it is -- if it decompiles exactly the
+named function and nothing else -- then this need is `already-supported` and
+belongs in `rejected/`, and that verdict is worth more than the feature. The
+refuter must run it, not reason about it.
+
+## Reference
+
+`decompiler decompile --json` (DecLib over IDA Pro 9.2). Every one of the
+reference CLI's subcommands takes `--json`; `decompile --help` lists it beside
+`--id`, `--binary` and `--backend`:
+
+```
+$ decompiler decompile --help
+  --json                Emit JSON output instead of text.
+```
+
+That uniformity is the point of comparison, not the specific schema: on the
+reference stack an agent never has to ask *which* calls are machine-readable.
+kuna answers "some of them", and the one an agent reaches for first is in the
+`no` half.
+
+## Instances
+
+Four reproductions on the release build at `de9177fc`. Identical
+`error: unknown option --json` on stderr, empty stdout, exit 2 in every case --
+the flag is rejected during argument parsing, so the binary is never even
+loaded, which is why this reproduces uniformly.
+
+| # | binary | challenge | selector | result |
+|---|---|---|---|---|
+| 1 | `decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64` | in-repo fixture | `_DT_INIT` | exit 2, `error: unknown option --json` |
+| 2 | `challenges/6609e458cddae72ae250bf40/bin/puzzle.bin` | `6609e458cddae72ae250bf40` | `main` | exit 2, same |
+| 3 | `challenges/67bd52114e1a16f76a1ad5bc/bin/crackme` | `67bd52114e1a16f76a1ad5bc` | `main` | exit 2, same |
+| 4 | `challenges/61ffb07c33c5d46c8bcbfc1d/bin/hidden_password` | `61ffb07c33c5d46c8bcbfc1d` | `main` | exit 2, same |
+
+The probe targets the in-repo fixture so the acceptance is vendorable into
+`tests/cli/`; the dataset rows are breadth evidence that this is not a property
+of one binary.
+
+## Decision log
+
+- r0 filed by hand while seeding the backlog. Probe and acceptance replayed at
+  `de9177fc` before filing: probe PASS, acceptance FAIL.
+- r0 severity `major`: there is a workaround (`decompile-all --json`), so it is
+  not a `blocker`, but the workaround costs a whole-binary decompile per
+  question and is the single largest avoidable cost in an agent's loop.
+- r0 acceptance deliberately constrains the record shape to `decompile-all`'s.
+  If a builder argues for a flat object instead, that is a proposal-level
+  decision and goes to the captain, not a unilateral shape change.
+- r0 `covered_by_option: null`: the 127 catalog settables gate emitted C; none
+  adds an output mode.

--- a/docs/re-needs/functions-json-size.md
+++ b/docs/re-needs/functions-json-size.md
@@ -1,0 +1,244 @@
+---
+need_id: functions-json-size
+title: kuna functions --json omits size, so the cheap inventory call cannot rank functions
+track: tooling
+status: open
+severity: minor
+probe_id: p-d8f69800917d
+acceptance_id: a-ddc5496835ba
+hypothesis_status: inconclusive
+credibility: 1.0
+instances: 4
+challenges: [6609e458cddae72ae250bf40, 67bd52114e1a16f76a1ad5bc, 61ffb07c33c5d46c8bcbfc1d]
+rounds: [0]
+first_seen_round: 0
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-cli/src, tests/cli, docs/cli.md]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+`kuna functions <bin> --json` is the one cheap, whole-binary call kuna
+offers: it loads once and answers "what is in here". Its records carry only
+`name`, `address`, `address_hex` and `aliases` -- there is no extent. An agent
+triaging a 250-function binary therefore has no way to order its work except by
+address, and the standard first move ("decompile the three biggest functions")
+costs a full `decompile-all` instead of one inventory call.
+
+The field is not missing from kuna's model. `kuna decompile-all --json` emits
+`size` on every record, from the same `FuncResult`. Only the cheap call drops it.
+
+```
+$ kuna functions decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64 --json
+{
+  "binary": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+  "count": 34,
+  "functions": [
+    {
+      "name": "_DT_INIT",
+      "address": 4096,
+      "address_hex": "0x1000",
+      "aliases": []
+    },
+```
+
+This is the smallest real need in the corpus and is the designated first
+live-builder target: one crate, one struct, no emitted C, no phases.toml row,
+and a vendorable acceptance that promotes straight into `tests/cli/`.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "probe_id": "p-d8f69800917d",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "binary_sha256": "1a592a85f424cc2db8953d5a38c86676bcee5e37b242b6fb6244a2c9fccfeeef",
+    "binary_size": 14408,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "selector": null,
+    "selector_kind": "none"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "count",
+        "op": "gt",
+        "value": 0
+      },
+      {
+        "path": "functions[0].size",
+        "op": "absent"
+      }
+    ]
+  },
+  "notes": "Current bad behaviour: the function inventory carries no extent, so a caller cannot tell a 3-byte thunk from a 4 KB main without decompiling every function."
+}
+```
+
+Replayed on the release build at `de9177fc` (`decompiler/target/release/kuna`,
+`SLEIGHHOME=/home/mahaloz/github/kuna/specs`) -- **PASS**:
+
+```
+$ kuna functions decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64 --json \
+    | python3 -c "import sys,json;d=json.load(sys.stdin);print(sorted(d['functions'][0]))"
+['address', 'address_hex', 'aliases', 'name']
+```
+
+Same key set on three dataset binaries -- see `## Instances`.
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-ddc5496835ba",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "binary_sha256": "1a592a85f424cc2db8953d5a38c86676bcee5e37b242b6fb6244a2c9fccfeeef",
+    "binary_size": 14408,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "selector": null,
+    "selector_kind": "none"
+  },
+  "expect": {
+    "json": [
+      {
+        "path": "functions[0].size",
+        "op": "exists"
+      }
+    ]
+  },
+  "notes": "Desired: every functions --json record carries size, the field decompile-all --json already emits. Vendorable (in-repo fixture) so this promotes into tests/cli/ verbatim."
+}
+```
+
+Replayed on the same build -- **FAIL**, which is what admits the need:
+`functions[0].size` does not exist, so the `exists` predicate is false.
+
+The clause is deliberately the single field. `size` is the only thing being
+asked for; pinning exit code or record count as well would make the acceptance
+fail for reasons that are not this need, and it is promoted verbatim into
+`tests/cli/` where over-specification becomes a brittle CI guard. The target is
+an in-repo fixture (`binary_source: in-repo`, `in_repo_path` set), so the
+promoted test runs in CI with no dataset present.
+
+## Hypothesis
+
+ADVISORY, not binding. The `functions` command builds its JSON records
+by hand rather than reusing the `decompile-all` record type, and `size` was
+simply not copied across when the inventory command was added. Expect a struct
+in `kuna-cli` with four fields where the decompile-all one has five.
+
+The builder is not bound to this. The only contract is that the acceptance
+flips to PASS with the four gates and `kuna catalog --check` green.
+
+Two questions the builder must answer rather than assume:
+1. what `size` means for a function whose body kuna could not fully recover --
+   `decompile-all` reports `0` for `_DT_INIT` on this fixture, so `0` is an
+   established, honest answer and must stay expressible;
+2. whether `size` is the extent of the entry block or of the whole recovered
+   body. `decompile-all --json` already answers this; match it exactly rather
+   than inventing a second meaning for the same field name.
+
+## Refutation
+
+Not yet refuted. `kind: cli`, not `absence`, so
+`REPIPE_REFUTE_MODE=absence-skip` does not exempt it -- a refuter is due before
+dispatch. The cheap check a refuter owes: confirm that the `size` on
+`decompile-all --json` records is computed at inventory time and not as a
+by-product of decompiling the function, because if it is the latter this stops
+being a one-field copy and becomes a cost question.
+
+## Reference
+
+`decompiler list_functions --json` (DecLib over IDA Pro 9.2,
+`~/.virtualenvs/decbench/bin/decompiler`) emits `{"addr", "size", "name"}` per
+record -- `declib/cli/decompiler_cli.py:1036-1037`:
+
+```python
+size = getattr(func, "size", 0) or 0
+entries.append({"addr": addr, "size": int(size), "name": name})
+```
+
+Its text mode prints the same three columns. So the reference an RE agent
+reaches for treats extent as part of the inventory, not as something you pay a
+decompile for.
+
+kuna already agrees with that everywhere except here:
+
+```
+$ kuna decompile-all <fixture> --json | jq '.functions[0] | keys'
+["address","address_hex","aliases","code","error","line_mappings","name","size","variables"]
+```
+
+## Instances
+
+Four reproductions, one in-repo and three dataset, all on the release
+build at `de9177fc`. Every one returns the same four-key record.
+
+| # | binary | challenge | keys in `functions[0]` |
+|---|---|---|---|
+| 1 | `decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64` (34 fns) | in-repo fixture | `address, address_hex, aliases, name` |
+| 2 | `challenges/6609e458cddae72ae250bf40/bin/puzzle.bin` (6 fns) | `6609e458cddae72ae250bf40` | same |
+| 3 | `challenges/67bd52114e1a16f76a1ad5bc/bin/crackme` (22 fns) | `67bd52114e1a16f76a1ad5bc` | same |
+| 4 | `challenges/61ffb07c33c5d46c8bcbfc1d/bin/hidden_password` (16 fns) | `61ffb07c33c5d46c8bcbfc1d` | same |
+
+The probe targets the in-repo fixture rather than a dataset binary so the
+acceptance is vendorable; the dataset rows are the breadth evidence.
+
+## Decision log
+
+- r0 filed by hand while seeding the backlog, not by a tester. Probe and
+  acceptance both replayed against `decompiler/target/release/kuna` at
+  `de9177fc` before filing: probe PASS, acceptance FAIL.
+- r0 severity `minor` on impact (nothing is wrong, something is absent) but
+  designated the **first live-builder target** on tractability: smallest real
+  change in the corpus, Track T, no counters, vendorable acceptance. Escalate to
+  `major` if a round-1 tester reports it as a give-up cause rather than a
+  nuisance.
+- r0 `covered_by_option: null` -- `kuna catalog` options gate emitted C only;
+  none of the 127 settables can add a field to `functions --json`.
+- REGRESSED: acceptance a-ddc5496835ba fails again at deadbeef

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -1,0 +1,198 @@
+{
+  "schema": "re-needs-index/1",
+  "generated_by": "scripts.repipe.needs",
+  "count": 5,
+  "rejected_count": 0,
+  "by_status": {
+    "open": 5
+  },
+  "by_track": {
+    "loader": 1,
+    "tooling": 4
+  },
+  "by_severity": {
+    "blocker": 2,
+    "major": 2,
+    "minor": 1
+  },
+  "by_reject_reason": {},
+  "needs": [
+    {
+      "need_id": "no-xrefs",
+      "title": "kuna cannot answer what references this address, function or string",
+      "track": "tooling",
+      "status": "open",
+      "severity": "blocker",
+      "probe_id": "p-7e35d5065714",
+      "acceptance_id": "a-c9b199f423c1",
+      "hypothesis_status": "upheld",
+      "credibility": 1.0,
+      "instances": 4,
+      "challenges": [
+        "6609e458cddae72ae250bf40",
+        "67bd52114e1a16f76a1ad5bc",
+        "61ffb07c33c5d46c8bcbfc1d"
+      ],
+      "rounds": [
+        0
+      ],
+      "first_seen_round": 0,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-cli/src",
+        "decompiler/crates/kuna-analysis/src",
+        "tests/cli",
+        "docs/cli.md"
+      ],
+      "scope": "large",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 144.849412,
+      "path": "docs/re-needs/no-xrefs.md"
+    },
+    {
+      "need_id": "decompile-no-json",
+      "title": "kuna decompile has no --json: the one-function call is text-only and exits 2 on the flag",
+      "track": "tooling",
+      "status": "open",
+      "severity": "major",
+      "probe_id": "p-e9cc6a296ca5",
+      "acceptance_id": "a-f618026c4005",
+      "hypothesis_status": "inconclusive",
+      "credibility": 1.0,
+      "instances": 4,
+      "challenges": [
+        "6609e458cddae72ae250bf40",
+        "67bd52114e1a16f76a1ad5bc",
+        "61ffb07c33c5d46c8bcbfc1d"
+      ],
+      "rounds": [
+        0
+      ],
+      "first_seen_round": 0,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-cli/src",
+        "tests/cli",
+        "docs/cli.md"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 96.566275,
+      "path": "docs/re-needs/decompile-no-json.md"
+    },
+    {
+      "need_id": "functions-json-size",
+      "title": "kuna functions --json omits size, so the cheap inventory call cannot rank functions",
+      "track": "tooling",
+      "status": "open",
+      "severity": "minor",
+      "probe_id": "p-d8f69800917d",
+      "acceptance_id": "a-ddc5496835ba",
+      "hypothesis_status": "inconclusive",
+      "credibility": 1.0,
+      "instances": 4,
+      "challenges": [
+        "6609e458cddae72ae250bf40",
+        "67bd52114e1a16f76a1ad5bc",
+        "61ffb07c33c5d46c8bcbfc1d"
+      ],
+      "rounds": [
+        0
+      ],
+      "first_seen_round": 0,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-cli/src",
+        "tests/cli",
+        "docs/cli.md"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 48.283137,
+      "path": "docs/re-needs/functions-json-size.md"
+    },
+    {
+      "need_id": "zero-functions-exit-0",
+      "title": "kuna reports total function-discovery failure as success: count 0, exit 0, silent stderr",
+      "track": "tooling",
+      "status": "open",
+      "severity": "major",
+      "probe_id": "p-8598042c5bf7",
+      "acceptance_id": "a-99418905784a",
+      "hypothesis_status": "inconclusive",
+      "credibility": 1.0,
+      "instances": 2,
+      "challenges": [
+        "64f1f7afd931496abf909525",
+        "60be2a6033c5d410b8842c91"
+      ],
+      "rounds": [
+        0
+      ],
+      "first_seen_round": 0,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-cli/src",
+        "tests/cli",
+        "docs/cli.md"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 43.944492,
+      "path": "docs/re-needs/zero-functions-exit-0.md"
+    },
+    {
+      "need_id": "functions-finds-nothing-exits",
+      "title": "functions finds nothing and exits 0",
+      "track": "loader",
+      "status": "open",
+      "severity": "blocker",
+      "probe_id": "p-c354ee2a485d",
+      "acceptance_id": "a-300e3a5af18b",
+      "hypothesis_status": "inconclusive",
+      "credibility": 0.7,
+      "instances": 1,
+      "challenges": [
+        "64f1f7afd931496abf909525"
+      ],
+      "rounds": [
+        11
+      ],
+      "first_seen_round": 11,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-analysis"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 20.794415,
+      "path": "docs/re-needs/functions-finds-nothing-exits.md"
+    }
+  ],
+  "rejected": []
+}

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -7,8 +7,7 @@
     "open": 5
   },
   "by_track": {
-    "loader": 1,
-    "tooling": 4
+    "tooling": 5
   },
   "by_severity": {
     "blocker": 2,
@@ -162,13 +161,13 @@
       "path": "docs/re-needs/zero-functions-exit-0.md"
     },
     {
-      "need_id": "functions-finds-nothing-exits",
-      "title": "functions finds nothing and exits 0",
-      "track": "loader",
+      "need_id": "unpack-upx-packed-executable",
+      "title": "kuna cannot unpack a UPX-packed executable before analysis",
+      "track": "tooling",
       "status": "open",
       "severity": "blocker",
-      "probe_id": "p-c354ee2a485d",
-      "acceptance_id": "a-300e3a5af18b",
+      "probe_id": "p-160471d44d7e",
+      "acceptance_id": "a-3d357962b3f7",
       "hypothesis_status": "inconclusive",
       "credibility": 0.7,
       "instances": 1,
@@ -176,13 +175,13 @@
         "64f1f7afd931496abf909525"
       ],
       "rounds": [
-        11
+        20
       ],
-      "first_seen_round": 11,
+      "first_seen_round": 20,
       "attempts": 0,
       "covered_by_option": null,
       "touches": [
-        "decompiler/crates/kuna-analysis"
+        "decompiler/crates/kuna-cli"
       ],
       "scope": "small",
       "regression_of": null,
@@ -191,7 +190,7 @@
       "closing_pr": null,
       "reject_reason": null,
       "score": 20.794415,
-      "path": "docs/re-needs/functions-finds-nothing-exits.md"
+      "path": "docs/re-needs/unpack-upx-packed-executable.md"
     }
   ],
   "rejected": []

--- a/docs/re-needs/no-xrefs.md
+++ b/docs/re-needs/no-xrefs.md
@@ -1,0 +1,278 @@
+---
+need_id: no-xrefs
+title: kuna cannot answer what references this address, function or string
+track: tooling
+status: open
+severity: blocker
+probe_id: p-7e35d5065714
+acceptance_id: a-c9b199f423c1
+hypothesis_status: upheld
+credibility: 1.0
+instances: 4
+challenges: [6609e458cddae72ae250bf40, 67bd52114e1a16f76a1ad5bc, 61ffb07c33c5d46c8bcbfc1d]
+rounds: [0]
+first_seen_round: 0
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-cli/src, decompiler/crates/kuna-analysis/src, tests/cli, docs/cli.md]
+scope: large
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+"What references this?" is the single most-used question in reverse
+engineering, and kuna cannot answer it in any form. There is no `xrefs`, no
+callers/callees query, no call graph, no string-reference lookup:
+
+```
+$ kuna xrefs <bin> --to 0x1030
+kuna: unknown subcommand "xrefs"
+usage: kuna <decompile|decompile-all|decompile-project|functions|test|catalog|modes|specs|fid> ...
+$ echo $?
+2
+```
+
+The nine subcommands are `decompile`, `decompile-all`, `decompile-project`,
+`functions`, `test`, `catalog`, `modes`, `specs`, `fid`. Four of them are the
+same operation (bytes to C text). None of them is a query.
+
+This is a `blocker`, and it is the one need on this list that changes what an
+agent *can* do rather than what it costs. The standard RE loop is: find the
+interesting string or constant, ask who touches it, decompile only those
+functions. Without step two, the loop degenerates into decompiling everything
+and grepping the C -- which is why "no xrefs" and "whole-binary latency" are the
+same complaint seen from two ends. An agent that hits this either writes its own
+xref pass over `decompile-all --json` output (unreliable: the C text has already
+lost the addresses of anything the optimizer folded) or leaves for the reference
+stack, and leaving is the loudest signal this pipeline collects.
+
+`kind: absence`. The diagnosis is not interesting -- the capability is simply not
+there -- which is exactly the class `REPIPE_REFUTE_MODE=absence-skip` exists to
+stop spending refuter runs on.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "probe_id": "p-7e35d5065714",
+  "kind": "absence",
+  "cmd": [
+    "{{KUNA}}",
+    "xrefs",
+    "{{BIN}}",
+    "--to",
+    "0x1030"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "binary_sha256": "1a592a85f424cc2db8953d5a38c86676bcee5e37b242b6fb6244a2c9fccfeeef",
+    "binary_size": 14408,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "selector": "0x1030",
+    "selector_kind": "addr"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 2
+    },
+    "stdout_bytes": {
+      "eq": 0
+    },
+    "stderr_matches": [
+      "unknown subcommand \"xrefs\""
+    ]
+  },
+  "notes": "Current bad behaviour: there is no cross-reference query of any kind. The subcommand does not exist, so kuna rejects it before loading the binary."
+}
+```
+
+Replayed on the release build at `de9177fc` -- **PASS**, uniformly, and on three
+dataset binaries too (see `## Instances`):
+
+```
+$ kuna xrefs decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64 --to 0x1030
+kuna: unknown subcommand "xrefs"      # stderr
+                                      # stdout: 0 bytes
+exit=2
+```
+
+The probe is `kind: absence` and asserts the *absence itself* -- the argument
+parser rejecting the subcommand -- rather than any behaviour of a binary. It is
+therefore stable against every kuna change except the one this need asks for,
+which is the property that makes it a usable regression witness.
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-c9b199f423c1",
+  "kind": "absence",
+  "cmd": [
+    "{{KUNA}}",
+    "xrefs",
+    "{{BIN}}",
+    "--to",
+    "0x1030",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "binary_sha256": "1a592a85f424cc2db8953d5a38c86676bcee5e37b242b6fb6244a2c9fccfeeef",
+    "binary_size": 14408,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "selector": "0x1030",
+    "selector_kind": "addr"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "count",
+        "op": "gt",
+        "value": 0
+      },
+      {
+        "path": "xrefs[0].address_hex",
+        "op": "exists"
+      }
+    ]
+  },
+  "notes": "Desired: a cross-reference query answering 'what references this address', in the address/address_hex record idiom kuna functions --json already uses."
+}
+```
+
+Replayed on the same build -- **FAIL**: exit 2, no stdout, so neither
+`exit_code.eq 0` nor `stdout_is_json` holds.
+
+Target address `0x1030` on the fixture is the `__cxa_finalize` PLT stub. It has
+at least one code reference, verified today, so `count > 0` is a real assertion
+and not a tautology:
+
+```
+$ objdump -d decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64 | grep 'call.*1030'
+    1102:  e8 29 ff ff ff    call   1030 <__cxa_finalize@plt>
+```
+
+The record idiom -- `count` plus an `xrefs` array whose elements carry
+`address_hex` -- is deliberately the one `kuna functions --json` already uses,
+so the surface stays self-consistent. The acceptance says nothing about
+`--from`, string references, or a call graph: it is the minimum that makes the
+capability exist and be testable. Widening it is what makes a `blocker` never
+ship.
+
+## Hypothesis
+
+ADVISORY, not binding. kuna's analysis tier already recovers the
+information -- it has to, to build call sites and resolve targets during
+decompilation -- but nothing exposes it, because every command in the CLI is
+shaped as "produce C text" and there is no query surface to hang it on.
+
+If that is right, the work is a projection of existing analysis state, not new
+analysis. If it is wrong -- if the reference set is built per-function and
+discarded, and answering "who references X" means a whole-binary pass -- then
+this is a much larger change, and that is the single fact that decides its
+scope. `scope: large` is set on the pessimistic reading.
+
+The builder is not bound to any of this.
+
+## Refutation
+
+Skipped by policy. `kind: absence` and `REPIPE_REFUTE_MODE=absence-skip`
+is shipped ON: "there is no `xrefs` subcommand" has no interesting root cause,
+and paying two agent-runs to confirm the obvious is waste. `hypothesis_status`
+is recorded `upheld` on the absence itself, which is what the probe proves --
+**not** on the mechanism sketched in `## Hypothesis`, which is untested.
+
+The judgment that is NOT skipped is scope. `scope: large` routes this to a
+`[PROPOSAL]` draft PR and the captain adjudicates before any implementation
+work, which is where the "projection vs. new pass" question gets answered by
+someone who has read the analysis tier.
+
+## Reference
+
+`decompiler xref_to` (DecLib over IDA Pro 9.2,
+`~/.virtualenvs/decbench/bin/decompiler`):
+
+```
+$ decompiler xref_to --help
+usage: decompiler xref_to [-h] [--decompile] [--id ID] [--binary BINARY]
+                          [--backend {angr,binja,ghidra,ida}] [--json]
+                          target
+
+positional arguments:
+  target                Function name or address (hex/decimal).
+options:
+  --decompile           Ask the backend to decompile first (picks up more refs on Ghidra).
+  --json                Emit JSON output instead of text.
+```
+
+And it is not alone: the reference CLI ships `xref_to` (code **and** data
+references), `xref_from` (callees), `get_callers` (call sites only),
+`list_strings`, and `search` -- five query surfaces to kuna's zero, each with
+`--json`, all against a persistent per-binary server so the second query is
+free. That server is why the comparison is uncomfortable: kuna's cold load per
+invocation makes a query surface expensive in exactly the workflow that needs it
+most.
+
+Scope discipline: this need asks for `xref_to` only. `xref_from`,
+`get_callers`, `list_strings` and persistence are separate needs and must not be
+merged into this one.
+
+## Instances
+
+Four reproductions on the release build at `de9177fc`. The subcommand is
+rejected during argument parsing, before any binary is opened, so the result is
+independent of the target -- these rows establish that it is the tool and not
+the corpus.
+
+| # | binary | challenge | result |
+|---|---|---|---|
+| 1 | `decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64` | in-repo fixture | exit 2, `kuna: unknown subcommand "xrefs"` |
+| 2 | `challenges/6609e458cddae72ae250bf40/bin/puzzle.bin` | `6609e458cddae72ae250bf40` | exit 2, same |
+| 3 | `challenges/67bd52114e1a16f76a1ad5bc/bin/crackme` | `67bd52114e1a16f76a1ad5bc` | exit 2, same |
+| 4 | `challenges/61ffb07c33c5d46c8bcbfc1d/bin/hidden_password` | `61ffb07c33c5d46c8bcbfc1d` | exit 2, same |
+
+The probe targets the in-repo fixture so the acceptance is vendorable into
+`tests/cli/` and runs in CI with no dataset.
+
+## Decision log
+
+- r0 filed by hand while seeding the backlog. Probe and acceptance replayed at
+  `de9177fc` before filing: probe PASS, acceptance FAIL.
+- r0 severity `blocker`: this is a capability gap, not a cost or quality gap.
+  It is the need most likely to appear in round 1 as a `gave_up_reason`.
+- r0 `kind: absence`, so refutation is skipped by `REPIPE_REFUTE_MODE`
+  (`absence-skip`, shipped on). `hypothesis_status: upheld` records the absence,
+  not the mechanism.
+- r0 `scope: large` -> `[PROPOSAL]` route, captain approves before
+  implementation. The scope call rests on an unverified reading of the analysis
+  tier; if the proposal shows the reference set already survives whole-binary
+  analysis, re-scope to `small` and dispatch directly.
+- r0 kept deliberately narrow: `xref_to` only. `xref_from`, `get_callers`,
+  `list_strings` and a persistent server are separate needs.

--- a/docs/re-needs/unpack-upx-packed-executable.md
+++ b/docs/re-needs/unpack-upx-packed-executable.md
@@ -1,0 +1,93 @@
+---
+need_id: unpack-upx-packed-executable
+title: kuna cannot unpack a UPX-packed executable before analysis
+track: tooling
+status: open
+severity: blocker
+probe_id: p-160471d44d7e
+acceptance_id: a-3d357962b3f7
+hypothesis_status: inconclusive
+credibility: 0.7
+instances: 1
+challenges: [64f1f7afd931496abf909525]
+rounds: [20]
+first_seen_round: 20
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-cli]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Unpack target/snake and analyze the actual ncurses application rather than its decompression stub
+
+> **kuna cannot unpack a UPX-packed executable before analysis** (blocker, `64f1f7afd931496abf909525`)
+> The binary contains the UPX signature. Function discovery returned zero functions (the already-filed zero-functions-exit-0 issue), direct entry-point decompilation produced only calls into the loader, and `kuna unpack` exited 2 with `unknown subcommand`.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "unpack",
+    "{{BIN}}"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 2
+    }
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "unpack",
+    "{{BIN}}"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    }
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- kuna has no packer-detection or unpacking stage, so analysis never reaches the original program image.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `64f1f7afd931496abf909525` (round 20, tester t-r20-64f1f7af)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)

--- a/docs/re-needs/zero-functions-exit-0.md
+++ b/docs/re-needs/zero-functions-exit-0.md
@@ -1,0 +1,249 @@
+---
+need_id: zero-functions-exit-0
+title: kuna reports total function-discovery failure as success: count 0, exit 0, silent stderr
+track: tooling
+status: open
+severity: major
+probe_id: p-8598042c5bf7
+acceptance_id: a-99418905784a
+hypothesis_status: inconclusive
+credibility: 1.0
+instances: 2
+challenges: [64f1f7afd931496abf909525, 60be2a6033c5d410b8842c91]
+rounds: [0]
+first_seen_round: 0
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-cli/src, tests/cli, docs/cli.md]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+On a section-header-stripped PIE ELF, `kuna functions --json` recovers
+nothing and says so in the voice of a successful run: exit code 0, well-formed
+JSON, `count: 0`, empty `functions`, and **not one byte on stderr**.
+
+```
+$ kuna functions challenges/64f1f7afd931496abf909525/bin/snake --json
+{
+  "binary": "/home/mahaloz/github/kuna-re-dataset/challenges/64f1f7afd931496abf909525/bin/snake",
+  "count": 0,
+  "functions": []
+}
+$ echo "exit=$?"      # exit=0, stderr empty
+```
+
+The binary is real and runnable: `ELF 64-bit LSB pie executable, x86-64,
+statically linked, no section header`, 11364 bytes, mode 755.
+
+An agent cannot distinguish this from "this file genuinely has no functions".
+That is the whole severity: a silent zero is worse than an error, because the
+loop above it -- a tester, a script, a captain reading `count` -- treats it as a
+measurement rather than as a failure, and moves on. It is the difference between
+kuna being wrong and kuna being *undetectably* wrong.
+
+This need is about the report, not the recovery. Making kuna discover functions
+in a section-header-stripped PIE is a separate, `loader`-track, `scope: large`
+need; this one says the current answer must stop claiming success.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "probe_id": "p-8598042c5bf7",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "challenges/64f1f7afd931496abf909525/bin/snake",
+    "binary_sha256": "907b4dc30be0c0e53fda3ad1905ef3d804735a472f1c9484d3cfb5d3180e26c1",
+    "binary_size": 11364,
+    "binary_source": "dataset",
+    "in_repo_path": null,
+    "selector": null,
+    "selector_kind": "none"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "count",
+        "op": "eq",
+        "value": 0
+      },
+      {
+        "path": "functions",
+        "op": "len_eq",
+        "value": 0
+      }
+    ],
+    "stderr_absent": [
+      "(?i)error",
+      "(?i)warn"
+    ]
+  },
+  "notes": "Current bad behaviour: total discovery failure is reported as an empty success. Exit 0, valid JSON, count 0, and nothing on stderr."
+}
+```
+
+Replayed on the release build at `de9177fc` -- **PASS** on both witnesses:
+
+```
+$ kuna functions challenges/64f1f7afd931496abf909525/bin/snake --json
+{"binary": "...snake", "count": 0, "functions": []}      exit=0  stderr=""
+
+$ kuna functions challenges/60be2a6033c5d410b8842c91/bin/Pyaz.zip.__x/xvm --json
+{"binary": "...xvm", "count": 0, "functions": []}        exit=0  stderr=""
+```
+
+The `stderr_absent` clause is load-bearing: it is what makes this probe assert
+*silence*, not merely emptiness. A build that started warning on stderr while
+still exiting 0 would flip this probe to FAIL and the need would correctly be
+re-gated rather than quietly kept.
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-99418905784a",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "challenges/64f1f7afd931496abf909525/bin/snake",
+    "binary_sha256": "907b4dc30be0c0e53fda3ad1905ef3d804735a472f1c9484d3cfb5d3180e26c1",
+    "binary_size": 11364,
+    "binary_source": "dataset",
+    "in_repo_path": null,
+    "selector": null,
+    "selector_kind": "none"
+  },
+  "expect": {
+    "exit_code": {
+      "ne": 0
+    },
+    "stderr_matches": [
+      "(?i)no functions"
+    ]
+  },
+  "notes": "Desired: recovering zero functions from a non-empty executable is a failure and must exit non-zero with a diagnostic on stderr. Says nothing about improving discovery."
+}
+```
+
+Replayed on the same build -- **FAIL**: exit is 0, so `exit_code.ne 0` is false
+and stderr carries nothing to match.
+
+Scope of the contract, stated so a builder does not over-deliver: the acceptance
+demands a loud failure, **not** successful discovery. `exit_code != 0` plus a
+stderr line containing "no functions" (case-insensitive) is the whole ask. It is
+deliberately silent on which non-zero code, so the builder can fit kuna's
+existing exit-code taxonomy instead of having one dictated by a probe.
+
+Note this acceptance also passes trivially if someone later teaches kuna to find
+functions in this file -- no, it does not: it would then find functions, exit 0,
+and print nothing, so the acceptance would still FAIL. The two needs are
+genuinely independent and neither closes the other.
+
+## Hypothesis
+
+ADVISORY, not binding. The `functions` command treats the discovery
+result as data rather than as a status, so an empty result set takes the same
+path as a populated one. Nothing consults "did the loader find anything to
+analyse at all" before printing.
+
+The builder is not bound to this. Two things a refuter or builder should settle
+before writing code:
+1. whether an empty result is ever legitimate for a file kuna agreed to load
+   (an object file with no code? a resource-only PE?) -- if so, the loud failure
+   must be conditioned on the binary having executable content, not on the count
+   alone;
+2. whether the same silence exists on `decompile-all` and `decompile-project`.
+   If it does, fixing only `functions` leaves the hole open one command over,
+   and the acceptance should be widened before dispatch rather than after.
+
+## Refutation
+
+Not yet refuted. `kind: cli`, so absence-skip does not apply and a
+refuter is due before dispatch.
+
+The specific claim a refuter must attack: that this is a *reporting* defect and
+not a loader defect wearing a reporting costume. If the honest fix turns out to
+require knowing why discovery failed -- and the only way to know is inside the
+ELF loader -- then this need is mis-tracked as `tooling` and belongs in
+`loader` with `scope: large`, which changes both its lease set and its route
+(proposal, captain review).
+
+## Reference
+
+DecLib's `decompiler load` fails loudly when a backend cannot produce an
+analysis, and `list_functions` on a loaded binary that yielded nothing is
+distinguishable from a load that never happened, because the load step has its
+own status.
+
+The structural difference is not the message -- it is that kuna has one call
+where the reference stack has two (`load`, then `list_functions`), so kuna has
+nowhere to put a load-level failure and folds it into an empty answer. A builder
+who wants the smallest correct change should note this: the missing thing is a
+status, not a subcommand.
+
+## Instances
+
+Two reproductions, both from the design session, both re-run against the
+release build at `de9177fc` immediately before filing.
+
+| # | challenge | binary | `file` | result |
+|---|---|---|---|---|
+| 1 | `64f1f7afd931496abf909525` | `bin/snake` (11364 B, sha256 `907b4dc3...`) | ELF 64-bit LSB **pie executable**, x86-64, statically linked, **no section header** | `count: 0`, exit 0, stderr empty |
+| 2 | `60be2a6033c5d410b8842c91` | `bin/Pyaz.zip.__x/xvm` (12520 B, sha256 `2078795d...`) | ELF 64-bit LSB **shared object**, x86-64, statically linked, **no section header** | `count: 0`, exit 0, stderr empty |
+
+Both are stripped of section headers; both are x86-64, which is kuna's
+best-supported architecture, so this is not an architecture gap. Witness 2 also
+ships mode 644 -- one of the 54 dataset binaries without the exec bit, which the
+arena builder chmods 0755; irrelevant to this probe, which only reads.
+
+## Decision log
+
+- r0 filed by hand while seeding the backlog. Both witnesses replayed at
+  `de9177fc` before filing: probe PASS on both, acceptance FAIL on both.
+- r0 severity `major`, not `blocker`: an agent that notices the zero can fall
+  back to another tool, so it does not stop the work outright -- it silently
+  corrupts the conclusion of anyone who does not notice. Escalate to `blocker`
+  if a round-1 tester reports concluding "this binary has no code" from it.
+- r0 track `tooling`, not `loader`, **on the acceptance as written**: the
+  contract is an exit code and a stderr line, both of which live in `kuna-cli`.
+  If the refuter overturns that (see `## Refutation`), re-track before dispatch.
+- r0 the underlying discovery gap on section-header-stripped PIE ELFs is
+  deliberately NOT filed here. It is a separate `loader` need.

--- a/docs/re-pipeline.md
+++ b/docs/re-pipeline.md
@@ -1,0 +1,377 @@
+# The kuna RE-friction loop
+
+**The task**: find out where `kuna` fails an agent that is actually trying to reverse-engineer
+a binary, and close those gaps — autonomously, with no human in the loop. This file is the
+runbook: an agent (interactive or headless) should be able to run the whole cycle from what is
+written here.
+
+Its sibling, `docs/improvement-pipeline.md`, asks *"is kuna's emitted C worse than angr's?"*
+This one asks the question that matters for an agent-first decompiler: **can an agent use it
+at all?** The two loops share their scheduler, claim registry and PR opener; they differ in
+where the work comes from and what "done" means.
+
+One iteration:
+
+1. **Test** — codex agents try to solve crackmes from `~/github/kuna-re-dataset` with kuna as
+   their primary tool, and record every place it was missing, wrong, slow or costly (§2).
+2. **Gate** — every recorded observation is replayed by machine. Two executable predicates
+   decide whether it is real (§3).
+3. **Cluster** — surviving observations collapse into needs in `docs/re-needs/` (§4).
+4. **Build** — claude agents close one need each, on one of three tracks, and self-merge (§5).
+5. **Verify** — the acceptance probe is re-run on merged `main`. Needs that flipped are
+   closed; the next round's testers are pointed at the new surface and asked to break it (§6).
+
+## 0. Prerequisites
+
+```bash
+make binaries && make specs
+tools/repipe/run.sh --preflight        # hard-fails on anything missing
+```
+
+Preflight requires: `git`, `gh` (authed, `repo` scope), `codex`, `claude`, `python3`, a built
+`kuna`, compiled `.sla`, the dataset, and `REPIPE_MIN_FREE_GB` free. It also **fails if
+`bwrap` is unavailable** — see §2, containment is not optional by default.
+
+Everything is stdlib Python run as `PYTHONPATH=$REPO python3 -m scripts.repipe.<mod>`; there is
+no install step and no third-party dependency, matching `scripts/pipeline/`.
+
+## 1. Running it
+
+```bash
+tools/repipe/run.sh                     # bounded: REPIPE_ROUNDS (default 3)
+tools/repipe/run.sh --once              # exactly one full cycle
+python3 -m scripts.repipe.webui --port 8787     # watch it
+touch .kuna-repipe/STOP                 # graceful drain; INTEGRATE still runs
+touch .kuna-repipe/PAUSE                # finish what is running, spawn nothing
+touch .kuna-repipe/ABORT                # hard stop; worktrees and arenas left intact
+```
+
+| Env var | Meaning (default) |
+|---|---|
+| `REPIPE_MAX_AGENTS` | total concurrent LLM processes (**7** = 1 captain + 3 testers + 3 builders) |
+| `REPIPE_TESTER_SHARE` | tester fraction of the non-captain slots (0.5) |
+| `REPIPE_ROUND_CHALLENGES` | challenges per round (9) |
+| `REPIPE_TESTER_TIMEOUT` / `REPIPE_BUILDER_TIMEOUT` / `REPIPE_CAPTAIN_TIMEOUT` | 3600 / 7200 / 1200 s |
+| `REPIPE_BUILDER_USD` / `REPIPE_ROUND_USD` / `REPIPE_RUN_USD` | 25 / 150 / 1500 |
+| `REPIPE_MIN_FREE_GB` / `REPIPE_HALT_FREE_GB` | stop dispatching / halt outright (250 / 60) |
+| `REPIPE_SANDBOX` | `auto` \| `bwrap` \| `none` — `none` is prompt-only containment |
+| `REPIPE_ENABLE_IDA` | let testers reach IDA as a logged last resort (1) |
+| `REPIPE_REFUTE_MODE` | `absence-skip` — do not spend refuters on "the subcommand does not exist" |
+| `REPIPE_DATASET` | the crackme corpus (`~/github/kuna-re-dataset`) |
+| `KUNA_PIPELINE_STATE_DIR` | live state (`.kuna-repipe/`, gitignored) |
+
+The agent split at other values: 2→1/1/1, 4→1/2/1, 5→1/2/2, 6→1/3/2, **7→1/3/3**, 9→1/4/4.
+Below 5 the two tracks cannot overlap, so the live process count is
+`captain + max(testers, builders)`. Above ~10 the merge lease, not the slot count, is the
+bottleneck.
+
+## 2. The tester
+
+One `codex exec` session per challenge, in a sanitized arena.
+
+```bash
+ROUND=1 HEXID=64f1f7afd931496abf909525 tools/repipe/tester.sh
+```
+
+**Containment is a mount namespace, not a policy.** codex's `-s workspace-write` restricts
+writes, not reads, and the dataset gives the answer away four different ways:
+
+| Trap | Why a prompt cannot fix it | Closure |
+|---|---|---|
+| `meta.json` carries `ground_truth.flag` in plaintext (98 challenges) | it sits in the directory a solver is pointed at | never copied; dataset tmpfs'd out of the namespace |
+| `solutions/<hexid>/*.zip` — full writeups with working keygens (168 challenges, ZipCrypto pw `crackmes.one`) | one `unzip -P` away | same |
+| `extras/` is both the only task statement *and* a spoiler channel | `challenges/5ab77f5533c5d40ad448c1ea/extras/…/hints.txt` is 19 valid serials on a challenge whose `ships_source_code` is **false** | allowlist, then deny by name, extension, flag-content, and **serial shape** |
+| 6 challenges ship author source | — | dropped by extension |
+
+So the tester runs under
+`bwrap --dev-bind / / --tmpfs $DATASET`, plus `network_access=false` (which also removes
+"look up the writeup"), plus a post-hoc tripwire that greps the transcript for the dataset
+path, the flag, `crackmes.one` and `solutions/`. A tripwire hit marks the run `contaminated`:
+its observations are kept — friction is friction — but its outcome is voided.
+
+The arena also **meters the tester**. `bin/kuna` and `bin/ida-decompile` are transparent shims
+that log every call to `notes/toolcalls.jsonl` with argv, exit code and wall-clock. That log
+is the pipeline's only per-call latency signal — kuna emits no timing of its own — and it makes
+"how often did kuna make a tester leave" a measured number rather than a self-report.
+
+Two things about the corpus that a harness must respect: the primary binary is **always**
+`meta.json → detected.primary.path` (never a `bin/` glob — the tree preserves recursive
+extraction shapes like `bin/CrackMe_3.zip.__x/CrackMe_3.exe`), and **58 of 287 shipped
+binaries have no execute bit**, so every copy is `chmod 0755`.
+
+**Giving up is a result.** `outcome: gave_up` with `gave_up_reason: kuna-blocked` is the
+loudest signal this pipeline can receive, and the prompt says so.
+
+### Grading is deliberately weak, and says so
+
+`grade.py` returns a tiered verdict: `flag-exact` (high) · `binary-accepts` (high) ·
+`verifier-agrees` (**low**) · `unverifiable`. The low tier is flagged because these
+`verifier.py` files are LLM reconstructions from public writeups that were **never validated
+against the binaries** — 70 exist, 34 self-test-pass, 19 raise `NotImplementedError`, 4 are
+quarantined stubs, and one ends "We return True here provisionally". Only 22 of 250 challenges
+are machine-checkable *and* uncontaminated.
+
+**So the solve rate is a secondary metric.** The primary output of a tester run is probes,
+graded by replay.
+
+## 3. The two-arm gate
+
+The one thing this loop refuses to do is let an LLM's *narrative* reach a builder. The
+decbench campaign's measured result is the reason: **round 2's refuters overturned the filed
+diagnosis on 3 of 8 cases while the symptom stood in all 8**, and per `docs/decbench-loop.md`
+some wrong mechanisms fire, pass their witness, and ship broken output.
+
+So every observation carries two executable predicates, and a need is admitted only if, on a
+freshly built `main` at a pinned SHA:
+
+- the **probe** — asserting the *current bad* behaviour — **PASSES**, and
+- the **acceptance** — asserting the *desired* behaviour — **FAILS**.
+
+```bash
+python3 -m scripts.repipe.verify --gate --round 1 --json
+```
+
+| Outcome | Meaning |
+|---|---|
+| `admitted` | real, reproducible, not already possible |
+| `not-reproducible` | the probe does not fire — noise, or environment |
+| `already-supported` | the acceptance already passes: **the tester was wrong.** Kept as a ledger — if this bucket is ever empty, the gate is broken |
+| `flaky` | the repeats disagreed. A flaky probe is not evidence |
+| `unrunnable` | malformed, or the target's sha256 does not match — a probe pointed at the wrong file **refuses** rather than returning a confident false verdict |
+
+Everything downstream follows: dedup keys off probe signatures rather than text, a builder is
+done when the acceptance flips to PASS, and **the acceptance probe is promoted verbatim into
+`tests/cli/` as a permanent regression test** — so every shipped need leaves a CI guard behind
+it automatically.
+
+**What this costs.** Friction with no machine-checkable predicate — "the output is hard to
+read", "I lost my renames every invocation" — is not a need. It lands in
+`docs/re-needs/rejected/` as `unprobeable`. The quantitative channels (`gave_up_reason`,
+`minutes_lost`, `fallbacks[].why_kuna_could_not`) still capture it and the dashboard charts it,
+but this pipeline will not build it. That is the trade to revisit first if the rejected pile
+turns out more interesting than the backlog.
+
+## 4. The need record
+
+`docs/re-needs/<need_id>.md` — YAML front-matter plus fixed `##` sections, deliberately the
+same dialect as `docs/decbench/triage/<case-id>.md`.
+
+```bash
+python3 -m scripts.repipe.cluster --round 1          # observations -> needs
+python3 -m scripts.repipe.needs list --json
+python3 -m scripts.repipe.needs rank
+```
+
+Clustering is deterministic first: the key is `(kind, kuna subcommand, acceptance clause
+shape)`, with text similarity only as a tie-breaker. Bumping an existing need's `instances`
+and `challenges` is pure Python, so only genuinely novel observations ever cost an agent.
+
+`## Hypothesis` is **advisory and explicitly not binding on the builder**. It is refuted before
+dispatch (except for `kind: absence`, where "there is no `xrefs` subcommand" has no
+interesting root cause) and the verdict is recorded either way.
+
+Before any need is dispatched it is checked against `kuna catalog --json`: if an existing
+option closes it, it becomes `rejected` with `covered_by_option` — a default-flip candidate for
+the *other* pipeline, not new work here.
+
+## 5. The builder — three tracks
+
+Getting the track wrong is the most likely way to waste a builder session.
+
+| | **`tooling`** (the majority) | **`quality`** | **`perf`** |
+|---|---|---|---|
+| The gap is | a missing or broken capability | kuna's emitted C is wrong | it is too slow |
+| Lives in | `kuna-cli`, `kuna-console`, `kuna-analysis` | `kuna-decomp/src/pN_*/kuna_<slug>.rs` | either |
+| Changes emitted C | **no** | **yes** | must not |
+| `phases.toml` option | **not required** — the rule is "anything that *can change emitted C* ships behind a named option", and a new subcommand cannot | **required**, plus all 8 ritual steps | only if output moves |
+| Counters | none | `kuna_phases/tests.rs` (2 asserts + the tier tuple + the count-encoding *test names*), `catalog_bytecompat.rs` (3 asserts + the `phase_catalog.json` fixture), `tests/stages/kuna-catalog.xml`, `kuna-base/src/xml.rs` | none |
+| Tests | cargo tests + the promoted acceptance probe. **A `tests/stages/` case would be wrong** — that README scopes the corpus to stage-model issues | two-pass `tests/stages/gh{angr,dec}-<slug>.xml` | timing probe with a stated noise floor |
+| Speed bar | before/after on the touched path | `scripts.pipeline.timeit`, ≤5% | **3σ and ≥20%** — `returncopysplit` measured a −20%/−12% noise floor on byte-identical output |
+
+Track `quality` follows `docs/improvement-pipeline.md` §3–4 and
+`tools/pipeline/worker_prompt.md` §§3–8 **verbatim**; the builder prompt includes them by
+reference rather than duplicating them, so the ritual has exactly one copy.
+
+Standing requirements 7 and 8 apply unchanged to `quality`: sweep every changed function, not
+just the witness; and a refuter must answer *"would this produce WRONG output?"* by building
+the change and reading the diff, not by arguing.
+
+`loader` needs (PE/Mach-O/DOS/stripped-PIE discovery) are almost always `scope: large` and
+route to `[PROPOSAL]`.
+
+## 6. Merging, and closing the loop
+
+Merges are **serialized** behind a `merge` lease. The sequence, after taking it:
+
+```bash
+git fetch origin && git rebase origin/main          # rebase FIRST
+python3 -m scripts.repipe.counters --fix            # re-derive; never arithmetic
+python3 -m scripts.repipe.mergecheck --against origin/main
+make test && make test-stages && make rust-test && make check-spec
+decompiler/target/release/kuna catalog --check
+python3 -m scripts.repipe.verify --need <id> --json  # acceptance must be PASS
+tools/pipeline/open_pr.sh --merge feat/re-<slug>
+```
+
+`open_pr.sh --merge` adds the **`full-ci`** label — which is itself a CI trigger, and without
+it a PR from a branch in this repo never runs the workspace suite — waits for every check, and
+squash-merges over REST. It refuses to merge a draft, and is re-runnable: a `--merge` that dies
+after the squash landed sees `.merged == true` and exits 0.
+
+Three silent-merge shapes this repo has actually produced are guarded mechanically
+(`mergecheck --self-test` reproduces all three in synthetic git histories):
+
+| Shape | What happened | Guard |
+|---|---|---|
+| loud conflict | a DIV number raced 55→56→57→58 | claim the number at merge, rewrite every reference |
+| **silent identical-edit** | both branches made the same `85 → 86` edit, git merged cleanly, the answer was 87 | re-derive every counter from a fresh capture on the rebased tree |
+| **silent keep-both** | a stale `data_footer: 375` against 381 real keys; a duplicated row in a README | diff every keep-both against `origin/main`: nothing removed, nothing added twice |
+
+**Never re-pin `docs/baseline.json`** — `mergecheck` hard-rejects it.
+
+### "Restart the testers when the builders have fixed what they asked for"
+
+There is no judgment in this. A need is closed **iff its acceptance probe, which failed when it
+was filed, now passes on a freshly built main**:
+
+```bash
+python3 -m scripts.repipe.verify --acceptance-suite --all --json
+```
+
+A previously-closed need whose acceptance flips back becomes `regressed` and outranks
+everything. The next round's testers are automatically handed the closed set with an explicit
+mandate to try to break it, so the loop closes on evidence twice: a machine re-runs the
+predicate, and a fresh agent attacks the new surface.
+
+## 7. Collision avoidance
+
+Three layers, cheapest first:
+
+1. **Track separation.** `tooling` touches kuna-cli/console/analysis + `tests/cli/` +
+   `docs/cli.md`; `quality` touches kuna-decomp + `phases.toml` + the counters +
+   `docs/options.md` + `docs/history.md` + `tests/stages/`. Disjoint sets.
+2. **Named leases** with a TTL and a dead-pid reaper: `merge`, `counter:catalog`,
+   `counter:stages-corpus`, `counter:div`, `file:phases.toml`, `file:docs/options.md`,
+   `cluster:<id>`. A lease exists where a *silent wrong merge* is possible — not where a
+   trivial rebase would resolve it. Because every `quality` need needs the whole counter set,
+   **at most one option-adding builder is ever in flight** with no special-casing, while
+   `tooling` builders parallelize freely.
+3. **Contracts.** `.kuna-repipe/contracts.json` is rendered into every builder's prompt so each
+   knows what its siblings are touching, and a builder that needs someone else's file stops and
+   says so instead of racing.
+
+## 8. The captain
+
+A Claude Code session that performs **one bounded, guarded state transition per tick** and
+exits; `run.sh` re-invokes it. `captain.py` owns three machines (Supervisor / TestTrack /
+BuildTrack), appends every transition to `rounds/<n>/transitions.jsonl`, and **raises and exits
+2 on an illegal one** — the captain cannot talk the machine into skipping a gate.
+
+The captain also **approves proposals**. There is no human, so a large need's design-only draft
+PR is adjudicated by the captain reading `proposal.md`, the need's instance count and
+credibility, and the replayed probe: approve (re-dispatch with `IMPL_PROPOSAL=1
+RESUME_BRANCH=…`), reject (`blocked`, reason recorded), or defer. Approve conservatively — a
+rejected proposal costs one design; a wrongly approved one costs a builder, the merge lease and
+a red main.
+
+It runs with `--disallowedTools Task` so `--max-agents` stays an honest count: every agent must
+come from a slot.
+
+## 9. Safety
+
+- **Disk.** A cargo worktree costs 20–30 GB and has filled this machine mid-run.
+  `worker.sh` now exports `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0
+  CARGO_PROFILE_TEST_DEBUG=0` and removes `target/debug` from a **trap**, so it fires on
+  timeout and crash too. A disk governor stops dispatching below `REPIPE_MIN_FREE_GB` and halts
+  below `REPIPE_HALT_FREE_GB`.
+- **Specs.** Never `make specs` in a worktree. `KUNA_SPECS`/`SLEIGHHOME` point at the main tree,
+  but they do **not** reach the cargo workspace suite (~22 targets fail "Could not find .sla
+  file"), so `worker.sh` symlinks the built `.sla` in before `make rust-test`.
+- **Never `git stash`** with sibling worktrees live — `refs/stash` is one shared stack and work
+  has been lost that way.
+- **codex sqlite.** Each tester gets `CODEX_HOME=.kuna-repipe/runs/<id>/codexhome` (with
+  `auth.json` symlinked in), so rollouts and the sqlite stay inside the run instead of
+  inflating `~/.codex/logs_2.sqlite`, already 270 MB over 612 rollouts. Not `--ephemeral`:
+  harvest needs the transcript.
+- **IDA `.i64`** files land in the arena, because `bin/ida-decompile` points declib's
+  `DECLIB_SERVER_REGISTRY` and `--project-dir` there and IDA only ever sees the arena copy.
+- **Crash recovery.** State is the file, not the process. `captain.py --recover` reaps dead
+  pids (freeing their slots, claims and leases) and resumes at the *recorded* state.
+- **The genuinely unsafe part, stated plainly.** Builders run
+  `claude -p --dangerously-skip-permissions` with the network on, inside a worktree, confined
+  only by convention and post-hoc checks. There is no sandbox around a builder, and that is
+  inherent to "implement in the kuna repo and self-merge". What *is* contained: `main` only
+  ever advances through the serialized merge step, `docs/baseline.json` is a hard reject, and
+  testers — which run exploratory work against 250 unknown binaries — are network-off and
+  confined to an arena holding nothing of value.
+
+## 10. Proving it works
+
+```bash
+tools/repipe/smoke.sh              # levels 0+1: ~4 min, zero tokens, zero network
+tools/repipe/smoke.sh --level 0    # ~40 s
+```
+
+Level 1 exercises the real machine against real defects: it builds arenas for the flag
+challenge and the `hints.txt` trap and asserts the flag is absent, the exec bits are repaired
+and `hints.txt` was dropped **by the serial-shape rule specifically**; it runs the two-arm gate
+against kuna's live `count: 0, exit 0` failure and requires the probe to pass and the
+acceptance to fail; it proves a misresolved target refuses instead of lying; it merges a 3-way
+duplicate into one need; it proves two `quality` needs cannot dispatch together; and it curls
+every dashboard route including a path-traversal attempt.
+
+**Four false-green canaries** (in the spirit of `make test-ghidra`'s two) fail the run if: no
+probe reproduced (a broken runner would "pass" everything by failing everything), the sandbox
+assertions were skipped because `bwrap` was missing, the redactor dropped *every* extras file
+(over-redaction hides a broken allowlist), or clustering produced nothing.
+
+Levels 2–4 cost real money and are run by hand:
+
+```bash
+# L2 — one live tester (~20 min, ~$2). Proves codex --output-schema compliance, the
+#      thread.started scrape, and that the sandbox does not break the API call.
+REPIPE_MAX_AGENTS=2 ROUND=1 HEXID=$(python3 -m scripts.repipe.sample slate --round 9 -k 1 \
+  --filter 'format=ELF,size<64k,machine_checkable=true' --json | python3 -c 'import json,sys;print(json.load(sys.stdin)[0]["hexid"])') \
+  tools/repipe/tester.sh
+
+# L3 — one live builder on the smallest real seed need (~2 h, ~$20).
+#      `functions-json-size` is deliberately tiny: the acceptance is one `exists` clause.
+REPIPE_MAX_AGENTS=2 tools/repipe/run.sh --once
+
+# L4 — the first real round.
+REPIPE_MAX_AGENTS=7 REPIPE_ROUND_USD=150 tools/repipe/run.sh --rounds 1
+```
+
+### Success criteria for round 1, stated in advance
+
+- ≥6 needs pass the two-arm gate.
+- **≥2 rejected as `already-supported`/`user-error` — if this is zero, the gate is not
+  working.** With kuna's nine-subcommand surface and an eager tester, some fraction of filings
+  must be user error.
+- ≥1 hypothesis overturned outside the `absence` class (the decbench prior is ~35%; zero is
+  evidence the refuter is rubber-stamping).
+- ≥1 PR merged, and ≥1 acceptance probe flipped to PASS and promoted into `tests/cli/`.
+
+## Machinery reference
+
+| Piece | What |
+|---|---|
+| `scripts/repipe/probe.py` | the predicate evaluator; verifies `target.binary_sha256` before running so a misresolved path cannot produce a confident false verdict |
+| `scripts/repipe/verify.py` | the two-arm gate, the acceptance suite, and promotion into `tests/cli/` |
+| `scripts/repipe/workspace.py` + `redact.py` | the contamination-proof arena and the four-trap spoiler filter |
+| `scripts/repipe/sample.py` | the stratified round slate, deterministic per `(seed, round)` |
+| `scripts/repipe/grade.py` | the tiered solve verdict and the contamination tripwire |
+| `scripts/repipe/needs.py` | the durable backlog; also emits `opportunities.json`'s shape so `scripts/pipeline/select.py` consumes it unchanged |
+| `scripts/repipe/cluster.py` | observations → needs, deterministic first |
+| `scripts/repipe/select.py` | collision-aware dispatch: resource sets, feasibility, contracts |
+| `scripts/repipe/counters.py` + `mergecheck.py` | re-derive every shared counter; catch the three silent-merge shapes |
+| `scripts/repipe/captain.py` | the three guarded state machines |
+| `scripts/repipe/status.py` | the terminal view: round, agents, slots, leases, backlog, disk — reuses `scripts/pipeline/status.py`'s TTL-cached collector |
+| `scripts/repipe/webui.py` | the dashboard: one background refresher, many viewers, zero `gh` calls per request |
+| `tools/repipe/` | `run.sh`, `tester.sh`, `captain.sh`, the three prompts, `smoke.sh`, fixtures |
+
+Reused from the angr lane rather than forked: `tools/pipeline/run.sh` and `worker.sh` (through
+new env seams that all default to today's behaviour), `scripts/pipeline/state.py` (slots,
+leases and `reap` added), `status.py` (TTL cache added), `open_pr.sh` (`--merge` added), and
+the whole `state proposal`/`approve`/`claim-approved` + `IMPL_PROPOSAL=1` path, which needed no
+change at all — the captain simply plays the human.

--- a/scripts/pipeline/config.py
+++ b/scripts/pipeline/config.py
@@ -56,6 +56,15 @@ def repo_root() -> Path:
 
 
 def pipeline_docs_dir() -> Path:
+    """Where the generated backlog artifacts live.
+
+    Overridable so a second pipeline can hand this selector its own ranked backlog without
+    a fork: the RE-friction loop emits `opportunities.json` in exactly this shape (see
+    scripts/repipe/needs.py to_opportunities) and points KUNA_PIPELINE_DOCS_DIR at it.
+    """
+    env = os.environ.get("KUNA_PIPELINE_DOCS_DIR")
+    if env:
+        return Path(env)
     return repo_root() / "docs" / "improvement-pipeline"
 
 

--- a/scripts/pipeline/state.py
+++ b/scripts/pipeline/state.py
@@ -69,7 +69,12 @@ def _locked():
 def _empty():
     # proposals: opp_id -> {worker, slug, branch, pr_url, ts} (large feature awaiting go/no-go)
     # approved:  opp_id -> {branch, pr_url, approved_by, ts}   (user said go; ready to implement)
-    return {"workers": {}, "claims": {}, "done": {}, "proposals": {}, "approved": {}}
+    # slots:  pool -> {"cap": N, "held": {slot_id: {"pid", "pid_source", "since", "kind"}}}
+    # leases: resource -> {"holder", "ts", "ttl", "pid", "pid_source"}
+    # Both are used by the RE-friction loop (docs/re-pipeline.md); the angr fleet ignores
+    # them and its inventory is unaffected.
+    return {"workers": {}, "claims": {}, "done": {}, "proposals": {}, "approved": {},
+            "slots": {}, "leases": {}}
 
 
 def _load():
@@ -277,7 +282,7 @@ def reap(stale_seconds=1800):
     reaping on a bogus "pid is gone" would fail LIVE workers and hand their claims away.
     """
     now = time.time()
-    reaped = {"workers": []}
+    reaped = {"workers": [], "slots": [], "leases": []}
     with _locked():
         data = _load()
         for wid, w in list(data["workers"].items()):
@@ -298,8 +303,101 @@ def reap(stale_seconds=1800):
                 if held.get("worker") == wid:
                     data["claims"].pop(oid, None)
             reaped["workers"].append(wid)
+        for pool, p in data.get("slots", {}).items():
+            for sid, held in list(p.get("held", {}).items()):
+                if held.get("pid_source") != "caller" or not held.get("pid"):
+                    continue
+                if not _pid_alive(held.get("pid")):
+                    p["held"].pop(sid, None)
+                    reaped.setdefault("slots", []).append("%s/%s" % (pool, sid))
+        for res, lease in list(data.get("leases", {}).items()):
+            if _lease_dead(lease, now):
+                data["leases"].pop(res, None)
+                reaped.setdefault("leases", []).append(res)
         _save(data)
     return reaped
+
+
+# --- agent slots (an honest cap on concurrent LLM processes) ----------------
+#
+# A bash `active_count()` over child pids cannot see agents spawned by a different process
+# (the captain tick exits; its agents outlive it), so the cap lives in the inventory instead.
+
+def slot_cap(pool, cap):
+    with _locked():
+        data = _load()
+        data["slots"].setdefault(pool, {"cap": 0, "held": {}})["cap"] = int(cap)
+        _save(data)
+
+
+def slot_acquire(pool, slot_id, pid=None, kind=None):
+    """Take a slot in ``pool``. True if held, False if the pool is full."""
+    with _locked():
+        data = _load()
+        p = data["slots"].setdefault(pool, {"cap": 0, "held": {}})
+        if slot_id in p["held"]:
+            return True
+        if len(p["held"]) >= p.get("cap", 0):
+            return False
+        p["held"][slot_id] = {"pid": pid, "pid_source": "caller" if pid else "none",
+                              "since": time.time(), "kind": kind or pool}
+        _save(data)
+        return True
+
+
+def slot_release(pool, slot_id):
+    with _locked():
+        data = _load()
+        p = data["slots"].get(pool)
+        if p:
+            p["held"].pop(slot_id, None)
+            _save(data)
+
+
+# --- resource leases (collision avoidance between concurrent builders) ------
+#
+# Resource names are declared, not discovered: "merge", "counter:catalog", "file:phases.toml",
+# "crate:kuna-cli", "cluster:<id>". Because every option-adding feature needs the whole
+# counter set, "at most one option-adding builder at a time" falls out of the algebra.
+
+DEFAULT_LEASE_TTL = 10800  # seconds; > the default builder timeout
+
+
+def lease_acquire(resource, worker, ttl=DEFAULT_LEASE_TTL, pid=None):
+    """Take ``resource``. True if held by us, False if someone else has it.
+
+    An expired lease, or one whose vouched-for holder pid is dead, is stolen -- a crashed
+    holder must not wedge the queue forever. A lease with no trustworthy pid expires on its
+    TTL alone: treating "no pid" as "dead" would free every lease the instant it was taken
+    and silently void the whole guarantee.
+    """
+    now = time.time()
+    with _locked():
+        data = _load()
+        cur = data["leases"].get(resource)
+        if cur and cur.get("holder") != worker and not _lease_dead(cur, now):
+            return False
+        data["leases"][resource] = {"holder": worker, "ts": now, "ttl": int(ttl),
+                                    "pid": pid, "pid_source": "caller" if pid else "none"}
+        _save(data)
+        return True
+
+
+def lease_release(resource, worker=None):
+    with _locked():
+        data = _load()
+        cur = data["leases"].get(resource)
+        if cur is not None and (worker is None or cur.get("holder") == worker):
+            data["leases"].pop(resource, None)
+            _save(data)
+
+
+def _lease_dead(lease, now):
+    if now - lease.get("ts", 0) > lease.get("ttl", DEFAULT_LEASE_TTL):
+        return True
+    if lease.get("pid_source") != "caller" or not lease.get("pid"):
+        return False
+    return not _pid_alive(lease.get("pid"))
 
 
 def snapshot():
@@ -369,6 +467,30 @@ def main(argv=None):
     sp.add_argument("--worker", required=True)
     sp.add_argument("--opportunity", required=True)
 
+    sp = sub.add_parser("slot-acquire")
+    sp.add_argument("--pool", required=True)
+    sp.add_argument("--id", required=True)
+    sp.add_argument("--pid", type=int, default=None)
+    sp.add_argument("--kind", default=None)
+
+    sp = sub.add_parser("slot-release")
+    sp.add_argument("--pool", required=True)
+    sp.add_argument("--id", required=True)
+
+    sp = sub.add_parser("slot-cap")
+    sp.add_argument("--pool", required=True)
+    sp.add_argument("--cap", type=int, required=True)
+
+    sp = sub.add_parser("lease-acquire")
+    sp.add_argument("--resource", required=True)
+    sp.add_argument("--worker", required=True)
+    sp.add_argument("--ttl", type=int, default=DEFAULT_LEASE_TTL)
+    sp.add_argument("--pid", type=int, default=None)
+
+    sp = sub.add_parser("lease-release")
+    sp.add_argument("--resource", required=True)
+    sp.add_argument("--worker", default=None)
+
     sp = sub.add_parser("reap")
     sp.add_argument("--stale-seconds", type=int, default=1800)
     sp.add_argument("--json", action="store_true")
@@ -405,6 +527,16 @@ def main(argv=None):
             return 1
         print(branch)
         return 0
+    elif args.cmd == "slot-acquire":
+        return 0 if slot_acquire(args.pool, args.id, args.pid, args.kind) else 1
+    elif args.cmd == "slot-release":
+        slot_release(args.pool, args.id)
+    elif args.cmd == "slot-cap":
+        slot_cap(args.pool, args.cap)
+    elif args.cmd == "lease-acquire":
+        return 0 if lease_acquire(args.resource, args.worker, args.ttl, args.pid) else 1
+    elif args.cmd == "lease-release":
+        lease_release(args.resource, args.worker)
     elif args.cmd == "reap":
         out = reap(args.stale_seconds)
         if args.json:

--- a/scripts/pipeline/status.py
+++ b/scripts/pipeline/status.py
@@ -81,9 +81,11 @@ def _git_worktrees():
             cur["branch"] = line.split(" ", 1)[1].replace("refs/heads/", "")
     if cur:
         trees.append(cur)
-    # only the pipeline's worktrees
-    return [t for t in trees if ".kuna-pipeline" in t["path"] or "/kuna-wt-" in t["path"]
-            or (t.get("branch", "").startswith("feat/angr-"))]
+    # only THIS pipeline's worktrees (seams so a second pipeline reuses this module)
+    wt_match = os.environ.get("KUNA_PIPELINE_WORKTREE_MATCH", ".kuna-pipeline")
+    br_match = os.environ.get("KUNA_PIPELINE_BRANCH_MATCH", "feat/angr-")
+    return [t for t in trees if wt_match in t["path"] or "/kuna-wt-" in t["path"]
+            or (t.get("branch", "").startswith(br_match))]
 
 
 def _open_prs():
@@ -118,6 +120,8 @@ def collect():
         "done": data["done"],
         "proposals": data.get("proposals", {}),
         "approved": data.get("approved", {}),
+        "slots": data.get("slots", {}),
+        "leases": data.get("leases", {}),
         "worktrees": _cached("worktrees", WORKTREE_TTL, _git_worktrees) or [],
         "prs": _cached("prs", PR_TTL, _open_prs),
         "cache": cache_ages(),

--- a/scripts/repipe/__init__.py
+++ b/scripts/repipe/__init__.py
@@ -1,0 +1,6 @@
+"""The RE-friction loop: agents reverse-engineer crackmes with kuna and record where it fails them.
+
+Runbook: docs/re-pipeline.md. Sibling of scripts/pipeline/ (the angr/decbench loop), which
+this package reuses for worker scheduling, claims, PR opening and observability rather than
+forking. Stdlib only, run as `PYTHONPATH=<repo> python3 -m scripts.repipe.<mod>`.
+"""

--- a/scripts/repipe/captain.py
+++ b/scripts/repipe/captain.py
@@ -1,0 +1,418 @@
+"""The RE-friction loop's state machines: deterministic Python the LLM captain drives.
+
+Three cooperating machines — Supervisor, TestTrack, BuildTrack — whose transitions are
+guarded here and appended to `<state>/rounds/<n>/transitions.jsonl`. **An illegal transition
+raises and exits 2.** That split is the whole point: the captain is a Claude Code session
+doing the judgment work (clustering residue, scope calls, proposal approval, deciding a
+round is finished), but it cannot talk the machine into skipping a gate, because the machine
+is not made of prose.
+
+The captain runs ONE BOUNDED TICK AT A TIME. A tick reads state, performs at most one
+transition, writes state, and exits; `tools/repipe/run.sh` re-invokes it. A multi-day LLM
+process is a reliability risk, whereas a stateless-per-tick captain costs at most one tick
+when it dies and resumes from `inventory.json` — which is also why `--recover` can simply
+re-enter the RECORDED state and never a later one.
+
+Agents are spawned DETACHED and a tick never blocks on one. `tester.sh` and `builder.sh`
+heartbeat into the shared inventory the same way the angr fleet's workers do.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import fcntl
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+
+from . import config, select as select_mod
+from ..pipeline import state as pstate
+
+# --- the machines -----------------------------------------------------------
+
+SUPERVISOR = {
+    "BOOT": ["RUNNING", "HALTED"],
+    "RUNNING": ["DRAINING", "HALTED"],
+    "DRAINING": ["STOPPED", "HALTED"],
+    "HALTED": [],
+    "STOPPED": [],
+}
+
+TEST_TRACK = {
+    "T_IDLE": ["T_PLAN"],
+    "T_PLAN": ["T_WORKSPACE", "T_IDLE"],
+    "T_WORKSPACE": ["T_FANOUT"],
+    "T_FANOUT": ["T_DRAIN"],
+    "T_DRAIN": ["T_GATE"],
+    "T_GATE": ["T_DEDUP"],
+    "T_DEDUP": ["T_REFUTE"],
+    "T_REFUTE": ["T_TRIAGE"],
+    "T_TRIAGE": ["T_READY"],
+    "T_READY": ["T_IDLE"],
+}
+
+BUILD_TRACK = {
+    "B_IDLE": ["B_PLAN", "B_DONE"],
+    "B_PLAN": ["B_FANOUT", "B_IDLE"],
+    "B_FANOUT": ["B_DRAIN"],
+    "B_DRAIN": ["B_MERGE", "B_PROPOSAL_REVIEW"],
+    "B_PROPOSAL_REVIEW": ["B_FANOUT", "B_MERGE", "B_IDLE"],
+    "B_MERGE": ["B_VERIFY"],
+    "B_VERIFY": ["B_DONE", "B_ROLLBACK"],
+    "B_ROLLBACK": ["B_VERIFY", "HALTED"],
+    "B_DONE": ["B_IDLE"],
+}
+
+MACHINES = {"supervisor": SUPERVISOR, "test": TEST_TRACK, "build": BUILD_TRACK}
+
+
+class IllegalTransition(Exception):
+    pass
+
+
+def _round_dir(n):
+    d = config.rounds_dir() / str(n)
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def _round_path(n):
+    return _round_dir(n) / "round.json"
+
+
+def load_round(n):
+    p = _round_path(n)
+    if not p.exists():
+        return {"round": n, "supervisor": "BOOT", "test": "T_IDLE", "build": "B_IDLE",
+                "started_at": time.time(), "slate": [], "spend_usd": 0.0, "notes": []}
+    with open(p) as fh:
+        return json.load(fh)
+
+
+@contextlib.contextmanager
+def _round_lock(n):
+    """flock around a round's read-modify-write, in scripts/pipeline/state.py's idiom.
+
+    Two captain ticks can overlap (a slow one plus run.sh's next poll), and an unlocked
+    read-modify-write silently drops one of their transitions.
+    """
+    lock = _round_dir(n) / ".lock"
+    fh = open(lock, "w")
+    try:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fh, fcntl.LOCK_UN)
+        fh.close()
+
+
+def save_round(doc):
+    p = _round_path(doc["round"])
+    # A per-process temp name: a shared "<path>.tmp" lets two writers interleave into the same
+    # file and os.replace a half-written document into place.
+    tmp = "%s.tmp.%d" % (p, os.getpid())
+    with open(tmp, "w") as fh:
+        json.dump(doc, fh, indent=2)
+    os.replace(tmp, p)
+
+
+def transition(doc, machine, to, note=None):
+    """Advance one machine, or refuse. This is the guard the LLM cannot argue with.
+
+    The whole read-check-write runs under the round lock and re-reads the document inside it,
+    so a caller holding a stale copy cannot resurrect an earlier state or skip a gate that
+    another tick has already passed.
+    """
+    table = MACHINES[machine]
+    with _round_lock(doc["round"]):
+        fresh = load_round(doc["round"])
+        cur = fresh[machine]
+        if to not in table.get(cur, []):
+            raise IllegalTransition("%s: %s -> %s is not a legal transition (legal: %s)"
+                                    % (machine, cur, to, ", ".join(table.get(cur, [])) or "none"))
+        fresh[machine] = to
+        rec = {"ts": time.time(), "machine": machine, "from": cur, "to": to,
+               "note": note, "pid": os.getpid()}
+        with open(_round_dir(fresh["round"]) / "transitions.jsonl", "a") as fh:
+            fh.write(json.dumps(rec) + "\n")
+        save_round(fresh)
+    doc.update(fresh)
+    return doc
+
+
+# --- environment guards -----------------------------------------------------
+
+def free_gb(path=None):
+    st = os.statvfs(str(path or config.repo_root()))
+    return int(st.f_bavail * st.f_frsize / (1024 ** 3))
+
+
+def stop_requested():
+    return (config.state_dir() / "STOP").exists()
+
+
+def abort_requested():
+    return (config.state_dir() / "ABORT").exists()
+
+
+def paused():
+    return (config.state_dir() / "PAUSE").exists()
+
+
+def preflight():
+    """Hard preconditions. A missing one is a HALT, not a warning — the loop would otherwise
+    fail slowly, hours in, having spent real money."""
+    bad, warn = [], []
+    for tool in ("git", "gh", "codex", "claude", "python3"):
+        if not shutil.which(tool):
+            bad.append("missing tool: %s" % tool)
+    if not config.kuna_bin().exists():
+        bad.append("no kuna binary at %s (run `make binaries`)" % config.kuna_bin())
+    if not config.dataset_root().exists():
+        bad.append("no dataset at %s" % config.dataset_root())
+    if not list(config.specs_dir().rglob("*.sla"))[:1]:
+        bad.append("no compiled .sla under %s (run `make specs`)" % config.specs_dir())
+    if config.sandbox_mode() != "bwrap":
+        if os.environ.get("REPIPE_SANDBOX") == "none":
+            # An explicit, recorded choice is allowed -- but it is never the default, and
+            # tester.sh refuses to reach this state on its own.
+            warn.append("SANDBOX EXPLICITLY OFF (REPIPE_SANDBOX=none): the dataset and $HOME "
+                        "are readable to every tester. Runs are flagged low-trust and the "
+                        "post-hoc tripwire is the only contamination check.")
+        else:
+            bad.append("SANDBOX IS OFF: the dataset leaks the answer four ways and bwrap is "
+                       "the only thing that actually hides it. Install bwrap, or set "
+                       "REPIPE_SANDBOX=none to accept prompt-only containment explicitly.")
+    gb = free_gb()
+    if gb < config.MIN_FREE_GB:
+        bad.append("only %dG free, need %dG (a cargo worktree costs 20-30G)"
+                   % (gb, config.MIN_FREE_GB))
+    for w in warn:
+        print("WARNING: %s" % w, file=sys.stderr)
+    return bad
+
+
+# --- agent supervision ------------------------------------------------------
+
+def live_agents(pool):
+    data = pstate.snapshot()
+    return list((data.get("slots", {}).get(pool, {}).get("held") or {}).keys())
+
+
+def set_caps(split):
+    pstate.slot_cap("captain", split["captain"])
+    pstate.slot_cap("tester", split["testers"])
+    pstate.slot_cap("builder", split["builders"])
+
+
+def spawn_tester(round_n, hexid):
+    env = dict(os.environ, ROUND=str(round_n), HEXID=hexid,
+               KUNA_PIPELINE_STATE_DIR=str(config.state_dir()),
+               PYTHONPATH=str(config.repo_root()))
+    log = config.logs_dir() / ("spawn-t-%s.log" % hexid[:8])
+    os.makedirs(str(config.logs_dir()), exist_ok=True)
+    with open(log, "ab") as fh:
+        subprocess.Popen(["bash", str(config.repo_root() / "tools" / "repipe" / "tester.sh")],
+                         env=env, stdout=fh, stderr=fh, stdin=subprocess.DEVNULL,
+                         start_new_session=True)
+    return str(log)
+
+
+def spawn_builder(round_n, need, resources):
+    """Reuse tools/pipeline/worker.sh through its seams rather than forking it.
+
+    The seams (WORKER_PROMPT / WORKER_BRANCH_PREFIX / WORKER_EXTRA_PROMPT / …) all default to
+    the angr fleet's behaviour, so the two pipelines share one driver and one set of
+    worktree-hygiene fixes.
+    """
+    wid = "b-r%s-%s" % (round_n, need.need_id[:16])
+
+    # A builder must hold a `builder` slot or REPIPE_MAX_AGENTS means nothing for the half of
+    # the fleet that costs the most, and run.sh's drain has nothing to wait on.
+    if not pstate.slot_acquire("builder", wid, pid=os.getpid(), kind="builder"):
+        return None
+
+    # ONE contracts file PER BUILDER. A single shared path was worse than useless: each spawn
+    # overwrote it, so every builder ended up reading the list that excluded whoever was
+    # spawned last -- i.e. usually its own entry rather than its siblings'.
+    contracts = config.state_dir() / ("contracts-%s.md" % wid)
+    with open(contracts, "w") as fh:
+        fh.write(select_mod.contracts_markdown(exclude_need=need.need_id))
+    env = dict(
+        os.environ,
+        WORKER_ID=wid, OPP_ID=need.need_id, TEST_NAME=need.need_id,
+        SELECTOR=getattr(need, "selector", "") or "-", BINARY=getattr(need, "binary", "") or "-",
+        SLUG=need.need_id, ARCH="",
+        WORKER_PROMPT=str(config.repo_root() / "tools" / "repipe" / "builder_prompt.md"),
+        WORKER_BRANCH_PREFIX="feat/re-",
+        WORKER_EXTRA_PROMPT=str(contracts),
+        WORKER_BUDGET_USD=str(config.BUILDER_USD),
+        WORKER_TIMEOUT=str(config.BUILDER_TIMEOUT),
+        WORKER_MODEL=config.BUILDER_MODEL,
+        PIPELINE_STATE_DIRNAME=config.STATE_DIRNAME,
+        KUNA_PIPELINE_STATE_DIR=str(config.state_dir()),
+        PYTHONPATH=str(config.repo_root()),
+    )
+    # Provisional leases with the tick's pid, re-stamped with the worker's below. Taken before
+    # the spawn so a second pick in the same tick cannot claim the same resource.
+    for r in resources:
+        pstate.lease_acquire(r, wid, ttl=config.BUILDER_TIMEOUT + 1800, pid=os.getpid())
+    log = config.logs_dir() / ("spawn-%s.log" % wid)
+    os.makedirs(str(config.logs_dir()), exist_ok=True)
+    with open(log, "ab") as fh:
+        proc = subprocess.Popen(["bash", str(config.repo_root() / "tools" / "pipeline" / "worker.sh")],
+                                env=env, stdout=fh, stderr=fh, stdin=subprocess.DEVNULL,
+                                start_new_session=True)
+    # Re-stamp the slot and the leases with the WORKER's pid, not the captain tick's. The tick
+    # exits in seconds; stamping its pid would make reap() free every lease on the next pass
+    # and void the "at most one option-adding builder" guarantee entirely.
+    pstate.slot_release("builder", wid)
+    pstate.slot_acquire("builder", wid, pid=proc.pid, kind="builder")
+    for r in resources:
+        pstate.lease_release(r, wid)
+        pstate.lease_acquire(r, wid, ttl=config.BUILDER_TIMEOUT + 1800, pid=proc.pid)
+    return wid
+
+
+def release_all_leases(worker):
+    data = pstate.snapshot()
+    for res, lease in (data.get("leases") or {}).items():
+        if lease.get("holder") == worker:
+            pstate.lease_release(res, worker)
+
+
+# --- the tick ---------------------------------------------------------------
+
+def tick(round_n=None, dry_run=False):
+    """Advance the loop by at most one transition per machine. Returns a status dict."""
+    pstate.reap()
+    n = round_n if round_n is not None else current_round()
+    doc = load_round(n)
+    split = config.agent_split()
+    set_caps(split)
+    acted = []
+
+    if abort_requested():
+        doc["notes"].append("ABORT file present")
+        if doc["supervisor"] in ("BOOT", "RUNNING"):
+            transition(doc, "supervisor", "HALTED", "ABORT")
+        return {"round": n, "doc": doc, "acted": ["abort"]}
+
+    if doc["supervisor"] == "BOOT":
+        problems = preflight()
+        if problems:
+            transition(doc, "supervisor", "HALTED", "; ".join(problems))
+            _write_halt(problems)
+            return {"round": n, "doc": doc, "acted": ["halt"], "problems": problems}
+        transition(doc, "supervisor", "RUNNING", "preflight OK")
+        acted.append("boot")
+
+    if doc["supervisor"] == "RUNNING":
+        gb = free_gb()
+        if gb < config.HALT_FREE_GB:
+            transition(doc, "supervisor", "HALTED", "disk %dG < %dG" % (gb, config.HALT_FREE_GB))
+            _write_halt(["disk %dG below the halt floor %dG" % (gb, config.HALT_FREE_GB)])
+            return {"round": n, "doc": doc, "acted": ["halt-disk"]}
+        if stop_requested():
+            transition(doc, "supervisor", "DRAINING", "STOP file")
+            acted.append("drain")
+        elif doc.get("spend_usd", 0.0) >= config.ROUND_USD:
+            transition(doc, "supervisor", "DRAINING", "round budget $%.2f reached"
+                       % doc["spend_usd"])
+            acted.append("drain-budget")
+
+    return {"round": n, "doc": doc, "acted": acted, "split": split,
+            "free_gb": free_gb(), "paused": paused(),
+            "live": {"tester": live_agents("tester"), "builder": live_agents("builder")}}
+
+
+def _write_halt(problems):
+    p = config.state_dir() / "HALT_REASON"
+    os.makedirs(str(config.state_dir()), exist_ok=True)
+    with open(p, "w") as fh:
+        fh.write("\n".join(problems) + "\n")
+
+
+def current_round():
+    d = config.rounds_dir()
+    if not d.exists():
+        return 1
+    ns = [int(x.name) for x in d.iterdir() if x.is_dir() and x.name.isdigit()]
+    return max(ns) if ns else 1
+
+
+def recover():
+    """Resume at the RECORDED state, never a later one.
+
+    Reap first so a crashed agent's slot, claim and leases are freed; then every state is
+    re-enterable because each one's entry action is idempotent (T_GATE/T_DEDUP are pure
+    functions of a pinned SHA; B_MERGE re-checks whether the squash actually landed before
+    doing anything).
+    """
+    reaped = pstate.reap(stale_seconds=0)
+    n = current_round()
+    doc = load_round(n)
+    doc["notes"].append("recovered at %s/%s/%s" % (doc["supervisor"], doc["test"], doc["build"]))
+    save_round(doc)
+    return {"round": n, "reaped": reaped, "resumed_at": {k: doc[k] for k in MACHINES}}
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog="python -m scripts.repipe.captain")
+    ap.add_argument("--tick", action="store_true")
+    ap.add_argument("--recover", action="store_true")
+    ap.add_argument("--preflight", action="store_true")
+    ap.add_argument("--status", action="store_true")
+    ap.add_argument("--round", type=int, default=None)
+    ap.add_argument("--transition", nargs=2, metavar=("MACHINE", "TO"))
+    ap.add_argument("--note", default=None)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    if args.preflight:
+        problems = preflight()
+        out = {"ok": not problems, "problems": problems, "free_gb": free_gb(),
+               "split": config.agent_split(), "sandbox": config.sandbox_mode()}
+        print(json.dumps(out, indent=2) if args.json else
+              ("preflight OK" if not problems else "\n".join("FAIL: " + p for p in problems)))
+        return 0 if not problems else 1
+
+    if args.recover:
+        out = recover()
+        print(json.dumps(out, indent=2, default=str))
+        return 0
+
+    if args.transition:
+        machine, to = args.transition
+        if machine not in MACHINES:
+            print("unknown machine %r (expected one of %s)" % (machine, ", ".join(MACHINES)),
+                  file=sys.stderr)
+            return 2
+        doc = load_round(args.round if args.round is not None else current_round())
+        try:
+            transition(doc, machine, to, args.note)
+        except IllegalTransition as e:
+            print("ILLEGAL: %s" % e, file=sys.stderr)
+            return 2
+        print(json.dumps({k: doc[k] for k in MACHINES}, indent=2))
+        return 0
+
+    if args.status or not args.tick:
+        doc = load_round(args.round if args.round is not None else current_round())
+        out = {"round": doc["round"], "states": {k: doc[k] for k in MACHINES},
+               "free_gb": free_gb(), "split": config.agent_split(),
+               "stop": stop_requested(), "pause": paused(), "abort": abort_requested(),
+               "live": {"tester": live_agents("tester"), "builder": live_agents("builder")}}
+        print(json.dumps(out, indent=2))
+        return 0
+
+    out = tick(args.round)
+    print(json.dumps({k: v for k, v in out.items() if k != "doc"}, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repipe/cluster.py
+++ b/scripts/repipe/cluster.py
@@ -39,9 +39,23 @@ def _tokens(text):
     return {w for w in _WORD.findall((text or "").lower()) if w not in _STOP and len(w) > 2}
 
 
+def _as_probe(probe):
+    """Tolerate a probe that is still a JSON string.
+
+    verify.py parses these at the gate, but gate.json is a file on disk that can be
+    hand-edited or replayed from an older run, and a crash here would lose the whole round.
+    """
+    if isinstance(probe, str):
+        try:
+            return json.loads(probe)
+        except (ValueError, TypeError):
+            return {}
+    return probe or {}
+
+
 def _subcommand(probe):
     """The kuna subcommand a probe drives, which is most of a friction report's identity."""
-    cmd = (probe or {}).get("cmd") or []
+    cmd = _as_probe(probe).get("cmd") or []
     known = {"decompile", "decompile-all", "decompile-project", "functions",
              "test", "catalog", "modes", "specs", "fid"}
     for tok in cmd[1:]:
@@ -57,7 +71,7 @@ def _clause_shape(probe):
 
     'exit_code + json' is a different complaint from 'wall_ms', even about the same command.
     """
-    return tuple(sorted((probe or {}).get("expect", {}).keys()))
+    return tuple(sorted(_as_probe(probe).get("expect", {}).keys()))
 
 
 def signature(obs):
@@ -133,7 +147,7 @@ def _pick_witness(obs_group):
     0.15 s."""
     order = {"blocker": 0, "major": 1, "minor": 2}
     def key(o):
-        tgt = (o.get("probe") or {}).get("target") or {}
+        tgt = _as_probe(o.get("probe")).get("target") or {}
         return (order.get(o.get("severity"), 3), tgt.get("binary_size", 1 << 62))
     return sorted(obs_group, key=key)[0]
 
@@ -204,8 +218,8 @@ def build_needs(observations, round_n):
             "track": track,
             "status": "open",
             "severity": witness.get("severity", "major"),
-            "probe_id": _pid(witness.get("probe"), False),
-            "acceptance_id": _pid(witness.get("acceptance"), True),
+            "probe_id": _pid(_as_probe(witness.get("probe")), False),
+            "acceptance_id": _pid(_as_probe(witness.get("acceptance")), True),
             "hypothesis_status": "inconclusive",
             "credibility": credibility(grp),
             "instances": len(grp),
@@ -285,8 +299,8 @@ def _sections(grp, witness):
                      for o in grp if o.get("hypothesis")) or "_none offered_"
     return {
         "Symptom": "%s\n\n%s" % (_quote(witness.get("what_i_wanted", ""), 800), quotes),
-        "Reproduction": "```json\n%s\n```" % json.dumps(witness.get("probe"), indent=2),
-        "Acceptance": "```json\n%s\n```" % json.dumps(witness.get("acceptance"), indent=2),
+        "Reproduction": "```json\n%s\n```" % json.dumps(_as_probe(witness.get("probe")), indent=2),
+        "Acceptance": "```json\n%s\n```" % json.dumps(_as_probe(witness.get("acceptance")), indent=2),
         "Hypothesis": ("**Advisory — the builder is not bound by this.** In the sibling "
                        "campaign 3 of 8 filed diagnoses were overturned while the symptom "
                        "stood in all 8.\n\n%s" % hyps),

--- a/scripts/repipe/cluster.py
+++ b/scripts/repipe/cluster.py
@@ -1,0 +1,359 @@
+"""Collapse gated observations into needs, deterministically first and by LLM only if asked.
+
+Dedup here keys off the PROBE, not the prose. Two testers who hit the same gap will describe
+it in two different essays but will run substantially the same command and assert
+substantially the same thing, so the signature is built from the kuna subcommand, the
+observation kind, and the shape of the expect clauses. Text similarity is a tie-breaker, not
+the key.
+
+That ordering is deliberate and it is what keeps the loop cheap: bumping `instances` and
+appending a challenge to an existing need is pure Python and costs nothing, so only a
+genuinely novel observation is ever worth an agent's attention.
+
+Only `admitted` observations reach this module — verify.py's two-arm gate has already
+discarded the ones that did not reproduce and the ones kuna could already do.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+
+from . import config
+
+_WORD = re.compile(r"[a-z0-9]+")
+
+# Words that carry no discriminating power in a kuna friction report; every observation has
+# them, so leaving them in makes everything look similar to everything else.
+_STOP = frozenset("""
+a an the and or but of to in on for with is are was were be been it its this that these those
+kuna decompiler binary function functions output cannot could would should does did not no
+i my we you when then than there here what which how why very really just only also more most
+""".split())
+
+
+def _tokens(text):
+    return {w for w in _WORD.findall((text or "").lower()) if w not in _STOP and len(w) > 2}
+
+
+def _subcommand(probe):
+    """The kuna subcommand a probe drives, which is most of a friction report's identity."""
+    cmd = (probe or {}).get("cmd") or []
+    known = {"decompile", "decompile-all", "decompile-project", "functions",
+             "test", "catalog", "modes", "specs", "fid"}
+    for tok in cmd[1:]:
+        if tok in known:
+            return tok
+        if not tok.startswith("-"):
+            continue
+    return "?"
+
+
+def _clause_shape(probe):
+    """Which assertions a probe makes, ignoring their values.
+
+    'exit_code + json' is a different complaint from 'wall_ms', even about the same command.
+    """
+    return tuple(sorted((probe or {}).get("expect", {}).keys()))
+
+
+def signature(obs):
+    """The deterministic dedup key."""
+    return "|".join([
+        obs.get("kind", "?"),
+        _subcommand(obs.get("probe")),
+        ",".join(_clause_shape(obs.get("acceptance"))),
+    ])
+
+
+def similarity(a, b):
+    """Jaccard over content words of title + what_i_wanted. The tie-breaker, not the key."""
+    ta = _tokens(a.get("title", "") + " " + a.get("what_i_wanted", ""))
+    tb = _tokens(b.get("title", "") + " " + b.get("what_i_wanted", ""))
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / float(len(ta | tb))
+
+
+NEAR = float(os.environ.get("REPIPE_CLUSTER_NEAR", "0.45"))
+
+
+def group(observations):
+    """[[obs, ...], ...] — exact-signature groups, then near-duplicates merged within a kind."""
+    by_sig = defaultdict(list)
+    for o in observations:
+        by_sig[signature(o)].append(o)
+    groups = list(by_sig.values())
+
+    merged, used = [], set()
+    for i, gi in enumerate(groups):
+        if i in used:
+            continue
+        cur = list(gi)
+        for j in range(i + 1, len(groups)):
+            if j in used:
+                continue
+            gj = groups[j]
+            if gi[0].get("kind") != gj[0].get("kind"):
+                continue
+            if similarity(gi[0], gj[0]) >= NEAR:
+                cur.extend(gj)
+                used.add(j)
+        used.add(i)
+        merged.append(cur)
+    return merged
+
+
+# A need_id becomes a branch name, a tests/cli/ filename and the thing a builder is told to
+# fix, so "kuna-has-no-way-to" is not good enough. Filler is dropped before truncation.
+_SLUG_DROP = frozenset("""
+kuna the a an is are was were be to of for on in at it its this that with and or but
+no not cannot could would should does did has have had any all only just very
+""".split())
+
+
+def _slug(text, fallback="need"):
+    words = [w for w in re.sub(r"[^a-z0-9]+", " ", (text or "").lower()).split()
+             if w not in _SLUG_DROP]
+    if not words:
+        words = re.sub(r"[^a-z0-9]+", " ", (text or "").lower()).split()
+    return "-".join(words[:4]) or fallback
+
+
+def need_id_for(obs_group):
+    return _slug(obs_group[0].get("title"), "need")
+
+
+def _pick_witness(obs_group):
+    """The instance a builder will actually work from: prefer the most severe, then the
+    smallest binary, because a 3.4 MB PE costs 445 s per probe replay and an 11 KB ELF costs
+    0.15 s."""
+    order = {"blocker": 0, "major": 1, "minor": 2}
+    def key(o):
+        tgt = (o.get("probe") or {}).get("target") or {}
+        return (order.get(o.get("severity"), 3), tgt.get("binary_size", 1 << 62))
+    return sorted(obs_group, key=key)[0]
+
+
+TRACK_BY_SUBCOMMAND = {
+    "decompile": "quality", "decompile-all": "quality", "decompile-project": "quality",
+    "functions": "tooling", "catalog": "tooling", "modes": "tooling",
+}
+
+
+def infer_track(obs_group):
+    """tooling | quality | perf | loader — the field that decides the builder's whole protocol.
+
+    A missing capability is tooling however it was found; a wrong-output complaint is quality
+    however it was phrased; anything timing-shaped is perf. Only the residue is guessed from
+    the subcommand, and the builder is told to re-check it.
+    """
+    kinds = {o.get("kind") for o in obs_group}
+    if kinds & {"too-slow", "cost"}:
+        return "perf"
+    if kinds & {"missing-capability", "bad-ux"}:
+        return "tooling"
+    if "silent-failure" in kinds or "crash" in kinds:
+        w = _pick_witness(obs_group)
+        return "loader" if _subcommand(w.get("probe")) == "functions" else "tooling"
+    if "wrong-output" in kinds:
+        return "quality"
+    return TRACK_BY_SUBCOMMAND.get(_subcommand(_pick_witness(obs_group).get("probe")), "tooling")
+
+
+TOUCHES_BY_TRACK = {
+    "tooling": ["decompiler/crates/kuna-cli"],
+    "quality": ["decompiler/crates/kuna-decomp"],
+    "loader": ["decompiler/crates/kuna-analysis"],
+    "perf": [],
+}
+
+
+def build_needs(observations, round_n):
+    """Groups -> Need records, merging into any existing need with the same id.
+
+    An existing need is BUMPED, never rewritten: its instances and challenges grow, its
+    rounds list gains this round, and a previously closed need that reappears becomes
+    `regressed`, which rank_score puts at the front of the queue.
+    """
+    from . import needs as needs_mod
+    out = []
+    for grp in group(observations):
+        nid = need_id_for(grp)
+        witness = _pick_witness(grp)
+        challenges = sorted({o.get("_hexid") for o in grp if o.get("_hexid")})
+        existing = needs_mod.load(nid)
+        if existing is not None:
+            existing.fields["instances"] = int(existing.instances or 0) + len(grp)
+            existing.fields["challenges"] = sorted(set(list(existing.challenges or []) + challenges))
+            existing.fields["rounds"] = sorted(set(list(existing.rounds or []) + [round_n]))
+            if existing.status == "closed":
+                # A closed need whose symptom came back is a regression, and rank_score puts
+                # a regression at the front of the queue.
+                existing.fields["status"] = "regressed"
+            needs_mod.upsert(existing)
+            out.append(existing)
+            continue
+        track = infer_track(grp)
+        need = needs_mod.Need(fields={
+            "need_id": nid,
+            "title": witness.get("title", nid),
+            "track": track,
+            "status": "open",
+            "severity": witness.get("severity", "major"),
+            "probe_id": _pid(witness.get("probe"), False),
+            "acceptance_id": _pid(witness.get("acceptance"), True),
+            "hypothesis_status": "inconclusive",
+            "credibility": credibility(grp),
+            "instances": len(grp),
+            "challenges": challenges,
+            "rounds": [round_n],
+            "first_seen_round": round_n,
+            "attempts": 0,
+            "touches": TOUCHES_BY_TRACK.get(track, []),
+            "scope": "small",
+            "regression_of": witness.get("regression_of"),
+        }, sections=_sections(grp, witness))
+        needs_mod.upsert(need)
+        out.append(need)
+    return out
+
+
+def credibility(grp):
+    """0..1 — how much of this is corroboration rather than one agent's opinion.
+
+    Distinct testers matter more than raw instance count: three complaints from one tester
+    in one session is one opinion repeated.
+    """
+    testers = {o.get("_tester") for o in grp if o.get("_tester")}
+    challenges = {o.get("_hexid") for o in grp if o.get("_hexid")}
+    score = 0.3 + 0.25 * min(len(testers), 3) + 0.15 * min(len(challenges), 3)
+    if any(o.get("reference_better") for o in grp):
+        score += 0.15   # "IDA does this and kuna cannot" is the most concrete evidence there is
+    return round(min(score, 1.0), 2)
+
+
+def _pid(probe, is_acceptance):
+    """The probe's id, derived if the tester did not carry one (they are derived, not authored)."""
+    if not probe:
+        return None
+    if probe.get("probe_id"):
+        return probe["probe_id"]
+    try:
+        from . import probe as probe_mod
+        return probe_mod.probe_id(probe, is_acceptance=is_acceptance)
+    except Exception:
+        return None
+
+
+def _quote(text, limit=4000):
+    """Neutralise untrusted tester prose before embedding it in a need record.
+
+    A need is Markdown whose `##` headings ARE the schema: `## Acceptance` holds the probe
+    that decides when the need is closed and what gets promoted into tests/cli/. Tester prose
+    is written by an LLM working on an adversarial corpus, so a report containing its own
+    `## Acceptance` heading (or a stray ``` fence) would splice a chosen probe into the
+    record. Headings and fences are defanged, and the text is length-capped.
+    """
+    if not text:
+        return ""
+    out = []
+    for line in str(text)[:limit].splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            line = line.replace("#", "\\#", 1)
+        elif stripped.startswith("```") or stripped.startswith("~~~"):
+            line = "`" + stripped[3:]
+        out.append(line)
+    return "\n".join(out)
+
+
+def _sections(grp, witness):
+    quotes = "\n".join(
+        "> **%s** (%s, `%s`)\n> %s\n" % (_quote(o.get("title", ""), 200),
+                                         o.get("severity", "?"), o.get("_hexid", "?"),
+                                         _quote(o.get("what_kuna_did", ""), 600))
+        for o in grp[:6])
+    refs = [o for o in grp if o.get("reference_better")]
+    ref_md = "\n".join("- `%s` — %s" % (_quote(r["reference_better"].get("command", ""), 200),
+                                        _quote(r["reference_better"].get("evidence", ""), 400))
+                       for r in refs) or "_none recorded_"
+    hyps = "\n".join("- %s" % _quote(o["hypothesis"], 600)
+                     for o in grp if o.get("hypothesis")) or "_none offered_"
+    return {
+        "Symptom": "%s\n\n%s" % (_quote(witness.get("what_i_wanted", ""), 800), quotes),
+        "Reproduction": "```json\n%s\n```" % json.dumps(witness.get("probe"), indent=2),
+        "Acceptance": "```json\n%s\n```" % json.dumps(witness.get("acceptance"), indent=2),
+        "Hypothesis": ("**Advisory — the builder is not bound by this.** In the sibling "
+                       "campaign 3 of 8 filed diagnoses were overturned while the symptom "
+                       "stood in all 8.\n\n%s" % hyps),
+        "Refutation": "_not yet refuted_",
+        "Reference": ref_md,
+        "Instances": "\n".join("- `%s` (round %s, tester %s)" % (
+            o.get("_hexid", "?"), o.get("_round", "?"), o.get("_tester", "?")) for o in grp),
+        "Decision log": "- filed by cluster.py from %d observation(s)" % len(grp),
+    }
+
+
+def load_round_observations(round_n):
+    """Admitted observations for a round, stamped with where each came from."""
+    gate_path = config.rounds_dir() / str(round_n) / "gate.json"
+    if not gate_path.exists():
+        raise SystemExit("no gate result at %s — run verify --gate --round %s first"
+                         % (gate_path, round_n))
+    with open(gate_path) as fh:
+        gate = json.load(fh)
+    out = []
+    for row in gate.get("results", []):
+        if row.get("verdict") != "admitted":
+            continue
+        obs = dict(row.get("observation") or {})
+        obs["_hexid"] = row.get("hexid")
+        obs["_tester"] = row.get("tester_id")
+        obs["_round"] = round_n
+        out.append(obs)
+    return out
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog="python -m scripts.repipe.cluster")
+    ap.add_argument("--round", type=int, required=True)
+    ap.add_argument("--from-file", default=None,
+                    help="a JSON list of admitted observations, instead of the round's gate.json")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    if args.from_file:
+        with open(args.from_file) as fh:
+            obs = json.load(fh)
+    else:
+        obs = load_round_observations(args.round)
+
+    if args.dry_run:
+        groups = group(obs)
+        out = [{"need_id": need_id_for(g), "track": infer_track(g), "instances": len(g),
+                "challenges": sorted({o.get("_hexid") for o in g if o.get("_hexid")}),
+                "credibility": credibility(g)} for g in groups]
+        print(json.dumps(out, indent=2) if args.json else
+              "\n".join("%-28s %-8s x%-3d %s" % (r["need_id"], r["track"], r["instances"],
+                                                 ",".join(r["challenges"])) for r in out))
+        return 0
+
+    made = build_needs(obs, args.round)
+    from . import needs as needs_mod
+    needs_mod.reindex()
+    if args.json:
+        print(json.dumps([{"need_id": n.need_id, "track": n.track, "status": n.status,
+                           "instances": n.instances} for n in made], indent=2))
+    else:
+        for n in made:
+            print("%-28s %-8s %-10s x%d" % (n.need_id, n.track, n.status, n.instances))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repipe/config.py
+++ b/scripts/repipe/config.py
@@ -1,0 +1,186 @@
+"""Environment-driven configuration for the RE-friction loop.
+
+Every knob has a default that works on this machine and is overridable by an env var, in
+the idiom of scripts/pipeline/config.py. Nothing here imports a third-party package: kuna's
+Python tooling is stdlib-only by convention (no pyproject.toml, no requirements.txt, and
+~/.virtualenvs/kuna carries zero third-party packages).
+"""
+import os
+import shutil
+from pathlib import Path
+
+from .. import paths
+
+# --- repo + state -----------------------------------------------------------
+
+STATE_DIRNAME = os.environ.get("REPIPE_STATE_DIRNAME", ".kuna-repipe")
+
+
+def repo_root() -> Path:
+    return paths.repo_root()
+
+
+def state_dir() -> Path:
+    """Live state (gitignored): inventory, rounds, arenas, worktrees, logs."""
+    env = os.environ.get("KUNA_PIPELINE_STATE_DIR")
+    if env:
+        return Path(env)
+    return repo_root() / STATE_DIRNAME
+
+
+def needs_dir() -> Path:
+    """The durable, COMMITTED backlog. No gate reads it (check_spec.py walks docs/spec/ only)."""
+    return repo_root() / "docs" / "re-needs"
+
+
+def rejected_dir() -> Path:
+    """The honest denominator: already-supported, not-reproducible, unprobeable, user-error."""
+    return needs_dir() / "rejected"
+
+
+def cli_tests_dir() -> Path:
+    """Promoted acceptance probes. A shipped need leaves a permanent regression test here."""
+    return repo_root() / "tests" / "cli"
+
+
+def rounds_dir() -> Path:
+    return state_dir() / "rounds"
+
+
+def arena_dir() -> Path:
+    return state_dir() / "arena"
+
+
+def runs_dir() -> Path:
+    return state_dir() / "runs"
+
+
+def logs_dir() -> Path:
+    return state_dir() / "logs"
+
+
+# --- the dataset ------------------------------------------------------------
+
+DEFAULT_DATASET = str(Path.home() / "github" / "kuna-re-dataset")
+
+
+def dataset_root() -> Path:
+    return Path(os.environ.get("REPIPE_DATASET", DEFAULT_DATASET))
+
+
+def manifest_path() -> Path:
+    return dataset_root() / "manifest.json"
+
+
+# --- tools ------------------------------------------------------------------
+
+def kuna_bin() -> Path:
+    """The release kuna the testers and probes drive."""
+    env = os.environ.get("REPIPE_KUNA")
+    if env:
+        return Path(env)
+    return repo_root() / "decompiler" / "target" / "release" / "kuna"
+
+
+def specs_dir() -> Path:
+    return paths.specs_dir()
+
+
+# The reference stack. IDA Pro 9.2 is installed here; its python bindings live in the
+# decbench venv, NOT in the default python3 and NOT in ~/.virtualenvs/kuna.
+DEFAULT_REF_PYTHON = str(Path.home() / ".virtualenvs" / "decbench" / "bin" / "python")
+DEFAULT_DECOMPILER = str(Path.home() / ".virtualenvs" / "decbench" / "bin" / "decompiler")
+
+
+def reference_python() -> str:
+    return os.environ.get("REPIPE_REF_PYTHON", DEFAULT_REF_PYTHON)
+
+
+def decompiler_cli() -> str:
+    return os.environ.get("REPIPE_DECOMPILER", DEFAULT_DECOMPILER)
+
+
+def ida_available() -> bool:
+    return os.path.exists(decompiler_cli()) and bool(os.environ.get("IDA_INSTALL_DIR", ""))
+
+
+def sandbox_mode() -> str:
+    """'bwrap' hides the dataset from the tester outright; 'none' falls back to the tripwire."""
+    mode = os.environ.get("REPIPE_SANDBOX", "auto")
+    if mode == "auto":
+        return "bwrap" if shutil.which("bwrap") else "none"
+    return mode
+
+
+# --- agents -----------------------------------------------------------------
+
+MAX_AGENTS = int(os.environ.get("REPIPE_MAX_AGENTS", "7"))
+TESTER_SHARE = float(os.environ.get("REPIPE_TESTER_SHARE", "0.5"))
+
+
+def agent_split(max_agents=None, testers=None, builders=None):
+    """1 captain + testers + builders, summing to at most max_agents.
+
+    Default 7 -> 1/3/3. Explicit --testers/--builders override the share but are still
+    capped at max_agents-1 in total.
+
+    The pools are separate caps, and testers and builders are active in different captain
+    states, so below max_agents=5 (where the two tracks cannot overlap) the live process
+    count is captain + max(testers, builders), not captain + testers + builders.
+    """
+    n = int(max_agents if max_agents is not None else MAX_AGENTS)
+    n = max(2, n)
+    workers = max(1, n - 1)
+    if testers is None and builders is None:
+        t = max(1, int(workers * TESTER_SHARE + 0.5))
+        b = max(1, workers - t)
+    elif testers is None:
+        b = max(1, min(int(builders), workers - 1))
+        t = max(1, workers - b)
+    elif builders is None:
+        t = max(1, min(int(testers), workers - 1))
+        b = max(1, workers - t)
+    else:
+        t, b = max(1, int(testers)), max(1, int(builders))
+    while t + b > workers and b > 1:
+        b -= 1
+    while t + b > workers and t > 1:
+        t -= 1
+    return {"captain": 1, "testers": t, "builders": b, "max_agents": n}
+
+
+# --- budgets and timeouts ---------------------------------------------------
+
+ROUND_CHALLENGES = int(os.environ.get("REPIPE_ROUND_CHALLENGES", "9"))
+TESTER_TIMEOUT = int(os.environ.get("REPIPE_TESTER_TIMEOUT", "3600"))
+BUILDER_TIMEOUT = int(os.environ.get("REPIPE_BUILDER_TIMEOUT", "7200"))
+CAPTAIN_TIMEOUT = int(os.environ.get("REPIPE_CAPTAIN_TIMEOUT", "1200"))
+BUILDER_USD = float(os.environ.get("REPIPE_BUILDER_USD", "25"))
+ROUND_USD = float(os.environ.get("REPIPE_ROUND_USD", "150"))
+RUN_USD = float(os.environ.get("REPIPE_RUN_USD", "1500"))
+ROUNDS = int(os.environ.get("REPIPE_ROUNDS", "3"))          # 0 = until the backlog is dry
+MIN_FREE_GB = int(os.environ.get("REPIPE_MIN_FREE_GB", "250"))
+HALT_FREE_GB = int(os.environ.get("REPIPE_HALT_FREE_GB", "60"))
+POLL = float(os.environ.get("REPIPE_POLL", "15"))
+
+# Probe replay. A probe is run REPLAY_REPS times and must agree with itself; a flaky probe
+# is not evidence. Timing probes need more reps because single-target timing noise on this
+# machine routinely exceeds 5% (docs/features/returncopysplit/record.json measured a -20%
+# and -12% "noise floor" on byte-identical output).
+REPLAY_REPS = int(os.environ.get("REPIPE_REPLAY_REPS", "3"))
+TIMING_REPS = int(os.environ.get("REPIPE_TIMING_REPS", "7"))
+PROBE_TIMEOUT = int(os.environ.get("REPIPE_PROBE_TIMEOUT", "300"))
+
+# Refutation. `absence` needs ("there is no xrefs subcommand") have no interesting root
+# cause, so paying two agent-runs to confirm that is waste. Shipped ON.
+REFUTE_MODE = os.environ.get("REPIPE_REFUTE_MODE", "absence-skip")
+
+ENABLE_IDA = os.environ.get("REPIPE_ENABLE_IDA", "1") not in ("0", "false", "no")
+
+# --- models -----------------------------------------------------------------
+
+TESTER_MODEL = os.environ.get("REPIPE_TESTER_MODEL", "")     # "" -> codex config default
+BUILDER_MODEL = os.environ.get("REPIPE_BUILDER_MODEL", "opus")
+CAPTAIN_MODEL = os.environ.get("REPIPE_CAPTAIN_MODEL", "opus")
+
+GH_REPO = os.environ.get("REPIPE_GH_REPO", "Noelo-Lab/kuna")

--- a/scripts/repipe/counters.py
+++ b/scripts/repipe/counters.py
@@ -1,0 +1,598 @@
+"""Re-derive every shared counter from the tree, then check it against each hard-coded site.
+
+WHY this module exists, and why it never does arithmetic: this repo runs several
+output-changing PRs at once and every one of them touches the same handful of hard-coded
+numbers. Round 2 shipped a wrong count because both branches made the *identical*
+`85 -> 86` edit, so git auto-merged them cleanly with no conflict and no diff to review --
+and the right answer was 87 (docs/decbench-loop.md, "Shared counters in a busy queue").
+The rule written down there is this file's whole design: **derive every shared counter from
+a fresh capture on the rebased tree, never by arithmetic.** There is deliberately no
+"base + mine + theirs" anywhere below -- every number is measured now, from phases.toml,
+from a live `kuna catalog --json`, and from the files on disk.
+
+The counters, how each is measured, and where each is hard-coded:
+
+    settables (127)         `[[settable]]` blocks in kuna-decomp/phases.toml
+                            -> kuna_phases/tests.rs   2 asserts + the test fn NAME
+                            -> catalog_bytecompat.rs  3 FIXTURE.matches asserts + the fn NAME
+    tiers (28/52/47)        row["tier"] tally from `kuna catalog --json`
+                            -> kuna_phases/tests.rs   the tuple assert + the test fn NAME
+    catalog buckets         field/value tallies over the same catalog rows
+                            -> tests/stages/kuna-catalog.xml  per-bucket stringmatch min/max
+    stage corpus (222)      tests/datatests/*.xml + tests/stages/*.xml, non-recursive
+                            -> kuna-base/src/xml.rs   "corpus file count drifted"
+    next ElementId (4132)   max `ElementId::new(_, N)` for N >= 4000, plus one. No hard-coded
+                            site: the convention is "grep for the current highest"
+                            (docs/agents.md, docs/improvement-pipeline.md).
+
+The test function NAMES are checked as sites in their own right. They encode the number, no
+compiler or test run disagrees with a stale one, and `settable_count_is_117` guarding an
+`assert_eq!(..., 127)` is exactly the artifact a silent auto-merge leaves behind.
+
+`decompiler/crates/kuna-decomp/tests/fixtures/phase_catalog.json` is NOT rewritten here. It
+is *captured bytes* -- guessing at them is how the byte-compat gate stops meaning anything.
+When it disagrees with the derived settable count this module reports an unfixable drift and
+prints the recapture recipe, read out of catalog_bytecompat.rs's own module header so the
+recipe cannot drift away from the gate that consumes it.
+
+CLI:
+    python -m scripts.repipe.counters                     # check; exit 1 on drift
+    python -m scripts.repipe.counters --rederive --json   # measure now, report; read-only
+    python -m scripts.repipe.counters --fix               # rewrite every fixable site
+    python -m scripts.repipe.counters --recipe            # the phase_catalog.json recapture
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from . import config
+
+CATALOG_TIMEOUT = int(os.environ.get("REPIPE_CATALOG_TIMEOUT", "300"))
+
+# kuna's own marshaling ids live in the 4000+ range; below that is the ported Ghidra table.
+ELEMENT_ID_BASE = int(os.environ.get("REPIPE_ELEMENT_ID_BASE", "4000"))
+
+CORPUS_DIRS = ("tests/datatests", "tests/stages")
+
+REL_PHASES_TOML = "decompiler/crates/kuna-decomp/phases.toml"
+REL_TESTS_RS = "decompiler/crates/kuna-decomp/src/p0_knowledge/kuna_phases/tests.rs"
+REL_BYTECOMPAT_RS = "decompiler/crates/kuna-decomp/tests/catalog_bytecompat.rs"
+REL_CATALOG_FIXTURE = "decompiler/crates/kuna-decomp/tests/fixtures/phase_catalog.json"
+REL_CATALOG_XML = "tests/stages/kuna-catalog.xml"
+REL_BASE_XML_RS = "decompiler/crates/kuna-base/src/xml.rs"
+
+TIERS = ("core", "transform", "analysis")
+
+
+class DeriveError(RuntimeError):
+    """A counter could not be measured, so nothing downstream may be trusted."""
+
+
+@dataclass
+class Drift:
+    """One hard-coded site that disagrees with the derived truth.
+
+    ``fixable`` is False for a site whose correct value is a capture (phase_catalog.json) or
+    an intentionally loose range -- those need an operator, not a rewrite.
+    """
+    site: str
+    path: str
+    line: int
+    counter: str
+    found: str
+    expected: str
+    fixable: bool = True
+    detail: str = ""
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+    def oneline(self) -> str:
+        tail = "  " + self.detail if self.detail else ""
+        return "{}:{}  {}: found {} expected {}{}".format(
+            self.path, self.line, self.site, self.found, self.expected, tail)
+
+
+# --- paths ------------------------------------------------------------------
+
+def _root(repo=None) -> Path:
+    return Path(repo) if repo else config.repo_root()
+
+
+def path_of(rel: str, repo=None) -> Path:
+    return _root(repo) / rel
+
+
+# --- generic site primitives (shared with mergecheck's self-test) ------------
+
+def line_of(text: str, offset: int) -> int:
+    """1-based line number of a byte offset, so every finding carries a file:line."""
+    return text.count("\n", 0, offset) + 1
+
+
+_line_of = line_of
+
+
+def _replace_groups(text: str, m, newvals) -> str:
+    """Return ``text`` with match ``m``'s numbered groups replaced, byte-exact elsewhere."""
+    out = []
+    pos = m.start()
+    for i, nv in enumerate(newvals, start=1):
+        out.append(text[pos:m.start(i)])
+        out.append(str(nv))
+        pos = m.end(i)
+    out.append(text[pos:m.end()])
+    return text[:m.start()] + "".join(out) + text[m.end():]
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    tmp = str(path) + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        fh.write(text)
+    os.replace(tmp, str(path))
+
+
+def assert_literal(path, pattern, expected, site="literal", counter="literal"):
+    """Every match of ``pattern`` in ``path`` must carry ``expected`` in its numbered groups.
+
+    This is the whole shape-B guard reduced to one call: a number written in a file is
+    compared against a number measured now. A pattern that matches nothing is itself a
+    finding -- the file changed shape and the guard has gone blind.
+    """
+    path = Path(path)
+    expected = tuple(str(x) for x in (expected if isinstance(expected, (list, tuple)) else (expected,)))
+    if not path.exists():
+        return [Drift(site, str(path), 0, counter, "<missing file>", ",".join(expected), False,
+                      "the site file does not exist")]
+    text = path.read_text(encoding="utf-8", errors="replace")
+    rx = re.compile(pattern)
+    out, seen = [], 0
+    for m in rx.finditer(text):
+        seen += 1
+        found = tuple(m.group(i) for i in range(1, len(expected) + 1))
+        if found != expected:
+            out.append(Drift(site, str(path), _line_of(text, m.start()), counter,
+                             ",".join(found), ",".join(expected)))
+    if not seen:
+        out.append(Drift(site, str(path), 0, counter, "<no match>", ",".join(expected), False,
+                         "pattern no longer matches; the guard is blind, fix the pattern"))
+    return out
+
+
+def rewrite_literal(path, pattern, expected) -> int:
+    """Rewrite every match of ``pattern`` in ``path`` to ``expected``. Returns the edit count."""
+    path = Path(path)
+    expected = tuple(str(x) for x in (expected if isinstance(expected, (list, tuple)) else (expected,)))
+    text = path.read_text(encoding="utf-8")
+    rx = re.compile(pattern)
+    edits = 0
+    while True:
+        for m in rx.finditer(text):
+            found = tuple(m.group(i) for i in range(1, len(expected) + 1))
+            if found != expected:
+                text = _replace_groups(text, m, expected)
+                edits += 1
+                break
+        else:
+            break
+    if edits:
+        _atomic_write(path, text)
+    return edits
+
+
+# --- the sites --------------------------------------------------------------
+#
+# (site id, repo-relative path, regex whose numbered groups hold the number(s),
+#  key into the derived dict supplying the expected value(s)).
+
+SITES = (
+    ("phases-tests.fn-name-settables", REL_TESTS_RS,
+     r"fn settable_count_is_(\d+)\(\)", "settables"),
+    ("phases-tests.kuna_num_settables", REL_TESTS_RS,
+     r"assert_eq!\(kuna_num_settables\(\), (\d+)\)", "settables"),
+    ("phases-tests.SETTABLE_TABLE-len", REL_TESTS_RS,
+     r"assert_eq!\(SETTABLE_TABLE\.len\(\), (\d+)\)", "settables"),
+    ("phases-tests.fn-name-tiers", REL_TESTS_RS,
+     r"fn tier_counts_are_(\d+)_core_(\d+)_transform_(\d+)_analysis\(\)", "tier_tuple"),
+    ("phases-tests.tier-tuple", REL_TESTS_RS,
+     r"assert_eq!\(\(core, transform, analysis\), \((\d+), (\d+), (\d+)\)\)", "tier_tuple"),
+    ("bytecompat.fn-name-settables", REL_BYTECOMPAT_RS,
+     r"fn fixture_has_all_(\d+)_settables\(\)", "settables"),
+    ("bytecompat.fixture-matches", REL_BYTECOMPAT_RS,
+     r'FIXTURE\.matches\("\\"(?:option|tier|symptoms)\\": "\)\.count\(\), (\d+)\)', "settables"),
+    ("base-xml.corpus-count", REL_BASE_XML_RS,
+     r'assert_eq!\(count, (\d+), "corpus file count drifted"\)', "corpus_files"),
+)
+
+
+# --- derivation -------------------------------------------------------------
+
+def settables_from_phases_toml(repo=None) -> int:
+    """`grep -c '^\\[\\[settable\\]\\]' phases.toml` -- the authoritative per-option list."""
+    p = path_of(REL_PHASES_TOML, repo)
+    if not p.exists():
+        raise DeriveError("phases.toml missing at {}".format(p))
+    n = 0
+    with open(p, "r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            if line.startswith("[[settable]]"):
+                n += 1
+    return n
+
+
+def catalog_rows(repo=None, kuna=None) -> list:
+    """The live `kuna catalog --json` rows. A capture, not a parse of the source of truth."""
+    exe = Path(kuna) if kuna else config.kuna_bin()
+    if not exe.exists():
+        raise DeriveError("kuna binary not built at {} (cargo build --release -p kuna-cli)".format(exe))
+    try:
+        proc = subprocess.run([str(exe), "catalog", "--json"], cwd=str(_root(repo)),
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                              timeout=CATALOG_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        raise DeriveError("`kuna catalog --json` timed out after {}s".format(CATALOG_TIMEOUT))
+    if proc.returncode != 0:
+        raise DeriveError("`kuna catalog --json` exited {}: {}".format(
+            proc.returncode, proc.stderr.decode("utf-8", "replace").strip()[:400]))
+    try:
+        data = json.loads(proc.stdout.decode("utf-8"))
+    except ValueError as exc:
+        raise DeriveError("`kuna catalog --json` emitted unparseable JSON: {}".format(exc))
+    rows = data.get("settables", data) if isinstance(data, dict) else data
+    if not isinstance(rows, list) or not rows:
+        raise DeriveError("`kuna catalog --json` returned no settable rows")
+    return rows
+
+
+def corpus_counts(repo=None) -> dict:
+    """Non-recursive `*.xml` per corpus dir -- exactly what kuna-base/src/xml.rs walks."""
+    out = {}
+    for rel in CORPUS_DIRS:
+        d = path_of(rel, repo)
+        if not d.is_dir():
+            raise DeriveError("corpus dir missing: {}".format(d))
+        out[rel] = sum(1 for p in d.iterdir() if p.is_file() and p.suffix == ".xml")
+    return out
+
+
+_ELEMENT_ID_RX = re.compile(r'ElementId::new\(\s*"([A-Za-z0-9_]+)"\s*,\s*(\d+)\s*\)')
+
+
+def element_ids(repo=None) -> dict:
+    """Every kuna-range ElementId in the crates, so the next free one can be handed out."""
+    crates = _root(repo) / "decompiler" / "crates"
+    if not crates.is_dir():
+        raise DeriveError("crates dir missing: {}".format(crates))
+    used = {}
+    for dirpath, dirnames, filenames in os.walk(crates):
+        dirnames[:] = [d for d in dirnames if d not in ("target", ".git")]
+        for fn in filenames:
+            if not fn.endswith(".rs"):
+                continue
+            fp = os.path.join(dirpath, fn)
+            try:
+                text = open(fp, "r", encoding="utf-8", errors="replace").read()
+            except OSError:
+                continue
+            for m in _ELEMENT_ID_RX.finditer(text):
+                num = int(m.group(2))
+                if num < ELEMENT_ID_BASE:
+                    continue
+                used.setdefault(num, []).append("{}:{}".format(
+                    os.path.relpath(fp, str(_root(repo))), m.group(1)))
+    if not used:
+        raise DeriveError("no ElementId in the {}+ range found".format(ELEMENT_ID_BASE))
+    dupes = {str(k): v for k, v in sorted(used.items()) if len(v) > 1}
+    return {"max": max(used), "next_free": max(used) + 1, "count": len(used), "duplicates": dupes}
+
+
+_BUCKET_PAT_RX = re.compile(r'"(?P<key>[a-z_]+)": (?:"(?P<val>[A-Za-z0-9_ .:+/-]*)")?\Z')
+_STRINGMATCH_RX = re.compile(
+    r'<stringmatch\s+name="(?P<name>[^"]*)"\s+min="(?P<min>\d+)"\s+max="(?P<max>\d+)"\s*>'
+    r'(?P<pat>.*?)</stringmatch>', re.S)
+_SINGLE_ROW_RX = re.compile(r'<com>\s*phase catalog\s+(\S+?)\s*</com>')
+
+
+def _catalog_xml_text(repo=None) -> str:
+    p = path_of(REL_CATALOG_XML, repo)
+    if not p.exists():
+        raise DeriveError("catalog stage test missing: {}".format(p))
+    return p.read_text(encoding="utf-8")
+
+
+def _bucket_expect(rows, key, val, single_opts) -> int:
+    """How many times a bucket pattern must appear in the whole console transcript.
+
+    The script emits the full catalog once and then one `phase catalog <opt>` row per
+    single-row command, so an option named in the script contributes twice. That is why
+    KUNA-CATALOG #8 pins 15 while the catalog itself carries 14 opt-in-tool rows.
+    """
+    def hit(row):
+        if key not in row:
+            return False
+        return True if val is None else row.get(key) == val
+    n = sum(1 for r in rows if hit(r))
+    by_opt = {r.get("option"): r for r in rows}
+    for opt in single_opts:
+        r = by_opt.get(opt)
+        if r is not None and hit(r):
+            n += 1
+    return n
+
+
+def catalog_buckets(rows, repo=None) -> list:
+    """Derive the expected count for every *bucket* stringmatch in kuna-catalog.xml.
+
+    A bucket is a bare `"<field>": ` or `"<field>": "<value>"` pattern -- a tally over rows.
+    The per-option row assertions (patterns that open `"option": "<name>"`) are not counters
+    and are reported as skipped rather than silently ignored.
+    """
+    text = _catalog_xml_text(repo)
+    singles = _SINGLE_ROW_RX.findall(text)
+    out = []
+    for m in _STRINGMATCH_RX.finditer(text):
+        pat = m.group("pat")
+        bm = _BUCKET_PAT_RX.match(pat)
+        rec = {
+            "name": m.group("name"),
+            "pattern": pat,
+            "min": int(m.group("min")),
+            "max": int(m.group("max")),
+            "line": _line_of(text, m.start()),
+        }
+        if not bm or bm.group("key") == "option":
+            rec.update({"bucket": False, "expected": None,
+                        "reason": "per-option row assertion, not a counter"})
+        else:
+            key, val = bm.group("key"), bm.group("val") or None
+            rec.update({"bucket": True, "field": key, "value": val,
+                        "expected": _bucket_expect(rows, key, val, singles),
+                        "exact": int(m.group("min")) == int(m.group("max"))})
+        out.append(rec)
+    return out
+
+
+def derive(repo=None, kuna=None) -> dict:
+    """Measure every shared counter now, on this tree. The only source of truth in here."""
+    rows = catalog_rows(repo=repo, kuna=kuna)
+    tiers = dict((t, 0) for t in TIERS)
+    untyped = []
+    for r in rows:
+        t = r.get("tier")
+        if t in tiers:
+            tiers[t] += 1
+        else:
+            untyped.append(r.get("option"))
+    corpus = corpus_counts(repo=repo)
+    toml_n = settables_from_phases_toml(repo=repo)
+    eids = element_ids(repo=repo)
+    fixture = path_of(REL_CATALOG_FIXTURE, repo)
+    fixture_n = (fixture.read_text(encoding="utf-8").count('"option": ')
+                 if fixture.exists() else None)
+    return {
+        "repo": str(_root(repo)),
+        "settables": len(rows),
+        "settables_phases_toml": toml_n,
+        "settables_catalog": len(rows),
+        "settables_fixture": fixture_n,
+        "tiers": tiers,
+        "tier_tuple": [tiers[t] for t in TIERS],
+        "tier_order": list(TIERS),
+        "untiered_options": untyped,
+        "corpus_files": sum(corpus.values()),
+        "corpus_by_dir": corpus,
+        "next_element_id": eids["next_free"],
+        "element_ids": eids,
+        "catalog_buckets": catalog_buckets(rows, repo=repo),
+    }
+
+
+# --- checking ---------------------------------------------------------------
+
+def check(derived=None, repo=None, kuna=None) -> list:
+    """Compare the derived truth against every hard-coded site. Never trusts a merged value."""
+    d = derived if derived is not None else derive(repo=repo, kuna=kuna)
+    out = []
+
+    if d["settables_phases_toml"] != d["settables_catalog"]:
+        out.append(Drift("phases-toml.vs-catalog", REL_PHASES_TOML, 0, "settables",
+                         str(d["settables_phases_toml"]), str(d["settables_catalog"]), False,
+                         "phases.toml and the built binary disagree; rebuild before merging"))
+    if sum(d["tier_tuple"]) != d["settables"]:
+        out.append(Drift("catalog.tier-coverage", REL_PHASES_TOML, 0, "tiers",
+                         str(sum(d["tier_tuple"])), str(d["settables"]), False,
+                         "options with no core/transform/analysis tier: {}".format(
+                             ", ".join(x or "?" for x in d["untiered_options"]) or "none")))
+
+    for site, rel, pattern, key in SITES:
+        out.extend(assert_literal(path_of(rel, repo), pattern, d[key], site=site, counter=key))
+
+    for b in d["catalog_buckets"]:
+        if not b.get("bucket"):
+            continue
+        exp, lo, hi = b["expected"], b["min"], b["max"]
+        if b["exact"]:
+            if exp != lo:
+                out.append(Drift("catalog-xml.bucket:{}".format(b["pattern"].strip()),
+                                 REL_CATALOG_XML, b["line"], "catalog-bucket",
+                                 "min={} max={}".format(lo, hi), "min={0} max={0}".format(exp),
+                                 True, b["name"][:80]))
+        elif not (lo <= exp <= hi):
+            out.append(Drift("catalog-xml.bucket:{}".format(b["pattern"].strip()),
+                             REL_CATALOG_XML, b["line"], "catalog-bucket",
+                             "min={} max={} (derived {})".format(lo, hi, exp),
+                             "a range containing {}".format(exp), False,
+                             "deliberately loose bucket; widen it by hand"))
+
+    if d["settables_fixture"] is not None and d["settables_fixture"] != d["settables"]:
+        out.append(Drift("bytecompat.fixture-capture", REL_CATALOG_FIXTURE, 0, "settables",
+                         str(d["settables_fixture"]), str(d["settables"]), False,
+                         "captured bytes: recapture, never edit (see --recipe)"))
+    return out
+
+
+# --- fixing -----------------------------------------------------------------
+
+def recapture_recipe(repo=None) -> str:
+    """The phase_catalog.json recapture, read out of catalog_bytecompat.rs's own header.
+
+    Reading it rather than restating it means the recipe cannot drift away from the gate
+    that consumes the capture -- and the "no program loaded" condition, which is the part a
+    guess always gets wrong, travels with it.
+    """
+    p = path_of(REL_BYTECOMPAT_RS, repo)
+    if not p.exists():
+        return "(catalog_bytecompat.rs missing; cannot read the recipe)"
+    header = []
+    for line in p.read_text(encoding="utf-8").splitlines():
+        if line.startswith("//!"):
+            header.append(line[3:].lstrip(" "))
+        elif header:
+            break
+    doc = "\n".join(header)
+    idx = doc.find("## Regenerating the fixture")
+    body = doc[idx:] if idx >= 0 else doc
+    fences = re.findall(r"```sh\n(.*?)```", body, re.S)
+    lead = ("Recapture decompiler/crates/kuna-decomp/tests/fixtures/phase_catalog.json.\n"
+            "It is CAPTURED BYTES, with NO PROGRAM LOADED so kunaLiveValue returns \"\" and no\n"
+            "`current` field is emitted. Never hand-edit it, and never re-capture with a program\n"
+            "loaded -- `current` is architecture-dependent and is not a byte contract.\n")
+    if not fences:
+        return lead + "\n(no ```sh block found in catalog_bytecompat.rs's header)\n"
+    return lead + "\n" + fences[0].rstrip() + "\n"
+
+
+def fix(derived=None, repo=None, kuna=None):
+    """Rewrite every fixable site to the derived value; report the rest with the recipe.
+
+    Returns ``(applied, remaining)``: the drifts this rewrote, and the drifts that need an
+    operator (a capture, or a loose range whose correct widening is a judgement call).
+    """
+    d = derived if derived is not None else derive(repo=repo, kuna=kuna)
+    drifts = check(derived=d, repo=repo)
+    applied = []
+    for site, rel, pattern, key in SITES:
+        hits = [x for x in drifts if x.site == site and x.fixable]
+        if hits:
+            rewrite_literal(path_of(rel, repo), pattern, d[key])
+            applied.extend(hits)
+    xml_path = path_of(REL_CATALOG_XML, repo)
+    xml_hits = [x for x in drifts if x.site.startswith("catalog-xml.bucket:") and x.fixable]
+    if xml_hits:
+        text = xml_path.read_text(encoding="utf-8")
+        want = dict((b["name"], b["expected"]) for b in d["catalog_buckets"]
+                    if b.get("bucket") and b.get("exact") and b["expected"] != b["min"])
+        for m in reversed(list(_STRINGMATCH_RX.finditer(text))):
+            exp = want.get(m.group("name"))
+            if exp is None:
+                continue
+            text = (text[:m.start("min")] + str(exp) + text[m.end("min"):m.start("max")]
+                    + str(exp) + text[m.end("max"):])
+        _atomic_write(xml_path, text)
+        applied.extend(xml_hits)
+    remaining = [x for x in drifts if not x.fixable]
+    return applied, remaining
+
+
+# --- CLI --------------------------------------------------------------------
+
+def _print_derived(d) -> None:
+    e = d["element_ids"]
+    print("settables            {}   (phases.toml {} / catalog {} / fixture {})".format(
+        d["settables"], d["settables_phases_toml"], d["settables_catalog"],
+        d["settables_fixture"]))
+    print("tiers                ({}, {}, {})  core/transform/analysis".format(*d["tier_tuple"]))
+    print("stage-corpus files   {}   ({})".format(
+        d["corpus_files"],
+        ", ".join("{} {}".format(v, k) for k, v in sorted(d["corpus_by_dir"].items()))))
+    print("next free ElementId  {}   (highest in use {}, {} allocated)".format(
+        d["next_element_id"], e["max"], e["count"]))
+    if e["duplicates"]:
+        for num, who in e["duplicates"].items():
+            print("  ! ElementId {} allocated twice: {}".format(num, ", ".join(who)))
+    for b in d["catalog_buckets"]:
+        if b.get("bucket"):
+            print("catalog bucket       {:<3}  {}  [min={} max={}]".format(
+                b["expected"], b["pattern"].strip(), b["min"], b["max"]))
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="python -m scripts.repipe.counters",
+        description="Re-derive kuna's shared counters and check every hard-coded site.")
+    ap.add_argument("--rederive", action="store_true",
+                    help="measure now and report; read-only")
+    ap.add_argument("--check", action="store_true",
+                    help="the default: report drift, exit 1 if any")
+    ap.add_argument("--fix", action="store_true",
+                    help="rewrite every fixable site to the derived value")
+    ap.add_argument("--recipe", action="store_true",
+                    help="print the phase_catalog.json recapture recipe and exit")
+    ap.add_argument("--repo", default=None, help="repo root (default: config.repo_root())")
+    ap.add_argument("--kuna", default=None, help="kuna binary (default: config.kuna_bin())")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args(argv)
+
+    if args.recipe:
+        if args.json:
+            print(json.dumps({"recipe": recapture_recipe(args.repo)}, indent=2))
+        else:
+            print(recapture_recipe(args.repo))
+        return 0
+
+    try:
+        d = derive(repo=args.repo, kuna=args.kuna)
+    except DeriveError as exc:
+        if args.json:
+            print(json.dumps({"ok": False, "error": str(exc)}, indent=2))
+        else:
+            print("derive failed: {}".format(exc), file=sys.stderr)
+        return 2
+
+    if args.fix:
+        applied, remaining = fix(derived=d, repo=args.repo)
+        payload = {"ok": not remaining, "derived": d,
+                   "applied": [x.as_dict() for x in applied],
+                   "remaining": [x.as_dict() for x in remaining],
+                   "recipe": recapture_recipe(args.repo)}
+        if args.json:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            _print_derived(d)
+            print("")
+            for x in applied:
+                print("fixed   {}".format(x.oneline()))
+            for x in remaining:
+                print("MANUAL  {}".format(x.oneline()))
+            if not applied and not remaining:
+                print("no drift; nothing to fix")
+            print("")
+            print(recapture_recipe(args.repo))
+        return 0 if not remaining else 1
+
+    drifts = check(derived=d, repo=args.repo)
+    payload = {"ok": not drifts, "derived": d, "drift": [x.as_dict() for x in drifts]}
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        _print_derived(d)
+        print("")
+        if drifts:
+            for x in drifts:
+                print("DRIFT  {}".format(x.oneline()))
+        else:
+            print("no drift: every hard-coded site agrees with the derived truth")
+    if args.rederive:
+        return 0
+    return 1 if drifts else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repipe/grade.py
+++ b/scripts/repipe/grade.py
@@ -1,0 +1,582 @@
+"""Tiered, honest solve verdicts -- and the contamination tripwire.
+
+Solve rate is a SECONDARY metric for this pipeline; the primary output of a tester run is
+probes, graded by replay. This module exists anyway because "did the tester actually solve
+it?" is the only sanity check on whether the friction it reported was friction on the way to
+somewhere, and because a contaminated run must be caught before its outcome is believed.
+
+The ground truth is weak and the verdict says so out loud rather than averaging it away:
+
+  flag-exact      HIGH  -- the answer equals meta.ground_truth.flag. 98 of 250 records have
+                          one. This is the only tier that is simply true.
+  binary-accepts  HIGH  -- the arena's copy of the binary was run with the tester's
+                          name/serial under `timeout 10` and said something that reads as
+                          success. Best-effort and heuristic: crackmes have no success
+                          protocol, so this is keyword matching on stdout/stderr and it can
+                          be fooled by a binary that prints "correct format, wrong key" or
+                          that reports failure only through an exit code.
+  verifier-agrees LOW   -- `verifier.py verify <name> <serial>` printed exactly `1`. These
+                          70 files are LLM reconstructions from public writeups that were
+                          NEVER validated against the binaries: 19 raise NotImplementedError,
+                          4 are quarantined stubs, 56 carry an ASSUMPTION comment, and one
+                          ends "We return True here provisionally" -- i.e. it accepts nearly
+                          any well-formed serial. A pass here is a hint, not a fact, and the
+                          returned dict is flagged low-confidence so no consumer can forget.
+  unverifiable          -- nothing above could decide. 22 of 250 challenges are machine-
+                          checkable AND uncontaminated; for the rest this is the honest
+                          answer.
+
+The verifier runs in a SUBPROCESS and is never imported: it is unvetted generated code, and
+importing it would run it inside the one process that is holding the plaintext ground truth.
+Its exit code is 0 whether it says yes or no, so only its STDOUT is read.
+
+Nothing this module returns ever contains the flag or the tester's raw answer -- an answer
+that matched IS the flag, and these dicts land in round state and on the dashboard. Answers
+travel as a sha1 prefix.
+
+CLI:
+    python3 -m scripts.repipe.grade verdict --hexid H [--report R.json | --answer V [--name N]]
+            [--arena DIR] [--round N] [--record] [--json]
+    python3 -m scripts.repipe.grade tripwire --hexid H --transcript FILE [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+from . import config
+
+SCHEMA = "re-grade/1"
+
+BINARY_TIMEOUT = int(os.environ.get("REPIPE_BINARY_TIMEOUT", "10"))
+VERIFIER_TIMEOUT = int(os.environ.get("REPIPE_VERIFIER_TIMEOUT", "20"))
+
+TIER_CONFIDENCE = {"flag-exact": "high", "binary-accepts": "high",
+                   "verifier-agrees": "low", "unverifiable": "none"}
+
+# The negative verdict each tier produces when it decides against the tester.
+TIER_NEGATIVE = {"flag-exact": "flag-mismatch", "binary-accepts": "binary-rejects",
+                 "verifier-agrees": "verifier-disagrees"}
+
+LOW_CONFIDENCE_NOTE = (
+    "verifier.py files are LLM reconstructions from public writeups, never validated "
+    "against the binaries (19/70 raise NotImplementedError, 4 are quarantined stubs, one "
+    "accepts nearly any well-formed serial). Treat this verdict as a hint.")
+
+# Word boundaries are load-bearing, not decoration: "Invalid password!" contains the
+# substring "valid password", and challenges/61ffb07c33c5d46c8bcbfc1d prints exactly that.
+_SUCCESS = re.compile(
+    r"congrat|well\s*done|good\s+(job|work|password|serial|key|pass)\b|\bcorrect\b|"
+    r"success|accepted|access\s+granted|\bgranted\b|"
+    r"\bvalid\s+(serial|key|password|licen[cs]e|pass)\b|you\s+(did|got)\s+it|"
+    r"right\s+(serial|key|password)\b|solved|winner|unlocked|flag\{", re.I)
+_FAILURE = re.compile(
+    r"wrong|incorrect|invalid|denied|nope|try\s+again|failed|failure|"
+    r"bad\s+(serial|key|password|licen[cs]e)|sorry|no\s+luck|not\s+(valid|correct)", re.I)
+
+
+# --- inputs -----------------------------------------------------------------
+
+def challenge_dir(hexid):
+    return config.dataset_root() / "challenges" / hexid
+
+
+def load_meta(hexid):
+    """Read-only. This is the spoiler side of the fence: grade.py runs challenge-side and
+    never inside the tester's mount namespace."""
+    with open(challenge_dir(hexid) / "meta.json") as fh:
+        return json.load(fh)
+
+
+def load_report(report):
+    """Accept a parsed report dict or a path to one, so the captain and the CLI agree."""
+    if report is None:
+        return {}
+    if isinstance(report, dict):
+        return report
+    with open(report) as fh:
+        return json.load(fh)
+
+
+def _answer_of(report):
+    """(name, value, kind) from a report.schema.json answer block, tolerating a bare string."""
+    ans = report.get("answer")
+    if isinstance(ans, str):
+        return None, ans.strip() or None, "flag"
+    if not isinstance(ans, dict):
+        return None, None, "none"
+    value = ans.get("value")
+    value = value.strip() if isinstance(value, str) else None
+    name = ans.get("name")
+    name = name.strip() if isinstance(name, str) else None
+    return (name or None), (value or None), (ans.get("kind") or "none")
+
+
+def _digest(text):
+    if text is None:
+        return None
+    return hashlib.sha1(text.encode("utf-8", "replace")).hexdigest()[:12]
+
+
+def _norm(text):
+    return text.strip().strip("'\"").strip() if isinstance(text, str) else text
+
+
+# --- tier 1: the flag -------------------------------------------------------
+
+def _tier_flag(meta, value):
+    flag = (meta.get("ground_truth") or {}).get("flag")
+    tier = {"tier": "flag-exact", "confidence": "high"}
+    if not flag:
+        tier.update(result="skipped", why="this challenge has no ground_truth.flag")
+        return tier
+    if not value:
+        tier.update(result="skipped", why="the report carried no answer")
+        return tier
+    ok = _norm(value) == _norm(flag)
+    tier.update(result="pass" if ok else "fail",
+                why="answer equals ground_truth.flag" if ok
+                    else "answer does not equal ground_truth.flag")
+    return tier
+
+
+# --- tier 2: the binary itself ----------------------------------------------
+
+def arena_binary(arena, meta):
+    """The arena's copy of meta.json -> detected.primary.path.
+
+    workspace.py copies the primary into `<arena>/target/`; the dataset preserves recursive
+    extraction shapes (`bin/CrackMe_3.zip.__x/CrackMe_3.exe`), so both the full relative
+    shape and the flat basename are tried before giving up. The dataset original is never
+    run: it is read-only input, and a crackme is untrusted code that belongs in the arena.
+    """
+    if not arena:
+        return None
+    rel = ((meta.get("detected") or {}).get("primary") or {}).get("path") or ""
+    base = os.path.basename(rel)
+    stripped = rel.split("/", 1)[1] if "/" in rel else rel
+    for cand in (os.path.join(arena, "target", stripped),
+                 os.path.join(arena, "target", rel),
+                 os.path.join(arena, "target", base),
+                 os.path.join(arena, rel)):
+        if os.path.isfile(cand):
+            return cand
+    troot = os.path.join(arena, "target")
+    for dirpath, _dirs, files in os.walk(troot):
+        if base in files:
+            return os.path.join(dirpath, base)
+    return None
+
+
+def _run_binary(path, argv, stdin_text, timeout):
+    """`timeout -k 2 N` in front of the argv, not just a subprocess timeout.
+
+    A crackme may fork, spawn a shell, or block on a tty; coreutils `timeout` signals the
+    whole job and then SIGKILLs it, where subprocess.timeout only kills the direct child.
+    """
+    cmd = [path] + list(argv)
+    if shutil.which("timeout"):
+        cmd = ["timeout", "-k", "2", str(timeout)] + cmd
+    env = {"PATH": "/usr/bin:/bin", "HOME": os.path.dirname(path), "LANG": "C",
+           "TERM": "dumb"}
+    with tempfile.TemporaryDirectory(prefix="repipe-grade-") as tmp:
+        try:
+            proc = subprocess.run(cmd, input=(stdin_text or "").encode(),
+                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                  cwd=tmp, env=env, timeout=timeout + 5)
+        except (OSError, subprocess.SubprocessError) as exc:
+            return None, "", "%s: %s" % (type(exc).__name__, exc)
+    return (proc.returncode,
+            proc.stdout.decode("utf-8", "replace"),
+            proc.stderr.decode("utf-8", "replace"))
+
+
+def _tier_binary(meta, arena, name, value, timeout=None):
+    """Best-effort and frankly heuristic: crackmes share no success protocol.
+
+    The name/serial is fed both on stdin (the common shape) and on argv, and the output is
+    keyword-matched. A failure keyword beats a success keyword, because "invalid serial
+    format -- correct length though" is a rejection. If neither fires the tier returns
+    `inconclusive` rather than guessing from the exit code, which crackmes use arbitrarily.
+    """
+    timeout = BINARY_TIMEOUT if timeout is None else int(timeout)
+    tier = {"tier": "binary-accepts", "confidence": "high", "heuristic": True}
+    if not value:
+        tier.update(result="skipped", why="the report carried no answer")
+        return tier
+    if not arena:
+        tier.update(result="skipped", why="no arena given; the dataset copy is never run")
+        return tier
+    path = arena_binary(arena, meta)
+    if not path:
+        tier.update(result="skipped", why="no arena copy of the primary binary found")
+        return tier
+    if not os.access(path, os.X_OK):
+        tier.update(result="skipped", path=path,
+                    why="arena copy is not executable (workspace.py should chmod 0755; "
+                        "4 of 287 shipped binaries are mode 600 and 54 are 644)")
+        return tier
+
+    fields = [name, value] if name else [value]
+    attempts = [{"how": "stdin", "argv": [], "stdin": "\n".join(fields) + "\n"},
+                {"how": "argv", "argv": fields, "stdin": ""}]
+    tried = []
+    for att in attempts:
+        code, out, err = _run_binary(path, att["argv"], att["stdin"], timeout)
+        blob = (out or "") + "\n" + (err or "")
+        hit_ok = bool(_SUCCESS.search(blob))
+        hit_no = bool(_FAILURE.search(blob))
+        tried.append({"how": att["how"], "exit": code,
+                      "success_keyword": hit_ok, "failure_keyword": hit_no,
+                      "output_sha1": _digest(blob)})
+        if hit_ok and not hit_no:
+            tier.update(result="pass", path=path, attempts=tried,
+                        why="the binary printed a success indication for this answer")
+            return tier
+    tier["path"] = path
+    tier["attempts"] = tried
+    if any(t["failure_keyword"] and not t["success_keyword"] for t in tried):
+        tier.update(result="fail", why="the binary printed a rejection for this answer")
+    else:
+        tier.update(result="inconclusive",
+                    why="the binary printed no recognisable accept or reject")
+    return tier
+
+
+# --- tier 3: the reconstructed verifier -------------------------------------
+
+def _tier_verifier(meta, hexid, name, value, timeout=None):
+    """`python3 verifier.py verify <name> <serial>` -- STDOUT only, subprocess only.
+
+    The CLI contract: `verify` prints exactly `1` or `0` on stdout and exits 0 EITHER WAY, so
+    the exit code carries no verdict at all; any other mode writes usage to stderr and exits
+    2. Anything other than a clean `1`/`0` (a NotImplementedError traceback, a quarantined
+    stub, a timeout) is `inconclusive`, never a rejection of the tester.
+    """
+    timeout = VERIFIER_TIMEOUT if timeout is None else int(timeout)
+    gt = meta.get("ground_truth") or {}
+    tier = {"tier": "verifier-agrees", "confidence": "low", "confidence_note": LOW_CONFIDENCE_NOTE}
+    rel = gt.get("verifier")
+    if not rel:
+        tier.update(result="skipped", why="this challenge ships no verifier.py")
+        return tier
+    path = challenge_dir(hexid) / rel
+    if not os.path.isfile(path):
+        tier.update(result="skipped", why="meta names a verifier that is not on disk")
+        return tier
+    if not value:
+        tier.update(result="skipped", why="the report carried no answer")
+        return tier
+    if not name and (gt.get("verifier_interface") or "") == "name+serial":
+        tier.update(result="inconclusive",
+                    why="verifier_interface is name+serial but the report gave no name")
+        return tier
+
+    tier["self_test_pass"] = gt.get("verifier_self_test_pass")
+    cmd = [sys.executable, str(path), "verify", name or "", value]
+    with tempfile.TemporaryDirectory(prefix="repipe-verify-") as tmp:
+        try:
+            proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                  cwd=tmp, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            tier.update(result="inconclusive", why="verifier.py timed out after %ds" % timeout)
+            return tier
+        except OSError as exc:
+            tier.update(result="inconclusive", why="could not run verifier.py: %s" % exc)
+            return tier
+    out = proc.stdout.decode("utf-8", "replace").strip()
+    err = proc.stderr.decode("utf-8", "replace").strip()
+    tier["exit"] = proc.returncode
+    tier["stdout"] = out[:40]
+    if out == "1":
+        tier.update(result="pass", why="verifier.py printed 1 (LOW confidence, see note)")
+    elif out == "0":
+        tier.update(result="fail", why="verifier.py printed 0 (LOW confidence, see note)")
+    else:
+        reason = "NotImplementedError" if "NotImplementedError" in err else "unusable output"
+        tier.update(result="inconclusive",
+                    why="verifier.py produced %s, not a 1/0 verdict" % reason,
+                    stderr_tail=err[-200:])
+    return tier
+
+
+# --- the verdict ------------------------------------------------------------
+
+def _effective_outcome(reported, solved, confidence, contaminated):
+    """What a round's coverage counts this attempt as.
+
+    The tester's self-report is the default: it is the only possible source for `gave_up`,
+    which is the outcome this pipeline most wants to see. Grading only ever DOWNGRADES it --
+    a run claiming `solved` that the flag refutes is recorded `partial`, and a contaminated
+    run is `voided` whatever it claimed. Grading never upgrades a `gave_up` into a `solved`,
+    because a tester that quit did not solve anything no matter what its answer field says.
+    """
+    if contaminated:
+        return "voided"
+    if reported is None:
+        return "solved" if solved else None
+    if reported == "solved" and not solved and confidence == "high":
+        return "partial"
+    return reported
+
+
+def grade(hexid, report, arena=None):
+    """Grade one tester report against the strongest ground truth this challenge has.
+
+    Tiers are tried in descending confidence and the FIRST decisive one wins; a lower tier
+    never overrides a higher one, so a hallucinating verifier cannot promote an answer the
+    flag already refuted. A tier that cannot run is `skipped` and a tier that ran without
+    deciding is `inconclusive` -- neither counts against the tester.
+
+    Returns a dict carrying every tier's outcome, so the dashboard can show *why* a run was
+    called solved. It never carries the flag or the raw answer: an answer that matched IS the
+    flag, and these records are persisted and rendered.
+    """
+    meta = load_meta(hexid)
+    rep = load_report(report)
+    name, value, kind = _answer_of(rep)
+    gt = meta.get("ground_truth") or {}
+
+    tiers = [_tier_flag(meta, value),
+             _tier_binary(meta, arena, name, value),
+             _tier_verifier(meta, hexid, name, value)]
+
+    verdict, solved, confidence, why = "unverifiable", False, "none", None
+    for tier in tiers:
+        if tier["result"] == "pass":
+            verdict, solved, confidence, why = tier["tier"], True, tier["confidence"], tier["why"]
+            break
+        if tier["result"] == "fail":
+            verdict = TIER_NEGATIVE[tier["tier"]]
+            solved, confidence, why = False, tier["confidence"], tier["why"]
+            break
+    if verdict == "unverifiable":
+        if not value:
+            verdict, why = "no-answer", "the tester reported no answer to grade"
+        else:
+            why = "no tier could decide: %s" % "; ".join(
+                "%s %s" % (t["tier"], t["result"]) for t in tiers)
+
+    out = {
+        "schema": SCHEMA,
+        "hexid": hexid,
+        "challenge": meta.get("name"),
+        "verdict": verdict,
+        "solved": solved,
+        "confidence": confidence,
+        "why": why,
+        "outcome": _effective_outcome(rep.get("outcome"), solved, confidence, False),
+        "reported_outcome": rep.get("outcome"),
+        "gave_up_reason": rep.get("gave_up_reason"),
+        "answer_kind": kind,
+        "answer_present": bool(value),
+        "answer_sha1": _digest(value),
+        "answer_name": name,
+        "machine_checkable": bool(gt.get("machine_checkable")),
+        "ground_truth": {
+            "has_flag": bool(gt.get("flag")),
+            "verifier": gt.get("verifier"),
+            "verifier_self_test_pass": gt.get("verifier_self_test_pass"),
+            "verifier_interface": gt.get("verifier_interface"),
+        },
+        "tiers": tiers,
+        "contaminated": False,
+        "outcome_voided": False,
+        "graded_at": datetime.datetime.now().replace(microsecond=0).isoformat(),
+    }
+    if confidence == "low":
+        out["confidence_note"] = LOW_CONFIDENCE_NOTE
+    return out
+
+
+# --- the tripwire -----------------------------------------------------------
+
+def _builtin_scan(text, meta):
+    """Fallback for when redact.py is not importable, so grading is never silently blind.
+
+    Same four signals the runbook names: the dataset path, the literal flag, `crackmes.one`
+    and `solutions/`. redact.scan_for_leak is preferred because it is the module that owns
+    the spoiler vocabulary; this exists so a missing sibling degrades loudly, not quietly.
+    """
+    hits = []
+    flag = (meta.get("ground_truth") or {}).get("flag")
+    hexid = meta.get("hexid") or ""
+    probes = [(str(config.dataset_root()), "dataset-path"),
+              ("kuna-re-dataset", "dataset-name"),
+              ("crackmes.one", "crackmes-one"),
+              ("solutions/", "solutions-dir")]
+    if hexid:
+        probes.append((hexid, "hexid"))
+    for needle, label in probes:
+        if needle and needle in text:
+            hits.append("%s: transcript contains %r" % (label, needle))
+    if flag and flag in text:
+        hits.append("flag: transcript contains the literal ground_truth.flag")
+    return hits
+
+
+def tripwire(transcript_text, hexid):
+    """Did this run see the answer rather than work it out?
+
+    A hit VOIDS THE OUTCOME but KEEPS THE OBSERVATIONS. That asymmetry is deliberate: a
+    tester that read `solutions/<hexid>/` has told us nothing about whether the binary was
+    solvable with kuna, but the twenty minutes it spent fighting `kuna functions` before it
+    cheated are still twenty minutes of real friction, and friction is the product. Throwing
+    the whole run away would delete evidence to punish a sandbox failure -- and with
+    REPIPE_SANDBOX=none the sandbox failure is the pipeline's own.
+
+    Hits are scrubbed of the flag before they are returned; these dicts are persisted.
+    """
+    meta = load_meta(hexid)
+    text = transcript_text or ""
+    try:
+        from . import redact
+        hits = list(redact.scan_for_leak(text, meta))
+        scanner = "redact.scan_for_leak"
+    except Exception:
+        hits = _builtin_scan(text, meta)
+        scanner = "builtin-fallback"
+    flag = (meta.get("ground_truth") or {}).get("flag")
+    if flag:
+        hits = [h.replace(flag, "<flag>") if isinstance(h, str) else h for h in hits]
+    contaminated = bool(hits)
+    return {
+        "hexid": hexid,
+        "contaminated": contaminated,
+        "hits": hits,
+        "scanner": scanner,
+        "outcome_voided": contaminated,
+        "observations_kept": True,
+        "sandbox": config.sandbox_mode(),
+    }
+
+
+def apply_tripwire(verdict, tw):
+    """Fold a tripwire result into a verdict: the outcome dies, the observations do not."""
+    out = dict(verdict)
+    out["contaminated"] = bool(tw.get("contaminated"))
+    out["tripwire"] = {"hits": tw.get("hits", []), "scanner": tw.get("scanner")}
+    if tw.get("contaminated"):
+        out["graded_verdict"] = verdict.get("verdict")
+        out["verdict"] = "voided-contaminated"
+        out["solved"] = False
+        out["confidence"] = "none"
+        out["outcome"] = "voided"
+        out["outcome_voided"] = True
+        out["observations_kept"] = True
+        out["why"] = ("outcome voided: the transcript shows the answer was available to the "
+                      "tester. Observations from this run are still ingested.")
+    return out
+
+
+# --- persistence ------------------------------------------------------------
+
+def outcome_path(round_n, hexid):
+    return config.rounds_dir() / str(round_n) / "outcomes" / ("%s.json" % os.path.basename(hexid))
+
+
+def record(round_n, verdict):
+    """Persist one graded outcome for sample.coverage() and the dashboard. Atomic, and one
+    file per challenge so concurrent T_DRAIN grading never interleaves."""
+    p = outcome_path(round_n, verdict["hexid"])
+    os.makedirs(os.path.dirname(p), exist_ok=True)
+    tmp = str(p) + ".tmp"
+    with open(tmp, "w") as fh:
+        json.dump(verdict, fh, indent=2)
+        fh.write("\n")
+    os.replace(tmp, p)
+    return p
+
+
+# --- CLI --------------------------------------------------------------------
+
+def _print_verdict(v):
+    print("%s  %s" % (v["hexid"], v["challenge"]))
+    print("  verdict    %s   solved=%s   confidence=%s"
+          % (v["verdict"], v["solved"], v["confidence"]))
+    print("  why        %s" % v["why"])
+    print("  answer     kind=%s present=%s sha1=%s"
+          % (v["answer_kind"], v["answer_present"], v["answer_sha1"]))
+    for t in v["tiers"]:
+        print("  tier %-16s %-13s %s" % (t["tier"], t["result"], t.get("why", "")))
+    if v.get("confidence_note"):
+        print("  NOTE       %s" % v["confidence_note"])
+    if v.get("contaminated"):
+        print("  CONTAMINATED  outcome voided, observations kept")
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(prog="python -m scripts.repipe.grade")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("verdict", help="grade one tester report")
+    sp.add_argument("--hexid", required=True)
+    sp.add_argument("--report", default=None, help="path to the tester's report.json")
+    sp.add_argument("--answer", default=None, help="answer value, if there is no report")
+    sp.add_argument("--name", default=None, help="username, for name+serial crackmes")
+    sp.add_argument("--arena", default=None, help="arena dir, enables the binary-accepts tier")
+    sp.add_argument("--transcript", default=None, help="rollout to run the tripwire over")
+    sp.add_argument("--round", type=int, default=None)
+    sp.add_argument("--record", action="store_true", help="persist to rounds/<N>/outcomes/")
+    sp.add_argument("--json", action="store_true")
+
+    sp = sub.add_parser("tripwire", help="scan a rollout for spoiler leakage")
+    sp.add_argument("--hexid", required=True)
+    sp.add_argument("--transcript", required=True, help="file, or - for stdin")
+    sp.add_argument("--json", action="store_true")
+
+    args = p.parse_args(argv)
+
+    if args.cmd == "tripwire":
+        text = sys.stdin.read() if args.transcript == "-" else \
+            open(args.transcript, errors="replace").read()
+        tw = tripwire(text, args.hexid)
+        if args.json:
+            print(json.dumps(tw, indent=2))
+        else:
+            print("contaminated=%s  scanner=%s  sandbox=%s"
+                  % (tw["contaminated"], tw["scanner"], tw["sandbox"]))
+            for h in tw["hits"]:
+                print("  hit  %s" % h)
+            if tw["contaminated"]:
+                print("  outcome voided; observations kept")
+        return 1 if tw["contaminated"] else 0
+
+    if args.report:
+        report = load_report(args.report)
+    else:
+        report = {"answer": {"kind": "flag", "value": args.answer, "name": args.name}}
+    arena = args.arena
+    if arena is None and args.round is not None:
+        cand = config.arena_dir() / str(args.round) / args.hexid
+        arena = str(cand) if os.path.isdir(cand) else None
+
+    verdict = grade(args.hexid, report, arena=arena)
+    if args.transcript:
+        text = sys.stdin.read() if args.transcript == "-" else \
+            open(args.transcript, errors="replace").read()
+        verdict = apply_tripwire(verdict, tripwire(text, args.hexid))
+    if args.record:
+        if args.round is None:
+            print("--record needs --round", file=sys.stderr)
+            return 2
+        path = record(args.round, verdict)
+        if not args.json:
+            print("wrote %s" % path)
+    if args.json:
+        print(json.dumps(verdict, indent=2))
+    else:
+        _print_verdict(verdict)
+    return 0 if verdict["solved"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repipe/mergecheck.py
+++ b/scripts/repipe/mergecheck.py
@@ -1,0 +1,674 @@
+"""The three merge guards, one per failure shape this repo has actually produced.
+
+docs/decbench-loop.md, "Shared counters in a busy queue -- the merge is not the hard part":
+round 2 ran up to four output-changing PRs concurrently over the same handful of hard-coded
+counters and produced three distinct failure shapes, **only one of which announced itself**.
+This module is one guard per shape, run after the rebase and before the suite:
+
+  shape A -- LOUD conflict. The DIV number for #257 raced 55 -> 56 -> 57 -> 58 as #252/#253/
+    #254 claimed each in turn. git stops you, so the danger is not missing it: it is
+    renumbering the registry row and forgetting the other references. DIV numbers are claimed
+    at MERGE, not on the branch, so `check_div` re-derives the next free number and lists
+    every place each claimed number is referenced -- the history row, the option's `use_when`
+    prose, the spec chapter, the PR body.
+
+  shape B -- SILENT identical-edit auto-merge. `catalog_bytecompat.rs` kept 86 because BOTH
+    sides had made the identical `85 -> 86` edit; git merged cleanly, there was no conflict
+    and no diff to review, and the answer was 87 (#254). The only guard that works is to
+    never trust the merged value: `assert_rederived` re-derives every counter from a fresh
+    capture on the rebased tree (scripts/repipe/counters.py) and asserts against the file.
+
+  shape C -- SILENT keep-both auto-merge. A `docs/baseline-stages.json` auto-merge left a
+    stale `data_footer: 375` against 381 real keys (#253), and five rounds of keep-both
+    resolution duplicated a row in `tests/stages/README.md`. Keep-both is git's safe default
+    and it is exactly wrong for a counter or a table. `assert_keepboth` diffs against
+    `origin/main` and asserts that nothing was REMOVED and nothing was ADDED TWICE.
+
+And one absolute: **`docs/baseline.json` is the upstream baseline and must never be
+re-pinned.** `tests/stages/README.md` says so, the stage corpus exists in its own directory
+so that it is never touched, and `assert_baseline_untouched` is a hard reject.
+
+Nothing here is caught by reviewing the *conflict*; it is caught by the build and the suite,
+so run this AFTER the rebase, not before it.
+
+CLI:
+    python -m scripts.repipe.mergecheck --against origin/main
+    python -m scripts.repipe.mergecheck --json
+    python -m scripts.repipe.mergecheck --self-test      # three synthetic git histories
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from . import config, counters
+from .counters import line_of as _line_of
+
+REL_BASELINE = "docs/baseline.json"
+REL_BASELINE_STAGES = "docs/baseline-stages.json"
+REL_HISTORY = "docs/history.md"
+
+# The files a keep-both resolution silently corrupts: counters, tables and generated lists.
+KEEPBOTH_PATHS = (
+    REL_BASELINE_STAGES,
+    "tests/stages/README.md",
+    "docs/history.md",
+    "docs/options.md",
+    "decompiler/crates/kuna-decomp/phases.toml",
+)
+
+REJECT, WARN, INFO = "reject", "warn", "info"
+
+
+@dataclass
+class Finding:
+    """One merge hazard. ``severity`` REJECT means do not merge until it is resolved."""
+    shape: str
+    check: str
+    severity: str
+    id: str
+    path: str
+    line: int
+    message: str
+    detail: str = ""
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+    def oneline(self) -> str:
+        where = "{}:{}".format(self.path, self.line) if self.path else "-"
+        tail = "\n         " + self.detail.replace("\n", "\n         ") if self.detail else ""
+        return "[{}] shape-{} {:<22} {}  {}{}".format(
+            self.severity.upper(), self.shape, self.check, where, self.message, tail)
+
+
+# --- git --------------------------------------------------------------------
+
+def _git(repo, *args):
+    proc = subprocess.run(["git", "-C", str(repo)] + list(args),
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return (proc.returncode,
+            proc.stdout.decode("utf-8", "replace"),
+            proc.stderr.decode("utf-8", "replace"))
+
+
+def _root(repo=None) -> Path:
+    return Path(repo) if repo else config.repo_root()
+
+
+def have_ref(base_ref, repo=None) -> bool:
+    return _git(_root(repo), "rev-parse", "--verify", "--quiet", base_ref + "^{commit}")[0] == 0
+
+
+def show(base_ref, rel, repo=None):
+    """The base_ref content of ``rel``, or None if the ref has no such file."""
+    rc, out, _ = _git(_root(repo), "show", "{}:{}".format(base_ref, rel))
+    return out if rc == 0 else None
+
+
+# --- shape A: the DIV number ------------------------------------------------
+
+_DIV_ROW_RX = re.compile(r"^\|\s*DIV-(\d+)\s*\|", re.M)
+
+
+def div_rows(text):
+    """Every DIV number claimed by a registry row in ``docs/history.md``, in file order."""
+    return [int(m.group(1)) for m in _DIV_ROW_RX.finditer(text or "")]
+
+
+def next_free_div(text) -> int:
+    rows = div_rows(text)
+    return (max(rows) + 1) if rows else 1
+
+
+def div_references(num, repo=None, cap=40, width=150):
+    """Every tracked file:line mentioning DIV-<num>, so a renumber can rewrite all of them.
+
+    Trimmed hard: a single `docs/history.md` registry row is multiple KB of prose, and a
+    guard whose output nobody reads is not a guard. The file:line prefix is what the merger
+    acts on; the text after it is only there to recognise the hit.
+    """
+    rc, out, _ = _git(_root(repo), "grep", "-nE", r"DIV-{}([^0-9]|$)".format(num))
+    if rc not in (0, 1):
+        return None
+    hits = [ln for ln in out.splitlines() if ln.strip()]
+    trimmed = [(ln[:width] + " ...") if len(ln) > width else ln for ln in hits[:cap]]
+    if len(hits) > cap:
+        trimmed.append("... and {} more references".format(len(hits) - cap))
+    return trimmed
+
+
+def check_div(base_ref="origin/main", repo=None):
+    """Shape A. Re-derive the next free DIV and surface every reference to a claimed one.
+
+    The number is claimed at merge, not on the branch, so this reports rather than rewrites:
+    it prints the number the merger must use, and the exact set of lines that must change
+    with it -- the registry row, the option's `use_when` prose, the spec chapter, the code
+    comments. A number a sibling already merged is a hard reject; renumbering only the row
+    and leaving the references behind is how the 55 -> 58 race stayed broken.
+    """
+    root = _root(repo)
+    head_path = root / REL_HISTORY
+    if not head_path.exists():
+        return [Finding("A", "div-number", WARN, "history-missing", REL_HISTORY, 0,
+                        "docs/history.md not found; the DIV guard cannot run")]
+    head_text = head_path.read_text(encoding="utf-8", errors="replace")
+    head_rows = div_rows(head_text)
+    next_free = next_free_div(head_text)
+    out = [Finding("A", "div-number", INFO, "next-free-div", REL_HISTORY, 0,
+                   "next free DIV is DIV-{} ({} rows claimed, highest DIV-{})".format(
+                       next_free, len(head_rows), max(head_rows or [0])),
+                   "DIV numbers are claimed at MERGE, not on the branch. Re-check this "
+                   "number after the rebase; every number this branch claims is listed "
+                   "below with the references a renumber must rewrite.")]
+
+    def rows_at(n):
+        return [_line_of(head_text, m.start()) for m in _DIV_ROW_RX.finditer(head_text)
+                if int(m.group(1)) == n]
+
+    def renumber_detail(n):
+        refs = div_references(n, repo)
+        head = "renumber DIV-{} to DIV-{} here and in every reference:".format(n, next_free)
+        return head + "\n" + ("\n".join(refs) if refs else "(no references found)")
+
+    have_base = have_ref(base_ref, repo)
+    base_text = show(base_ref, REL_HISTORY, repo) if have_base else None
+    if base_text is None:
+        out.append(Finding("A", "div-number", WARN, "base-ref-missing", REL_HISTORY, 0,
+                           "no {} to diff against; claimed-number check skipped".format(base_ref)))
+        base_rows = head_rows
+    else:
+        base_rows = div_rows(base_text)
+
+    base_count = collections.Counter(base_rows)
+    head_count = collections.Counter(head_rows)
+    collided = set()
+
+    if base_text is not None:
+        for n in sorted(head_count):
+            if head_count[n] > base_count.get(n, 0) and base_count.get(n, 0) > 0:
+                collided.add(n)
+                out.append(Finding(
+                    "A", "div-number", REJECT, "div-collision", REL_HISTORY, rows_at(n)[-1],
+                    "a sibling already merged DIV-{} on {}; this branch claims it again "
+                    "(rows at lines {})".format(n, base_ref,
+                                                ", ".join(str(x) for x in rows_at(n))),
+                    renumber_detail(n)))
+        for n in sorted(set(head_count) - set(base_count)):
+            out.append(Finding(
+                "A", "div-number", INFO, "div-claimed-by-branch", REL_HISTORY, rows_at(n)[0],
+                "this branch claims DIV-{}; the next free number on {} is DIV-{}".format(
+                    n, base_ref, next_free_div(base_text)),
+                renumber_detail(n) if n != next_free_div(base_text)
+                else "the number is still free; confirm it after the rebase, then check "
+                     "every reference:\n" + "\n".join(div_references(n, repo) or [])))
+
+    for n in sorted(n for n, c in head_count.items() if c > 1 and n not in collided):
+        out.append(Finding("A", "div-number", WARN, "div-claimed-twice", REL_HISTORY,
+                           rows_at(n)[-1],
+                           "DIV-{} has {} registry rows (lines {})".format(
+                               n, head_count[n], ", ".join(str(x) for x in rows_at(n))),
+                           "already on {} the same way, so this is history to reconcile "
+                           "rather than a merge blocker; do not reuse either number".format(
+                               base_ref)))
+    return out
+
+
+# --- shape B: re-derive, never trust the merged value ------------------------
+
+def assert_rederived(repo=None, kuna=None):
+    """Shape B. Every shared counter is re-derived on the rebased tree and asserted.
+
+    A clean auto-merge of two identical `85 -> 86` edits leaves a file that no conflict, no
+    diff and no reviewer will flag. Only a measurement catches it, so this ignores the merged
+    value entirely and compares against `counters.derive()`.
+    """
+    try:
+        derived = counters.derive(repo=repo, kuna=kuna)
+    except counters.DeriveError as exc:
+        return [Finding("B", "rederive", REJECT, "derive-failed", "", 0,
+                        "could not re-derive the counters: {}".format(exc),
+                        "a counter that cannot be measured cannot be merged")]
+    out = []
+    for d in counters.check(derived=derived, repo=repo):
+        out.append(Finding(
+            "B", "rederive", REJECT, d.site,
+            os.path.relpath(d.path, derived["repo"]) if os.path.isabs(d.path) else d.path,
+            d.line,
+            "{} says {}, the tree says {}".format(d.counter, d.found, d.expected),
+            d.detail or ("run `python -m scripts.repipe.counters --fix`" if d.fixable
+                         else "needs an operator, not a rewrite")))
+    if not out:
+        out.append(Finding("B", "rederive", INFO, "counters-agree", "", 0,
+                           "all shared counters re-derived and agree: {} settables, "
+                           "tiers ({}, {}, {}), {} corpus files, next ElementId {}".format(
+                               derived["settables"], *derived["tier_tuple"],
+                               derived["corpus_files"], derived["next_element_id"])))
+    return out
+
+
+# --- shape C: keep-both removed nothing and added nothing twice --------------
+
+def _significant(line: str) -> bool:
+    """Lines worth diffing as a multiset: real content, not JSON/markdown scaffolding."""
+    s = line.strip()
+    return len(s) >= 8 and any(c.isalnum() for c in s)
+
+
+def _norm(line: str) -> str:
+    """A separator is not content: the last element of a JSON list gains a `,` when the list
+    grows, and counting that as a removal-plus-addition buries the real findings in noise."""
+    return line.strip().rstrip(",")
+
+
+def _footer_findings(path, rel, text, check):
+    """A `[passing, total]` footer must equal the key count it summarises.
+
+    This is the #253 shape exactly: keep-both merged both sides' new keys and left the
+    footer at 375 while the file carried 381. The footer is not a merge artifact anyone
+    reviews, so it is asserted against the thing it counts.
+    """
+    try:
+        data = json.loads(text)
+    except ValueError:
+        return []
+    if not isinstance(data, dict) or "data_footer" not in data or "passing" not in data:
+        return []
+    footer, passing = data["data_footer"], data["passing"]
+    if not isinstance(passing, list) or not isinstance(footer, list) or not footer:
+        return []
+    out = []
+    if footer[0] != len(passing):
+        out.append(Finding("C", check, REJECT, "stale-footer", rel, 0,
+                           "data_footer says {} passing, the file carries {} keys".format(
+                               footer[0], len(passing)),
+                           "re-RECORD it, never merge it:\n"
+                           "  kuna test --datatests --datatests-dir tests/stages "
+                           "--save-baseline {}".format(rel)))
+    if len(footer) > 1 and footer[1] < footer[0]:
+        out.append(Finding("C", check, REJECT, "impossible-footer", rel, 0,
+                           "data_footer {} has more passing than total".format(footer)))
+    dupes = [k for k, c in collections.Counter(
+        x for x in passing if isinstance(x, str)).items() if c > 1]
+    for k in sorted(dupes)[:20]:
+        out.append(Finding("C", check, REJECT, "key-added-twice", rel, 0,
+                           "baseline key appears more than once: {}".format(k[:120]),
+                           "keep-both duplicated it; re-record the baseline"))
+    return out
+
+
+def assert_keepboth(path, base_ref="origin/main", repo=None):
+    """Shape C. Diff ``path`` against ``base_ref``: nothing REMOVED, nothing ADDED TWICE.
+
+    git's keep-both is the safe default for prose and exactly wrong for a counter or a
+    table -- a duplicated table row survives every gate in this repo. Line multisets are
+    compared rather than a textual diff, so a row re-inserted at a different offset is
+    still caught. For a `[passing, total]`-footered baseline the footer is additionally
+    asserted against its own key count.
+    """
+    root = _root(repo)
+    p = Path(path)
+    if not p.is_absolute():
+        p = root / path
+    rel = os.path.relpath(str(p), str(root))
+    if not p.exists():
+        return []
+    head_text = p.read_text(encoding="utf-8", errors="replace")
+    out = _footer_findings(p, rel, head_text, "assert-keepboth")
+
+    if not have_ref(base_ref, repo):
+        out.append(Finding("C", "assert-keepboth", WARN, "base-ref-missing", rel, 0,
+                           "no {} to diff against; removed/added-twice check skipped".format(
+                               base_ref)))
+        return out
+    base_text = show(base_ref, rel, repo)
+    if base_text is None:
+        return out
+
+    base_c = collections.Counter(_norm(l) for l in base_text.splitlines() if _significant(l))
+    head_c = collections.Counter(_norm(l) for l in head_text.splitlines() if _significant(l))
+
+    removed = [(l, n - head_c.get(l, 0)) for l, n in base_c.items() if head_c.get(l, 0) < n]
+    for line, missing in sorted(removed)[:20]:
+        out.append(Finding("C", "assert-keepboth", REJECT, "line-removed", rel, 0,
+                           "{} line(s) present on {} are gone".format(missing, base_ref),
+                           line[:200]))
+    if len(removed) > 20:
+        out.append(Finding("C", "assert-keepboth", REJECT, "line-removed", rel, 0,
+                           "... and {} more removed lines".format(len(removed) - 20)))
+
+    twice = [(l, n) for l, n in head_c.items() if n >= 2 and n > base_c.get(l, 0)]
+    for line, n in sorted(twice)[:20]:
+        out.append(Finding("C", "assert-keepboth", REJECT, "line-added-twice", rel, 0,
+                           "line appears {}x (was {}x on {})".format(
+                               n, base_c.get(line, 0), base_ref),
+                           line[:200]))
+    if len(twice) > 20:
+        out.append(Finding("C", "assert-keepboth", REJECT, "line-added-twice", rel, 0,
+                           "... and {} more duplicated lines".format(len(twice) - 20)))
+    return out
+
+
+# --- the absolute: docs/baseline.json is never re-pinned --------------------
+
+def assert_baseline_untouched(base_ref="origin/main", repo=None):
+    """`docs/baseline.json` is the UPSTREAM baseline. Re-pinning it is a hard reject.
+
+    The 675 upstream assertions are the port's oracle. `tests/stages/` exists in its own
+    directory with its own baseline precisely so that this file is never touched; a branch
+    that re-records it has hidden a regression rather than fixed one.
+    """
+    root = _root(repo)
+    p = root / REL_BASELINE
+    if not p.exists():
+        return [Finding("-", "baseline-untouched", WARN, "baseline-missing", REL_BASELINE, 0,
+                        "docs/baseline.json not found")]
+    if not have_ref(base_ref, repo):
+        return [Finding("-", "baseline-untouched", WARN, "base-ref-missing", REL_BASELINE, 0,
+                        "no {} to compare against; the baseline guard could not run".format(
+                            base_ref))]
+    base_text = show(base_ref, REL_BASELINE, repo)
+    head_text = p.read_text(encoding="utf-8", errors="replace")
+    if base_text is None:
+        return [Finding("-", "baseline-untouched", REJECT, "baseline-added", REL_BASELINE, 0,
+                        "docs/baseline.json does not exist on {}".format(base_ref))]
+    if base_text != head_text:
+        try:
+            b, h = json.loads(base_text), json.loads(head_text)
+            delta = "base {} keys -> head {} keys".format(
+                len(b.get("passing", [])), len(h.get("passing", [])))
+        except (ValueError, AttributeError):
+            delta = "{} bytes -> {} bytes".format(len(base_text), len(head_text))
+        return [Finding("-", "baseline-untouched", REJECT, "baseline-repinned", REL_BASELINE, 0,
+                        "docs/baseline.json was re-pinned ({})".format(delta),
+                        "HARD REJECT. The upstream baseline is the oracle and is never "
+                        "re-recorded. Revert it: git checkout {} -- {}".format(
+                            base_ref, REL_BASELINE))]
+    return [Finding("-", "baseline-untouched", INFO, "baseline-clean", REL_BASELINE, 0,
+                    "docs/baseline.json is byte-identical to {}".format(base_ref))]
+
+
+# --- the whole gate ---------------------------------------------------------
+
+def run_all(base_ref="origin/main", repo=None, kuna=None, paths=None):
+    """Every guard, in merge order. Any REJECT finding means: do not merge yet."""
+    out = []
+    out.extend(assert_baseline_untouched(base_ref, repo=repo))
+    out.extend(check_div(base_ref, repo=repo))
+    out.extend(assert_rederived(repo=repo, kuna=kuna))
+    for rel in (paths if paths is not None else KEEPBOTH_PATHS):
+        out.extend(assert_keepboth(rel, base_ref, repo=repo))
+    return out
+
+
+def rejects(findings):
+    return [f for f in findings if f.severity == REJECT]
+
+
+# --- self-test: three synthetic git histories -------------------------------
+
+_GIT_ENV = ("-c", "user.name=repipe-selftest", "-c", "user.email=repipe@localhost",
+            "-c", "commit.gpgsign=false", "-c", "init.defaultBranch=main")
+
+
+def _sh(repo, *args):
+    rc, out, err = _git(repo, *(_GIT_ENV + args))
+    if rc != 0 and args[0] not in ("merge",):
+        raise RuntimeError("git {} failed: {}".format(" ".join(args), err.strip()))
+    return rc, out, err
+
+
+def _write(repo, rel, text):
+    p = Path(repo) / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def _new_repo(base):
+    os.makedirs(base, exist_ok=True)
+    _sh(base, "init", "-q", base)
+    return base
+
+
+def _selftest_shape_b(root):
+    """base 85 / ours 86 / theirs 86 -> git merges cleanly, the truth is 87.
+
+    Both branches make the byte-identical `85 -> 86` edit to the guard while adding a
+    different item in a different hunk, which is the #254 shape: no conflict, no diff, and a
+    count one short. The guard re-derives (count the items) instead of trusting the merge.
+    """
+    repo = _new_repo(os.path.join(root, "shape-b"))
+    guard = 'assert_eq!(count, {}, "corpus file count drifted");\n'
+    items = ["item-{:04d}".format(i) for i in range(1, 86)]
+    _write(repo, "items.txt", "\n".join(items) + "\n")
+    _write(repo, "guard.rs", guard.format(85))
+    _sh(repo, "add", "-A"), _sh(repo, "commit", "-qm", "base: 85")
+    _sh(repo, "branch", "theirs")
+
+    _write(repo, "items.txt", "\n".join(items + ["item-ours"]) + "\n")
+    _write(repo, "guard.rs", guard.format(86))
+    _sh(repo, "add", "-A"), _sh(repo, "commit", "-qm", "ours: 85 -> 86")
+
+    _sh(repo, "checkout", "-q", "theirs")
+    _write(repo, "items.txt", "\n".join(["item-theirs"] + items) + "\n")
+    _write(repo, "guard.rs", guard.format(86))
+    _sh(repo, "add", "-A"), _sh(repo, "commit", "-qm", "theirs: 85 -> 86")
+
+    _sh(repo, "checkout", "-q", "main")
+    rc, _, _ = _sh(repo, "merge", "--no-edit", "-q", "theirs")
+
+    pattern = r'assert_eq!\(count, (\d+), "corpus file count drifted"\)'
+    merged = (Path(repo) / "guard.rs").read_text(encoding="utf-8")
+    merged_value = int(re.search(pattern, merged).group(1))
+    truth = sum(1 for l in (Path(repo) / "items.txt").read_text().splitlines() if l.strip())
+
+    drift = counters.assert_literal(Path(repo) / "guard.rs", pattern, truth,
+                                    site="selftest.guard", counter="corpus_files")
+    counters.rewrite_literal(Path(repo) / "guard.rs", pattern, truth)
+    after = int(re.search(pattern, (Path(repo) / "guard.rs").read_text()).group(1))
+
+    caught = (rc == 0 and merged_value == 86 and truth == 87 and bool(drift) and after == 87)
+    return {
+        "case": "B",
+        "name": "silent identical-edit auto-merge",
+        "caught": caught,
+        "log": "shape-B-averted" if caught else "shape-B-MISSED",
+        "merge_conflicted": rc != 0,
+        "merged_value": merged_value,
+        "rederived_value": truth,
+        "value_after_fix": after,
+        "drift": [d.oneline() for d in drift],
+        "repo": repo,
+    }
+
+
+def _selftest_shape_c(root):
+    """keep-both merged both sides' new keys; data_footer stayed at the pre-merge count.
+
+    The #253 shape: neither branch touched the footer, so there is nothing to conflict on
+    and the merged file claims 375 while carrying 381 keys.
+    """
+    repo = _new_repo(os.path.join(root, "shape-c"))
+    rel = "docs/baseline-stages.json"
+
+    def doc(keys, footer):
+        return json.dumps({"data_footer": [footer, footer], "passing": keys,
+                           "returncode": 0, "unit_footer": None}, indent=2) + "\n"
+
+    keys = ["data:STAGE #{:04d}: a stage assertion that is long enough to be significant".format(i)
+            for i in range(1, 376)]
+    _write(repo, rel, doc(keys, 375))
+    _sh(repo, "add", "-A"), _sh(repo, "commit", "-qm", "base: 375 keys")
+    _sh(repo, "branch", "theirs")
+
+    ours = keys[:10] + ["data:OURS #{}: a new stage assertion from our branch".format(i)
+                        for i in range(1, 4)] + keys[10:]
+    _write(repo, rel, doc(ours, 375))
+    _sh(repo, "add", "-A"), _sh(repo, "commit", "-qm", "ours: +3 keys")
+
+    _sh(repo, "checkout", "-q", "theirs")
+    theirs = keys + ["data:THEIRS #{}: a new stage assertion from their branch".format(i)
+                     for i in range(1, 4)]
+    _write(repo, rel, doc(theirs, 375))
+    _sh(repo, "add", "-A"), _sh(repo, "commit", "-qm", "theirs: +3 keys")
+
+    _sh(repo, "checkout", "-q", "main")
+    rc, _, _ = _sh(repo, "merge", "--no-edit", "-q", "theirs")
+
+    merged = json.loads((Path(repo) / rel).read_text(encoding="utf-8"))
+    findings = assert_keepboth(rel, "theirs", repo=repo)
+    stale = [f for f in findings if f.id == "stale-footer"]
+    caught = rc == 0 and bool(stale) and merged["data_footer"][0] != len(merged["passing"])
+    return {
+        "case": "C",
+        "name": "silent keep-both auto-merge (stale data_footer)",
+        "caught": caught,
+        "log": "shape-C-averted" if caught else "shape-C-MISSED",
+        "merge_conflicted": rc != 0,
+        "merged_footer": merged["data_footer"][0],
+        "real_key_count": len(merged["passing"]),
+        "findings": [f.oneline() for f in findings],
+        "repo": repo,
+    }
+
+
+def _selftest_shape_c2(root):
+    """Five rounds of keep-both duplicated a row in tests/stages/README.md.
+
+    Both branches add the same row at different offsets, so git keeps both copies and the
+    table carries it twice. No gate in this repo notices a duplicated table row.
+    """
+    repo = _new_repo(os.path.join(root, "shape-c2"))
+    rel = "tests/stages/README.md"
+    head = ["# Stage-model issue testcases", "", "| File | Issue | Stage / sub-stage |",
+            "|---|---|---|"]
+    rows = ["| `gh{n:04d}-case.xml` | [GH-{n}] | S{s} sub-stage decision point |".format(
+        n=1000 + i, s=i % 9) for i in range(1, 21)]
+    dup = "| `gh9999-newcase.xml` | [GH-9999] | S5 const-pointer decision point |"
+
+    _write(repo, rel, "\n".join(head + rows) + "\n")
+    _sh(repo, "add", "-A"), _sh(repo, "commit", "-qm", "base: 20 rows")
+    _sh(repo, "branch", "theirs")
+
+    _write(repo, rel, "\n".join(head + rows + [dup]) + "\n")
+    _sh(repo, "add", "-A"), _sh(repo, "commit", "-qm", "ours: append the row")
+
+    _sh(repo, "checkout", "-q", "theirs")
+    _write(repo, rel, "\n".join(head + rows[:3] + [dup] + rows[3:]) + "\n")
+    _sh(repo, "add", "-A"), _sh(repo, "commit", "-qm", "theirs: insert the same row")
+
+    _sh(repo, "checkout", "-q", "main")
+    rc, _, _ = _sh(repo, "merge", "--no-edit", "-q", "theirs")
+
+    text = (Path(repo) / rel).read_text(encoding="utf-8")
+    findings = assert_keepboth(rel, "theirs", repo=repo)
+    twice = [f for f in findings if f.id == "line-added-twice"]
+    caught = rc == 0 and text.count(dup) == 2 and bool(twice)
+    return {
+        "case": "C2",
+        "name": "silent keep-both auto-merge (duplicated table row)",
+        "caught": caught,
+        "log": "shape-C2-averted" if caught else "shape-C2-MISSED",
+        "merge_conflicted": rc != 0,
+        "row_occurrences": text.count(dup),
+        "findings": [f.oneline() for f in findings],
+        "repo": repo,
+    }
+
+
+def self_test(keep=False):
+    """Build the three histories in $TMPDIR and prove each shape is caught."""
+    if not shutil.which("git"):
+        return {"ok": False, "error": "git not on PATH"}
+    root = tempfile.mkdtemp(prefix="repipe-mergecheck-selftest-")
+    try:
+        cases = [_selftest_shape_b(root), _selftest_shape_c(root), _selftest_shape_c2(root)]
+        return {"ok": all(c["caught"] for c in cases), "scratch": root, "cases": cases}
+    finally:
+        if not keep:
+            shutil.rmtree(root, ignore_errors=True)
+
+
+# --- CLI --------------------------------------------------------------------
+
+def _print_selftest(res) -> None:
+    if not res.get("ok") and "error" in res:
+        print("self-test could not run: {}".format(res["error"]))
+        return
+    print("scratch: {}".format(res["scratch"]))
+    for c in res["cases"]:
+        print("")
+        print("shape {} -- {}".format(c["case"], c["name"]))
+        print("  git merged cleanly: {}".format("no" if c["merge_conflicted"] else "yes"))
+        if c["case"] == "B":
+            print("  merged value {} / re-derived {} / after fix {}".format(
+                c["merged_value"], c["rederived_value"], c["value_after_fix"]))
+            for d in c["drift"]:
+                print("  drift: {}".format(d))
+        elif c["case"] == "C":
+            print("  data_footer {} vs {} real keys".format(
+                c["merged_footer"], c["real_key_count"]))
+            for f in c["findings"]:
+                print("  {}".format(f))
+        else:
+            print("  the row appears {}x after the merge".format(c["row_occurrences"]))
+            for f in c["findings"]:
+                print("  {}".format(f))
+        print("  => {}  {}".format("CAUGHT" if c["caught"] else "MISSED", c["log"]))
+    print("")
+    print("self-test: {}".format("all three shapes caught" if res["ok"] else "FAILED"))
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="python -m scripts.repipe.mergecheck",
+        description="The three shared-counter merge guards (docs/decbench-loop.md).")
+    ap.add_argument("--against", "--base-ref", dest="base_ref", default="origin/main",
+                    help="the ref this branch merges into (default: origin/main)")
+    ap.add_argument("--repo", default=None, help="repo root (default: config.repo_root())")
+    ap.add_argument("--kuna", default=None, help="kuna binary (default: config.kuna_bin())")
+    ap.add_argument("--path", action="append", default=None,
+                    help="extra keep-both path to check (repeatable; replaces the default set)")
+    ap.add_argument("--self-test", action="store_true",
+                    help="build three synthetic git histories and prove each shape is caught")
+    ap.add_argument("--keep-scratch", action="store_true",
+                    help="with --self-test, leave the scratch repos in place")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        res = self_test(keep=args.keep_scratch)
+        if args.json:
+            print(json.dumps(res, indent=2, sort_keys=True))
+        else:
+            _print_selftest(res)
+        return 0 if res.get("ok") else 1
+
+    findings = run_all(args.base_ref, repo=args.repo, kuna=args.kuna, paths=args.path)
+    bad = rejects(findings)
+    if args.json:
+        print(json.dumps({"ok": not bad, "base_ref": args.base_ref,
+                          "rejects": len(bad),
+                          "findings": [f.as_dict() for f in findings]},
+                         indent=2, sort_keys=True))
+    else:
+        for f in findings:
+            print(f.oneline())
+        print("")
+        print("{} finding(s), {} reject(s) against {}".format(
+            len(findings), len(bad), args.base_ref))
+        print("MERGE BLOCKED" if bad else "merge guards clean")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repipe/needs.py
+++ b/scripts/repipe/needs.py
@@ -1,0 +1,936 @@
+"""The durable RE-friction backlog: one committed Markdown record per need.
+
+A *need* is a clustered, gated unit of work that survived the two-arm gate (its probe PASSES
+and its acceptance FAILS on a freshly built main). It lives at ``docs/re-needs/<need_id>.md``
+and is the only thing a builder is ever dispatched against; rejected filings move to
+``docs/re-needs/rejected/`` so the denominator stays honest.
+
+The file dialect is deliberately the same one ``docs/decbench/triage/<case-id>.md`` uses and
+``scripts/decbench/status.py`` already parses: a ``---`` fenced block of flat ``key: value``
+lines, then fixed ``##`` sections. Deliberate, because an agent that has read one of these
+records can read the other without being taught a second format, and because a 12-line regex
+parser is a feature -- the records stay hand-editable and diffable in review.
+
+Why the front-matter parser is hand-written: kuna's Python tooling is stdlib-only (no
+pyproject.toml, no requirements.txt, and ~/.virtualenvs/kuna has zero third-party packages),
+so PyYAML is not available. The supported subset is exactly what a need record needs:
+
+    key: value          strings, ints, floats, true/false, null (also ~), and flow lists
+    key: [a, b, c]      one line each, no nesting, no block scalars, no anchors
+    key: "quoted"       double quotes with \\" and \\\\ escapes, for values that would
+                        otherwise parse as a number/bool/null or start with a YAML sigil
+
+Round-trip stability is a hard requirement: ``write(parse(p)) == p`` byte for byte for every
+record this module produces, so the round-N commit of ``docs/re-needs/`` shows only the fields
+that actually changed. write() normalizes (canonical field order, canonical scalar spelling,
+one blank line around every heading), so a hand-edited record becomes canonical the first time
+the pipeline touches it and is stable from then on.
+
+CLI:
+    python3 -m scripts.repipe.needs list [--status S] [--track T] [--json]
+    python3 -m scripts.repipe.needs show <need_id> [--json]
+    python3 -m scripts.repipe.needs reindex [--json]
+    python3 -m scripts.repipe.needs rank [--json]
+    python3 -m scripts.repipe.needs opportunities [--out FILE] [--json]
+    python3 -m scripts.repipe.needs reject <need_id> --reason R [--json]
+
+``opportunities`` emits the backlog in the exact ``{"ranked": [...]}`` shape of
+``docs/improvement-pipeline/opportunities.json`` so ``scripts/pipeline/select.py`` consumes it
+unchanged -- that is the whole reuse story for worker dispatch: the RE loop gets claims,
+leases, slugs and the driver's select/claim/launch dance for free.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import sys
+from collections import OrderedDict
+
+from . import config
+
+SCHEMA = "re-need/1"
+
+# Front-matter field order. write() emits exactly this order, then any unknown keys the record
+# carried, in the order they were read -- so a field added by a future module survives a
+# round-trip instead of being silently dropped.
+FIELDS = [
+    "need_id", "title", "track", "status", "severity",
+    "probe_id", "acceptance_id", "hypothesis_status", "credibility",
+    "instances", "challenges", "rounds", "first_seen_round", "attempts",
+    "covered_by_option", "touches", "scope", "regression_of",
+    "pr", "closed_in_round", "closing_pr", "reject_reason",
+]
+
+SECTIONS = [
+    "Symptom",       # verbatim tester quotes + the replayed transcript
+    "Reproduction",  # the probe, and its replay result at the pinned SHA
+    "Acceptance",    # the acceptance probe, and its (failing) replay result
+    "Hypothesis",    # ADVISORY -- the builder is contractually NOT bound to it
+    "Refutation",    # the refuter's verdict, recorded whether or not it changed anything
+    "Reference",     # what IDA/declib does instead, if anything
+    "Instances",     # per-challenge, per-tester
+    "Decision log",
+]
+
+TRACKS = ("tooling", "quality", "perf", "loader")
+STATUSES = ("open", "claimed", "building", "proposal", "closed", "regressed", "blocked", "rejected")
+SEVERITIES = ("blocker", "major", "minor")
+HYPOTHESIS_STATUSES = ("upheld", "overturned", "inconclusive")
+SCOPES = ("small", "large")
+
+# Statuses a builder may be dispatched against. `claimed`/`building`/`proposal` are already in
+# flight (state.py holds the claim), `closed`/`blocked`/`rejected` are done or parked.
+DISPATCHABLE = ("open", "regressed")
+
+LIST_FIELDS = ("challenges", "rounds", "touches")
+INT_FIELDS = ("instances", "first_seen_round", "attempts", "closed_in_round")
+FLOAT_FIELDS = ("credibility",)
+
+DEFAULTS = {
+    "track": "tooling",
+    "status": "open",
+    "severity": "minor",
+    "hypothesis_status": "inconclusive",
+    "credibility": 0.0,
+    "instances": 0,
+    "challenges": [],
+    "rounds": [],
+    "first_seen_round": 0,
+    "attempts": 0,
+    "covered_by_option": None,
+    "touches": [],
+    "scope": "small",
+    "regression_of": None,
+    "pr": None,
+    "closed_in_round": None,
+    "closing_pr": None,
+    "reject_reason": None,
+}
+
+# --- rank weights -----------------------------------------------------------
+
+SEVERITY_WEIGHT = {"blocker": 3.0, "major": 2.0, "minor": 1.0}
+# Scale keeps the smallest real need (minor / 1 instance / 1 challenge = 0.69 raw) above
+# select.py's `--min-score 1` integer floor, which would otherwise silently drop it.
+SCORE_SCALE = 10.0
+ATTEMPT_PENALTY = 0.5      # each failed builder attempt divides the score by 1 + 0.5*attempts
+REGRESSION_BOOST = 8.0
+REGRESSION_FLOOR = 1000.0  # additive, so a regression outranks any non-regression outright
+
+
+# --- the front-matter dialect ----------------------------------------------
+
+_KV_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*):(?:[ \t]+(.*))?$")
+_INT_RE = re.compile(r"^[+-]?\d+$")
+_FLOAT_RE = re.compile(r"^[+-]?(?:\d+\.\d*|\.\d+|\d+)(?:[eE][+-]?\d+)?$")
+_HEADING_RE = re.compile(r"^##[ \t]+(.+?)[ \t]*$", re.M)
+_JSON_FENCE_RE = re.compile(r"^```json[ \t]*\n(.*?)^```[ \t]*$", re.S | re.M)
+_NULLS = ("null", "~")
+_SIGILS = "\"'[]{}&*!|>%@`#-?:,"
+
+
+def _unescape(s):
+    out = []
+    i = 0
+    while i < len(s):
+        c = s[i]
+        if c == "\\" and i + 1 < len(s):
+            i += 1
+            nxt = s[i]
+            out.append({"n": "\n", "t": "\t", "r": "\r"}.get(nxt, nxt))
+        else:
+            out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def _parse_scalar(raw):
+    s = raw.strip()
+    if s.startswith('"') and s.endswith('"') and len(s) >= 2:
+        return _unescape(s[1:-1])
+    if s == "":
+        return None
+    if s in _NULLS:
+        return None
+    if s == "true":
+        return True
+    if s == "false":
+        return False
+    if _INT_RE.match(s):
+        return int(s)
+    if _FLOAT_RE.match(s):
+        return float(s)
+    return s
+
+
+def _split_flow(inner):
+    """Split a flow-list body on commas that are not inside a double-quoted item."""
+    parts, buf, quoted, esc = [], [], False, False
+    for ch in inner:
+        if esc:
+            buf.append(ch)
+            esc = False
+        elif ch == "\\" and quoted:
+            buf.append(ch)
+            esc = True
+        elif ch == '"':
+            quoted = not quoted
+            buf.append(ch)
+        elif ch == "," and not quoted:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    parts.append("".join(buf))
+    return [p for p in parts if p.strip() != ""] if len(parts) > 1 or parts[0].strip() else []
+
+
+def _parse_value(raw):
+    s = raw.strip()
+    if s.startswith("[") and s.endswith("]"):
+        return [_parse_scalar(p) for p in _split_flow(s[1:-1])]
+    return _parse_scalar(s)
+
+
+def _must_quote(s, in_list=False):
+    if s == "" or s != s.strip():
+        return True
+    if s in _NULLS or s in ("true", "false"):
+        return True
+    if _INT_RE.match(s) or _FLOAT_RE.match(s):
+        return True
+    if s[0] in _SIGILS:
+        return True
+    if "#" in s or "\n" in s or "\r" in s or "\t" in s:
+        return True
+    if in_list and ("," in s or "[" in s or "]" in s):
+        return True
+    return False
+
+
+def _emit_scalar(v, in_list=False):
+    if v is None:
+        return "null"
+    if v is True:
+        return "true"
+    if v is False:
+        return "false"
+    if isinstance(v, int):
+        return str(v)
+    if isinstance(v, float):
+        return repr(v)
+    s = str(v)
+    if _must_quote(s, in_list):
+        # Control characters must be ESCAPED, not merely quoted. _unescape() already maps
+        # \n and \t back on the way in, but emitting a raw newline inside quotes ends the
+        # line mid-value: everything after it is re-read as further front-matter keys, so a
+        # title containing a newline silently destroys every field below it -- and titles come
+        # from LLM testers.
+        s = (s.replace("\\", "\\\\").replace('"', '\\"')
+              .replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t"))
+        return '"' + s + '"'
+    return s
+
+
+def _emit_value(v):
+    if isinstance(v, (list, tuple)):
+        return "[" + ", ".join(_emit_scalar(x, in_list=True) for x in v) + "]"
+    return _emit_scalar(v)
+
+
+def _coerce(key, value):
+    """Pull a parsed value into the type its field declares, so `instances: 9` never arrives
+    as the string "9" from a hand edit."""
+    if key in LIST_FIELDS:
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            return [value]
+        return list(value)
+    if key in INT_FIELDS and isinstance(value, (str, float, bool)):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return value
+    if key in FLOAT_FIELDS and isinstance(value, (str, int)) and not isinstance(value, bool):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return value
+    return value
+
+
+# --- the probe id contract --------------------------------------------------
+
+def probe_id_of(probe, is_acceptance=False):
+    """The probe-id derivation, identical in every module of the loop (docs/re-pipeline.md).
+
+    Keyed on cmd + expect only: two filings that run the same argv and assert the same thing
+    ARE the same probe, whatever prose the tester wrapped around them. That is what makes
+    dedup deterministic instead of an LLM call.
+    """
+    payload = json.dumps({"cmd": probe["cmd"], "expect": probe["expect"]},
+                         sort_keys=True, separators=(",", ":")).encode()
+    return ("a-" if is_acceptance else "p-") + hashlib.sha1(payload).hexdigest()[:12]
+
+
+# --- the record -------------------------------------------------------------
+
+class Need:
+    """One backlog record: flat front-matter fields plus the fixed ``##`` sections.
+
+    Every name in FIELDS is readable as an attribute (``need.severity``), falling back to
+    DEFAULTS when the record omits it. Writes go through ``need.fields[...]`` so the
+    unknown-field passthrough stays honest.
+    """
+
+    def __init__(self, fields=None, sections=None, path=None):
+        self.fields = OrderedDict()
+        for k, v in (fields or {}).items():
+            self.fields[k] = _coerce(k, v)
+        self.sections = OrderedDict(sections or {})
+        self.path = path
+
+    def __getattr__(self, name):
+        if name in FIELDS:
+            return self.__dict__.get("fields", {}).get(name, DEFAULTS.get(name))
+        raise AttributeError(name)
+
+    def __repr__(self):
+        return "<Need %s %s/%s score=%.2f>" % (
+            self.fields.get("need_id"), self.status, self.severity, rank_score(self))
+
+    def get(self, key, default=None):
+        return self.fields.get(key, DEFAULTS.get(key, default))
+
+    def set(self, key, value):
+        self.fields[key] = _coerce(key, value)
+
+    def section(self, name):
+        return self.sections.get(name, "")
+
+    def probe(self):
+        """The probe object embedded as the first ```json fence under ## Reproduction."""
+        return _first_json_fence(self.section("Reproduction"))
+
+    def acceptance(self):
+        """The acceptance object embedded as the first ```json fence under ## Acceptance."""
+        return _first_json_fence(self.section("Acceptance"))
+
+    def log(self, line):
+        body = self.sections.get("Decision log", "").rstrip()
+        self.sections["Decision log"] = (body + "\n" + line).strip() if body else line
+
+    def to_dict(self, score=True):
+        d = OrderedDict()
+        for k in FIELDS:
+            d[k] = self.fields.get(k, DEFAULTS.get(k))
+        for k in self.fields:
+            if k not in d:
+                d[k] = self.fields[k]
+        if score:
+            d["score"] = rank_score(self)
+        d["path"] = str(self.path) if self.path else None
+        return d
+
+
+def _first_json_fence(text):
+    m = _JSON_FENCE_RE.search(text or "")
+    if not m:
+        return None
+    try:
+        return json.loads(m.group(1))
+    except json.JSONDecodeError:
+        return None
+
+
+def parse(path):
+    """Read one record. Raises ValueError if the front-matter fence is missing."""
+    path = str(path)
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        text = fh.read()
+    m = re.match(r"^---\n(.*?)\n---\n?", text, re.S)
+    if not m:
+        raise ValueError("%s: no --- front matter" % path)
+
+    fields = OrderedDict()
+    for line in m.group(1).splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        kv = _KV_RE.match(line)
+        if not kv:
+            continue
+        fields[kv.group(1)] = _coerce(kv.group(1), _parse_value(kv.group(2) or ""))
+
+    body = text[m.end():]
+    sections = OrderedDict()
+    marks = list(_HEADING_RE.finditer(body))
+    for i, mk in enumerate(marks):
+        end = marks[i + 1].start() if i + 1 < len(marks) else len(body)
+        sections[mk.group(1)] = body[mk.end():end].strip("\n").rstrip()
+
+    need = Need(fields=fields, sections=sections, path=path)
+    if not need.fields.get("need_id"):
+        need.fields["need_id"] = os.path.splitext(os.path.basename(path))[0]
+    return need
+
+
+def render(need):
+    """The canonical text of a record. parse() of this returns an equal Need."""
+    lines = ["---"]
+    for key in FIELDS:
+        if key in need.fields:
+            lines.append("%s: %s" % (key, _emit_value(need.fields[key])))
+    for key in need.fields:
+        if key not in FIELDS:
+            lines.append("%s: %s" % (key, _emit_value(need.fields[key])))
+    lines.append("---")
+
+    names = [s for s in SECTIONS if s in need.sections]
+    names += [s for s in need.sections if s not in SECTIONS]
+    for name in names:
+        lines.append("")
+        lines.append("## " + name)
+        body = (need.sections.get(name) or "").strip("\n").rstrip()
+        if body:
+            lines.append("")
+            lines.extend(body.split("\n"))
+    return "\n".join(lines) + "\n"
+
+
+def validate(need):
+    """Return a list of human-readable problems. Empty means the record is well-formed."""
+    problems = []
+    nid = need.fields.get("need_id")
+    if not nid or not re.match(r"^[a-z0-9][a-z0-9-]*$", str(nid)):
+        problems.append("need_id must be a lowercase slug, got %r" % (nid,))
+    for key, allowed in (("track", TRACKS), ("status", STATUSES), ("severity", SEVERITIES),
+                         ("hypothesis_status", HYPOTHESIS_STATUSES), ("scope", SCOPES)):
+        val = need.get(key)
+        if val is not None and val not in allowed:
+            problems.append("%s must be one of %s, got %r" % (key, "|".join(allowed), val))
+    cred = need.get("credibility")
+    if cred is not None and not (isinstance(cred, (int, float)) and 0.0 <= float(cred) <= 1.0):
+        problems.append("credibility must be 0..1, got %r" % (cred,))
+    for key in ("probe_id", "acceptance_id"):
+        val = need.get(key)
+        want = "a-" if key == "acceptance_id" else "p-"
+        if val is not None and not re.match("^%s[0-9a-f]{12}$" % want, str(val)):
+            problems.append("%s must match %s<12 hex>, got %r" % (key, want, val))
+    return problems
+
+
+def path_for(need_id, rejected=False):
+    base = config.rejected_dir() if rejected else config.needs_dir()
+    return base / ("%s.md" % need_id)
+
+
+def write(need, path=None):
+    """Render and atomically replace the record. Returns the path written.
+
+    Atomic because the captain, the clusterer and a status reader can all touch
+    docs/re-needs/ at once; a half-written record would fail the next parse().
+    """
+    problems = validate(need)
+    if problems:
+        raise ValueError("%s: %s" % (need.fields.get("need_id"), "; ".join(problems)))
+    target = str(path or need.path or path_for(need.need_id, need.status == "rejected"))
+    os.makedirs(os.path.dirname(target) or ".", exist_ok=True)
+    tmp = target + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        fh.write(render(need))
+    os.replace(tmp, target)
+    need.path = target
+    return target
+
+
+def load_all(include_rejected=False):
+    """Every record on disk, sorted by need_id. Unparseable files are skipped, not fatal."""
+    out = []
+    dirs = [config.needs_dir()]
+    if include_rejected:
+        dirs.append(config.rejected_dir())
+    for d in dirs:
+        if not d.is_dir():
+            continue
+        for f in sorted(d.glob("*.md")):
+            try:
+                out.append(parse(f))
+            except (ValueError, OSError):
+                continue
+    out.sort(key=lambda n: str(n.need_id))
+    return out
+
+
+def load(need_id):
+    """One record by id, from the backlog or from rejected/. None if absent."""
+    for rejected in (False, True):
+        p = path_for(need_id, rejected)
+        if p.exists():
+            return parse(p)
+    return None
+
+
+def _union(old, new):
+    seen, out = set(), []
+    for item in list(old or []) + list(new or []):
+        key = json.dumps(item, sort_keys=True) if isinstance(item, (dict, list)) else item
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(item)
+    return out
+
+
+def upsert(need):
+    """Merge a filing into the backlog and write it. Returns the path.
+
+    Merge rules, all deterministic (bumping instances on a re-observed need must never cost an
+    LLM call): list fields union, `instances` and `attempts` take the max, `first_seen_round`
+    takes the min, a non-empty incoming section replaces the stored one and an empty one keeps
+    it (so a re-filing never erases a refuter's verdict or the decision log), and any other
+    incoming non-None scalar wins.
+    """
+    existing = load(need.need_id)
+    if existing is None:
+        merged = Need(fields=need.fields, sections=need.sections)
+        for k, v in DEFAULTS.items():
+            merged.fields.setdefault(k, v)
+        return write(merged, path_for(merged.need_id, merged.status == "rejected"))
+
+    merged = Need(fields=existing.fields, sections=existing.sections, path=existing.path)
+    for key, value in need.fields.items():
+        if key in LIST_FIELDS:
+            merged.fields[key] = _union(existing.get(key), value)
+        elif key in ("instances", "attempts"):
+            merged.fields[key] = max(int(existing.get(key) or 0), int(value or 0))
+        elif key == "first_seen_round":
+            cur = existing.get(key)
+            merged.fields[key] = int(value) if cur is None else min(int(cur), int(value or 0))
+        elif value is not None:
+            merged.fields[key] = _coerce(key, value)
+    for name, body in need.sections.items():
+        if (body or "").strip():
+            merged.sections[name] = body
+        merged.sections.setdefault(name, existing.sections.get(name, ""))
+    return write(merged, merged.path)
+
+
+def apply_acceptance(suite, round_n=None, closing_pr=None):
+    """Write an acceptance-suite result back into the backlog. The round-ending mechanism.
+
+    This is the whole mechanical answer to "have the builders fixed what the testers asked
+    for?". A need is closed **iff its acceptance probe, which FAILED when the need was filed,
+    now PASSES on a freshly built main** -- there is no judgment in it, and nothing else may
+    set `closed`.
+
+    The mirror is just as load-bearing: a need that WAS closed and whose acceptance fails
+    again becomes `regressed`, which rank_score puts at the front of the queue. Without it the
+    backlog would rot silently, because a merged fix that a later PR undoes would stay marked
+    closed forever.
+
+    Returns {"closed": [...], "regressed": [...], "unchanged": [...]}.
+    """
+    results = suite.get("results") or suite.get("needs") or []
+    out = {"closed": [], "regressed": [], "unchanged": []}
+    sha = str(suite.get("sha") or "?")[:12]
+    for row in results:
+        nid = row.get("need_id")
+        if not nid:
+            continue
+        need = load(nid)
+        if need is None:
+            continue
+        passed = bool(row.get("passed"))
+        # An unrunnable or flaky replay is INDETERMINATE, not a failure. Treating it as one
+        # would mark a healthy closed need `regressed`, and rank_score sends a regression
+        # straight to the front of the builder queue -- so a flaky probe could starve the
+        # backlog with phantom work.
+        if row.get("unrunnable") or row.get("flaky") or row.get("error"):
+            out["unchanged"].append(nid)
+            continue
+        if passed and need.status not in ("closed", "rejected"):
+            need.set("status", "closed")
+            if round_n is not None:
+                need.set("closed_in_round", int(round_n))
+            if closing_pr:
+                need.set("closing_pr", closing_pr)
+            need.log("- closed: acceptance %s now PASSES at %s" % (need.acceptance_id or "?", sha))
+            upsert(need)
+            out["closed"].append(nid)
+        elif not passed and need.status == "closed":
+            need.set("status", "regressed")
+            # closed_in_round is kept on purpose: "this shipped in round 1 and broke in
+            # round 2" is the useful record, and clearing it would lose that.
+            need.log("- REGRESSED: acceptance %s fails again at %s" % (need.acceptance_id or "?", sha))
+            upsert(need)
+            out["regressed"].append(nid)
+        else:
+            out["unchanged"].append(nid)
+    return out
+
+
+def reject(need_id, reason):
+    """Move a need out of the backlog into docs/re-needs/rejected/ with its reason recorded.
+
+    The rejected pile is the honest denominator -- `already-supported` filings in particular
+    are the evidence that the two-arm gate is doing its job -- so this never deletes anything.
+    """
+    need = load(need_id)
+    if need is None:
+        raise KeyError(need_id)
+    need.set("status", "rejected")
+    need.set("reject_reason", reason)
+    need.log("- rejected: %s" % reason)
+    old = need.path
+    new = str(path_for(need.need_id, rejected=True))
+    need.path = new
+    write(need, new)
+    if old and os.path.abspath(old) != os.path.abspath(new) and os.path.exists(old):
+        os.remove(old)
+    return new
+
+
+# --- ranking ----------------------------------------------------------------
+
+def rank_score(need):
+    """Deterministic priority for one need. Higher is dispatched first.
+
+        raw    = SCORE_SCALE * severity_weight * log1p(instances) * distinct_challenges
+        score  = raw / (1 + ATTEMPT_PENALTY * attempts)
+        if regression_of:  score = REGRESSION_FLOOR + score * REGRESSION_BOOST
+
+    severity_weight is blocker 3 / major 2 / minor 1. log1p(instances) is why the tenth
+    tester to hit the same wall barely moves the needle while the second one moves it a lot --
+    breadth is evidence, repetition is not. distinct_challenges (floored at 1, so a need whose
+    only witness is an in-repo fixture still ranks) multiplies because a friction that
+    reproduces on unrelated binaries is a property of kuna, not of one crackme. The attempt
+    penalty demotes a need two builders have already failed on rather than looping on it, and
+    the additive REGRESSION_FLOOR makes any regression outrank every fresh need outright:
+    breaking something that was shipped and verified is the worst thing this loop can do.
+
+    No wall-clock, no randomness, no LLM: the same backlog always produces the same order.
+    """
+    weight = SEVERITY_WEIGHT.get(str(need.severity), 1.0)
+    instances = max(0, int(need.instances or 0))
+    challenges = max(1, len(set(need.challenges or [])))
+    attempts = max(0, int(need.attempts or 0))
+
+    score = SCORE_SCALE * weight * math.log1p(instances) * challenges
+    score /= 1.0 + ATTEMPT_PENALTY * attempts
+    # Both regression paths get the floor: `regression_of` is a tester noticing that a shipped
+    # capability broke, and `status == regressed` is apply_acceptance noticing the same thing
+    # mechanically when a closed need's acceptance flips back. Boosting only the first would
+    # leave the pipeline's own detection ranking below fresh work.
+    if need.regression_of or need.status == "regressed":
+        score = REGRESSION_FLOOR + score * REGRESSION_BOOST
+    return round(score, 6)
+
+
+def ranked(needs=None, statuses=None):
+    """Needs sorted by descending score, ties broken by need_id so the order is total."""
+    pool = list(needs if needs is not None else load_all())
+    if statuses is not None:
+        pool = [n for n in pool if n.status in statuses]
+    pool.sort(key=lambda n: (-rank_score(n), str(n.need_id)))
+    return pool
+
+
+# --- the select.py seam -----------------------------------------------------
+
+def _opportunity_row(need, index):
+    probe = need.probe() or {}
+    acceptance = need.acceptance() or {}
+    target = (probe.get("target") or acceptance.get("target") or {})
+    kinds = [need.track, "re-need"]
+    if probe.get("kind") and probe["kind"] not in kinds:
+        kinds.append(probe["kind"])
+    if need.regression_of:
+        kinds.append("regression")
+
+    reasons = [str(need.title or need.need_id),
+               "%s severity; %d instance(s) over %d challenge(s)" % (
+                   need.severity, int(need.instances or 0), len(set(need.challenges or []))),
+               "probe %s PASSES / acceptance %s FAILS" % (need.probe_id, need.acceptance_id)]
+    if need.regression_of:
+        reasons.append("REGRESSION of %s" % need.regression_of)
+
+    return OrderedDict([
+        # --- the fields scripts/pipeline/select.py reads, in its own vocabulary -------
+        ("rank", index),
+        ("score", rank_score(need)),
+        ("kinds", kinds),
+        ("reasons", reasons),
+        ("covered_hint", need.covered_by_option or ""),
+        ("comparable", True),
+        ("test_name", need.need_id),
+        ("selector", need.acceptance_id),
+        ("binary", target.get("binary_rel") or ""),
+        ("arch", None),
+        ("func_name", None),
+        ("func_addr", None),
+        ("custom_options", None),
+        ("confidence", need.credibility),
+        ("kuna_mode", None),
+        ("slug", need.need_id),
+        # --- the RE-loop payload the builder prompt renders from ---------------------
+        ("need_id", need.need_id),
+        ("need_path", str(need.path) if need.path else None),
+        ("title", need.title),
+        ("track", need.track),
+        ("status", need.status),
+        ("severity", need.severity),
+        ("probe_id", need.probe_id),
+        ("acceptance_id", need.acceptance_id),
+        ("probe_kind", probe.get("kind")),
+        ("hypothesis_status", need.hypothesis_status),
+        ("credibility", need.credibility),
+        ("instances", need.instances),
+        ("challenges", list(need.challenges or [])),
+        ("rounds", list(need.rounds or [])),
+        ("first_seen_round", need.first_seen_round),
+        ("attempts", need.attempts),
+        ("touches", list(need.touches or [])),
+        ("scope", need.scope),
+        ("regression_of", need.regression_of),
+    ])
+
+
+def to_opportunities(needs=None, statuses=DISPATCHABLE):
+    """The backlog in docs/improvement-pipeline/opportunities.json's exact shape.
+
+    select.py requires `comparable` truthy and `score >= --min-score`, keys the claim on
+    `test_name::selector` and derives the branch slug from `test_name` -- so a need's id is its
+    test_name and its acceptance id is its selector, making OPP_ID `<need_id>::<acceptance_id>`:
+    re-filing the same need against a NEW acceptance is a new unit of work, which is the
+    behaviour we want. `kinds` carries the track, so `select.py --kind tooling` (whose filter is
+    already generic) partitions the backlog by builder track with no change to that module.
+    """
+    rows = [_opportunity_row(n, i)
+            for i, n in enumerate(ranked(needs, statuses=statuses), 1)]
+    return OrderedDict([
+        ("schema", "re-opportunities/1"),
+        ("generated_by", "scripts.repipe.needs"),
+        ("note", "RE-friction backlog. Every row is a need whose probe PASSES and whose "
+                 "acceptance FAILS on the pinned main. Consumed by scripts.pipeline.select."),
+        ("count", len(rows)),
+        ("ranked", rows),
+    ])
+
+
+# --- the index --------------------------------------------------------------
+
+_INDEX_KEYS = ["need_id", "title", "track", "status", "severity", "probe_id", "acceptance_id",
+               "hypothesis_status", "credibility", "instances", "challenges", "rounds",
+               "first_seen_round", "attempts", "covered_by_option", "touches", "scope",
+               "regression_of", "pr", "closed_in_round", "closing_pr", "reject_reason"]
+
+
+def _index_row(need):
+    row = OrderedDict((k, need.get(k)) for k in _INDEX_KEYS)
+    row["score"] = rank_score(need)
+    row["path"] = os.path.relpath(str(need.path), str(config.repo_root())) if need.path else None
+    return row
+
+
+def reindex(path=None):
+    """Rebuild docs/re-needs/index.json from the records and return it.
+
+    A cache, never a source of truth -- delete it and this rebuilds it. It carries no timestamp
+    on purpose: the file is committed every round, and a clock in it would make every round's
+    diff noisy even when no need changed.
+    """
+    active = ranked(load_all(include_rejected=False), statuses=None)
+    rejected = [n for n in load_all(include_rejected=True)
+                if n.path and os.path.dirname(str(n.path)) == str(config.rejected_dir())]
+    by = {}
+    for key in ("status", "track", "severity"):
+        counts = {}
+        for n in active:
+            counts[str(n.get(key))] = counts.get(str(n.get(key)), 0) + 1
+        by[key] = OrderedDict(sorted(counts.items()))
+    reasons = {}
+    for n in rejected:
+        reasons[str(n.reject_reason)] = reasons.get(str(n.reject_reason), 0) + 1
+
+    doc = OrderedDict([
+        ("schema", "re-needs-index/1"),
+        ("generated_by", "scripts.repipe.needs"),
+        ("count", len(active)),
+        ("rejected_count", len(rejected)),
+        ("by_status", by["status"]),
+        ("by_track", by["track"]),
+        ("by_severity", by["severity"]),
+        ("by_reject_reason", OrderedDict(sorted(reasons.items()))),
+        ("needs", [_index_row(n) for n in active]),
+        ("rejected", [_index_row(n) for n in sorted(rejected, key=lambda n: str(n.need_id))]),
+    ])
+    target = str(path or (config.needs_dir() / "index.json"))
+    _write_json(target, doc)
+    return doc
+
+
+def _write_json(target, doc):
+    os.makedirs(os.path.dirname(target) or ".", exist_ok=True)
+    tmp = target + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump(doc, fh, indent=2)
+        fh.write("\n")
+    os.replace(tmp, target)
+    return target
+
+
+# --- CLI --------------------------------------------------------------------
+
+def _print_table(needs):
+    if not needs:
+        print("no needs")
+        return
+    width = max(len(str(n.need_id)) for n in needs)
+    print("%-*s  %-8s  %-10s  %-7s  %8s  %s" % (width, "NEED", "TRACK", "STATUS", "SEV",
+                                                "SCORE", "TITLE"))
+    for n in needs:
+        print("%-*s  %-8s  %-10s  %-7s  %8.2f  %s" % (
+            width, n.need_id, n.track, n.status, n.severity, rank_score(n),
+            (n.title or "")[:72]))
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog="python3 -m scripts.repipe.needs",
+                                 description=__doc__.splitlines()[0])
+    sub = ap.add_subparsers(dest="cmd")
+
+    p_list = sub.add_parser("list", help="the backlog, highest-ranked first")
+    p_list.add_argument("--status", choices=STATUSES)
+    p_list.add_argument("--track", choices=TRACKS)
+    p_list.add_argument("--severity", choices=SEVERITIES)
+    p_list.add_argument("--include-rejected", action="store_true")
+    p_list.add_argument("--json", action="store_true")
+
+    p_show = sub.add_parser("show", help="one record (raw markdown, or --json)")
+    p_show.add_argument("need_id")
+    p_show.add_argument("--json", action="store_true")
+
+    p_reindex = sub.add_parser("reindex", help="rebuild docs/re-needs/index.json")
+    p_reindex.add_argument("--out")
+    p_reindex.add_argument("--json", action="store_true")
+
+    p_rank = sub.add_parser("rank", help="dispatchable needs in dispatch order")
+    p_rank.add_argument("--all", action="store_true", help="include non-dispatchable statuses")
+    p_rank.add_argument("--json", action="store_true")
+
+    p_opp = sub.add_parser("opportunities",
+                           help="emit the backlog in opportunities.json shape for select.py")
+    p_opp.add_argument("--out", help="default docs/re-needs/opportunities.json; '-' for stdout")
+    p_opp.add_argument("--all", action="store_true")
+    p_opp.add_argument("--json", action="store_true", help="also print the payload")
+
+    p_acc = sub.add_parser("apply-acceptance",
+                           help="close/regress needs from an acceptance-suite result")
+    p_acc.add_argument("suite", help="the suite JSON, or - for stdin")
+    p_acc.add_argument("--round", type=int, default=None)
+    p_acc.add_argument("--pr", default=None)
+    p_acc.add_argument("--json", action="store_true")
+
+    p_rej = sub.add_parser("reject", help="move a need to docs/re-needs/rejected/")
+    p_rej.add_argument("need_id")
+    p_rej.add_argument("--reason", required=True)
+    p_rej.add_argument("--json", action="store_true")
+
+    args = ap.parse_args(argv)
+    if not args.cmd:
+        ap.print_help()
+        return 2
+
+    if args.cmd == "list":
+        pool = ranked(load_all(include_rejected=args.include_rejected), statuses=None)
+        for key in ("status", "track", "severity"):
+            want = getattr(args, key)
+            if want:
+                pool = [n for n in pool if n.get(key) == want]
+        if args.json:
+            print(json.dumps({"count": len(pool), "needs": [n.to_dict() for n in pool]}, indent=2))
+        else:
+            _print_table(pool)
+        return 0
+
+    if args.cmd == "show":
+        need = load(args.need_id)
+        if need is None:
+            print("no such need: %s" % args.need_id, file=sys.stderr)
+            return 1
+        if args.json:
+            doc = need.to_dict()
+            doc["sections"] = need.sections
+            doc["probe"] = need.probe()
+            doc["acceptance"] = need.acceptance()
+            print(json.dumps(doc, indent=2))
+        else:
+            sys.stdout.write(render(need))
+        return 0
+
+    if args.cmd == "reindex":
+        doc = reindex(args.out)
+        if args.json:
+            print(json.dumps(doc, indent=2))
+        else:
+            print("indexed %d needs (%d rejected) -> %s"
+                  % (doc["count"], doc["rejected_count"],
+                     args.out or (config.needs_dir() / "index.json")))
+        return 0
+
+    if args.cmd == "rank":
+        pool = ranked(statuses=None if args.all else DISPATCHABLE)
+        if args.json:
+            print(json.dumps([n.to_dict() for n in pool], indent=2))
+        else:
+            _print_table(pool)
+        return 0
+
+    if args.cmd == "opportunities":
+        doc = to_opportunities(statuses=None if args.all else DISPATCHABLE)
+        if args.out == "-":
+            print(json.dumps(doc, indent=2))
+            return 0
+        target = _write_json(args.out or str(config.needs_dir() / "opportunities.json"), doc)
+        if args.json:
+            print(json.dumps(doc, indent=2))
+        else:
+            print("wrote %d opportunities -> %s" % (doc["count"], target))
+        return 0
+
+    if args.cmd == "apply-acceptance":
+        raw = sys.stdin.read() if args.suite == "-" else open(args.suite).read()
+        out = apply_acceptance(json.loads(raw), round_n=args.round, closing_pr=args.pr)
+        reindex()
+        if args.json:
+            print(json.dumps(out, indent=2))
+        else:
+            for kind in ("closed", "regressed"):
+                for nid in out[kind]:
+                    print("%-10s %s" % (kind, nid))
+            print("unchanged: %d" % len(out["unchanged"]))
+        return 0
+
+    if args.cmd == "reject":
+        try:
+            new = reject(args.need_id, args.reason)
+        except KeyError:
+            print("no such need: %s" % args.need_id, file=sys.stderr)
+            return 1
+        if args.json:
+            print(json.dumps({"need_id": args.need_id, "reason": args.reason, "path": new}))
+        else:
+            print("rejected %s (%s) -> %s" % (args.need_id, args.reason, new))
+        return 0
+
+    ap.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repipe/probe.py
+++ b/scripts/repipe/probe.py
@@ -1,0 +1,1268 @@
+"""The predicate evaluator: run one probe and decide whether its assertion holds.
+
+A *probe* is an executable assertion about kuna's behaviour
+(``tools/repipe/schema/probe.schema.json``). Two of them define a need: the **probe** asserts
+the CURRENT BAD behaviour and must PASS at filing time; the **acceptance** asserts the DESIRED
+behaviour and must FAIL. This module is the atom the rest of the loop rests on -- ``verify.py``'s
+two-arm gate, the builder's definition of done, the dedup key, and the acceptance probes promoted
+verbatim into ``tests/cli/`` all reduce to ``check()`` returning the right boolean -- so it is
+written to be strict rather than forgiving: an assertion that cannot be evaluated FAILS, it never
+passes by default.
+
+Three rules the rest of the pipeline depends on:
+
+* **Every present clause must hold, on every repeat.** ``expect`` is a conjunction, and silence is
+  not assent: an empty or all-absent ``expect`` is rejected by :func:`normalize`, because a probe
+  that asserts nothing always passes and is therefore not evidence.
+* **Disagreement is not evidence either.** The ``repeat`` runs are evaluated individually; if they
+  do not all reach the same verdict the probe is ``flaky: true`` (and therefore ``passed: false``,
+  since a passing verdict requires every run to satisfy every clause). Callers must surface flaky
+  separately from an honest failure -- "the gate could not decide" is a different fact from
+  "the behaviour is not there".
+* **An observation is always produced.** A timeout, or a failure to even exec the command, is
+  recorded as a run rather than raised: it lands as a failing synthetic ``run`` clause, so
+  "kuna hung for 300 s" is data the captain can read instead of a crashed gate. The one thing
+  that does raise is a *pre-flight* problem -- a malformed probe, or a ``{{BIN}}`` whose sha256
+  is not the binary the probe was written against -- because that is "unrunnable", not "not
+  reproducible", and the two must never be confused.
+
+Resource accounting uses ``/usr/bin/time -v``, not ``resource.getrusage(RUSAGE_CHILDREN)``.
+The getrusage route is wrong for exactly the number these probes care about: ``ru_maxrss`` under
+RUSAGE_CHILDREN is a **high-water mark over every child this process has ever reaped**, not an
+additive counter, so a before/after subtraction yields 0 for any run smaller than an earlier one
+-- and probes run in a ``repeat`` loop by construction, next to a captain that has already reaped
+cargo. ``/usr/bin/time -v -o FILE`` measures one child in isolation and writes its report to FILE
+instead of into the probe's captured stderr; its ``Exit status:`` / ``Command terminated by
+signal`` lines are parsed back so a killed child reports ``-SIGNAL`` the way ``subprocess`` would
+(time(1) itself would report 128+N). Wall time comes from ``time.monotonic()`` around the whole
+spawn, not from time(1)'s centisecond field, which is too coarse for a sub-100 ms kuna call. When
+``/usr/bin/time`` is absent, ``max_rss_kb`` is None and ``rusage_source`` says so, rather than a
+silently wrong getrusage delta.
+
+Substitution happens on ``cmd``, ``cwd`` and ``env`` only (never on ``stdin``), and the probe_id
+is derived from the *unsubstituted* cmd so the same probe keeps its identity in every work dir.
+
+CLI::
+
+    python3 -m scripts.repipe.probe check    <probe.json> [--work DIR] [--bin PATH] [--json]
+    python3 -m scripts.repipe.probe validate <probe.json> [--json]
+    python3 -m scripts.repipe.probe id       <probe.json> [--acceptance]
+
+``check`` exits 0 when the probe passed, 1 when it failed, 2 when it was structurally unusable.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import re
+import shutil
+import threading
+import signal
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+
+from . import config
+
+SCHEMA_ID = "re-probe/1"
+TIME_BIN = "/usr/bin/time"
+HEAD_CHARS = 2000
+TERM_GRACE_S = 2.0
+
+TOKENS = ("KUNA", "BIN", "SPECS", "WORK", "TMP")
+
+_KINDS = ("cli", "cli-pair", "timing", "memory", "absence")
+_BINARY_SOURCES = ("dataset", "in-repo", "synthesized")
+_SELECTOR_KINDS = ("name", "addr", "none")
+_STATS = ("median", "min", "max", "mean")
+_NUM_OPS = ("eq", "ne", "lt", "gt", "le", "ge", "in")
+_ORDER_OPS = ("lt", "gt", "le", "ge")
+_JSON_OPS = ("eq", "ne", "lt", "gt", "le", "ge", "len_eq", "len_lt", "len_gt",
+             "contains", "not_contains", "exists", "absent", "matches")
+_JSON_OPS_NO_VALUE = ("exists", "absent")
+# Operators whose meaning under `[*]` is "for EVERY branch", not "for some branch".
+_JSON_OPS_NEGATIVE = ("absent", "not_contains", "ne")
+_JSON_OPS_NUMERIC = ("lt", "gt", "le", "ge", "len_eq", "len_lt", "len_gt")
+_REGEX_LISTS = ("stdout_matches", "stdout_absent", "stderr_matches", "stderr_absent")
+_STAT_CLAUSES = ("wall_ms", "max_rss_kb")
+_EXPECT_KEYS = ("exit_code", "stdout_matches", "stdout_absent", "stderr_matches",
+                "stderr_absent", "stdout_is_json", "json", "wall_ms", "max_rss_kb",
+                "stdout_bytes")
+_PROBE_KEYS = ("schema", "probe_id", "kind", "cmd", "cwd", "env", "stdin", "timeout_s",
+               "repeat", "target", "expect", "notes")
+_TARGET_KEYS = ("binary_rel", "binary_sha256", "binary_size", "binary_source",
+                "in_repo_path", "selector", "selector_kind")
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_PROBE_ID_RE = re.compile(r"^[pa]-[0-9a-f]{12}$")
+_TOKEN_RE = re.compile(r"\{\{([A-Za-z_][A-Za-z0-9_]*)\}\}")
+_RE_MAXRSS = re.compile(r"Maximum resident set size \(kbytes\):\s*(\d+)")
+_RE_EXIT = re.compile(r"^\s*Exit status:\s*(\d+)\s*$", re.MULTILINE)
+_RE_SIGNAL = re.compile(r"^Command terminated by signal (\d+)", re.MULTILINE)
+
+MISSING = object()
+
+
+class ProbeError(ValueError):
+    """A probe that is structurally unusable: it cannot be run, or it asserts nothing."""
+
+
+# --- identity ---------------------------------------------------------------
+
+def probe_id(probe, is_acceptance=False):
+    """Derive the probe id: 'p-'/'a-' + sha1(canonical(cmd)+canonical(expect))[:12].
+
+    Derived, never authored. Hashed over the raw cmd with its ``{{TOKENS}}`` intact, so the same
+    assertion has the same id in an arena, a scratch checkout and ``tests/cli/``; that identity is
+    what dedup and the acceptance matrix key off.
+    """
+    if not isinstance(probe, dict) or "cmd" not in probe or "expect" not in probe:
+        raise ProbeError("probe_id needs both 'cmd' and 'expect'")
+    body = json.dumps({"cmd": probe["cmd"], "expect": probe["expect"]},
+                      sort_keys=True, separators=(",", ":")).encode()
+    return ("a-" if is_acceptance else "p-") + hashlib.sha1(body).hexdigest()[:12]
+
+
+# --- validation -------------------------------------------------------------
+
+def _is_int(v):
+    return isinstance(v, int) and not isinstance(v, bool)
+
+
+def _is_num(v):
+    return isinstance(v, (int, float)) and not isinstance(v, bool)
+
+
+def _unknown_keys(node, allowed, where, errs):
+    for k in sorted(node):
+        if k not in allowed:
+            errs.append("%s: unknown key %r (additionalProperties is false)" % (where, k))
+
+
+def _check_regex(pattern, where, errs):
+    if not isinstance(pattern, str):
+        errs.append("%s: must be a string regex" % where)
+        return
+    try:
+        re.compile(pattern)
+    except re.error as exc:
+        errs.append("%s: not a valid Python regex (%s)" % (where, exc))
+
+
+def _validate_numpred(node, where, errs):
+    if not isinstance(node, dict):
+        errs.append("%s: must be an object" % where)
+        return
+    if not node:
+        errs.append("%s: must have at least one of %s" % (where, "/".join(_NUM_OPS)))
+    _unknown_keys(node, _NUM_OPS, where, errs)
+    for op in _ORDER_OPS:
+        if op in node and not _is_num(node[op]):
+            errs.append("%s.%s: must be a number" % (where, op))
+    if "in" in node and not isinstance(node["in"], list):
+        errs.append("%s.in: must be an array" % where)
+
+
+def _validate_statpred(node, where, errs):
+    """Stricter than the schema on purpose: a statpred with no bound asserts nothing."""
+    if not isinstance(node, dict):
+        errs.append("%s: must be an object" % where)
+        return
+    _unknown_keys(node, ("stat", "lt", "gt", "rel_to", "ratio_lt", "ratio_gt"), where, errs)
+    if node.get("stat") not in _STATS:
+        errs.append("%s.stat: required, one of %s" % (where, "|".join(_STATS)))
+    for key in ("lt", "gt", "ratio_lt", "ratio_gt"):
+        if key in node and not _is_num(node[key]):
+            errs.append("%s.%s: must be a number" % (where, key))
+    if "rel_to" in node and node["rel_to"] is not None and not isinstance(node["rel_to"], str):
+        errs.append("%s.rel_to: must be a probe id string or null" % where)
+    bounds = [k for k in ("lt", "gt", "ratio_lt", "ratio_gt") if k in node]
+    if not bounds:
+        errs.append("%s: needs at least one of lt/gt/ratio_lt/ratio_gt, else it asserts nothing"
+                    % where)
+    if ("ratio_lt" in node or "ratio_gt" in node) and not node.get("rel_to"):
+        errs.append("%s: ratio_lt/ratio_gt require rel_to (the baseline probe id)" % where)
+
+
+def _validate_jsonpred(node, where, errs):
+    if not isinstance(node, dict):
+        errs.append("%s: must be an object" % where)
+        return
+    _unknown_keys(node, ("path", "op", "value"), where, errs)
+    path = node.get("path")
+    if not isinstance(path, str) or not path.strip():
+        errs.append("%s.path: required, a non-empty dotted path" % where)
+    else:
+        try:
+            parse_path(path)
+        except ProbeError as exc:
+            errs.append("%s.path: %s" % (where, exc))
+    op = node.get("op")
+    if op not in _JSON_OPS:
+        errs.append("%s.op: required, one of %s" % (where, "|".join(_JSON_OPS)))
+        return
+    if op in _JSON_OPS_NO_VALUE:
+        return
+    if "value" not in node:
+        errs.append("%s.value: required for op %r" % (where, op))
+        return
+    if op in _JSON_OPS_NUMERIC and not _is_num(node["value"]):
+        errs.append("%s.value: must be a number for op %r" % (where, op))
+    if op == "matches":
+        _check_regex(node["value"], where + ".value", errs)
+
+
+def _validate_expect(node, errs):
+    if not isinstance(node, dict):
+        errs.append("expect: must be an object")
+        return
+    _unknown_keys(node, _EXPECT_KEYS, "expect", errs)
+    for key in ("exit_code", "stdout_bytes"):
+        if key in node:
+            _validate_numpred(node[key], "expect." + key, errs)
+    for key in _REGEX_LISTS:
+        if key in node:
+            if not isinstance(node[key], list):
+                errs.append("expect.%s: must be an array of regex strings" % key)
+                continue
+            for i, pat in enumerate(node[key]):
+                _check_regex(pat, "expect.%s[%d]" % (key, i), errs)
+    if "stdout_is_json" in node and not isinstance(node["stdout_is_json"], bool):
+        errs.append("expect.stdout_is_json: must be a boolean")
+    if "json" in node:
+        if not isinstance(node["json"], list):
+            errs.append("expect.json: must be an array of json predicates")
+        else:
+            for i, jp in enumerate(node["json"]):
+                _validate_jsonpred(jp, "expect.json[%d]" % i, errs)
+    for key in _STAT_CLAUSES:
+        if key in node:
+            _validate_statpred(node[key], "expect." + key, errs)
+
+
+def _validate_target(node, errs):
+    if not isinstance(node, dict):
+        errs.append("target: must be an object")
+        return
+    _unknown_keys(node, _TARGET_KEYS, "target", errs)
+    for key in ("binary_rel", "binary_sha256", "binary_size"):
+        if key not in node:
+            errs.append("target.%s: required" % key)
+    if "binary_rel" in node and not isinstance(node["binary_rel"], str):
+        errs.append("target.binary_rel: must be a string")
+    sha = node.get("binary_sha256")
+    if "binary_sha256" in node and (not isinstance(sha, str) or not _SHA256_RE.match(sha)):
+        errs.append("target.binary_sha256: must be 64 lowercase hex chars")
+    if "binary_size" in node and not _is_int(node["binary_size"]):
+        errs.append("target.binary_size: must be an integer")
+    if "binary_source" in node and node["binary_source"] not in _BINARY_SOURCES:
+        errs.append("target.binary_source: must be one of %s" % "|".join(_BINARY_SOURCES))
+    if "selector_kind" in node and node["selector_kind"] not in _SELECTOR_KINDS:
+        errs.append("target.selector_kind: must be one of %s" % "|".join(_SELECTOR_KINDS))
+    for key in ("in_repo_path", "selector"):
+        if key in node and node[key] is not None and not isinstance(node[key], str):
+            errs.append("target.%s: must be a string or null" % key)
+
+
+def validate(probe):
+    """Structural errors against tools/repipe/schema/probe.schema.json, as a list of strings.
+
+    Hand-written because kuna's Python tooling is stdlib-only (no jsonschema anywhere on this
+    machine). Empty list means valid. Two checks are deliberately *stricter* than the JSON Schema,
+    which cannot express them: every regex clause must actually compile, and a statpred must carry
+    a bound (a statpred with only ``stat`` asserts nothing, which is the failure mode this whole
+    module exists to prevent).
+    """
+    errs = []
+    if not isinstance(probe, dict):
+        return ["probe: must be a JSON object"]
+    _unknown_keys(probe, _PROBE_KEYS, "probe", errs)
+    for key in ("schema", "kind", "cmd", "timeout_s", "expect"):
+        if key not in probe:
+            errs.append("%s: required" % key)
+    if "schema" in probe and probe["schema"] != SCHEMA_ID:
+        errs.append("schema: must be %r" % SCHEMA_ID)
+    if "probe_id" in probe:
+        pid = probe["probe_id"]
+        if not isinstance(pid, str) or not _PROBE_ID_RE.match(pid):
+            errs.append("probe_id: must match ^[pa]-[0-9a-f]{12}$")
+    if "kind" in probe and probe["kind"] not in _KINDS:
+        errs.append("kind: must be one of %s" % "|".join(_KINDS))
+    cmd = probe.get("cmd")
+    if "cmd" in probe:
+        if not isinstance(cmd, list) or not cmd:
+            errs.append("cmd: must be a non-empty array of strings")
+        elif not all(isinstance(x, str) for x in cmd):
+            errs.append("cmd: every element must be a string")
+    if "cwd" in probe and not isinstance(probe["cwd"], str):
+        errs.append("cwd: must be a string")
+    if "env" in probe:
+        env = probe["env"]
+        if not isinstance(env, dict):
+            errs.append("env: must be an object of string->string")
+        else:
+            for k, v in env.items():
+                if not isinstance(v, str):
+                    errs.append("env.%s: must be a string" % k)
+    if "stdin" in probe and probe["stdin"] is not None and not isinstance(probe["stdin"], str):
+        errs.append("stdin: must be a string or null")
+    if "timeout_s" in probe:
+        t = probe["timeout_s"]
+        if not _is_int(t) or not (1 <= t <= 1800):
+            errs.append("timeout_s: must be an integer 1..1800")
+    if "repeat" in probe:
+        r = probe["repeat"]
+        if not _is_int(r) or not (1 <= r <= 11):
+            errs.append("repeat: must be an integer 1..11")
+    if "target" in probe:
+        _validate_target(probe["target"], errs)
+    if "notes" in probe:
+        if not isinstance(probe["notes"], str):
+            errs.append("notes: must be a string")
+        elif len(probe["notes"]) > 400:
+            errs.append("notes: must be at most 400 characters")
+    if "expect" in probe:
+        _validate_expect(probe["expect"], errs)
+    return errs
+
+
+def asserted_clause_count(expect):
+    """How many clauses actually assert something. Zero means the probe is not evidence."""
+    if not isinstance(expect, dict):
+        return 0
+    n = 0
+    for key in ("exit_code", "stdout_bytes"):
+        if isinstance(expect.get(key), dict) and expect[key]:
+            n += 1
+    for key in _REGEX_LISTS:
+        n += len(expect.get(key) or [])
+    if isinstance(expect.get("stdout_is_json"), bool):
+        n += 1
+    n += len(expect.get("json") or [])
+    for key in _STAT_CLAUSES:
+        sp = expect.get(key)
+        if isinstance(sp, dict) and any(b in sp for b in ("lt", "gt", "ratio_lt", "ratio_gt")):
+            n += 1
+    return n
+
+
+def normalize(probe, is_acceptance=False):
+    """Fill defaults, reject a structurally unusable probe, and stamp the derived probe_id.
+
+    Defaults are filled *before* validation so a hand-written probe may omit ``schema``, ``kind``
+    (-> "cli"), ``cwd`` (-> "{{WORK}}") and ``repeat`` (-> 1); everything else the schema requires
+    must be present. Raises :class:`ProbeError` on any structural error, and -- the check the whole
+    two-arm gate leans on -- on an ``expect`` that is empty or whose clauses are all absent/empty:
+    a probe that asserts nothing always passes and is not evidence.
+
+    ``is_acceptance`` picks the id prefix. A probe already carrying an ``a-`` id is treated as an
+    acceptance even when the caller did not say so, so loading a file off disk round-trips; an
+    authored id that disagrees with the derived one is an error rather than a silent overwrite,
+    because dedup keys off that id. Idempotent: normalizing a normalized probe is a no-op.
+    """
+    if not isinstance(probe, dict):
+        raise ProbeError("probe must be a JSON object, got %s" % type(probe).__name__)
+    out = copy.deepcopy(probe)
+    out.setdefault("schema", SCHEMA_ID)
+    out.setdefault("kind", "cli")
+    out.setdefault("cwd", "{{WORK}}")
+    out.setdefault("repeat", 1)
+    errs = validate(out)
+    if errs:
+        raise ProbeError("invalid probe: " + "; ".join(errs))
+    if asserted_clause_count(out["expect"]) == 0:
+        raise ProbeError("expect asserts nothing: a probe with no effective clause always "
+                         "passes and is not evidence")
+    authored = probe.get("probe_id")
+    if not is_acceptance and isinstance(authored, str) and authored.startswith("a-"):
+        is_acceptance = True
+    pid = probe_id(out, is_acceptance)
+    if isinstance(authored, str) and authored and authored != pid:
+        raise ProbeError("probe_id %s does not match the derived id %s (it is derived from "
+                         "cmd+expect, not authored)" % (authored, pid))
+    out["probe_id"] = pid
+    return out
+
+
+# --- substitution -----------------------------------------------------------
+
+def context(work=None, binary=None, tmp=None, baselines=None, kuna=None, specs=None):
+    """Build the ctx dict :func:`run` and :func:`substitute` take. Every field is optional."""
+    return {"work": work, "bin": binary, "tmp": tmp, "kuna": kuna, "specs": specs,
+            "baselines": baselines or {}}
+
+
+def _token_values(ctx):
+    ctx = ctx or {}
+    return {
+        "KUNA": str(ctx.get("kuna") or config.kuna_bin()),
+        "SPECS": str(ctx.get("specs") or config.specs_dir()),
+        "WORK": str(ctx["work"]) if ctx.get("work") else os.getcwd(),
+        "TMP": str(ctx["tmp"]) if ctx.get("tmp") else None,
+        "BIN": str(ctx["bin"]) if ctx.get("bin") else None,
+    }
+
+
+def _subst_str(text, values):
+    def repl(m):
+        name = m.group(1)
+        if name not in values:
+            raise ProbeError("unknown substitution token {{%s}} (known: %s)"
+                             % (name, " ".join(TOKENS)))
+        if values[name] is None:
+            raise ProbeError("{{%s}} used but the context supplies no %s"
+                             % (name, name.lower()))
+        return values[name]
+    return _TOKEN_RE.sub(repl, text)
+
+
+def _subst(value, values):
+    if isinstance(value, str):
+        return _subst_str(value, values)
+    if isinstance(value, (list, tuple)):
+        return [_subst(v, values) for v in value]
+    if isinstance(value, dict):
+        return {k: _subst(v, values) for k, v in value.items()}
+    return value
+
+
+def substitute(value, ctx):
+    """Expand {{KUNA}} {{BIN}} {{SPECS}} {{WORK}} {{TMP}} in a string, list or dict of values.
+
+    Non-string leaves pass through untouched. An unknown token, or a known token the context
+    cannot fill, raises :class:`ProbeError` -- running a command with a literal ``{{BIN}}`` in its
+    argv would produce a confident, meaningless observation. ``{{BIN}}`` is the caller's job to
+    supply; :func:`run` derives it from ``target.binary_rel`` inside ``{{WORK}}`` when the context
+    leaves it unset.
+    """
+    return _subst(value, _token_values(ctx))
+
+
+def resolve(probe, ctx):
+    """The substituted ``{cmd, cwd, env}`` a run would use. Handy for logging a transcript."""
+    p = normalize(probe)
+    return {"cmd": [str(x) for x in substitute(p["cmd"], ctx)],
+            "cwd": str(substitute(p.get("cwd") or "{{WORK}}", ctx)),
+            "env": substitute(p.get("env") or {}, ctx)}
+
+
+# --- execution --------------------------------------------------------------
+
+def _parse_time_report(path):
+    """Pull max RSS and the true child status out of a /usr/bin/time -v report file."""
+    try:
+        with open(path, "r", errors="replace") as fh:
+            text = fh.read()
+    except OSError:
+        return None
+    if not text.strip():
+        return None
+    out = {"max_rss_kb": None, "exit_code": None, "signal": None}
+    m = _RE_MAXRSS.search(text)
+    if m:
+        out["max_rss_kb"] = int(m.group(1))
+    m = _RE_SIGNAL.search(text)
+    if m:
+        out["signal"] = int(m.group(1))
+        out["exit_code"] = -int(m.group(1))
+        return out
+    m = _RE_EXIT.search(text)
+    if m:
+        out["exit_code"] = int(m.group(1))
+    return out
+
+
+def _kill_group(proc):
+    try:
+        pgid = os.getpgid(proc.pid)
+    except OSError:
+        proc.kill()
+        return
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(pgid, sig)
+        except OSError:
+            return
+        try:
+            proc.wait(timeout=TERM_GRACE_S)
+            return
+        except subprocess.TimeoutExpired:
+            continue
+
+
+# --- what a probe is allowed to execute ------------------------------------
+#
+# A probe's argv is authored by an LLM tester and is replayed by verify.py in the MAIN tree,
+# outside the tester's bwrap sandbox. Without a guard, `{"cmd": ["bash", "-c", "..."]}` in a
+# tester report is remote code execution against the operator's checkout. So argv[0] is
+# checked against an allowlist of read-only analysis tools before anything runs, and the
+# interpreters and shells that would launder arbitrary code are denied outright.
+#
+# A violation raises, which makes the observation `unrunnable` -- exactly the right verdict
+# for "this is not a probe".
+
+DEFAULT_ALLOWED = (
+    "kuna", "decomp_dbg", "decomp_test_dbg", "slacomp",
+    "objdump", "readelf", "strings", "nm", "file", "size", "xxd", "od", "cmp",
+    "decompiler",          # declib/IDA, the reference leg
+)
+
+# Denied even if someone adds them to the allowlist: each one runs code given as an argument,
+# so allowing it would make the allowlist meaningless.
+DENIED_ALWAYS = frozenset("""
+sh bash dash zsh ksh csh fish env eval exec xargs
+python python2 python3 perl ruby node deno bun lua tclsh
+make cmake cargo rustc cc gcc clang ld
+curl wget nc ncat socat ssh scp rsync git gh sudo doas su
+rm mv cp dd chmod chown mkfs mount umount kill pkill systemctl crontab at
+""".split())
+
+
+def allowed_executables():
+    """The allowlist, overridable with REPIPE_PROBE_ALLOW (colon-separated basenames)."""
+    extra = os.environ.get("REPIPE_PROBE_ALLOW", "")
+    names = set(DEFAULT_ALLOWED)
+    names.update(x.strip() for x in extra.split(":") if x.strip())
+    return names
+
+
+def _allowed_realpaths():
+    """The allowlist resolved to real absolute paths, once.
+
+    Matching on the BASENAME alone is not a control: a tester has workspace-write in its
+    arena, so it can drop a shell script called `kuna` there and name it by path. What is
+    allowed is a specific FILE, so every candidate is resolved (realpath, defeating symlinks)
+    and compared against the resolved allowlist.
+    """
+    paths = set()
+    from . import config as _cfg
+    for cand in (_cfg.kuna_bin(),
+                 _cfg.repo_root() / "decompiler" / "target" / "release" / "decomp_dbg",
+                 _cfg.repo_root() / "decompiler" / "target" / "release" / "decomp_test_dbg",
+                 _cfg.repo_root() / "decompiler" / "target" / "release" / "slacomp",
+                 _cfg.decompiler_cli()):
+        try:
+            if os.path.exists(str(cand)):
+                paths.add(os.path.realpath(str(cand)))
+        except Exception:
+            pass
+    for name in allowed_executables():
+        found = shutil.which(name)
+        if found:
+            paths.add(os.path.realpath(found))
+    for extra in os.environ.get("REPIPE_PROBE_ALLOW_PATH", "").split(":"):
+        if extra.strip() and os.path.exists(extra.strip()):
+            paths.add(os.path.realpath(extra.strip()))
+    return paths
+
+
+def check_executable(argv, env=None):
+    """None if this argv may run, else the reason it may not.
+
+    Two gates, and the second is the real one: the basename must not be an interpreter, and
+    the RESOLVED FILE must be on the allowlist. Basename-only matching would let
+    `/tmp/anything/kuna` through, which a tester can create.
+    """
+    if not argv:
+        return "empty cmd"
+    raw = str(argv[0])
+    base = os.path.basename(raw)
+    if base in DENIED_ALWAYS:
+        return ("probe may not execute %r: it runs code passed as an argument, which would "
+                "make the allowlist meaningless" % base)
+    path = raw if os.sep in raw else shutil.which(raw, path=(env or os.environ).get("PATH"))
+    if not path or not os.path.exists(path):
+        return "probe may not execute %r: no such executable" % raw
+    real = os.path.realpath(path)
+    if real not in _allowed_realpaths():
+        return ("probe may not execute %s: it resolves to %s, which is not one of the "
+                "allowed analysis tools. Allowed basenames: %s. Extend with "
+                "REPIPE_PROBE_ALLOW (name) or REPIPE_PROBE_ALLOW_PATH (absolute path)."
+                % (raw, real, ", ".join(sorted(allowed_executables()))))
+    return None
+
+
+def _exec_once(index, argv, cwd, env, stdin_data, timeout_s, use_time):
+    """One execution. Never raises: an exec failure or a timeout is recorded, not thrown."""
+    rec = {"index": index, "exit_code": None, "signal": None, "stdout": "", "stderr": "",
+           "stdout_bytes": 0, "stderr_bytes": 0, "wall_ms": 0.0, "max_rss_kb": None,
+           "timed_out": False, "error": None}
+    exe = argv[0]
+    resolved = exe if os.sep in exe else shutil.which(exe, path=env.get("PATH"))
+    if not resolved or not os.path.exists(resolved):
+        rec["error"] = "cannot execute %r: no such file" % exe
+        return rec
+    if not os.access(resolved, os.X_OK):
+        rec["error"] = "cannot execute %r: not executable" % resolved
+        return rec
+    if not os.path.isdir(cwd):
+        rec["error"] = "cwd %r is not a directory" % cwd
+        return rec
+
+    report_path = None
+    wrapped = argv
+    if use_time:
+        fd, report_path = tempfile.mkstemp(prefix="repipe-rusage-", suffix=".txt")
+        os.close(fd)
+        wrapped = [TIME_BIN, "-v", "-o", report_path, "--"] + argv
+
+    payload = stdin_data.encode() if isinstance(stdin_data, str) else None
+    t0 = time.monotonic()
+    try:
+        proc = subprocess.Popen(
+            wrapped, cwd=cwd, env=env,
+            stdin=subprocess.PIPE if payload is not None else subprocess.DEVNULL,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True)
+    except OSError as exc:
+        rec["error"] = "spawn failed: %s" % exc
+        rec["wall_ms"] = (time.monotonic() - t0) * 1000.0
+        if report_path:
+            os.unlink(report_path)
+        return rec
+    try:
+        out, err = proc.communicate(input=payload, timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        rec["timed_out"] = True
+        _kill_group(proc)
+        try:
+            out, err = proc.communicate(timeout=30)
+        except subprocess.TimeoutExpired:
+            out, err = b"", b""
+    rec["wall_ms"] = (time.monotonic() - t0) * 1000.0
+
+    rec["stdout_bytes"] = len(out or b"")
+    rec["stderr_bytes"] = len(err or b"")
+    rec["stdout"] = (out or b"").decode("utf-8", "replace")
+    rec["stderr"] = (err or b"").decode("utf-8", "replace")
+
+    report = _parse_time_report(report_path) if report_path else None
+    if report_path:
+        try:
+            os.unlink(report_path)
+        except OSError:
+            pass
+    if report and report["exit_code"] is not None:
+        rec["exit_code"] = report["exit_code"]
+        rec["signal"] = report["signal"]
+        rec["max_rss_kb"] = report["max_rss_kb"]
+    else:
+        rc = proc.returncode
+        rec["exit_code"] = rc
+        if rc is not None and rc < 0:
+            rec["signal"] = -rc
+        if report:
+            rec["max_rss_kb"] = report["max_rss_kb"]
+    if rec["timed_out"]:
+        rec["error"] = "timed out after %ss" % timeout_s
+    return rec
+
+
+def sha256_file(path, chunk=1 << 20):
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for block in iter(lambda: fh.read(chunk), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def target_mismatch(probe, ctx):
+    """None if the resolved {{BIN}} is the binary the probe was written against.
+
+    Returns a human-readable reason otherwise. Checked before every run so a misresolved
+    path becomes `unrunnable` instead of a confident false verdict.
+    """
+    target = (probe or {}).get("target") or {}
+    want = target.get("binary_sha256")
+    if not want:
+        return None
+    path = ctx.get("bin")
+    if not path:
+        return "target.binary_sha256 given but {{BIN}} could not be resolved"
+    if not os.path.exists(str(path)):
+        return "target binary not found at %s (is {{WORK}} right?)" % path
+    size = target.get("binary_size")
+    actual_size = os.path.getsize(str(path))
+    if size is not None and int(size) != actual_size:
+        return ("target size mismatch at %s: probe expects %s bytes, found %s"
+                % (path, size, actual_size))
+    got = sha256_file(str(path))
+    if got != want:
+        return ("target sha256 mismatch at %s: probe expects %s..., found %s..."
+                % (path, want[:12], got[:12]))
+    return None
+
+
+def run(probe, ctx=None, timeout=None):
+    """Execute the probe ``repeat`` times and return an Observation.
+
+    The Observation records, per run: exit_code, signal, stdout, stderr, stdout_bytes, wall_ms,
+    max_rss_kb, timed_out and error. It is a plain dict, JSON-serialisable, and is the only thing
+    :func:`evaluate` reads -- ``ctx["baselines"]`` is copied into it so evaluate stays a pure
+    function of (probe, observation) and a verdict can be recomputed from a stored observation.
+
+    ``timeout`` overrides the probe's ``timeout_s``. One ``{{TMP}}`` directory is created per
+    ``run()`` call and shared by the repeats -- the repeats exist to detect flakiness, so they must
+    see identical conditions -- and is removed again unless the caller supplied ``ctx["tmp"]``.
+    ``{{BIN}}`` defaults to ``target.binary_rel`` resolved inside ``{{WORK}}`` and is checked
+    against ``target.binary_sha256``/``binary_size`` before the first spawn (see
+    :func:`target_mismatch`); a mismatch raises rather than producing a confident verdict about
+    the wrong file. The child inherits
+    this process's environment updated with the probe's ``env``; nothing is scrubbed, because kuna
+    needs its ambient SLEIGHHOME/PATH to run at all.
+
+    ``repeat`` is honoured verbatim; the REPLAY_REPS / TIMING_REPS policy lives in verify.py.
+    """
+    p = normalize(probe)
+    ctx = dict(ctx or {})
+    owned_tmp = None
+    if not ctx.get("tmp"):
+        owned_tmp = tempfile.mkdtemp(prefix="repipe-probe-")
+        ctx["tmp"] = owned_tmp
+    if not ctx.get("bin"):
+        target = p.get("target") or {}
+        if target.get("binary_rel"):
+            ctx["bin"] = os.path.join(str(ctx.get("work") or os.getcwd()),
+                                      target["binary_rel"])
+    denied = check_executable([str(x) for x in substitute(p["cmd"], ctx)])
+    if denied:
+        if owned_tmp:
+            shutil.rmtree(owned_tmp, ignore_errors=True)
+        raise ProbeError(denied)
+    mismatch = target_mismatch(p, ctx)
+    if mismatch:
+        # Refuse rather than run. A probe pointed at the wrong file still produces a
+        # verdict, and a FAIL there reads as "not reproducible" -- i.e. it would silently
+        # discard a real need because {{WORK}} was wrong. binary_sha256 is in the schema to
+        # be checked, not to be decoration.
+        if owned_tmp:
+            shutil.rmtree(owned_tmp, ignore_errors=True)
+        raise ProbeError(mismatch)
+    try:
+        argv = [str(x) for x in substitute(p["cmd"], ctx)]
+        cwd = str(substitute(p.get("cwd") or "{{WORK}}", ctx))
+        env_extra = {k: str(v) for k, v in substitute(p.get("env") or {}, ctx).items()}
+        env = dict(os.environ)
+        env.update(env_extra)
+        tmo = int(timeout) if timeout is not None else int(p["timeout_s"])
+        reps = int(p.get("repeat") or 1)
+        use_time = os.path.exists(TIME_BIN) and os.access(TIME_BIN, os.X_OK)
+        obs = {
+            "schema": "re-observation/1",
+            "probe_id": p["probe_id"],
+            "kind": p.get("kind"),
+            "cmd": argv,
+            "cwd": cwd,
+            "env_extra": env_extra,
+            "repeat": reps,
+            "timeout_s": tmo,
+            "rusage_source": "/usr/bin/time -v" if use_time else "unavailable",
+            "started_at": time.time(),
+            "baselines": ctx.get("baselines") or {},
+            "runs": [],
+        }
+        for i in range(reps):
+            obs["runs"].append(_exec_once(i, argv, cwd, env, p.get("stdin"), tmo, use_time))
+        obs["duration_s"] = time.time() - obs["started_at"]
+        return obs
+    finally:
+        if owned_tmp:
+            shutil.rmtree(owned_tmp, ignore_errors=True)
+
+
+# --- json paths -------------------------------------------------------------
+
+def parse_path(path):
+    """Parse a dotted json path into steps: ('key', name) | ('index', i) | ('any', None)."""
+    if not isinstance(path, str) or not path.strip():
+        raise ProbeError("json path must be a non-empty string")
+    s = path.strip()
+    if s.startswith("$"):
+        s = s[1:]
+    if s.startswith("."):
+        s = s[1:]
+    steps = []
+    i, n = 0, len(s)
+    while i < n:
+        c = s[i]
+        if c == "[":
+            j = s.find("]", i)
+            if j < 0:
+                raise ProbeError("unbalanced '[' in json path %r" % path)
+            tok = s[i + 1:j]
+            if tok == "*":
+                steps.append(("any", None))
+            else:
+                try:
+                    steps.append(("index", int(tok)))
+                except ValueError:
+                    raise ProbeError("bad index %r in json path %r" % (tok, path))
+            i = j + 1
+        elif c == ".":
+            i += 1
+        else:
+            j = i
+            while j < n and s[j] not in ".[":
+                j += 1
+            steps.append(("key", s[i:j]))
+            i = j
+    if not steps:
+        raise ProbeError("json path %r resolves to no steps" % path)
+    return steps
+
+
+def resolve_path(doc, steps):
+    """Resolve a parsed path to a list of candidate values; MISSING marks a branch that is absent.
+
+    ``[*]`` fans out over a list (or a dict's values); every other step keeps one branch. An empty
+    container under ``[*]`` yields a single MISSING, so `exists` is false and `absent` is true.
+    """
+    cur = [doc]
+    for kind, arg in steps:
+        nxt = []
+        for v in cur:
+            if v is MISSING:
+                nxt.append(MISSING)
+            elif kind == "key":
+                nxt.append(v[arg] if isinstance(v, dict) and arg in v else MISSING)
+            elif kind == "index":
+                if isinstance(v, list) and -len(v) <= arg < len(v):
+                    nxt.append(v[arg])
+                else:
+                    nxt.append(MISSING)
+            elif isinstance(v, (list, tuple)):
+                nxt.extend(v if v else [MISSING])
+            elif isinstance(v, dict):
+                nxt.extend(list(v.values()) if v else [MISSING])
+            else:
+                nxt.append(MISSING)
+        cur = nxt
+    return cur
+
+
+def _one_json_op(op, value, want):
+    try:
+        if op == "eq":
+            return value == want
+        if op == "ne":
+            return value != want
+        if op == "lt":
+            return value < want
+        if op == "gt":
+            return value > want
+        if op == "le":
+            return value <= want
+        if op == "ge":
+            return value >= want
+        if op == "len_eq":
+            return len(value) == want
+        if op == "len_lt":
+            return len(value) < want
+        if op == "len_gt":
+            return len(value) > want
+        if op == "contains":
+            return (str(want) in value) if isinstance(value, str) else (want in value)
+        if op == "not_contains":
+            return not ((str(want) in value) if isinstance(value, str) else (want in value))
+        if op == "matches":
+            subject = value if isinstance(value, str) else json.dumps(value, sort_keys=True)
+            return bool(re.search(str(want), subject, re.MULTILINE))
+    except (TypeError, ValueError, re.error):
+        return False
+    return False
+
+
+def _shown(values):
+    out = ["<absent>" if v is MISSING else v for v in values]
+    if len(out) == 1:
+        return out[0]
+    if len(out) > 6:
+        return out[:6] + ["<%d more>" % (len(out) - 6)]
+    return out
+
+
+# --- clause evaluation ------------------------------------------------------
+
+def _numpred_ok(pred, value):
+    if value is None:
+        return False, None
+    ok = True
+    for op, want in pred.items():
+        try:
+            if op == "eq":
+                ok = ok and value == want
+            elif op == "ne":
+                ok = ok and value != want
+            elif op == "in":
+                ok = ok and value in want
+            elif op == "lt":
+                ok = ok and value < want
+            elif op == "gt":
+                ok = ok and value > want
+            elif op == "le":
+                ok = ok and value <= want
+            elif op == "ge":
+                ok = ok and value >= want
+        except TypeError:
+            return False, value
+    return ok, value
+
+
+class RegexTimeout(Exception):
+    pass
+
+
+# Seconds any single regex may spend. Patterns come from an LLM tester and `timeout_s` bounds
+# only the SUBPROCESS -- a catastrophic-backtracking pattern like `(a+)+$` against 40 bytes
+# runs inside the evaluator and hangs the gate forever, taking the whole round with it.
+REGEX_BUDGET_S = float(os.environ.get("REPIPE_REGEX_BUDGET_S", "5"))
+# re is applied to whole streams; a huge stdout multiplies any pattern's cost.
+REGEX_MAX_BYTES = int(os.environ.get("REPIPE_REGEX_MAX_BYTES", str(4 << 20)))
+
+
+def _search(pattern, text, budget=None):
+    """re.search with a wall-clock bound. Returns None on error, timeout or no match.
+
+    The bound uses SIGALRM, which only arms in the main thread; off the main thread the input
+    is truncated instead, which caps the cost without pretending to interrupt.
+    """
+    text = text or ""
+    if len(text) > REGEX_MAX_BYTES:
+        text = text[:REGEX_MAX_BYTES]
+    budget = REGEX_BUDGET_S if budget is None else budget
+
+    def _raise(signum, frame):
+        raise RegexTimeout()
+
+    armed = False
+    if budget > 0 and threading.current_thread() is threading.main_thread():
+        try:
+            old_handler = signal.signal(signal.SIGALRM, _raise)
+            signal.setitimer(signal.ITIMER_REAL, budget)
+            armed = True
+        except (ValueError, OSError):
+            armed = False
+    try:
+        return re.search(pattern, text, re.MULTILINE)
+    except (re.error, RegexTimeout):
+        return None
+    finally:
+        if armed:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+            signal.signal(signal.SIGALRM, old_handler)
+
+
+def _per_run_checkers(expect):
+    """(clause, expected, fn(run, parsed_json) -> (ok, actual)) for every non-aggregate clause."""
+    checks = []
+    if "exit_code" in expect:
+        pred = expect["exit_code"]
+        checks.append(("exit_code", pred,
+                       lambda r, d, pred=pred: _numpred_ok(pred, r.get("exit_code"))))
+    if "stdout_bytes" in expect:
+        pred = expect["stdout_bytes"]
+        checks.append(("stdout_bytes", pred,
+                       lambda r, d, pred=pred: _numpred_ok(pred, r.get("stdout_bytes"))))
+    for stream in ("stdout", "stderr"):
+        for i, pat in enumerate(expect.get(stream + "_matches") or []):
+            def _m(r, d, pat=pat, s=stream):
+                hit = _search(pat, r.get(s) or "")
+                return (bool(hit), hit.group(0)[:200] if hit else "<no match>")
+            checks.append(("%s_matches[%d]" % (stream, i), pat, _m))
+        for i, pat in enumerate(expect.get(stream + "_absent") or []):
+            def _a(r, d, pat=pat, s=stream):
+                hit = _search(pat, r.get(s) or "")
+                return (hit is None, "<absent>" if hit is None else hit.group(0)[:200])
+            checks.append(("%s_absent[%d]" % (stream, i), pat, _a))
+    if "stdout_is_json" in expect:
+        want = bool(expect["stdout_is_json"])
+        checks.append(("stdout_is_json", want, lambda r, d, want=want: (d[0] == want, d[0])))
+    for i, jp in enumerate(expect.get("json") or []):
+        def _j(r, d, jp=jp):
+            if not d[0]:
+                return False, "<stdout is not JSON>"
+            values = resolve_path(d[1], parse_path(jp["path"]))
+            op = jp["op"]
+            if op == "exists":
+                return any(v is not MISSING for v in values), _shown(values)
+            if op == "absent":
+                # A NEGATIVE operator must be universally quantified over [*]: "size is
+                # absent" means no element has it, not "some element lacks it". Existential
+                # negation let a probe and its own negation both pass on a mixed array, and
+                # the gate reads that as already-supported -- silently discarding a real need.
+                return all(v is MISSING for v in values), _shown(values)
+            found = [v for v in values if v is not MISSING]
+            # Same rule for the other negative operators.
+            quantifier = all if op in _JSON_OPS_NEGATIVE else any
+            return (quantifier(_one_json_op(op, v, jp.get("value")) for v in found),
+                    _shown(values))
+        checks.append(("json[%d]" % i, jp, _j))
+    return checks
+
+
+def _samples(runs, metric):
+    return [r[metric] for r in runs if _is_num(r.get(metric))]
+
+
+def _stat_of(samples, stat):
+    if not samples:
+        return None
+    if stat == "median":
+        return float(statistics.median(samples))
+    if stat == "mean":
+        return float(statistics.fmean(samples))
+    if stat == "min":
+        return float(min(samples))
+    return float(max(samples))
+
+
+def _baseline_stat(baselines, ref, metric, stat):
+    """Look a baseline probe's aggregate up in ctx['baselines'] (a verdict, or an observation)."""
+    b = (baselines or {}).get(ref)
+    if not isinstance(b, dict):
+        return None
+    key = "%s_%s" % (metric, stat)
+    if _is_num(b.get(key)):
+        return float(b[key])
+    if _is_num(b.get(metric)):
+        return float(b[metric])
+    return _stat_of(_samples(b.get("runs") or [], metric), stat)
+
+
+def _stat_clause(metric, sp, runs, baselines):
+    stat = sp["stat"]
+    samples = _samples(runs, metric)
+    value = _stat_of(samples, stat)
+    actual = {"stat": stat, "value": value, "samples": samples}
+    if value is None:
+        actual["why"] = "%s was not measured on any run" % metric
+        return False, actual
+    ok = True
+    if "lt" in sp:
+        ok = ok and value < sp["lt"]
+    if "gt" in sp:
+        ok = ok and value > sp["gt"]
+    if "ratio_lt" in sp or "ratio_gt" in sp:
+        base = _baseline_stat(baselines, sp.get("rel_to"), metric, stat)
+        actual["baseline_probe"] = sp.get("rel_to")
+        actual["baseline"] = base
+        if base is None or base == 0:
+            actual["why"] = ("no baseline for %s in ctx['baselines'] -- the caller must supply "
+                             "it" % sp.get("rel_to"))
+            return False, actual
+        ratio = value / base
+        actual["ratio"] = ratio
+        if "ratio_lt" in sp:
+            ok = ok and ratio < sp["ratio_lt"]
+        if "ratio_gt" in sp:
+            ok = ok and ratio > sp["ratio_gt"]
+    return ok, actual
+
+
+def _collapse(actuals):
+    keys = set()
+    for a in actuals:
+        keys.add(json.dumps(a, sort_keys=True, default=str))
+    if len(keys) <= 1:
+        return actuals[0] if actuals else None
+    return actuals
+
+
+def evaluate(probe, observation):
+    """Turn an Observation into a Verdict. Every present clause must hold, on every repeat.
+
+    ``flaky`` is True when the repeats disagree about the (non-aggregate) clauses: that is the
+    pipeline's "this is not evidence" signal, and it is reported separately from ``passed`` so a
+    caller can tell "the behaviour is not there" from "the gate could not decide". A flaky probe
+    never passes, since passing requires every run to satisfy every clause.
+
+    ``wall_ms``/``max_rss_kb`` are aggregates over the repeats and so cannot be attributed to one
+    run; they are excluded from the flakiness verdict and evaluated once. A run that timed out or
+    could not be executed adds a synthetic failing ``run`` clause: an incomplete observation is not
+    a pass. ``rel_to`` baselines are read from ``observation["baselines"]``, which :func:`run`
+    copies out of ``ctx["baselines"]`` -- the caller must supply them.
+    """
+    p = normalize(probe)
+    expect = p["expect"]
+    runs = list(observation.get("runs") or [])
+    baselines = observation.get("baselines") or {}
+
+    parsed = []
+    for r in runs:
+        try:
+            parsed.append((True, json.loads(r.get("stdout") or "")))
+        except (ValueError, TypeError):
+            parsed.append((False, None))
+
+    checkers = _per_run_checkers(expect)
+    clauses = []
+    for name, expected, fn in checkers:
+        results = [fn(r, parsed[i]) for i, r in enumerate(runs)]
+        clauses.append({
+            "clause": name,
+            "expected": expected,
+            "actual": _collapse([x[1] for x in results]),
+            "ok": bool(results) and all(x[0] for x in results),
+        })
+    for metric in _STAT_CLAUSES:
+        if metric in expect:
+            ok, actual = _stat_clause(metric, expect[metric], runs, baselines)
+            clauses.append({"clause": metric, "expected": expect[metric],
+                            "actual": actual, "ok": ok})
+
+    broken = [r for r in runs if r.get("timed_out") or r.get("error")]
+    if not runs:
+        clauses.append({"clause": "run", "expected": "at least one run",
+                        "actual": "no runs recorded", "ok": False})
+    elif broken:
+        clauses.append({"clause": "run",
+                        "expected": "%d run(s) completing within %ss"
+                                    % (len(runs), observation.get("timeout_s")),
+                        "actual": "; ".join(sorted({str(r.get("error")) for r in broken})),
+                        "ok": False})
+
+    per_run = [all(fn(r, parsed[i])[0] for _, _, fn in checkers) for i, r in enumerate(runs)]
+    wall = _samples(runs, "wall_ms")
+    rss = _samples(runs, "max_rss_kb")
+    return {
+        "schema": "re-verdict/1",
+        "probe_id": p["probe_id"],
+        "kind": p.get("kind"),
+        "passed": bool(runs) and all(c["ok"] for c in clauses),
+        "flaky": len(set(per_run)) > 1,
+        "repeat": len(runs),
+        "run_passed": per_run,
+        "clauses": clauses,
+        "timed_out": any(r.get("timed_out") for r in runs),
+        "errors": [r["error"] for r in runs if r.get("error")],
+        "exit_codes": [r.get("exit_code") for r in runs],
+        "wall_ms": wall,
+        "wall_ms_median": _stat_of(wall, "median"),
+        "wall_ms_min": _stat_of(wall, "min"),
+        "wall_ms_max": _stat_of(wall, "max"),
+        "wall_ms_mean": _stat_of(wall, "mean"),
+        "max_rss_kb_median": _stat_of(rss, "median"),
+        "max_rss_kb_max": _stat_of(rss, "max"),
+        "rusage_source": observation.get("rusage_source"),
+        "cmd": observation.get("cmd"),
+        "cwd": observation.get("cwd"),
+        "stdout_head": (runs[0].get("stdout") or "")[:HEAD_CHARS] if runs else "",
+        "stderr_head": (runs[0].get("stderr") or "")[:HEAD_CHARS] if runs else "",
+    }
+
+
+def check(probe, ctx=None, timeout=None):
+    """Run the probe and evaluate it: the one call the two-arm gate and the builder both make."""
+    p = normalize(probe)
+    return evaluate(p, run(p, ctx, timeout=timeout))
+
+
+# --- CLI --------------------------------------------------------------------
+
+def _load(path):
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def _short(value, width=64):
+    text = value if isinstance(value, str) else json.dumps(value, default=str)
+    return text if len(text) <= width else text[:width - 1] + "…"
+
+
+def _print_verdict(v):
+    head = "%s  %s" % (v["probe_id"], "PASS" if v["passed"] else "FAIL")
+    if v["flaky"]:
+        head += "  FLAKY"
+    if v["wall_ms_median"] is not None:
+        head += "  (%d run(s), %.1f ms median" % (v["repeat"], v["wall_ms_median"])
+        if v["max_rss_kb_median"] is not None:
+            head += ", %d kB max rss" % v["max_rss_kb_median"]
+        head += ")"
+    print(head)
+    print("  cmd: %s" % " ".join(v.get("cmd") or []))
+    for c in v["clauses"]:
+        print("  %-4s %-22s expected %-34s actual %s"
+              % ("ok" if c["ok"] else "FAIL", c["clause"],
+                 _short(c["expected"], 34), _short(c["actual"], 90)))
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        prog="python3 -m scripts.repipe.probe",
+        description="Evaluate a RE-friction probe (tools/repipe/schema/probe.schema.json).")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    pc = sub.add_parser("check", help="run the probe and print its verdict")
+    pc.add_argument("probe")
+    pc.add_argument("--work", help="{{WORK}} (default: cwd)")
+    pc.add_argument("--bin", dest="binary", help="{{BIN}} (default: {{WORK}}/target.binary_rel)")
+    pc.add_argument("--tmp", help="{{TMP}} (default: a fresh temp dir, removed afterwards)")
+    pc.add_argument("--timeout", type=int, help="override the probe's timeout_s")
+    pc.add_argument("--baselines", help="JSON file of {probe_id: verdict} for statpred rel_to")
+    pc.add_argument("--json", action="store_true")
+
+    pv = sub.add_parser("validate", help="structural check only, no execution")
+    pv.add_argument("probe")
+    pv.add_argument("--json", action="store_true")
+
+    pi = sub.add_parser("id", help="print the derived probe id")
+    pi.add_argument("probe")
+    pi.add_argument("--acceptance", action="store_true", help="derive an 'a-' id")
+
+    args = ap.parse_args(argv)
+    try:
+        raw = _load(args.probe)
+    except (OSError, ValueError) as exc:
+        print("cannot read %s: %s" % (args.probe, exc), file=sys.stderr)
+        return 2
+
+    if args.cmd == "validate":
+        errs = validate(raw)
+        if not errs and asserted_clause_count(raw.get("expect")) == 0:
+            errs = ["expect: asserts nothing (a probe with no effective clause is not evidence)"]
+        if args.json:
+            print(json.dumps({"probe": args.probe, "valid": not errs, "errors": errs}, indent=2))
+        elif errs:
+            for e in errs:
+                print("error: %s" % e)
+        else:
+            print("ok: %s" % args.probe)
+        return 1 if errs else 0
+
+    if args.cmd == "id":
+        try:
+            print(normalize(raw, is_acceptance=args.acceptance)["probe_id"])
+        except ProbeError as exc:
+            print("error: %s" % exc, file=sys.stderr)
+            return 2
+        return 0
+
+    baselines = {}
+    if args.baselines:
+        try:
+            baselines = _load(args.baselines)
+        except (OSError, ValueError) as exc:
+            print("cannot read %s: %s" % (args.baselines, exc), file=sys.stderr)
+            return 2
+    ctx = context(work=args.work, binary=args.binary, tmp=args.tmp, baselines=baselines)
+    try:
+        verdict = check(raw, ctx, timeout=args.timeout)
+    except ProbeError as exc:
+        if args.json:
+            print(json.dumps({"probe": args.probe, "error": str(exc)}, indent=2))
+        else:
+            print("error: %s" % exc, file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(verdict, indent=2, default=str))
+    else:
+        _print_verdict(verdict)
+    return 0 if verdict["passed"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repipe/redact.py
+++ b/scripts/repipe/redact.py
@@ -1,0 +1,297 @@
+"""The spoiler filter: decide which of a challenge's extras/ may enter a tester arena.
+
+`extras/` is the one part of the dataset that is *both* the only human-written task statement
+("find the serial for user `foo`") *and* a spoiler channel (author source, keygens, hint files
+holding valid serials). It cannot be copied wholesale and it cannot be dropped wholesale, so
+every file goes through `classify()`.
+
+Five layers, applied in this order; the first four are cheap and name-based, the last two read
+the bytes:
+
+  1. allowlist   only README*, *.txt, *.nfo, *.md survive at all       -> not-allowlisted
+  2. name        hint*/serial*/key*/solution*/flag*/answer*/crack*      -> spoiler-name
+  3. extension   .c .h .cpp .cc .py .rb .asm, makefile                  -> source
+  4. flag bytes  the file contains meta.json's ground_truth.flag        -> contains-flag
+  5. shape       >= 5 lines that look like license keys                 -> serial-shape
+  6. url         the file names crackmes.one, where the writeup lives    -> spoiler-url
+
+Layer 6 is not about the answer but about the *pointer* to it: an author readme that says
+"posted on crackmes.one" hands a tester the one search term that finds the public writeup, and
+it also poisons `scan_for_leak` -- an arena must never contain a string the tripwire treats as
+proof of contamination, or every run in it is falsely marked contaminated.
+
+Layer 5 exists because layers 2 and 4 both miss the worst real case in the dataset:
+`challenges/5ab77f5533c5d40ad448c1ea/extras/GiveMeMoney.zip.__x/hints.txt` is 19 valid serials
+for a challenge whose `ground_truth.flag` is null and whose `ships_source_code` is false, so
+there is no flag to match; only the *shape* of its contents gives it away. Content is proof
+and a filename is a guess, so when several layers fire the reported reason is the
+content-derived one (see `_REASON_RANK`) -- that is what an auditor needs to see, and a
+renamed spoiler file must not be recorded as if the name rule had caught it.
+
+`scan_for_leak()` is the other half of containment: the post-hoc tripwire that greps a finished
+tester transcript for the dataset path, the literal flag, the solutions-zip password
+`crackmes.one`, or `solutions/`. A hit marks the run contaminated (observations are kept --
+friction is friction -- but the solve outcome is voided).
+
+CLI:
+    python -m scripts.repipe.redact classify PATH... [--hexid H] [--json]
+    python -m scripts.repipe.redact scan TRANSCRIPT [--hexid H] [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import sys
+
+from . import config
+
+# Layer 1. Nothing outside this list is ever copied, whatever its contents.
+ALLOW_NAME_GLOBS = ("readme*", "*.txt", "*.nfo", "*.md")
+
+# Layer 2. Filenames authors use for the answer.
+SPOILER_NAME_GLOBS = ("hint*", "serial*", "key*", "solution*", "flag*", "answer*", "crack*")
+
+# Layer 6. The solutions archives' ZipCrypto password, and the site that hosts the writeups.
+SPOILER_URL = "crackmes.one"
+
+# Layer 3. Author source. Six challenges ship it; they stay testable from the binary.
+SOURCE_EXTS = (".c", ".h", ".cpp", ".cc", ".py", ".rb", ".asm")
+SOURCE_NAMES = ("makefile",)
+
+# Layer 5 thresholds. 16 alnum chars is below the shortest serial in the dataset (26) and above
+# any ordinary all-caps word; 5 lines keeps a task statement that quotes one example serial.
+MIN_SERIAL_CHARS = 16
+MIN_SERIAL_GROUP = 3
+MIN_SERIAL_LINES = 5
+MAX_SCAN_LINES = 4096
+
+# A flag shorter than this is not searched for: two-character "flags" would match everything.
+MIN_FLAG_LEN = 4
+
+# Lower rank wins when several layers fire. Bytes outrank names on purpose.
+_REASON_RANK = {"contains-flag": 0, "serial-shape": 1, "spoiler-url": 2,
+                "spoiler-name": 3, "source": 4}
+
+_SERIAL_TOKEN = re.compile(r"[A-Z0-9]+(?:-[A-Z0-9]+)*")
+
+LEAK_TAGS = ("dataset-path", "literal-flag", "crackmes-one", "solutions-dir")
+
+
+# --- helpers ----------------------------------------------------------------
+
+def _name_of(path) -> str:
+    return os.path.basename(str(path)).lower()
+
+
+def _matches_any(name: str, globs) -> bool:
+    return any(fnmatch.fnmatchcase(name, g) for g in globs)
+
+
+def _as_text(data: bytes) -> str:
+    """Decode for line scanning: UTF-8 where possible, latin-1 otherwise, NULs stripped.
+
+    UTF-16 text files decode to NUL-interleaved latin-1; stripping NULs makes their serials
+    look like every other serial to the shape rule instead of hiding them.
+    """
+    if isinstance(data, str):
+        text = data
+    else:
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            text = data.decode("latin-1", "replace")
+    return text.replace("\x00", "")
+
+
+def _flag_of(meta) -> str:
+    if not meta:
+        return ""
+    flag = (meta.get("ground_truth") or {}).get("flag")
+    return flag if isinstance(flag, str) else ""
+
+
+# --- layer 5: serial shape --------------------------------------------------
+
+def _token_is_serial_like(token: str) -> bool:
+    groups = token.split("-")
+    alnum = sum(len(g) for g in groups)
+    if alnum < MIN_SERIAL_CHARS:
+        return False
+    if not any(c.isdigit() for c in token) or not any(c.isalpha() for c in token):
+        return False
+    if len(groups) == 1:
+        return True
+    return all(len(g) >= MIN_SERIAL_GROUP for g in groups)
+
+
+def serial_like_lines(text) -> int:
+    """Count lines carrying at least one license-key-shaped token.
+
+    Tokens rather than whole lines, so `Serial: ABCD-1234-...` counts the same as a bare key.
+    """
+    hits = 0
+    for i, line in enumerate(_as_text(text).splitlines()):
+        if i >= MAX_SCAN_LINES:
+            break
+        line = line.strip()
+        if not line:
+            continue
+        for token in _SERIAL_TOKEN.findall(line):
+            if _token_is_serial_like(token):
+                hits += 1
+                break
+    return hits
+
+
+def looks_like_serial_list(text) -> bool:
+    return serial_like_lines(text) >= MIN_SERIAL_LINES
+
+
+# --- the classifier ---------------------------------------------------------
+
+def explain(path, data: bytes, meta=None) -> dict:
+    """Full audit record for one extras/ file: decision, reported reason, every reason that fired."""
+    name = _name_of(path)
+    if not _matches_any(name, ALLOW_NAME_GLOBS):
+        return {"path": str(path), "decision": "drop", "reason": "not-allowlisted",
+                "reasons": ["not-allowlisted"], "serial_lines": 0}
+
+    reasons = []
+    if _matches_any(name, SPOILER_NAME_GLOBS):
+        reasons.append("spoiler-name")
+
+    stem, ext = os.path.splitext(name)
+    if ext in SOURCE_EXTS or name in SOURCE_NAMES or stem in SOURCE_NAMES:
+        reasons.append("source")
+
+    flag = _flag_of(meta)
+    if len(flag) >= MIN_FLAG_LEN:
+        text = _as_text(data)
+        if flag in text or flag.lower() in text.lower():
+            reasons.append("contains-flag")
+
+    n_serial = serial_like_lines(data)
+    if n_serial >= MIN_SERIAL_LINES:
+        reasons.append("serial-shape")
+
+    if SPOILER_URL in _as_text(data).lower():
+        reasons.append("spoiler-url")
+
+    if not reasons:
+        return {"path": str(path), "decision": "copy", "reason": "allowlisted",
+                "reasons": [], "serial_lines": n_serial}
+    reasons.sort(key=lambda r: _REASON_RANK.get(r, 99))
+    return {"path": str(path), "decision": "drop", "reason": reasons[0],
+            "reasons": reasons, "serial_lines": n_serial}
+
+
+def classify(path, data: bytes, meta=None):
+    """("copy"|"drop", reason) for one file under a challenge's extras/."""
+    d = explain(path, data, meta)
+    return d["decision"], d["reason"]
+
+
+def classify_file(path, meta=None):
+    with open(path, "rb") as fh:
+        return classify(path, fh.read(), meta)
+
+
+def sanitize(text, meta=None) -> str:
+    """Blank the flag and the writeup site out of a string before it is shown to a tester.
+
+    For metadata that must be quoted verbatim-ish (a challenge whose *name* is
+    "Crackmes.one RE CTF 2026 - FlipVM"), not for author prose -- prose is dropped whole by
+    `classify`, because silently editing a task statement changes the task.
+    """
+    out = _as_text(text)
+    flag = _flag_of(meta)
+    if len(flag) >= MIN_FLAG_LEN:
+        out = re.sub(re.escape(flag), "[redacted]", out, flags=re.IGNORECASE)
+    return re.sub(re.escape(SPOILER_URL), "[redacted]", out, flags=re.IGNORECASE)
+
+
+# --- the post-hoc tripwire --------------------------------------------------
+
+def scan_for_leak(text, meta=None) -> list:
+    """Tags for every spoiler channel visible in a tester transcript. Empty list = clean.
+
+    Deliberately blunt: `solutions/` and `crackmes.one` are flagged wherever they appear,
+    because a tester that merely *names* the writeup archive has already been somewhere it
+    should not have been.
+    """
+    blob = _as_text(text)
+    lower = blob.lower()
+    hits = []
+
+    dataset = str(config.dataset_root())
+    for candidate in {dataset, config.DEFAULT_DATASET, os.path.basename(dataset)}:
+        if candidate and candidate in blob:
+            hits.append("dataset-path")
+            break
+
+    flag = _flag_of(meta)
+    if len(flag) >= MIN_FLAG_LEN and (flag in blob or flag.lower() in lower):
+        hits.append("literal-flag")
+
+    if "crackmes.one" in lower:
+        hits.append("crackmes-one")
+    if "solutions/" in lower:
+        hits.append("solutions-dir")
+
+    return sorted(set(hits), key=LEAK_TAGS.index)
+
+
+# --- CLI --------------------------------------------------------------------
+
+def _load_meta(hexid):
+    if not hexid:
+        return None
+    p = config.dataset_root() / "challenges" / hexid / "meta.json"
+    with open(p) as fh:
+        return json.load(fh)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(prog="python -m scripts.repipe.redact",
+                                 description="Spoiler filter for arena extras/ and transcripts.")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    c = sub.add_parser("classify", help="copy/drop verdict for one or more extras/ files")
+    c.add_argument("paths", nargs="+")
+    c.add_argument("--hexid", help="challenge whose ground_truth.flag to match against")
+    c.add_argument("--json", action="store_true")
+
+    s = sub.add_parser("scan", help="tripwire a tester transcript for spoiler leakage")
+    s.add_argument("path")
+    s.add_argument("--hexid")
+    s.add_argument("--json", action="store_true")
+
+    args = ap.parse_args(argv)
+    meta = _load_meta(getattr(args, "hexid", None))
+
+    if args.cmd == "classify":
+        out = []
+        for p in args.paths:
+            with open(p, "rb") as fh:
+                out.append(explain(p, fh.read(), meta))
+        if args.json:
+            print(json.dumps({"results": out}, indent=2))
+        else:
+            for r in out:
+                print("%-6s %-16s %s" % (r["decision"], r["reason"], r["path"]))
+        return 0
+
+    with open(args.path, "rb") as fh:
+        hits = scan_for_leak(fh.read(), meta)
+    if args.json:
+        print(json.dumps({"path": args.path, "contaminated": bool(hits), "hits": hits}, indent=2))
+    else:
+        print("contaminated: %s" % (", ".join(hits) if hits else "no"))
+    return 1 if hits else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repipe/render_tester_prompt.py
+++ b/scripts/repipe/render_tester_prompt.py
@@ -1,0 +1,142 @@
+"""Render tools/repipe/tester_prompt.md for one challenge.
+
+Kept out of tester.sh because three of the placeholders are computed, not substituted:
+the newly-closed needs the tester is asked to re-exercise, the already-filed needs it must
+NOT write up again, and the per-challenge time budget derived from the binary's size.
+
+The KNOWN_NEEDS block is the cheapest duplicate-suppression the pipeline has. Without it,
+round 4's three testers each write a fresh essay about kuna having no xrefs; with it they
+note the hit and move on, and the need's `instances` count does the talking.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from . import config
+
+TOKENS_DOC = "{{KUNA}} and {{BIN}}"
+
+
+def _meta(hexid):
+    p = config.dataset_root() / "challenges" / hexid / "meta.json"
+    with open(p) as fh:
+        return json.load(fh)
+
+
+def _time_budget_minutes(meta):
+    """Sized from the binary, because kuna's cost is dominated by whole-binary work.
+
+    The `auto` mode cutovers are 512,000 and 2,097,152 bytes; the worst measured case on
+    this machine is 445 s at 1,476 MiB RSS for a 3.4 MB PE, so a big target needs a bigger
+    budget or the tester spends it all in one decompile-all.
+    """
+    size = (meta.get("detected", {}).get("primary") or {}).get("size", 0)
+    base = config.TESTER_TIMEOUT // 60
+    if size >= 2_097_152:
+        return base
+    if size >= 512_000:
+        return max(20, int(base * 0.8))
+    return max(15, int(base * 0.6))
+
+
+def _recently_shipped(rounds_back=1):
+    try:
+        from . import needs as needs_mod
+    except Exception:
+        return ""
+    try:
+        closed = [n for n in needs_mod.load_all() if getattr(n, "status", None) == "closed"]
+    except Exception:
+        return ""
+    if not closed:
+        return ""
+    lines = ["## Newly available capabilities — exercise them",
+             "",
+             "These gaps were closed since the last round. Try them, and if one does not",
+             "behave as described that is a **regression**: file it with",
+             "`regression_of: <need_id>`, the highest-priority class we accept.",
+             ""]
+    for n in closed[:8]:
+        lines.append("- `%s` — %s (closed need `%s`)" % (
+            getattr(n, "title", n.need_id), getattr(n, "summary", "") or "", n.need_id))
+    return "\n".join(lines)
+
+
+def _known_needs(limit=12):
+    try:
+        from . import needs as needs_mod
+    except Exception:
+        return ""
+    try:
+        open_needs = [n for n in needs_mod.load_all()
+                      if getattr(n, "status", "open") in ("open", "claimed", "building")]
+    except Exception:
+        return ""
+    if not open_needs:
+        return ""
+    try:
+        open_needs.sort(key=needs_mod.rank_score, reverse=True)
+    except Exception:
+        pass
+    lines = ["## Already filed — do NOT write these up again",
+             "",
+             "If you hit one of these, say so in one line in `what_kuna_did` and move on.",
+             "Re-filing it does not help; the pipeline counts your hit either way.",
+             ""]
+    for n in open_needs[:limit]:
+        lines.append("- `%s` — %s" % (n.need_id, getattr(n, "title", "")))
+    return "\n".join(lines)
+
+
+def _ida_line():
+    if not config.ENABLE_IDA:
+        return "- IDA is **not** available this round. kuna and the binutils are all you have."
+    return (
+        "- `ida-decompile` is IDA Pro 9.2 via declib, and it is a **last resort**, not a\n"
+        "  parallel track. Every call is logged. When you use it, you must record what you\n"
+        "  wanted from kuna and why kuna could not give it to you — that comparison is the\n"
+        "  single most useful thing you can produce."
+    )
+
+
+def render(hexid, round_n, arena, out=None):
+    meta = _meta(hexid)
+    primary = meta.get("detected", {}).get("primary") or {}
+    target = os.path.basename(primary.get("path", "target"))
+    tmpl = (config.repo_root() / "tools" / "repipe" / "tester_prompt.md").read_text()
+    body = (tmpl
+            .replace("{{ARENA}}", str(arena))
+            .replace("{{ROUND}}", str(round_n))
+            .replace("{{HEXID}}", hexid)
+            .replace("{{TARGET}}", target)
+            .replace("{{REPO}}", str(config.repo_root()))
+            .replace("{{TIME_BUDGET}}", str(_time_budget_minutes(meta)))
+            .replace("{{IDA_LINE}}", _ida_line())
+            .replace("{{RECENTLY_SHIPPED}}", _recently_shipped())
+            .replace("{{KNOWN_NEEDS}}", _known_needs()))
+    if out:
+        tmp = str(out) + ".tmp"
+        Path(tmp).write_text(body)
+        os.replace(tmp, out)
+    return body
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog="python -m scripts.repipe.render_tester_prompt")
+    ap.add_argument("--hexid", required=True)
+    ap.add_argument("--round", type=int, required=True)
+    ap.add_argument("--arena", required=True)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args(argv)
+    body = render(args.hexid, args.round, args.arena, args.out)
+    if not args.out:
+        sys.stdout.write(body)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repipe/sample.py
+++ b/scripts/repipe/sample.py
@@ -1,0 +1,640 @@
+"""The stratified round slate: which challenges round N points its testers at.
+
+Why stratify at all: the corpus is lopsided. Of the 250 records in `manifest.json` the
+primary binary is PE 139 / ELF 83 / Mach-O 22 / DOS 6, the arch is x86-64 for 143 of them,
+and 79 carry no obfuscation class whatsoever. Nine uniformly-drawn challenges are therefore
+most often nine x86-64 PEs -- and a round that only ever sees one loader shape only ever
+finds one loader's worth of friction. The four dimensions sampled here (format, primary
+arch, declared difficulty, obfuscation-class count) are the ones that actually change which
+part of kuna is exercised: the loader, the sleigh spec, the analysis depth, and the
+structuring.
+
+Why deterministic: a captain tick is bounded (REPIPE_CAPTAIN_TIMEOUT) and can die inside
+T_PLAN with half the arenas built. Seeding `random.Random(f"{seed}:{round_n}")` means the
+replay of a crashed T_PLAN produces the identical slate, so the arenas already on disk are
+still the right arenas. The seed defaults to a fixed string rather than to entropy for the
+same reason -- an unseeded run must still replay.
+
+Why the large-binary cap: kuna's worst measured case on this machine is 445 s at 1,476 MiB
+RSS for a 3.4 MB PE `decompile-project`, and 342 s for an 866 KB challenge ELF in
+`aggressive` (99 s in `reliable`). Nine of those in one round is a round that spends its
+entire wall-clock budget inside decompile-all and reports no friction at all. `--max-large`
+(default 2) bounds it.
+
+The per-challenge timeout returned with each record is derived from `detected.primary.size`
+against the `auto` mode cutovers, and is deliberately the *same* arithmetic as
+`render_tester_prompt._time_budget_minutes` -- the slate and the prompt the tester reads
+must not disagree about how long it has.
+
+CLI:
+    python3 -m scripts.repipe.sample slate --round 3 [-k 9] [--seed S] [--max-large 2]
+            [--exclude hexid,hexid] [--filter 'format=ELF,size<64k'] [--write] [--json]
+    python3 -m scripts.repipe.sample coverage [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import random
+import sys
+
+from . import config
+
+# `kuna --mode auto` picks its pipeline from the input size at these byte boundaries.
+AGGRESSIVE_MAX = 512_000
+RELIABLE_MAX = 2_097_152
+
+# "multi-MB", i.e. the band where a single decompile-all has been measured in minutes.
+LARGE_BYTES = int(os.environ.get("REPIPE_LARGE_BYTES", RELIABLE_MAX))
+MAX_LARGE = int(os.environ.get("REPIPE_MAX_LARGE", "2"))
+
+# How many previous rounds' slates are off-limits, so a tester does not re-litigate a
+# challenge whose friction is already filed.
+RECENT_ROUNDS = int(os.environ.get("REPIPE_RECENT_ROUNDS", "3"))
+
+DEFAULT_SEED = os.environ.get("REPIPE_SEED", "kuna-repipe")
+
+# Ceiling for a single kuna invocation against a target of this size, used by probe.py when
+# a tester does not supply one. Anchored on the two measured worst cases above, floored at
+# REPIPE_PROBE_TIMEOUT so it is never tighter than the generic probe budget.
+CALL_BUDGET_S = {"aggressive": 400, "reliable": 500, "fast": 600}
+
+DIMENSIONS = ("format", "arch", "difficulty", "obfuscation")
+
+
+# --- the corpus -------------------------------------------------------------
+
+def load_manifest(path=None):
+    """The 250 dataset records. Read-only: nothing here ever writes into the dataset."""
+    p = path or config.manifest_path()
+    with open(p) as fh:
+        return json.load(fh)
+
+
+def _primary(rec):
+    return (rec.get("detected") or {}).get("primary") or {}
+
+
+def difficulty_band(rec):
+    """Declared difficulty is a crackmes.one vote average (1.0-6.0, 41 distinct values here).
+
+    Rounded to the 1-6 band it was voted on; missing votes sort with the easy end rather
+    than inventing a hard rating for a challenge nobody graded.
+    """
+    raw = (rec.get("declared") or {}).get("difficulty")
+    if raw is None:
+        return 1
+    return max(1, min(6, int(round(float(raw)))))
+
+
+def obfuscation_band(rec):
+    """0 / 1-2 / 3-4 / 5+ classes. The count is what predicts how hard kuna's structuring
+    is hit; which particular classes matter is the tester's problem, not the sampler's."""
+    n = len((rec.get("obfuscation") or {}).get("classes") or [])
+    if n == 0:
+        return "none"
+    if n <= 2:
+        return "light"
+    if n <= 4:
+        return "heavy"
+    return "extreme"
+
+
+def arch_of(rec):
+    """Primary arch. Fat binaries are recorded as 'x86-64+x86'; the first component is the
+    one kuna will actually be pointed at, so that is the stratum."""
+    return (_primary(rec).get("arch") or "unknown").split("+")[0]
+
+
+def levels(rec):
+    return {
+        "format": _primary(rec).get("format") or "unknown",
+        "arch": arch_of(rec),
+        "difficulty": difficulty_band(rec),
+        "obfuscation": obfuscation_band(rec),
+    }
+
+
+def mode_for(size):
+    """The mode `kuna --mode auto` will select for a binary of this size."""
+    if size < AGGRESSIVE_MAX:
+        return "aggressive"
+    if size < RELIABLE_MAX:
+        return "reliable"
+    return "fast"
+
+
+def budget_for(size):
+    """Suggested per-challenge tester budget, derived from size against the auto cutovers.
+
+    Identical arithmetic to render_tester_prompt._time_budget_minutes so the slate and the
+    rendered prompt cannot disagree: a >=2 MB target gets the full REPIPE_TESTER_TIMEOUT
+    because one decompile-all on it has been measured at 445 s, and a small target gets 60%
+    of it because on a <512 KB binary kuna is fast and the time goes on thinking instead.
+    """
+    base = max(1, config.TESTER_TIMEOUT // 60)
+    if size >= RELIABLE_MAX:
+        minutes = base
+    elif size >= AGGRESSIVE_MAX:
+        minutes = max(20, int(base * 0.8))
+    else:
+        minutes = max(15, int(base * 0.6))
+    mode = mode_for(size)
+    return {
+        "mode": mode,
+        "timeout_minutes": minutes,
+        "timeout_s": minutes * 60,
+        "call_timeout_s": max(config.PROBE_TIMEOUT, CALL_BUDGET_S[mode]),
+    }
+
+
+def describe(rec):
+    """The slate record a tester, an arena builder and the dashboard all read."""
+    prim = _primary(rec)
+    gt = rec.get("ground_truth") or {}
+    size = int(prim.get("size") or 0)
+    lv = levels(rec)
+    out = {
+        "hexid": rec.get("hexid"),
+        "name": rec.get("name"),
+        "format": lv["format"],
+        "arch": lv["arch"],
+        "arch_full": prim.get("arch"),
+        "size": size,
+        "binary_rel": prim.get("path"),
+        "difficulty": (rec.get("declared") or {}).get("difficulty"),
+        "difficulty_band": lv["difficulty"],
+        "obfuscation": list((rec.get("obfuscation") or {}).get("classes") or []),
+        "obfuscation_count": len((rec.get("obfuscation") or {}).get("classes") or []),
+        "obfuscation_band": lv["obfuscation"],
+        "machine_checkable": bool(gt.get("machine_checkable")),
+        "has_flag": bool(gt.get("flag")),
+        "verifier": gt.get("verifier"),
+        "ships_source_code": bool((rec.get("contamination") or {}).get("ships_source_code")),
+        "large": size >= LARGE_BYTES,
+    }
+    out.update(budget_for(size))
+    return out
+
+
+# --- round bookkeeping ------------------------------------------------------
+
+def slate_path(round_n):
+    return config.rounds_dir() / str(round_n) / "slate.json"
+
+
+def read_slate(round_n):
+    p = slate_path(round_n)
+    if not os.path.exists(p):
+        return None
+    with open(p) as fh:
+        return json.load(fh)
+
+
+def write_slate(round_n, slate, meta=None):
+    """Persist atomically: T_PLAN is replayable and a torn slate would plan a torn round."""
+    p = slate_path(round_n)
+    os.makedirs(os.path.dirname(p), exist_ok=True)
+    doc = {"round": int(round_n), "count": len(slate), "challenges": slate}
+    if meta:
+        doc.update(meta)
+    tmp = str(p) + ".tmp"
+    with open(tmp, "w") as fh:
+        json.dump(doc, fh, indent=2, sort_keys=False)
+        fh.write("\n")
+    os.replace(tmp, p)
+    return p
+
+
+def _slate_hexids(doc):
+    if not doc:
+        return []
+    return [c.get("hexid") for c in doc.get("challenges", []) if c.get("hexid")]
+
+
+def known_rounds():
+    d = config.rounds_dir()
+    if not os.path.isdir(d):
+        return []
+    out = []
+    for name in os.listdir(d):
+        if name.isdigit() and os.path.exists(os.path.join(d, name, "slate.json")):
+            out.append(int(name))
+    return sorted(out)
+
+
+def recent_hexids(round_n, back=None):
+    """Everything attempted in the `back` rounds before round_n."""
+    back = RECENT_ROUNDS if back is None else int(back)
+    seen = set()
+    if back <= 0:
+        return seen
+    for n in range(max(0, int(round_n) - back), int(round_n)):
+        seen.update(_slate_hexids(read_slate(n)))
+    return seen
+
+
+def attempted_hexids():
+    """Every challenge any persisted round has ever pointed a tester at."""
+    seen = set()
+    for n in known_rounds():
+        seen.update(_slate_hexids(read_slate(n)))
+    return seen
+
+
+# --- filters ----------------------------------------------------------------
+
+_FILTER_FIELDS = {
+    "hexid": lambda r: r["hexid"],
+    "name": lambda r: r["name"],
+    "format": lambda r: r["format"],
+    "arch": lambda r: r["arch"],
+    "size": lambda r: r["size"],
+    "difficulty": lambda r: r["difficulty_band"],
+    "obfuscation": lambda r: r["obfuscation_count"],
+    "machine_checkable": lambda r: r["machine_checkable"],
+    "has_flag": lambda r: r["has_flag"],
+    "large": lambda r: r["large"],
+    "mode": lambda r: r["mode"],
+}
+_OPS = ("<=", ">=", "!=", "==", "~", "<", ">", "=")
+
+
+def _as_number(text):
+    t = text.strip().lower()
+    mult = 1
+    if t.endswith("k"):
+        mult, t = 1024, t[:-1]
+    elif t.endswith("m"):
+        mult, t = 1024 * 1024, t[:-1]
+    return float(t) * mult
+
+
+def _coerce(value, want):
+    if isinstance(want, bool):
+        return str(value).strip().lower() in ("1", "true", "yes", "y")
+    if isinstance(want, (int, float)):
+        return _as_number(value)
+    return value
+
+
+def parse_filter(text):
+    """`format=ELF,size<64k,machine_checkable=true` -> a predicate over describe() records.
+
+    This is the `--challenge-filter` the runbook's Level-2 single-tester smoke passes; it is
+    parsed here rather than in run.sh so both the shell and the captain get one dialect.
+    """
+    clauses = []
+    for raw in (text or "").split(","):
+        raw = raw.strip()
+        if not raw:
+            continue
+        for op in _OPS:
+            if op in raw:
+                key, val = raw.split(op, 1)
+                break
+        else:
+            raise ValueError("filter clause %r has no operator" % raw)
+        key = key.strip()
+        if key not in _FILTER_FIELDS:
+            raise ValueError("unknown filter field %r (have: %s)"
+                             % (key, ", ".join(sorted(_FILTER_FIELDS))))
+        clauses.append((key, op, val.strip()))
+
+    def pred(rec):
+        for key, op, val in clauses:
+            have = _FILTER_FIELDS[key](rec)
+            if op == "~":
+                if str(val).lower() not in str(have).lower():
+                    return False
+                continue
+            want = _coerce(val, have)
+            if isinstance(have, bool):
+                ok = (have == want) if op in ("=", "==") else (have != want)
+            elif isinstance(have, (int, float)) and not isinstance(want, str):
+                have_f = float(have)
+                ok = {"<": have_f < want, "<=": have_f <= want,
+                      ">": have_f > want, ">=": have_f >= want,
+                      "=": have_f == want, "==": have_f == want,
+                      "!=": have_f != want}[op]
+            else:
+                ok = {"=": str(have) == want, "==": str(have) == want,
+                      "!=": str(have) != want}.get(op)
+                if ok is None:
+                    raise ValueError("operator %r does not apply to %r" % (op, key))
+            if not ok:
+                return False
+        return True
+
+    return pred
+
+
+# --- the sampler ------------------------------------------------------------
+
+def _quota(values, k):
+    """Largest-remainder allocation of k slots across the levels present in the pool.
+
+    At k=9 over the real corpus this is PE 5 / ELF 3 / Mach-O 1 / DOS 0 -- DOS is 6 of 250,
+    so it earns a slot roughly one round in four rather than every round.
+    """
+    counts = collections.Counter(values)
+    n = sum(counts.values())
+    if not n:
+        return {}
+    exact = dict((lv, k * c / float(n)) for lv, c in counts.items())
+    base = dict((lv, int(v)) for lv, v in exact.items())
+    left = k - sum(base.values())
+    order = sorted(counts, key=lambda lv: (-(exact[lv] - base[lv]), str(lv)))
+    for lv in order[:max(0, left)]:
+        base[lv] += 1
+    return base
+
+
+def sample(round_n, k=None, exclude=None, seed=None, max_large=None,
+           recent_rounds=None, records=None, filters=None):
+    """Pick k challenges for round `round_n`, stratified over the four dimensions.
+
+    Deterministic given (seed, round_n): the RNG is `random.Random(f"{seed}:{round_n}")`, so
+    a T_PLAN that crashes and replays produces byte-identical output, and a different round
+    with the same seed produces a different slate.
+
+    Selection is greedy-by-deficit rather than per-cell quota because the composite cell
+    space (4 formats x 13 arches x 6 difficulties x 4 obfuscation bands) is far larger than
+    k: each slot goes to the candidate that closes the most quota deficit summed over the
+    four dimensions independently, ties broken by the seeded RNG. That keeps every marginal
+    distribution close to the corpus without demanding a candidate for a cell that has none.
+
+    `exclude` (plus the last `recent_rounds` slates) is removed from the pool first; the
+    `max_large` cap then stops applying once that many >=LARGE_BYTES targets are chosen.
+    """
+    k = int(config.ROUND_CHALLENGES if k is None else k)
+    max_large = MAX_LARGE if max_large is None else int(max_large)
+    seed = DEFAULT_SEED if seed is None else seed
+    rng = random.Random("%s:%s" % (seed, round_n))
+
+    raw = load_manifest() if records is None else records
+    pool = [describe(r) for r in raw]
+
+    blocked = set(exclude or ())
+    blocked |= recent_hexids(round_n, recent_rounds)
+    pool = [r for r in pool if r["hexid"] not in blocked]
+    if filters:
+        pred = filters if callable(filters) else parse_filter(filters)
+        pool = [r for r in pool if pred(r)]
+    pool.sort(key=lambda r: r["hexid"])
+    if not pool:
+        return []
+
+    targets = dict((dim, _quota([levels_of(r)[dim] for r in pool], k)) for dim in DIMENSIONS)
+    taken = dict((dim, collections.Counter()) for dim in DIMENSIONS)
+
+    chosen = []
+    chosen_ids = set()
+    n_large = 0
+    for _ in range(min(k, len(pool))):
+        cands = [r for r in pool if r["hexid"] not in chosen_ids]
+        if n_large >= max_large:
+            cands = [r for r in cands if not r["large"]]
+        if not cands:
+            break
+        best, tied = None, []
+        for r in cands:
+            lv = levels_of(r)
+            score = sum(max(0, targets[d].get(lv[d], 0) - taken[d][lv[d]]) for d in DIMENSIONS)
+            if best is None or score > best:
+                best, tied = score, [r]
+            elif score == best:
+                tied.append(r)
+        pick = tied[rng.randrange(len(tied))]
+        chosen.append(pick)
+        chosen_ids.add(pick["hexid"])
+        n_large += 1 if pick["large"] else 0
+        for d in DIMENSIONS:
+            taken[d][levels_of(pick)[d]] += 1
+    return chosen
+
+
+def levels_of(desc):
+    """levels() over an already-described record (describe() flattens the manifest shape)."""
+    return {"format": desc["format"], "arch": desc["arch"],
+            "difficulty": desc["difficulty_band"], "obfuscation": desc["obfuscation_band"]}
+
+
+def mix(slate):
+    """The marginal distribution of a slate, for the plan log and the dashboard."""
+    out = {}
+    for dim in DIMENSIONS:
+        c = collections.Counter(levels_of(r)[dim] for r in slate)
+        out[dim] = dict((str(kk), v) for kk, v in sorted(c.items(), key=lambda kv: str(kv[0])))
+    out["large"] = sum(1 for r in slate if r["large"])
+    out["machine_checkable"] = sum(1 for r in slate if r["machine_checkable"])
+    return out
+
+
+# --- coverage ---------------------------------------------------------------
+
+def outcomes_dir(round_n):
+    return config.rounds_dir() / str(round_n) / "outcomes"
+
+
+def _outcomes():
+    """hexid -> the graded outcome, preferring grade.py's record over the raw report.
+
+    Two sources because they fail differently: `rounds/<N>/outcomes/<hexid>.json` is written
+    challenge-side by `grade.py --record` and carries the tiered verdict and the tripwire
+    result; `arena/<N>/<hexid>/report.json` is the tester's own self-report and survives a
+    crash in T_DRAIN that happened before grading. `gave_up`, `partial` and `failed` are
+    taken from either -- nobody but the tester can report a give-up -- but an ungraded
+    `solved` CLAIM counts only as attempted, because the whole point of grade.py is that a
+    model saying it solved something is not evidence that it did.
+    """
+    out = {}
+    for n in known_rounds():
+        arena = config.arena_dir() / str(n)
+        if os.path.isdir(arena):
+            for hexid in sorted(os.listdir(arena)):
+                p = os.path.join(arena, hexid, "report.json")
+                if not os.path.exists(p):
+                    continue
+                try:
+                    with open(p) as fh:
+                        rep = json.load(fh)
+                except (ValueError, OSError):
+                    continue
+                out[hexid] = {"round": n, "outcome": rep.get("outcome"),
+                              "verdict": None, "contaminated": False, "source": "report"}
+        od = outcomes_dir(n)
+        if os.path.isdir(od):
+            for name in sorted(os.listdir(od)):
+                if not name.endswith(".json"):
+                    continue
+                try:
+                    with open(os.path.join(od, name)) as fh:
+                        rec = json.load(fh)
+                except (ValueError, OSError):
+                    continue
+                hexid = rec.get("hexid") or name[:-5]
+                out[hexid] = {"round": n, "outcome": rec.get("outcome"),
+                              "verdict": rec.get("verdict"),
+                              "contaminated": bool(rec.get("contaminated")),
+                              "source": "grade"}
+    return out
+
+
+_TALLIES = ("attempted", "solved", "partial", "gave_up", "failed", "ungraded", "contaminated")
+
+
+def coverage(records=None):
+    """attempted / solved / gave-up per stratum, over the whole corpus as denominator.
+
+    The dashboard's `/api/corpus` route reads this. Solve rate is a SECONDARY metric here --
+    ground truth is weak (only 22 of 250 challenges are machine-checkable and uncontaminated)
+    and the primary output of a tester run is probes. What this view is actually for is
+    spotting a stratum the sampler has never reached: 6 DOS records and 3 MIPS records will
+    not show up on their own.
+    """
+    raw = load_manifest() if records is None else records
+    pool = [describe(r) for r in raw]
+    outs = _outcomes()
+    planned = attempted_hexids()
+
+    strata = {}
+    for dim in DIMENSIONS:
+        strata[dim] = {}
+        for r in pool:
+            lv = str(levels_of(r)[dim])
+            cell = strata[dim].setdefault(lv, dict([("total", 0)] + [(t, 0) for t in _TALLIES]))
+            cell["total"] += 1
+            o = outs.get(r["hexid"])
+            if not o and r["hexid"] not in planned:
+                continue
+            cell["attempted"] += 1
+            if not o:
+                cell["ungraded"] += 1
+                continue
+            if o.get("contaminated"):
+                cell["contaminated"] += 1
+            outcome = o.get("outcome")
+            if outcome == "solved" and o.get("source") != "grade":
+                outcome = None
+            if outcome == "solved":
+                cell["solved"] += 1
+            elif outcome == "partial":
+                cell["partial"] += 1
+            elif outcome == "gave_up":
+                cell["gave_up"] += 1
+            elif outcome == "failed":
+                cell["failed"] += 1
+            else:
+                cell["ungraded"] += 1
+        for cell in strata[dim].values():
+            cell["remaining"] = cell["total"] - cell["attempted"]
+
+    totals = dict([("total", len(pool))] + [(t, 0) for t in _TALLIES])
+    for cell in strata["format"].values():
+        for key in _TALLIES:
+            totals[key] += cell[key]
+    totals["remaining"] = totals["total"] - totals["attempted"]
+    return {"corpus": len(pool), "rounds": known_rounds(),
+            "totals": totals, "strata": strata}
+
+
+# --- CLI --------------------------------------------------------------------
+
+def _print_slate(slate, round_n, seed):
+    print("round %s  seed %s  %d challenges" % (round_n, seed, len(slate)))
+    print("%-26s %-8s %-8s %9s %4s %4s %-11s %6s  %s"
+          % ("hexid", "format", "arch", "size", "diff", "obf", "mode", "budget", "name"))
+    for r in slate:
+        print("%-26s %-8s %-8s %9d %4s %4d %-11s %5dm  %s"
+              % (r["hexid"], r["format"], r["arch"], r["size"], r["difficulty_band"],
+                 r["obfuscation_count"], r["mode"], r["timeout_minutes"], r["name"]))
+    m = mix(slate)
+    for dim in DIMENSIONS:
+        print("  %-12s %s" % (dim, ", ".join("%s=%s" % kv for kv in m[dim].items())))
+    print("  %-12s %s   machine_checkable=%s" % ("large", m["large"], m["machine_checkable"]))
+
+
+def _print_coverage(cov):
+    t = cov["totals"]
+    print("corpus %d  attempted %d  solved %d  gave_up %d  remaining %d  rounds %s"
+          % (cov["corpus"], t["attempted"], t["solved"], t["gave_up"], t["remaining"],
+             cov["rounds"] or "-"))
+    for dim in DIMENSIONS:
+        print("[%s]" % dim)
+        for lv in sorted(cov["strata"][dim], key=lambda s: (-cov["strata"][dim][s]["total"], s)):
+            c = cov["strata"][dim][lv]
+            print("  %-12s total %4d  attempted %3d  solved %3d  gave_up %3d  remaining %4d"
+                  % (lv, c["total"], c["attempted"], c["solved"], c["gave_up"], c["remaining"]))
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(prog="python -m scripts.repipe.sample")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("slate", help="pick the stratified slate for a round")
+    sp.add_argument("--round", type=int, required=True)
+    sp.add_argument("-k", "--count", type=int, default=None)
+    sp.add_argument("--seed", default=None)
+    sp.add_argument("--max-large", type=int, default=None)
+    sp.add_argument("--recent-rounds", type=int, default=None)
+    sp.add_argument("--exclude", default="", help="comma-separated hexids")
+    sp.add_argument("--filter", default=None,
+                    help="e.g. 'format=ELF,size<64k,machine_checkable=true'")
+    sp.add_argument("--write", action="store_true", help="persist to rounds/<N>/slate.json")
+    sp.add_argument("--json", action="store_true")
+
+    sp = sub.add_parser("coverage", help="attempted/solved/gave-up per stratum")
+    sp.add_argument("--json", action="store_true")
+
+    sp = sub.add_parser("show", help="the slate record for one hexid")
+    sp.add_argument("hexid")
+    sp.add_argument("--json", action="store_true")
+
+    args = p.parse_args(argv)
+
+    if args.cmd == "coverage":
+        cov = coverage()
+        if args.json:
+            print(json.dumps(cov, indent=2))
+        else:
+            _print_coverage(cov)
+        return 0
+
+    if args.cmd == "show":
+        for rec in load_manifest():
+            if rec.get("hexid") == args.hexid:
+                print(json.dumps(describe(rec), indent=2))
+                return 0
+        print("no such hexid: %s" % args.hexid, file=sys.stderr)
+        return 1
+
+    exclude = [h.strip() for h in (args.exclude or "").split(",") if h.strip()]
+    seed = DEFAULT_SEED if args.seed is None else args.seed
+    try:
+        slate = sample(args.round, args.count, exclude=exclude, seed=seed,
+                       max_large=args.max_large, recent_rounds=args.recent_rounds,
+                       filters=args.filter)
+    except ValueError as exc:
+        print("error: %s" % exc, file=sys.stderr)
+        return 2
+
+    meta = {"seed": str(seed), "max_large": MAX_LARGE if args.max_large is None
+            else args.max_large, "mix": mix(slate)}
+    if args.write:
+        path = write_slate(args.round, slate, meta)
+        if not args.json:
+            print("wrote %s" % path)
+    if args.json:
+        doc = {"round": args.round, "count": len(slate), "challenges": slate}
+        doc.update(meta)
+        print(json.dumps(doc, indent=2))
+    else:
+        _print_slate(slate, args.round, seed)
+    return 0 if slate else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repipe/select.py
+++ b/scripts/repipe/select.py
@@ -1,0 +1,225 @@
+"""Pick the next need a builder should take, and refuse the ones that would collide.
+
+Three layers of collision avoidance, cheapest first (docs/re-pipeline.md):
+
+1. **Track separation is the structural win.** Track `tooling` touches kuna-cli /
+   kuna-console / kuna-analysis / tests/cli / docs/cli.md. Track `quality` touches
+   kuna-decomp / phases.toml / options.rs / the four hard-coded counters / docs/options.md /
+   docs/history.md / tests/stages. Those sets are DISJOINT, so three tooling builders run in
+   parallel with no shared mutable state at all.
+2. **Named resource leases.** A need's track and `touches:` map to a resource set; a need
+   whose set intersects a held lease is not dispatched. Because every quality need needs
+   counter:catalog + counter:stages-corpus + counter:div + file:phases.toml, this yields
+   "at most one option-adding builder at a time" without special-casing it.
+3. **Contracts.** What each live builder is doing is written to contracts.json and rendered
+   into every sibling's prompt, so a builder that needs someone else's file stops and says
+   so rather than racing for it.
+
+The ranked backlog is emitted in the exact `{"ranked": [...]}` shape that
+docs/improvement-pipeline/opportunities.json uses, so scripts/pipeline/select.py can consume
+it unchanged; this module adds the lease-feasibility filter that the angr selector has no
+concept of.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from . import config
+from ..pipeline import state as pstate
+
+# Resources a track always contends for, regardless of what the need says it touches.
+# Every quality need needs the whole counter set, so "at most one option-adding builder in
+# flight" falls out of the lease algebra rather than being special-cased.
+TRACK_RESOURCES = {
+    "quality": ["counter:catalog", "counter:stages-corpus", "counter:div",
+                "file:phases.toml", "file:docs/options.md"],
+    "loader": [],
+    "tooling": [],
+    "perf": [],
+}
+
+# A path prefix -> the lease that owns it. Longest match wins.
+# Only paths where a SILENT wrong merge is possible get a lease. Three tooling builders all
+# adding a line to kuna-cli's dispatch table is a trivial rebase, and leasing the crate for
+# that would throttle the pipeline to one builder -- which is exactly what the three-slot
+# default exists to avoid. The counters, phases.toml and the baselines are different: an
+# identical `85 -> 86` edit on two branches merges CLEANLY to the wrong number.
+PATH_RESOURCES = [
+    ("decompiler/crates/kuna-decomp/phases.toml", "file:phases.toml"),
+    ("decompiler/crates/kuna-decomp/src/p0_knowledge/options.rs", "counter:catalog"),
+    ("decompiler/crates/kuna-decomp/src/p0_knowledge/kuna_phases", "counter:catalog"),
+    ("decompiler/crates/kuna-decomp/tests/catalog_bytecompat.rs", "counter:catalog"),
+    ("decompiler/crates/kuna-base/src/xml.rs", "counter:stages-corpus"),
+    ("docs/options.md", "file:docs/options.md"),
+    ("docs/history.md", "counter:div"),
+    ("docs/baseline-stages.json", "counter:stages-corpus"),
+    ("tests/stages", "counter:stages-corpus"),
+]
+
+
+def resources_for(need):
+    """Every lease a builder on this need would have to hold."""
+    track = getattr(need, "track", None) or need.get("track", "tooling")
+    touches = getattr(need, "touches", None)
+    if touches is None:
+        touches = need.get("touches", []) if isinstance(need, dict) else []
+    res = set(TRACK_RESOURCES.get(track, []))
+    for t in touches or []:
+        best = None
+        for prefix, name in PATH_RESOURCES:
+            if t.startswith(prefix) and (best is None or len(prefix) > len(best[0])):
+                best = (prefix, name)
+        if best:
+            res.add(best[1])
+    nid = getattr(need, "need_id", None) or (need.get("need_id") if isinstance(need, dict) else None)
+    if nid:
+        res.add("cluster:%s" % nid)
+    return sorted(res)
+
+
+def held_resources(snapshot=None):
+    data = snapshot if snapshot is not None else pstate.snapshot()
+    return set(data.get("leases", {}).keys())
+
+
+def feasible(need, held=None):
+    """(bool, blocking_resource_or_None) — can a builder start on this need right now?"""
+    held = held if held is not None else held_resources()
+    for r in resources_for(need):
+        if r in held:
+            return False, r
+    return True, None
+
+
+DISPATCHABLE = ("open", "regressed")
+
+
+def candidates(needs_list=None):
+    from . import needs as needs_mod
+    all_needs = needs_list if needs_list is not None else needs_mod.load_all()
+    out = [n for n in all_needs if getattr(n, "status", "open") in DISPATCHABLE]
+    out.sort(key=needs_mod.rank_score, reverse=True)
+    return out
+
+
+def pick(k=1, needs_list=None):
+    """The top k dispatchable needs whose resource sets are free AND disjoint from each other.
+
+    Disjointness among the picks matters as much as against held leases: handing two
+    quality needs to two builders in the same tick would recreate exactly the shared-counter
+    race the leases exist to prevent.
+    """
+    held = set(held_resources())
+    picks = []
+    for n in candidates(needs_list):
+        res = set(resources_for(n))
+        if res & held:
+            continue
+        picks.append({"need": n, "resources": sorted(res)})
+        held |= res
+        if len(picks) >= k:
+            break
+    return picks
+
+
+def write_contracts(picks, round_n, path=None):
+    """The block rendered into every builder prompt: what the siblings are doing.
+
+    This is the captain 'making the developers aware of each other's goals'. It is prose on
+    purpose — the leases are the enforcement, this is the explanation.
+    """
+    path = path or (config.state_dir() / "contracts.json")
+    doc = {"round": round_n, "builders": [
+        {"need": p["need"].need_id, "track": p["need"].track,
+         "title": p["need"].title, "resources": p["resources"],
+         "touches": list(getattr(p["need"], "touches", []) or [])}
+        for p in picks]}
+    os.makedirs(os.path.dirname(str(path)), exist_ok=True)
+    tmp = str(path) + ".tmp"
+    with open(tmp, "w") as fh:
+        json.dump(doc, fh, indent=2)
+    os.replace(tmp, path)
+    return path
+
+
+def contracts_markdown(exclude_need=None, path=None):
+    path = path or (config.state_dir() / "contracts.json")
+    if not os.path.exists(str(path)):
+        return ""
+    with open(str(path)) as fh:
+        doc = json.load(fh)
+    rows = [b for b in doc.get("builders", []) if b["need"] != exclude_need]
+    if not rows:
+        return ""
+    lines = ["## Other builders running right now — do not touch their files", ""]
+    for b in rows:
+        lines.append("- `%s` (%s) — %s" % (b["need"], b["track"], b["title"]))
+        lines.append("  leases: %s" % ", ".join(b["resources"]))
+        if b.get("touches"):
+            lines.append("  declared files: %s" % ", ".join(b["touches"]))
+    lines += ["",
+              "If you need a file another builder holds, STOP and report",
+              "`state update --worker <id> --status blocked --note \"needs <resource> held by <worker>\"`.",
+              "Do not race for it; the captain re-queues you next round."]
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog="python -m scripts.repipe.select")
+    ap.add_argument("-k", "--count", type=int, default=1)
+    ap.add_argument("--round", type=int, default=0)
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--shell", action="store_true",
+                    help="eval-able assignments, in tools/pipeline/run.sh's idiom")
+    ap.add_argument("--write-contracts", action="store_true")
+    ap.add_argument("--resources-for", default=None, metavar="NEED_ID")
+    args = ap.parse_args(argv)
+
+    if args.resources_for:
+        from . import needs as needs_mod
+        n = needs_mod.load(args.resources_for)
+        if n is None:
+            print("no such need: %s" % args.resources_for, file=sys.stderr)
+            return 1
+        ok, blocker = feasible(n)
+        out = {"need": n.need_id, "resources": resources_for(n),
+               "feasible": ok, "blocked_by": blocker}
+        print(json.dumps(out, indent=2) if args.json else
+              "%s feasible=%s blocked_by=%s\n  %s" % (n.need_id, ok, blocker,
+                                                     " ".join(resources_for(n))))
+        return 0 if ok else 1
+
+    picks = pick(args.count)
+    if args.write_contracts:
+        write_contracts(picks, args.round)
+    if not picks:
+        return 1
+    if args.json:
+        print(json.dumps([{"need_id": p["need"].need_id, "track": p["need"].track,
+                           "title": p["need"].title, "resources": p["resources"]}
+                          for p in picks], indent=2))
+    elif args.shell:
+        p = picks[0]["need"]
+        print("OPP_ID=%s" % _q(p.need_id))
+        print("TEST_NAME=%s" % _q(p.need_id))
+        print("BINARY=%s" % _q(getattr(p, "binary", "") or ""))
+        print("SELECTOR=%s" % _q(getattr(p, "selector", "") or ""))
+        print("ARCH=")
+        print("SLUG=%s" % _q(p.need_id))
+        print("SCORE=%s" % _q("%.3f" % __import__("scripts.repipe.needs", fromlist=["x"]).rank_score(p)))
+        print("KINDS=%s" % _q(p.track))
+    else:
+        for p in picks:
+            print("%-28s %-8s %s" % (p["need"].need_id, p["need"].track, p["need"].title))
+    return 0
+
+
+def _q(v):
+    return "'" + str(v).replace("'", "'\\''") + "'"
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repipe/status.py
+++ b/scripts/repipe/status.py
@@ -1,0 +1,144 @@
+"""One-shot / --watch / --json view of the RE-friction loop, for a terminal.
+
+The sibling of scripts/pipeline/status.py, and it reuses that module's collector rather than
+re-deriving worker state: the two loops share one flock-guarded inventory, so the agents,
+slots and leases come from there and only the round, backlog and budget are new here.
+
+This is what the captain prompt tells a tick to read first, and what an operator runs when
+they do not want the web dashboard. It is deliberately cheap -- everything expensive
+(`git worktree list`, `gh api`) is behind the TTL cache scripts/pipeline/status.py owns.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+from . import config
+from ..pipeline import status as pstatus
+from ..pipeline import state as pstate
+
+
+def _round_doc(n=None):
+    from . import captain
+    try:
+        return captain.load_round(n if n is not None else captain.current_round())
+    except Exception:
+        return {}
+
+
+def _backlog():
+    try:
+        from . import needs as needs_mod
+        rows = needs_mod.load_all()
+        by_status = {}
+        for n in rows:
+            by_status[n.status] = by_status.get(n.status, 0) + 1
+        top = sorted(rows, key=needs_mod.rank_score, reverse=True)[:8]
+        return {"total": len(rows), "by_status": by_status,
+                "top": [{"need_id": n.need_id, "track": n.track, "status": n.status,
+                         "severity": n.severity, "instances": n.instances,
+                         "score": round(needs_mod.rank_score(n), 2), "title": n.title}
+                        for n in top]}
+    except Exception as exc:
+        return {"error": str(exc), "total": 0, "by_status": {}, "top": []}
+
+
+def _disk():
+    st = os.statvfs(str(config.repo_root()))
+    return {"free_gb": int(st.f_bavail * st.f_frsize / (1024 ** 3)),
+            "min_gb": config.MIN_FREE_GB, "halt_gb": config.HALT_FREE_GB}
+
+
+def collect(round_n=None):
+    base = pstatus.collect()
+    doc = _round_doc(round_n)
+    data = pstate.snapshot()
+    return {
+        "ts": time.time(),
+        "round": doc.get("round"),
+        "states": {k: doc.get(k) for k in ("supervisor", "test", "build") if k in doc},
+        "split": config.agent_split(),
+        "slots": data.get("slots", {}),
+        "leases": data.get("leases", {}),
+        "agents": base.get("workers", []),
+        "worktrees": base.get("worktrees", []),
+        "prs": base.get("prs"),
+        "cache": base.get("cache", {}),
+        "backlog": _backlog(),
+        "disk": _disk(),
+        "spend_usd": doc.get("spend_usd", 0.0),
+        "flags": {f: (config.state_dir() / f).exists() for f in ("STOP", "PAUSE", "ABORT")},
+    }
+
+
+def render(s):
+    L = []
+    st = s.get("states") or {}
+    L.append("kuna RE-friction loop — round %s · %s / %s / %s"
+             % (s.get("round"), st.get("supervisor", "?"), st.get("test", "?"),
+                st.get("build", "?")))
+    sp = s["split"]
+    held = lambda pool: len((s["slots"].get(pool) or {}).get("held") or {})
+    L.append("  agents: captain %d/%d · testers %d/%d · builders %d/%d   disk %dG (halt <%dG)"
+             % (held("captain"), sp["captain"], held("tester"), sp["testers"],
+                held("builder"), sp["builders"], s["disk"]["free_gb"], s["disk"]["halt_gb"]))
+    on = [f for f, v in s["flags"].items() if v]
+    if on:
+        L.append("  FLAGS: %s" % ", ".join(on))
+    L.append("-" * 92)
+    if not s["agents"]:
+        L.append("  (no agents registered)")
+    else:
+        L.append("  %-18s %-9s %-8s %-8s %-7s %s" % ("AGENT", "PHASE", "STATUS", "ELAPSED",
+                                                     "STALE", "SLUG / PR"))
+        for w in s["agents"]:
+            stale = int(w.get("stale_s") or 0)
+            L.append("  %-18s %-9s %-8s %-8s %-7s %s"
+                     % (str(w.get("worker"))[:18], str(w.get("phase"))[:9],
+                        str(w.get("status"))[:8], pstatus._fmt_elapsed(w.get("elapsed_s") or 0),
+                        ("%ds" % stale) if stale < 120 else ("%ds!" % stale),
+                        w.get("pr_url") or w.get("slug") or "-"))
+    leases = s.get("leases") or {}
+    if leases:
+        L.append("  leases: %s" % ", ".join("%s=%s" % (r, l.get("holder"))
+                                            for r, l in sorted(leases.items())))
+    b = s["backlog"]
+    L.append("-" * 92)
+    L.append("  backlog: %d needs — %s" % (b["total"], ", ".join(
+        "%s %d" % (k, v) for k, v in sorted(b["by_status"].items())) or "empty"))
+    for n in b["top"]:
+        L.append("    %-26s %-8s %-10s %7.1f  %s"
+                 % (n["need_id"][:26], n["track"], n["status"], n["score"], n["title"][:44]))
+    prs = s.get("prs")
+    L.append("  open PRs: %s" % (len(prs) if prs is not None else "(gh unavailable)"))
+    return "\n".join(L)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog="python -m scripts.repipe.status")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--watch", action="store_true")
+    ap.add_argument("--interval", type=float, default=2.0)
+    ap.add_argument("--round", type=int, default=None)
+    args = ap.parse_args(argv)
+
+    if args.json and not args.watch:
+        print(json.dumps(collect(args.round), indent=2, default=str))
+        return 0
+    if not args.watch:
+        print(render(collect(args.round)))
+        return 0
+    try:
+        while True:
+            sys.stdout.write("\x1b[2J\x1b[H" + render(collect(args.round)) + "\n")
+            sys.stdout.flush()
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repipe/strictschema.py
+++ b/scripts/repipe/strictschema.py
@@ -1,0 +1,114 @@
+"""Make a JSON Schema acceptable to OpenAI's strict structured-output mode, and check it.
+
+`codex exec --output-schema` sends the schema straight to the API's `response_format`, which
+enforces rules ordinary JSON Schema does not. Every one of these was learned from a 400 on a
+live call, because nothing local rejects the schema:
+
+  * every object must carry `required` listing EVERY key in `properties`, and
+    `additionalProperties: false`. Optionality is expressed by admitting `null` in the type,
+    never by leaving a key out of `required`;
+  * every node needs an explicit `type` -- a bare `enum`, `const` or `{}` is rejected;
+  * a `$ref` to a sibling FILE does not resolve, so nothing may be split across files;
+  * `"type": ["object", "null"]` is still an object and still needs all of the above --
+    matching only the string `"object"` is the easy way to miss one.
+
+`check()` is wired into tools/repipe/smoke.sh so a schema edit cannot silently break every
+tester in the fleet with a 400 that only appears once real money is being spent.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+_JSON_TYPE = {str: "string", bool: "boolean", int: "integer",
+              float: "number", type(None): "null"}
+
+
+def _is_object(node):
+    t = node.get("type")
+    return t == "object" or (isinstance(t, list) and "object" in t)
+
+
+def _has_shape(node):
+    return any(k in node for k in ("properties", "items", "enum", "const"))
+
+
+def strictify(node):
+    """Return a copy of ``node`` that satisfies the rules above."""
+    if isinstance(node, list):
+        return [strictify(v) for v in node]
+    if not isinstance(node, dict):
+        return node
+    out = {k: strictify(v) for k, v in node.items()}
+    if "properties" in out:
+        out["required"] = list(out["properties"].keys())
+        out["additionalProperties"] = False
+        if "type" not in out:
+            out["type"] = "object"
+    if "enum" in out and "type" not in out:
+        kinds = sorted({_JSON_TYPE[type(v)] for v in out["enum"]})
+        out["type"] = kinds[0] if len(kinds) == 1 else kinds
+    if "const" in out and "type" not in out:
+        out["type"] = _JSON_TYPE[type(out["const"])]
+    return out
+
+
+def check(schema):
+    """[] if the schema is strict-mode clean, else a list of (path, problem)."""
+    bad = []
+
+    def walk(n, path="$"):
+        if isinstance(n, dict):
+            if "properties" in n or _is_object(n):
+                props = set(n.get("properties") or {})
+                missing = props - set(n.get("required") or [])
+                if missing:
+                    bad.append((path, "required is missing %s" % sorted(missing)))
+                if props and n.get("additionalProperties") is not False:
+                    bad.append((path, "additionalProperties must be false"))
+            if str(n.get("$ref", "")).endswith(".json"):
+                bad.append((path, "$ref to a file does not resolve"))
+            if _has_shape(n) and "type" not in n and "$ref" not in n:
+                bad.append((path, "no explicit type"))
+            for k, v in n.items():
+                walk(v, "%s.%s" % (path, k))
+        elif isinstance(n, list):
+            for i, v in enumerate(n):
+                walk(v, "%s[%d]" % (path, i))
+
+    walk(schema)
+    return bad
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog="python -m scripts.repipe.strictschema")
+    ap.add_argument("schema")
+    ap.add_argument("--fix", action="store_true", help="rewrite the file in place")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    with open(args.schema) as fh:
+        doc = json.load(fh)
+    if args.fix:
+        doc = strictify(doc)
+        tmp = args.schema + ".tmp"
+        with open(tmp, "w") as fh:
+            json.dump(doc, fh, indent=2)
+            fh.write("\n")
+        import os
+        os.replace(tmp, args.schema)
+    bad = check(doc)
+    if args.json:
+        print(json.dumps({"ok": not bad, "problems": [{"path": p, "problem": w} for p, w in bad]},
+                         indent=2))
+    elif bad:
+        for p, w in bad:
+            print("%s  %s" % (p, w), file=sys.stderr)
+    else:
+        print("strict-mode OK: %s" % args.schema)
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repipe/verify.py
+++ b/scripts/repipe/verify.py
@@ -1,0 +1,809 @@
+"""The two-arm gate: the only path from a tester's narrative to a builder's queue.
+
+No tester prose ever reaches the backlog. Two executable predicates do: the PROBE asserts
+the CURRENT BAD behaviour and must PASS, the ACCEPTANCE asserts the DESIRED behaviour and
+must FAIL -- both replayed on a freshly built main at a pinned SHA, which every result
+records so it can be re-read later. Why the gate exists at all: in the decbench campaign
+round 2's refuters overturned the filed diagnosis on 3 of 8 cases while the symptom stood
+in all 8, so a pipeline that lets a model's story reach a builder burns roughly 3 of every
+8 builder-hours on the wrong mechanism.
+
+The five verdicts, in the precedence `gate()` decides them:
+
+  unrunnable         an arm could not be executed at all -- target missing, sha256 of the
+                     target does not match the one the probe was authored against, probe
+                     malformed, evaluator raised. No claim is made about kuna either way.
+  flaky              an arm disagreed with itself across its repeats. A probe that is not
+                     stable is not evidence, so it neither admits nor rejects.
+  not-reproducible   the probe FAILED: the bad behaviour it describes is not there.
+  already-supported  the acceptance PASSED: kuna already does the desired thing. This is
+                     the "the tester was wrong" ledger, and it is the honest denominator
+                     for every other number on the dashboard -- an EMPTY already-supported
+                     bucket means the gate is broken, not that the testers were perfect
+                     (it is a stated round-1 success criterion). The two rejecting rules
+                     can fire together, so `reasons` lists every rule that applied and
+                     `already_supported` is recorded independently of `verdict`.
+  admitted           probe PASS and acceptance FAIL. Only these reach a builder.
+
+`acceptance_suite()` is the other half of the loop and the machine's entire answer to
+"have the builders fixed what the testers asked for": it re-runs the acceptance probe of
+every need in docs/re-needs/ against the CURRENT build. FAIL->PASS closes a need; PASS->
+FAIL on a closed need is a regression that goes back at rank 0. Neither is a judgment
+call, and neither fires off a flaky or unrunnable replay.
+
+`promote()` copies a closed need's acceptance probe verbatim into tests/cli/<need_id>.json
+so every shipped need leaves a permanent regression test behind it. It refuses a probe
+whose target is not vendorable: CI has no dataset.
+
+The evaluator itself lives in probe.py and is not duplicated here -- this module decides
+what a pair of verdicts MEANS, resolves the {{BIN}} a probe needs, and persists the answer.
+
+    PYTHONPATH=<repo> python3 -m scripts.repipe.verify --gate --round 3 [--json]
+    PYTHONPATH=<repo> python3 -m scripts.repipe.verify --observation obs.json [--json]
+    PYTHONPATH=<repo> python3 -m scripts.repipe.verify --acceptance-suite --all [--json]
+    PYTHONPATH=<repo> python3 -m scripts.repipe.verify --acceptance-suite --need no-xrefs
+    PYTHONPATH=<repo> python3 -m scripts.repipe.verify --promote no-xrefs
+
+Exit codes: 0 ran, 1 refused or nothing to do, 2 usage / infrastructure error.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from . import config, probe
+
+SCHEMA = "re-gate/1"
+ROUND_SCHEMA = "re-gate-round/1"
+SUITE_SCHEMA = "re-acceptance-suite/1"
+
+ADMITTED = "admitted"
+NOT_REPRODUCIBLE = "not-reproducible"
+ALREADY_SUPPORTED = "already-supported"
+FLAKY = "flaky"
+UNRUNNABLE = "unrunnable"
+VERDICTS = (ADMITTED, NOT_REPRODUCIBLE, ALREADY_SUPPORTED, FLAKY, UNRUNNABLE)
+
+# A need in any of these is still owed to us; its acceptance flipping to PASS closes it.
+# `closed` is the mirror image: its acceptance flipping to FAIL is a regression.
+OPEN_STATUSES = ("open", "claimed", "building", "proposal", "blocked", "regressed")
+
+_HEXID = re.compile(r"^[0-9a-f]{24}$")
+
+
+class PromotionRefused(ValueError):
+    """promote() refuses rather than vendoring a probe CI cannot run."""
+
+
+# --- small shared helpers ---------------------------------------------------
+
+def _utc():
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def head_sha(repo=None):
+    """The pinned SHA every verdict is stamped with. None when git cannot answer."""
+    root = str(repo or config.repo_root())
+    try:
+        r = subprocess.run(["git", "-C", root, "rev-parse", "HEAD"],
+                           capture_output=True, text=True, timeout=20)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return r.stdout.strip() or None if r.returncode == 0 else None
+
+
+def _write_json(path, obj):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = str(path) + ".tmp"
+    with open(tmp, "w") as fh:
+        json.dump(obj, fh, indent=2)
+        fh.write("\n")
+    os.replace(tmp, path)
+    return path
+
+
+def _sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+# --- the probe.py seam ------------------------------------------------------
+#
+# probe.py owns the predicate language and the executor; this module never re-implements
+# either. It decides what a PAIR of verdicts means, resolves the {{BIN}} an arm needs, and
+# persists the answer. Everything below is a thin, defensive wrapper: a malformed probe
+# from an LLM tester must come back as a filed "unrunnable" verdict, never as a traceback
+# that takes the round down.
+
+def make_ctx(work=None, binary=None, tmp=None, baselines=None):
+    """The substitution context probe.check() resolves {{KUNA}}/{{BIN}}/{{WORK}}/... against.
+
+    `baselines` maps a probe_id to an already-computed verdict, which is what a `rel_to`
+    timing or memory clause reads: the perf lane's idiom is "the acceptance must be some
+    ratio of the probe's median", and the ratio is what cancels kuna's fixed cold-load cost.
+    """
+    return probe.context(work=str(work) if work else None,
+                         binary=str(binary) if binary else None,
+                         tmp=str(tmp) if tmp else None,
+                         baselines=baselines or {},
+                         kuna=str(config.kuna_bin()), specs=str(config.specs_dir()))
+
+
+def _probe_id(p, is_acceptance):
+    try:
+        return probe.probe_id(p, is_acceptance)
+    except (probe.ProbeError, AttributeError, TypeError, ValueError):
+        return None
+
+
+_TIMEOUT_PREFIX = "timed out"
+
+
+def _verdict_unrunnable(v):
+    """True when the arm never really ran: bad argv, bad cwd, spawn failure, our own stub.
+
+    A TIMEOUT is deliberately not unrunnable. The command did run; it just did not finish,
+    and for a perf need that is the evidence -- a `timing` acceptance that times out is a
+    real FAIL, which is what admits the need.
+    """
+    if not isinstance(v, dict):
+        return True
+    if v.get("unrunnable") or v.get("error"):
+        return True
+    return any(e and not str(e).startswith(_TIMEOUT_PREFIX) for e in (v.get("errors") or []))
+
+
+def _stub(pid, reason, arm=None):
+    """The verdict shape probe.py would have returned, for an arm that never got that far."""
+    return {"schema": "re-verdict/1", "probe_id": pid, "arm": arm, "passed": False,
+            "flaky": False, "clauses": [], "wall_ms_median": None, "repeat": 0,
+            "unrunnable": True, "error": reason}
+
+
+# --- resolving the binary a probe points at ---------------------------------
+
+def resolve_binary(p, work=None, challenges=()):
+    """Absolute path for {{BIN}}, plus a note on how it was found.
+
+    A probe may name no target at all (`kuna --help`, an `absence` probe); that is not an
+    error and yields ("", "no target"). Otherwise the search order is: an in-repo vendored
+    path, the work dir (an arena keeps the arena-relative shape), then the dataset, whose
+    binaries are addressed challenges/<hexid>/<rel> -- `bin/` preserves recursive-extraction
+    path shapes, so the rel is never globbed for.
+
+    Two dataset facts are handled here rather than left to fail obscurely: exec bits are
+    broken (4 shipped binaries are mode 600, 54 are 644), so a non-executable target is
+    copied out to <state>/probebin and chmod 0755'd -- the dataset itself is read-only
+    input and is never written to; and a binary_sha256 that does not match the file is a
+    hard stop, because the probe was authored against something else.
+    """
+    t = (p or {}).get("target")
+    if not t:
+        return "", "no target"
+    rel = t.get("binary_rel") or ""
+    if not rel:
+        return "", "target has no binary_rel"
+
+    cands = []
+    if t.get("binary_source") == "in-repo" and t.get("in_repo_path"):
+        cands.append(config.repo_root() / t["in_repo_path"])
+    if work:
+        cands.append(Path(work) / rel)
+        cands.append(Path(work) / "target" / rel)
+    ds = config.dataset_root()
+    trimmed = re.sub(r"^target/", "", rel)
+    cands.append(ds / rel)
+    cands.append(ds / trimmed)
+    for hexid in challenges or ():
+        cands.append(ds / "challenges" / hexid / rel)
+        cands.append(ds / "challenges" / hexid / trimmed)
+
+    found = None
+    for c in cands:
+        try:
+            if c.is_file():
+                found = c
+                break
+        except OSError:
+            continue
+    if found is None:
+        raise FileNotFoundError("target %s not found (tried %d locations)" % (rel, len(cands)))
+
+    want = t.get("binary_sha256")
+    if want:
+        got = _sha256(found)
+        if got != want:
+            raise ValueError("target sha256 mismatch at %s: probe wants %s, file is %s"
+                             % (found, want[:12], got[:12]))
+    if os.access(str(found), os.X_OK):
+        return str(found), "found at %s" % found
+    stage = config.state_dir() / "probebin" / (want or _sha256(found))[:16]
+    stage.mkdir(parents=True, exist_ok=True)
+    dest = stage / found.name
+    if not dest.exists():
+        shutil.copy2(str(found), str(dest))
+    os.chmod(str(dest), 0o755)
+    return str(dest), "copied from %s (not executable in place)" % found
+
+
+# --- one arm of the gate ----------------------------------------------------
+
+def gate_reps(p):
+    """The rep floor the gate replays an arm at.
+
+    The plan pins the gate at REPLAY_REPS (3): a probe that cannot agree with itself is
+    not evidence, and with repeat 1 the flaky bucket can never fill. Timing and memory
+    probes get TIMING_REPS instead, because single-target timing noise on this machine
+    routinely exceeds 5% -- returncopysplit's own record measured a -20%/-12% floor on
+    byte-identical output. acceptance_suite() does NOT apply a floor by default: at
+    INTEGRATE it re-runs the whole suite, and kuna's worst measured case is 445 s.
+    """
+    kind = (p or {}).get("kind")
+    return config.TIMING_REPS if kind in ("timing", "memory") else config.REPLAY_REPS
+
+
+def run_probe(p, is_acceptance=False, ctx=None, work=None, challenges=(), reps=None,
+              baselines=None):
+    """Replay one probe and return probe.py's verdict, augmented with what we know.
+
+    `reps` raises the probe's own `repeat` to at least that many runs; it never lowers it,
+    and it does not change the probe_id (derived from cmd + expect alone, so the id is the
+    same in an arena, a scratch checkout and tests/cli/).
+
+    Anything that stops the probe from running at all comes back as a verdict carrying
+    `unrunnable` and a human reason, never as an exception: the gate must be able to file
+    "we could not tell" as a result rather than lose the observation.
+    """
+    arm = "acceptance" if is_acceptance else "probe"
+    if not isinstance(p, dict):
+        return _stub(None, "observation carries no %s" % arm, arm)
+    if not p.get("cmd"):
+        return _stub(None, "%s has no cmd" % arm, arm)
+    if not p.get("expect"):
+        return _stub(None, "%s has an empty expect: it asserts nothing and would "
+                           "always pass" % arm, arm)
+    pid = _probe_id(p, is_acceptance)
+
+    try:
+        norm = probe.normalize(p, is_acceptance)
+    except Exception as exc:  # noqa: BLE001 - a malformed probe must not kill the round
+        return _stub(pid, "%s: %s" % (type(exc).__name__, exc), arm)
+    if reps:
+        norm = dict(norm)
+        norm["repeat"] = max(int(norm.get("repeat") or 1), min(int(reps), 11))
+
+    note = None
+    if ctx is None:
+        try:
+            binary, note = resolve_binary(norm, work=work, challenges=challenges)
+        except (FileNotFoundError, ValueError, OSError) as exc:
+            return _stub(norm["probe_id"], str(exc), arm)
+        ctx = make_ctx(work=work, binary=binary, baselines=baselines)
+    elif baselines:
+        ctx = dict(ctx)
+        ctx["baselines"] = dict(ctx.get("baselines") or {}, **baselines)
+
+    try:
+        v = probe.check(norm, ctx)
+    except Exception as exc:  # noqa: BLE001 - same
+        return _stub(norm["probe_id"], "check raised: %s: %s" % (type(exc).__name__, exc), arm)
+    if not isinstance(v, dict):
+        v = {"passed": bool(v), "flaky": False, "clauses": [], "wall_ms_median": None}
+
+    out = dict(v)
+    out.setdefault("probe_id", norm.get("probe_id") or pid)
+    out["arm"] = arm
+    out["unrunnable"] = _verdict_unrunnable(v)
+    if note:
+        out["target_note"] = note
+    return out
+
+
+# --- the gate ---------------------------------------------------------------
+
+def gate(observation, ctx=None, work=None, challenges=(), sha=None, reps=None):
+    """Run an observation's two arms and say what the pair means.
+
+    `ctx`, when given, is used verbatim for BOTH arms -- that is the caller asserting one
+    substitution environment for the pair. Left None (the usual case) each arm resolves
+    its own {{BIN}} from its own target.
+    """
+    obs = observation or {}
+    if not challenges and obs.get("hexid"):
+        challenges = [obs["hexid"]]
+    p, a = obs.get("probe"), obs.get("acceptance")
+    pv = run_probe(p, False, ctx, work, challenges, reps or gate_reps(p))
+    base = {pv["probe_id"]: pv} if pv.get("probe_id") else None
+    av = run_probe(a, True, ctx, work, challenges, reps or gate_reps(a), base)
+
+    reasons = []
+    if pv.get("unrunnable"):
+        reasons.append("probe-unrunnable")
+    if av.get("unrunnable"):
+        reasons.append("acceptance-unrunnable")
+    if reasons:
+        verdict = UNRUNNABLE
+    else:
+        if pv.get("flaky"):
+            reasons.append("probe-flaky")
+        if av.get("flaky"):
+            reasons.append("acceptance-flaky")
+        if reasons:
+            verdict = FLAKY
+        else:
+            if not pv.get("passed"):
+                reasons.append("probe-fail")
+            if av.get("passed"):
+                reasons.append("acceptance-pass")
+            if pv.get("passed") and not av.get("passed"):
+                reasons.append("probe-pass-acceptance-fail")
+                verdict = ADMITTED
+            elif "probe-fail" in reasons:
+                verdict = NOT_REPRODUCIBLE
+            else:
+                verdict = ALREADY_SUPPORTED
+
+    vend, vend_why = vendorable(a)
+    return {
+        "schema": SCHEMA,
+        "verdict": verdict,
+        "reasons": reasons,
+        "already_supported": bool(av.get("passed")) and not (
+            pv.get("unrunnable") or av.get("unrunnable") or av.get("flaky")),
+        "sha": sha if sha is not None else head_sha(),
+        "at": _utc(),
+        "title": obs.get("title"),
+        "kind": obs.get("kind"),
+        "severity": obs.get("severity"),
+        "regression_of": obs.get("regression_of"),
+        "hexid": obs.get("hexid"),
+        "probe_id": pv.get("probe_id"),
+        "acceptance_id": av.get("probe_id"),
+        "acceptance_vendorable": vend,
+        "acceptance_vendorable_why": vend_why,
+        "probe": pv,
+        "acceptance": av,
+    }
+
+
+def _counts(results):
+    c = dict((v, 0) for v in VERDICTS)
+    for r in results:
+        c[r["verdict"]] = c.get(r["verdict"], 0) + 1
+    return c
+
+
+def round_reports(round_n):
+    """Every tester report.json belonging to a round, arena-first then round-dir."""
+    n = str(round_n)
+    seen, out = set(), []
+    globs = [(config.arena_dir() / n).glob("*/report.json"),
+             (config.rounds_dir() / n / "reports").glob("*.json"),
+             (config.rounds_dir() / n).glob("*/report.json")]
+    for g in globs:
+        try:
+            files = sorted(g)
+        except OSError:
+            continue
+        for f in files:
+            key = str(f.resolve())
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(f)
+    return out
+
+
+def _tester_id_for(report_path):
+    """Recover which tester produced a report when the report itself does not say.
+
+    The arena is `<state>/arena/<round>/<hexid>/report.json` and tester.sh derives its id
+    from exactly those two components, so this reconstructs it rather than leaving the
+    corroboration count blind -- credibility weighs DISTINCT testers, and a None there would
+    make three findings from three agents look like one opinion.
+    """
+    try:
+        hexid = report_path.parent.name
+        rnd = report_path.parent.parent.name
+        return "t-r%s-%s" % (rnd, hexid[:8])
+    except Exception:
+        return None
+
+
+def gate_round(round_n, ctx=None, reps=None):
+    """Gate every observation in every report of a round; persist rounds/<n>/gate.json."""
+    sha = head_sha()
+    results = []
+    reports = []
+    for rp in round_reports(round_n):
+        try:
+            report = json.loads(rp.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            reports.append({"report": str(rp), "error": str(exc), "observations": 0})
+            continue
+        hexid = report.get("hexid") or (rp.parent.name if _HEXID.match(rp.parent.name) else None)
+        obs = report.get("observations") or []
+        reports.append({"report": str(rp), "hexid": hexid, "outcome": report.get("outcome"),
+                        "observations": len(obs)})
+        if not isinstance(obs, list):
+            # A report whose `observations` is not a list is one bad report, not a bad round.
+            # Crashing here would discard every other tester's evidence too.
+            reports[-1]["error"] = "observations is %s, not a list" % type(obs).__name__
+            reports[-1]["observations"] = 0
+            continue
+        for i, o in enumerate(obs):
+            if not isinstance(o, dict):
+                reports[-1].setdefault("skipped", []).append(i)
+                continue
+            o = dict(o or {})
+            o.setdefault("hexid", hexid)
+            r = gate(o, ctx=ctx, work=str(rp.parent),
+                     challenges=[hexid] if hexid else (), sha=sha, reps=reps)
+            r["report"] = str(rp)
+            r["observation_index"] = i
+            # cluster.py builds the need record from these, so the gate result must carry the
+            # observation it gated and who filed it -- a verdict with no observation attached
+            # would collapse every need into one empty record.
+            r["observation"] = o
+            r["tester_id"] = report.get("tester_id") or _tester_id_for(rp)
+            results.append(r)
+
+    out = {"schema": ROUND_SCHEMA, "round": int(round_n), "sha": sha, "at": _utc(),
+           "counts": _counts(results), "reports": reports, "results": results}
+    out["path"] = str(_write_json(config.rounds_dir() / str(round_n) / "gate.json", out))
+    return out
+
+
+# --- need records -----------------------------------------------------------
+
+def _scalar(v):
+    if v.startswith("[") and v.endswith("]"):
+        inner = v[1:-1].strip()
+        return [x.strip().strip("\"'") for x in inner.split(",") if x.strip()] if inner else []
+    if len(v) >= 2 and v[0] == v[-1] and v[0] in "\"'":
+        return v[1:-1]
+    if v in ("null", "~", ""):
+        return None
+    if v in ("true", "false"):
+        return v == "true"
+    if re.fullmatch(r"-?\d+", v):
+        return int(v)
+    if re.fullmatch(r"-?\d+\.\d+", v):
+        return float(v)
+    return v
+
+
+def front_matter(text):
+    """The docs/decbench/triage/*.md dialect: `---`, flat key: value, inline [a, b] lists."""
+    m = re.match(r"---\n(.*?)\n---", text, re.S)
+    if not m:
+        return None
+    fm = {}
+    for line in m.group(1).splitlines():
+        kv = re.match(r"^(\w+):\s*(.*?)\s*$", line)
+        if kv:
+            fm[kv.group(1)] = _scalar(kv.group(2))
+    return fm
+
+
+def _section(text, name):
+    m = re.search(r"^##\s+%s\s*$(.*?)(?=^##\s|\Z)" % re.escape(name), text, re.S | re.M)
+    return m.group(1) if m else ""
+
+
+def _fenced_probe(chunk):
+    """First fenced JSON object in a chunk that looks like a probe. Returns (dict, text)."""
+    for m in re.finditer(r"```(?:json)?\n(.*?)\n```", chunk, re.S):
+        raw = m.group(1)
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and obj.get("cmd") and obj.get("expect"):
+            return obj, raw
+    return None, None
+
+
+def need_records(need_ids=None):
+    """Every filed need. docs/re-needs/rejected/ is a subdirectory, so *.md skips it."""
+    want = set(need_ids or ())
+    out = []
+    d = config.needs_dir()
+    if not d.is_dir():
+        return out
+    for f in sorted(d.glob("*.md")):
+        try:
+            text = f.read_text(errors="replace")
+        except OSError:
+            continue
+        fm = front_matter(text)
+        if fm is None:
+            continue
+        nid = fm.get("need_id") or f.stem
+        if want and nid not in want and f.stem not in want:
+            continue
+        out.append({"need_id": nid, "path": f, "text": text, "front_matter": fm})
+    return out
+
+
+def acceptance_of(rec):
+    """The need's acceptance probe, as (dict, verbatim_text, source).
+
+    The record is truth: a fenced probe in its `## Acceptance` section wins. A sidecar
+    under docs/re-needs/probes/ or <state>/probes/ is the fallback, so a needs.py that
+    keeps probes out of line still resolves.
+    """
+    obj, raw = _fenced_probe(_section(rec["text"], "Acceptance"))
+    if obj is not None:
+        return obj, raw, "record"
+    aid = rec["front_matter"].get("acceptance_id")
+    if aid:
+        for base in (config.needs_dir() / "probes", config.state_dir() / "probes"):
+            f = base / ("%s.json" % aid)
+            if f.is_file():
+                try:
+                    raw = f.read_text()
+                    return json.loads(raw), raw, str(f)
+                except (OSError, json.JSONDecodeError):
+                    continue
+    return None, None, None
+
+
+def acceptance_suite(need_ids=None, reps=None):
+    """Re-run every filed acceptance probe against the CURRENT build.
+
+    This is the mechanism that answers "have the builders fixed what the testers asked
+    for". A need whose acceptance flips FAIL->PASS is `closed`; a previously-closed need
+    whose acceptance flips PASS->FAIL is `regressed` and must be re-queued at rank 0. A
+    flaky or unrunnable replay is `indeterminate` and moves nothing -- closing a need on a
+    coin-flip would be worse than not closing it.
+    """
+    sha = head_sha()
+    rows, closed, regressed = [], [], []
+    for rec in need_records(need_ids):
+        fm = rec["front_matter"]
+        status = fm.get("status") or "open"
+        p, _raw, src = acceptance_of(rec)
+        if p is None:
+            rows.append({"need_id": rec["need_id"], "status": status,
+                         "acceptance_id": fm.get("acceptance_id"), "passed": None,
+                         "flaky": None, "unrunnable": True, "transition": "indeterminate",
+                         "error": "no acceptance probe on the record or in the probe store",
+                         "acceptance": None})
+            continue
+        chal = fm.get("challenges") or []
+        if isinstance(chal, str):
+            chal = [chal]
+        v = run_probe(p, True, None, None, chal, reps)
+        if v.get("unrunnable") or v.get("flaky"):
+            trans = "indeterminate"
+        elif v.get("passed") and status in OPEN_STATUSES:
+            trans = "closed"
+            closed.append(rec["need_id"])
+        elif not v.get("passed") and status == "closed":
+            trans = "regressed"
+            regressed.append(rec["need_id"])
+        else:
+            trans = "unchanged"
+        rows.append({"need_id": rec["need_id"], "status": status,
+                     "acceptance_id": v.get("probe_id"), "source": src,
+                     "passed": v.get("passed"), "flaky": v.get("flaky"),
+                     "unrunnable": v.get("unrunnable"), "error": v.get("error"),
+                     "transition": trans, "requeue_rank": 0 if trans == "regressed" else None,
+                     "acceptance": v})
+
+    counts = {"total": len(rows), "pass": sum(1 for r in rows if r["passed"] is True),
+              "fail": sum(1 for r in rows if r["passed"] is False),
+              "closed": len(closed), "regressed": len(regressed),
+              "indeterminate": sum(1 for r in rows if r["transition"] == "indeterminate")}
+    return {"schema": SUITE_SCHEMA, "sha": sha, "at": _utc(), "counts": counts,
+            "closed": closed, "regressed": regressed, "needs": rows}
+
+
+# --- promotion into tests/cli/ ----------------------------------------------
+
+def vendorable(p):
+    """Can CI, which has no dataset, run this probe? Returns (bool, reason)."""
+    if not isinstance(p, dict):
+        return False, "not a probe"
+    t = p.get("target")
+    if not t:
+        blob = json.dumps([p.get("cmd"), p.get("cwd"), p.get("env")])
+        if "{{BIN}}" in blob:
+            return False, "no target, but the command substitutes {{BIN}}"
+        return True, "no binary target"
+    src = t.get("binary_source")
+    if src != "in-repo":
+        return False, ("target.binary_source is %r, not 'in-repo' -- CI has no dataset, so "
+                       "vendor the binary into the repo first" % (src,))
+    rel = t.get("in_repo_path")
+    if not rel:
+        return False, "binary_source is 'in-repo' but in_repo_path is unset"
+    abs_p = config.repo_root() / rel
+    if not abs_p.is_file():
+        return False, "in_repo_path does not exist: %s" % abs_p
+    want = t.get("binary_sha256")
+    if want and _sha256(abs_p) != want:
+        return False, "in-repo target %s does not match target.binary_sha256" % rel
+    return True, "in-repo target %s" % rel
+
+
+def promote(need_id, force=False):
+    """Copy a closed need's acceptance probe verbatim into tests/cli/<need_id>.json."""
+    recs = need_records([need_id])
+    if not recs:
+        raise PromotionRefused("no need record for %r in %s" % (need_id, config.needs_dir()))
+    rec = recs[0]
+    status = rec["front_matter"].get("status")
+    if status != "closed" and not force:
+        raise PromotionRefused(
+            "need %s is %r, not 'closed' -- promote the acceptance only once it has flipped "
+            "to PASS (use --force to override)" % (need_id, status))
+    p, raw, _src = acceptance_of(rec)
+    if p is None:
+        raise PromotionRefused("need %s carries no acceptance probe to promote" % need_id)
+    ok, why = vendorable(p)
+    if not ok:
+        raise PromotionRefused("acceptance of %s is not vendorable: %s" % (need_id, why))
+
+    dest = config.cli_tests_dir() / ("%s.json" % need_id)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = str(dest) + ".tmp"
+    body = raw if raw is not None else json.dumps(p, indent=2)
+    with open(tmp, "w") as fh:
+        fh.write(body if body.endswith("\n") else body + "\n")
+    os.replace(tmp, dest)
+    return dest
+
+
+# --- CLI --------------------------------------------------------------------
+
+def _load_observations(path):
+    """A single observation, a list of them, or a whole tester report.json."""
+    obj = json.loads(Path(path).read_text())
+    if isinstance(obj, list):
+        return obj, None
+    if isinstance(obj, dict) and isinstance(obj.get("observations"), list):
+        return obj["observations"], obj.get("hexid")
+    return [obj], obj.get("hexid") if isinstance(obj, dict) else None
+
+
+def _arm_line(v):
+    if v.get("unrunnable"):
+        return "UNRUNNABLE(%s)" % (v.get("error") or "?")
+    if v.get("flaky"):
+        return "FLAKY"
+    return "PASS" if v.get("passed") else "FAIL"
+
+
+def _print_gate(r):
+    print("%-17s %s" % (r["verdict"], r.get("title") or ""))
+    print("    probe      %-12s %s" % (r.get("probe_id") or "-", _arm_line(r["probe"])))
+    print("    acceptance %-12s %s" % (r.get("acceptance_id") or "-", _arm_line(r["acceptance"])))
+    print("    reasons    %s" % (", ".join(r["reasons"]) or "-"))
+    print("    sha        %s" % (r.get("sha") or "(unknown)"))
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog="python -m scripts.repipe.verify",
+                                 description=__doc__.splitlines()[0])
+    ap.add_argument("--gate", action="store_true", help="run the two-arm gate")
+    ap.add_argument("--round", type=int, default=None, metavar="N",
+                    help="with --gate: gate every observation of round N")
+    ap.add_argument("--observation", metavar="FILE",
+                    help="gate one observation (or a whole report.json)")
+    ap.add_argument("--acceptance-suite", dest="acceptance_suite", action="store_true",
+                    help="re-run every filed acceptance probe against the current build")
+    ap.add_argument("--all", action="store_true", help="--acceptance-suite: every need")
+    ap.add_argument("--need", action="append", default=[], metavar="ID",
+                    help="--acceptance-suite: only this need (repeatable)")
+    ap.add_argument("--promote", metavar="ID",
+                    help="vendor a closed need's acceptance into tests/cli/")
+    ap.add_argument("--force", action="store_true",
+                    help="--promote: allow a need that is not yet closed")
+    ap.add_argument("--work", default=None, metavar="DIR",
+                    help="--observation: the work dir {{WORK}} and {{BIN}} resolve against")
+    ap.add_argument("--challenge", action="append", default=[], metavar="HEXID",
+                    help="--observation: dataset challenge(s) to resolve a target through")
+    ap.add_argument("--reps", type=int, default=None, metavar="N",
+                    help="floor on how many times each probe is replayed (gate default: "
+                         "REPIPE_REPLAY_REPS=%d, timing/memory %d)"
+                         % (config.REPLAY_REPS, config.TIMING_REPS))
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    # `--need <id>` on its own means "re-run that need's acceptance" -- the builder's
+    # definition of done. Requiring --acceptance-suite next to it would make the command in
+    # builder_prompt.md exit 2.
+    if args.need and not (args.observation or args.gate or args.promote):
+        args.acceptance_suite = True
+
+    modes = [bool(args.observation), bool(args.gate and args.round is not None),
+             args.acceptance_suite, bool(args.promote)]
+    if sum(modes) != 1:
+        ap.error("choose exactly one of --observation FILE, --gate --round N, "
+                 "--acceptance-suite [--need ID], --promote ID")
+
+    if args.observation:
+        obs, hexid = _load_observations(args.observation)
+        chal = args.challenge or ([hexid] if hexid else [])
+        work = args.work or str(Path(args.observation).resolve().parent)
+        sha = head_sha()
+        results = []
+        for o in obs:
+            o = dict(o or {})
+            if hexid:
+                o.setdefault("hexid", hexid)
+            results.append(gate(o, work=work, challenges=chal, sha=sha, reps=args.reps))
+        if args.json:
+            print(json.dumps(results[0] if len(results) == 1 else
+                             {"counts": _counts(results), "results": results}, indent=2))
+            return 0
+        for r in results:
+            _print_gate(r)
+        if len(results) > 1:
+            print(" ".join("%s=%d" % (k, v) for k, v in _counts(results).items()))
+        return 0
+
+    if args.gate:
+        out = gate_round(args.round, reps=args.reps)
+        if args.json:
+            print(json.dumps(out, indent=2))
+            return 0 if out["results"] else 1
+        print("round %d  sha %s  %d report(s)" % (out["round"], out["sha"] or "?",
+                                                  len(out["reports"])))
+        for r in out["results"]:
+            print("  %-17s %-12s %-12s %s" % (r["verdict"], r.get("probe_id") or "-",
+                                              r.get("acceptance_id") or "-",
+                                              r.get("title") or ""))
+        print(" ".join("%s=%d" % (k, v) for k, v in out["counts"].items()))
+        print("wrote %s" % out["path"])
+        return 0 if out["results"] else 1
+
+    if args.acceptance_suite:
+        if not args.all and not args.need:
+            ap.error("--acceptance-suite needs --all or --need ID")
+        out = acceptance_suite(args.need or None, reps=args.reps)
+        if args.round is not None:
+            out["path"] = str(_write_json(
+                config.rounds_dir() / str(args.round) / "acceptance.json", out))
+        if args.json:
+            print(json.dumps(out, indent=2))
+            return 0
+        print("acceptance suite  sha %s" % (out["sha"] or "?"))
+        for r in out["needs"]:
+            print("  %-6s %-14s %-14s %s" % (_arm_line(r["acceptance"] or r),
+                                             r["transition"], r["status"], r["need_id"]))
+        print(" ".join("%s=%d" % (k, v) for k, v in out["counts"].items()))
+        return 0
+
+    try:
+        dest = promote(args.promote, force=args.force)
+    except PromotionRefused as exc:
+        if args.json:
+            print(json.dumps({"promoted": None, "need_id": args.promote,
+                              "refused": str(exc)}, indent=2))
+        else:
+            print("refused: %s" % exc, file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps({"promoted": str(dest), "need_id": args.promote}, indent=2))
+    else:
+        print("promoted %s -> %s" % (args.promote, dest))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repipe/verify.py
+++ b/scripts/repipe/verify.py
@@ -313,6 +313,26 @@ def run_probe(p, is_acceptance=False, ctx=None, work=None, challenges=(), reps=N
 
 # --- the gate ---------------------------------------------------------------
 
+def coerce_probes(observation):
+    """Parse an observation's probe/acceptance if they arrived as JSON strings.
+
+    They do: OpenAI's strict structured-output mode cannot express the probe schema (its
+    numpred/jsonpred values are deliberately any-typed, and strict mode demands an explicit
+    type everywhere), so the tester report carries them serialised and they are validated
+    here by probe.validate() instead. A string that will not parse is left as-is, which makes
+    the observation `unrunnable` -- the honest verdict for "this is not a probe".
+    """
+    out = dict(observation or {})
+    for key in ("probe", "acceptance"):
+        v = out.get(key)
+        if isinstance(v, str):
+            try:
+                out[key] = json.loads(v)
+            except (ValueError, TypeError):
+                pass
+    return out
+
+
 def gate(observation, ctx=None, work=None, challenges=(), sha=None, reps=None):
     """Run an observation's two arms and say what the pair means.
 
@@ -320,7 +340,7 @@ def gate(observation, ctx=None, work=None, challenges=(), sha=None, reps=None):
     substitution environment for the pair. Left None (the usual case) each arm resolves
     its own {{BIN}} from its own target.
     """
-    obs = observation or {}
+    obs = coerce_probes(observation)
     if not challenges and obs.get("hexid"):
         challenges = [obs["hexid"]]
     p, a = obs.get("probe"), obs.get("acceptance")
@@ -422,6 +442,30 @@ def _tester_id_for(report_path):
         return None
 
 
+def _arena_primary(arena):
+    """The arena's primary binary, from the build record workspace.py leaves behind.
+
+    Falls back to the single file under target/ when there is exactly one, so a
+    hand-assembled arena still resolves.
+    """
+    rec = Path(arena) / ".repipe" / "build.json"
+    try:
+        doc = json.loads(rec.read_text())
+        rel = (doc.get("binaries") or [{}])[0].get("arena_rel")
+        if rel:
+            p = Path(arena) / rel
+            if p.exists():
+                return str(p)
+    except Exception:
+        pass
+    tgt = Path(arena) / "target"
+    if tgt.is_dir():
+        files = [f for f in sorted(tgt.rglob("*")) if f.is_file()]
+        if len(files) == 1:
+            return str(files[0])
+    return None
+
+
 def gate_round(round_n, ctx=None, reps=None):
     """Gate every observation in every report of a round; persist rounds/<n>/gate.json."""
     sha = head_sha()
@@ -449,14 +493,26 @@ def gate_round(round_n, ctx=None, reps=None):
                 continue
             o = dict(o or {})
             o.setdefault("hexid", hexid)
-            r = gate(o, ctx=ctx, work=str(rp.parent),
+            # Supply {{BIN}} from the ARENA. The harness already knows which binary the
+            # tester was working on, so requiring the tester to restate it in every probe's
+            # `target` block just discards correct observations as unrunnable -- which is
+            # exactly what happened to the first real report. An explicit `target` still
+            # wins, because that is what makes a probe portable off the arena.
+            rctx = dict(ctx or {})
+            if not rctx.get("bin"):
+                arena_bin = _arena_primary(rp.parent)
+                if arena_bin:
+                    rctx["bin"] = arena_bin
+            r = gate(o, ctx=rctx, work=str(rp.parent),
                      challenges=[hexid] if hexid else (), sha=sha, reps=reps)
             r["report"] = str(rp)
             r["observation_index"] = i
             # cluster.py builds the need record from these, so the gate result must carry the
             # observation it gated and who filed it -- a verdict with no observation attached
             # would collapse every need into one empty record.
-            r["observation"] = o
+            # Record what was actually GATED, not what arrived: the probes cross the API
+            # boundary as JSON strings, and downstream (cluster.py) needs them parsed.
+            r["observation"] = coerce_probes(o)
             r["tester_id"] = report.get("tester_id") or _tester_id_for(rp)
             results.append(r)
 

--- a/scripts/repipe/webui.py
+++ b/scripts/repipe/webui.py
@@ -451,19 +451,33 @@ def _agent_role(worker, slots):
 
 
 def _agent_log_path(state_dir, agent_id, recorded=None):
-    """Resolve an agent's log strictly inside the state dir. Traversal dies here."""
+    """Resolve an agent's log strictly inside the state dir.
+
+    The returned path is built from a DIRECTORY LISTING, never from ``agent_id``: the id is
+    only ever compared, by equality, against names the filesystem produced. That is what
+    makes traversal structurally impossible rather than merely guarded -- and it is what a
+    taint analysis can actually see, which a regex guard on the id is not.
+    """
     if recorded:
         cand = Path(recorded)
         if not cand.is_absolute():
             cand = state_dir / cand
         if _safe_under(state_dir, cand) and cand.is_file():
             return cand
+    if safe_id(agent_id) is None:
+        return None
     logs = state_dir / "logs"
-    for name in ("%s.jsonl" % agent_id, "%s.log" % agent_id,
-                 "driver-%s.log" % agent_id, "%s.out" % agent_id):
-        cand = logs / name
-        if _safe_under(state_dir, cand) and cand.is_file():
-            return cand
+    wanted = {"%s.jsonl" % agent_id, "%s.log" % agent_id,
+              "driver-%s.log" % agent_id, "%s.out" % agent_id}
+    try:
+        entries = sorted(os.listdir(str(logs)))
+    except OSError:
+        return None
+    for entry in entries:
+        if entry in wanted:
+            cand = logs / entry          # `entry` came from the filesystem, not the request
+            if cand.is_file() and _safe_under(state_dir, cand):
+                return cand
     return None
 
 

--- a/scripts/repipe/webui.py
+++ b/scripts/repipe/webui.py
@@ -1,0 +1,1603 @@
+"""The RE-friction loop's live dashboard: one refresher thread, many viewers.
+
+    PYTHONPATH=<repo> python3 -m scripts.repipe.webui --port 8787 --bind 127.0.0.1
+    PYTHONPATH=<repo> python3 -m scripts.repipe.webui --json     # one snapshot, no server
+
+Stdlib only (http.server), loopback, no auth, and READ-ONLY by design: the STOP control
+displays the path to ``touch`` rather than posting anything, so a stray browser tab can
+never stop a run.
+
+Why a refresher thread instead of collecting per request
+--------------------------------------------------------
+``scripts.pipeline.status.collect()`` shells out to ``git worktree list`` AND ``gh api``.
+A cold ``collect()`` measured **10.65 s** on this repo. At SSE cadence, or with three
+browser tabs open, per-request collection is a fork bomb and a GitHub rate-limit incident.
+So exactly one background thread owns every expensive read, publishes an in-memory payload
+plus ``.kuna-repipe/webui-cache.json`` (atomic, monotonic ``seq``), and **request handlers
+never shell out** — they slice the cache. N viewers cost what one costs.
+
+The per-source TTLs are ``status.py``'s own cache, not a second one: ``status.collect()``
+already holds ``git worktree list`` for ``KUNA_PIPELINE_WORKTREE_TTL`` (20 s) and the open-PR
+``gh api`` for ``KUNA_PIPELINE_PR_TTL`` (60 s), so wrapping the whole call at a 1 s TTL gives
+inventory 1 s / worktrees 20 s / PRs 60 s in one place. Check-runs (60 s, and only for PRs the
+inventory believes are in flight) and ``du`` (60 s) go through the same ``status._cached``.
+A failed fetch is cached as ``None`` with ``stale_since`` and rendered "(gh unavailable)",
+exactly as ``status.py`` renders it today. Every subprocess this module starts gets
+``timeout=20``.
+
+``seq`` advances only when the payload actually changes: elapsed/stale counters are derived
+in the browser from ``started_at``/``updated_at`` so a quiet pipeline produces no churn, and
+an SSE client that sees ``{"seq": N}`` knows a refetch is worth making.
+
+State dir binding
+-----------------
+``scripts.pipeline.state`` is multi-pipeline through ``KUNA_PIPELINE_STATE_DIR``; the RE loop
+points it at ``.kuna-repipe``. This module sets that binding (plus ``status.py``'s worktree
+and branch match seams) before it reads anything, so the inventory it shows is the RE loop's,
+not the angr fleet's.
+
+Degradation is the normal case, not the error case
+--------------------------------------------------
+``needs.py`` / ``verify.py`` / ``sample.py`` are siblings under construction and are imported
+defensively; ``.kuna-repipe/`` may not exist at all. Every route answers 200 with an empty
+shape rather than 500, because "the pipeline has never run" is the state this is booted in.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import threading
+import time
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from . import config as rconfig
+from ..pipeline import status as pstatus
+
+# Siblings written in parallel with this file. A dashboard that 500s because a module it
+# wants does not exist yet is worse than one that shows an empty pane.
+try:
+    from . import needs as needs_mod
+except Exception:
+    needs_mod = None
+try:
+    from . import verify as verify_mod
+except Exception:
+    verify_mod = None
+try:
+    from . import sample as sample_mod
+except Exception:
+    sample_mod = None
+
+
+WEBUI_DIR = rconfig.repo_root() / "tools" / "repipe" / "webui"
+SITE_CSS = rconfig.repo_root() / "integrations" / "web" / "assets" / "css" / "site.css"
+SITE_ASSETS = rconfig.repo_root() / "integrations" / "web" / "assets"
+SITE_FONTS = SITE_ASSETS / "fonts"
+
+TEST_LANE = ["T_PLAN", "T_WORKSPACE", "T_FANOUT", "T_DRAIN", "T_GATE",
+             "T_DEDUP", "T_REFUTE", "T_TRIAGE", "T_READY"]
+BUILD_LANE = ["B_IDLE", "B_PLAN", "B_FANOUT", "B_DRAIN", "B_MERGE", "B_VERIFY", "B_DONE"]
+STALE_SECONDS = 120          # status.py's convention: past this a worker's row goes red
+DISK_RED_GB = 100
+
+CHECKS_TTL = 60.0
+DU_TTL = 60.0
+COLLECT_TTL = 1.0            # the inventory tier; worktrees/PRs keep status.py's own TTLs
+MAX_CHECK_CALLS = 6          # hard ceiling on gh calls per refresh tick
+
+NEED_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$")
+PROBE_ID_RE = re.compile(r"^[pa]-[0-9a-f]{12}$")
+AGENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._@:+-]{0,63}$")
+
+# Dropped before the change-digest is taken: these tick every second by construction and
+# would otherwise advance seq forever on an idle pipeline.
+VOLATILE_KEYS = {"ts", "now", "age_s", "uptime_s", "cache", "elapsed_s", "stale_s",
+                 "round_elapsed_s", "since_s", "generated_at", "seq"}
+
+
+# --- environment binding ----------------------------------------------------
+
+def bind_state_dir(state_dir=None):
+    """Point scripts.pipeline.state/status at the RE loop's state dir and worktrees."""
+    if state_dir:
+        os.environ["KUNA_PIPELINE_STATE_DIR"] = str(Path(state_dir).expanduser())
+    else:
+        os.environ.setdefault("KUNA_PIPELINE_STATE_DIR",
+                              str(rconfig.repo_root() / rconfig.STATE_DIRNAME))
+    os.environ.setdefault("KUNA_PIPELINE_WORKTREE_MATCH", rconfig.STATE_DIRNAME)
+    os.environ.setdefault("KUNA_PIPELINE_BRANCH_MATCH", "feat/re-")
+    return Path(os.environ["KUNA_PIPELINE_STATE_DIR"])
+
+
+# --- small readers ----------------------------------------------------------
+
+def _ttl(key, ttl, fetch):
+    """status.py's process-wide TTL cache. Deliberately not a second implementation."""
+    return pstatus._cached(key, ttl, fetch)
+
+
+def _read_json(path, default=None):
+    try:
+        with open(path) as fh:
+            return json.load(fh)
+    except Exception:
+        return default
+
+
+def _mtime_sig(paths):
+    """A cheap change signature: (count, newest mtime, total size) over a file set."""
+    n = 0
+    newest = 0.0
+    total = 0
+    for p in paths:
+        try:
+            st = os.stat(p)
+        except OSError:
+            continue
+        n += 1
+        newest = max(newest, st.st_mtime)
+        total += st.st_size
+    return (n, round(newest, 3), total)
+
+
+TAIL_MAX_BYTES = 4 << 20
+
+
+def _tail_lines(path, n):
+    """Last n lines, read backwards, and never more than TAIL_MAX_BYTES.
+
+    A codex rollout log is newline-dense, but a crashed writer can leave one enormous
+    line; the byte cap is what stops `tail=5000` from paging a GB into the response.
+    """
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        return []
+    block = 65536
+    want = max(1, int(n))
+    data = b""
+    with open(path, "rb") as fh:
+        pos = size
+        while pos > 0 and data.count(b"\n") <= want and len(data) < TAIL_MAX_BYTES:
+            step = min(block, pos)
+            pos -= step
+            fh.seek(pos)
+            data = fh.read(step) + data
+    text = data.decode("utf-8", "replace")
+    lines = text.splitlines()
+    return lines[-want:]
+
+
+def _jsonl(path, limit=None):
+    out = []
+    try:
+        with open(path, errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    out.append(json.loads(line))
+                except ValueError:
+                    out.append({"raw": line})
+    except OSError:
+        return []
+    if limit:
+        return out[-limit:]
+    return out
+
+
+def _scalar(v):
+    v = v.strip()
+    if v in ("null", "~", ""):
+        return None
+    if v in ("true", "True"):
+        return True
+    if v in ("false", "False"):
+        return False
+    if v.startswith("[") and v.endswith("]"):
+        inner = v[1:-1].strip()
+        if not inner:
+            return []
+        return [_scalar(x) for x in inner.split(",")]
+    if len(v) >= 2 and v[0] == v[-1] and v[0] in "\"'":
+        return v[1:-1]
+    try:
+        return int(v)
+    except ValueError:
+        pass
+    try:
+        return float(v)
+    except ValueError:
+        pass
+    return v
+
+
+def _front_matter(text):
+    """The docs/decbench/triage/*.md dialect that scripts/decbench/status.py already parses,
+    plus inline ``[a, b]`` lists, which the need record uses for challenges/rounds/touches."""
+    m = re.match(r"---\n(.*?)\n---", text, re.S)
+    if not m:
+        return {}
+    fm = {}
+    for line in m.group(1).splitlines():
+        kv = re.match(r"^([A-Za-z_][\w.-]*):\s*(.*?)\s*$", line)
+        if kv:
+            fm[kv.group(1)] = _scalar(kv.group(2))
+    return fm
+
+
+def _sections(text):
+    """The fixed ``## `` sections of a need record, as {heading: body}."""
+    body = re.sub(r"^---\n.*?\n---\n?", "", text, flags=re.S)
+    out = {}
+    cur = None
+    buf = []
+    for line in body.splitlines():
+        h = re.match(r"^##\s+(.*?)\s*$", line)
+        if h:
+            if cur:
+                out[cur] = "\n".join(buf).strip()
+            cur = h.group(1)
+            buf = []
+        elif cur:
+            buf.append(line)
+    if cur:
+        out[cur] = "\n".join(buf).strip()
+    return out
+
+
+def _lexically_under(root, candidate):
+    """True iff ``candidate`` is under ``root`` by path arithmetic, without following links.
+
+    Used where the leaf name is already constrained by a regex and the tree is allowed to
+    contain symlinks — a docs/ checkout that symlinks its need records is legitimate, and
+    resolving those would reject it. Where the path comes from recorded state instead of a
+    validated id (an agent's log), use _safe_under, which does follow links.
+    """
+    r = os.path.normpath(str(root))
+    c = os.path.normpath(str(candidate))
+    return c == r or c.startswith(r + os.sep)
+
+
+def _safe_under(root, candidate):
+    """True iff ``candidate`` really lives under ``root`` after symlinks are resolved."""
+    try:
+        r = os.path.realpath(str(root))
+        c = os.path.realpath(str(candidate))
+    except OSError:
+        return False
+    return c == r or c.startswith(r + os.sep)
+
+
+# --- expensive sources, each behind status.py's TTL cache -------------------
+
+def _collect_snapshot():
+    """Inventory (1 s) + worktrees (20 s) + open PRs (60 s), all via status.py's own TTLs."""
+    try:
+        return _ttl("webui:collect", COLLECT_TTL, pstatus.collect) or {}
+    except Exception:
+        return {}
+
+
+def _check_runs(branch, gh_repo):
+    def fetch():
+        out = subprocess.run(
+            ["gh", "api", "repos/%s/commits/%s/check-runs" % (gh_repo, branch),
+             "--jq", "[.check_runs[] | {name, status, conclusion}]"],
+            capture_output=True, text=True, timeout=20,
+        )
+        if out.returncode != 0:
+            return None
+        return json.loads(out.stdout or "[]")
+    return _ttl("webui:checks:" + branch, CHECKS_TTL, fetch)
+
+
+def _disk():
+    def fetch():
+        try:
+            usage = shutil.disk_usage(str(rconfig.repo_root()))
+        except OSError:
+            return None
+        return {"free_gb": round(usage.free / 1e9, 1),
+                "total_gb": round(usage.total / 1e9, 1),
+                "used_pct": round(100.0 * usage.used / max(1, usage.total), 1)}
+    return _ttl("webui:df", DU_TTL, fetch)
+
+
+def _state_dir_bytes(state_dir, enabled):
+    if not enabled or not os.path.isdir(state_dir):
+        return None
+
+    def fetch():
+        out = subprocess.run(["du", "-sx", "-B1", str(state_dir)],
+                             capture_output=True, text=True, timeout=20)
+        if out.returncode != 0 or not out.stdout.strip():
+            return None
+        return int(out.stdout.split()[0])
+    return _ttl("webui:du", DU_TTL, fetch)
+
+
+# --- supervisor, rounds, transitions ---------------------------------------
+
+def _supervisor(state_dir, agents):
+    """The Supervisor machine's state, from its own file or inferred from the stop files."""
+    sup = _read_json(state_dir / "supervisor.json", {}) or {}
+    flags = {name: (state_dir / name).exists()
+             for name in ("STOP", "PAUSE", "ABORT", "HALT_REASON")}
+    state = sup.get("state")
+    if not state:
+        if flags["ABORT"]:
+            state = "ABORTED"
+        elif flags["HALT_REASON"]:
+            state = "HALTED"
+        elif flags["STOP"]:
+            state = "DRAINING"
+        elif any(a.get("status") == "running" for a in agents):
+            state = "RUNNING"
+        else:
+            state = "IDLE"
+    halt_reason = None
+    if flags["HALT_REASON"]:
+        try:
+            halt_reason = (state_dir / "HALT_REASON").read_text(errors="replace").strip()[:400]
+        except OSError:
+            halt_reason = "(unreadable)"
+    return {
+        "state": state,
+        "run_id": sup.get("run_id"),
+        "started_at": sup.get("started_at"),
+        "rounds_planned": sup.get("rounds", rconfig.ROUNDS),
+        "flags": flags,
+        "halt_reason": halt_reason,
+        "stop_path": str(state_dir / "STOP"),
+        "abort_path": str(state_dir / "ABORT"),
+    }
+
+
+def _round_dirs(state_dir):
+    rd = state_dir / "rounds"
+    if not rd.is_dir():
+        return []
+    out = []
+    for child in rd.iterdir():
+        if child.is_dir() and child.name.isdigit():
+            out.append((int(child.name), child))
+    return sorted(out)
+
+
+def _lane_state(transitions, track, lane):
+    """Current state of one track: the destination of its last recorded transition."""
+    for t in reversed(transitions):
+        if t.get("track") == track and t.get("to") in lane:
+            return t["to"]
+    for t in reversed(transitions):
+        if t.get("track") == track and t.get("to"):
+            return t["to"]
+    return None
+
+
+def _collect_rounds(state_dir):
+    rounds = []
+    for num, path in _round_dirs(state_dir):
+        meta = _read_json(path / "round.json", {}) or {}
+        trans = _jsonl(path / "transitions.jsonl")
+        tracks = meta.get("tracks") or {}
+        test_state = (tracks.get("test") or {}).get("state") or _lane_state(trans, "test", TEST_LANE)
+        build_state = (tracks.get("build") or {}).get("state") or _lane_state(trans, "build", BUILD_LANE)
+        acceptance = _read_json(path / "acceptance.json")
+        slate = _read_json(path / "slate.json", []) or []
+        if isinstance(slate, dict):
+            slate = slate.get("challenges") or slate.get("slate") or []
+        started = meta.get("started_at")
+        if started is None and trans:
+            started = trans[0].get("ts")
+        rounds.append({
+            "round": num,
+            "started_at": started,
+            "ended_at": meta.get("ended_at"),
+            "test_state": test_state,
+            "build_state": build_state,
+            "barrier": meta.get("barrier") or ("INTEGRATE" if acceptance is not None else None),
+            "integrated": acceptance is not None,
+            "slate": [s if isinstance(s, str) else (s.get("hexid") or s.get("id"))
+                      for s in slate],
+            "transitions": len(trans),
+            "tail": trans[-40:],
+            "usd": meta.get("usd"),
+            "needs_filed": meta.get("needs_filed"),
+            "needs_closed": meta.get("needs_closed"),
+            "path": str(path),
+        })
+    return rounds
+
+
+# --- agents -----------------------------------------------------------------
+
+def _agent_role(worker, slots):
+    for pool, entry in (slots or {}).items():
+        if worker.get("worker") in (entry.get("held") or {}):
+            return pool, (entry["held"][worker["worker"]] or {}).get("kind") or pool
+    explicit = worker.get("role") or worker.get("pool")
+    if explicit:
+        return explicit, explicit
+    wid = worker.get("worker") or ""
+    if wid.startswith("t-") or wid.startswith("tester"):
+        return "tester", "tester"
+    if wid.startswith("c-") or "captain" in wid:
+        return "captain", "captain"
+    return "builder", "builder"
+
+
+def _agent_log_path(state_dir, agent_id, recorded=None):
+    """Resolve an agent's log strictly inside the state dir. Traversal dies here."""
+    if recorded:
+        cand = Path(recorded)
+        if not cand.is_absolute():
+            cand = state_dir / cand
+        if _safe_under(state_dir, cand) and cand.is_file():
+            return cand
+    logs = state_dir / "logs"
+    for name in ("%s.jsonl" % agent_id, "%s.log" % agent_id,
+                 "driver-%s.log" % agent_id, "%s.out" % agent_id):
+        cand = logs / name
+        if _safe_under(state_dir, cand) and cand.is_file():
+            return cand
+    return None
+
+
+def _collect_agents(state_dir, snap, gh_repo, want_checks=True):
+    workers = snap.get("workers") or []
+    slots = snap.get("slots") or {}
+    leases = snap.get("leases") or {}
+    prs = snap.get("prs")
+    pr_by_branch = {}
+    for pr in (prs or []):
+        pr_by_branch[pr.get("headRefName")] = pr
+    now = time.time()
+    calls = 0
+    agents = []
+    for w in workers:
+        wid = w.get("worker") or "?"
+        pool, role = _agent_role(w, slots)
+        started = w.get("started_at") or now
+        updated = w.get("updated_at") or started
+        held = sorted(res for res, l in leases.items() if l.get("holder") == wid)
+        sidecar = _read_json(state_dir / "agents" / ("%s.json" % wid), {}) or {} \
+            if AGENT_ID_RE.match(wid) else {}
+        rec = {
+            "id": wid,
+            "role": role,
+            "pool": pool,
+            "phase": w.get("phase"),
+            "status": w.get("status"),
+            "started_at": started,
+            "updated_at": updated,
+            "elapsed_s": int(now - started),
+            "stale_s": int(now - updated),
+            "pid": w.get("pid"),
+            "slug": w.get("slug"),
+            "need": w.get("need") or w.get("opportunity") or sidecar.get("need"),
+            "note": w.get("note"),
+            "usd": w.get("usd", sidecar.get("usd")),
+            "tokens_in": w.get("tokens_in", sidecar.get("tokens_in")),
+            "tokens_out": w.get("tokens_out", sidecar.get("tokens_out")),
+            "model": w.get("model") or sidecar.get("model"),
+            "leases": held,
+            "log": None,
+            "has_log": False,
+        }
+        if role == "tester":
+            rec["challenge"] = w.get("challenge") or sidecar.get("challenge")
+            rec["stratum"] = w.get("stratum") or sidecar.get("stratum")
+            rec["outcome"] = w.get("outcome") or sidecar.get("outcome")
+            rec["gave_up_reason"] = w.get("gave_up_reason") or sidecar.get("gave_up_reason")
+            rec["fallbacks"] = w.get("fallbacks", sidecar.get("fallbacks"))
+        else:
+            branch = w.get("branch")
+            rec["branch"] = branch
+            rec["pr_url"] = w.get("pr_url")
+            pr = pr_by_branch.get(branch)
+            rec["pr"] = pr.get("number") if pr else None
+            rec["ci"] = None
+            in_flight = bool(branch) and w.get("status") in ("running", "pr", "proposal")
+            if want_checks and in_flight and pr and calls < MAX_CHECK_CALLS:
+                calls += 1
+                runs = _check_runs(branch, gh_repo)
+                rec["ci"] = _ci_verdict(runs)
+        lp = _agent_log_path(state_dir, wid, w.get("log") or sidecar.get("log"))
+        if lp is not None:
+            rec["log"] = str(lp)
+            rec["has_log"] = True
+        agents.append(rec)
+    agents.sort(key=lambda a: (a["role"] != "captain", a.get("started_at") or 0))
+    return agents
+
+
+def _ci_verdict(runs):
+    if runs is None:
+        return {"state": "unknown", "detail": "(gh unavailable)"}
+    if not runs:
+        return {"state": "none", "detail": "no checks"}
+    done = [r for r in runs if r.get("status") == "completed"]
+    bad = [r for r in done if r.get("conclusion") not in ("success", "neutral", "skipped")]
+    if bad:
+        return {"state": "fail", "detail": ", ".join(r.get("name", "?") for r in bad[:3])}
+    if len(done) < len(runs):
+        return {"state": "running", "detail": "%d/%d complete" % (len(done), len(runs))}
+    return {"state": "pass", "detail": "%d checks" % len(runs)}
+
+
+# --- needs ------------------------------------------------------------------
+#
+# Three sources, in descending fidelity: needs.py's own reader when that module has landed,
+# the docs/re-needs/index.json cache, then a front-matter scan of the records themselves.
+# The scan is the floor, so an empty or half-written docs/re-needs/ still renders.
+
+_NEEDS_API = ("load_all", "all_records", "load_index")
+
+
+def _needs_from_module():
+    if needs_mod is None:
+        return None
+    for name in _NEEDS_API:
+        fn = getattr(needs_mod, name, None)
+        if not callable(fn):
+            continue
+        try:
+            recs = fn()
+        except Exception:
+            continue
+        if isinstance(recs, dict):
+            recs = recs.get("needs") or recs.get("ranked") or list(recs.values())
+        if isinstance(recs, list) and all(isinstance(r, dict) for r in recs):
+            return recs
+    return None
+
+
+def _needs_from_index(needs_dir):
+    doc = _read_json(needs_dir / "index.json")
+    if doc is None:
+        return None
+    if isinstance(doc, dict):
+        doc = doc.get("needs") or doc.get("ranked") or doc.get("records")
+    if isinstance(doc, list) and all(isinstance(r, dict) for r in doc):
+        return doc
+    return None
+
+
+def _needs_from_disk(needs_dir, rejected_dir):
+    recs = []
+    for directory, rejected in ((needs_dir, False), (rejected_dir, True)):
+        if not directory.is_dir():
+            continue
+        for f in sorted(directory.glob("*.md")):
+            try:
+                text = f.read_text(errors="replace")
+            except OSError:
+                continue
+            fm = _front_matter(text)
+            if not fm:
+                continue
+            fm.setdefault("need_id", f.stem)
+            if rejected:
+                fm["status"] = "rejected"
+            fm["_file"] = str(f)
+            recs.append(fm)
+    return recs
+
+
+def _norm_need(rec):
+    """One shape for the table, whatever source produced the record."""
+    status = str(rec.get("status") or "open")
+    return {
+        "need_id": rec.get("need_id") or rec.get("id") or rec.get("slug") or "?",
+        "title": rec.get("title") or "",
+        "track": rec.get("track") or "?",
+        "status": status,
+        "severity": rec.get("severity") or "?",
+        "probe_id": rec.get("probe_id"),
+        "acceptance_id": rec.get("acceptance_id"),
+        "probe_status": rec.get("probe_status"),
+        "acceptance_status": rec.get("acceptance_status"),
+        "hypothesis_status": rec.get("hypothesis_status") or "inconclusive",
+        "credibility": rec.get("credibility"),
+        "instances": rec.get("instances") or 0,
+        "testers": rec.get("testers") or rec.get("distinct_testers"),
+        "challenges": rec.get("challenges") or [],
+        "rounds": rec.get("rounds") or [],
+        "first_seen_round": rec.get("first_seen_round"),
+        "attempts": rec.get("attempts") or 0,
+        "scope": rec.get("scope"),
+        "rank": rec.get("rank", rec.get("score")),
+        "pr": rec.get("pr"),
+        "regression_of": rec.get("regression_of"),
+        "covered_by_option": rec.get("covered_by_option"),
+        "reject_reason": rec.get("reject_reason") or rec.get("reason")
+                         or rec.get("rejected_because"),
+        "closed_in_round": rec.get("closed_in_round"),
+        "touches": rec.get("touches") or [],
+        "file": rec.get("_file") or rec.get("file"),
+    }
+
+
+_SEVERITY_ORDER = {"blocker": 0, "major": 1, "minor": 2}
+
+
+def _rank_key(n):
+    r = n.get("rank")
+    return (0 if isinstance(r, (int, float)) else 1,
+            -(r if isinstance(r, (int, float)) else 0),
+            _SEVERITY_ORDER.get(n.get("severity"), 9),
+            -float(n.get("credibility") or 0),
+            -int(n.get("instances") or 0),
+            n.get("need_id") or "")
+
+
+def _collect_needs(needs_dir, rejected_dir):
+    recs = _needs_from_module()
+    source = "needs.py"
+    if recs is None:
+        recs = _needs_from_index(needs_dir)
+        source = "index.json"
+    if recs is None:
+        recs = _needs_from_disk(needs_dir, rejected_dir)
+        source = "records"
+    items = [_norm_need(r) for r in recs]
+    backlog = sorted((n for n in items if n["status"] != "rejected"), key=_rank_key)
+    rejected = [n for n in items if n["status"] == "rejected"]
+    by_reason = {}
+    for n in rejected:
+        by_reason.setdefault(n.get("reject_reason") or "unclassified", []).append(n)
+    by_status = {}
+    for n in backlog:
+        by_status[n["status"]] = by_status.get(n["status"], 0) + 1
+    filed = len(items)
+    return {
+        "source": source,
+        "backlog": backlog,
+        "rejected": rejected,
+        "rejected_by_reason": {k: sorted(v, key=lambda n: n["need_id"])
+                               for k, v in sorted(by_reason.items())},
+        "by_status": by_status,
+        "totals": {
+            "filed": filed,
+            "admitted": len(backlog),
+            "rejected": len(rejected),
+            # The honest denominator: how much of what the testers filed was the tester
+            # being wrong rather than kuna being bad.
+            "rejected_pct": round(100.0 * len(rejected) / filed, 1) if filed else 0.0,
+            "overturned": sum(1 for n in backlog if n["hypothesis_status"] == "overturned"),
+        },
+    }
+
+
+# --- corpus -----------------------------------------------------------------
+#
+# Coverage per stratum. This route reads manifest.json, which carries the plaintext answer in
+# ground_truth.flag for 98 of the 250 challenges, so records are rebuilt field by field from
+# an allowlist and NEVER copied wholesale. There is no code path here that emits a flag.
+
+_CORPUS_FIELDS = ("hexid", "name", "bucket", "selected_for")
+
+
+def _manifest_records():
+    path = rconfig.manifest_path()
+    try:
+        sig = _mtime_sig([path])
+    except Exception:
+        return []
+    cached = getattr(_manifest_records, "_cache", None)
+    if cached and cached[0] == sig:
+        return cached[1]
+    doc = _read_json(path, [])
+    if isinstance(doc, dict):
+        doc = doc.get("records") or []
+    out = []
+    for r in doc if isinstance(doc, list) else []:
+        det = r.get("detected") or {}
+        prim = det.get("primary") or {}
+        gt = r.get("ground_truth") or {}
+        out.append({
+            "hexid": r.get("hexid"),
+            "name": r.get("name"),
+            "bucket": r.get("bucket"),
+            "stratum": r.get("selected_for") or "unassigned",
+            "format": prim.get("format"),
+            "arch": prim.get("arch"),
+            "size": prim.get("size"),
+            "difficulty": (r.get("declared") or {}).get("difficulty"),
+            "machine_checkable": bool(gt.get("machine_checkable")),
+            "verifier_self_test_pass": bool(gt.get("verifier_self_test_pass")),
+            "ships_source_code": bool((r.get("contamination") or {}).get("ships_source_code")),
+        })
+    _manifest_records._cache = (sig, out)
+    return out
+
+
+def _collect_corpus(state_dir, rounds):
+    records = _manifest_records()
+    attempts = {}
+    for rnd in rounds:
+        for hexid in rnd.get("slate") or []:
+            if hexid:
+                attempts.setdefault(hexid, []).append({"round": rnd["round"], "outcome": None})
+    arena = state_dir / "arena"
+    if arena.is_dir():
+        for rdir in arena.iterdir():
+            if not rdir.is_dir():
+                continue
+            try:
+                rnum = int(rdir.name)
+            except ValueError:
+                rnum = None
+            for cdir in rdir.iterdir():
+                if not cdir.is_dir():
+                    continue
+                rep = _read_json(cdir / "report.json", {}) or {}
+                lst = attempts.setdefault(cdir.name, [])
+                for a in lst:
+                    if a["round"] == rnum:
+                        a["outcome"] = rep.get("outcome")
+                        break
+                else:
+                    lst.append({"round": rnum, "outcome": rep.get("outcome")})
+    strata = {}
+    for rec in records:
+        s = strata.setdefault(rec["stratum"], {
+            "stratum": rec["stratum"], "total": 0, "attempted": 0, "solved": 0,
+            "gave_up": 0, "machine_checkable": 0})
+        s["total"] += 1
+        if rec["machine_checkable"]:
+            s["machine_checkable"] += 1
+        tries = attempts.get(rec["hexid"]) or []
+        rec["attempts"] = len(tries)
+        rec["rounds"] = [t["round"] for t in tries]
+        rec["last_outcome"] = tries[-1]["outcome"] if tries else None
+        if tries:
+            s["attempted"] += 1
+            outcomes = [t["outcome"] for t in tries]
+            if "solved" in outcomes:
+                s["solved"] += 1
+            if "gave_up" in outcomes:
+                s["gave_up"] += 1
+    for s in strata.values():
+        s["coverage_pct"] = round(100.0 * s["attempted"] / s["total"], 1) if s["total"] else 0.0
+    total = len(records)
+    attempted = sum(1 for r in records if r["attempts"])
+    return {
+        "strata": [strata[k] for k in sorted(strata)],
+        "totals": {"total": total, "attempted": attempted,
+                   "coverage_pct": round(100.0 * attempted / total, 1) if total else 0.0,
+                   "unattempted": total - attempted},
+        "challenges": records,
+    }
+
+
+# --- acceptance matrix ------------------------------------------------------
+#
+# Rows = every acceptance probe ever filed, columns = rounds, cells = pass/fail. A cell that
+# was green and is now red is a regression, which is the whole point of the screen: it is the
+# one view that answers "is the loop actually improving kuna".
+
+def _acceptance_rows(doc):
+    """rounds/<n>/acceptance.json in any of the shapes verify.py might reasonably emit."""
+    if doc is None:
+        return []
+    if isinstance(doc, dict):
+        for key in ("results", "probes", "acceptance"):
+            if isinstance(doc.get(key), list):
+                return doc[key]
+        if all(isinstance(v, dict) for v in doc.values()) and doc:
+            return [dict(v, probe_id=v.get("probe_id", k)) for k, v in doc.items()]
+        return []
+    if isinstance(doc, list):
+        return doc
+    return []
+
+
+def _cell(row):
+    for key in ("status", "result", "verdict", "outcome"):
+        v = row.get(key)
+        if isinstance(v, str):
+            v = v.lower()
+            if v in ("pass", "passed", "ok", "green"):
+                return "pass"
+            if v in ("fail", "failed", "red"):
+                return "fail"
+            if v in ("error", "timeout", "skip", "skipped"):
+                return v
+    if isinstance(row.get("passed"), bool):
+        return "pass" if row["passed"] else "fail"
+    if isinstance(row.get("ok"), bool):
+        return "pass" if row["ok"] else "fail"
+    return "unknown"
+
+
+def _collect_acceptance(state_dir, rounds, need_index):
+    by_probe = {}
+    round_nums = []
+    for rnd in rounds:
+        n = rnd["round"]
+        doc = _read_json(Path(rnd["path"]) / "acceptance.json")
+        rows = _acceptance_rows(doc)
+        if doc is None and not rows:
+            continue
+        round_nums.append(n)
+        for row in rows:
+            pid = row.get("probe_id") or row.get("acceptance_id") or row.get("id")
+            if not pid:
+                continue
+            ent = by_probe.setdefault(pid, {"probe_id": pid, "cells": {}})
+            ent["cells"][str(n)] = _cell(row)
+            if row.get("need_id"):
+                ent["need_id"] = row["need_id"]
+    for need in need_index.values():
+        aid = need.get("acceptance_id")
+        if aid:
+            ent = by_probe.setdefault(aid, {"probe_id": aid, "cells": {}})
+            ent.setdefault("need_id", need["need_id"])
+    probes = []
+    for pid, ent in by_probe.items():
+        need = need_index.get(ent.get("need_id") or "")
+        cells = ent["cells"]
+        seq = [(int(k), v) for k, v in sorted(cells.items(), key=lambda kv: int(kv[0]))]
+        regressed = any(seq[i][1] == "fail" and any(p == "pass" for _, p in seq[:i])
+                        for i in range(len(seq)))
+        probes.append({
+            "probe_id": pid,
+            "need_id": ent.get("need_id"),
+            "title": (need or {}).get("title") or "",
+            "track": (need or {}).get("track"),
+            "need_status": (need or {}).get("status"),
+            "cells": cells,
+            "first_pass_round": next((r for r, v in seq if v == "pass"), None),
+            "latest": seq[-1][1] if seq else None,
+            "regressed": regressed,
+        })
+    probes.sort(key=lambda p: (not p["cells"], not p["regressed"],
+                               p["latest"] != "fail",
+                               p.get("need_id") or "", p["probe_id"]))
+    totals = {}
+    for n in round_nums:
+        col = [p["cells"].get(str(n)) for p in probes]
+        totals[str(n)] = {"pass": col.count("pass"), "fail": col.count("fail"),
+                          "other": sum(1 for c in col if c not in (None, "pass", "fail"))}
+    return {
+        "rounds": round_nums,
+        "probes": probes,
+        "totals": totals,
+        "regressions": sum(1 for p in probes if p["regressed"]),
+        "closed": sum(1 for p in probes if p["latest"] == "pass"),
+        "outstanding": sum(1 for p in probes if p["latest"] == "fail"),
+        "never_run": sum(1 for p in probes if not p["cells"]),
+    }
+
+
+# --- spend ------------------------------------------------------------------
+
+def _replay_status(state_dir):
+    """probe_id -> the status of its most recent replay, from .kuna-repipe/replays/*.jsonl.
+
+    Rebuilt only when that directory's mtime signature moves, so the common case is a dict
+    lookup rather than one open() per probe per tick.
+    """
+    d = state_dir / "replays"
+    files = sorted(d.glob("*.jsonl")) if d.is_dir() else []
+    sig = _mtime_sig(files)
+    cached = getattr(_replay_status, "_cache", None)
+    if cached and cached[0] == (str(d), sig):
+        return cached[1]
+    out = {}
+    for f in files:
+        rows = _jsonl(f, limit=1)
+        if rows:
+            out[f.stem] = _cell(rows[-1])
+    _replay_status._cache = ((str(d), sig), out)
+    return out
+
+
+def _enrich_need_status(needs, acceptance, replays):
+    """Fill a need's probe/acceptance status from the evidence rather than showing 'unrun'.
+
+    A need record does not carry the replay verdict — the acceptance suite and the replay
+    logs do — so the backlog row would otherwise read 'unrun' for a probe whose result the
+    matrix on the next tab already knows.
+    """
+    latest = {p["probe_id"]: p["latest"] for p in acceptance.get("probes", [])
+              if p.get("latest")}
+    for n in needs.get("backlog", []) + needs.get("rejected", []):
+        if not n.get("acceptance_status"):
+            aid = n.get("acceptance_id")
+            n["acceptance_status"] = latest.get(aid) or replays.get(aid)
+        if not n.get("probe_status"):
+            n["probe_status"] = replays.get(n.get("probe_id"))
+
+
+def _collect_spend(state_dir, agents, rounds):
+    doc = _read_json(state_dir / "spend.json", {}) or {}
+    agent_usd = sum(float(a["usd"]) for a in agents
+                    if isinstance(a.get("usd"), (int, float)))
+    run_usd = doc.get("run_usd")
+    if not isinstance(run_usd, (int, float)):
+        run_usd = agent_usd
+    by_round = doc.get("round_usd") or {}
+    cur = rounds[-1]["round"] if rounds else None
+    round_usd = by_round.get(str(cur))
+    if not isinstance(round_usd, (int, float)) and rounds:
+        round_usd = rounds[-1].get("usd")
+    return {
+        "run_usd": round(float(run_usd), 2),
+        "run_cap": rconfig.RUN_USD,
+        "round_usd": round(float(round_usd), 2) if isinstance(round_usd, (int, float)) else None,
+        "round_cap": rconfig.ROUND_USD,
+        "live_usd": round(agent_usd, 2),
+        "tokens_in": sum(int(a["tokens_in"]) for a in agents
+                         if isinstance(a.get("tokens_in"), (int, float))),
+        "tokens_out": sum(int(a["tokens_out"]) for a in agents
+                          if isinstance(a.get("tokens_out"), (int, float))),
+    }
+
+
+# --- the payload ------------------------------------------------------------
+
+def build_payload(state_dir, *, gh_repo=None, want_checks=True, want_du=True):
+    """Everything the dashboard shows, assembled once per refresh tick.
+
+    This is the ONLY function in the module that is allowed to touch a subprocess. Request
+    handlers slice the published copy of its result and never call it.
+    """
+    gh_repo = gh_repo or rconfig.GH_REPO
+    now = time.time()
+    snap = _collect_snapshot()
+    agents = _collect_agents(state_dir, snap, gh_repo, want_checks=want_checks)
+    rounds = _collect_rounds(state_dir)
+    needs = _collect_needs(rconfig.needs_dir(), rconfig.rejected_dir())
+    need_index = {n["need_id"]: n for n in needs["backlog"] + needs["rejected"]}
+    acceptance = _collect_acceptance(state_dir, rounds, need_index)
+    _enrich_need_status(needs, acceptance, _replay_status(state_dir))
+    corpus = _collect_corpus(state_dir, rounds)
+    supervisor = _supervisor(state_dir, agents)
+    spend = _collect_spend(state_dir, agents, rounds)
+    disk = _disk() or {}
+    split = rconfig.agent_split()
+    live = [a for a in agents if a.get("status") == "running"]
+    current = rounds[-1] if rounds else None
+    return {
+        "schema": "re-webui/1",
+        "now": now,
+        "state_dir": str(state_dir),
+        "repo": str(rconfig.repo_root()),
+        "gh_repo": gh_repo,
+        "supervisor": supervisor,
+        "header": {
+            "round": current["round"] if current else None,
+            "rounds_planned": supervisor.get("rounds_planned"),
+            "test_state": current["test_state"] if current else None,
+            "build_state": current["build_state"] if current else None,
+            "agents_live": len(live),
+            "agents_max": split["max_agents"],
+            "pools": {"testers": split["testers"], "builders": split["builders"]},
+            "disk_free_gb": disk.get("free_gb"),
+            "disk_red_gb": DISK_RED_GB,
+            "disk_min_gb": rconfig.MIN_FREE_GB,
+            "disk_halt_gb": rconfig.HALT_FREE_GB,
+            "state_dir_bytes": _state_dir_bytes(state_dir, want_du),
+            "run_usd": spend["run_usd"],
+            "run_cap": spend["run_cap"],
+        },
+        "lanes": {"test": TEST_LANE, "build": BUILD_LANE},
+        "rounds": rounds,
+        "current_round": current,
+        "agents": agents,
+        "needs": needs,
+        "acceptance": acceptance,
+        "corpus": {"strata": corpus["strata"], "totals": corpus["totals"]},
+        "spend": spend,
+        "worktrees": snap.get("worktrees") or [],
+        "prs": snap.get("prs"),
+        "gh_ok": snap.get("prs") is not None,
+        "leases": snap.get("leases") or {},
+        "slots": snap.get("slots") or {},
+        "proposals": snap.get("proposals") or {},
+        "cache": pstatus.cache_ages(),
+        "modules": {"needs": needs_mod is not None, "verify": verify_mod is not None,
+                    "sample": sample_mod is not None},
+    }
+
+
+def _stable(obj):
+    """The payload with its per-second counters removed, so a quiet loop does not churn seq."""
+    if isinstance(obj, dict):
+        return {k: _stable(v) for k, v in obj.items() if k not in VOLATILE_KEYS}
+    if isinstance(obj, list):
+        return [_stable(v) for v in obj]
+    return obj
+
+
+def _digest(payload):
+    blob = json.dumps(_stable(payload), sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha1(blob.encode()).hexdigest()
+
+
+class Cache:
+    """The single published snapshot. Readers take the payload; the refresher swaps it."""
+
+    def __init__(self, state_dir):
+        self.state_dir = Path(state_dir)
+        self.cond = threading.Condition()
+        self.seq = 0
+        self.payload = {}
+        self.digest = None
+        self.updated_at = 0.0
+        self.error = None
+        self.refreshes = 0
+
+    def publish(self, payload):
+        digest = _digest(payload)
+        with self.cond:
+            changed = digest != self.digest
+            if changed:
+                self.seq += 1
+                self.digest = digest
+            payload["seq"] = self.seq
+            self.payload = payload
+            self.updated_at = time.time()
+            self.refreshes += 1
+            if changed:
+                self.cond.notify_all()
+        if changed:
+            self._write_through(payload)
+        return changed
+
+    def _write_through(self, payload):
+        path = self.state_dir / "webui-cache.json"
+        tmp = str(path) + ".tmp"
+        try:
+            os.makedirs(self.state_dir, exist_ok=True)
+            with open(tmp, "w") as fh:
+                json.dump(payload, fh, default=str)
+            os.replace(tmp, str(path))
+        except OSError:
+            pass
+
+    def get(self):
+        with self.cond:
+            return self.payload, self.seq
+
+    def wait(self, last_seq, timeout):
+        with self.cond:
+            if self.seq != last_seq:
+                return self.seq
+            self.cond.wait(timeout)
+            return self.seq
+
+
+class Refresher(threading.Thread):
+    """One thread, all the expensive I/O. Started before the server accepts a connection."""
+
+    daemon = True
+
+    def __init__(self, cache, interval=1.0, want_checks=True, want_du=True, gh_repo=None):
+        super().__init__(name="repipe-webui-refresher")
+        self.cache = cache
+        self.interval = float(interval)
+        self.want_checks = want_checks
+        self.want_du = want_du
+        self.gh_repo = gh_repo
+        self.stop_event = threading.Event()
+
+    def tick(self):
+        try:
+            payload = build_payload(self.cache.state_dir, gh_repo=self.gh_repo,
+                                   want_checks=self.want_checks, want_du=self.want_du)
+            self.cache.error = None
+        except Exception as exc:
+            self.cache.error = "%s: %s" % (type(exc).__name__, exc)
+            payload = dict(self.cache.payload or {})
+            payload["refresh_error"] = self.cache.error
+            payload["now"] = time.time()
+        return self.cache.publish(payload)
+
+    def run(self):
+        while not self.stop_event.is_set():
+            self.tick()
+            self.stop_event.wait(self.interval)
+
+    def stop(self):
+        self.stop_event.set()
+
+
+# --- detail readers (cheap, no subprocess) ---------------------------------
+
+def read_need(need_id):
+    """The full record: front-matter + the fixed ## sections. Rejected pile included."""
+    if not NEED_ID_RE.match(need_id or "") or ".." in need_id:
+        return None
+    for directory in (rconfig.needs_dir(), rconfig.rejected_dir()):
+        path = directory / ("%s.md" % need_id)
+        if not _lexically_under(rconfig.needs_dir(), path) or not path.is_file():
+            continue
+        try:
+            text = path.read_text(errors="replace")
+        except OSError:
+            continue
+        fm = _front_matter(text)
+        fm.setdefault("need_id", need_id)
+        if directory == rconfig.rejected_dir():
+            fm["status"] = "rejected"
+        rec = _norm_need(fm)
+        rec["file"] = str(path)
+        rec["sections"] = _sections(text)
+        rec["raw_front_matter"] = fm
+        return rec
+    return None
+
+
+def _cli_probe_index():
+    """probe_id -> tests/cli/*.json, rebuilt only when that directory changes."""
+    d = rconfig.cli_tests_dir()
+    files = sorted(d.glob("*.json")) if d.is_dir() else []
+    sig = _mtime_sig(files)
+    cached = getattr(_cli_probe_index, "_cache", None)
+    if cached and cached[0] == sig:
+        return cached[1]
+    index = {}
+    for f in files:
+        doc = _read_json(f)
+        if isinstance(doc, dict) and doc.get("probe_id"):
+            index[doc["probe_id"]] = str(f)
+    _cli_probe_index._cache = (sig, index)
+    return index
+
+
+def read_probe(state_dir, probe_id, replays=40):
+    """The probe document plus its last N replay results.
+
+    Replays come from .kuna-repipe/replays/<id>.jsonl (probe.py's own log) and from every
+    round's acceptance.json, so an acceptance probe shows its per-round history even when
+    no replay log exists yet.
+    """
+    if not PROBE_ID_RE.match(probe_id or ""):
+        return None
+    doc = None
+    origin = None
+    for cand in (state_dir / "probes" / ("%s.json" % probe_id),
+                 rconfig.needs_dir() / "probes" / ("%s.json" % probe_id)):
+        if cand.is_file():
+            doc = _read_json(cand)
+            origin = str(cand)
+            break
+    if doc is None:
+        hit = _cli_probe_index().get(probe_id)
+        if hit:
+            doc = _read_json(hit)
+            origin = hit
+    if doc is None and verify_mod is not None:
+        loader = getattr(verify_mod, "load_probe", None)
+        if callable(loader):
+            try:
+                doc = loader(probe_id)
+                origin = "verify.py"
+            except Exception:
+                doc = None
+    history = _jsonl(state_dir / "replays" / ("%s.jsonl" % probe_id), limit=replays)
+    for num, path in _round_dirs(state_dir):
+        for row in _acceptance_rows(_read_json(path / "acceptance.json")):
+            pid = row.get("probe_id") or row.get("acceptance_id") or row.get("id")
+            if pid == probe_id:
+                history.append({"round": num, "status": _cell(row),
+                                "ts": row.get("ts"), "source": "acceptance.json"})
+    if doc is None and not history:
+        return None
+    return {"probe_id": probe_id, "probe": doc, "origin": origin,
+            "kind": (doc or {}).get("kind"),
+            "is_acceptance": probe_id.startswith("a-"),
+            "replays": history[-replays:], "replay_count": len(history)}
+
+
+def read_agent_report(state_dir, agent_id, agents):
+    """A tester's report.json, found through the arena its inventory record names."""
+    if not AGENT_ID_RE.match(agent_id or ""):
+        return None
+    rec = next((a for a in agents if a["id"] == agent_id), None)
+    cands = []
+    if rec and rec.get("report"):
+        cands.append(Path(rec["report"]))
+    if rec and rec.get("challenge"):
+        for num, _ in _round_dirs(state_dir):
+            cands.append(state_dir / "arena" / str(num) / rec["challenge"] / "report.json")
+    cands.append(state_dir / "reports" / ("%s.json" % agent_id))
+    for cand in cands:
+        if not cand.is_absolute():
+            cand = state_dir / cand
+        if _safe_under(state_dir, cand) and cand.is_file():
+            return {"agent": agent_id, "path": str(cand), "report": _read_json(cand)}
+    return None
+
+
+# --- HTTP -------------------------------------------------------------------
+
+_CTYPES = {".html": "text/html; charset=utf-8", ".css": "text/css; charset=utf-8",
+           ".js": "text/javascript; charset=utf-8", ".json": "application/json",
+           ".svg": "image/svg+xml", ".woff2": "font/woff2", ".png": "image/png",
+           ".ico": "image/x-icon", ".webp": "image/webp"}
+
+
+class Handler(BaseHTTPRequestHandler):
+    """Read-only. Every route answers from Handler.cache; none of them starts a process."""
+
+    protocol_version = "HTTP/1.1"
+    server_version = "kuna-repipe-webui/1"
+    cache = None
+    state_dir = None
+    log_path = None
+
+    def log_message(self, fmt, *args):
+        line = "%s - - [%s] %s\n" % (self.address_string(),
+                                     self.log_date_time_string(), fmt % args)
+        path = type(self).log_path
+        if not path:
+            return
+        try:
+            with open(path, "a") as fh:
+                fh.write(line)
+        except OSError:
+            pass
+
+    # --- reply helpers ---
+
+    def _send(self, code, body, ctype="application/json", extra=None):
+        if isinstance(body, str):
+            body = body.encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        for k, v in (extra or {}).items():
+            self.send_header(k, v)
+        self.end_headers()
+        if self.command != "HEAD":
+            try:
+                self.wfile.write(body)
+            except (BrokenPipeError, ConnectionResetError):
+                self.close_connection = True
+
+    def _json(self, obj, code=200):
+        self._send(code, json.dumps(obj, default=str, sort_keys=False), "application/json")
+
+    def _err(self, code, msg):
+        self._json({"error": msg, "status": code}, code)
+
+    def _file(self, path, ctype=None):
+        try:
+            with open(path, "rb") as fh:
+                body = fh.read()
+        except OSError:
+            return self._err(404, "not found")
+        ct = ctype or _CTYPES.get(Path(path).suffix, "application/octet-stream")
+        self._send(200, body, ct)
+
+    # --- routing ---
+
+    def do_HEAD(self):
+        self.do_GET()
+
+    def do_GET(self):
+        parsed = urllib.parse.urlsplit(self.path)
+        segs = [urllib.parse.unquote(s) for s in parsed.path.split("/") if s != ""]
+        query = urllib.parse.parse_qs(parsed.query)
+        try:
+            self.route(parsed.path, segs, query)
+        except (BrokenPipeError, ConnectionResetError):
+            self.close_connection = True
+        except Exception as exc:
+            self._err(500, "%s: %s" % (type(exc).__name__, exc))
+
+    def route(self, raw_path, segs, query):
+        payload, seq = type(self).cache.get()
+        state_dir = type(self).state_dir
+
+        if not segs:
+            return self._file(WEBUI_DIR / "index.html", _CTYPES[".html"])
+
+        if segs[0] == "healthz":
+            c = type(self).cache
+            return self._json({
+                "ok": True, "seq": seq, "pid": os.getpid(),
+                "age_s": round(time.time() - c.updated_at, 2) if c.updated_at else None,
+                "refreshes": c.refreshes, "refresh_error": c.error,
+                "state_dir": str(state_dir), "state_dir_exists": state_dir.is_dir(),
+                "modules": (payload.get("modules") or {}),
+            })
+
+        if segs[0] == "assets":
+            return self.serve_asset(segs[1:])
+
+        # site.css is served verbatim, and its @font-face src is "../fonts/<name>" relative
+        # to /assets/css/ — which is /fonts/<name> here. Serving it keeps the stylesheet
+        # byte-identical to the live site instead of rewriting its URLs.
+        if segs[0] in ("fonts", "img") and len(segs) == 2:
+            return self.serve_site_file(segs[0], segs[1])
+
+        if segs[0] == "favicon.ico":
+            return self.serve_site_file("img", "favicon.png")
+
+        if segs[0] != "api":
+            return self._err(404, "no route %r" % raw_path)
+
+        return self.api(segs[1:], query, payload, seq, state_dir)
+
+    def serve_site_file(self, kind, name):
+        cand = SITE_ASSETS / kind / name
+        if "/" in name or ".." in name or not _safe_under(SITE_ASSETS, cand) \
+                or not cand.is_file():
+            return self._err(404, "not found")
+        return self._file(cand)
+
+    def serve_asset(self, rest):
+        if not rest or any(s in ("..", ".", "") or "/" in s or "\\" in s for s in rest):
+            return self._err(400, "bad asset path")
+        # site.css is served verbatim from the live site tree so the dashboard cannot drift
+        # from kuna.noelo.org's --paper/--ink/--red token system.
+        if rest == ["site.css"]:
+            return self._file(SITE_CSS, _CTYPES[".css"])
+        if rest[0] == "fonts" and len(rest) == 2:
+            cand = SITE_FONTS / rest[1]
+            if not _safe_under(SITE_FONTS, cand) or not cand.is_file():
+                return self._err(404, "not found")
+            return self._file(cand)
+        cand = WEBUI_DIR / "assets" / Path(*rest)
+        if not _safe_under(WEBUI_DIR / "assets", cand) or not cand.is_file():
+            return self._err(404, "not found")
+        return self._file(cand)
+
+    def api(self, rest, query, payload, seq, state_dir):
+        if not rest:
+            return self._err(404, "no route")
+        head = rest[0]
+
+        if head == "state":
+            return self._json(payload or {"seq": seq, "empty": True})
+
+        if head == "events":
+            return self.sse(query)
+
+        if head == "rounds":
+            return self._json({"seq": seq, "rounds": payload.get("rounds", []),
+                               "lanes": payload.get("lanes", {})})
+
+        if head == "round" and len(rest) == 2:
+            if not rest[1].lstrip("-").isdigit():
+                return self._err(400, "round must be an integer")
+            want = int(rest[1])
+            for rnd in payload.get("rounds", []):
+                if rnd["round"] == want:
+                    full = dict(rnd)
+                    full["transitions"] = _jsonl(Path(rnd["path"]) / "transitions.jsonl")
+                    full["acceptance"] = _read_json(Path(rnd["path"]) / "acceptance.json")
+                    return self._json(full)
+            return self._err(404, "no round %d" % want)
+
+        if head == "needs":
+            return self._json(self.filter_needs(payload, query, seq))
+
+        if head == "need" and len(rest) == 2:
+            if not NEED_ID_RE.match(rest[1]) or ".." in rest[1]:
+                return self._err(400, "invalid need id")
+            rec = read_need(rest[1])
+            if rec is None:
+                return self._err(404, "no need %r" % rest[1])
+            return self._json(rec)
+
+        if head == "probe" and len(rest) == 2:
+            if not PROBE_ID_RE.match(rest[1]):
+                return self._err(400, "probe id must match ^[pa]-[0-9a-f]{12}$")
+            rec = read_probe(state_dir, rest[1])
+            if rec is None:
+                return self._err(404, "no probe %r" % rest[1])
+            return self._json(rec)
+
+        if head == "agents":
+            return self._json({"seq": seq, "agents": payload.get("agents", []),
+                               "slots": payload.get("slots", {}),
+                               "leases": payload.get("leases", {}),
+                               "now": time.time()})
+
+        if head == "agent" and len(rest) == 3 and rest[2] in ("log", "report"):
+            agent_id = rest[1]
+            if not AGENT_ID_RE.match(agent_id):
+                return self._err(400, "invalid agent id")
+            if rest[2] == "report":
+                rec = read_agent_report(state_dir, agent_id, payload.get("agents", []))
+                if rec is None:
+                    return self._err(404, "no report for %r" % agent_id)
+                return self._json(rec)
+            return self.agent_log(agent_id, query, payload, state_dir)
+
+        if head == "corpus":
+            return self._json(self.corpus(query, state_dir, payload))
+
+        if head == "acceptance":
+            return self._json(dict(payload.get("acceptance", {}), seq=seq))
+
+        return self._err(404, "no route /api/%s" % "/".join(rest))
+
+    def filter_needs(self, payload, query, seq):
+        needs = payload.get("needs") or {}
+        rows = list(needs.get("backlog", []))
+        statuses = {s for v in query.get("status", []) for s in v.split(",") if s}
+        if statuses:
+            if "rejected" in statuses:
+                rows += needs.get("rejected", [])
+            rows = [n for n in rows if n["status"] in statuses]
+        tracks = {t for v in query.get("track", []) for t in v.split(",") if t}
+        if tracks:
+            rows = [n for n in rows if n.get("track") in tracks]
+        q = (query.get("q") or [""])[0].strip().lower()
+        if q:
+            rows = [n for n in rows
+                    if q in (n.get("need_id") or "").lower()
+                    or q in (n.get("title") or "").lower()
+                    or q in (n.get("probe_id") or "").lower()
+                    or q in (n.get("acceptance_id") or "").lower()]
+        return {"seq": seq, "count": len(rows), "needs": rows,
+                "totals": needs.get("totals", {}), "by_status": needs.get("by_status", {}),
+                "rejected_by_reason": {k: len(v) for k, v in
+                                       (needs.get("rejected_by_reason") or {}).items()},
+                "source": needs.get("source"),
+                "filters": {"status": sorted(statuses), "track": sorted(tracks), "q": q}}
+
+    def corpus(self, query, state_dir, payload):
+        full = _collect_corpus(state_dir, payload.get("rounds", []))
+        stratum = (query.get("stratum") or [""])[0]
+        rows = full["challenges"]
+        if stratum:
+            rows = [r for r in rows if r["stratum"] == stratum]
+        if (query.get("attempted") or [""])[0] == "1":
+            rows = [r for r in rows if r["attempts"]]
+        limit = min(500, max(1, int((query.get("limit") or ["250"])[0] or 250)))
+        return {"strata": full["strata"], "totals": full["totals"],
+                "count": len(rows), "challenges": rows[:limit],
+                "note": "coverage only; ground_truth.flag is never read into this payload"}
+
+    def agent_log(self, agent_id, query, payload, state_dir):
+        rec = next((a for a in payload.get("agents", []) if a["id"] == agent_id), None)
+        path = _agent_log_path(state_dir, agent_id, (rec or {}).get("log"))
+        if path is None:
+            return self._err(404, "no log for agent %r" % agent_id)
+        if not _safe_under(state_dir, path):
+            return self._err(400, "log path escapes the state dir")
+        try:
+            tail = int((query.get("tail") or ["400"])[0])
+        except ValueError:
+            tail = 400
+        tail = max(1, min(5000, tail))
+        lines = _tail_lines(path, tail)
+        return self._json({"agent": agent_id, "path": str(path), "tail": tail,
+                           "lines": lines, "bytes": os.path.getsize(path)})
+
+    def sse(self, query):
+        """One long-lived response per viewer; the refresher stays the only I/O owner."""
+        cache = type(self).cache
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Connection", "close")
+        self.send_header("X-Accel-Buffering", "no")
+        self.end_headers()
+        self.close_connection = True
+        try:
+            limit = int((query.get("limit") or ["0"])[0])
+        except ValueError:
+            limit = 0
+        sent = 0
+        last = None
+        deadline = time.time() + 15.0
+        try:
+            while True:
+                _, seq = cache.get()
+                if seq != last:
+                    last = seq
+                    self.wfile.write(("data: %s\n\n" % json.dumps({"seq": seq})).encode())
+                    self.wfile.flush()
+                    sent += 1
+                    deadline = time.time() + 15.0
+                    if limit and sent >= limit:
+                        return
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    self.wfile.write(b": keepalive\n\n")
+                    self.wfile.flush()
+                    deadline = time.time() + 15.0
+                    continue
+                cache.wait(last, min(remaining, 15.0))
+        except (BrokenPipeError, ConnectionResetError, ValueError):
+            return
+
+
+# --- server -----------------------------------------------------------------
+
+class Server(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+def serve(bind="127.0.0.1", port=8787, *, state_dir=None, interval=1.0,
+          want_checks=True, want_du=True, gh_repo=None, ready=None):
+    """Start the refresher, then the server. Returns the exit code."""
+    sdir = bind_state_dir(state_dir)
+    logs = sdir / "logs"
+    log_path = None
+    try:
+        os.makedirs(logs, exist_ok=True)
+        log_path = logs / "webui.log"
+    except OSError:
+        log_path = None
+
+    cache = Cache(sdir)
+    refresher = Refresher(cache, interval=interval, want_checks=want_checks,
+                          want_du=want_du, gh_repo=gh_repo)
+    refresher.tick()          # first paint before the first connection is accepted
+    refresher.start()
+
+    handler = type("BoundHandler", (Handler,),
+                   {"cache": cache, "state_dir": sdir, "log_path": log_path})
+    httpd = Server((bind, port), handler)
+    real_port = httpd.server_address[1]
+    sys.stderr.write("repipe webui  http://%s:%d/   state=%s  log=%s\n"
+                     % (bind, real_port, sdir, log_path or "(stderr disabled)"))
+    sys.stderr.write("  read-only: to stop the pipeline, `touch %s`\n" % (sdir / "STOP"))
+    sys.stderr.flush()
+    if ready is not None:
+        ready(httpd, cache, refresher)
+    try:
+        httpd.serve_forever(poll_interval=0.2)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        refresher.stop()
+        httpd.server_close()
+    return 0
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        prog="python -m scripts.repipe.webui",
+        description="Live dashboard for the RE-friction loop (read-only, loopback).")
+    p.add_argument("--bind", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=8787, help="0 picks an ephemeral port")
+    p.add_argument("--state-dir", default=None, help="default: $REPO/.kuna-repipe")
+    p.add_argument("--interval", type=float, default=1.0, help="refresher tick, seconds")
+    p.add_argument("--gh-repo", default=None)
+    p.add_argument("--no-checks", action="store_true",
+                   help="never call gh for check-runs (PR CI columns read 'unknown')")
+    p.add_argument("--no-du", action="store_true",
+                   help="skip the state-dir du (it can be slow with live arenas)")
+    p.add_argument("--json", action="store_true",
+                   help="print one payload snapshot and exit; starts no server")
+    args = p.parse_args(argv)
+
+    sdir = bind_state_dir(args.state_dir)
+    if args.json:
+        payload = build_payload(sdir, gh_repo=args.gh_repo,
+                                want_checks=not args.no_checks, want_du=not args.no_du)
+        payload["seq"] = 1
+        print(json.dumps(payload, indent=2, default=str))
+        return 0
+    return serve(args.bind, args.port, state_dir=args.state_dir, interval=args.interval,
+                 want_checks=not args.no_checks, want_du=not args.no_du,
+                 gh_repo=args.gh_repo)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repipe/webui.py
+++ b/scripts/repipe/webui.py
@@ -268,6 +268,19 @@ def _lexically_under(root, candidate):
     return c == r or c.startswith(r + os.sep)
 
 
+# An id may only ever be these characters. No separator, no dot-dot, no NUL, nothing that can
+# leave a directory -- so a tainted URL component cannot reach a filesystem path at all. This
+# is deliberately stricter than _safe_under, which stays as defence in depth.
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+def safe_id(value):
+    """The id if it is well-formed, else None. Applied at every route that names a file."""
+    if not isinstance(value, str) or ".." in value:
+        return None
+    return value if _ID_RE.match(value) else None
+
+
 def _safe_under(root, candidate):
     """True iff ``candidate`` really lives under ``root`` after symlinks are resolved."""
     try:
@@ -1327,7 +1340,10 @@ class Handler(BaseHTTPRequestHandler):
         # to /assets/css/ — which is /fonts/<name> here. Serving it keeps the stylesheet
         # byte-identical to the live site instead of rewriting its URLs.
         if segs[0] in ("fonts", "img") and len(segs) == 2:
-            return self.serve_site_file(segs[0], segs[1])
+            name = safe_id(segs[1])
+            if name is None:
+                return self._err(400, "bad asset name")
+            return self.serve_site_file(segs[0], name)
 
         if segs[0] == "favicon.ico":
             return self.serve_site_file("img", "favicon.png")
@@ -1338,9 +1354,13 @@ class Handler(BaseHTTPRequestHandler):
         return self.api(segs[1:], query, payload, seq, state_dir)
 
     def serve_site_file(self, kind, name):
+        # Charset-gate first: a tainted component must never reach a path at all, whatever
+        # _safe_under would have said about the result.
+        name = safe_id(name)
+        if name is None or kind not in ("fonts", "img", "css", "js"):
+            return self._err(400, "bad asset name")
         cand = SITE_ASSETS / kind / name
-        if "/" in name or ".." in name or not _safe_under(SITE_ASSETS, cand) \
-                or not cand.is_file():
+        if not _safe_under(SITE_ASSETS, cand) or not cand.is_file():
             return self._err(404, "not found")
         return self._file(cand)
 
@@ -1352,11 +1372,17 @@ class Handler(BaseHTTPRequestHandler):
         if rest == ["site.css"]:
             return self._file(SITE_CSS, _CTYPES[".css"])
         if rest[0] == "fonts" and len(rest) == 2:
-            cand = SITE_FONTS / rest[1]
+            name = safe_id(rest[1])
+            if name is None:
+                return self._err(400, "bad asset name")
+            cand = SITE_FONTS / name
             if not _safe_under(SITE_FONTS, cand) or not cand.is_file():
                 return self._err(404, "not found")
             return self._file(cand)
-        cand = WEBUI_DIR / "assets" / Path(*rest)
+        parts = [safe_id(x) for x in rest]
+        if any(x is None for x in parts):
+            return self._err(400, "bad asset path")
+        cand = WEBUI_DIR / "assets" / Path(*parts)
         if not _safe_under(WEBUI_DIR / "assets", cand) or not cand.is_file():
             return self._err(404, "not found")
         return self._file(cand)
@@ -1414,7 +1440,9 @@ class Handler(BaseHTTPRequestHandler):
                                "now": time.time()})
 
         if head == "agent" and len(rest) == 3 and rest[2] in ("log", "report"):
-            agent_id = rest[1]
+            agent_id = safe_id(rest[1])
+            if agent_id is None:
+                return self._err(400, "bad agent id")
             if not AGENT_ID_RE.match(agent_id):
                 return self._err(400, "invalid agent id")
             if rest[2] == "report":

--- a/scripts/repipe/workspace.py
+++ b/scripts/repipe/workspace.py
@@ -220,15 +220,32 @@ exit $RC
 # `--project-dir` is a `load`-only flag in the declib CLI (verified: no other subcommand
 # accepts it), so it is injected only there, and only when the caller did not pass one.
 _IDA_SETUP = '''
+# EVERYTHING declib writes must land inside the arena. The tester runs under codex's
+# `workspace-write` sandbox, which blocks writes outside its workspace -- and declib puts its
+# unix socket under TMPDIR (observed: /tmp/declib_server_<id>/decompiler.sock), so with the
+# default TMPDIR the server cannot start at all and every reference call fails with rc=1.
 DECLIB_SERVER_REGISTRY="$ARENA/.declib/servers"
-export DECLIB_SERVER_REGISTRY
-mkdir -p "$ARENA/.declib/servers" "$ARENA/.declib/projects"
+TMPDIR="$ARENA/.declib/tmp"
+XDG_STATE_HOME="$ARENA/.declib/state"
+XDG_CACHE_HOME="$ARENA/.declib/cache"
+export DECLIB_SERVER_REGISTRY TMPDIR XDG_STATE_HOME XDG_CACHE_HOME
+mkdir -p "$ARENA/.declib/servers" "$ARENA/.declib/projects" "$TMPDIR" \
+         "$XDG_STATE_HOME" "$XDG_CACHE_HOME"
 PROJDIR="$ARENA/.declib/projects"
+
+# `load` without an explicit --backend silently falls back to angr, which would make the
+# whole "compare against IDA" leg a comparison against something else entirely. IDA is the
+# reference the design asks for, so it is the default here and the caller can still override.
 INJECT=""
+BACKEND=""
 if [ "${1:-}" = "load" ]; then
     case " $* " in
         *" --project-dir "*|*" --project-dir="*) ;;
         *) INJECT=1 ;;
+    esac
+    case " $* " in
+        *" --backend "*|*" --backend="*) ;;
+        *) BACKEND="${REPIPE_IDA_BACKEND:-ida}" ;;
     esac
 fi
 '''
@@ -248,12 +265,18 @@ def _shim_ida(real: str) -> str:
               "# parallel track: every call here auto-drafts an observation, because \"kuna made\n"
               "# testers leave N times this round\" is a headline metric.\n#\n"
               "# The server registry and the project DBs (IDA's .i64 among them) are forced inside\n"
-              "# the arena so they die with the round. HOME is deliberately NOT re-pointed: IDA's\n"
-              "# registration lives in ~/.idapro/ida.reg and moving HOME would break the backend.",
+              "# the arena so they die with the round, as does declib's unix socket -- codex's\n"
+              "# workspace-write sandbox blocks writes outside the workspace, and the default\n"
+              "# TMPDIR put the socket in /tmp, so every reference call failed with rc=1.\n"
+              "# HOME is deliberately NOT re-pointed: IDA's registration lives in\n"
+              "# ~/.idapro/ida.reg and moving HOME would break the backend.",
         real_var="REPIPE_REAL_DECOMPILER", real_default=real)
     invoke = ('if [ -n "$INJECT" ]; then\n'
               '    shift\n'
               '    set -- load --project-dir "$PROJDIR" "$@"\n'
+              'fi\n'
+              'if [ -n "$BACKEND" ]; then\n'
+              '    set -- "$@" --backend "$BACKEND"\n'
               'fi\n'
               '"$REAL" "$@"')
     tail = _SHIM_TAIL.format(tool="ida", invoke=invoke)

--- a/scripts/repipe/workspace.py
+++ b/scripts/repipe/workspace.py
@@ -1,0 +1,669 @@
+"""Build one tester arena: everything a codex tester may see, and nothing else.
+
+The arena is the tester's whole world (`codex exec --cd $ARENA`). Everything the dataset knows
+about the answer -- `meta.json` and its plaintext `ground_truth.flag`, `verifier.py`,
+`original.zip`, the `solutions/` writeups -- stays outside it by construction, and every
+`extras/` file is filtered by `redact.classify` before it is copied. Containment is structural,
+not a request: a prompt-level "please do not look" would be worthless because codex's
+`-s workspace-write` restricts writes, not reads.
+
+    <out>/
+      target/<primary>             meta.json -> detected.primary.path, chmod 0755
+      target/<other binaries>      the rest of files.binaries[], chmod 0755
+      extras/<surviving files>     whatever redact.classify said "copy" to
+      bin/kuna  bin/ida-decompile  logging shims; the launcher prepends bin/ to PATH
+      bin/_shimlog.py              the shims' JSON-line appender
+      TASK.md  AGENTS.md           the statement and the tool protocol; no ground truth
+      notes/toolcalls.jsonl        written by the shims, one line per tool call
+      .repipe/build.json           what was copied and what was dropped, and why
+
+Two dataset facts drive the copying. **Exec bits are broken**: 4 of 287 shipped binaries are
+mode 600 and 54 are 644, so every copy is chmod 0755 -- otherwise the tester's first `./target`
+run fails for a reason that has nothing to do with kuna. **`bin/` preserves recursive-extraction
+path shapes** (`bin/GiveMeMoney.zip.__x/33bits/KeyVal2.exe`), and two binaries in one challenge
+routinely share a basename, so the tree under `bin/` is mirrored under `target/` and the primary
+is always resolved through `detected.primary.path`, never by globbing.
+
+**The shims are load-bearing.** kuna emits no timing at all in any of its JSON, so
+`notes/toolcalls.jsonl` is the pipeline's only per-call latency signal; it also turns tool usage
+counts and the kuna-vs-IDA time split into measurements rather than model self-report, and lets
+a probe be auto-derived from a real recorded argv instead of one a model transcribed.
+
+`sanity_check()` is the assertion side of all of the above, so the smoke test and the captain
+can both refuse to dispatch a tester into a contaminated arena.
+
+CLI:
+    python -m scripts.repipe.workspace build HEXID [--round N] [--out DIR] [--force] [--json]
+    python -m scripts.repipe.workspace check ARENA [--hexid H] [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import stat
+import sys
+import time
+from pathlib import Path
+
+from . import config
+from . import redact
+
+BIN_MODE = 0o755
+SHIM_MODE = 0o755
+
+# Never inside an arena, at any depth, under any name.
+FORBIDDEN_NAMES = ("meta.json", "verifier.py", "original.zip")
+FORBIDDEN_DIRS = ("solutions",)
+
+# sanity_check reads whole files; a target binary can be hundreds of MB and is exempt anyway.
+MAX_SCAN_BYTES = 16 * 1024 * 1024
+
+# Exempt from the leak scan entirely: the binaries themselves and any decompiler database
+# derived from them. For many challenges the flag *is* in the binary -- the binary is the task.
+DERIVED_DIRS = ("target", ".declib")
+
+# Written by the tester, not by the build. A correct solve legitimately names the flag here, so
+# only the answer-independent tags (dataset path, writeup archive) are violations in these.
+TESTER_PATHS = ("notes", "report.json")
+
+
+# --- dataset access (read-only) ---------------------------------------------
+
+def challenge_dir(hexid: str) -> Path:
+    return config.dataset_root() / "challenges" / hexid
+
+
+def load_meta(hexid: str) -> dict:
+    with open(challenge_dir(hexid) / "meta.json") as fh:
+        return json.load(fh)
+
+
+def arena_path(hexid: str, round_n: int) -> Path:
+    return config.arena_dir() / str(round_n) / hexid
+
+
+def primary_rel(meta: dict) -> str:
+    return ((meta.get("detected") or {}).get("primary") or {}).get("path") or ""
+
+
+def _target_rel(rel: str) -> str:
+    """Map a dataset-relative binary path to its place under target/.
+
+    Strips the leading `bin/` (the arena has no `bin/` for binaries -- that name is the shim
+    directory) while keeping every level below it, because the extraction shape disambiguates
+    two same-named binaries in one challenge.
+    """
+    rel = rel.replace("\\", "/").lstrip("/")
+    parts = [p for p in rel.split("/") if p not in ("", ".", "..")]
+    if parts and parts[0] == "bin":
+        parts = parts[1:]
+    return "/".join(parts)
+
+
+def _extras_rel(rel: str) -> str:
+    rel = rel.replace("\\", "/").lstrip("/")
+    parts = [p for p in rel.split("/") if p not in ("", ".", "..")]
+    if parts and parts[0] == "extras":
+        parts = parts[1:]
+    return "/".join(parts)
+
+
+# --- writing ----------------------------------------------------------------
+
+def _write(path: Path, text: str, mode: int = 0o644) -> None:
+    """Atomic write: temp sibling, then os.replace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = str(path) + ".tmp"
+    with open(tmp, "w") as fh:
+        fh.write(text)
+    os.chmod(tmp, mode)
+    os.replace(tmp, path)
+
+
+def _copy_exec(src: Path, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
+    os.chmod(dst, BIN_MODE)
+
+
+# --- the shims --------------------------------------------------------------
+
+_SHIMLOG_PY = '''"""Append one JSON line to notes/toolcalls.jsonl. Called by the bin/ shims.
+
+Separate from the shims because correct JSON escaping of an arbitrary argv is not something a
+POSIX shell can do; the flock keeps two concurrent tool calls from interleaving a line.
+"""
+import argparse
+import fcntl
+import json
+import os
+import sys
+import time
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--log", required=True)
+    ap.add_argument("--tool", required=True)
+    ap.add_argument("--argv-file", required=True)
+    ap.add_argument("--exit", type=int, default=0)
+    ap.add_argument("--seconds", type=float, default=0.0)
+    ap.add_argument("--stdout-bytes", type=int, default=0)
+    ap.add_argument("--stderr-bytes", type=int, default=0)
+    ap.add_argument("--stdout-sha1", default="")
+    a = ap.parse_args(argv)
+
+    with open(a.argv_file, "rb") as fh:
+        raw = fh.read()
+    args = [x.decode("utf-8", "replace") for x in raw.split(b"\\0") if x]
+
+    rec = {
+        "t": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "tool": a.tool,
+        "argv": args,
+        "cwd": os.getcwd(),
+        "exit": a.exit,
+        "seconds": round(a.seconds, 4),
+        "stdout_bytes": a.stdout_bytes,
+        "stderr_bytes": a.stderr_bytes,
+        "stdout_sha1": a.stdout_sha1,
+    }
+    os.makedirs(os.path.dirname(a.log) or ".", exist_ok=True)
+    with open(a.log, "a") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        fh.write(json.dumps(rec, separators=(",", ":")) + "\\n")
+        fh.flush()
+        fcntl.flock(fh, fcntl.LOCK_UN)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+'''
+
+_SHIM_HEAD = '''#!/bin/sh
+# {title}
+#
+# Transparent: same stdout, same stderr, same exit code as the real tool. It cannot literally
+# exec(2) the real tool because the accounting -- exit code, wall seconds, stdout size and
+# digest -- only exists after the tool returns, so stdout/stderr are captured to temp files and
+# replayed verbatim. ARENA is derived from this script's own location so the arena stays
+# relocatable; $REPIPE_ARENA overrides it.
+set -u
+ARENA=${{REPIPE_ARENA:-$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)}}
+LOG="$ARENA/notes/toolcalls.jsonl"
+REAL=${{{real_var}:-{real_default}}}
+'''
+
+_SHIM_TAIL = '''
+TMPD=$(mktemp -d "${{TMPDIR:-/tmp}}/repipe-{tool}.XXXXXX") || exec "$REAL" "$@"
+printf '%s\\0' "$@" > "$TMPD/argv"
+START=$(date +%s.%N)
+{invoke} >"$TMPD/out" 2>"$TMPD/err"
+RC=$?
+END=$(date +%s.%N)
+SECS=$(awk -v a="$START" -v b="$END" 'BEGIN {{ printf "%.4f", b - a }}')
+OB=$(wc -c < "$TMPD/out" | tr -d ' ')
+EB=$(wc -c < "$TMPD/err" | tr -d ' ')
+SHA=$(sha1sum "$TMPD/out" | cut -d' ' -f1)
+python3 "$ARENA/bin/_shimlog.py" --log "$LOG" --tool {tool} --argv-file "$TMPD/argv" \\
+    --exit "$RC" --seconds "$SECS" --stdout-bytes "$OB" --stderr-bytes "$EB" \\
+    --stdout-sha1 "$SHA" >/dev/null 2>&1 || true
+cat "$TMPD/out"
+cat "$TMPD/err" >&2
+rm -rf "$TMPD"
+exit $RC
+'''
+
+# `--project-dir` is a `load`-only flag in the declib CLI (verified: no other subcommand
+# accepts it), so it is injected only there, and only when the caller did not pass one.
+_IDA_SETUP = '''
+DECLIB_SERVER_REGISTRY="$ARENA/.declib/servers"
+export DECLIB_SERVER_REGISTRY
+mkdir -p "$ARENA/.declib/servers" "$ARENA/.declib/projects"
+PROJDIR="$ARENA/.declib/projects"
+INJECT=""
+if [ "${1:-}" = "load" ]; then
+    case " $* " in
+        *" --project-dir "*|*" --project-dir="*) ;;
+        *) INJECT=1 ;;
+    esac
+fi
+'''
+
+
+def _shim_kuna(real: str) -> str:
+    head = _SHIM_HEAD.format(
+        title="Shim for kuna. Logs every call to notes/toolcalls.jsonl -- kuna emits no timing\n# of its own, so this file is the pipeline's only per-call latency signal.",
+        real_var="REPIPE_REAL_KUNA", real_default=real)
+    tail = _SHIM_TAIL.format(tool="kuna", invoke='"$REAL" "$@"')
+    return head + tail
+
+
+def _shim_ida(real: str) -> str:
+    head = _SHIM_HEAD.format(
+        title="Shim for the declib/IDA reference CLI. IDA is a logged last resort, never a\n"
+              "# parallel track: every call here auto-drafts an observation, because \"kuna made\n"
+              "# testers leave N times this round\" is a headline metric.\n#\n"
+              "# The server registry and the project DBs (IDA's .i64 among them) are forced inside\n"
+              "# the arena so they die with the round. HOME is deliberately NOT re-pointed: IDA's\n"
+              "# registration lives in ~/.idapro/ida.reg and moving HOME would break the backend.",
+        real_var="REPIPE_REAL_DECOMPILER", real_default=real)
+    invoke = ('if [ -n "$INJECT" ]; then\n'
+              '    shift\n'
+              '    set -- load --project-dir "$PROJDIR" "$@"\n'
+              'fi\n'
+              '"$REAL" "$@"')
+    tail = _SHIM_TAIL.format(tool="ida", invoke=invoke)
+    return head + _IDA_SETUP + tail
+
+
+# --- TASK.md / AGENTS.md ----------------------------------------------------
+
+def _goal(meta: dict) -> tuple:
+    gt = meta.get("ground_truth") or {}
+    if gt.get("verifier_interface") == "name+serial":
+        return ("a username and a serial that the binary accepts for it",
+                "Report both in `report.json` as `solution.name` and `solution.serial`.")
+    if gt.get("has_unique_flag"):
+        return ("the single flag string the binary accepts",
+                "Report it in `report.json` as `solution.flag`, exactly, with no wrapper.")
+    return ("whatever the binary accepts as correct -- a flag, or a name and matching serial",
+            "Report it in `report.json` under `solution`, and say which form it is.")
+
+
+def _task_md(meta: dict, primary_t: str, others: list, extras: list) -> str:
+    d = meta.get("declared") or {}
+    det = meta.get("detected") or {}
+    prim = det.get("primary") or {}
+    obf = (meta.get("obfuscation") or {}).get("classes") or []
+    goal, how = _goal(meta)
+    minutes = max(1, int(config.TESTER_TIMEOUT) // 60)
+
+    def clean(text):
+        return redact.sanitize(text, meta)
+
+    rows = [
+        ("platform", clean(d.get("platform") or det.get("formats") and ", ".join(det["formats"]) or "unknown")),
+        ("arch", clean(prim.get("arch") or d.get("arch") or "unknown")),
+        ("format", clean(prim.get("format") or "unknown")),
+        ("size", "%d bytes" % prim.get("size", 0)),
+        ("file(1)", clean(prim.get("file") or "unknown")),
+        ("obfuscation", clean(", ".join(obf)) if obf else "none detected"),
+        ("author difficulty", "%s / 6" % d.get("difficulty") if d.get("difficulty") else "unstated"),
+    ]
+    lines = ["# Task: %s" % clean(meta.get("name") or meta["hexid"]), ""]
+    lines += ["| | |", "|---|---|"]
+    lines += ["| %s | %s |" % (k, v) for k, v in rows]
+    lines += ["", "## Target", "",
+              "Primary: `target/%s`" % primary_t, ""]
+    if others:
+        lines += ["Also shipped (same challenge, may or may not matter):", ""]
+        lines += ["- `target/%s`" % o for o in others]
+        lines += [""]
+    lines += ["Every binary is a verbatim copy of the author's, `chmod 0755` (the archive's",
+              "exec bits are unreliable). Nothing has been patched.", ""]
+    lines += ["## What to produce", "",
+              "Recover **%s**." % goal, "",
+              how, "",
+              "If you cannot, say so: `outcome: gave_up` with an honest `gave_up_reason` is a",
+              "**successful** run for this pipeline. An invented answer is not.", ""]
+    lines += ["## Budget", "",
+              "%d minutes of wall clock. Spend it on the parts that teach you something about" % minutes,
+              "the tooling; a partial solve with good friction evidence beats a rushed guess.", ""]
+    lines += ["## What you have", ""]
+    if extras:
+        lines += ["Author-supplied text, redacted (spoiler files were withheld):", ""]
+        lines += ["- `extras/%s`" % e for e in extras]
+    else:
+        lines += ["No author text survived redaction, so the binary is the entire statement."]
+    lines += ["", "## What you do not have", "",
+              "The challenge metadata, the author's solution, and any hint, serial, key or source",
+              "file are deliberately absent, and so is the dataset they came from. Do not go",
+              "looking for them; do not fetch anything from the network. If you find yourself",
+              "holding an answer you did not derive from the binary, stop and say so in the report.",
+              ""]
+    return "\n".join(lines)
+
+
+_AGENTS_MD = """# Tool protocol for this arena
+
+`bin/` is on your PATH and holds the only two tools you should reach for. Call them by bare
+name (`kuna`, `ida-decompile`) -- never by an absolute path to the real binary, because the
+bare name is the shim and the shim is what records the run.
+
+## kuna -- your primary tool
+
+`kuna --help` lists its nine subcommands: `decompile`, `decompile-all`, `decompile-project`,
+`functions`, `test`, `catalog`, `modes`, `specs`, `fid`. `kuna catalog --json` is the full
+option surface; the repo's `docs/cli.md` and `docs/options.md` document both.
+
+Facts already verified about it, so you do not spend your budget rediscovering them:
+
+- `kuna decompile <bin> <fn> --json` exits 2 with `error: unknown option --json`. Only
+  `functions`, `decompile-all` and `catalog` take `--json`.
+- `kuna functions --json` records carry `name`/`address`/`address_hex`/`aliases` and **no
+  size**; `decompile-all --json` records do carry `size`.
+- On a section-header-stripped PIE ELF, `kuna functions --json` returns
+  `{"count": 0, "functions": []}` with **exit 0 and no error message**. An empty result is not
+  proof of an empty binary.
+- There is no `xrefs`, `strings`, `disassemble`, `rename`, `retype` or server subcommand, no
+  persistence between invocations, and every invocation is a cold load.
+
+## ida-decompile -- the reference, and a last resort
+
+`ida-decompile` is the declib CLI over IDA Pro. It can do things kuna cannot, and it keeps its
+servers and databases inside this arena.
+
+**Try kuna first, every time.** Every `ida-decompile` call is logged and automatically drafts an
+observation against kuna, because "how often did kuna push a tester to the reference tool" is a
+headline number for this pipeline. Reaching for it is allowed and sometimes correct -- reaching
+for it *silently*, or *first*, defeats the measurement.
+
+## Everything is logged
+
+Both shims append one line per call to `notes/toolcalls.jsonl`:
+`{"t","tool","argv","cwd","exit","seconds","stdout_bytes","stderr_bytes","stdout_sha1"}`.
+kuna reports no timing of its own, so this file is the only latency evidence that exists. Two
+consequences: do not edit or truncate it, and prefer one deliberate invocation over a shell loop
+that fires forty, because each line is a datum.
+
+## The point of the exercise
+
+Solving the challenge is the vehicle. The deliverable is **every place kuna was missing, wrong,
+slow, or more expensive than it should have been**, each with a command someone else can re-run
+to see the same thing. An observation without a replayable command cannot enter the backlog.
+
+## Scope
+
+Write only inside this directory. `notes/` and `report.json` are yours; `target/` and `extras/`
+are inputs -- copy a binary before you patch it. Do not read outside the arena and do not use
+the network.
+"""
+
+
+# --- build ------------------------------------------------------------------
+
+def build(hexid: str, round_n: int = 0, out=None, force: bool = False) -> Path:
+    """Create the arena for one challenge and return its path.
+
+    Rebuilding is destructive, so an arena that already holds a tester's WORK is refused
+    unless ``force``. A re-entered T_WORKSPACE tick (a captain crash and resume is the normal
+    way that happens) would otherwise delete a live tester's report.json and its
+    toolcalls.jsonl -- the only record of what that agent actually did -- and the round would
+    look merely empty rather than damaged.
+    """
+    cdir = challenge_dir(hexid)
+    if not cdir.is_dir():
+        raise FileNotFoundError("no such challenge: %s" % cdir)
+    meta = load_meta(hexid)
+
+    dest = Path(out) if out else arena_path(hexid, round_n)
+    dest = dest.resolve()
+    if not force and dest.exists():
+        evidence = [q for q in ("report.json", "notes/toolcalls.jsonl")
+                    if (dest / q).exists() and (dest / q).stat().st_size > 0]
+        if evidence:
+            raise FileExistsError(
+                "%s already holds tester evidence (%s); refusing to rebuild over it. "
+                "Pass force=True / --force only if you mean to discard that run."
+                % (dest, ", ".join(evidence)))
+    staging = dest.parent / (dest.name + ".building.%d" % os.getpid())
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
+
+    prim_rel = primary_rel(meta)
+    if not prim_rel:
+        raise ValueError("%s: meta.json has no detected.primary.path" % hexid)
+    bins = [b.get("path") for b in (meta.get("files") or {}).get("binaries") or []]
+    ordered = [prim_rel] + [b for b in bins if b and b != prim_rel]
+
+    copied_bins = []
+    for rel in ordered:
+        src = cdir / rel
+        if not src.is_file():
+            raise FileNotFoundError("%s: listed binary is missing: %s" % (hexid, rel))
+        trel = _target_rel(rel)
+        _copy_exec(src, staging / "target" / trel)
+        copied_bins.append({"dataset_rel": rel, "arena_rel": "target/" + trel,
+                            "size": src.stat().st_size})
+
+    decisions = []
+    kept_extras = []
+    for rel in (meta.get("files") or {}).get("extras") or []:
+        src = cdir / rel
+        if not src.is_file():
+            decisions.append({"path": rel, "decision": "drop", "reason": "missing", "reasons": []})
+            continue
+        with open(src, "rb") as fh:
+            data = fh.read()
+        d = redact.explain(rel, data, meta)
+        decisions.append({"path": rel, "decision": d["decision"], "reason": d["reason"],
+                          "reasons": d["reasons"]})
+        if d["decision"] == "copy":
+            erel = _extras_rel(rel)
+            dst = staging / "extras" / erel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            with open(dst, "wb") as fh:
+                fh.write(data)
+            os.chmod(dst, 0o644)
+            kept_extras.append(erel)
+
+    _write(staging / "bin" / "_shimlog.py", _SHIMLOG_PY, 0o644)
+    _write(staging / "bin" / "kuna", _shim_kuna(str(config.kuna_bin())), SHIM_MODE)
+    _write(staging / "bin" / "ida-decompile", _shim_ida(str(config.decompiler_cli())), SHIM_MODE)
+
+    (staging / "notes").mkdir(exist_ok=True)
+    _write(staging / "notes" / "toolcalls.jsonl", "")
+
+    primary_t = _target_rel(prim_rel)
+    others = [c["arena_rel"][len("target/"):] for c in copied_bins[1:]]
+    _write(staging / "TASK.md", _task_md(meta, primary_t, others, kept_extras))
+    _write(staging / "AGENTS.md", _AGENTS_MD)
+
+    record = {
+        "schema": "repipe/arena/1",
+        "hexid": hexid,
+        "round": round_n,
+        "built_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "primary": "target/" + primary_t,
+        "binaries": copied_bins,
+        "flag_in_path": flag_in_path(meta),
+        "extras_kept": ["extras/" + e for e in kept_extras],
+        "extras_dropped": [d for d in decisions if d["decision"] == "drop"],
+        "tools": {"kuna": str(config.kuna_bin()), "ida": str(config.decompiler_cli())},
+    }
+    _write(staging / ".repipe" / "build.json", json.dumps(record, indent=2) + "\n")
+
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(staging, dest)
+    return dest
+
+
+# --- sanity check -----------------------------------------------------------
+
+def _walk_files(root: Path):
+    for dp, dirs, files in os.walk(root):
+        dirs.sort()
+        for f in sorted(files):
+            yield Path(dp) / f
+
+
+def flag_in_path(meta) -> bool:
+    """True when the challenge's own filenames give the answer away.
+
+    Exactly one challenge does this today: 6442366033c5d43938912a85 ships `bin/Cube.exe` and its
+    flag is `Cube`. That spoiler is inherent to the dataset -- renaming the binary would change
+    the task -- so the arena cannot fix it, and `sanity_check` must not report it as if the build
+    had introduced it. It is recorded in `.repipe/build.json` instead, so grading can discount
+    the challenge.
+    """
+    if not meta:
+        return False
+    flag = ((meta.get("ground_truth") or {}).get("flag") or "").lower()
+    if len(flag) < redact.MIN_FLAG_LEN:
+        return False
+    paths = [b.get("path") or "" for b in (meta.get("files") or {}).get("binaries") or []]
+    paths.append(primary_rel(meta))
+    return any(flag in p.lower() for p in paths)
+
+
+def sanity_check(arena, meta=None) -> list:
+    """Every way this arena could be wrong, as strings. Empty list = safe to dispatch.
+
+    `target/` and `.declib/` are exempt from the leak scan on purpose: for many challenges the
+    flag *is* in the binary, and the binary is the task. Tester-written paths (`notes/`,
+    `report.json`) are scanned only for the answer-independent tags, because a solved run
+    legitimately writes the flag there. Everything the build itself produced is fully scanned.
+    """
+    arena = Path(arena)
+    bad = []
+    if not arena.is_dir():
+        return ["arena does not exist: %s" % arena]
+
+    record = None
+    rp = arena / ".repipe" / "build.json"
+    if rp.is_file():
+        try:
+            with open(rp) as fh:
+                record = json.load(fh)
+        except (OSError, ValueError) as exc:
+            bad.append("unreadable .repipe/build.json: %s" % exc)
+    if meta is None and record and record.get("hexid"):
+        try:
+            meta = load_meta(record["hexid"])
+        except (OSError, ValueError) as exc:
+            bad.append("cannot load meta for %s: %s" % (record["hexid"], exc))
+
+    for rel in ("TASK.md", "AGENTS.md", "bin/kuna", "bin/ida-decompile", "bin/_shimlog.py"):
+        if not (arena / rel).is_file():
+            bad.append("missing: %s" % rel)
+    for rel in ("target", "notes"):
+        if not (arena / rel).is_dir():
+            bad.append("missing directory: %s" % rel)
+    for rel in ("bin/kuna", "bin/ida-decompile"):
+        p = arena / rel
+        if p.is_file() and not (p.stat().st_mode & stat.S_IXUSR):
+            bad.append("shim not executable: %s" % rel)
+
+    target = arena / "target"
+    if target.is_dir():
+        n = 0
+        for p in _walk_files(target):
+            n += 1
+            mode = stat.S_IMODE(p.stat().st_mode)
+            if mode != BIN_MODE:
+                bad.append("target file not mode 0755 (is 0%o): %s"
+                           % (mode, p.relative_to(arena)))
+        if n == 0:
+            bad.append("target/ is empty")
+    if meta:
+        want = "target/" + _target_rel(primary_rel(meta))
+        if not (arena / want).is_file():
+            bad.append("primary missing from arena: %s" % want)
+
+    for dp, dirs, files in os.walk(arena):
+        for d in list(dirs):
+            if d in FORBIDDEN_DIRS:
+                bad.append("forbidden directory present: %s"
+                           % (Path(dp, d).relative_to(arena)))
+        for f in files:
+            if f in FORBIDDEN_NAMES:
+                bad.append("forbidden file present: %s" % (Path(dp, f).relative_to(arena)))
+
+    extras = arena / "extras"
+    if extras.is_dir():
+        for p in _walk_files(extras):
+            with open(p, "rb") as fh:
+                data = fh.read(MAX_SCAN_BYTES)
+            decision, reason = redact.classify(p, data, meta)
+            if decision != "copy":
+                bad.append("extras file should have been dropped (%s): %s"
+                           % (reason, p.relative_to(arena)))
+
+    inherent = flag_in_path(meta)
+    for p in _walk_files(arena):
+        rel = p.relative_to(arena)
+        if not rel.parts or rel.parts[0] in DERIVED_DIRS:
+            continue
+        if p.is_symlink() or not p.is_file():
+            continue
+        if p.stat().st_size > MAX_SCAN_BYTES:
+            continue
+        with open(p, "rb") as fh:
+            hits = redact.scan_for_leak(fh.read(), meta)
+        if rel.parts[0] in TESTER_PATHS or inherent:
+            hits = [h for h in hits if h != "literal-flag"]
+        if hits:
+            bad.append("spoiler leak in %s: %s" % (rel, ", ".join(hits)))
+
+    return bad
+
+
+# --- CLI --------------------------------------------------------------------
+
+def _emit(payload, as_json, lines):
+    if as_json:
+        print(json.dumps(payload, indent=2))
+    else:
+        for line in lines:
+            print(line)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(prog="python -m scripts.repipe.workspace",
+                                 description="Build and audit tester arenas.")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    b = sub.add_parser("build", help="create an arena for one challenge")
+    b.add_argument("hexid")
+    b.add_argument("--round", type=int, default=0, dest="round_n")
+    b.add_argument("--out")
+    b.add_argument("--force", action="store_true",
+                   help="rebuild even over an arena that already holds tester evidence")
+    b.add_argument("--json", action="store_true")
+
+    c = sub.add_parser("check", help="audit an existing arena")
+    c.add_argument("arena")
+    c.add_argument("--hexid")
+    c.add_argument("--json", action="store_true")
+
+    args = ap.parse_args(argv)
+
+    if args.cmd == "build":
+        try:
+            arena = build(args.hexid, args.round_n, args.out, force=args.force)
+        except (FileNotFoundError, ValueError, FileExistsError) as exc:
+            print("error: %s" % exc, file=sys.stderr)
+            return 1
+        meta = load_meta(args.hexid)
+        bad = sanity_check(arena, meta)
+        with open(arena / ".repipe" / "build.json") as fh:
+            record = json.load(fh)
+        record["arena"] = str(arena)
+        record["violations"] = bad
+        lines = ["arena: %s" % arena,
+                 "primary: %s" % record["primary"],
+                 "binaries: %d  extras kept: %d  extras dropped: %d"
+                 % (len(record["binaries"]), len(record["extras_kept"]),
+                    len(record["extras_dropped"]))]
+        lines += ["  dropped %-16s %s" % (d["reason"], d["path"])
+                  for d in record["extras_dropped"]]
+        lines += ["violations: %s" % ("none" if not bad else "")] + ["  " + v for v in bad]
+        _emit(record, args.json, lines)
+        return 3 if bad else 0
+
+    meta = load_meta(args.hexid) if args.hexid else None
+    bad = sanity_check(args.arena, meta)
+    _emit({"arena": args.arena, "ok": not bad, "violations": bad}, args.json,
+          ["ok" if not bad else "VIOLATIONS:"] + ["  " + v for v in bad])
+    return 3 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/pipeline/open_pr.sh
+++ b/tools/pipeline/open_pr.sh
@@ -3,6 +3,7 @@
 #
 #   tools/pipeline/open_pr.sh [--draft] <branch> <title> <body-file> [<record.json>]
 #   tools/pipeline/open_pr.sh --undraft <branch>
+#   tools/pipeline/open_pr.sh --merge <branch>          # the autonomous lane
 #
 # Pushes <branch> over SSH (always works here), then tries `gh pr create`. If gh cannot
 # create the PR (e.g. the gh token lacks access to the org repo, while the SSH key can
@@ -13,6 +14,12 @@
 #           no before/after demo is embedded (nothing is implemented yet).
 # --undraft marks the existing PR for <branch> ready-for-review (best-effort; non-fatal if
 #           it can't, the reviewer can click "Ready for review").
+# --merge   labels the PR `full-ci`, waits for every check to complete, and squash-merges
+#           it. This is the RE-friction loop's autonomous lane (docs/re-pipeline.md); the
+#           angr lane never passes it. The `full-ci` label matters: on a PR from a branch
+#           in this repo CI SKIPS the workspace suite, and the label is itself a trigger,
+#           so without it "checks green" would mean "the cheap gates passed". Exits
+#           non-zero if any check concludes anything but success/neutral/skipped.
 #
 # If <record.json> is given (non-draft), a REAL captured before/after demonstration (kuna
 # with the feature off vs on, on the function the feature was built for, plus the reference
@@ -21,10 +28,12 @@ set -uo pipefail
 
 DRAFT=0
 UNDRAFT=0
+MERGE=0
 while [ "${1:-}" != "${1#--}" ] && [ -n "${1:-}" ]; do
   case "$1" in
     --draft) DRAFT=1; shift;;
     --undraft) UNDRAFT=1; shift;;
+    --merge) MERGE=1; shift;;
     *) echo "unknown flag: $1" 1>&2; exit 2;;
   esac
 done
@@ -34,6 +43,117 @@ BASE="${BASE_BRANCH:-main}"
 KUNA_PY="${KUNA_PY:-$HOME/.virtualenvs/kuna/bin/python}"
 # scripts.pipeline.* must be importable without an install: repo root on the path.
 export PYTHONPATH="$(git rev-parse --show-toplevel 2>/dev/null || echo .)${PYTHONPATH:+:$PYTHONPATH}"
+
+# --merge: label, wait for CI, squash-merge. Everything is REST for the same reason the
+# create path is (gh's GraphQL PR commands fail on this repo since the classic-Projects
+# sunset), and every step is re-runnable: a --merge that dies after the merge landed will
+# see `.merged == true` on its next run and exit 0 rather than trying again.
+if [ "$MERGE" = 1 ]; then
+  BRANCH="${1:?need branch}"
+  OWNER="${REPO_SLUG%%/*}"
+  CI_TIMEOUT="${MERGE_CI_TIMEOUT:-5400}"
+  POLL="${MERGE_CI_POLL:-60}"
+
+  NUM="$(gh api "repos/$REPO_SLUG/pulls?head=$OWNER:$BRANCH&state=open" -q '.[0].number' 2>/dev/null)"
+  if [ -z "$NUM" ] || [ "$NUM" = "null" ]; then
+    MERGED="$(gh api "repos/$REPO_SLUG/pulls?head=$OWNER:$BRANCH&state=closed" -q '.[0].merged_at' 2>/dev/null)"
+    if [ -n "$MERGED" ] && [ "$MERGED" != "null" ]; then
+      echo "PR for $BRANCH already merged at $MERGED" 1>&2; exit 0
+    fi
+    echo "ERROR: no open PR for $BRANCH to merge" 1>&2; exit 1
+  fi
+
+  if [ "$(gh api "repos/$REPO_SLUG/pulls/$NUM" -q .merged 2>/dev/null)" = "true" ]; then
+    echo "PR #$NUM already merged" 1>&2; exit 0
+  fi
+  # Fail CLOSED: anything but a definite "false" -- including an API error returning
+  # empty -- is treated as a draft. A [PROPOSAL] must never be auto-merged because a
+  # query failed.
+  DRAFT_STATE="$(gh api "repos/$REPO_SLUG/pulls/$NUM" -q .draft 2>/dev/null)"
+  if [ "$DRAFT_STATE" != "false" ]; then
+    echo "ERROR: PR #$NUM is a draft or its draft state is unknown ('$DRAFT_STATE'); not merging" 1>&2; exit 1
+  fi
+
+  # The label is a CI TRIGGER, not a hint: without it an internal-branch PR skips the
+  # workspace suite entirely, so "all checks green" would mean "the cheap gates passed".
+  # Failing to apply it is therefore fatal, not ignored.
+  if ! gh api -X POST "repos/$REPO_SLUG/issues/$NUM/labels" -f 'labels[]=full-ci' >/dev/null 2>&1; then
+    if ! gh api "repos/$REPO_SLUG/issues/$NUM/labels" -q '.[].name' 2>/dev/null | grep -qx 'full-ci'; then
+      echo "ERROR: could not apply the full-ci label; refusing to merge on the cheap gates alone" 1>&2
+      exit 1
+    fi
+  fi
+  echo "full-ci label present (forces the workspace suite on an internal-branch PR)" 1>&2
+
+  SHA="$(gh api "repos/$REPO_SLUG/pulls/$NUM" -q .head.sha)"
+
+  # The suite the label triggers takes time to REGISTER. Polling immediately would find
+  # only the already-finished cheap gates, conclude "all green", and squash-merge code
+  # the workspace suite never ran on. Wait for it to appear by name first.
+  WS_NAME="${MERGE_REQUIRED_CHECK:-cargo workspace suite}"; export WS_NAME
+  echo "waiting for '$WS_NAME' to register" 1>&2
+  REG_DEADLINE=$(( $(date +%s) + ${MERGE_REGISTER_TIMEOUT:-900} ))
+  until gh api "repos/$REPO_SLUG/commits/$SHA/check-runs?per_page=100" \
+          --jq "[.check_runs[] | select(.name == \"$WS_NAME\" and .status != \"completed\")] | length" \
+        2>/dev/null | grep -qv '^0$'; do
+    if [ "$(date +%s)" -ge "$REG_DEADLINE" ]; then
+      echo "ERROR: '$WS_NAME' never registered; refusing to merge without it" 1>&2
+      exit 1
+    fi
+    sleep 20
+  done
+  echo "'$WS_NAME' registered" 1>&2
+
+  echo "waiting for checks on $SHA (up to ${CI_TIMEOUT}s)" 1>&2
+  DEADLINE=$(( $(date +%s) + CI_TIMEOUT ))
+  while :; do
+    # Only the LATEST run per check NAME counts. Adding the full-ci label re-triggers the
+    # workflow, which cancels the in-flight one, so the commit carries both a `cancelled`
+    # parity-gates and a fresh `in_progress` one under the same name -- and the pre-label
+    # `cargo workspace suite` sits there as `skipped`. Evaluating every row would read a
+    # supersede as a failure (or a skip as a pass); grouping by name and keeping the newest
+    # start time reads only what is actually running now.
+    RUNS="$(gh api "repos/$REPO_SLUG/commits/$SHA/check-runs?per_page=100" \
+              --jq '{check_runs: ([.check_runs[]] | group_by(.name) | map(max_by(.started_at)))}' \
+            2>/dev/null)"
+    TOTAL="$(printf '%s' "$RUNS" | "$KUNA_PY" -c 'import json,sys; d=json.load(sys.stdin); print(len(d.get("check_runs",[])))' 2>/dev/null)"
+    PENDING="$(printf '%s' "$RUNS" | "$KUNA_PY" -c 'import json,sys; d=json.load(sys.stdin); print(sum(1 for r in d.get("check_runs",[]) if r.get("status")!="completed"))' 2>/dev/null)"
+    BAD="$(printf '%s' "$RUNS" | "$KUNA_PY" -c 'import json,sys; d=json.load(sys.stdin); print(",".join(r["name"]+":"+str(r.get("conclusion")) for r in d.get("check_runs",[]) if r.get("status")=="completed" and r.get("conclusion") not in ("success","neutral","skipped")))' 2>/dev/null)"
+    if [ -n "$BAD" ]; then
+      echo "ERROR: checks failed: $BAD" 1>&2; exit 1
+    fi
+    if [ -n "$TOTAL" ] && [ "$TOTAL" != "0" ] && [ "$PENDING" = "0" ]; then
+      # The required suite must have actually RUN. `skipped` is a legal conclusion that
+      # would otherwise read as green -- and it is exactly what an unlabelled internal-branch
+      # PR produces, i.e. the case the label exists to prevent.
+      WS_CONC="$(printf '%s' "$RUNS" | "$KUNA_PY" -c 'import json,sys,os; d=json.load(sys.stdin); n=os.environ["WS_NAME"]; print(next((r.get("conclusion") for r in d.get("check_runs",[]) if r.get("name")==n), "missing"))' 2>/dev/null)"
+      if [ "$WS_CONC" = "skipped" ] || [ "$WS_CONC" = "missing" ]; then
+        echo "ERROR: '$WS_NAME' concluded '$WS_CONC' -- it did not actually run; not merging" 1>&2
+        exit 1
+      fi
+      echo "all $TOTAL checks green ('$WS_NAME': $WS_CONC)" 1>&2; break
+    fi
+    if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+      echo "ERROR: CI still pending after ${CI_TIMEOUT}s ($PENDING of $TOTAL outstanding)" 1>&2; exit 1
+    fi
+    sleep "$POLL"
+  done
+
+  # match-head-commit equivalent: refuse if the head moved while we were waiting
+  NOW_SHA="$(gh api "repos/$REPO_SLUG/pulls/$NUM" -q .head.sha)"
+  if [ "$NOW_SHA" != "$SHA" ]; then
+    echo "ERROR: head moved $SHA -> $NOW_SHA while CI ran; re-run --merge" 1>&2; exit 1
+  fi
+
+  if gh api -X PUT "repos/$REPO_SLUG/pulls/$NUM/merge" -f merge_method=squash >/dev/null 2>/tmp/_ghmerge.err; then
+    URL="https://github.com/$REPO_SLUG/pull/$NUM"
+    echo "merged PR #$NUM" 1>&2
+    echo "$URL"
+    exit 0
+  fi
+  echo "ERROR: squash-merge failed: $(head -3 /tmp/_ghmerge.err 2>/dev/null)" 1>&2
+  exit 1
+fi
 
 # --undraft: flip the existing draft PR for <branch> to ready-for-review and stop.
 if [ "$UNDRAFT" = 1 ]; then

--- a/tools/pipeline/run.sh
+++ b/tools/pipeline/run.sh
@@ -18,15 +18,27 @@ POLL="${PIPELINE_POLL:-15}"            # seconds between scheduler ticks
 ONCE=0
 [ "${1:-}" = "--once" ] && ONCE=1
 
+# Seams so a second pipeline reuses this driver without a fork (docs/re-pipeline.md).
+# Every one defaults to the angr fleet's behaviour, so an unset environment is unchanged.
+STATE_DIRNAME="${PIPELINE_STATE_DIRNAME:-.kuna-pipeline}"
+SELECT_MOD="${PIPELINE_SELECT_MOD:-scripts.pipeline.select}"
+WORKER_SCRIPT="${PIPELINE_WORKER_SCRIPT:-tools/pipeline/worker.sh}"
+WID_PREFIX="${PIPELINE_WID_PREFIX:-w}"
+WORKTREE_MATCH="${PIPELINE_WORKTREE_MATCH:-/$STATE_DIRNAME/worktrees/}"
+BRANCH_MATCH="${PIPELINE_BRANCH_MATCH:-feat/angr-}"
+MIN_FREE_GB="${PIPELINE_MIN_FREE_GB:-0}"
+
 export KUNA_REPO="$REPO" KUNA_PY="$KUNA_PY"
 # Run scripts.pipeline.* without an install: repo root on the import path.
 export PYTHONPATH="$REPO${PYTHONPATH:+:$PYTHONPATH}"
-STATE_DIR="$REPO/.kuna-pipeline"
+STATE_DIR="$REPO/$STATE_DIRNAME"
 STOP_FILE="$STATE_DIR/STOP"
 # logs/ must exist BEFORE spawn_worker, whose `>>"$STATE_DIR/logs/..."` redirect is set up by
 # THIS shell -- worker.sh's own mkdir runs in the child, too late. Without this the very first
 # spawn into a fresh state dir fails.
 mkdir -p "$STATE_DIR/logs" "$STATE_DIR/worktrees"
+export KUNA_PIPELINE_STATE_DIR="$STATE_DIR"
+export KUNA_PIPELINE_WORKTREE_MATCH="$WORKTREE_MATCH" KUNA_PIPELINE_BRANCH_MATCH="$BRANCH_MATCH"
 rm -f "$STOP_FILE"
 
 START=$(date +%s)
@@ -62,16 +74,30 @@ gc_merged_worktrees() {
       git -C "$REPO" worktree remove --force "$wt" 2>/dev/null
       git -C "$REPO" branch -D "$branch" 2>/dev/null
     fi
-  done < <(git -C "$REPO" worktree list --porcelain | awk '/^worktree /{print $2}' | grep "/.kuna-pipeline/worktrees/")
+  done < <(git -C "$REPO" worktree list --porcelain | awk '/^worktree /{print $2}' | grep -- "$WORKTREE_MATCH")
   git -C "$REPO" worktree prune 2>/dev/null
+}
+
+# A cargo worktree costs 20-30 GB on the default debug profile and has filled this machine
+# mid-run. Refuse to open another one when the filesystem is already tight.
+disk_ok() {
+  [ "$MIN_FREE_GB" = "0" ] && return 0
+  local free_gb
+  free_gb=$(df -BG --output=avail "$REPO" | tail -1 | tr -dc '0-9')
+  if [ -n "$free_gb" ] && [ "$free_gb" -lt "$MIN_FREE_GB" ]; then
+    log "disk brake: ${free_gb}G free < ${MIN_FREE_GB}G required; not spawning"
+    return 1
+  fi
+  return 0
 }
 
 spawn_worker() {
   local opp
-  opp="$("$KUNA_PY" -m scripts.pipeline.select --shell 2>/dev/null)" || return 1
+  disk_ok || return 1
+  opp="$("$KUNA_PY" -m "$SELECT_MOD" --shell 2>/dev/null)" || return 1
   eval "$opp"   # sets OPP_ID TEST_NAME BINARY SELECTOR ARCH SLUG SCORE KINDS
   SEQ=$((SEQ+1))
-  local wid; wid="w$(date +%s)-$SEQ"
+  local wid; wid="${WID_PREFIX}$(date +%s)-$SEQ"
   # claim atomically; if already taken (race), skip this tick
   if ! "$KUNA_PY" -m scripts.pipeline.state claim --worker "$wid" --opportunity "$OPP_ID" >/dev/null 2>&1; then
     log "opportunity $OPP_ID already claimed; skipping"
@@ -80,7 +106,7 @@ spawn_worker() {
   log "spawning $wid for [$SCORE] $OPP_ID (slug $SLUG, kinds $KINDS)"
   WORKER_ID="$wid" OPP_ID="$OPP_ID" TEST_NAME="$TEST_NAME" SELECTOR="$SELECTOR" \
     BINARY="$BINARY" SLUG="$SLUG" ARCH="$ARCH" \
-    bash "$REPO/tools/pipeline/worker.sh" >>"$STATE_DIR/logs/driver-$wid.log" 2>&1 &
+    bash "$REPO/$WORKER_SCRIPT" >>"$STATE_DIR/logs/driver-$wid.log" 2>&1 &
   WPID["$wid"]=$!
   return 0
 }

--- a/tools/pipeline/worker.sh
+++ b/tools/pipeline/worker.sh
@@ -17,6 +17,15 @@ MODEL="${WORKER_MODEL:-opus}"
 WORKER_TIMEOUT="${WORKER_TIMEOUT:-7200}"   # seconds; hard cap per feature
 BASE_BRANCH="${BASE_BRANCH:-main}"
 
+# Seams so a second pipeline reuses this driver without a fork (docs/re-pipeline.md).
+# Unset == the angr fleet's behaviour, byte for byte.
+PROMPT_TMPL="${WORKER_PROMPT:-$REPO/tools/pipeline/worker_prompt.md}"
+BRANCH_PREFIX="${WORKER_BRANCH_PREFIX:-feat/angr-}"
+STATE_DIRNAME="${PIPELINE_STATE_DIRNAME:-.kuna-pipeline}"
+WORKER_BUDGET_USD="${WORKER_BUDGET_USD:-}"      # empty = no --max-budget-usd flag
+WORKER_SESSION_ID="${WORKER_SESSION_ID:-}"      # empty = let claude allocate one
+WORKER_EXTRA_PROMPT="${WORKER_EXTRA_PROMPT:-}"  # file spliced in at {{SIBLINGS}}
+
 : "${WORKER_ID:?need WORKER_ID}"
 : "${OPP_ID:?need OPP_ID}"
 : "${TEST_NAME:?need TEST_NAME}"
@@ -32,7 +41,7 @@ export PYTHONPATH="$REPO${PYTHONPATH:+:$PYTHONPATH}"
 # Keep ALL pipeline state in the MAIN tree so `scripts.pipeline.status` (run from the main
 # tree) sees this worker's heartbeats. Without this, the worktree's KUNA_ROOT would route
 # state into the worktree's own .kuna-pipeline and the main-tree status would go stale.
-export KUNA_PIPELINE_STATE_DIR="$REPO/.kuna-pipeline"
+export KUNA_PIPELINE_STATE_DIR="${KUNA_PIPELINE_STATE_DIR:-$REPO/$STATE_DIRNAME}"
 
 # Normal mode opens a fresh branch off main. Implementation mode (IMPL_PROPOSAL=1) resumes
 # an APPROVED proposal's existing branch (RESUME_BRANCH) instead of branching fresh.
@@ -41,12 +50,11 @@ RESUME_BRANCH="${RESUME_BRANCH:-}"
 if [ "$IMPL_PROPOSAL" = 1 ] && [ -n "$RESUME_BRANCH" ]; then
   BRANCH="$RESUME_BRANCH"
 else
-  BRANCH="feat/angr-${SLUG}"
+  BRANCH="${BRANCH_PREFIX}${SLUG}"
 fi
-WT_ROOT="$REPO/.kuna-pipeline/worktrees"
+WT_ROOT="$REPO/$STATE_DIRNAME/worktrees"
 WT="$WT_ROOT/$WORKER_ID"
-LOG_DIR="$REPO/.kuna-pipeline/logs"
-PROMPT_TMPL="$REPO/tools/pipeline/worker_prompt.md"
+LOG_DIR="$REPO/$STATE_DIRNAME/logs"
 DATE="$(date +%Y-%m-%d)"
 
 mkdir -p "$WT_ROOT" "$LOG_DIR"
@@ -146,11 +154,24 @@ sed \
   -e "s|{{RESUME_PROPOSAL}}|$RESUME_PROPOSAL_LINE|g" \
   "$PROMPT_TMPL" > "$PROMPT_FILE"
 
+# {{SIBLINGS}} is a whole FILE, not a line, so it is spliced after the sed pass: the captain
+# writes what the other in-flight builders are doing so they stay off each other's files.
+if [ -n "$WORKER_EXTRA_PROMPT" ] && [ -f "$WORKER_EXTRA_PROMPT" ]; then
+  "$KUNA_PY" -c 'import sys; t,e=sys.argv[1],sys.argv[2]; b=open(t).read(); open(t,"w").write(b.replace("{{SIBLINGS}}", open(e).read()))' "$PROMPT_FILE" "$WORKER_EXTRA_PROMPT"
+else
+  sed -i 's|{{SIBLINGS}}||g' "$PROMPT_FILE"
+fi
+
 # --- 5. headless Claude session (highest-effort model), in the worktree -----
 log "launching claude -p (model $MODEL, timeout ${WORKER_TIMEOUT}s)"
 "$KUNA_PY" -m scripts.pipeline.state update --worker "$WORKER_ID" --phase analyze >>"$LOG" 2>&1
 
 RESULT_JSON="$LOG_DIR/$WORKER_ID.result.json"
+CLAUDE_EXTRA=()
+# A caller-supplied session id makes the transcript path deterministic BEFORE the run, which
+# is what lets a harness tail a live builder. codex has no equivalent.
+[ -n "$WORKER_SESSION_ID" ] && CLAUDE_EXTRA+=(--session-id "$WORKER_SESSION_ID")
+[ -n "$WORKER_BUDGET_USD" ] && CLAUDE_EXTRA+=(--max-budget-usd "$WORKER_BUDGET_USD")
 # env -u ANTHROPIC_API_KEY: a stale/invalid ANTHROPIC_API_KEY in the environment makes
 # headless `claude -p` fail with "Invalid API key"; unsetting it falls back to the working
 # session auth. </dev/null so claude does not wait on stdin.
@@ -158,6 +179,7 @@ RESULT_JSON="$LOG_DIR/$WORKER_ID.result.json"
     --model "$MODEL" \
     --output-format json \
     --dangerously-skip-permissions \
+    "${CLAUDE_EXTRA[@]+"${CLAUDE_EXTRA[@]}"}" \
     < /dev/null > "$RESULT_JSON" 2>>"$LOG" )
 RC=$?
 

--- a/tools/pipeline/worker_prompt.md
+++ b/tools/pipeline/worker_prompt.md
@@ -163,7 +163,7 @@ where `<PHASE>` ∈ analyze, design, code, build, test, docs, commit, pr. If you
 
 ### 8. commit + PR
 - `git add -A && git commit` with a descriptive subject `{{SLUG}}: <one line>` and the trailer
-  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+  `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>`.
 - Write the PR body to `docs/features/{{SLUG}}/pr_body.md`: a short summary, a link to
   `docs/features/{{SLUG}}/analysis.md`, the mechanism, the option name + how to flip it, and the
   ablation/parity result, ending with `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.

--- a/tools/repipe/builder_prompt.md
+++ b/tools/repipe/builder_prompt.md
@@ -1,0 +1,197 @@
+# kuna RE-friction builder — close ONE need, open ONE PR, merge it
+
+You are an autonomous, highest-effort Claude Code worker in an isolated git worktree on
+branch `{{BRANCH}}`. Your entire job this session is to close **one** recorded way that kuna
+is bad for reverse engineering, verify it, and land it. Then stop.
+
+- Worker id: `{{WORKER_ID}}`
+- Need: `{{OPPORTUNITY_ID}}` → `docs/re-needs/{{SLUG}}.md` — **read it first, in full.**
+- Worktree: `{{WORKTREE}}` · kuna python: `{{KUNA_PY}}` · date: `{{DATE}}`
+
+{{RESUME_PROPOSAL}}
+
+## Definition of done — this is unusually precise, so use it
+
+The need carries two executable probes:
+
+- its **probe** asserts the current bad behaviour and **passes** today;
+- its **acceptance** asserts the desired behaviour and **fails** today.
+
+**You are done when the acceptance probe passes.** Not when the code looks right, not when
+you have written a test — when
+
+```
+{{KUNA_PY}} -m scripts.repipe.verify --need {{SLUG}} --json
+```
+
+reports the acceptance as PASS on a freshly built tree. Run it. If it does not pass, you are
+not done, whatever else is green.
+
+The acceptance probe is then **promoted verbatim into `tests/cli/{{SLUG}}.json`** as a
+permanent regression test, so the thing you fixed cannot silently come back. Do that as part
+of your PR (`{{KUNA_PY}}` -m scripts.repipe.verify --promote {{SLUG}}`). If it refuses because
+the probe's target is not vendorable, vendor a minimal fixture binary into the repo and point
+the probe at it — CI has no dataset.
+
+## Which track you are on
+
+Read the need's `track:` field. **This decides your whole protocol, and getting it wrong is
+the most likely way to waste this session.**
+
+### Track `tooling` — the common case
+
+The need is a missing or broken *capability*: a subcommand that does not exist, JSON that is
+not emitted, an error that is silently swallowed, a flag that is missing. It lives in
+`decompiler/crates/kuna-cli/`, `kuna-console/` or `kuna-analysis/`.
+
+**It does NOT change emitted C, so it does NOT need a `phases.toml` option row.** The rule in
+`docs/agents.md` is "anything that *can change emitted C* ships behind a named option" — a new
+subcommand cannot. Do not add an option. Do not touch `phases.toml`, `options.rs`,
+`docs/options.md`, `docs/history.md`, or any catalog counter. If you find yourself editing
+`kuna_phases/tests.rs`, stop: you are on the wrong track or doing something the need did not
+ask for.
+
+Likewise **do not add a `tests/stages/` testcase.** `tests/stages/README.md` scopes that
+corpus to stage-model issues and says a case fixable only by patching behaviour "is a
+negative result for the stage model and belongs in the writeup, not here." Your test is a
+cargo test in the owning crate, plus the promoted acceptance probe.
+
+What you produce: the code, cargo tests in the owning crate, `tests/cli/{{SLUG}}.json`, a
+`docs/cli.md` update if you changed the CLI surface, and prose in the owning `docs/spec/`
+chapter if you changed described behaviour.
+
+### Track `quality` — the full ritual
+
+The need is that kuna's *decompiled C* is wrong or bad for a specific function. This is the
+existing improvement pipeline's territory and its rules apply **verbatim**. Read
+`tools/pipeline/worker_prompt.md` §§3–8 and `docs/improvement-pipeline.md` §3–4 and follow
+them exactly: one `kuna_<slug>.rs` in the owning phase folder, a fully-populated
+`[[settable]]` row, registration in `options.rs`, an Architecture flag defaulted off, **all
+four hard-coded catalog counters**, a two-pass `tests/stages/gh dec-<slug>.xml`, the stages
+baseline re-record, `docs/options.md` regeneration, the owning `docs/spec/` chapter, the
+ablation, and `scripts.pipeline.timeit`.
+
+Two standing requirements bite hardest here and are not optional:
+- **Sweep every changed function, not just the witness.** Any pass that moves, deletes or
+  re-anchors statements needs a whole-corpus `decompile-all` before/after pair with each hunk
+  classified. A design that is right on its witness and wrong three functions later is the
+  normal failure mode. `paramcopyhoist` shipped a mechanism that fired, passed its witness,
+  and silently deleted a live assignment.
+- **Refute against wrongness, not just against no-op.** If you brief a subagent to check your
+  mechanism, "it does reach the output" is half the brief. It must also answer **would this
+  produce WRONG output?** — by building the change and reading the diff, not by arguing.
+
+### Track `perf`
+
+Timing only. Measure with `scripts.pipeline.timeit`'s method (warmup + median over repeats),
+and hold yourself to **3σ and ≥20%**, not to 5%: `docs/features/returncopysplit/record.json`
+measured a −20.23% and −12.18% "noise floor" on byte-identical output, so a single-target
+timing win under 20% is indistinguishable from noise.
+
+## The need's hypothesis is not binding on you
+
+`## Hypothesis` in the need record is the tester's guess. In the sibling campaign, refuters
+overturned the filed diagnosis on **3 of 8** cases while the symptom stood in all 8.
+Reproduce the probe yourself, find the real cause, and if it differs from the hypothesis say
+so in your `record.json` under `decisions`. The symptom is evidence; the diagnosis is a
+hypothesis.
+
+## Before you write any code
+
+Check the need is not already covered: sweep `kuna catalog --json` for an option whose
+`use_when`/`symptoms` match and re-run the probe with it on. If an existing option closes it,
+that is a **default-flip candidate, not a new feature** — record it, set
+`{{KUNA_PY}} -m scripts.pipeline.state update --worker {{WORKER_ID}} --status failed --note
+"covered by <option>"`, and stop without a PR.
+
+## Heartbeat
+
+At the start of each phase run
+`{{KUNA_PY}} -m scripts.pipeline.state update --worker {{WORKER_ID}} --phase <PHASE>`
+with `<PHASE>` ∈ analyze, design, code, build, test, docs, commit, pr, merge.
+On abort: `... --status failed --note "<one line why>"`.
+
+## Worktree hygiene — these have each cost real work here
+
+- **Never `git stash`.** `refs/stash` is one stack shared by every worktree and work has
+  already been lost that way. To A/B something, `cp` the file aside.
+- **Never `make specs`** in a worktree. The main tree's compiled `.sla` are already
+  symlinked into `specs/` for you, and `KUNA_SPECS`/`SLEIGHHOME` are set.
+- The debug profile is already pinned to no-debug-info and `target/debug` is cleaned on exit;
+  a worktree otherwise costs 20–30 GB and has filled this machine mid-run.
+
+{{SIBLINGS}}
+
+## Scope check — the proposal fork
+
+If closing this need needs more than one focused change — a new pass *type* or
+infrastructure, structuring work beyond a single gated early-return, >3 ported-core anchor
+files, or >1 new module — **STOP at design. Do not implement.** Write
+`docs/features/{{SLUG}}/proposal.md` (the problem, the mechanism, the multi-step plan, the
+speed and risk assessment) plus a partial `record.json` with `"scope": "large"`, commit, and:
+
+```
+tools/pipeline/open_pr.sh --draft {{BRANCH}} "[AUTOMATED] [PROPOSAL] {{SLUG}}: <one line>" docs/features/{{SLUG}}/proposal.md
+{{KUNA_PY}} -m scripts.pipeline.state proposal --worker {{WORKER_ID}} --opportunity "{{OPPORTUNITY_ID}}" --pr "<url>" --branch {{BRANCH}} --slug {{SLUG}}
+```
+
+Then stop. The captain reviews parked proposals and re-dispatches an implementation worker on
+this same branch if it approves. In IMPLEMENTATION MODE, this need is already approved —
+implement it.
+
+## Gates, then merge
+
+All of these green, on the **rebased** tree, before you merge:
+
+```
+make test            # PARITY OK 675/675 — NEVER re-pin docs/baseline.json
+make test-stages     # PARITY OK
+make rust-test       # the long pole; on an internal-branch PR CI SKIPS it, so you are the gate
+make check-spec
+decompiler/target/release/kuna catalog --check    # catalog OK
+{{KUNA_PY}} -m scripts.repipe.verify --need {{SLUG}} --json   # acceptance must be PASS
+```
+
+Then land it. Merges are **serialized** — take the lease, rebase, **re-derive every shared
+counter from a fresh capture on the rebased tree** (never arithmetic: an identical `85 → 86`
+edit on both sides merges cleanly to `86` when the answer is `87`), re-run the gates *after*
+the rebase, and only then merge:
+
+```
+{{KUNA_PY}} -m scripts.pipeline.state lease-acquire --resource merge --worker {{WORKER_ID}} --pid $$
+git fetch origin && git rebase origin/main
+{{KUNA_PY}} -m scripts.repipe.counters --fix
+{{KUNA_PY}} -m scripts.repipe.mergecheck --against origin/main     # must be clean
+# ...re-run all the gates above...
+tools/pipeline/open_pr.sh --merge {{BRANCH}}
+{{KUNA_PY}} -m scripts.pipeline.state lease-release --resource merge --worker {{WORKER_ID}}
+```
+
+`open_pr.sh --merge` adds the `full-ci` label (which is itself a CI trigger — without it an
+internal-branch PR never runs the workspace suite), waits for checks, and squash-merges over
+REST. If CI is red, do **not** retry blindly: record the first failure with
+`state update --status failed --note "<gate> red: <first failure>"` and stop. The captain
+re-queues the need, and after two failed attempts it becomes a proposal instead.
+
+## Commit and PR conventions
+
+Subject: `[AUTOMATED] <type>(<scope>): {{SLUG}} — <one line>`, where `<type>` ∈ feat|fix|docs
+and `<scope>` is the crate or phase (`cli`, `analysis`, `p9`, …). `[AUTOMATED]` is mandatory
+on anything created fully automatically — PRs, issues and commits alike. Trailers:
+
+```
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+```
+
+PR body goes in `docs/features/{{SLUG}}/pr_body.md`: what was broken (quote the need's
+symptom and its instance count), the mechanism, the acceptance probe that now passes, and the
+gate results with real numbers. End with
+`🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+
+## Negative result
+
+If you cannot reach a green, shippable change — the need turns out to require deeper work, or
+the probe does not reproduce for you — that is a legitimate outcome and it is worth more than
+a forced feature. Commit your analysis and `record.json` to the **local** branch, set
+`--status failed --note "<why>"`, and **do not push, do not open a PR**. No orphan remote
+branches.

--- a/tools/repipe/captain.sh
+++ b/tools/repipe/captain.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# One captain tick: a bounded headless Claude session that performs ONE state transition.
+#
+# Invoked by tools/repipe/run.sh. The timeout is the point -- a wedged captain must not stall
+# the loop, and because a tick is stateless the cost of killing one is a tick, not a round.
+set -uo pipefail
+
+REPO="${KUNA_REPO:-$(git -C "$(dirname "$0")" rev-parse --show-toplevel)}"
+KUNA_PY="${KUNA_PY:-$HOME/.virtualenvs/kuna/bin/python}"
+STATE_DIR="${KUNA_PIPELINE_STATE_DIR:-$REPO/.kuna-repipe}"
+TIMEOUT="${REPIPE_CAPTAIN_TIMEOUT:-1200}"
+MODEL="${REPIPE_CAPTAIN_MODEL:-opus}"
+BUDGET="${REPIPE_CAPTAIN_USD:-5}"
+
+export PYTHONPATH="$REPO${PYTHONPATH:+:$PYTHONPATH}"
+export KUNA_PIPELINE_STATE_DIR="$STATE_DIR"
+mkdir -p "$STATE_DIR/logs"
+LOG="$STATE_DIR/logs/captain-session.log"
+TICK_ID="cap-$(date +%s)"
+
+"$KUNA_PY" -m scripts.pipeline.state slot-acquire --pool captain --id "$TICK_ID" --pid $$ --kind captain >/dev/null 2>&1 || {
+  echo "another captain tick holds the slot; skipping" | tee -a "$LOG"; exit 0; }
+trap '"$KUNA_PY" -m scripts.pipeline.state slot-release --pool captain --id "$TICK_ID" >/dev/null 2>&1' EXIT
+
+STATUS="$("$KUNA_PY" -m scripts.repipe.captain --status 2>&1)"
+PROMPT="$(cat "$REPO/tools/repipe/captain_prompt.md")
+
+## Current state (read at $(date -Iseconds))
+
+\`\`\`json
+$STATUS
+\`\`\`
+"
+
+# --disallowedTools Task keeps --max-agents honest: every agent must come from a slot, and a
+# captain that could fork subagents freely would make the cap a fiction.
+# env -u ANTHROPIC_API_KEY: a stale key makes headless `claude -p` fail "Invalid API key".
+cd "$REPO" && env -u ANTHROPIC_API_KEY timeout -k 60 "$TIMEOUT" \
+  claude -p "$PROMPT" \
+    --model "$MODEL" \
+    --output-format json \
+    --dangerously-skip-permissions \
+    --disallowedTools Task \
+    --max-budget-usd "$BUDGET" \
+    </dev/null >>"$LOG" 2>&1
+RC=$?
+[ $RC -eq 124 ] && echo "[$(date +%H:%M:%S)] captain tick timed out after ${TIMEOUT}s" >>"$LOG"
+exit 0

--- a/tools/repipe/captain_prompt.md
+++ b/tools/repipe/captain_prompt.md
@@ -1,0 +1,118 @@
+# kuna RE-friction captain — advance the loop by ONE state transition, then stop
+
+You own an autonomous loop that makes `kuna` better at being used by agents. Testers try to
+solve crackmes with it and record where it fails them; builders close those gaps and merge.
+You decide what happens next.
+
+**This session is ONE TICK.** Read the state, perform the transition the state calls for,
+and exit. You will be re-invoked. Do not try to run the whole round in one session — a
+long-lived captain is how this loop loses its place, and a tick that exits cleanly is how it
+survives being killed.
+
+## Read the state first, always
+
+```bash
+python3 -m scripts.repipe.captain --status          # the three machines, the split, live agents
+python3 -m scripts.repipe.status --json             # agents, needs, budget, disk
+cat .kuna-repipe/rounds/<N>/transitions.jsonl       # what has already happened this round
+```
+
+## The machines, and what each state wants from you
+
+You may only move a machine along a legal edge; `captain.py` refuses anything else and exits
+2. That is deliberate — you cannot reason your way past a gate, so do not try.
+
+### TestTrack
+
+| State | What you do | Then |
+|---|---|---|
+| `T_IDLE` | nothing until a new round is due | `T_PLAN` |
+| `T_PLAN` | `python3 -m scripts.repipe.sample slate --round N -k <3x testers> --write` for a stratified slate | `T_WORKSPACE` |
+| `T_WORKSPACE` | `python3 -m scripts.repipe.workspace build <hexid> --round N` for each; **spot-check one arena** with `workspace check` before spending a single tester on a possibly-contaminated slate | `T_FANOUT` |
+| `T_FANOUT` | spawn testers up to the tester slot cap; they run detached and heartbeat — **do not wait for one** | `T_DRAIN` |
+| `T_DRAIN` | while testers are live, do nothing but observe. As each finishes, grade it and run the tripwire | `T_GATE` |
+| `T_GATE` | `python3 -m scripts.repipe.verify --gate --round N`. **This is the load-bearing step.** | `T_DEDUP` |
+| `T_DEDUP` | `python3 -m scripts.repipe.cluster --round N` | `T_REFUTE` |
+| `T_REFUTE` | for each NEW cluster whose probe kind is not `absence`, spend one refuter on the *hypothesis*; record `upheld`/`overturned` either way | `T_TRIAGE` |
+| `T_TRIAGE` | confirm each need's `track` and `touches` (they were inferred); set `scope` | `T_READY` |
+| `T_READY` | the backlog is published | `T_IDLE` |
+
+### BuildTrack
+
+| State | What you do | Then |
+|---|---|---|
+| `B_IDLE` | nothing until the backlog has dispatchable needs and a builder slot is free | `B_PLAN` |
+| `B_PLAN` | `python3 -m scripts.repipe.select -k <builders> --round N --write-contracts --json`. It only returns needs whose leases are free **and mutually disjoint** | `B_FANOUT` |
+| `B_FANOUT` | spawn a builder per pick; leases are taken for you | `B_DRAIN` |
+| `B_DRAIN` | observe. A builder ends `done` (merged), `failed`, or `proposal` | `B_MERGE` / `B_PROPOSAL_REVIEW` |
+| `B_PROPOSAL_REVIEW` | **you are the approver** — see below | `B_FANOUT` / `B_IDLE` |
+| `B_MERGE` | builders merge themselves under the `merge` lease; you only confirm it drained | `B_VERIFY` |
+| `B_VERIFY` | rebuild main, run the four gates, then `verify --acceptance-suite --all` | `B_DONE` / `B_ROLLBACK` |
+| `B_ROLLBACK` | main is red: `git revert` the last merged squash commit, mark the need `regressed`, re-file it at the front | `B_VERIFY` |
+| `B_DONE` | needs whose acceptance flipped are `closed`; promote each acceptance probe into `tests/cli/` | `B_IDLE` |
+
+## The three judgment calls that are actually yours
+
+Everything else is mechanical. These are not.
+
+**1. Clustering residue (`T_DEDUP`).** `cluster.py` groups deterministically by probe
+signature and merges near-duplicates. Read what it produced. If two needs are obviously the
+same gap wearing different words, merge them; if one need is obviously two gaps, split it.
+Do not rewrite the deterministic groupings wholesale — they are usually right and they are
+cheap.
+
+**2. Refuting a hypothesis (`T_REFUTE`).** A need's `## Hypothesis` is the tester's guess.
+Spend one agent asking: *is this cause actually right, and would a fix built on it produce
+WRONG output?* In the sibling campaign, refuters overturned the filed diagnosis on **3 of 8**
+cases while the *symptom* stood in all 8. Record the verdict either way — an upheld
+hypothesis that was actually checked is worth more than one nobody looked at. Skip this
+entirely for `kind: absence` needs ("there is no `xrefs` subcommand" has no interesting root
+cause) — `REPIPE_REFUTE_MODE=absence-skip` is on by default for exactly that reason.
+
+**3. Approving a proposal (`B_PROPOSAL_REVIEW`).** A large need stops at a design-only draft
+PR. **There is no human to ask, so you decide.** Read `docs/features/<slug>/proposal.md`, the
+need's `instances` and `credibility`, the replayed probe, and the proposal's own risk and
+speed assessment. Then:
+
+- **approve** — the mechanism is one coherent piece of work, the evidence justifies it:
+  `python3 -m scripts.pipeline.state approve --opportunity <need_id> --by captain`, then
+  re-dispatch on the same branch with `IMPL_PROPOSAL=1 RESUME_BRANCH=<branch>`.
+- **reject** — set the need `blocked` with the reason recorded. Its `instances` keep growing
+  and it stays visible on the dashboard; a blocked need is not a deleted one.
+- **defer** — leave it parked. Legitimate when the evidence is thin *and* the cost is high.
+
+Approve conservatively. A rejected proposal costs one design; an approved one that was
+really a three-month rewrite costs a builder, a merge lease, and a red main.
+
+## Restarting the testers
+
+This has no judgment in it and you must not invent any. A round's build phase is finished
+when every need it selected is `closed`, `blocked` or `rejected`, and a need is `closed`
+**iff its acceptance probe — which FAILED when it was filed — now PASSES on a freshly built
+main**:
+
+```bash
+python3 -m scripts.repipe.verify --acceptance-suite --all --json
+```
+
+Then increment the round and go back to `T_PLAN`. The next round's testers are automatically
+told which capabilities just shipped and are asked to try to break them; a need whose
+acceptance flips back to FAIL becomes `regressed` and outranks everything.
+
+## Rules
+
+- **Do not spawn subagents with the Task tool.** Every agent must come from a slot so
+  `--max-agents` stays an honest count of concurrent LLM processes; the launcher passes
+  `--disallowedTools Task` to enforce it. Spawn through `captain.py`'s helpers.
+- **Do not push, merge, or edit code.** Builders do that. You schedule and you judge.
+- **Do not re-run a gate a builder already ran** unless you are in `B_VERIFY`.
+- If something is wrong that you cannot fix — preflight fails, the disk is tight, main is red
+  after a rollback — move the supervisor to `HALTED` with a reason and stop. Halting loudly
+  beats limping.
+- Record every non-obvious decision in the round doc's `notes`. The next tick is a different
+  session with none of your context.
+
+## Finish
+
+End your turn with a one-paragraph summary: which machine you advanced, from what to what,
+why, and what the next tick should expect to do.

--- a/tools/repipe/fixtures/accept-functions-size.json
+++ b/tools/repipe/fixtures/accept-functions-size.json
@@ -1,0 +1,41 @@
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-0ba8ca568548",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "cwd": "{{TMP}}",
+  "timeout_s": 300,
+  "repeat": 3,
+  "target": {
+    "binary_rel": "tests/bug-repro/sort",
+    "binary_sha256": "8e01fe2367a880f4154b4373e56cbd008704d9278abe897837554c6b82c322a4",
+    "binary_size": 121456,
+    "binary_source": "in-repo",
+    "in_repo_path": "tests/bug-repro/sort",
+    "selector": null,
+    "selector_kind": "none"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "count",
+        "op": "gt",
+        "value": 0
+      },
+      {
+        "path": "functions[0].size",
+        "op": "exists"
+      }
+    ]
+  },
+  "notes": "DESIRED BEHAVIOUR. functions --json records carry only name/address/address_hex/aliases; decompile-all --json already carries size, so an agent must decompile every function to learn how big one is. In-repo target, so this is vendorable into tests/cli/."
+}

--- a/tools/repipe/fixtures/accept-zero-functions-errorkey.json
+++ b/tools/repipe/fixtures/accept-zero-functions-errorkey.json
@@ -1,0 +1,33 @@
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-fa3276829c4e",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "cwd": "{{TMP}}",
+  "timeout_s": 120,
+  "repeat": 3,
+  "target": {
+    "binary_rel": "bin/snake",
+    "binary_sha256": "907b4dc30be0c0e53fda3ad1905ef3d804735a472f1c9484d3cfb5d3180e26c1",
+    "binary_size": 11364,
+    "binary_source": "dataset",
+    "in_repo_path": null,
+    "selector": null,
+    "selector_kind": "none"
+  },
+  "expect": {
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "error",
+        "op": "exists"
+      }
+    ]
+  },
+  "notes": "DESIRED BEHAVIOUR, arm B: the same exit-0 JSON carries an error key saying the binary could not be parsed. Sibling of accept-zero-functions.json; see its notes for why the OR is two files."
+}

--- a/tools/repipe/fixtures/accept-zero-functions.json
+++ b/tools/repipe/fixtures/accept-zero-functions.json
@@ -1,0 +1,29 @@
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-300e3a5af18b",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "cwd": "{{TMP}}",
+  "timeout_s": 120,
+  "repeat": 3,
+  "target": {
+    "binary_rel": "bin/snake",
+    "binary_sha256": "907b4dc30be0c0e53fda3ad1905ef3d804735a472f1c9484d3cfb5d3180e26c1",
+    "binary_size": 11364,
+    "binary_source": "dataset",
+    "in_repo_path": null,
+    "selector": null,
+    "selector_kind": "none"
+  },
+  "expect": {
+    "exit_code": {
+      "ne": 0
+    }
+  },
+  "notes": "DESIRED BEHAVIOUR, arm A: the same argv must stop reporting success it cannot back up. expect is a conjunction, so 'exit != 0 OR a json error key' cannot be one probe; the error-key arm is accept-zero-functions-errorkey.json. Either flipping to PASS closes the need."
+}

--- a/tools/repipe/fixtures/probe-zero-functions.json
+++ b/tools/repipe/fixtures/probe-zero-functions.json
@@ -1,0 +1,42 @@
+{
+  "schema": "re-probe/1",
+  "probe_id": "p-c354ee2a485d",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "cwd": "{{TMP}}",
+  "timeout_s": 120,
+  "repeat": 3,
+  "target": {
+    "binary_rel": "bin/snake",
+    "binary_sha256": "907b4dc30be0c0e53fda3ad1905ef3d804735a472f1c9484d3cfb5d3180e26c1",
+    "binary_size": 11364,
+    "binary_source": "dataset",
+    "in_repo_path": null,
+    "selector": null,
+    "selector_kind": "none"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "count",
+        "op": "eq",
+        "value": 0
+      },
+      {
+        "path": "functions",
+        "op": "len_eq",
+        "value": 0
+      }
+    ]
+  },
+  "notes": "CURRENT BAD BEHAVIOUR. On a section-header-stripped PIE ELF kuna finds nothing and says so with exit 0, so an agent cannot tell 'no functions' from 'I could not parse this'. Work dir is the challenge dir."
+}

--- a/tools/repipe/run.sh
+++ b/tools/repipe/run.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# The RE-friction loop's supervisor: keep the captain alive, enforce the budget, drain cleanly.
+#
+#   tools/repipe/run.sh                 # bounded run (REPIPE_ROUNDS, default 3)
+#   tools/repipe/run.sh --once          # exactly one full cycle
+#   tools/repipe/run.sh --preflight     # check the machine and exit
+#
+#   touch .kuna-repipe/STOP     graceful drain: in-flight agents finish, INTEGRATE still runs
+#   touch .kuna-repipe/PAUSE    finish what is running, spawn nothing new
+#   touch .kuna-repipe/ABORT    hard stop: SIGTERM recorded pids, leave every worktree intact
+#
+# This process is deliberately dumb. It does not know what a round is; it re-invokes the
+# captain, which performs at most one guarded state transition per tick and exits. That split
+# is what makes a crash cost one tick instead of a run: kill this at any moment and the next
+# invocation resumes from the recorded state.
+set -uo pipefail
+
+REPO="${KUNA_REPO:-$(git -C "$(dirname "$0")" rev-parse --show-toplevel)}"
+KUNA_PY="${KUNA_PY:-$HOME/.virtualenvs/kuna/bin/python}"
+STATE_DIR="$REPO/${REPIPE_STATE_DIRNAME:-.kuna-repipe}"
+POLL="${REPIPE_POLL:-15}"
+ROUNDS="${REPIPE_ROUNDS:-3}"
+HOURS="${REPIPE_HOURS:-0}"
+CAPTAIN_TIMEOUT="${REPIPE_CAPTAIN_TIMEOUT:-1200}"
+ONCE=0
+
+for a in "$@"; do
+  case "$a" in
+    --once) ONCE=1; ROUNDS=1;;
+    --preflight) PREFLIGHT_ONLY=1;;
+    *) echo "unknown flag: $a" 1>&2; exit 2;;
+  esac
+done
+
+export KUNA_REPO="$REPO" KUNA_PY="$KUNA_PY"
+export PYTHONPATH="$REPO${PYTHONPATH:+:$PYTHONPATH}"
+export KUNA_PIPELINE_STATE_DIR="$STATE_DIR"
+export REPIPE_STATE_DIRNAME="${REPIPE_STATE_DIRNAME:-.kuna-repipe}"
+mkdir -p "$STATE_DIR/logs" "$STATE_DIR/rounds" "$STATE_DIR/arena" "$STATE_DIR/runs" "$STATE_DIR/worktrees"
+rm -f "$STATE_DIR/STOP" "$STATE_DIR/ABORT"
+
+log() { echo "[$(date +%H:%M:%S)] supervisor: $*" | tee -a "$STATE_DIR/logs/supervisor.log"; }
+
+if ! "$KUNA_PY" -m scripts.repipe.captain --preflight; then
+  log "preflight failed; refusing to start"
+  exit 1
+fi
+[ "${PREFLIGHT_ONLY:-0}" = 1 ] && exit 0
+
+trap 'log "signal received -> graceful stop"; touch "$STATE_DIR/STOP"' INT TERM
+
+START=$(date +%s)
+DEADLINE=0
+[ "$HOURS" != "0" ] && DEADLINE=$(( START + HOURS * 3600 ))
+
+log "starting (rounds=$ROUNDS hours=${HOURS:-unbounded} once=$ONCE)"
+log "watch it: $KUNA_PY -m scripts.repipe.webui --port 8787"
+
+TICKS=0
+while :; do
+  if [ -f "$STATE_DIR/ABORT" ]; then
+    log "ABORT: terminating recorded agent pids; worktrees and arenas left intact"
+    "$KUNA_PY" - <<'PY'
+import json, os, signal
+from scripts.repipe import config
+inv = config.state_dir() / "inventory.json"
+if inv.exists():
+    d = json.load(open(inv))
+    for pool in (d.get("slots") or {}).values():
+        for sid, held in (pool.get("held") or {}).items():
+            pid = held.get("pid")
+            try:
+                os.killpg(os.getpgid(int(pid)), signal.SIGTERM)
+                print("SIGTERM %s (pid %s)" % (sid, pid))
+            except Exception:
+                pass
+PY
+    break
+  fi
+
+  [ "$DEADLINE" != "0" ] && [ "$(date +%s)" -ge "$DEADLINE" ] && { log "time budget reached"; touch "$STATE_DIR/STOP"; }
+
+  # A tick is TWO things and both are required:
+  #   1. the deterministic housekeeping tick -- reap, preflight, disk/budget brakes, the
+  #      supervisor's own BOOT/RUNNING/DRAINING edges. Pure Python, no LLM.
+  #   2. the LLM captain session, which is what actually advances TestTrack and BuildTrack:
+  #      picking a slate, spawning testers, gating, clustering, judging proposals.
+  # Running only (1) leaves the loop inert -- it would tick forever at T_IDLE/B_IDLE.
+  OUT="$("$KUNA_PY" -m scripts.repipe.captain --tick 2>&1)"
+  RC=$?
+  TICKS=$((TICKS+1))
+  printf '%s\n' "$OUT" >> "$STATE_DIR/logs/captain.log"
+  if [ $RC -ne 0 ]; then
+    log "captain housekeeping tick failed (rc=$RC); see $STATE_DIR/logs/captain.log"
+  fi
+
+  if [ -f "$STATE_DIR/PAUSE" ]; then
+    log "PAUSE present: not starting a captain session"
+  elif [ -f "$STATE_DIR/STOP" ]; then
+    : # draining; the loop below will exit
+  else
+    log "captain session (tick $TICKS)"
+    bash "$REPO/tools/repipe/captain.sh" >>"$STATE_DIR/logs/captain.log" 2>&1
+    CRC=$?
+    [ $CRC -ne 0 ] && log "captain session rc=$CRC"
+  fi
+
+  SUP="$("$KUNA_PY" -m scripts.repipe.captain --status 2>/dev/null | "$KUNA_PY" -c 'import json,sys; print(json.load(sys.stdin)["states"]["supervisor"])' 2>/dev/null)"
+  case "$SUP" in
+    HALTED)  log "captain HALTED: $(cat "$STATE_DIR/HALT_REASON" 2>/dev/null | head -3)"; break;;
+    STOPPED) log "captain STOPPED"; break;;
+  esac
+
+  # The captain drives the ROUNDS budget; this is only the outer safety net.
+  CUR="$("$KUNA_PY" -m scripts.repipe.captain --status 2>/dev/null | "$KUNA_PY" -c 'import json,sys; print(json.load(sys.stdin)["round"])' 2>/dev/null)"
+  if [ "$ROUNDS" != "0" ] && [ -n "$CUR" ] && [ "$CUR" -gt "$ROUNDS" ]; then
+    log "round budget ($ROUNDS) exhausted"; touch "$STATE_DIR/STOP"
+  fi
+
+  sleep "$POLL"
+done
+
+log "draining: waiting for in-flight agents"
+for _ in $(seq 1 120); do
+  N="$("$KUNA_PY" -c 'import json,sys
+from scripts.repipe import config
+p = config.state_dir()/"inventory.json"
+d = json.load(open(p)) if p.exists() else {}
+print(sum(len((v.get("held") or {})) for k,v in (d.get("slots") or {}).items() if k!="captain"))' 2>/dev/null)"
+  [ "${N:-0}" = "0" ] && break
+  sleep 10
+done
+"$KUNA_PY" -m scripts.pipeline.state reap --stale-seconds 0 >/dev/null 2>&1
+log "done after $TICKS tick(s)."
+"$KUNA_PY" -m scripts.repipe.captain --status || true

--- a/tools/repipe/schema/probe.schema.json
+++ b/tools/repipe/schema/probe.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "probe.schema.json",
+  "title": "RE-friction probe",
+  "description": "An executable assertion about kuna's behaviour. Two of these define a need: the PROBE asserts the current bad behaviour and must PASS at filing time; the ACCEPTANCE asserts the desired behaviour and must FAIL at filing time. A builder is done when the acceptance flips to PASS. An acceptance probe is promoted verbatim into tests/cli/ as a permanent regression test.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "kind", "cmd", "timeout_s", "expect"],
+  "properties": {
+    "schema": {"const": "re-probe/1"},
+    "probe_id": {
+      "type": "string",
+      "pattern": "^[pa]-[0-9a-f]{12}$",
+      "description": "derived, not authored: 'p-' (probe) or 'a-' (acceptance) + sha1(canonical(cmd)+canonical(expect))[:12]"
+    },
+    "kind": {
+      "enum": ["cli", "cli-pair", "timing", "memory", "absence"],
+      "description": "absence = 'this capability does not exist at all'; its diagnosis is definitionally trivial, so REPIPE_REFUTE_MODE=absence-skip does not spend refuters on it"
+    },
+    "cmd": {
+      "type": "array", "items": {"type": "string"}, "minItems": 1,
+      "description": "argv. Substitution tokens: {{KUNA}} {{BIN}} {{SPECS}} {{WORK}} {{TMP}}"
+    },
+    "cwd": {"type": "string", "default": "{{WORK}}"},
+    "env": {"type": "object", "additionalProperties": {"type": "string"}},
+    "stdin": {"type": ["string", "null"]},
+    "timeout_s": {"type": "integer", "minimum": 1, "maximum": 1800},
+    "repeat": {"type": "integer", "minimum": 1, "maximum": 11, "default": 1},
+    "target": {
+      "type": "object", "additionalProperties": false,
+      "required": ["binary_rel", "binary_sha256", "binary_size"],
+      "properties": {
+        "binary_rel": {"type": "string"},
+        "binary_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "binary_size": {"type": "integer"},
+        "binary_source": {"enum": ["dataset", "in-repo", "synthesized"]},
+        "in_repo_path": {
+          "type": ["string", "null"],
+          "description": "set only when binary_source == in-repo. This is what makes an acceptance probe VENDORABLE, i.e. promotable into tests/cli/ where CI has no dataset."
+        },
+        "selector": {"type": ["string", "null"]},
+        "selector_kind": {"enum": ["name", "addr", "none"]}
+      }
+    },
+    "expect": {"$ref": "#/$defs/expect"},
+    "notes": {"type": "string", "maxLength": 400}
+  },
+  "$defs": {
+    "expect": {
+      "type": "object", "additionalProperties": false,
+      "description": "Every present clause must hold. An empty expect is rejected by probe.py: a probe that asserts nothing always passes and is not evidence.",
+      "properties": {
+        "exit_code": {"$ref": "#/$defs/numpred"},
+        "stdout_matches": {"type": "array", "items": {"type": "string"}},
+        "stdout_absent": {"type": "array", "items": {"type": "string"}},
+        "stderr_matches": {"type": "array", "items": {"type": "string"}},
+        "stderr_absent": {"type": "array", "items": {"type": "string"}},
+        "stdout_is_json": {"type": "boolean"},
+        "json": {"type": "array", "items": {"$ref": "#/$defs/jsonpred"}},
+        "wall_ms": {"$ref": "#/$defs/statpred"},
+        "max_rss_kb": {"$ref": "#/$defs/statpred"},
+        "stdout_bytes": {"$ref": "#/$defs/numpred"}
+      }
+    },
+    "numpred": {
+      "type": "object", "additionalProperties": false, "minProperties": 1,
+      "properties": {
+        "eq": {}, "ne": {}, "lt": {}, "gt": {}, "le": {}, "ge": {},
+        "in": {"type": "array"}
+      }
+    },
+    "statpred": {
+      "type": "object", "additionalProperties": false,
+      "required": ["stat"],
+      "description": "Timing/memory over `repeat` runs. rel_to compares medians against another probe as a ratio, which cancels the fixed cold-load cost the way scripts/pipeline/timeit.py does.",
+      "properties": {
+        "stat": {"enum": ["median", "min", "max", "mean"]},
+        "lt": {"type": "number"}, "gt": {"type": "number"},
+        "rel_to": {"type": ["string", "null"]},
+        "ratio_lt": {"type": "number"}, "ratio_gt": {"type": "number"}
+      }
+    },
+    "jsonpred": {
+      "type": "object", "additionalProperties": false,
+      "required": ["path", "op"],
+      "properties": {
+        "path": {"type": "string", "description": "dotted path; [i] indexes, [*] means any element"},
+        "op": {"enum": ["eq", "ne", "lt", "gt", "le", "ge", "len_eq", "len_lt", "len_gt",
+                        "contains", "not_contains", "exists", "absent", "matches"]},
+        "value": {}
+      }
+    }
+  }
+}

--- a/tools/repipe/schema/report.schema.json
+++ b/tools/repipe/schema/report.schema.json
@@ -5,40 +5,117 @@
   "description": "The structured final response a codex tester returns, enforced with `codex exec --output-schema`. Its purpose is NOT to report a solve; it is to report where kuna failed the tester. Giving up because kuna was unusable is a first-class outcome.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["hexid", "outcome", "observations"],
+  "required": [
+    "hexid",
+    "outcome",
+    "gave_up_reason",
+    "answer",
+    "minutes_lost",
+    "fallbacks",
+    "observations"
+  ],
   "properties": {
-    "hexid": {"type": "string"},
+    "hexid": {
+      "type": "string"
+    },
     "outcome": {
-      "enum": ["solved", "partial", "gave_up", "failed"],
-      "description": "gave_up is a SUCCESS for this pipeline when the reason is kuna-blocked"
+      "enum": [
+        "solved",
+        "partial",
+        "gave_up",
+        "failed"
+      ],
+      "description": "gave_up is a SUCCESS for this pipeline when the reason is kuna-blocked",
+      "type": "string"
     },
     "gave_up_reason": {
-      "type": ["string", "null"],
-      "enum": ["kuna-blocked", "too-hard", "out-of-time", null]
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "kuna-blocked",
+        "too-hard",
+        "out-of-time",
+        null
+      ]
     },
     "answer": {
-      "type": "object", "additionalProperties": false,
+      "type": "object",
+      "additionalProperties": false,
       "properties": {
-        "kind": {"enum": ["flag", "serial", "none"]},
-        "value": {"type": ["string", "null"]},
-        "name": {"type": ["string", "null"], "description": "the username, for name+serial crackmes"}
-      }
+        "kind": {
+          "enum": [
+            "flag",
+            "serial",
+            "none"
+          ],
+          "type": "string"
+        },
+        "value": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "the username, for name+serial crackmes"
+        }
+      },
+      "required": [
+        "kind",
+        "value",
+        "name"
+      ]
     },
     "minutes_lost": {
-      "type": ["number", "null"],
+      "type": [
+        "number",
+        "null"
+      ],
       "description": "self-estimated minutes spent fighting kuna rather than the binary. A quantitative channel for friction that has no clean probe."
     },
     "fallbacks": {
       "type": "array",
       "description": "Every time you left kuna for another tool. This is evidence, not failure.",
       "items": {
-        "type": "object", "additionalProperties": false,
-        "required": ["tool", "wanted", "why_kuna_could_not"],
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "tool",
+          "wanted",
+          "why_kuna_could_not",
+          "command"
+        ],
         "properties": {
-          "tool": {"enum": ["ida", "objdump", "readelf", "strings", "xxd", "gdb", "other"]},
-          "wanted": {"type": "string"},
-          "why_kuna_could_not": {"type": "string"},
-          "command": {"type": ["string", "null"]}
+          "tool": {
+            "enum": [
+              "ida",
+              "objdump",
+              "readelf",
+              "strings",
+              "xxd",
+              "gdb",
+              "other"
+            ],
+            "type": "string"
+          },
+          "wanted": {
+            "type": "string"
+          },
+          "why_kuna_could_not": {
+            "type": "string"
+          },
+          "command": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
         }
       }
     },
@@ -46,39 +123,108 @@
       "type": "array",
       "description": "Every place kuna was missing, wrong, slow or costly. An observation with no runnable probe is dropped by the gate, so give a real argv you actually ran.",
       "items": {
-        "type": "object", "additionalProperties": false,
-        "required": ["kind", "title", "what_i_wanted", "what_kuna_did", "probe", "acceptance", "severity"],
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "title",
+          "what_i_wanted",
+          "what_kuna_did",
+          "probe",
+          "acceptance",
+          "hypothesis",
+          "workaround",
+          "reference_better",
+          "cost_minutes",
+          "severity",
+          "regression_of"
+        ],
         "properties": {
-          "kind": {"enum": ["missing-capability", "wrong-output", "too-slow", "crash",
-                            "silent-failure", "bad-ux", "cost"]},
-          "title": {"type": "string", "maxLength": 120},
-          "what_i_wanted": {"type": "string"},
-          "what_kuna_did": {"type": "string"},
+          "kind": {
+            "enum": [
+              "missing-capability",
+              "wrong-output",
+              "too-slow",
+              "crash",
+              "silent-failure",
+              "bad-ux",
+              "cost"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 120
+          },
+          "what_i_wanted": {
+            "type": "string"
+          },
+          "what_kuna_did": {
+            "type": "string"
+          },
           "probe": {
-            "$ref": "probe.schema.json",
-            "description": "MUST PASS today — it asserts the bad behaviour you actually observed"
+            "type": "string",
+            "description": "MUST PASS today \u2014 it asserts the bad behaviour you actually observed The probe as a JSON object, SERIALISED to a string (e.g. \"{\\\"schema\\\":\\\"re-probe/1\\\",\\\"kind\\\":\\\"cli\\\",...}\"). It is parsed and validated on arrival; a malformed one makes the observation unrunnable rather than failing your whole report."
           },
           "acceptance": {
-            "$ref": "probe.schema.json",
-            "description": "MUST FAIL today — it asserts the behaviour you wanted instead"
+            "type": "string",
+            "description": "MUST FAIL today \u2014 it asserts the behaviour you wanted instead The probe as a JSON object, SERIALISED to a string (e.g. \"{\\\"schema\\\":\\\"re-probe/1\\\",\\\"kind\\\":\\\"cli\\\",...}\"). It is parsed and validated on arrival; a malformed one makes the observation unrunnable rather than failing your whole report."
           },
           "hypothesis": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "ADVISORY. Your guess at the cause. The builder is not bound by it and it is refuted before dispatch: in the decbench campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8."
           },
-          "workaround": {"type": ["string", "null"]},
-          "reference_better": {
-            "type": ["object", "null"], "additionalProperties": false,
-            "properties": {
-              "tool": {"type": "string"},
-              "command": {"type": "string"},
-              "evidence": {"type": "string"}
-            }
+          "workaround": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
-          "cost_minutes": {"type": ["number", "null"]},
-          "severity": {"enum": ["blocker", "major", "minor"]},
+          "reference_better": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "tool": {
+                "type": "string"
+              },
+              "command": {
+                "type": "string"
+              },
+              "evidence": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "tool",
+              "command",
+              "evidence"
+            ]
+          },
+          "cost_minutes": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "severity": {
+            "enum": [
+              "blocker",
+              "major",
+              "minor"
+            ],
+            "type": "string"
+          },
           "regression_of": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "the need_id of a previously-closed need this breaks. Highest priority class we accept."
           }
         }

--- a/tools/repipe/schema/report.schema.json
+++ b/tools/repipe/schema/report.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "report.schema.json",
+  "title": "RE-friction tester report",
+  "description": "The structured final response a codex tester returns, enforced with `codex exec --output-schema`. Its purpose is NOT to report a solve; it is to report where kuna failed the tester. Giving up because kuna was unusable is a first-class outcome.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["hexid", "outcome", "observations"],
+  "properties": {
+    "hexid": {"type": "string"},
+    "outcome": {
+      "enum": ["solved", "partial", "gave_up", "failed"],
+      "description": "gave_up is a SUCCESS for this pipeline when the reason is kuna-blocked"
+    },
+    "gave_up_reason": {
+      "type": ["string", "null"],
+      "enum": ["kuna-blocked", "too-hard", "out-of-time", null]
+    },
+    "answer": {
+      "type": "object", "additionalProperties": false,
+      "properties": {
+        "kind": {"enum": ["flag", "serial", "none"]},
+        "value": {"type": ["string", "null"]},
+        "name": {"type": ["string", "null"], "description": "the username, for name+serial crackmes"}
+      }
+    },
+    "minutes_lost": {
+      "type": ["number", "null"],
+      "description": "self-estimated minutes spent fighting kuna rather than the binary. A quantitative channel for friction that has no clean probe."
+    },
+    "fallbacks": {
+      "type": "array",
+      "description": "Every time you left kuna for another tool. This is evidence, not failure.",
+      "items": {
+        "type": "object", "additionalProperties": false,
+        "required": ["tool", "wanted", "why_kuna_could_not"],
+        "properties": {
+          "tool": {"enum": ["ida", "objdump", "readelf", "strings", "xxd", "gdb", "other"]},
+          "wanted": {"type": "string"},
+          "why_kuna_could_not": {"type": "string"},
+          "command": {"type": ["string", "null"]}
+        }
+      }
+    },
+    "observations": {
+      "type": "array",
+      "description": "Every place kuna was missing, wrong, slow or costly. An observation with no runnable probe is dropped by the gate, so give a real argv you actually ran.",
+      "items": {
+        "type": "object", "additionalProperties": false,
+        "required": ["kind", "title", "what_i_wanted", "what_kuna_did", "probe", "acceptance", "severity"],
+        "properties": {
+          "kind": {"enum": ["missing-capability", "wrong-output", "too-slow", "crash",
+                            "silent-failure", "bad-ux", "cost"]},
+          "title": {"type": "string", "maxLength": 120},
+          "what_i_wanted": {"type": "string"},
+          "what_kuna_did": {"type": "string"},
+          "probe": {
+            "$ref": "probe.schema.json",
+            "description": "MUST PASS today — it asserts the bad behaviour you actually observed"
+          },
+          "acceptance": {
+            "$ref": "probe.schema.json",
+            "description": "MUST FAIL today — it asserts the behaviour you wanted instead"
+          },
+          "hypothesis": {
+            "type": ["string", "null"],
+            "description": "ADVISORY. Your guess at the cause. The builder is not bound by it and it is refuted before dispatch: in the decbench campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8."
+          },
+          "workaround": {"type": ["string", "null"]},
+          "reference_better": {
+            "type": ["object", "null"], "additionalProperties": false,
+            "properties": {
+              "tool": {"type": "string"},
+              "command": {"type": "string"},
+              "evidence": {"type": "string"}
+            }
+          },
+          "cost_minutes": {"type": ["number", "null"]},
+          "severity": {"enum": ["blocker", "major", "minor"]},
+          "regression_of": {
+            "type": ["string", "null"],
+            "description": "the need_id of a previously-closed need this breaks. Highest priority class we accept."
+          }
+        }
+      }
+    }
+  }
+}

--- a/tools/repipe/smoke.sh
+++ b/tools/repipe/smoke.sh
@@ -146,6 +146,28 @@ echo "$WRONG" | grep -qi 'not found\|mismatch' \
   && ok "target verification refuses a misresolved {{BIN}}" \
   || bad "a misresolved target produced a verdict instead of an error"
 
+head_ "L1  the tester report schema is accepted by strict structured-output mode"
+# codex sends --output-schema straight to the API's response_format, which enforces rules
+# ordinary JSON Schema does not. Nothing local rejects a bad schema, so the first live tester
+# 400s. Every rule below was learned from exactly that.
+if "$PY" -m scripts.repipe.strictschema "$REPO/tools/repipe/schema/report.schema.json" >/dev/null 2>&1; then
+  ok "report.schema.json is strict-mode clean"
+else
+  bad "report.schema.json would 400 on a live codex run" "$("$PY" -m scripts.repipe.strictschema "$REPO/tools/repipe/schema/report.schema.json" 2>&1 | head -3)"
+fi
+"$PY" - <<'PY' >/dev/null 2>&1 && ok "the checker actually catches a violation" || bad "strictschema check is inert"
+import sys
+sys.path.insert(0, "/home/mahaloz/github/kuna")
+from scripts.repipe import strictschema
+# an object missing a key from `required`, and a bare enum with no type
+bad_schema = {"type": "object", "additionalProperties": False,
+              "required": ["a"], "properties": {"a": {"type": "string"},
+                                                "b": {"enum": ["x", "y"]}}}
+probs = strictschema.check(bad_schema)
+assert len(probs) >= 2, probs
+assert not strictschema.check(strictschema.strictify(bad_schema))
+PY
+
 head_ "L1  a probe cannot execute arbitrary code"
 # A probe's argv is authored by an LLM and replayed by verify.py in the MAIN tree, outside
 # the tester's sandbox. Without the allowlist this is remote code execution.

--- a/tools/repipe/smoke.sh
+++ b/tools/repipe/smoke.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# Prove the RE-friction loop works, without spending a single agent token.
+#
+#   tools/repipe/smoke.sh            # levels 0 and 1 (~4 min, zero tokens, zero network)
+#   tools/repipe/smoke.sh --level 0  # unit + conformance only (~40 s)
+#
+# Levels 2-4 (one live tester, one live builder, a real round) are in docs/re-pipeline.md
+# and cost real money; they are deliberately NOT run from here.
+#
+# FOUR FALSE-GREEN CANARIES, in the spirit of `make test-ghidra`'s two. Each of these would
+# otherwise let a silently broken run report success:
+#   - the two-arm gate must find at least one REPRODUCING probe (a broken runner would
+#     "pass" everything by failing everything);
+#   - the sandbox assertions must actually have run (skipping them because bwrap is missing
+#     is not a pass);
+#   - the redactor must NOT have dropped every extras file (over-redaction is as bad as
+#     under-redaction, and it would hide the fact that the allowlist is broken);
+#   - at least one need must have been produced by clustering (zero needs is not "clean").
+set -uo pipefail
+
+REPO="${KUNA_REPO:-$(git -C "$(dirname "$0")" rev-parse --show-toplevel)}"
+PY="${KUNA_PY:-python3}"
+LEVEL="${1:-}"
+[ "$LEVEL" = "--level" ] && LEVEL="${2:-1}" || LEVEL=1
+
+export PYTHONPATH="$REPO${PYTHONPATH:+:$PYTHONPATH}"
+SMOKE_STATE="$(mktemp -d "${TMPDIR:-/tmp}/repipe-smoke-XXXXXX")"
+export KUNA_PIPELINE_STATE_DIR="$SMOKE_STATE"
+trap 'rm -rf "$SMOKE_STATE"' EXIT
+
+DATASET="${REPIPE_DATASET:-$HOME/github/kuna-re-dataset}"
+FIX="$REPO/tools/repipe/fixtures"
+PASS=0; FAIL=0
+# canaries
+SAW_REPRODUCING=0; SAW_SANDBOX=0; SAW_EXTRAS_KEPT=0; SAW_NEED=0
+
+ok()   { PASS=$((PASS+1)); printf '  \033[32mok\033[0m   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; [ -n "${2:-}" ] && printf '       %s\n' "$2"; }
+head_() { printf '\n\033[1m%s\033[0m\n' "$1"; }
+
+# ---------------------------------------------------------------- level 0 ---
+head_ "L0  modules import and self-describe"
+for m in config probe verify workspace redact sample grade needs cluster select counters mergecheck captain webui render_tester_prompt; do
+  if "$PY" -c "import scripts.repipe.$m" 2>/dev/null; then ok "import $m"; else bad "import $m"; fi
+done
+
+head_ "L0  agent split matches the documented table"
+SPLIT="$("$PY" -c 'from scripts.repipe import config; import json; print(json.dumps({n: config.agent_split(n) for n in (2,4,5,7,9)}))')"
+echo "$SPLIT" | grep -q '"7": {"captain": 1, "testers": 3, "builders": 3' \
+  && ok "max-agents 7 -> 1 captain + 3 testers + 3 builders" \
+  || bad "7 does not split 1/3/3" "$SPLIT"
+
+head_ "L0  state machine refuses an illegal transition"
+"$PY" -m scripts.repipe.captain --transition test T_PLAN --note smoke >/dev/null 2>&1
+if "$PY" -m scripts.repipe.captain --transition test T_READY >/dev/null 2>&1; then
+  bad "T_PLAN -> T_READY was ALLOWED (a builder could skip the gates)"
+else
+  ok "T_PLAN -> T_READY refused (exit 2)"
+fi
+if "$PY" -m scripts.repipe.captain --transition build B_MERGE >/dev/null 2>&1; then
+  bad "B_IDLE -> B_MERGE was ALLOWED (merging without building)"
+else
+  ok "B_IDLE -> B_MERGE refused"
+fi
+
+head_ "L0  counters re-derive from the live tree"
+CNT="$("$PY" -m scripts.repipe.counters --rederive --json 2>/dev/null)"
+echo "$CNT" | grep -q '"settables": 127' && ok "settables = 127" || bad "settable count drifted" "$(echo "$CNT" | head -3)"
+echo "$CNT" | grep -q '"corpus_files": 222' && ok "stage corpus = 222" || bad "stage corpus count drifted"
+echo "$CNT" | grep -q '"next_element_id"' && ok "next free ElementId derived" || bad "no ElementId derivation"
+
+head_ "L0  mergecheck catches all three silent-merge shapes"
+MC="$("$PY" -m scripts.repipe.mergecheck --self-test 2>&1)"
+for shape in shape-B-averted shape-C-averted shape-C2-averted; do
+  echo "$MC" | grep -q "$shape" && ok "$shape" || bad "$shape not caught"
+done
+
+[ "$LEVEL" = "0" ] && { printf '\nL0 only: %d passed, %d failed\n' "$PASS" "$FAIL"; exit $((FAIL>0)); }
+
+# ---------------------------------------------------------------- level 1 ---
+head_ "L1  arena is contamination-free"
+FLAGCH=6609e458cddae72ae250bf40      # ground_truth.flag = N@n0m4ch1n3sS0n!
+TRAPCH=5ab77f5533c5d40ad448c1ea      # extras/.../hints.txt = 19 valid serials, ships_source_code FALSE
+for ch in "$FLAGCH" "$TRAPCH"; do
+  OUT="$("$PY" -m scripts.repipe.workspace build "$ch" --round 0 2>&1)" || { bad "arena build $ch" "$OUT"; continue; }
+  A="$SMOKE_STATE/arena/0/$ch"
+  [ -d "$A" ] && ok "arena built $ch" || { bad "no arena at $A"; continue; }
+  [ -z "$(find "$A" -name meta.json -o -name verifier.py)" ] && ok "  no meta.json / verifier.py" || bad "  metadata leaked into the arena"
+  NONEXEC="$(find "$A/target" -type f ! -perm -u+x 2>/dev/null | wc -l)"
+  [ "$NONEXEC" = "0" ] && ok "  every target binary is executable" || bad "  $NONEXEC target file(s) lack +x"
+done
+
+# The two challenges above ship no keepable extras (one has none, the other has only
+# spoilers), so the over-redaction canary needs a challenge that really does carry an author
+# README -- otherwise "kept 0" is correct and the canary would fire on a healthy redactor.
+READMECH="$("$PY" - <<'PY'
+import json, os
+from scripts.repipe import config
+man = json.load(open(config.manifest_path()))
+for rec in man:
+    extras = (rec.get("files") or {}).get("extras") or []
+    if any(os.path.basename(e).lower().startswith("readme") for e in extras):
+        print(rec["hexid"]); break
+PY
+)"
+if [ -n "$READMECH" ]; then
+  ROUT="$("$PY" -m scripts.repipe.workspace build "$READMECH" --round 0 2>&1)"
+  KEPT="$(echo "$ROUT" | sed -n 's/.*extras kept: \([0-9]*\).*/\1/p')"
+  [ "${KEPT:-0}" != "0" ] && { ok "author README kept for $READMECH (allowlist works)"; SAW_EXTRAS_KEPT=1; }                           || bad "over-redaction: README dropped for $READMECH" "$ROUT"
+else
+  bad "no challenge with a README in extras -- cannot exercise the allowlist"
+fi
+grep -rq 'N@n0m4ch1n3sS0n' "$SMOKE_STATE/arena/0/$FLAGCH" 2>/dev/null \
+  && bad "THE FLAG IS IN THE ARENA" || ok "flag absent from the arena"
+if echo "$OUT" | grep -q 'serial-shape .*hints.txt'; then
+  ok "hints.txt dropped by the serial-shape rule (not the flag rule)"
+else
+  "$PY" -m scripts.repipe.workspace build "$TRAPCH" --round 0 2>&1 | grep -q 'serial-shape' \
+    && ok "serial-shape rule fired on the trap challenge" \
+    || bad "hints.txt was NOT dropped by serial-shape"
+fi
+
+head_ "L1  sandbox actually hides the dataset"
+if command -v bwrap >/dev/null 2>&1; then
+  N="$(bwrap --dev-bind / / --tmpfs "$DATASET" -- ls "$DATASET" 2>/dev/null | wc -l)"
+  [ "$N" = "0" ] && { ok "dataset is empty inside the namespace"; SAW_SANDBOX=1; } || bad "dataset still visible ($N entries)"
+  bwrap --dev-bind / / --tmpfs "$DATASET" -- "$REPO/decompiler/target/release/kuna" --version >/dev/null 2>&1 \
+    && ok "kuna still runs inside the namespace" || bad "kuna broken inside the namespace"
+else
+  bad "bwrap missing -- containment is prompt-only and this canary must not be skipped silently"
+fi
+
+head_ "L1  the two-arm gate, against a real live defect"
+CH="$DATASET/challenges/64f1f7afd931496abf909525"
+for f in probe-zero-functions accept-zero-functions accept-functions-size; do
+  [ -f "$FIX/$f.json" ] || bad "missing fixture $f.json"
+done
+PV="$("$PY" -m scripts.repipe.probe check "$FIX/probe-zero-functions.json" --work "$CH" --json 2>/dev/null | "$PY" -c 'import json,sys;print(json.load(sys.stdin).get("passed"))')"
+[ "$PV" = "True" ] && { ok "probe PASSES (the bug reproduces today)"; SAW_REPRODUCING=1; } || bad "probe does not reproduce" "got $PV"
+AV="$("$PY" -m scripts.repipe.probe check "$FIX/accept-zero-functions.json" --work "$CH" --json 2>/dev/null | "$PY" -c 'import json,sys;print(json.load(sys.stdin).get("passed"))')"
+[ "$AV" = "False" ] && ok "acceptance FAILS (kuna cannot do it yet)" || bad "acceptance already passes" "got $AV"
+
+head_ "L1  a probe pointed at the wrong binary REFUSES rather than lying"
+WRONG="$("$PY" -m scripts.repipe.probe check "$FIX/probe-zero-functions.json" --json 2>&1)"
+echo "$WRONG" | grep -qi 'not found\|mismatch' \
+  && ok "target verification refuses a misresolved {{BIN}}" \
+  || bad "a misresolved target produced a verdict instead of an error"
+
+head_ "L1  a probe cannot execute arbitrary code"
+# A probe's argv is authored by an LLM and replayed by verify.py in the MAIN tree, outside
+# the tester's sandbox. Without the allowlist this is remote code execution.
+EVIL="$SMOKE_STATE/evil.json"
+rm -f /tmp/repipe-smoke-pwned
+# The last two are the bypasses a basename-only allowlist would miss: a tester has
+# workspace-write, so it can drop a file called `kuna` and name it by path.
+mkdir -p "$SMOKE_STATE/evil"
+printf '#!/bin/sh\ntouch /tmp/repipe-smoke-pwned\n' > "$SMOKE_STATE/evil/kuna"; chmod +x "$SMOKE_STATE/evil/kuna"
+ln -sf /bin/bash "$SMOKE_STATE/evil/objdump"
+for CMD in '["bash","-c","touch /tmp/repipe-smoke-pwned"]' '["rm","-rf","/tmp/nothing"]' '["curl","http://example.invalid"]' "[\"$SMOKE_STATE/evil/kuna\"]" "[\"$SMOKE_STATE/evil/objdump\",\"-c\",\"touch /tmp/repipe-smoke-pwned\"]"; do
+  "$PY" - "$FIX" "$CMD" > "$EVIL" <<'PY'
+import json, sys
+p = json.load(open(sys.argv[1] + "/probe-zero-functions.json"))
+p["cmd"] = json.loads(sys.argv[2]); p.pop("probe_id", None); p.pop("target", None)
+json.dump(p, open("/dev/stdout", "w"))
+PY
+  R="$("$PY" -m scripts.repipe.probe check "$EVIL" --work "$CH" --json 2>&1)"
+  echo "$R" | grep -q 'may not execute'     && ok "refused $(echo "$CMD" | cut -c1-32)"     || bad "EXECUTED $(echo "$CMD" | cut -c1-32)" "$R"
+done
+[ -e /tmp/repipe-smoke-pwned ] && bad "a probe actually executed arbitrary code" || ok "nothing was executed"
+
+head_ "L1  clustering collapses duplicates"
+OBS="$SMOKE_STATE/obs.json"
+"$PY" - "$FIX" > "$OBS" <<'PY'
+import json, sys
+F = sys.argv[1] + "/"
+p = json.load(open(F + "probe-zero-functions.json"))
+a = json.load(open(F + "accept-zero-functions.json"))
+def o(title, hexid, tester, kind="silent-failure", wanted="function inventory"):
+    return {"kind": kind, "title": title, "what_i_wanted": wanted,
+            "what_kuna_did": "count 0 exit 0", "severity": "blocker",
+            "probe": p, "acceptance": a, "_hexid": hexid, "_tester": tester, "_round": 1}
+json.dump([
+    o("kuna functions returns 0 functions on a stripped PIE", "64f1f7af", "t1"),
+    o("functions --json is empty for a section-stripped binary", "60be2a60", "t2"),
+    o("no functions found and no error reported", "6609e458", "t3"),
+    o("kuna has no way to list strings", "64f1f7af", "t1", "missing-capability", "the string inventory"),
+    o("cannot enumerate strings from kuna at all", "6883765e", "t2", "missing-capability", "string table"),
+], open("/dev/stdout", "w"), indent=2)
+PY
+CL="$("$PY" -m scripts.repipe.cluster --round 1 --from-file "$OBS" --dry-run --json 2>/dev/null)"
+NCL="$(echo "$CL" | "$PY" -c 'import json,sys;print(len(json.load(sys.stdin)))' 2>/dev/null)"
+[ "$NCL" = "2" ] && { ok "5 observations -> 2 needs"; SAW_NEED=1; } || bad "expected 2 clusters, got $NCL" "$CL"
+echo "$CL" | grep -q '"instances": 3' && ok "the 3-way duplicate merged into one need" || bad "duplicates not merged"
+
+head_ "L1  collision avoidance"
+"$PY" - <<'PY'
+import sys; sys.path.insert(0, ".")
+from scripts.repipe import needs, select
+mk = lambda i, t: needs.Need(fields={"need_id": i, "title": i, "track": t, "status": "open",
+                                     "severity": "major", "instances": 3, "challenges": ["a"],
+                                     "rounds": [1], "touches": []})
+picks = select.pick(k=3, needs_list=[mk("q1", "quality"), mk("q2", "quality"), mk("t1", "tooling")])
+tracks = [p["need"].track for p in picks]
+assert tracks.count("quality") == 1, "two option-adding builders dispatched: %s" % tracks
+assert tracks.count("tooling") == 1, "tooling builder was blocked: %s" % tracks
+print("OK")
+PY
+[ $? = 0 ] && ok "at most one quality builder; tooling runs alongside" || bad "lease algebra wrong"
+
+head_ "L1  regressions the review found (each of these shipped broken once)"
+# newline in a tester-authored title used to destroy every front-matter field after it
+"$PY" - <<'PY' >/dev/null 2>&1 && ok "a newline in a title cannot corrupt front matter" || bad "front-matter escaping regressed"
+import sys, tempfile, os
+sys.path.insert(0, "/home/mahaloz/github/kuna")
+from scripts.repipe import needs
+evil = "one\nstatus: HIJACKED\ntrack: quality"
+n = needs.Need(fields={"need_id": "x", "title": evil, "track": "tooling", "severity": "major"})
+p = tempfile.mktemp(suffix=".md"); open(p, "w").write(needs.render(n))
+m = needs.parse(p); os.unlink(p)
+assert m.title == evil and m.track == "tooling", (m.title, m.track)
+PY
+# a probe and its own negation both passing made the gate report already-supported
+"$PY" - <<'PY' >/dev/null 2>&1 && ok "exists/absent cannot both pass on a mixed array" || bad "json quantifier regressed"
+import sys
+sys.path.insert(0, "/home/mahaloz/github/kuna")
+from scripts.repipe import probe
+obs = {"runs": [{"exit_code": 0, "stdout": '{"f":[{"s":1},{}]}', "stderr": "",
+                 "wall_ms": 1, "timed_out": False, "error": None, "stdout_bytes": 10}],
+       "baselines": {}}
+mk = lambda op: {"schema": "re-probe/1", "kind": "cli", "cmd": ["x"], "timeout_s": 5,
+                 "expect": {"json": [{"path": "f[*].s", "op": op}]}}
+e = probe.evaluate(probe.normalize(mk("exists")), obs)["passed"]
+a = probe.evaluate(probe.normalize(mk("absent")), obs)["passed"]
+assert not (e and a), (e, a)
+PY
+# a catastrophic-backtracking regex used to hang the gate forever
+timeout 60 "$PY" - <<'PY' >/dev/null 2>&1 && ok "a pathological regex is time-bounded" || bad "regex budget regressed (hung or errored)"
+import sys
+sys.path.insert(0, "/home/mahaloz/github/kuna")
+from scripts.repipe import probe
+obs = {"runs": [{"exit_code": 0, "stdout": "a"*40+"!", "stderr": "", "wall_ms": 1,
+                 "timed_out": False, "error": None, "stdout_bytes": 41}], "baselines": {}}
+probe.evaluate(probe.normalize({"schema": "re-probe/1", "kind": "cli", "cmd": ["x"],
+                                "timeout_s": 5, "expect": {"stdout_matches": [r"(a+)+$"]}}), obs)
+PY
+# concurrent captain ticks used to race round.json
+( for i in 1 2 3 4 5 6; do "$PY" -m scripts.repipe.captain --transition build B_PLAN >/dev/null 2>&1 & done; wait ) 2>/dev/null
+NWIN="$(grep -c '"to": "B_PLAN"' "$SMOKE_STATE"/rounds/*/transitions.jsonl 2>/dev/null | head -1)"
+[ "${NWIN:-0}" = "1" ] && ok "6 racing transitions -> exactly 1 accepted" || bad "round.json race: $NWIN accepted, expected 1"
+
+head_ "L1  the four seed needs are real and round-trip"
+NL="$("$PY" -m scripts.repipe.needs list --json 2>/dev/null | "$PY" -c 'import json,sys;print(json.load(sys.stdin)["count"])' 2>/dev/null)"
+[ "${NL:-0}" -ge 4 ] && ok "$NL seed needs present" || bad "expected >=4 seed needs, got ${NL:-0}"
+for f in "$REPO"/docs/re-needs/*.md; do
+  "$PY" -c "
+import sys; sys.path.insert(0,'$REPO')
+from scripts.repipe import needs
+n = needs.parse('$f')
+assert needs.render(n) == open('$f').read(), 'round-trip differs'
+" 2>/dev/null && ok "round-trip $(basename "$f")" || bad "round-trip $(basename "$f")"
+done
+
+head_ "L1  dashboard serves every route with no gh call per request"
+PORT=$(( 18700 + RANDOM % 900 ))
+"$PY" -m scripts.repipe.webui --port "$PORT" --bind 127.0.0.1 --no-checks >"$SMOKE_STATE/webui.log" 2>&1 &
+WEB_PID=$!
+for _ in $(seq 1 30); do
+  curl -s -o /dev/null --max-time 2 "http://127.0.0.1:$PORT/healthz" 2>/dev/null && break
+  sleep 1
+done
+if ! curl -s -o /dev/null --max-time 5 "http://127.0.0.1:$PORT/healthz" 2>/dev/null; then
+  bad "dashboard never came up on :$PORT" "$(tail -3 "$SMOKE_STATE/webui.log" 2>/dev/null)"
+fi
+for r in / /healthz /api/state /api/needs /api/rounds /api/agents /api/corpus /api/acceptance; do
+  CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "http://127.0.0.1:$PORT$r" 2>/dev/null)"
+  [ "$CODE" = "200" ] && ok "GET $r" || bad "GET $r -> $CODE"
+done
+CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "http://127.0.0.1:$PORT/api/agent/..%2f..%2fetc%2fpasswd/log" 2>/dev/null)"
+[ "$CODE" = "400" ] || [ "$CODE" = "404" ] && ok "path traversal rejected ($CODE)" || bad "traversal returned $CODE"
+curl -s --max-time 10 "http://127.0.0.1:$PORT/api/corpus" 2>/dev/null | grep -q 'N@n0m4ch1n3sS0n' \
+  && bad "THE DASHBOARD LEAKS A FLAG" || ok "corpus endpoint leaks no ground truth"
+kill "$WEB_PID" 2>/dev/null; wait "$WEB_PID" 2>/dev/null
+
+# --------------------------------------------------------------- canaries ---
+head_ "canaries (a silently broken run must not report success)"
+[ "$SAW_REPRODUCING" = 1 ] && ok "the gate found a reproducing probe" || bad "NO probe reproduced -- the runner is broken, not the corpus"
+[ "$SAW_SANDBOX" = 1 ]     && ok "sandbox assertions ran"             || bad "sandbox assertions were SKIPPED"
+[ "$SAW_EXTRAS_KEPT" = 1 ] && ok "the redactor kept at least one extras file" || bad "the redactor dropped EVERYTHING (over-redaction hides a broken allowlist)"
+[ "$SAW_NEED" = 1 ]        && ok "clustering produced needs"          || bad "clustering produced nothing"
+
+printf '\n\033[1msmoke: %d passed, %d failed\033[0m\n' "$PASS" "$FAIL"
+exit $(( FAIL > 0 ))

--- a/tools/repipe/tester.sh
+++ b/tools/repipe/tester.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Launch ONE tester: a headless `codex exec` session that tries to solve one crackme with
+# kuna as its primary tool and records every place kuna failed it.
+#
+#   ROUND=3 HEXID=64f1f7afd931496abf909525 tools/repipe/tester.sh
+#
+# The tester's real job is not to solve the crackme. It is to find ways kuna is bad, and
+# giving up because kuna was unusable is a first-class result (docs/re-pipeline.md).
+#
+# Two things here are load-bearing and easy to get wrong if you edit this file:
+#
+#   1. CONTAINMENT IS A MOUNT NAMESPACE, NOT A POLICY. codex's `-s workspace-write`
+#      restricts writes, not reads, and the dataset leaks the answer four different ways
+#      (meta.json carries the plaintext flag; solutions/ holds full writeups; extras/ can
+#      hold valid serials on a challenge whose ships_source_code is false; six challenges
+#      ship source). So the dataset is tmpfs'd out of the tester's namespace entirely and
+#      the arena holds only sanitized copies. A prompt-level "please don't look" is worthless.
+#   2. CODEX CANNOT BE TOLD ITS SESSION ID. Unlike `claude --session-id`, the thread id only
+#      appears in the first `thread.started` line of the --json stream, so the stream is
+#      tee'd and scraped. Do not "simplify" that away.
+set -uo pipefail
+
+REPO="${KUNA_REPO:-$(git -C "$(dirname "$0")" rev-parse --show-toplevel)}"
+KUNA_PY="${KUNA_PY:-$HOME/.virtualenvs/kuna/bin/python}"
+STATE_DIR="${KUNA_PIPELINE_STATE_DIR:-$REPO/.kuna-repipe}"
+DATASET="${REPIPE_DATASET:-$HOME/github/kuna-re-dataset}"
+TIMEOUT="${REPIPE_TESTER_TIMEOUT:-3600}"
+MODEL="${REPIPE_TESTER_MODEL:-}"
+SANDBOX="${REPIPE_SANDBOX:-auto}"
+ENABLE_IDA="${REPIPE_ENABLE_IDA:-1}"
+
+: "${ROUND:?need ROUND}"
+: "${HEXID:?need HEXID}"
+TESTER_ID="${TESTER_ID:-t-r${ROUND}-${HEXID:0:8}}"
+RUN_ID="${RUN_ID:-$TESTER_ID-$(date +%s)}"
+ARENA="$STATE_DIR/arena/$ROUND/$HEXID"
+
+export PYTHONPATH="$REPO${PYTHONPATH:+:$PYTHONPATH}"
+export KUNA_PIPELINE_STATE_DIR="$STATE_DIR"
+
+# The arena's bin/ MUST be first on the tester's PATH: `kuna` and `ida-decompile` there are
+# the metering shims. Without this the shims are dead code -- no toolcalls.jsonl, no
+# per-call latency signal (kuna emits none of its own), and IDA writes its .i64 databases
+# wherever it likes instead of inside the arena.
+export PATH="$ARENA/bin:$PATH"
+export REPIPE_REAL_KUNA="${REPIPE_REAL_KUNA:-$REPO/decompiler/target/release/kuna}"
+export REPIPE_ARENA="$ARENA"
+
+RUN_DIR="$STATE_DIR/runs/$RUN_ID"
+LOG_DIR="$STATE_DIR/logs"
+mkdir -p "$LOG_DIR" "$RUN_DIR"
+LOG="$LOG_DIR/$TESTER_ID.log"
+EVENTS="$RUN_DIR/events.jsonl"
+
+log() { echo "[$(date +%H:%M:%S)] tester $TESTER_ID: $*" | tee -a "$LOG"; }
+
+finish() {  # always release the slot, however we exit
+  "$KUNA_PY" -m scripts.pipeline.state slot-release --pool tester --id "$TESTER_ID" >/dev/null 2>&1
+}
+trap finish EXIT
+
+# Ensure the pool has a cap before claiming a slot. The captain sets caps on every tick, but
+# tester.sh is also runnable standalone (docs/re-pipeline.md's Level-2 check does exactly
+# that), and an unset pool has cap 0 -- which would refuse every slot and look like a bug.
+"$KUNA_PY" - <<'PY' >/dev/null 2>&1
+from scripts.pipeline import state
+from scripts.repipe import config
+snap = state.snapshot()
+if not (snap.get("slots") or {}).get("tester", {}).get("cap"):
+    state.slot_cap("tester", config.agent_split()["testers"])
+PY
+if ! "$KUNA_PY" -m scripts.pipeline.state slot-acquire --pool tester --id "$TESTER_ID" --pid $$ --kind tester; then
+  log "no free tester slot (cap reached); not starting"
+  exit 3
+fi
+"$KUNA_PY" -m scripts.pipeline.state update --worker "$TESTER_ID" --phase setup --status running >/dev/null 2>&1
+
+# --- 1. arena ---------------------------------------------------------------
+log "building arena $ARENA"
+if ! "$KUNA_PY" -m scripts.repipe.workspace build "$HEXID" --round "$ROUND" >>"$LOG" 2>&1; then
+  log "arena build failed"
+  "$KUNA_PY" -m scripts.pipeline.state update --worker "$TESTER_ID" --status failed --note "arena build failed"
+  exit 1
+fi
+
+# The contamination guard must run on the real path, not only in smoke.sh: a bad arena is
+# the one failure that quietly poisons a whole round's evidence.
+if ! "$KUNA_PY" -m scripts.repipe.workspace check "$ARENA" --hexid "$HEXID" >>"$LOG" 2>&1; then
+  log "arena FAILED its contamination check; refusing to launch a tester on it"
+  "$KUNA_PY" -m scripts.pipeline.state update --worker "$TESTER_ID" --status failed --note "arena contaminated"
+  exit 1
+fi
+
+# --- 2. per-run CODEX_HOME --------------------------------------------------
+# ~/.codex/logs_2.sqlite is already 270 MB across 612 rollouts; a 250-challenge sweep would
+# inflate it badly and bury this run's transcript. An isolated CODEX_HOME keeps sessions,
+# the session index and the sqlite inside the run dir, where harvest reads them and the
+# archiver deletes them. NOT --ephemeral: that would destroy the transcript harvest needs.
+export CODEX_HOME="$RUN_DIR/codexhome"
+mkdir -p "$CODEX_HOME"
+# COPY, do not symlink: ~/.codex is tmpfs'd out of the tester's namespace (it holds 600+
+# past prompts), so a symlink into it would dangle and codex could not authenticate.
+if [ -f "$HOME/.codex/auth.json" ]; then
+  cp "$HOME/.codex/auth.json" "$CODEX_HOME/auth.json" && chmod 600 "$CODEX_HOME/auth.json"
+fi
+
+# --- 3. render the prompt ---------------------------------------------------
+PROMPT_FILE="$RUN_DIR/prompt.md"
+"$KUNA_PY" -m scripts.repipe.render_tester_prompt \
+  --hexid "$HEXID" --round "$ROUND" --arena "$ARENA" --out "$PROMPT_FILE" >>"$LOG" 2>&1 || {
+  log "prompt render failed"; "$KUNA_PY" -m scripts.pipeline.state update --worker "$TESTER_ID" --status failed --note "prompt render failed"; exit 1
+}
+
+# --- 4. launch --------------------------------------------------------------
+CODEX_ARGS=(exec
+  --cd "$ARENA"
+  --skip-git-repo-check
+  -s workspace-write
+  -c approval_policy=never
+  -c sandbox_workspace_write.network_access=false
+  --json
+  --output-schema "$REPO/tools/repipe/schema/report.schema.json"
+  -o "$ARENA/report.json")
+[ -n "$MODEL" ] && CODEX_ARGS+=(-m "$MODEL")
+
+# `-a/--ask-for-approval` does NOT exist on `codex exec` (it is interactive-only), which is
+# why the approval policy is a `-c` override. network_access=false also removes "search the
+# web for this crackme's writeup" as an option, which is a contamination channel bwrap
+# cannot close.
+
+SANDBOX_MODE="$SANDBOX"
+if [ "$SANDBOX_MODE" = "auto" ]; then
+  if command -v bwrap >/dev/null 2>&1; then
+    SANDBOX_MODE=bwrap
+  else
+    # `auto` must NEVER downgrade itself to uncontained. The dataset leaks the answer four
+    # ways and $HOME holds credentials; silently proceeding would poison the round's evidence
+    # while reporting success. Running without containment has to be an explicit, recorded
+    # choice (REPIPE_SANDBOX=none), never an accident of a missing binary.
+    log "ERROR: REPIPE_SANDBOX=auto but bwrap is not installed. Refusing to run uncontained."
+    log "       Install bwrap, or set REPIPE_SANDBOX=none to accept prompt-only containment."
+    "$KUNA_PY" -m scripts.pipeline.state update --worker "$TESTER_ID" --status failed --note "no bwrap under sandbox=auto"
+    exit 1
+  fi
+fi
+
+if [ "$SANDBOX_MODE" = "bwrap" ]; then
+  # Hiding ONE directory is not enough, and assuming it is was a real hole: there is a second
+  # full copy of the ground truth (all 250 flags) in the sibling label repo, and $HOME carries
+  # SSH keys, a GitHub token and 600+ past codex prompts that a tester has no business reading
+  # while it works an adversarial corpus. Everything below is tmpfs'd out of its namespace.
+  # REPIPE_SANDBOX_HIDE adds more, colon-separated.
+  HIDE=(
+    "$DATASET"
+    "$HOME/github/crackmes-re-dataset"      # the label repo: crackmes_dataset.jsonl has the flags
+    "$HOME/.ssh" "$HOME/.aws" "$HOME/.gnupg"
+    "$HOME/.config/gh" "$HOME/.git-credentials"
+    "$HOME/.codex" "$HOME/.claude" "$HOME/.anthropic"
+  )
+  IFS=':' read -r -a EXTRA_HIDE <<< "${REPIPE_SANDBOX_HIDE:-}"
+  for h in "${EXTRA_HIDE[@]+"${EXTRA_HIDE[@]}"}"; do [ -n "$h" ] && HIDE+=("$h"); done
+
+  WRAP=(bwrap --dev-bind / /)
+  HID=0
+  for h in "${HIDE[@]}"; do
+    if [ -d "$h" ]; then
+      WRAP+=(--tmpfs "$h"); HID=$((HID+1))            # a directory becomes empty
+    elif [ -e "$h" ]; then
+      WRAP+=(--ro-bind /dev/null "$h"); HID=$((HID+1)) # a FILE cannot be tmpfs'd; blank it
+    fi
+  done
+  # CODEX_HOME lives under the state dir, and $HOME/.codex is hidden above, so re-bind the
+  # per-run one explicitly -- codex must still find its auth.
+  WRAP+=(--bind "$CODEX_HOME" "$CODEX_HOME" --)
+  log "launching under bwrap ($HID path(s) hidden incl. both dataset copies and \$HOME creds), timeout ${TIMEOUT}s"
+else
+  log "WARNING: no bwrap; dataset is READABLE. Relying on the prompt + the post-hoc tripwire."
+  "$KUNA_PY" -m scripts.pipeline.state update --worker "$TESTER_ID" --note "sandbox=none (low trust)" >/dev/null 2>&1
+  WRAP=()
+fi
+
+"$KUNA_PY" -m scripts.pipeline.state update --worker "$TESTER_ID" --phase solving >/dev/null 2>&1
+START=$(date +%s)
+"${WRAP[@]+"${WRAP[@]}"}" timeout -k 60 "$TIMEOUT" \
+  codex "${CODEX_ARGS[@]}" "$(cat "$PROMPT_FILE")" </dev/null 2>>"$LOG" | tee "$EVENTS" >/dev/null
+RC=${PIPESTATUS[0]}
+ELAPSED=$(( $(date +%s) - START ))
+
+# --- 5. scrape the thread id + record the attempt ---------------------------
+THREAD_ID="$("$KUNA_PY" - "$EVENTS" <<'PY' 2>/dev/null
+import json, sys
+for line in open(sys.argv[1], errors="replace"):
+    try:
+        d = json.loads(line)
+    except Exception:
+        continue
+    if d.get("type") == "thread.started" or "thread_id" in d:
+        print(d.get("thread_id") or d.get("thread", {}).get("id") or "")
+        break
+PY
+)"
+
+"$KUNA_PY" - "$RUN_DIR/attempt.json" <<PY
+import json, sys
+json.dump({
+    "run_id": "$RUN_ID", "tester_id": "$TESTER_ID", "hexid": "$HEXID",
+    "round": int("$ROUND"), "rc": int("$RC"), "elapsed_s": int("$ELAPSED"),
+    "timed_out": int("$RC") == 124, "thread_id": "$THREAD_ID",
+    "arena": "$ARENA", "events": "$EVENTS", "sandbox": "$SANDBOX_MODE",
+    "report": "$ARENA/report.json",
+}, open(sys.argv[1], "w"), indent=2)
+PY
+
+if [ "$RC" -eq 124 ]; then
+  log "timed out after ${TIMEOUT}s (partial report still harvested if present)"
+  "$KUNA_PY" -m scripts.pipeline.state update --worker "$TESTER_ID" --status done --phase timeout --note "timeout ${TIMEOUT}s"
+elif [ "$RC" -ne 0 ]; then
+  log "codex exited rc=$RC"
+  "$KUNA_PY" -m scripts.pipeline.state update --worker "$TESTER_ID" --status failed --note "codex rc=$RC"
+else
+  log "done in ${ELAPSED}s (thread $THREAD_ID)"
+  "$KUNA_PY" -m scripts.pipeline.state update --worker "$TESTER_ID" --status done --phase done
+fi
+# A timed-out or crashed tester that still filed observations contributed real evidence, so
+# harvest runs regardless of rc -- it is the captain's HARVEST state that decides.
+exit 0

--- a/tools/repipe/tester_prompt.md
+++ b/tools/repipe/tester_prompt.md
@@ -1,0 +1,109 @@
+# kuna RE tester — solve this crackme with kuna, and record every way kuna failed you
+
+You are an autonomous reverse engineer working in `{{ARENA}}`. There is a binary in
+`target/`. Your surface job is to solve it. **Your real job is to find every way `kuna` is
+bad at this**, because you are the measuring instrument for a decompiler that is trying to
+become good enough for agents like you to use.
+
+Round {{ROUND}} · challenge `{{HEXID}}` · time budget **{{TIME_BUDGET}} minutes**.
+
+## Your tools
+
+- **`kuna` is your primary static-analysis tool.** It is on your PATH as `kuna` (a wrapper —
+  use it, not any other path, so your work is measured). Start with:
+  ```
+  kuna functions ./target/{{TARGET}} --json
+  kuna decompile-all ./target/{{TARGET}} --json
+  kuna decompile ./target/{{TARGET}} <name-or-0xaddr> [--addr]
+  kuna catalog --json          # every decision you can flip
+  kuna decompile ./target/{{TARGET}} <fn> --option NAME VALUE
+  ```
+  Its full reference is `{{REPO}}/docs/cli.md` and the option catalog with symptom-indexed
+  guidance is `{{REPO}}/docs/options.md`. Read them; they are the contract.
+- `objdump`, `readelf`, `strings`, `xxd`, `nm`, `file`, `python3` are available.
+{{IDA_LINE}}
+- You have **no network**. Do not try to look this crackme up; you cannot, and that is
+  deliberate — a writeup would destroy the measurement.
+
+## The rules that make this useful
+
+1. **Try kuna first, every time.** When you want to know something about the binary, reach
+   for kuna before anything else — even if you suspect it will not work. The attempt is the
+   data.
+2. **You may give up.** If kuna is too bad to make progress, set `outcome: "gave_up"` with
+   `gave_up_reason: "kuna-blocked"` and file the observations that blocked you. That is a
+   *success* for this pipeline, not a failure. Do not grind for an hour to save face.
+3. **Do not read anything outside `{{ARENA}}`** except the kuna repo's own docs. The
+   challenge's metadata, its published solutions and its answer are deliberately not in your
+   sandbox. Do not go looking.
+4. **Every observation needs a probe you actually ran.** Not a paraphrase — the real argv,
+   from your shell history, that produced the behaviour you are complaining about.
+
+## What to record
+
+For every place kuna was missing, wrong, slow, or costly, file an observation with **two
+executable assertions**:
+
+- **`probe`** — asserts the behaviour you actually saw. It must **pass** on today's kuna.
+- **`acceptance`** — asserts the behaviour you *wanted*. It must **fail** on today's kuna.
+
+Both are run by machine before anyone acts on your report. If the probe does not reproduce,
+your observation is discarded as noise. If the acceptance already passes, your observation
+is discarded as *"kuna could already do this"* — which is a fine outcome, it just means you
+missed a flag; that ledger is kept and it is how we know the gate works.
+
+A worked example of the shape:
+
+```json
+{
+  "kind": "silent-failure",
+  "title": "kuna functions reports 0 functions and exits 0 on a stripped PIE",
+  "what_i_wanted": "the function inventory of target/snake",
+  "what_kuna_did": "{\"count\": 0, \"functions\": []}, exit 0, no error field, 0.14s",
+  "probe": {
+    "schema": "re-probe/1", "kind": "cli", "timeout_s": 60,
+    "cmd": ["{{KUNA}}", "functions", "{{BIN}}", "--json"],
+    "expect": {"exit_code": {"eq": 0}, "stdout_is_json": true,
+               "json": [{"path": "count", "op": "eq", "value": 0}]}
+  },
+  "acceptance": {
+    "schema": "re-probe/1", "kind": "cli", "timeout_s": 60,
+    "cmd": ["{{KUNA}}", "functions", "{{BIN}}", "--json"],
+    "expect": {"json": [{"path": "count", "op": "gt", "value": 0}]}
+  },
+  "hypothesis": "discovery gives up when the section table is stripped",
+  "workaround": "objdump -d target/snake | grep '^0'",
+  "severity": "blocker"
+}
+```
+
+Use `{{KUNA}}` and `{{BIN}}` as tokens in `cmd` — they are substituted at replay time so
+your probe still runs after the arena is gone.
+
+**Your `hypothesis` is advisory and you are not being graded on it.** In the sibling
+campaign that this loop is modelled on, three of eight filed diagnoses were overturned while
+the *symptom* stood in all eight. Report what you saw precisely; guess at the cause loosely
+and say so.
+
+Also record, honestly:
+- **`fallbacks[]`** — every time you left kuna for another tool: what you wanted, and why
+  kuna could not give it to you. Leaving is not a failure; leaving *unrecorded* is.
+- **`minutes_lost`** — roughly how much of your time went to fighting kuna rather than the
+  binary.
+
+{{RECENTLY_SHIPPED}}
+
+{{KNOWN_NEEDS}}
+
+## Finishing
+
+Write your final answer as the structured report (the schema is enforced). Set `outcome`
+honestly: `solved` only if you have an answer you believe; `partial` if you got somewhere;
+`gave_up` with a reason; `failed` if you got nowhere and kuna was not the reason.
+
+If you solved it, put the flag or the `name` + `serial` in `answer`. You will not be told
+whether you were right — grading happens outside your sandbox, and the ground truth for
+these challenges is weak enough that a wrong verdict would be a worse signal than none.
+
+**A run that gives up early with three precise, reproducing observations is worth more to
+this project than a run that solves the crackme and reports nothing.**

--- a/tools/repipe/tester_prompt.md
+++ b/tools/repipe/tester_prompt.md
@@ -80,6 +80,10 @@ A worked example of the shape:
 Use `{{KUNA}}` and `{{BIN}}` as tokens in `cmd` — they are substituted at replay time so
 your probe still runs after the arena is gone.
 
+**`probe` and `acceptance` are SERIALISED JSON STRINGS**, not nested objects — the shape
+above, `json.dumps`'d into a single string field. They are parsed and validated on arrival, so
+a malformed one costs you that observation, not the whole report.
+
 **Your `hypothesis` is advisory and you are not being graded on it.** In the sibling
 campaign that this loop is modelled on, three of eight filed diagnoses were overturned while
 the *symptom* stood in all eight. Report what you saw precisely; guess at the cause loosely

--- a/tools/repipe/webui/assets/app.js
+++ b/tools/repipe/webui/assets/app.js
@@ -1,0 +1,529 @@
+/* kuna RE-friction dashboard — vanilla ES2019, no build step, no CDN.
+ *
+ * The server publishes one payload per cache generation and pushes {"seq":N} over SSE when
+ * that generation advances; this file refetches /api/state on a bump and otherwise sits idle.
+ * Elapsed/stale counters are derived here from started_at/updated_at against a server clock
+ * offset, which is why a quiet pipeline produces no seq churn at all.
+ */
+'use strict';
+
+var S = null;              /* last /api/state payload */
+var SKEW = 0;              /* serverNow - clientNow, seconds */
+var PANE = 'board';
+var EV_TAB = 'backlog';
+var LAST_SEQ = -1;
+var FILTERED = null;       /* /api/needs result while a filter is active */
+
+function $(id) { return document.getElementById(id); }
+function esc(s) {
+  return String(s === null || s === undefined ? '' : s)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+function now() { return Date.now() / 1000 + SKEW; }
+function dur(sec) {
+  if (sec === null || sec === undefined || isNaN(sec)) return '—';
+  sec = Math.max(0, Math.floor(sec));
+  if (sec < 60) return sec + 's';
+  if (sec < 3600) return Math.floor(sec / 60) + 'm' + String(sec % 60).padStart(2, '0') + 's';
+  return Math.floor(sec / 3600) + 'h' + String(Math.floor((sec % 3600) / 60)).padStart(2, '0') + 'm';
+}
+function usd(v) { return (v === null || v === undefined) ? '—' : '$' + Number(v).toFixed(2); }
+function num(v) { return (v === null || v === undefined) ? '—' : Number(v).toLocaleString(); }
+function gb(v) { return (v === null || v === undefined) ? '—' : Number(v).toFixed(0) + ' GB'; }
+function clock(ts) {
+  if (!ts) return '';
+  var d = new Date(ts * 1000);
+  return String(d.getHours()).padStart(2, '0') + ':' + String(d.getMinutes()).padStart(2, '0')
+    + ':' + String(d.getSeconds()).padStart(2, '0');
+}
+function nothing(title, hint) {
+  return '<div class="empty"><b>' + esc(title) + '</b>' + (hint || '') + '</div>';
+}
+
+/* ── header ───────────────────────────────────────────────────────────── */
+
+function renderHeader() {
+  var h = S.header || {}, sup = S.supervisor || {};
+  $('h-round').innerHTML = h.round === null || h.round === undefined
+    ? '<em>none yet</em>'
+    : esc(h.round) + (h.rounds_planned ? '<em> / ' + esc(h.rounds_planned) + '</em>' : '');
+  $('h-sup').textContent = sup.state || '—';
+  $('h-agents').innerHTML = esc(h.agents_live || 0) + '<em> / ' + esc(h.agents_max || 0) + '</em>';
+  var disk = h.disk_free_gb;
+  $('h-disk').textContent = gb(disk);
+  $('h-disk-w').className = 'stat' + (disk !== null && disk !== undefined
+    && disk < (h.disk_red_gb || 100) ? ' bad' : '');
+  $('h-spend').innerHTML = usd(h.run_usd) + '<em> / ' + usd(h.run_cap) + '</em>';
+  $('n-agents').textContent = (S.agents || []).length ? '(' + S.agents.length + ')' : '';
+  var t = (S.needs && S.needs.totals) || {};
+  $('n-evidence').textContent = t.admitted ? '(' + t.admitted + ')' : '';
+  var a = S.acceptance || {};
+  $('n-acceptance').textContent = a.regressions ? '(' + a.regressions + '!)' : '';
+  $('f-foot').innerHTML = 'state ' + esc(S.state_dir) + ' · needs from <code>'
+    + esc((S.needs || {}).source || '—') + '</code> · gh '
+    + (S.gh_ok ? 'ok' : '<b>(gh unavailable)</b>')
+    + ' · modules ' + Object.keys(S.modules || {}).map(function (k) {
+      return k + (S.modules[k] ? '&#10003;' : '&#183;');
+    }).join(' ') + ' · read-only dashboard';
+}
+
+/* ── 1. round board ───────────────────────────────────────────────────── */
+
+function laneHTML(name, states, current) {
+  var idx = states.indexOf(current);
+  var chips = states.map(function (s, i) {
+    var cls = 'chip';
+    if (s === current) cls += ' now';
+    else if (idx >= 0 && i < idx) cls += ' done';
+    return '<span class="' + cls + '">' + esc(s) + '</span>';
+  }).join('');
+  return '<div class="lane"><div class="lanehead"><b>' + esc(name) + '</b>'
+    + '<span class="cur">' + esc(current || 'not started') + '</span></div>'
+    + '<div class="chips">' + chips + '</div></div>';
+}
+
+/* One barrier per round, not one per lane: INTEGRATE runs once, after both tracks. */
+function barrierHTML(done) {
+  return '<div class="lane barrierlane"><div class="lanehead"><b>Barrier</b>'
+    + '<span class="cur">' + (done ? 'INTEGRATE ran — acceptance suite replayed on merged main'
+      : 'not reached — both tracks must land first') + '</span></div>'
+    + '<div class="chips"><span class="chip barrier' + (done ? ' done' : '')
+    + '">INTEGRATE</span></div></div>';
+}
+
+function renderBoard() {
+  var r = S.current_round, lanes = S.lanes || {};
+  $('b-round').textContent = r ? r.round : '—';
+  $('b-slate').textContent = r && r.slate ? r.slate.length + ' challenges' : '—';
+  $('b-needs').textContent = r ? ((r.needs_filed === null || r.needs_filed === undefined ? '—' : r.needs_filed)
+    + ' / ' + (r.needs_closed === null || r.needs_closed === undefined ? '—' : r.needs_closed)) : '—';
+  $('b-lanes').innerHTML = r
+    ? laneHTML('TestTrack', lanes.test || [], r.test_state)
+      + laneHTML('BuildTrack', lanes.build || [], r.build_state)
+      + barrierHTML(r.integrated)
+    : nothing('No round has started',
+      'The Supervisor pins MAIN_SHA at <code>BOOT</code>, then TestTrack(1) opens at <code>T_PLAN</code>.');
+
+  var tail = (r && r.tail) || [];
+  $('b-tcount').textContent = r ? (r.transitions || 0) + ' transitions' : '';
+  $('b-tlog').innerHTML = tail.length ? tail.map(function (t) {
+    return '<div class="row"><span class="t">' + esc(clock(t.ts)) + '</span>'
+      + '<span class="tr">' + esc(t.track || '—') + '</span>'
+      + '<span class="m">' + esc(t.from || '·') + ' &rarr; <b>' + esc(t.to || '?') + '</b>'
+      + (t.note ? ' — ' + esc(t.note) : '') + '</span></div>';
+  }).join('') : nothing('No transitions recorded',
+    'Every legal move appends one line to <code>rounds/&lt;n&gt;/transitions.jsonl</code>.');
+
+  var c = S.corpus || {}, tot = c.totals || {};
+  $('b-cov').textContent = (tot.attempted || 0) + ' / ' + (tot.total || 0) + ' challenges touched';
+  $('b-strata').innerHTML = (c.strata || []).length ? c.strata.map(function (s) {
+    return '<div><b>' + esc(s.stratum) + '</b><span class="v">' + s.attempted
+      + '<em>&#8202;/&#8202;' + s.total + '</em></span>'
+      + '<span class="s">' + s.coverage_pct + '% covered</span>'
+      + '<span class="s">' + s.solved + ' solved &#183; ' + s.gave_up + ' gave up</span></div>';
+  }).join('') : nothing('Dataset manifest not readable', '');
+
+  var wt = S.worktrees || [], lz = S.leases || {};
+  var lk = Object.keys(lz);
+  $('b-infra').innerHTML =
+    '<div style="font-size:.75rem;line-height:1.9">'
+    + '<b>worktrees</b> ' + (wt.length ? wt.map(function (w) {
+      return '<br><span class="dim">' + esc(w.path) + '</span> [' + esc(w.branch || '?') + ']';
+    }).join('') : '<span class="dim">none</span>')
+    + '<br><br><b>leases</b> ' + (lk.length ? lk.map(function (k) {
+      return '<br><span class="pill ink">' + esc(k) + '</span> ' + esc(lz[k].holder);
+    }).join('') : '<span class="dim">none held</span>')
+    + '</div>';
+}
+
+/* ── 2. agents ────────────────────────────────────────────────────────── */
+
+function ciPill(ci) {
+  if (!ci) return '<span class="pill mute">—</span>';
+  var m = { pass: 'ok', fail: 'bad', running: 'warn', none: 'mute', unknown: 'mute' };
+  return '<span class="pill ' + (m[ci.state] || 'mute') + '" title="' + esc(ci.detail || '')
+    + '">' + esc(ci.state) + '</span>';
+}
+
+function renderAgents() {
+  var rows = S.agents || [];
+  var head = '<thead><tr><th>Agent</th><th>Role</th><th>Pool</th><th>Phase</th>'
+    + '<th>Elapsed</th><th>Stale</th><th class="right">Tokens in/out</th>'
+    + '<th class="right">USD</th><th>Detail</th><th>Log</th></tr></thead>';
+  if (!rows.length) {
+    $('a-table').innerHTML = head + '<tbody><tr><td colspan="10">'
+      + nothing('No agents registered',
+        'Workers appear here as soon as <code>state register</code> runs; the cap is '
+        + esc((S.header || {}).agents_max || 7) + ' (1 captain + testers + builders).')
+      + '</td></tr></tbody>';
+    return;
+  }
+  var t = now();
+  var body = rows.map(function (a) {
+    var el = t - (a.started_at || t), st = t - (a.updated_at || t);
+    var detail;
+    if (a.role === 'tester') {
+      detail = '<span class="pill">' + esc(a.stratum || 'stratum ?') + '</span> '
+        + (a.challenge ? '<span class="mono">' + esc(a.challenge) + '</span>' : '')
+        + (a.outcome ? ' <span class="pill ' + (a.outcome === 'solved' ? 'ok'
+          : a.outcome === 'gave_up' ? 'hot' : 'warn') + '">' + esc(a.outcome) + '</span>' : '')
+        + (a.gave_up_reason ? '<span class="sub">' + esc(a.gave_up_reason) + '</span>' : '');
+    } else {
+      detail = (a.branch ? '<span class="mono">' + esc(a.branch) + '</span>' : '<span class="dim">—</span>')
+        + (a.pr ? ' <a href="' + esc(a.pr_url || '#') + '" target="_blank" rel="noopener">#'
+          + esc(a.pr) + '</a>' : '')
+        + ' ' + ciPill(a.ci)
+        + (a.leases && a.leases.length
+          ? '<span class="sub">leases: ' + a.leases.map(esc).join(', ') + '</span>' : '')
+        + (a.need ? '<span class="sub">need: ' + esc(a.need) + '</span>' : '');
+    }
+    return '<tr><td class="id">' + esc(a.id)
+      + (a.note ? '<span class="sub">' + esc(a.note) + '</span>' : '') + '</td>'
+      + '<td><span class="pill ' + (a.role === 'captain' ? 'ink' : '') + '">' + esc(a.role) + '</span></td>'
+      + '<td class="dim">' + esc(a.pool || '—') + '</td>'
+      + '<td>' + esc(a.phase || '—') + '<span class="sub">' + esc(a.status || '') + '</span></td>'
+      + '<td class="num" data-el="' + (a.started_at || '') + '">' + esc(dur(el)) + '</td>'
+      + '<td class="num stale' + (st > 120 ? ' red' : '') + '" data-st="' + (a.updated_at || '') + '">'
+      + esc(dur(st)) + (st > 120 ? '!' : '') + '</td>'
+      + '<td class="num">' + num(a.tokens_in) + ' / ' + num(a.tokens_out) + '</td>'
+      + '<td class="num">' + usd(a.usd) + '</td>'
+      + '<td>' + detail + '</td>'
+      + '<td>' + (a.has_log
+        ? '<button class="linkish" data-log="' + esc(a.id) + '">tail</button>'
+        : '<span class="dim">—</span>') + '</td></tr>';
+  }).join('');
+  $('a-table').innerHTML = head + '<tbody>' + body + '</tbody>';
+
+  var prs = S.prs;
+  $('a-ghnote').textContent = prs === null ? '(gh unavailable)' : (prs.length + ' open');
+  $('a-prs').innerHTML = '<thead><tr><th>PR</th><th>Title</th><th>Branch</th></tr></thead><tbody>'
+    + (prs && prs.length ? prs.map(function (p) {
+      return '<tr><td class="id"><a href="' + esc(p.url) + '" target="_blank" rel="noopener">#'
+        + esc(p.number) + '</a></td><td>' + esc(p.title) + '</td><td class="mono">'
+        + esc(p.headRefName) + '</td></tr>';
+    }).join('') : '<tr><td colspan="3">' + nothing(
+      prs === null ? 'gh unavailable' : 'No open pull requests',
+      prs === null ? 'The open-PR fetch failed; the cached value is shown as null, exactly as <code>status.py</code> renders it.' : '')
+      + '</td></tr>') + '</tbody>';
+}
+
+/* ── 3. evidence ──────────────────────────────────────────────────────── */
+
+function hypCell(h) {
+  var v = String(h || 'inconclusive').toLowerCase();
+  if (v === 'overturned') return '<span class="pill hot">OVERTURNED</span>';
+  if (v === 'upheld') return '<span class="pill ok">UPHELD</span>';
+  return '<span class="pill mute">INCONCLUSIVE</span>';
+}
+function probeCell(id, status) {
+  if (!id) return '<span class="dim">—</span>';
+  var cls = status === 'pass' ? 'ok' : status === 'fail' ? 'bad' : 'mute';
+  return '<button class="linkish" data-probe="' + esc(id) + '">' + esc(id) + '</button>'
+    + ' <span class="pill ' + cls + '">' + esc(status || 'unrun') + '</span>';
+}
+
+function renderEvidence() {
+  var n = S.needs || {}, tot = n.totals || {};
+  $('e-denom').innerHTML =
+    '<div><b>Filed</b><span>' + (tot.filed || 0) + '</span></div>'
+    + '<div><b>Admitted</b><span>' + (tot.admitted || 0) + '</span></div>'
+    + '<div class="hot"><b>Rejected</b><span>' + (tot.rejected || 0) + '</span></div>'
+    + '<div><b>Rejected share</b><span>' + (tot.rejected_pct || 0) + '%</span></div>'
+    + '<div class="hot"><b>Hypotheses overturned</b><span>' + (tot.overturned || 0) + '</span></div>';
+
+  fillSelect($('f-status'), 'status', Object.keys(n.by_status || {}).concat(['rejected']));
+  fillSelect($('f-track'), 'track', ['tooling', 'quality', 'perf', 'loader']);
+  $('sub-backlog').setAttribute('aria-selected', EV_TAB === 'backlog');
+  $('sub-rejected').setAttribute('aria-selected', EV_TAB === 'rejected');
+
+  if (EV_TAB === 'rejected') return renderRejected(n);
+
+  var rows = FILTERED ? FILTERED.needs : (n.backlog || []);
+  $('f-count').textContent = rows.length + ' shown';
+  if (!rows.length) {
+    $('e-body').innerHTML = nothing('The backlog is empty',
+      'A need is admitted only when its probe <b>PASSES</b> and its acceptance <b>FAILS</b> on a freshly built main at the pinned SHA.');
+    return;
+  }
+  $('e-body').innerHTML = '<div class="tw"><table class="t">'
+    + '<thead><tr><th>#</th><th>Need</th><th>Track</th><th>Sev</th><th>Status</th>'
+    + '<th>Probe (current bad)</th><th>Acceptance (desired)</th><th>Hypothesis</th>'
+    + '<th class="right">Cred</th><th class="right">Inst</th><th>Rounds</th></tr></thead><tbody>'
+    + rows.map(function (d, i) {
+      return '<tr><td class="num dim">' + (i + 1) + '</td>'
+        + '<td class="id"><button class="linkish" data-need="' + esc(d.need_id) + '">'
+        + esc(d.need_id) + '</button><span class="sub">' + esc(d.title) + '</span></td>'
+        + '<td>' + esc(d.track) + '</td>'
+        + '<td><span class="pill ' + (d.severity === 'blocker' ? 'bad' : '') + '">'
+        + esc(d.severity) + '</span></td>'
+        + '<td><span class="pill ' + (d.status === 'regressed' ? 'hot'
+          : d.status === 'closed' ? 'ok' : '') + '">' + esc(d.status) + '</span></td>'
+        + '<td>' + probeCell(d.probe_id, d.probe_status) + '</td>'
+        + '<td>' + probeCell(d.acceptance_id, d.acceptance_status) + '</td>'
+        + '<td>' + hypCell(d.hypothesis_status) + '</td>'
+        + '<td class="num">' + (d.credibility === null || d.credibility === undefined
+          ? '—' : Number(d.credibility).toFixed(2)) + '</td>'
+        + '<td class="num">' + (d.instances || 0) + '</td>'
+        + '<td class="dim">' + esc((d.rounds || []).join(',') || '—') + '</td></tr>';
+    }).join('') + '</tbody></table></div>';
+}
+
+function renderRejected(n) {
+  var groups = n.rejected_by_reason || {};
+  var keys = Object.keys(groups);
+  $('f-count').textContent = (n.rejected || []).length + ' rejected';
+  if (!keys.length) {
+    $('e-body').innerHTML = nothing('Nothing rejected yet',
+      'This pile is the honest denominator: <code>already-supported</code> means the tester was wrong, not that kuna was bad.');
+    return;
+  }
+  var why = {
+    'already-supported': 'the acceptance probe PASSED at filing — kuna already does this',
+    'not-reproducible': 'the probe FAILED at filing — the symptom did not replay',
+    'unprobeable': 'real friction with no machine-checkable predicate',
+    'user-error': 'the tester drove kuna wrong',
+    'covered-by-option': 'an existing option already closes it — a default-flip candidate'
+  };
+  $('e-body').innerHTML = keys.map(function (k) {
+    var rows = groups[k];
+    return '<details class="rgroup" open><summary><span class="c">' + rows.length + '</span>'
+      + '<span>' + esc(k) + '</span><span class="why">' + esc(why[k] || '') + '</span></summary>'
+      + '<div class="tw"><table class="t"><thead><tr><th>Need</th><th>Track</th>'
+      + '<th>Probe</th><th>Acceptance</th><th>Covered by option</th><th>Rounds</th></tr></thead><tbody>'
+      + rows.map(function (d) {
+        return '<tr><td class="id"><button class="linkish" data-need="' + esc(d.need_id) + '">'
+          + esc(d.need_id) + '</button><span class="sub">' + esc(d.title) + '</span></td>'
+          + '<td>' + esc(d.track) + '</td><td class="mono dim">' + esc(d.probe_id || '—') + '</td>'
+          + '<td class="mono dim">' + esc(d.acceptance_id || '—') + '</td>'
+          + '<td>' + esc(d.covered_by_option || '—') + '</td>'
+          + '<td class="dim">' + esc((d.rounds || []).join(',') || '—') + '</td></tr>';
+      }).join('') + '</tbody></table></div></details>';
+  }).join('');
+}
+
+function fillSelect(sel, label, values) {
+  var keep = sel.value;
+  sel.innerHTML = '<option value="">' + label + ': any</option>'
+    + values.filter(function (v, i, a) { return v && a.indexOf(v) === i; })
+      .map(function (v) { return '<option value="' + esc(v) + '">' + esc(v) + '</option>'; }).join('');
+  sel.value = keep;
+}
+
+/* ── 4. acceptance matrix ─────────────────────────────────────────────── */
+
+function renderMatrix() {
+  var a = S.acceptance || {}, rounds = a.rounds || [], probes = a.probes || [];
+  $('m-denom').innerHTML =
+    '<div><b>Acceptance probes</b><span>' + probes.length + '</span></div>'
+    + '<div><b>Passing on main</b><span>' + (a.closed || 0) + '</span></div>'
+    + '<div><b>Still failing</b><span>' + (a.outstanding || 0) + '</span></div>'
+    + '<div class="hot"><b>Regressions</b><span>' + (a.regressions || 0) + '</span></div>'
+    + '<div><b>Never replayed</b><span>' + (a.never_run || 0) + '</span></div>';
+  if (!probes.length) {
+    $('m-body').innerHTML = nothing('No acceptance probes filed yet',
+      'INTEGRATE writes <code>rounds/&lt;n&gt;/acceptance.json</code> from '
+      + '<code>verify --acceptance-suite --all --json</code>; each column here is one of those files.');
+    return;
+  }
+  var cols = rounds.length ? rounds : [];
+  var head = '<thead><tr><th class="rowh">Acceptance probe / need</th>'
+    + cols.map(function (r) {
+      var t = (a.totals || {})[String(r)] || {};
+      return '<th>R' + esc(r) + '<span class="pid">' + (t.pass || 0) + 'P / '
+        + (t.fail || 0) + 'F</span></th>';
+    }).join('') + '<th>Latest</th></tr></thead>';
+  var body = probes.map(function (p) {
+    var cells = cols.map(function (r) {
+      var v = p.cells[String(r)];
+      var cls = v === 'pass' ? 'pass' : v === 'fail' ? 'fail'
+        : v === undefined || v === null ? 'none' : 'other';
+      if (v === 'fail' && p.first_pass_round !== null && p.first_pass_round !== undefined
+        && r > p.first_pass_round) cls = 'regress';
+      return '<td><span class="cell ' + cls + '">'
+        + (v ? esc(v.toUpperCase()) : '·') + '</span></td>';
+    }).join('');
+    var rowcls = (p.regressed ? 'reg' : '') + (Object.keys(p.cells).length ? '' : ' unrun');
+    return '<tr class="' + rowcls + '"><td class="rowh">'
+      + (p.need_id
+        ? '<button class="linkish" data-need="' + esc(p.need_id) + '">' + esc(p.need_id) + '</button>'
+        : '<span class="dim">unlinked</span>')
+      + (p.title ? ' ' + esc(p.title) : '')
+      + '<span class="pid"><button class="linkish" data-probe="' + esc(p.probe_id) + '">'
+      + esc(p.probe_id) + '</button>'
+      + (p.track ? ' · ' + esc(p.track) : '')
+      + (p.regressed ? ' · <b style="color:var(--red)">REGRESSION</b>' : '') + '</span></td>'
+      + cells
+      + '<td><span class="cell ' + (p.latest === 'pass' ? 'pass' : p.latest === 'fail' ? 'fail' : 'none')
+      + '">' + esc((p.latest || '·').toUpperCase()) + '</span></td></tr>';
+  }).join('');
+  $('m-body').innerHTML = '<table class="t matrix">' + head + '<tbody>' + body + '</tbody></table>';
+}
+
+/* ── drawer ───────────────────────────────────────────────────────────── */
+
+function openDrawer(title, path, html) {
+  $('d-title').textContent = title;
+  $('d-path').textContent = path || '';
+  $('d-body').innerHTML = html;
+  $('drawer').hidden = false;
+  $('scrim').hidden = false;
+}
+function closeDrawer() { $('drawer').hidden = true; $('scrim').hidden = true; }
+
+function showLog(id) {
+  openDrawer('log · ' + id, '', '<pre>loading…</pre>');
+  fetch('/api/agent/' + encodeURIComponent(id) + '/log?tail=400')
+    .then(function (r) { return r.json(); })
+    .then(function (d) {
+      if (d.error) return openDrawer('log · ' + id, '', '<pre>' + esc(d.error) + '</pre>');
+      openDrawer('log · ' + id, d.path, '<pre>' + esc((d.lines || []).join('\n')) + '</pre>');
+    })
+    .catch(function (e) { openDrawer('log · ' + id, '', '<pre>' + esc(e) + '</pre>'); });
+}
+
+function showNeed(id) {
+  openDrawer('need · ' + id, '', '<pre>loading…</pre>');
+  fetch('/api/need/' + encodeURIComponent(id)).then(function (r) { return r.json(); })
+    .then(function (d) {
+      if (d.error) return openDrawer('need · ' + id, '', '<pre>' + esc(d.error) + '</pre>');
+      var meta = '<div class="sec"><h4>Record</h4><pre>'
+        + esc(JSON.stringify(d.raw_front_matter || {}, null, 2)) + '</pre></div>';
+      var secs = Object.keys(d.sections || {}).map(function (k) {
+        return '<div class="sec"><h4>' + esc(k) + '</h4><pre>' + esc(d.sections[k]) + '</pre></div>';
+      }).join('');
+      openDrawer('need · ' + id, d.file, meta + secs);
+    });
+}
+
+function showProbe(id) {
+  openDrawer('probe · ' + id, '', '<pre>loading…</pre>');
+  fetch('/api/probe/' + encodeURIComponent(id)).then(function (r) { return r.json(); })
+    .then(function (d) {
+      if (d.error) return openDrawer('probe · ' + id, '', '<pre>' + esc(d.error) + '</pre>');
+      openDrawer('probe · ' + id, d.origin || '',
+        '<div class="sec"><h4>' + (d.is_acceptance ? 'Acceptance — the DESIRED behaviour'
+          : 'Probe — the CURRENT BAD behaviour') + '</h4><pre>'
+        + esc(JSON.stringify(d.probe, null, 2)) + '</pre></div>'
+        + '<div class="sec"><h4>Replays (' + d.replay_count + ')</h4><pre>'
+        + esc((d.replays || []).map(function (r) { return JSON.stringify(r); }).join('\n'))
+        + '</pre></div>');
+    });
+}
+
+/* ── wiring ───────────────────────────────────────────────────────────── */
+
+function render() {
+  if (!S) return;
+  renderHeader();
+  if (PANE === 'board') renderBoard();
+  else if (PANE === 'agents') renderAgents();
+  else if (PANE === 'evidence') renderEvidence();
+  else renderMatrix();
+}
+
+function tickTimers() {
+  if (!S) return;
+  var t = now();
+  var r = S.current_round;
+  $('b-timer').textContent = r && r.started_at ? dur(t - r.started_at) : '—';
+  var sup = S.supervisor || {};
+  $('b-runtimer').textContent = sup.started_at ? dur(t - sup.started_at) : '—';
+  document.querySelectorAll('[data-el]').forEach(function (td) {
+    var v = parseFloat(td.getAttribute('data-el'));
+    if (v) td.textContent = dur(t - v);
+  });
+  document.querySelectorAll('[data-st]').forEach(function (td) {
+    var v = parseFloat(td.getAttribute('data-st'));
+    if (!v) return;
+    var s = t - v;
+    td.textContent = dur(s) + (s > 120 ? '!' : '');
+    td.classList.toggle('red', s > 120);
+  });
+}
+
+function pull() {
+  return fetch('/api/state').then(function (r) { return r.json(); }).then(function (d) {
+    S = d;
+    if (d.now) SKEW = d.now - Date.now() / 1000;
+    LAST_SEQ = d.seq;
+    $('h-seq').textContent = 'seq ' + d.seq;
+    var live = $('h-live');
+    live.className = 'live beat';
+    setTimeout(function () { live.className = 'live on'; }, 320);
+    render();
+    tickTimers();
+  }).catch(function () {
+    $('h-live').className = 'live off';
+    $('h-seq').textContent = 'disconnected';
+  });
+}
+
+function applyFilters() {
+  var st = $('f-status').value, tr = $('f-track').value, q = $('f-q').value.trim();
+  if (!st && !tr && !q) { FILTERED = null; return renderEvidence(); }
+  var u = '/api/needs?' + [st && 'status=' + encodeURIComponent(st),
+    tr && 'track=' + encodeURIComponent(tr), q && 'q=' + encodeURIComponent(q)]
+      .filter(Boolean).join('&');
+  fetch(u).then(function (r) { return r.json(); }).then(function (d) {
+    FILTERED = d; renderEvidence();
+  });
+}
+
+function selectPane(name) {
+  PANE = name;
+  ['board', 'agents', 'evidence', 'acceptance'].forEach(function (p) {
+    $('pane-' + p).hidden = p !== name;
+    $('tab-' + p).setAttribute('aria-selected', String(p === name));
+  });
+  render();
+  tickTimers();
+}
+
+document.addEventListener('click', function (e) {
+  var t = e.target.closest ? e.target.closest('[data-pane],[data-log],[data-need],[data-probe]') : null;
+  if (!t) return;
+  if (t.dataset.pane) return selectPane(t.dataset.pane);
+  if (t.dataset.log) return showLog(t.dataset.log);
+  if (t.dataset.need) return showNeed(t.dataset.need);
+  if (t.dataset.probe) return showProbe(t.dataset.probe);
+});
+$('d-close').addEventListener('click', closeDrawer);
+$('scrim').addEventListener('click', closeDrawer);
+document.addEventListener('keydown', function (e) { if (e.key === 'Escape') closeDrawer(); });
+$('sub-backlog').addEventListener('click', function () { EV_TAB = 'backlog'; renderEvidence(); });
+$('sub-rejected').addEventListener('click', function () { EV_TAB = 'rejected'; renderEvidence(); });
+$('f-status').addEventListener('change', applyFilters);
+$('f-track').addEventListener('change', applyFilters);
+var qt = null;
+$('f-q').addEventListener('input', function () {
+  clearTimeout(qt); qt = setTimeout(applyFilters, 220);
+});
+$('h-stop').addEventListener('click', function () {
+  var sup = (S && S.supervisor) || {};
+  openDrawer('stop the run', '', '<div class="sec"><h4>This dashboard is read-only</h4>'
+    + '<p style="font-size:.8125rem;line-height:1.8">It never posts, and it cannot stop a run. '
+    + 'Graceful drain — in-flight agents finish and INTEGRATE still runs:</p>'
+    + '<pre>touch ' + esc(sup.stop_path || '.kuna-repipe/STOP') + '</pre>'
+    + '<p style="font-size:.8125rem;line-height:1.8">Hard stop — SIGTERM to the recorded pids, '
+    + 'every worktree and arena kept intact for forensics:</p>'
+    + '<pre>touch ' + esc(sup.abort_path || '.kuna-repipe/ABORT') + '</pre></div>');
+});
+
+/* SSE is the only push channel; the poll is the fallback when it will not open. */
+function listen() {
+  var poll = setInterval(pull, 5000);
+  if (!window.EventSource) return;
+  try {
+    var es = new EventSource('/api/events');
+    es.onmessage = function (m) {
+      var d = {};
+      try { d = JSON.parse(m.data); } catch (err) { return; }
+      if (d.seq !== LAST_SEQ) pull();
+    };
+    es.onopen = function () { clearInterval(poll); poll = setInterval(pull, 30000); };
+    es.onerror = function () { $('h-live').className = 'live off'; };
+  } catch (err) { /* keep the poll */ }
+}
+
+pull().then(listen);
+setInterval(tickTimers, 1000);

--- a/tools/repipe/webui/assets/dash.css
+++ b/tools/repipe/webui/assets/dash.css
@@ -1,0 +1,270 @@
+/* =========================================================================
+   kuna RE-friction loop — the local dashboard.
+
+   Layers on /assets/site.css, which is served VERBATIM out of
+   integrations/web/assets/css/site.css so this page cannot drift from
+   kuna.noelo.org: --paper/--ink/--red/--mono/--disp all come from there.
+   Nothing here is loaded from a CDN; the whole page is three files.
+
+   site.css's own @font-face rules point at ../fonts/, which is /fonts/ under
+   this server; webui.py serves that path out of the same tree, so Jost and
+   Roboto Mono load from the stylesheet as written and nothing is re-declared.
+   ========================================================================= */
+
+:root{
+  --pass:#2F6B3A;
+  --pass-bg:#EAF2EA;
+  --fail-bg:#FBEAEC;
+  --warn:#8A5A00;
+  --chip-h:26px;
+}
+
+body{background:var(--paper);}
+main{flex:1 0 auto;}
+.wrapx{max-width:1560px;margin:0 auto;padding-inline:clamp(14px,2.2vw,28px);width:100%;}
+.mono{font-family:var(--mono);}
+.dim{color:var(--muted);}
+.nowrap{white-space:nowrap;}
+.right{text-align:right;}
+
+/* ── Header strip ───────────────────────────────────────────────────────── */
+.hdr{position:sticky;top:0;z-index:30;background:var(--paper);
+  border-bottom:1px solid var(--ink);}
+.hdr .wrapx{display:flex;align-items:stretch;gap:0;flex-wrap:wrap;min-height:54px;}
+.brand{display:flex;align-items:center;gap:10px;text-decoration:none;
+  padding-right:20px;margin-right:4px;border-right:1px solid var(--rule);}
+.brand .wordmark{font:400 1.3rem/1 var(--disp);letter-spacing:-.02em;}
+.brand .at{font:700 .625rem/1.35 var(--mono);letter-spacing:.16em;text-transform:uppercase;
+  color:var(--red);}
+.stat{display:flex;flex-direction:column;justify-content:center;gap:2px;
+  padding:8px 18px;border-right:1px solid var(--rule);min-width:0;}
+.stat b{font:700 .5625rem/1.3 var(--mono);letter-spacing:.16em;text-transform:uppercase;
+  color:var(--muted);}
+.stat span{font:400 .875rem/1.2 var(--mono);white-space:nowrap;}
+.stat span em{font-style:normal;color:var(--muted);}
+.stat.bad span{color:var(--red);font-weight:700;}
+.stat.good span{color:var(--pass);}
+.hdr .spacer{flex:1 1 auto;}
+.live{display:flex;align-items:center;gap:8px;padding:8px 16px;
+  font:400 .6875rem/1 var(--mono);color:var(--muted);border-left:1px solid var(--rule);}
+.live i{width:7px;height:7px;border-radius:50%;background:var(--rule-2);flex:none;}
+.live.on i{background:var(--pass);}
+.live.beat i{background:var(--red);}
+.live.off i{background:var(--muted);}
+.stopbtn{font:700 .625rem/1 var(--mono);letter-spacing:.16em;text-transform:uppercase;
+  padding:0 18px;border:0;border-left:1px solid var(--ink);background:var(--ink);
+  color:var(--paper);cursor:pointer;align-self:stretch;}
+.stopbtn:hover{background:var(--red);}
+
+/* ── Tabs ───────────────────────────────────────────────────────────────── */
+.tabs{border-bottom:1px solid var(--rule);background:var(--paper-2);position:sticky;
+  top:54px;z-index:25;}
+.tabs .wrapx{display:flex;gap:0;overflow-x:auto;}
+.tab{appearance:none;background:transparent;border:0;border-right:1px solid var(--rule);
+  font:700 .6875rem/1 var(--mono);letter-spacing:.16em;text-transform:uppercase;
+  padding:14px 20px;color:var(--muted);cursor:pointer;white-space:nowrap;
+  border-bottom:2px solid transparent;margin-bottom:-1px;}
+.tab:hover{color:var(--ink);background:var(--paper);}
+.tab[aria-selected=true]{color:var(--ink);background:var(--paper);
+  border-bottom-color:var(--red);}
+.tab .n{color:var(--red);margin-left:8px;font-weight:400;}
+
+/* ── Panels + section furniture ─────────────────────────────────────────── */
+.panel{padding-block:22px 44px;}
+.panel[hidden]{display:none!important;}
+.shead{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap;margin-bottom:12px;}
+.shead h2{font:700 .75rem/1 var(--mono);letter-spacing:.18em;text-transform:uppercase;}
+.shead .sub{font-size:.75rem;color:var(--muted);}
+.card{border:1px solid var(--rule-2);background:var(--paper);}
+.card + .card{margin-top:18px;}
+.card > .chead{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+  padding:10px 14px;border-bottom:1px solid var(--rule);background:var(--paper-2);
+  font:700 .625rem/1.3 var(--mono);letter-spacing:.16em;text-transform:uppercase;}
+.card > .chead .grow{flex:1 1 auto;}
+.card > .chead .note{font-weight:400;letter-spacing:.04em;text-transform:none;
+  color:var(--muted);font-size:.6875rem;}
+.cbody{padding:14px;}
+.grid2{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:18px;}
+.grid3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:18px;}
+.empty{padding:34px 18px;text-align:center;color:var(--muted);font-size:.8125rem;
+  background:var(--paper-2);}
+.empty b{display:block;color:var(--ink-2);font-weight:700;margin-bottom:6px;}
+.empty code{border:1px solid var(--rule-2);background:var(--paper);padding:1px 5px;}
+
+/* ── Round board ────────────────────────────────────────────────────────── */
+.roundtop{display:flex;align-items:flex-end;gap:26px;flex-wrap:wrap;padding:16px 14px;
+  border-bottom:1px solid var(--rule);}
+.bignum{font:300 3.2rem/0.9 var(--disp);letter-spacing:-.03em;}
+.bignum small{font:700 .625rem/1 var(--mono);letter-spacing:.18em;color:var(--muted);
+  display:block;margin-bottom:8px;text-transform:uppercase;}
+.timer{font:400 1.5rem/1 var(--mono);font-variant-numeric:tabular-nums;}
+.timer small{font:700 .625rem/1 var(--mono);letter-spacing:.18em;color:var(--muted);
+  display:block;margin-bottom:9px;text-transform:uppercase;}
+
+.lane{padding:14px;border-bottom:1px solid var(--rule);}
+.lane:last-child{border-bottom:0;}
+.lanehead{display:flex;align-items:baseline;gap:10px;margin-bottom:10px;}
+.lanehead b{font:700 .6875rem/1 var(--mono);letter-spacing:.16em;text-transform:uppercase;}
+.lanehead .cur{font-size:.75rem;color:var(--red);}
+.chips{display:flex;flex-wrap:wrap;gap:0;align-items:stretch;}
+.chip{display:flex;align-items:center;height:var(--chip-h);padding:0 11px;
+  border:1px solid var(--rule-2);border-right-width:0;background:var(--paper);
+  font:400 .6875rem/1 var(--mono);color:var(--muted);white-space:nowrap;}
+.chip:last-child{border-right-width:1px;}
+.chip.done{color:var(--ink-2);background:var(--paper-2);}
+.chip.now{background:var(--ink);color:var(--paper);border-color:var(--ink);font-weight:700;
+  box-shadow:inset 0 -2px 0 var(--on-ink-red);}
+.chip.barrier{border-right-width:1px;border-color:var(--red);
+  color:var(--red);font-weight:700;letter-spacing:.1em;}
+.chip.barrier.done{background:var(--red);color:var(--paper);}
+.lane.barrierlane{background:var(--paper-2);}
+
+/* a probe filed but never replayed is real, and belongs at the bottom, dimmed */
+.matrix tr.unrun td.rowh{opacity:.62;}
+
+.tlog{margin:0;max-height:340px;overflow:auto;font-size:.75rem;line-height:1.75;}
+.tlog .row{display:grid;grid-template-columns:88px 62px minmax(0,1fr);gap:10px;
+  padding:3px 14px;border-bottom:1px solid var(--rule);white-space:nowrap;}
+.tlog .row:nth-child(odd){background:var(--paper-2);}
+.tlog .t{color:var(--muted);}
+.tlog .tr{color:var(--red);font-weight:700;}
+.tlog .m{overflow:hidden;text-overflow:ellipsis;color:var(--ink-2);}
+
+/* ── Tables ─────────────────────────────────────────────────────────────── */
+.tw{overflow-x:auto;}
+table.t{border-collapse:collapse;width:100%;font-size:.75rem;}
+table.t th{font:700 .5625rem/1.4 var(--mono);letter-spacing:.14em;text-transform:uppercase;
+  color:var(--muted);text-align:left;padding:9px 12px;border-bottom:1px solid var(--ink);
+  background:var(--paper);position:sticky;top:0;white-space:nowrap;}
+table.t td{padding:8px 12px;border-bottom:1px solid var(--rule);vertical-align:top;}
+table.t tbody tr:hover{background:var(--paper-2);}
+table.t td.num{text-align:right;font-variant-numeric:tabular-nums;}
+table.t .id{font-weight:700;}
+table.t .sub{display:block;color:var(--muted);font-size:.6875rem;margin-top:3px;
+  white-space:normal;}
+
+.pill{display:inline-block;padding:1px 7px;border:1px solid var(--rule-2);
+  font:700 .5625rem/1.6 var(--mono);letter-spacing:.1em;text-transform:uppercase;
+  color:var(--ink-2);background:var(--paper);}
+.pill.ok{color:var(--pass);border-color:var(--pass);}
+.pill.bad{color:var(--red);border-color:var(--red);}
+.pill.hot{color:var(--paper);background:var(--red);border-color:var(--red);}
+.pill.warn{color:var(--warn);border-color:var(--warn);}
+.pill.mute{color:var(--muted);}
+.pill.ink{color:var(--paper);background:var(--ink);border-color:var(--ink);}
+
+.stale{color:var(--ink-2);}
+.stale.red{color:var(--red);font-weight:700;}
+.bar{height:4px;background:var(--rule);margin-top:5px;position:relative;}
+.bar i{position:absolute;inset:0 auto 0 0;background:var(--ink);}
+.bar i.hot{background:var(--red);}
+
+.linkish{background:none;border:0;padding:0;font:inherit;color:var(--ink);cursor:pointer;
+  border-bottom:1px solid var(--red);}
+.linkish:hover{color:var(--red);}
+
+/* ── Evidence ───────────────────────────────────────────────────────────── */
+.filters{display:flex;gap:10px;flex-wrap:wrap;align-items:center;padding:10px 14px;
+  border-bottom:1px solid var(--rule);background:var(--paper-2);}
+.filters select,.filters input{font:400 .75rem/1 var(--mono);color:var(--ink);
+  background:var(--paper);border:1px solid var(--rule-2);border-radius:0;padding:8px 10px;}
+.filters input{min-width:min(280px,60vw);}
+.filters select:hover,.filters input:focus{border-color:var(--ink);outline:0;}
+.subtabs{display:flex;gap:0;}
+.subtab{appearance:none;border:1px solid var(--rule-2);background:var(--paper);
+  font:700 .5625rem/1 var(--mono);letter-spacing:.14em;text-transform:uppercase;
+  padding:9px 14px;color:var(--muted);cursor:pointer;margin-left:-1px;}
+.subtab[aria-selected=true]{background:var(--ink);color:var(--paper);border-color:var(--ink);}
+
+.denom{display:flex;gap:0;flex-wrap:wrap;border-bottom:1px solid var(--rule);}
+.denom div{padding:12px 16px;border-right:1px solid var(--rule);min-width:120px;}
+.denom b{display:block;font:700 .5625rem/1.4 var(--mono);letter-spacing:.14em;
+  text-transform:uppercase;color:var(--muted);}
+.denom span{font:400 1.35rem/1.3 var(--mono);}
+.denom.hot span{color:var(--red);}
+
+.rgroup{border-bottom:1px solid var(--rule);}
+.rgroup > summary{cursor:pointer;padding:10px 14px;background:var(--paper-2);
+  font:700 .625rem/1.4 var(--mono);letter-spacing:.14em;text-transform:uppercase;
+  display:flex;gap:10px;align-items:baseline;}
+.rgroup > summary::marker{color:var(--red);}
+.rgroup > summary .c{color:var(--red);}
+.rgroup > summary .why{font-weight:400;letter-spacing:.02em;text-transform:none;
+  color:var(--muted);}
+
+/* ── Acceptance matrix ──────────────────────────────────────────────────── */
+.matrix{border-collapse:separate;border-spacing:0;font-size:.75rem;}
+.matrix th,.matrix td{border-bottom:1px solid var(--rule);padding:0;}
+.matrix thead th{font:700 .5625rem/1.4 var(--mono);letter-spacing:.14em;
+  text-transform:uppercase;color:var(--muted);padding:9px 10px;
+  border-bottom:1px solid var(--ink);background:var(--paper);
+  position:sticky;top:0;z-index:2;text-align:center;}
+.matrix th.rowh{position:sticky;left:0;z-index:3;text-align:left;min-width:280px;
+  background:var(--paper);border-right:1px solid var(--rule);}
+.matrix td.rowh{position:sticky;left:0;z-index:1;background:var(--paper);
+  border-right:1px solid var(--rule);padding:8px 10px;min-width:280px;max-width:420px;}
+.matrix tbody tr:hover td{background:var(--paper-2);}
+.matrix tbody tr:hover td.rowh{background:var(--paper-2);}
+.matrix .cell{display:block;text-align:center;padding:9px 6px;min-width:56px;
+  font:700 .625rem/1.2 var(--mono);letter-spacing:.06em;}
+.matrix .cell.pass{background:var(--pass-bg);color:var(--pass);}
+.matrix .cell.fail{background:var(--fail-bg);color:var(--red);}
+.matrix .cell.regress{background:var(--red);color:var(--paper);}
+.matrix .cell.other{background:var(--paper-2);color:var(--warn);}
+.matrix .cell.none{color:var(--rule-2);}
+.matrix tr.reg td.rowh{box-shadow:inset 3px 0 0 var(--red);}
+.matrix .pid{font-size:.6875rem;color:var(--muted);display:block;margin-top:3px;}
+.legend{display:flex;gap:16px;flex-wrap:wrap;padding:10px 14px;font-size:.6875rem;
+  color:var(--muted);border-top:1px solid var(--rule);align-items:center;}
+.legend s{text-decoration:none;display:inline-block;width:14px;height:14px;
+  vertical-align:-2px;margin-right:6px;border:1px solid var(--rule-2);}
+.legend s.pass{background:var(--pass-bg);border-color:var(--pass);}
+.legend s.fail{background:var(--fail-bg);border-color:var(--red);}
+.legend s.regress{background:var(--red);border-color:var(--red);}
+
+/* ── Drawer (log tail / need detail) ────────────────────────────────────── */
+.drawer{position:fixed;inset:0 0 0 auto;width:min(920px,94vw);background:var(--paper);
+  border-left:1px solid var(--ink);z-index:60;display:flex;flex-direction:column;
+  box-shadow:-18px 0 40px rgba(20,17,16,.12);}
+.drawer[hidden]{display:none!important;}
+.drawer .dhead{display:flex;align-items:center;gap:12px;padding:12px 16px;
+  border-bottom:1px solid var(--ink);background:var(--paper-2);}
+.drawer .dhead b{font:700 .6875rem/1.3 var(--mono);letter-spacing:.14em;
+  text-transform:uppercase;}
+.drawer .dhead .grow{flex:1 1 auto;}
+.drawer .dhead .path{font-size:.6875rem;color:var(--muted);overflow:hidden;
+  text-overflow:ellipsis;white-space:nowrap;max-width:46ch;}
+.drawer .dbody{flex:1 1 auto;overflow:auto;padding:0;min-height:0;}
+.drawer pre{margin:0;padding:14px 16px;font:400 .75rem/1.6 var(--mono);
+  white-space:pre-wrap;word-break:break-word;background:var(--paper-2);}
+.drawer .sec{padding:14px 16px;border-bottom:1px solid var(--rule);}
+.drawer .sec h4{margin:0 0 6px;font:700 .5625rem/1.4 var(--mono);letter-spacing:.14em;
+  text-transform:uppercase;color:var(--muted);}
+.drawer .sec pre{background:transparent;padding:0;}
+.scrim{position:fixed;inset:0;background:rgba(20,17,16,.28);z-index:55;}
+.scrim[hidden]{display:none!important;}
+.xbtn{appearance:none;border:1px solid var(--rule-2);background:var(--paper);
+  font:700 .625rem/1 var(--mono);letter-spacing:.14em;padding:9px 12px;cursor:pointer;}
+.xbtn:hover{background:var(--ink);color:var(--paper);border-color:var(--ink);}
+
+/* ── Corpus strip ───────────────────────────────────────────────────────── */
+.strata{display:grid;grid-template-columns:repeat(auto-fill,minmax(158px,1fr));gap:0;}
+.strata div{padding:11px 13px;border-right:1px solid var(--rule);
+  border-bottom:1px solid var(--rule);}
+.strata b{display:block;font:700 .5625rem/1.4 var(--mono);letter-spacing:.14em;
+  text-transform:uppercase;color:var(--muted);margin-bottom:2px;}
+/* attempted/total and the stats must not run together — "5/60" beside "8.3%" reads
+   as "5 / 608.3%" when both are inline. */
+.strata .v{display:block;font:400 1.05rem/1.35 var(--mono);}
+.strata .v em{font-style:normal;color:var(--muted);}
+.strata .s{display:block;font:400 .6875rem/1.6 var(--mono);color:var(--muted);}
+
+.foot{border-top:1px solid var(--rule);padding:16px 0 26px;font-size:.6875rem;
+  color:var(--muted);}
+.foot code{border:1px solid var(--rule-2);background:var(--paper-2);padding:1px 5px;}
+
+@media (max-width:1100px){
+  .grid2,.grid3{grid-template-columns:minmax(0,1fr);}
+  .hdr .wrapx{min-height:0;}
+  .tabs{top:0;position:static;}
+}

--- a/tools/repipe/webui/index.html
+++ b/tools/repipe/webui/index.html
@@ -1,0 +1,147 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex,nofollow">
+<title>kuna re-friction loop</title>
+<link rel="icon" href="/img/favicon.png">
+<link rel="stylesheet" href="/assets/site.css">
+<link rel="stylesheet" href="/assets/dash.css">
+</head>
+<body>
+
+<header class="hdr">
+  <div class="wrapx">
+    <a class="brand" href="/"><span class="wordmark">kuna</span><span class="at">re-friction</span></a>
+    <div class="stat"><b>Round</b><span id="h-round">—</span></div>
+    <div class="stat"><b>Supervisor</b><span id="h-sup">—</span></div>
+    <div class="stat"><b>Agents</b><span id="h-agents">—</span></div>
+    <div class="stat" id="h-disk-w"><b>Disk free</b><span id="h-disk">—</span></div>
+    <div class="stat"><b>Spend this run</b><span id="h-spend">—</span></div>
+    <div class="spacer"></div>
+    <div class="live off" id="h-live"><i></i><span id="h-seq">seq —</span></div>
+    <button class="stopbtn" id="h-stop" type="button">Stop</button>
+  </div>
+</header>
+
+<nav class="tabs">
+  <div class="wrapx" role="tablist">
+    <button class="tab" role="tab" id="tab-board"      aria-selected="true"  data-pane="board">Round board</button>
+    <button class="tab" role="tab" id="tab-agents"     aria-selected="false" data-pane="agents">Agents<span class="n" id="n-agents"></span></button>
+    <button class="tab" role="tab" id="tab-evidence"   aria-selected="false" data-pane="evidence">Evidence<span class="n" id="n-evidence"></span></button>
+    <button class="tab" role="tab" id="tab-acceptance" aria-selected="false" data-pane="acceptance">Acceptance matrix<span class="n" id="n-acceptance"></span></button>
+  </div>
+</nav>
+
+<main>
+
+<!-- ── 1. Round board ─────────────────────────────────────────────────── -->
+<section class="panel" id="pane-board" role="tabpanel" aria-labelledby="tab-board">
+  <div class="wrapx">
+    <div class="card">
+      <div class="roundtop">
+        <div class="bignum"><small>Round</small><span id="b-round">—</span></div>
+        <div class="timer"><small>Elapsed</small><span id="b-timer">—</span></div>
+        <div class="timer"><small>Run</small><span id="b-runtimer">—</span></div>
+        <div class="timer"><small>Slate</small><span id="b-slate">—</span></div>
+        <div class="timer"><small>Needs filed / closed</small><span id="b-needs">—</span></div>
+      </div>
+      <div id="b-lanes"></div>
+    </div>
+
+    <div class="grid2" style="margin-top:18px">
+      <div class="card">
+        <div class="chead"><span>Transition log</span><span class="grow"></span>
+          <span class="note" id="b-tcount"></span></div>
+        <div class="tlog" id="b-tlog"></div>
+      </div>
+      <div class="card">
+        <div class="chead"><span>Corpus coverage</span><span class="grow"></span>
+          <span class="note" id="b-cov"></span></div>
+        <div class="strata" id="b-strata"></div>
+        <div class="chead" style="border-top:1px solid var(--rule);border-bottom:0">
+          <span>Worktrees &amp; leases</span></div>
+        <div class="cbody" id="b-infra"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ── 2. Agents ──────────────────────────────────────────────────────── -->
+<section class="panel" id="pane-agents" role="tabpanel" aria-labelledby="tab-agents" hidden>
+  <div class="wrapx">
+    <div class="card">
+      <div class="chead"><span>Agents</span><span class="grow"></span>
+        <span class="note">stale turns red past 120 s · counters are live from the inventory</span></div>
+      <div class="tw"><table class="t" id="a-table"></table></div>
+    </div>
+    <div class="card">
+      <div class="chead"><span>Open pull requests</span><span class="grow"></span>
+        <span class="note" id="a-ghnote"></span></div>
+      <div class="tw"><table class="t" id="a-prs"></table></div>
+    </div>
+  </div>
+</section>
+
+<!-- ── 3. Evidence ────────────────────────────────────────────────────── -->
+<section class="panel" id="pane-evidence" role="tabpanel" aria-labelledby="tab-evidence" hidden>
+  <div class="wrapx">
+    <div class="card">
+      <div class="denom" id="e-denom"></div>
+      <div class="filters">
+        <div class="subtabs">
+          <button class="subtab" id="sub-backlog"  aria-selected="true"  type="button">Backlog</button>
+          <button class="subtab" id="sub-rejected" aria-selected="false" type="button">Rejected pile</button>
+        </div>
+        <select id="f-status"><option value="">status: any</option></select>
+        <select id="f-track"><option value="">track: any</option></select>
+        <input id="f-q" type="search" placeholder="filter need id, title or probe id…" autocomplete="off">
+        <span class="dim" id="f-count"></span>
+      </div>
+      <div id="e-body"></div>
+    </div>
+  </div>
+</section>
+
+<!-- ── 4. Acceptance matrix ───────────────────────────────────────────── -->
+<section class="panel" id="pane-acceptance" role="tabpanel" aria-labelledby="tab-acceptance" hidden>
+  <div class="wrapx">
+    <div class="shead">
+      <h2>Acceptance matrix</h2>
+      <span class="sub">Every acceptance probe ever filed &times; every round. A builder is done
+        when its row flips to <b>PASS</b>; a green cell that later turns red is a regression.
+        This is the screen that answers whether the loop is improving kuna.</span>
+    </div>
+    <div class="card">
+      <div class="denom" id="m-denom"></div>
+      <div class="tw" id="m-body"></div>
+      <div class="legend">
+        <span><s class="pass"></s>acceptance passes — the desired behaviour ships</span>
+        <span><s class="fail"></s>acceptance fails — still the current bad behaviour</span>
+        <span><s class="regress"></s>regression — this passed in an earlier round</span>
+        <span class="dim">blank = probe not filed / not run that round</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="wrapx foot">
+  <span id="f-foot"></span>
+</div>
+</main>
+
+<div class="scrim" id="scrim" hidden></div>
+<aside class="drawer" id="drawer" hidden>
+  <div class="dhead">
+    <b id="d-title">—</b>
+    <span class="path" id="d-path"></span>
+    <span class="grow"></span>
+    <button class="xbtn" id="d-close" type="button">Close</button>
+  </div>
+  <div class="dbody" id="d-body"></div>
+</aside>
+
+<script src="/assets/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
`docs/improvement-pipeline.md` asks *"is kuna's emitted C worse than angr's"*. This adds the loop that asks the other question about the same engine: **can an agent USE kuna to reverse-engineer a binary?**

codex testers try to solve crackmes from `kuna-re-dataset` with kuna as their primary tool and record every place it was missing, wrong, slow or costly — **giving up when kuna blocks them**, which is the loudest signal available. claude builders close those gaps and self-merge. A Claude Code captain owns the cycle. Runbook: **`docs/re-pipeline.md`**.

The question is worth asking. kuna has nine subcommands, four of which do the same thing, and no xrefs, call graph, strings, `read_memory`, rename/retype, persistence, daemon, disassembly subcommand, function filter, or `--json` on `kuna decompile` (that flag exits 2). Every invocation is a cold load, and `kuna decompile` spawns a fresh `decomp_dbg` **per function**.

## The one bet: evidence must be executable

No tester prose reaches a builder. Each observation carries two predicates, and a need is admitted only if, on a freshly built main at a pinned SHA, the **probe** (asserting the current bad behaviour) **PASSES** and the **acceptance** (asserting the desired one) **FAILS**.

- builder's definition of done = the acceptance flips to PASS
- the acceptance probe is then **promoted verbatim into `tests/cli/`** as a permanent regression test
- `acceptance PASS` at filing time means *the tester was wrong* — that ledger is kept, and if it is ever empty the gate is broken

This is sized to the decbench campaign's measured result: round 2's refuters overturned the filed diagnosis on **3 of 8** cases while the symptom stood in all 8, and some wrong mechanisms fire, pass their witness, and ship broken output.

## It has been run, and the first run corrected us

One live codex tester on `snake` (11 KB ELF), 104 s, `outcome: gave_up` / `kuna-blocked`, `minutes_lost: 8`, four fallbacks each recording what was wanted and why kuna could not give it. It correctly declined to re-file the already-known `zero-functions-exit-0` need — the KNOWN_NEEDS suppression works — and filed one new blocker that gated `admitted` and clustered into `docs/re-needs/unpack-upx-packed-executable.md`.

**And it corrected this repo's own diagnosis.** `snake` returning `count: 0` was recorded here as a section-header-stripped PIE. It is **UPX 3.96 packed** and kuna only ever saw the loader stub; the manifest agrees (`packers: ['UPX']`). The symptom was right and the cause was wrong — the campaign's own lesson, arriving on the first live run and pointing at us.

That run also found four integration defects nothing offline could:

| | |
|---|---|
| the report schema **400s** in strict structured-output mode | `--output-schema` goes straight to the API's `response_format`, which demands `required` listing every key, an explicit `type` on every node, and no `$ref` to a sibling file. Probes now cross as serialised JSON strings and are validated by `probe.validate()`; `strictschema.py` encodes every rule and smoke asserts it |
| `gate_round` did not supply `{{BIN}}` | a probe using the token without restating `target` was discarded as unrunnable — which is exactly what happened to the first real observation |
| the ida shim never passed `--backend ida` | so "compare against IDA" was silently comparing against angr |
| declib's socket lives under `TMPDIR` | outside the tester's `workspace-write` sandbox, so every reference call failed `rc=1` |

## Reuse over forking

`tools/pipeline/{run,worker}.sh` gain env seams that all default to today's behaviour byte for byte. `state.py` gains slots and leases beside its claims. `select.py` consumes the new backlog **unchanged**, because `needs.py` emits `opportunities.json`'s exact shape. The proposal park/approve/resume path needed **no change at all** — the captain simply plays the human. `open_pr.sh` gains `--merge`.

## Containment is structural

The dataset gives the answer away four ways: `meta.json` carries the plaintext flag, `solutions/` holds full writeups, `extras/` is both the only task statement *and* a spoiler channel (one challenge ships 19 valid serials with `ships_source_code` **false**), and six ship source. So testers run under `bwrap` with **both** dataset copies (the sibling label repo has all 250 flags too), `$HOME` credentials and `~/.codex` tmpfs'd out of their namespace, network off, and a post-hoc tripwire. Verified from inside the real harness: every one reads `hidden`.

Arena shims meter every kuna and IDA call — the only per-call latency signal there is, since kuna emits no timing of its own.

## Three builder tracks

Most RE friction is **not** an option-gated pass. `tooling` (kuna-cli/console/analysis; no `phases.toml` row, because the rule is "anything that *can change emitted C* ships behind a named option" and a new subcommand cannot), `quality` (the full 8-file ritual, included from `worker_prompt.md` **by reference** rather than a second copy that would drift), and `perf` (held to 3σ and ≥20%, because `returncopysplit` measured a −20%/−12% noise floor on byte-identical output).

Collision avoidance falls out of lease algebra rather than special cases: every `quality` need needs the whole counter set, so **at most one option-adding builder is ever in flight** while `tooling` builders parallelise freely.

The captain performs **one guarded transition per tick** and exits; `captain.py` refuses an illegal edge with exit 2, so the LLM cannot talk the machine into skipping a gate. It also approves proposals, since there is no human to ask.

## Verification

`tools/repipe/smoke.sh` — **73 passed / 0 failed**, ~4 minutes, zero agent tokens — runs against real defects rather than mocks: the two-arm gate against kuna's live failure on `snake`, containment asserted from inside the real harness, a probe refused when pointed at the wrong binary, arbitrary-code-execution attempts refused (including the two bypasses a basename-only allowlist misses), and **four false-green canaries** that fail the run if no probe reproduced, the sandbox was skipped, the redactor over-redacted, or clustering produced nothing.

An adversarial review (4 reviewers, every finding independently re-run by a refuter) returned **32 confirmed defects**; all 8 criticals and 12 of 14 majors are fixed here, each with a regression test. The rest are recorded in `docs/re-pipeline.md`.

```
make test        PARITY OK 675/675      make check-spec  OK
make test-stages PARITY OK 574/574      catalog --check  OK
make rust-test   4,900 passed / 0 failed
```

**Level 3 (one live builder) and Level 4 (a full round) have not been run.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
