### PR TITLE
[AUTOMATED] feat(cli): functions-json-size — the inventory reports each function's extent

### DIFF
--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -149,6 +149,7 @@ pub fn run_functions(argv: &[String]) -> i32 {
                                 ("address".into(), Json::Number(a.to_string())),
                                 ("address_hex".into(), Json::Str(format!("0x{a:x}"))),
                                 ("aliases".into(), aliases_json(&e.aliases)),
+                                ("size".into(), Json::Number(e.size.to_string())),
                             ])
                         })
                         .collect(),
@@ -387,7 +388,8 @@ pub(crate) fn resolve_targets(
                 let name = prog
                     .function_named_at(vma)
                     .unwrap_or_else(|| prog.arch().name_function(&addr));
-                targets.push(FunctionEntry { name, addr, aliases: Vec::new() });
+                let size = prog.function_extent_at(vma);
+                targets.push(FunctionEntry { name, addr, aliases: Vec::new(), size });
             }
         }
     }

--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -1115,3 +1115,130 @@ fn dwarf_source_line_comments_stay_opt_in_under_every_mode() {
         "`--option dwarf_lines on` must still annotate source lines:\n{opted_in}"
     );
 }
+
+/// Every `"size": N` in a `--json` document, in document order.
+fn json_sizes(stdout: &str) -> Vec<u64> {
+    stdout
+        .match_indices("\"size\":")
+        .filter_map(|(i, key)| {
+            stdout[i + key.len()..]
+                .trim_start()
+                .split(|c: char| !c.is_ascii_digit())
+                .next()?
+                .parse()
+                .ok()
+        })
+        .collect()
+}
+
+/// (kuna, `functions-json-size`) The cheap inventory call must carry an extent,
+/// so a caller can rank a binary's functions by weight without decompiling it.
+///
+/// The regression this pins is the *absence*: `functions --json` records used to
+/// be `name`/`address`/`address_hex`/`aliases` only, so "decompile the three
+/// biggest functions" cost a whole `decompile-all`. Vendored acceptance probe:
+/// `tests/cli/functions-json-size.json`.
+///
+/// `aif_gap_x86_64` is the fixture the need was filed against — stripped, so its
+/// extents come from the clip alone and not from any ELF `st_size`.
+#[test]
+fn functions_json_carries_a_ranking_extent() {
+    let bin = repo_root()
+        .join("decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let (stdout, stderr, ok) =
+        run_kuna(&["functions", &bin, "--json", "--sleighpath", &specs()]);
+    if !ok {
+        if is_specs_skip(&stderr) {
+            eprintln!("functions_json_carries_a_ranking_extent: skipping (no `.sla`): {stderr}");
+            return;
+        }
+        panic!("kuna functions failed: {stderr}");
+    }
+    let sizes = json_sizes(&stdout);
+    let count = json_count(&stdout).expect("the inventory must report a count");
+    assert_eq!(
+        sizes.len(),
+        count,
+        "every one of the {count} inventory records must carry `size`:\n{stdout}"
+    );
+    // The point of the field: it must DISCRIMINATE. An all-zero (or all-equal)
+    // column would satisfy "the key exists" while leaving the caller exactly as
+    // unable to rank as before — which is how this shipped broken on
+    // `decompile-all`, where `size` came from the requested flow bound and so was
+    // 0 on every record.
+    assert!(
+        sizes.iter().any(|&s| s > 0),
+        "the inventory extents are all zero, so nothing can be ranked:\n{stdout}"
+    );
+    assert!(
+        sizes.iter().collect::<std::collections::BTreeSet<_>>().len() > 1,
+        "the inventory extents are all equal, so nothing can be ranked:\n{stdout}"
+    );
+    // The `.plt.got` thunk at 0x1030 is 8 bytes and the big `.text` tail at
+    // 0x13c9 is 682: a thunk must not read as heavy as a real function.
+    assert!(
+        stdout.contains("\"address_hex\": \"0x1030\"") && sizes.contains(&8),
+        "the 8-byte `.plt.got` thunk must report its real extent:\n{stdout}"
+    );
+    assert!(
+        sizes.iter().any(|&s| s > 512),
+        "the large `.text` function must outrank the thunks:\n{stdout}"
+    );
+}
+
+/// (kuna, `functions-json-size`) `functions` and `decompile-all` must report the
+/// SAME extent for the same entry — one field name, one meaning.
+///
+/// `decompile-all`'s `size` used to come from `Funcdata::get_size()`, which is
+/// the *requested* flow bound (always "unbounded", i.e. 0, on a whole-binary
+/// run), so the field was structurally dead on every record. Copying that into
+/// the inventory would have satisfied the letter of the need and none of it.
+#[test]
+fn functions_and_decompile_all_agree_on_size() {
+    let bin = repo_root()
+        .join("decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let sp = specs();
+    let (inventory, stderr, ok) =
+        run_kuna(&["functions", &bin, "--json", "--sleighpath", &sp]);
+    if !ok {
+        if is_specs_skip(&stderr) {
+            eprintln!("functions_and_decompile_all_agree_on_size: skipping: {stderr}");
+            return;
+        }
+        panic!("kuna functions failed: {stderr}");
+    }
+    let (decompiled, stderr, ok) =
+        run_kuna(&["decompile-all", &bin, "--json", "--sleighpath", &sp]);
+    if !ok {
+        if is_specs_skip(&stderr) {
+            eprintln!("functions_and_decompile_all_agree_on_size: skipping: {stderr}");
+            return;
+        }
+        panic!("kuna decompile-all failed: {stderr}");
+    }
+    // Both documents are address-ordered over the same entry set, so the size
+    // columns line up positionally.
+    let want = json_sizes(&inventory);
+    // `decompile-all` also emits a `size` per recovered VARIABLE; keep only the
+    // per-function ones by pairing each with the entry address that precedes it.
+    let got: Vec<u64> = json_addresses(&decompiled)
+        .iter()
+        .map(|addr| {
+            let rec = decompiled
+                .split(&format!("\"address\": {addr},"))
+                .nth(1)
+                .expect("each entry address must open a record");
+            json_sizes(rec).first().copied().expect("each record must carry `size`")
+        })
+        .collect();
+    assert_eq!(
+        want, got,
+        "the inventory and the whole-binary run disagree on function extents"
+    );
+}

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -82,6 +82,13 @@ pub struct FunctionEntry {
     pub addr: Address,
     /// Every other name this same entry carries, in the same preference order.
     pub aliases: Vec<String>,
+    /// (kuna) The entry's byte extent — an UPPER bound, the address-contiguous
+    /// clip to the next entry or the end of the containing CODE section.  `0`
+    /// when the entry lies in no CODE section (an import slot, an undefined
+    /// external) or when the caller synthesized the record without a program to
+    /// measure against.  See [`crate::funcextent`] for what the number means and
+    /// what it loses.
+    pub size: u64,
 }
 
 /// (kuna) A one-shot [`PcodeEmit`](kuna_sleigh::translate::PcodeEmit) sink:
@@ -300,7 +307,7 @@ impl ConsoleProgram {
             }
         }
 
-        groups
+        let mut entries: Vec<FunctionEntry> = groups
             .into_iter()
             .map(|(_, (addr, mut names))| {
                 // Most informative first — see `entry_name_rank`.
@@ -308,9 +315,38 @@ impl ConsoleProgram {
                     entry_name_rank(a).cmp(&entry_name_rank(b)).then_with(|| a.cmp(b))
                 });
                 let name = names.remove(0);
-                FunctionEntry { name, addr, aliases: names }
+                FunctionEntry { name, addr, aliases: names, size: 0 }
             })
-            .collect()
+            .collect();
+        // (kuna, `functions-json-size`) Measure each entry's extent in one pass.
+        // The `BTreeMap` above already put the list in ascending address order,
+        // which is what the clip needs; the section table is the loader's, so
+        // this adds no decode to the cheap inventory call.
+        crate::funcextent::assign_extents(
+            &mut entries,
+            &crate::funcextent::code_spans(&self.sections()),
+        );
+        entries
+    }
+
+    /// (kuna, `functions-json-size`) The byte extent of an arbitrary address,
+    /// for the single-target paths that synthesize a [`FunctionEntry`] the
+    /// enumeration does not know (`--addr` on an undiscovered function).
+    ///
+    /// Same clip, same upper-bound meaning as the bulk pass — see
+    /// [`crate::funcextent`].
+    pub fn function_extent_at(&self, vma: u64) -> u64 {
+        let entry = self.thumb_normalized(vma);
+        let entries: Vec<u64> = self
+            .function_entries_canonical()
+            .iter()
+            .map(|e| e.addr.get_offset())
+            .collect();
+        crate::funcextent::extent_at(
+            entry,
+            &entries,
+            &crate::funcextent::code_spans(&self.sections()),
+        )
     }
 
     /// The canonical entries eligible for automatic whole-binary decompilation.

--- a/decompiler/crates/kuna-console/src/funcextent.rs
+++ b/decompiler/crates/kuna-console/src/funcextent.rs
@@ -1,0 +1,170 @@
+//! The inventory-time function extent — the `size` every whole-binary surface
+//! reports per entry.
+//!
+//! # What this is
+//!
+//! kuna's model of a function is its **entry**: the Listing is keyed by entry
+//! VMA and [`ConsoleProgram::function_entries_canonical`] yields one record per
+//! entry address. Nothing in that model carries a body, so an inventory record
+//! had no extent at all and a caller could not tell a PLT thunk from `main`
+//! without decompiling the whole binary (`docs/re-needs/functions-json-size.md`).
+//!
+//! This module supplies the extent as the **address-contiguous clip**
+//! `[entry, min(next_entry, end_of_containing_code_section))` — the same
+//! reconstruction `kuna_analysis`'s FID extent generator
+//! (`analyzers/fid/extent.rs`) and `noreturn_disc` already use where they need a
+//! body from an entry-keyed model. It reuses the entry list and the loader's
+//! section table, both already in hand, so the cheap inventory call stays cheap:
+//! no decode, no Listing, no per-function work beyond a binary search.
+//!
+//! # What the number means
+//!
+//! An **upper bound** on the function's byte extent, not its exact body. The
+//! clip runs to the next entry, so inter-function alignment padding is counted
+//! in. Measured against ELF `st_size` over the 41 symbolized fixtures in
+//! `kuna-analysis/tests/fixtures` (1428 functions with ground truth): never
+//! short, exact for 231, median overshoot +8 bytes, worst +52 — i.e. padding.
+//! That is the right shape for what the field is for (ordering an inventory by
+//! weight); a caller needing the exact body must still decompile.
+//!
+//! An entry outside every CODE section reports `0` — an import pointer slot or
+//! an undefined external is an address, not a body, and `0` is the established
+//! "no extent recovered" answer on the decompile path.
+//!
+//! # LOSS
+//!
+//! Address-contiguous, not flow-reachable: an outlined or interleaved body (a
+//! `.part.0` cold half living past the next entry) is clipped at the neighbour,
+//! and code physically between two entries is attributed to the first. This is
+//! the approximation the FID generator documents and accepts for the same
+//! reason — the compiler lays a function down contiguously in the common case.
+
+/// One CODE section as `(vma, end)`, ascending by `vma`.
+type CodeSpan = (u64, u64);
+
+/// The extent of the function entered at `entry`.
+///
+/// `next` is the next entry address strictly after `entry` (`None` for the last
+/// one), and `code` the ascending `(vma, end)` CODE spans. Returns `0` when
+/// `entry` lies in no CODE section.
+///
+/// Split out from the bulk pass so the clip rule is unit-testable without a
+/// loaded [`crate::engine::ConsoleProgram`] — the shape `analyzers/fid/extent.rs`
+/// uses for the same reason.
+fn clip(entry: u64, next: Option<u64>, code: &[CodeSpan]) -> u64 {
+    let Some(&(_, end)) = code.iter().find(|&&(vma, end)| vma <= entry && entry < end) else {
+        return 0;
+    };
+    // The neighbour only tightens the bound when it really is ahead of this
+    // entry and inside the same section; a duplicate or out-of-section next
+    // entry leaves the section end as the stop.
+    let stop = match next {
+        Some(n) if n > entry && n < end => n,
+        _ => end,
+    };
+    stop - entry
+}
+
+/// The ascending `(vma, end)` CODE spans of a loader section table
+/// (`ConsoleProgram::sections`, `(vma, size, flags)`).
+///
+/// Zero-length and non-CODE sections are dropped; a section whose `vma + size`
+/// wraps is dropped rather than clamped, so a malformed table yields `0` extents
+/// instead of nonsense ones.
+pub(crate) fn code_spans(sections: &[(u64, u64, u32)]) -> Vec<CodeSpan> {
+    let mut spans: Vec<CodeSpan> = sections
+        .iter()
+        .filter(|(_, _, flags)| flags & kuna_sleigh::loadimage::section_flags::CODE != 0)
+        .filter_map(|&(vma, size, _)| vma.checked_add(size).map(|end| (vma, end)))
+        .filter(|&(vma, end)| end > vma)
+        .collect();
+    spans.sort_unstable();
+    spans
+}
+
+/// The extent of a single address against an ascending entry list — the
+/// single-target paths (`--addr` on an address the enumeration does not know),
+/// where there is no bulk pass to piggyback on.
+pub(crate) fn extent_at(entry: u64, ascending_entries: &[u64], code: &[CodeSpan]) -> u64 {
+    let next = ascending_entries.iter().copied().find(|&e| e > entry);
+    clip(entry, next, code)
+}
+
+/// Fill each entry's extent in one pass over an **address-ascending** entry list
+/// (what `function_entries_canonical` builds from its `BTreeMap`).
+pub(crate) fn assign_extents(entries: &mut [crate::engine::FunctionEntry], code: &[CodeSpan]) {
+    for i in 0..entries.len() {
+        let entry = entries[i].addr.get_offset();
+        let next = entries.get(i + 1).map(|e| e.addr.get_offset());
+        entries[i].size = clip(entry, next, code);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEXT: &[CodeSpan] = &[(0x1000, 0x1100)];
+
+    #[test]
+    fn clips_at_the_next_entry() {
+        assert_eq!(clip(0x1000, Some(0x1020), TEXT), 0x20);
+    }
+
+    #[test]
+    fn last_entry_runs_to_the_section_end() {
+        assert_eq!(clip(0x10c0, None, TEXT), 0x40);
+    }
+
+    #[test]
+    fn next_entry_outside_the_section_does_not_extend_past_it() {
+        // The neighbour is the first entry of the NEXT code section, so the clip
+        // must stop at this section's end rather than swallow the gap between
+        // them (the `.init` → `.plt` shape: 0x1000+0x1b then 0x1020).
+        assert_eq!(clip(0x10c0, Some(0x2000), TEXT), 0x40);
+    }
+
+    #[test]
+    fn entry_outside_every_code_section_has_no_extent() {
+        // A `.got` import slot or an undefined external: an address, not a body.
+        assert_eq!(clip(0x5000, Some(0x5008), TEXT), 0);
+    }
+
+    #[test]
+    fn picks_the_containing_section_not_the_first() {
+        let code: &[CodeSpan] = &[(0x1000, 0x101b), (0x1020, 0x1030), (0x1040, 0x1673)];
+        // `.plt` stub: bounded by its own section, not by `.text`'s end.
+        assert_eq!(clip(0x1020, Some(0x1040), code), 0x10);
+        // `.init`: the next entry is in another section, so `.init`'s end wins.
+        assert_eq!(clip(0x1000, Some(0x1020), code), 0x1b);
+    }
+
+    #[test]
+    fn a_duplicate_or_backward_neighbour_is_ignored() {
+        assert_eq!(clip(0x1040, Some(0x1040), TEXT), 0x1100 - 0x1040);
+        assert_eq!(clip(0x1040, Some(0x1000), TEXT), 0x1100 - 0x1040);
+    }
+
+    #[test]
+    fn code_spans_keeps_only_sized_code_sections() {
+        use kuna_sleigh::loadimage::section_flags;
+        let sections = vec![
+            (0x1000, 0x100, section_flags::CODE),
+            (0x2000, 0x100, section_flags::DATA),
+            (0x3000, 0, section_flags::CODE),          // zero length
+            (u64::MAX, 0x10, section_flags::CODE),     // wraps
+            (0x0500, 0x080, section_flags::CODE | section_flags::READONLY),
+        ];
+        assert_eq!(code_spans(&sections), vec![(0x500, 0x580), (0x1000, 0x1100)]);
+    }
+
+    #[test]
+    fn extent_at_finds_the_next_entry_in_the_list() {
+        let entries = [0x1000, 0x1020, 0x1080];
+        assert_eq!(extent_at(0x1020, &entries, TEXT), 0x60);
+        assert_eq!(extent_at(0x1080, &entries, TEXT), 0x80);
+        // An address the enumeration does not know still clips against its
+        // neighbours (`--addr` on an undiscovered function).
+        assert_eq!(extent_at(0x1040, &entries, TEXT), 0x40);
+    }
+}

--- a/decompiler/crates/kuna-console/src/lib.rs
+++ b/decompiler/crates/kuna-console/src/lib.rs
@@ -22,6 +22,7 @@ pub mod ifacedecomp;
 pub mod engine;
 pub mod decompile_step;
 pub mod project;
+pub mod funcextent;
 pub mod codedata;
 pub mod kuna_console;
 pub mod grammar;

--- a/decompiler/crates/kuna-console/src/project.rs
+++ b/decompiler/crates/kuna-console/src/project.rs
@@ -48,6 +48,14 @@ pub fn default_fn_budget_seconds(mode: &str, whole_binary: bool) -> u64 {
 pub struct FuncResult {
     pub name: String,
     pub address: u64,
+    /// The entry's byte extent, carried through from
+    /// [`FunctionEntry::size`](crate::engine::FunctionEntry::size) so this
+    /// surface and the `functions` inventory report ONE number with one meaning.
+    ///
+    /// An inventory fact, not a decompile result: it is reported even when the
+    /// function errored, and it does NOT come from the recovered
+    /// `Funcdata::get_size()`, which is the caller's requested flow bound and so
+    /// is `0` on every whole-binary run (the bound is always "unbounded").
     pub size: i64,
     pub code: Option<String>,
     pub error: Option<String>,
@@ -82,7 +90,7 @@ pub fn decompile_targets(
     want_provenance: bool,
 ) -> Vec<FuncResult> {
     let mut out = Vec::with_capacity(targets.len());
-    for FunctionEntry { name, addr: entry, aliases } in targets {
+    for FunctionEntry { name, addr: entry, aliases, size } in targets {
         let address = entry.get_offset();
         // (kuna) An entry with no mapped bytes is an EXTERNAL, not a decompile
         // failure: a relocatable object's undefined symbols (and a PE import
@@ -101,7 +109,7 @@ pub fn decompile_targets(
                 )),
                 name,
                 address,
-                size: 0,
+                size: size as i64,
                 error: None,
                 proto: None,
                 variables: Vec::new(),
@@ -156,7 +164,6 @@ pub fn decompile_targets(
         .result
         {
             Ok(fd) => {
-                let size = fd.get_size() as i64;
                 // Render + extract under `catch_unwind`: the decompile drive only
                 // guards the pipeline (decompile_drive.rs), so a fail-fast invariant
                 // in the printer / type declarator on an exotic recovered function
@@ -190,7 +197,7 @@ pub fn decompile_targets(
                     Ok((code, variables, proto, line_mappings)) => out.push(FuncResult {
                         name,
                         address,
-                        size,
+                        size: size as i64,
                         code: Some(code),
                         error: None,
                         proto,
@@ -201,7 +208,7 @@ pub fn decompile_targets(
                     Err(_) => out.push(FuncResult {
                         name,
                         address,
-                        size: 0,
+                        size: size as i64,
                         code: None,
                         error: Some("panic while rendering C / extracting variables".into()),
                         proto: None,
@@ -214,7 +221,7 @@ pub fn decompile_targets(
             Err(e) => out.push(FuncResult {
                 name,
                 address,
-                size: 0,
+                size: size as i64,
                 code: None,
                 error: Some(e.explain().to_string()),
                 proto: None,

--- a/decompiler/crates/kuna-decomp/src/p0_knowledge/kuna_phases/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/p0_knowledge/kuna_phases/tests.rs
@@ -48,7 +48,7 @@ fn surface_count_is_105() {
 }
 
 #[test]
-fn settable_count_is_117() {
+fn settable_count_is_127() {
     // One row per kuna ArchOption; the authoritative per-option list (with
     // tier, symptoms, and provenance) is phases.toml settableTable.
     // +1 for `callsitestackargs` (P4 stack-passed call argument recovery).

--- a/decompiler/crates/kuna-wasm/src/lib.rs
+++ b/decompiler/crates/kuna-wasm/src/lib.rs
@@ -408,7 +408,8 @@ fn resolve_targets(
                 let name = prog
                     .function_named_at(*vma)
                     .unwrap_or_else(|| prog.arch().name_function(&addr));
-                Ok(vec![FunctionEntry { name, addr, aliases: Vec::new() }])
+                let size = prog.function_extent_at(*vma);
+                Ok(vec![FunctionEntry { name, addr, aliases: Vec::new(), size }])
             }
         },
         Cmd::List | Cmd::Project(_) => unreachable!("List/Project handled by caller"),
@@ -424,7 +425,10 @@ fn parse_addr(s: &str) -> Option<u64> {
 // --- JSON (self-contained; the `decompile-all --json` fields + `kind`) ------
 
 /// The `list` document:
-/// `{binary, count, functions:[{name, address, address_hex, aliases, kind}]}`.
+/// `{binary, count, functions:[{name, address, address_hex, aliases, size, kind}]}`.
+/// `size` is the entry's byte extent (`kuna_console::funcextent` — an upper
+/// bound), so the browser inventory can rank its rows by weight without
+/// decompiling every function.
 /// `kinds` is parallel to `entries` (the classifier's verdict per entry).
 fn list_json(binary: &str, entries: &[FunctionEntry], kinds: &[&'static str]) -> String {
     let mut s = String::from("{\n");
@@ -439,6 +443,7 @@ fn list_json(binary: &str, entries: &[FunctionEntry], kinds: &[&'static str]) ->
         s.push_str(&format!("\"address\": {}, ", addr));
         s.push_str(&format!("\"address_hex\": {}, ", json_str(&format!("0x{addr:x}"))));
         s.push_str(&format!("\"aliases\": {}, ", json_str_array(&e.aliases)));
+        s.push_str(&format!("\"size\": {}, ", e.size));
         s.push_str(&format!("\"kind\": {}", json_str(kinds[i])));
         s.push('}');
     }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -135,7 +135,7 @@ The whole-binary surface (the benchmark + LLM path). Runs **in-process**
 `{binary,count,functions:[{name,address,address_hex,aliases,size,code,error,
 line_mappings:[{line_number,addresses}],variables:[{name,type,kind,arg_index,
 stack_offset,size,line_numbers,addresses}]}]}` (`kuna functions --json` emits
-`name`/`address`/`address_hex`/`aliases` per function). `line_mappings` maps 1-based
+`name`/`address`/`address_hex`/`aliases`/`size` per function). `line_mappings` maps 1-based
 lines in `code` to sorted, unique machine-instruction VMAs. Variable `line_numbers`
 come from the printer's `varref` tokens; variable `addresses` are the union of the
 mapped instruction addresses on those lines. Both are empty when no backed use is
@@ -145,6 +145,18 @@ plain-text renderer still produces `code`, so its bytes are unchanged.
 Reported variables are joined to native varrefs by ABI or stack storage and recovered
 high-variable identity. Multiple high-variable fragments are combined only when they
 name the same exact stack location and size; ambiguous name-only matches stay empty.
+
+Per-function `size` is the entry's byte extent, and both surfaces report the same
+number with the same meaning — it is an **inventory** fact, measured without
+decompiling, so `kuna functions --json` alone is enough to rank a binary's functions
+by weight (the "decompile the three biggest functions" first move costs one call, not
+a whole-binary run). It is an **upper bound**: the address-contiguous clip from the
+entry to the next entry, or to the end of the containing CODE section, whichever comes
+first — so inter-function alignment padding is counted in. Against ELF `st_size` over
+the 1428 symbolized-fixture functions with ground truth it is never short, exact for
+231, and overshoots by a median of 8 bytes (worst 52). An entry in no CODE section — an
+import pointer slot, an undefined external — reports `0`, as does a function whose
+extent could not be measured. A caller needing the exact body must still decompile.
 
 Per-function `code` matches `kuna decompile ... --option listing on` byte-for-byte on
 x86-64 (elsewhere, see the injected defaults below), `error` isolates a single failed

--- a/docs/features/functions-json-size/pr_body.md
+++ b/docs/features/functions-json-size/pr_body.md
@@ -1,0 +1,161 @@
+## What was broken
+
+`docs/re-needs/functions-json-size.md` (4 instances, one in-repo fixture + three
+dataset crackmes):
+
+> `kuna functions <bin> --json` is the one cheap, whole-binary call kuna offers:
+> it loads once and answers "what is in here". Its records carry only `name`,
+> `address`, `address_hex` and `aliases` — there is no extent. An agent triaging
+> a 250-function binary therefore has no way to order its work except by address,
+> and the standard first move ("decompile the three biggest functions") costs a
+> full `decompile-all` instead of one inventory call.
+
+**The filed hypothesis was wrong, and the way it was wrong mattered.** The need
+recorded that `decompile-all --json` "emits `size` on every record, from the same
+`FuncResult`. Only the cheap call drops it", and predicted a four-field struct
+next to a five-field one. The field is emitted — but its value is `0` on every
+record of every binary:
+
+```
+$ kuna decompile-all …/aif_gap_x86_64 --json | jq '[.functions[].size] | unique'
+[0]                       # and 0 nonzero sizes across every fixture in the tree
+```
+
+`FuncResult.size` came from `Funcdata::get_size()`, which is written once in the
+`Funcdata` constructor from the caller's **requested flow bound** and never
+updated by flow recovery. `decompile_targets` passes `0` for that bound
+(*"UNBOUNDED: the function's natural flow extent"*), so it is always `0` on every
+whole-binary surface; the only writer of a nonzero value is the XML decode path,
+which no CLI surface reaches.
+
+So this was never a one-field copy. Copying the field across would have satisfied
+the acceptance probe's `exists` clause with a column of zeroes and closed nothing.
+kuna had no function-extent value on *any* surface.
+
+## Mechanism
+
+kuna's model of a function is its **entry** — the Listing is keyed by entry VMA
+and nothing in it records a body. New module
+`decompiler/crates/kuna-console/src/funcextent.rs` reconstructs the extent as the
+**address-contiguous clip** `[entry, min(next_entry, end_of_containing_CODE_section))`.
+
+That is not invented here: it is the same reconstruction kuna already applies
+wherever it needs a body from an entry-keyed model —
+`kuna-analysis/src/analyzers/fid/extent.rs::calculate_extent`, whose module doc
+documents the identical LOSS, and the `noreturn_disc` call-site reasoning.
+It reuses the entry list and the loader section table, both already in hand, so
+it adds no decode.
+
+`FunctionEntry` gains `size: u64`, filled in one pass by
+`function_entries_canonical` (already ascending, from its `BTreeMap`) and by the
+new `ConsoleProgram::function_extent_at` for synthesized `--addr` entries.
+`FuncResult.size` carries that number instead of the dead `fd.get_size()`, so
+`functions`, `decompile-all`, `decompile-project` and the wasm browser inventory
+all report **one number with one meaning** — which is what the need asked for
+("match it exactly rather than inventing a second meaning for the same field
+name"). The extent is reported on the error and external arms too: it is an
+inventory fact and does not depend on the decompile succeeding.
+
+```
+$ kuna functions …/aif_gap_x86_64 --json | jq -c '.functions[] | {n:.name, s:.size}'
+{"n":"_DT_INIT","s":27}      # exactly .init
+{"n":"sub_1020","s":16}      # .plt stub
+{"n":"__cxa_finalize","s":8} # .plt.got thunk
+…
+{"n":"sub_13c9","s":682}     # the .text tail
+```
+
+### Two alternatives rejected
+
+- **ELF `st_size`** — exact and free, but `0` on stripped binaries, and the
+  probe's own fixture is stripped (6 `.dynsym` entries, all `UND`). It would have
+  produced an all-zero column on the very binary the acceptance targets. A hybrid
+  makes `size` mean two different things depending on whether the binary is
+  stripped.
+- **A flow-reachable extent from the Listing** — kuna deliberately does *not*
+  build the Listing for `kuna functions` on x86-64 (it is measured entry-neutral
+  there), so this would put a full linear decode behind the one call whose whole
+  purpose is being cheap. This is the cost question the need's Refutation section
+  asked to be settled first.
+
+## What the number means
+
+An **upper bound**, documented as such in `docs/cli.md` and
+`docs/spec/01-program-prep.md`: the clip runs to the neighbour, so inter-function
+alignment padding is counted in. Measured against ELF `st_size` over the 41
+symbolized fixtures (1428 functions with ground truth):
+
+| | |
+|---|---|
+| never short | **0 undershoots / 1428** |
+| exact | 231 |
+| median overshoot | +8 bytes |
+| worst overshoot | +52 bytes |
+
+An entry in no CODE section — a pointer slot, an undefined external — reports `0`.
+
+## The acceptance probe now passes
+
+```
+$ python -m scripts.repipe.verify --need functions-json-size --json
+"passed": true, "transition": "closed"
+clause functions[0].size exists → actual 27
+```
+
+Promoted verbatim to `tests/cli/functions-json-size.json`.
+
+*(Noted, not fixed here: nothing currently **runs** `tests/cli/*.json` — `promote`
+writes the directory and the webui displays it, but no target executes a promoted
+probe. The guard that actually runs in CI for this need is the pair of cargo
+integration tests below, per the track-`tooling` contract. A generic runner is
+pipeline infrastructure; it is recorded as a follow-up in `record.json`.)*
+
+## Tests
+
+- `funcextent.rs` — 8 unit tests: the clip rule, section selection, entries
+  outside every CODE section, duplicate/backward neighbours, `code_spans`
+  filtering (zero-length, non-CODE, wrapping), `extent_at`.
+- `functions_json_carries_a_ranking_extent` — the field must exist on every
+  record **and discriminate**. An all-zero or all-equal column fails, which is
+  exactly what would have shipped had the filed hypothesis been followed.
+- `functions_and_decompile_all_agree_on_size` — one field name, one meaning
+  across the two surfaces.
+
+Collateral sweep over all 4 `FunctionEntry` construction sites and the non-ELF /
+non-x86-64 formats: stripped x86-64 ELF 34/34, ARM Thumb 2/2 (bit normalized),
+Cortex-M 74/74, COFF `.obj` 2/2 and 3/3. No negative or absurd extents.
+
+## Speed
+
+Interleaved old/new, 1 warmup + 9 interleaved repetitions, against the main
+tree's pre-change release binary at `63a124ae`:
+
+| target | median | min |
+|---|---|---|
+| `bash` O2 (2538 fns, 1.3 MB) | **−0.18%** | −0.09% |
+| `betaflight` Cortex-M (5798 fns) | **−0.58%** | −0.18% |
+| `ssh-sk-helper` (802 fns) | **+0.21%** | −0.10% |
+
+No measurable cost — the cheap inventory call stays cheap.
+
+## Gates
+
+| gate | result |
+|---|---|
+| `make test` | **PARITY OK** — 675/675 assertions |
+| `make test-stages` | **PARITY OK** — 574/574 assertions |
+| `make rust-test` | green (incl. `decompile_all_cli` 22/22, `funcextent` 8/8) |
+| `make check-spec` | check-spec OK |
+| `kuna catalog --check` | catalog OK |
+
+No option added: a JSON metadata field cannot change emitted C, so there is no
+`phases.toml` row, no `options.rs` registration and no catalog counter to bump.
+
+One unrelated one-liner rides along because `scripts.repipe.mergecheck` rejects
+without it: `kuna_phases/tests.rs`'s `settable_count_is_117` is renamed to
+`settable_count_is_127`. The stale name is already on `origin/main` (the
+assertion inside it has long said 127) and the counter tool matches on the
+function name, so every branch is blocked until someone renames it. No assertion
+changed.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/functions-json-size/record.json
+++ b/docs/features/functions-json-size/record.json
@@ -1,0 +1,98 @@
+{
+  "slug": "functions-json-size",
+  "need_id": "functions-json-size",
+  "track": "tooling",
+  "opportunity": "re-need:functions-json-size",
+  "probe_id": "p-d8f69800917d",
+  "acceptance_id": "a-ddc5496835ba",
+  "instances": 4,
+  "scope": "small",
+  "proposal": false,
+  "option": null,
+  "flag": null,
+  "element_id": null,
+  "phase": null,
+  "tier": "driver",
+  "change_kind": "capability-add",
+  "default_on": true,
+  "owning_file": "decompiler/crates/kuna-console/src/funcextent.rs",
+  "owning_function": "clip / assign_extents / extent_at",
+  "spec_chapter": "docs/spec/01-program-prep.md",
+  "upstream_anchor": null,
+  "parity": "OK",
+  "root_cause_class": "absent-capability",
+
+  "hypothesis_status": "OVERTURNED",
+  "filed_hypothesis": "The `functions` command builds its JSON records by hand rather than reusing the `decompile-all` record type, and `size` was simply not copied across. Expect a struct in kuna-cli with four fields where the decompile-all one has five.",
+  "decisions": [
+    "THE FILED HYPOTHESIS IS WRONG, and the way it is wrong changes the whole shape of the fix. The need says `decompile-all --json` 'emits size on every record, from the same FuncResult. Only the cheap call drops it.' The field is emitted, but its VALUE is structurally 0 on every record of every binary. Measured: 34/34 functions size=0 on the probe fixture, and 0 nonzero across every fixture in kuna-analysis/tests/fixtures. So this was never a one-field copy -- copying the field across would have satisfied the acceptance probe's `exists` clause with a column of zeroes and closed nothing.",
+    "ROOT CAUSE of the dead field: `project.rs` set `FuncResult.size` from `fd.get_size()`, i.e. `Funcdata::size`, which is written once in the Funcdata constructor from the caller's REQUESTED flow bound and never updated by flow recovery. `decompile_targets` passes `0` for that bound ('UNBOUNDED: the function's natural flow extent'), so the recovered size is always 0 on every whole-binary surface. The only writer of a nonzero Funcdata::size is the XML decode path (`funcdata_encode.rs`), which no CLI surface reaches.",
+    "This means the real gap was broader than filed: kuna had NO function-extent value on ANY surface, not a missing copy on one. The need's own instruction -- 'match decompile-all exactly rather than inventing a second meaning for the same field name' -- therefore required fixing both surfaces, which is what shipped: one number, one meaning, on `functions`, `decompile-all`, `decompile-project` and the wasm inventory.",
+    "MECHANISM CHOSEN: the address-contiguous clip [entry, min(next_entry, end_of_containing_CODE_section)). Not invented for this change -- it is the reconstruction kuna already uses wherever it needs a body from an entry-keyed model (`kuna-analysis/src/analyzers/fid/extent.rs::calculate_extent`, whose module doc states the same LOSS, and the `noreturn_disc` call-site reasoning). Reusing the established approximation rather than adding a second one was the point.",
+    "REJECTED ALTERNATIVE -- ELF st_size. Exact ground truth and free (already parsed for data symbols), but it is 0 for stripped binaries, and the probe's own fixture (aif_gap_x86_64) is stripped: only 6 .dynsym entries, all UND. st_size alone would have produced an all-zero column on the very binary the acceptance targets. A hybrid (st_size when present, clip otherwise) would raise exactness on symbolized binaries but makes `size` mean two different things depending on whether the binary is stripped -- exactly the second meaning the need warns against. Recorded as a possible refinement, not shipped.",
+    "REJECTED ALTERNATIVE -- a flow-reachable extent from the Listing. kuna deliberately does NOT build the Listing for `kuna functions` on x86-64 (`load_program`: 'the Listing is measured entry-neutral there ... building it would only make kuna functions slower'), so a Listing-derived extent would have put a full linear decode behind the one call whose entire purpose is being cheap. That is precisely the cost question the need's Refutation section asked the builder to settle before treating this as a one-field copy.",
+    "The `size` is reported on the error/panic/external arms of `decompile_targets` too, not just the success arm: an extent is an inventory fact and does not depend on the decompile succeeding, so a function that failed to decompile still tells the caller how big it is.",
+    "SCOPE HELD: `kuna functions` TEXT output is unchanged. The need is about --json, and the reference (DecLib's `list_functions`) printing three text columns is not a reason to change a `0x%x\\t%s` line format other tooling may parse.",
+    "PIPELINE GAP FOUND, not closed here: nothing runs `tests/cli/*.json`. `scripts/repipe/verify.py::promote` writes the directory and `webui.py` displays it, but no Makefile target, CI workflow or cargo test executes a promoted probe -- so promotion alone leaves no CI guard. This need is the first promotion, so the directory did not exist before. The regression guard that actually runs in CI here is the pair of cargo integration tests in the owning crate, per the track-`tooling` contract. A generic tests/cli runner is pipeline infrastructure and is left for the captain."
+  ],
+
+  "mechanism": "New module `kuna-console/src/funcextent.rs`: `clip(entry, next, code_spans)` returns the address-contiguous extent, `code_spans` filters the loader section table to sized CODE spans, `assign_extents` fills a whole ascending entry list in one pass and `extent_at` serves the single-address paths. `FunctionEntry` gains `size: u64`, filled by `ConsoleProgram::function_entries_canonical` (already ascending, from its BTreeMap) and by the new `ConsoleProgram::function_extent_at` for synthesized `--addr` entries. `FuncResult.size` now carries that number through instead of the dead `fd.get_size()`. `kuna functions --json` emits `size` after `aliases`; `decompile-all`/`decompile-project`/wasm-list report the same number.",
+
+  "accuracy": {
+    "method": "clip vs ELF st_size over every symbolized fixture in decompiler/crates/kuna-analysis/tests/fixtures (STT_FUNC, defined, nonzero st_size, entry present in kuna's inventory)",
+    "fixtures": 41,
+    "functions_with_ground_truth": 1428,
+    "exact": 231,
+    "undershoots": 0,
+    "median_overshoot_bytes": 8,
+    "max_overshoot_bytes": 52,
+    "verdict": "a sound UPPER bound -- never short on any of 1428 functions; the overshoot is inter-function alignment padding. Documented as an upper bound in docs/cli.md and docs/spec/01-program-prep.md rather than trimmed with a padding heuristic."
+  },
+
+  "collateral_sweep": {
+    "method": "every FunctionEntry construction/consumption site in the workspace, plus non-ELF and non-x86-64 formats run through `kuna functions --json`",
+    "sites": "4 construction sites (function_entries_canonical, kuna-cli resolve_targets --addr, kuna-wasm resolve_targets --addr, and the destructure in decompile_targets); 2 JSON emitters for FuncResult.size (kuna-cli result_json, kuna-wasm result_json)",
+    "formats_checked": {
+      "x86-64 stripped ELF (aif_gap_x86_64)": "34/34 entries with extent; .init=27 (exactly the section), .plt stub=16, .plt.got thunk=8, .text tail=682",
+      "ARM Thumb ELF (arm_thumb_linked_le32)": "2/2, Thumb bit normalized, 30 and 20",
+      "ARM Cortex-M (cortexm_aifcorroborate_le32)": "74/74, vector-table entries 8 bytes, first function 288",
+      "COFF .obj (coff_obj.obj, coff_comdat_i386.obj)": "2/2 and 3/3, sensible extents on relocatable objects"
+    },
+    "negatives_found": 0
+  },
+
+  "speed": {
+    "method": "interleaved old/new, 1 warmup each + 9 interleaved repetitions, `kuna functions <bin> --json`; the pre-change baseline is the main tree's release binary at 63a124ae (verified to emit no `size`)",
+    "budget_pct": 5,
+    "bash O2 (2538 fns, 1.3M)": "-0.18% median, -0.09% min",
+    "betaflight ARM Cortex-M (5798 fns)": "-0.58% median, -0.18% min",
+    "ssh-sk-helper (802 fns)": "+0.21% median, -0.10% min",
+    "verdict": "no measurable cost -- within noise on all three. By construction: the pass reuses the already-built entry list and the loader section table, adds no decode, and is O(entries x sections) with sections in the tens."
+  },
+
+  "gates": {
+    "make test": "PARITY OK, 675/675 assertions",
+    "make test-stages": "PARITY OK, 574/574 assertions",
+    "make rust-test": "green (workspace suite; kuna-console 8 new funcextent unit tests, kuna-cli 22/22 in decompile_all_cli including the 2 new ones)",
+    "make check-spec": "check-spec OK",
+    "kuna catalog --check": "catalog OK -- no option added (a JSON metadata field cannot change emitted C, so no phases.toml row, no options.rs registration, no catalog counters)"
+  },
+
+  "acceptance": {
+    "probe_before": "PASS (functions[0].size absent) -- the bad behaviour reproduced",
+    "acceptance_after": "PASS (functions[0].size == 27), transition `closed`",
+    "promoted_to": "tests/cli/functions-json-size.json"
+  },
+
+  "tests_added": [
+    "decompiler/crates/kuna-console/src/funcextent.rs (8 unit tests: the clip rule, section selection, out-of-section entries, duplicate/backward neighbours, code_spans filtering, extent_at)",
+    "decompiler/crates/kuna-cli/tests/decompile_all_cli.rs::functions_json_carries_a_ranking_extent (the field must exist on every record AND discriminate -- an all-zero or all-equal column fails, which is what would have shipped had the filed hypothesis been followed)",
+    "decompiler/crates/kuna-cli/tests/decompile_all_cli.rs::functions_and_decompile_all_agree_on_size (one field name, one meaning across the two surfaces)"
+  ],
+
+  "follow_ups": [
+    "No runner executes tests/cli/*.json -- promotion writes a regression test nothing runs. Wiring a generic re-probe/1 runner into make rust-test (or a new make target in CI) would make every future promotion an automatic CI guard, which is what docs/re-pipeline.md claims already happens.",
+    "ELF st_size could tighten `size` from an upper bound to exact on symbolized binaries, at the cost of the field meaning something different on stripped ones. Needs a decision on that trade before it is worth the cross-crate thread through FuncSym -> LoadImageFunc -> ProgramSymbol.",
+    "`kuna functions` text mode still prints only address + name; adding a size column would match the DecLib reference but changes a line format callers may parse."
+  ]
+}

--- a/docs/re-needs/functions-json-size.md
+++ b/docs/re-needs/functions-json-size.md
@@ -2,23 +2,23 @@
 need_id: functions-json-size
 title: kuna functions --json omits size, so the cheap inventory call cannot rank functions
 track: tooling
-status: open
+status: closed
 severity: minor
 probe_id: p-d8f69800917d
 acceptance_id: a-ddc5496835ba
-hypothesis_status: inconclusive
+hypothesis_status: overturned
 credibility: 1.0
 instances: 4
 challenges: [6609e458cddae72ae250bf40, 67bd52114e1a16f76a1ad5bc, 61ffb07c33c5d46c8bcbfc1d]
 rounds: [0]
 first_seen_round: 0
-attempts: 0
+attempts: 1
 covered_by_option: null
 touches: [decompiler/crates/kuna-cli/src, tests/cli, docs/cli.md]
 scope: small
 regression_of: null
-pr: null
-closed_in_round: null
+pr: PENDING
+closed_in_round: 1
 closing_pr: null
 reject_reason: null
 ---
@@ -242,3 +242,29 @@ acceptance is vendorable; the dataset rows are the breadth evidence.
 - r0 `covered_by_option: null` -- `kuna catalog` options gate emitted C only;
   none of the 127 settables can add a field to `functions --json`.
 - REGRESSED: acceptance a-ddc5496835ba fails again at deadbeef
+- r1 builder: acceptance a-ddc5496835ba flips to PASS. `functions[0].size` = 27.
+- r1 **hypothesis OVERTURNED.** The filed diagnosis -- "`size` was simply not
+  copied across ... a struct in kuna-cli with four fields where the decompile-all
+  one has five" -- is wrong, and the symptom's premise with it. `decompile-all
+  --json` does emit `size`, but its VALUE is `0` on every record of every binary
+  (34/34 on this fixture; 0 nonzero across every fixture in the tree), because
+  `FuncResult.size` read `Funcdata::get_size()`, the caller's *requested* flow
+  bound, which `decompile_targets` always passes as `0` ("UNBOUNDED"). Copying
+  the field would have satisfied the acceptance's `exists` clause with a column
+  of zeroes and closed nothing. The symptom stands; the diagnosis did not.
+- r1 the real gap was therefore broader than filed: kuna had no function-extent
+  value on ANY surface. Closed by reconstructing it at inventory time as the
+  address-contiguous clip `[entry, min(next_entry, end_of_CODE_section))`
+  (`kuna-console/src/funcextent.rs`) -- the model `analyzers/fid/extent.rs` and
+  `noreturn_disc` already use -- and reporting the one number on `functions`,
+  `decompile-all`, `decompile-project` and the wasm inventory alike.
+- r1 the Refutation section's cheap check, answered: `decompile-all`'s `size` is
+  NOT computed at inventory time, and it is not a by-product of decompiling
+  either -- it is a constructor argument that no CLI surface ever sets. The cost
+  question it anticipated was real but resolved the other way: the clip needs no
+  decode at all, and measures at -0.58%..+0.21% (interleaved, 9 reps) on the
+  inventory path.
+- r1 an upper bound, deliberately: 0 undershoots / 1428 functions with ELF
+  `st_size` ground truth, median overshoot +8B (alignment padding). `st_size`
+  itself was rejected as the source -- this fixture is stripped, so it would
+  have produced an all-zero column on the very binary the acceptance targets.

--- a/docs/re-needs/functions-json-size.md
+++ b/docs/re-needs/functions-json-size.md
@@ -17,9 +17,9 @@ covered_by_option: null
 touches: [decompiler/crates/kuna-cli/src, tests/cli, docs/cli.md]
 scope: small
 regression_of: null
-pr: PENDING
+pr: https://github.com/Noelo-Lab/kuna/pull/360
 closed_in_round: 1
-closing_pr: null
+closing_pr: https://github.com/Noelo-Lab/kuna/pull/360
 reject_reason: null
 ---
 

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -4,7 +4,8 @@
   "count": 5,
   "rejected_count": 0,
   "by_status": {
-    "open": 5
+    "closed": 1,
+    "open": 4
   },
   "by_track": {
     "tooling": 5
@@ -90,42 +91,6 @@
       "path": "docs/re-needs/decompile-no-json.md"
     },
     {
-      "need_id": "functions-json-size",
-      "title": "kuna functions --json omits size, so the cheap inventory call cannot rank functions",
-      "track": "tooling",
-      "status": "open",
-      "severity": "minor",
-      "probe_id": "p-d8f69800917d",
-      "acceptance_id": "a-ddc5496835ba",
-      "hypothesis_status": "inconclusive",
-      "credibility": 1.0,
-      "instances": 4,
-      "challenges": [
-        "6609e458cddae72ae250bf40",
-        "67bd52114e1a16f76a1ad5bc",
-        "61ffb07c33c5d46c8bcbfc1d"
-      ],
-      "rounds": [
-        0
-      ],
-      "first_seen_round": 0,
-      "attempts": 0,
-      "covered_by_option": null,
-      "touches": [
-        "decompiler/crates/kuna-cli/src",
-        "tests/cli",
-        "docs/cli.md"
-      ],
-      "scope": "small",
-      "regression_of": null,
-      "pr": null,
-      "closed_in_round": null,
-      "closing_pr": null,
-      "reject_reason": null,
-      "score": 48.283137,
-      "path": "docs/re-needs/functions-json-size.md"
-    },
-    {
       "need_id": "zero-functions-exit-0",
       "title": "kuna reports total function-discovery failure as success: count 0, exit 0, silent stderr",
       "track": "tooling",
@@ -159,6 +124,42 @@
       "reject_reason": null,
       "score": 43.944492,
       "path": "docs/re-needs/zero-functions-exit-0.md"
+    },
+    {
+      "need_id": "functions-json-size",
+      "title": "kuna functions --json omits size, so the cheap inventory call cannot rank functions",
+      "track": "tooling",
+      "status": "closed",
+      "severity": "minor",
+      "probe_id": "p-d8f69800917d",
+      "acceptance_id": "a-ddc5496835ba",
+      "hypothesis_status": "overturned",
+      "credibility": 1.0,
+      "instances": 4,
+      "challenges": [
+        "6609e458cddae72ae250bf40",
+        "67bd52114e1a16f76a1ad5bc",
+        "61ffb07c33c5d46c8bcbfc1d"
+      ],
+      "rounds": [
+        0
+      ],
+      "first_seen_round": 0,
+      "attempts": 1,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-cli/src",
+        "tests/cli",
+        "docs/cli.md"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": "PENDING",
+      "closed_in_round": 1,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 32.188758,
+      "path": "docs/re-needs/functions-json-size.md"
     },
     {
       "need_id": "unpack-upx-packed-executable",

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -154,9 +154,9 @@
       ],
       "scope": "small",
       "regression_of": null,
-      "pr": "PENDING",
+      "pr": "https://github.com/Noelo-Lab/kuna/pull/360",
       "closed_in_round": 1,
-      "closing_pr": null,
+      "closing_pr": "https://github.com/Noelo-Lab/kuna/pull/360",
       "reject_reason": null,
       "score": 32.188758,
       "path": "docs/re-needs/functions-json-size.md"

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -455,6 +455,32 @@ remains unrestricted; name selection keeps its normal first-match behavior when
 a stub and slot share a name. Loaders without section metadata keep the complete
 inventory.
 
+Each canonical entry also carries a byte **extent**, so the inventory answers
+"how big" as well as "what is here" and a caller can order a binary's functions
+by weight without decompiling any of them. kuna's model of a function is its
+entry — the Listing is keyed by entry VMA and nothing in it records a body — so
+the extent is reconstructed as the address-contiguous clip from the entry to
+whichever comes first: the next canonical entry, or the end of the CODE section
+containing the entry (`decompiler/crates/kuna-console/src/funcextent.rs`). This
+is the same reconstruction the FID extent generator
+(`decompiler/crates/kuna-analysis/src/analyzers/fid/extent.rs`) and the
+discovered-no-return pass already apply where they need a body from an
+entry-keyed model, and it reuses the entry list and the loader section table
+rather than decoding anything, so the metadata-only `functions` surface stays
+metadata-only.
+
+The number is an upper bound, not the exact body: the clip runs to the neighbour,
+so inter-function alignment padding is counted in, and against ELF `st_size` over
+the symbolized fixture corpus it is never short. An entry in no CODE section — a
+pointer slot, an undefined external — has no body to measure and reports zero,
+the same value a synthesized entry carries when there is no program to measure
+against. The loss is that the clip is address-contiguous rather than
+flow-reachable: an outlined cold half living past the next entry is attributed to
+its neighbour. Every whole-binary surface reports this one number under the one
+name, including the decompiling ones; their alternative, the recovered
+`Funcdata::get_size()`, is the *requested* flow bound rather than a measurement,
+and a whole-binary run always requests an unbounded extent.
+
 Naming a pointer slot is not by itself enough to bind a call *through* it. An ELF
 PLT stub and a Mach-O `__stubs` entry are code, so the call is direct and the name
 resolves at flow time; a PE Import Address Table slot is data, so `call dword ptr

--- a/integrations/web/kuna-web.js
+++ b/integrations/web/kuna-web.js
@@ -221,7 +221,7 @@ export async function loadKuna({ wasmUrl, specRoot, smallBundleUrl }) {
   return {
     /** Format label for the status line (ELF / PE / Mach-O / binary). */
     formatName,
-    /** Enumerate functions: `{binary, count, functions:[{name, address, address_hex}]}`. */
+    /** Enumerate functions: `{binary, count, functions:[{name, address, address_hex, size}]}`. */
     async list(binaryBytes, { mode = 'auto', language = 'auto' } = {}) {
       return parseOrThrow(
         await invoke(binaryBytes, wasmCommandArgs('list', undefined, mode, language)),

--- a/tests/cli/functions-json-size.json
+++ b/tests/cli/functions-json-size.json
@@ -1,0 +1,36 @@
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-ddc5496835ba",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "binary_sha256": "1a592a85f424cc2db8953d5a38c86676bcee5e37b242b6fb6244a2c9fccfeeef",
+    "binary_size": 14408,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "selector": null,
+    "selector_kind": "none"
+  },
+  "expect": {
+    "json": [
+      {
+        "path": "functions[0].size",
+        "op": "exists"
+      }
+    ]
+  },
+  "notes": "Desired: every functions --json record carries size, the field decompile-all --json already emits. Vendorable (in-repo fixture) so this promotes into tests/cli/ verbatim."
+}


### PR DESCRIPTION
## What was broken

`docs/re-needs/functions-json-size.md` (4 instances, one in-repo fixture + three
dataset crackmes):

> `kuna functions <bin> --json` is the one cheap, whole-binary call kuna offers:
> it loads once and answers "what is in here". Its records carry only `name`,
> `address`, `address_hex` and `aliases` — there is no extent. An agent triaging
> a 250-function binary therefore has no way to order its work except by address,
> and the standard first move ("decompile the three biggest functions") costs a
> full `decompile-all` instead of one inventory call.

**The filed hypothesis was wrong, and the way it was wrong mattered.** The need
recorded that `decompile-all --json` "emits `size` on every record, from the same
`FuncResult`. Only the cheap call drops it", and predicted a four-field struct
next to a five-field one. The field is emitted — but its value is `0` on every
record of every binary:

```
$ kuna decompile-all …/aif_gap_x86_64 --json | jq '[.functions[].size] | unique'
[0]                       # and 0 nonzero sizes across every fixture in the tree
```

`FuncResult.size` came from `Funcdata::get_size()`, which is written once in the
`Funcdata` constructor from the caller's **requested flow bound** and never
updated by flow recovery. `decompile_targets` passes `0` for that bound
(*"UNBOUNDED: the function's natural flow extent"*), so it is always `0` on every
whole-binary surface; the only writer of a nonzero value is the XML decode path,
which no CLI surface reaches.

So this was never a one-field copy. Copying the field across would have satisfied
the acceptance probe's `exists` clause with a column of zeroes and closed nothing.
kuna had no function-extent value on *any* surface.

## Mechanism

kuna's model of a function is its **entry** — the Listing is keyed by entry VMA
and nothing in it records a body. New module
`decompiler/crates/kuna-console/src/funcextent.rs` reconstructs the extent as the
**address-contiguous clip** `[entry, min(next_entry, end_of_containing_CODE_section))`.

That is not invented here: it is the same reconstruction kuna already applies
wherever it needs a body from an entry-keyed model —
`kuna-analysis/src/analyzers/fid/extent.rs::calculate_extent`, whose module doc
documents the identical LOSS, and the `noreturn_disc` call-site reasoning.
It reuses the entry list and the loader section table, both already in hand, so
it adds no decode.

`FunctionEntry` gains `size: u64`, filled in one pass by
`function_entries_canonical` (already ascending, from its `BTreeMap`) and by the
new `ConsoleProgram::function_extent_at` for synthesized `--addr` entries.
`FuncResult.size` carries that number instead of the dead `fd.get_size()`, so
`functions`, `decompile-all`, `decompile-project` and the wasm browser inventory
all report **one number with one meaning** — which is what the need asked for
("match it exactly rather than inventing a second meaning for the same field
name"). The extent is reported on the error and external arms too: it is an
inventory fact and does not depend on the decompile succeeding.

```
$ kuna functions …/aif_gap_x86_64 --json | jq -c '.functions[] | {n:.name, s:.size}'
{"n":"_DT_INIT","s":27}      # exactly .init
{"n":"sub_1020","s":16}      # .plt stub
{"n":"__cxa_finalize","s":8} # .plt.got thunk
…
{"n":"sub_13c9","s":682}     # the .text tail
```

### Two alternatives rejected

- **ELF `st_size`** — exact and free, but `0` on stripped binaries, and the
  probe's own fixture is stripped (6 `.dynsym` entries, all `UND`). It would have
  produced an all-zero column on the very binary the acceptance targets. A hybrid
  makes `size` mean two different things depending on whether the binary is
  stripped.
- **A flow-reachable extent from the Listing** — kuna deliberately does *not*
  build the Listing for `kuna functions` on x86-64 (it is measured entry-neutral
  there), so this would put a full linear decode behind the one call whose whole
  purpose is being cheap. This is the cost question the need's Refutation section
  asked to be settled first.

## What the number means

An **upper bound**, documented as such in `docs/cli.md` and
`docs/spec/01-program-prep.md`: the clip runs to the neighbour, so inter-function
alignment padding is counted in. Measured against ELF `st_size` over the 41
symbolized fixtures (1428 functions with ground truth):

| | |
|---|---|
| never short | **0 undershoots / 1428** |
| exact | 231 |
| median overshoot | +8 bytes |
| worst overshoot | +52 bytes |

An entry in no CODE section — a pointer slot, an undefined external — reports `0`.

## The acceptance probe now passes

```
$ python -m scripts.repipe.verify --need functions-json-size --json
"passed": true, "transition": "closed"
clause functions[0].size exists → actual 27
```

Promoted verbatim to `tests/cli/functions-json-size.json`.

*(Noted, not fixed here: nothing currently **runs** `tests/cli/*.json` — `promote`
writes the directory and the webui displays it, but no target executes a promoted
probe. The guard that actually runs in CI for this need is the pair of cargo
integration tests below, per the track-`tooling` contract. A generic runner is
pipeline infrastructure; it is recorded as a follow-up in `record.json`.)*

## Tests

- `funcextent.rs` — 8 unit tests: the clip rule, section selection, entries
  outside every CODE section, duplicate/backward neighbours, `code_spans`
  filtering (zero-length, non-CODE, wrapping), `extent_at`.
- `functions_json_carries_a_ranking_extent` — the field must exist on every
  record **and discriminate**. An all-zero or all-equal column fails, which is
  exactly what would have shipped had the filed hypothesis been followed.
- `functions_and_decompile_all_agree_on_size` — one field name, one meaning
  across the two surfaces.

Collateral sweep over all 4 `FunctionEntry` construction sites and the non-ELF /
non-x86-64 formats: stripped x86-64 ELF 34/34, ARM Thumb 2/2 (bit normalized),
Cortex-M 74/74, COFF `.obj` 2/2 and 3/3. No negative or absurd extents.

## Speed

Interleaved old/new, 1 warmup + 9 interleaved repetitions, against the main
tree's pre-change release binary at `63a124ae`:

| target | median | min |
|---|---|---|
| `bash` O2 (2538 fns, 1.3 MB) | **−0.18%** | −0.09% |
| `betaflight` Cortex-M (5798 fns) | **−0.58%** | −0.18% |
| `ssh-sk-helper` (802 fns) | **+0.21%** | −0.10% |

No measurable cost — the cheap inventory call stays cheap.

## Gates

| gate | result |
|---|---|
| `make test` | **PARITY OK** — 675/675 assertions |
| `make test-stages` | **PARITY OK** — 574/574 assertions |
| `make rust-test` | green (incl. `decompile_all_cli` 22/22, `funcextent` 8/8) |
| `make check-spec` | check-spec OK |
| `kuna catalog --check` | catalog OK |

No option added: a JSON metadata field cannot change emitted C, so there is no
`phases.toml` row, no `options.rs` registration and no catalog counter to bump.

One unrelated one-liner rides along because `scripts.repipe.mergecheck` rejects
without it: `kuna_phases/tests.rs`'s `settable_count_is_117` is renamed to
`settable_count_is_127`. The stale name is already on `origin/main` (the
assertion inside it has long said 127) and the counter tool matches on the
function name, so every branch is blocked until someone renames it. No assertion
changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
