### PR TITLE
Add AUR installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,18 @@ Kuna is distributed as a single Rust binary and can be run on most systems.
 It can be used either on the [CLI](#cli-usage), the [web browser](#web-browser-usage), or in the [Ghidra GUI](#ghidra-gui-usage) (as the decompiler backend).
 
 ### CLI Usage
-If building from source, you can find the `kuna` binary in `decompiler/target/release/kuna`.
-Otherwise, you can find it in the latest [release](https://github.com/Noelo-Lab/kuna/releases) for your OS (Linux, Windows, MacOS supported). 
+
+#### Installation
+- **Pre-built Binaries**: Download the latest release for your OS (Linux, Windows, macOS) from [releases](https://github.com/Noelo-Lab/kuna/releases).
+- **Arch Linux (AUR)**: Install directly from the AUR using your favorite AUR helper:
+  ```bash
+  yay -S kuna
+  # or
+  paru -S kuna
+  ```
+- **Building from Source**: Build the `kuna` binary in `decompiler/target/release/kuna` (see [Building from Source](#building-from-source)).
+
+#### Examples
 
 ```bash
 kuna decompile ./a.out main


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` to make it easier for users to install Kuna. The changes clarify the available installation options, including pre-built binaries, Arch Linux AUR, and building from source.

**Documentation improvements:**

* Expanded the installation section in `README.md` to clearly describe how to install Kuna using pre-built binaries, Arch Linux AUR, or by building from source, and provided example commands for AUR installation.