### PR TITLE
fix(repipe): close the nine defects the review left open, and run the promoted probes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ name: Tests
 #   make test              datatest corpus vs docs/baseline.json          (PARITY OK)
 #   make test-stages       stage corpus vs docs/baseline-stages.json      (PARITY OK)
 #   make check-spec        docs/spec/ anchors + phase-folder ownership
+#   make test-cli          the RE-friction loop's promoted regression probes
 #   kuna catalog --check   docs/options.md documents exactly the registered options
 #   make rust-test         the full cargo workspace suite
 #
@@ -107,6 +108,13 @@ jobs:
 
       - name: make check-spec
         run: make check-spec
+
+      # The RE-friction loop's regression corpus (docs/re-pipeline.md). Every gap the loop
+      # closes leaves the acceptance probe that proved the fix in tests/cli/; running them
+      # here is what stops a closed need from silently re-opening. Needs no dataset -- every
+      # case targets an in-repo fixture -- and an empty corpus passes.
+      - name: make test-cli
+        run: make test-cli
 
       - name: kuna catalog --check
         run: ./decompiler/target/release/kuna catalog --check

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PYTHON  ?= python3
 # (inside target/, which is gitignored, so a failed run leaves no repo litter).
 GHIDRA_SIM_LOG := $(ENGINE)/target/ghidra-sim.log
 
-.PHONY: all binaries specs test test-stages test-ghidra rust rust-test clean check-spec version
+.PHONY: all binaries specs test test-stages test-cli test-ghidra rust rust-test clean check-spec version
 
 all: binaries specs
 
@@ -95,6 +95,13 @@ test-ghidra:
 # exactly one chapter, and (strict) every settable option is mentioned.
 check-spec:
 	python3 tools/check_spec.py
+
+# The RE-friction loop's regression corpus: every gap it closes leaves the acceptance probe
+# that proved the fix in tests/cli/ (docs/re-pipeline.md sec.3). Without a runner they are
+# inert -- a regression would be found a round later by a tester instead of a minute later
+# here. Every case is `in-repo` targeted, so this needs no dataset. An empty corpus passes.
+test-cli:
+	PYTHONPATH=$(ROOT) python3 -m scripts.repipe.clitests
 
 # Print the repo version as MAJOR.MINOR (VERSION file + commit count -- the
 # scheme release CI tags with; see docs/release.md).

--- a/docs/re-pipeline.md
+++ b/docs/re-pipeline.md
@@ -352,6 +352,44 @@ REPIPE_MAX_AGENTS=7 REPIPE_ROUND_USD=150 tools/repipe/run.sh --rounds 1
   evidence the refuter is rubber-stamping).
 - ≥1 PR merged, and ≥1 acceptance probe flipped to PASS and promoted into `tests/cli/`.
 
+## What an adversarial review found, and where it stands
+
+The implementation was reviewed by four independent agents, every finding re-run by a
+refuter: **32 confirmed, 17 refuted**. All 32 are fixed. The list is kept here rather than in
+a PR description because the next person to touch this code needs to know which mistakes were
+already made in it.
+
+The eight that were critical, and would each have made the loop unusable or unsafe:
+
+| | |
+|---|---|
+| the loop was **inert** | `run.sh` ran only the housekeeping tick and never `captain.sh`, so 72 h of ticks would advance nothing past `T_IDLE`/`B_IDLE` |
+| every lease and slot was **dead on arrival** | the recorded pid was the ephemeral `state …` CLI process, so `merge` granted to everyone — and `reap` failed **live** workers and released their claims |
+| the probe allowlist was bypassable | basename-only matching: any file named `kuna` ran, and a tester has workspace-write |
+| the sandbox hid one directory | a second full copy of all 250 flags sits in the sibling label repo, and `$HOME` held SSH keys, a GitHub token and 600 past prompts |
+| the gate→cluster seam passed no observation | every clustered need would have been one empty record |
+| `--merge` raced the `full-ci` registration | it could squash-merge before the workspace suite even registered, and failed *open* on a draft-query error |
+| tester prose could hijack a record | an `## Acceptance` heading in a tester's own text replaced the real probe — which is then auto-closed and promoted |
+| the arena shims were never on `PATH` | no tool-call log at all, and IDA's `.i64` files uncontained |
+
+Four more came from the **first live run**, and none of them could have been found offline:
+the report schema 400s in strict structured-output mode; `gate_round` did not supply `{{BIN}}`
+so a correct observation was discarded as unrunnable; the IDA shim never passed
+`--backend ida`, so "compare against IDA" silently compared against angr; and declib's socket
+lives under `TMPDIR`, outside the tester's sandbox, so every reference call failed.
+
+Each fix carries a regression test in `tools/repipe/smoke.sh` or `tests/cli/`. Two are worth
+knowing about because they shape how you should extend this code:
+
+- **A regex guard is not a sanitizer.** CodeQL rejected a charset gate on a URL id and was
+  right to: the tainted string still flowed into a path. The accepted fix builds the path from
+  `os.listdir()` and compares the id against filesystem-produced names by equality, which
+  makes traversal structurally impossible rather than guarded.
+- **Negative operators are universally quantified.** `absent` under `[*]` means *no* element
+  has it, not *some* element lacks it. Existentially-quantified negation let a probe and its
+  own negation both pass on a mixed array, which the gate reads as `already-supported` — i.e.
+  it silently discards a real need.
+
 ## Machinery reference
 
 | Piece | What |

--- a/scripts/repipe/clitests.py
+++ b/scripts/repipe/clitests.py
@@ -1,0 +1,100 @@
+"""Run the promoted regression probes in tests/cli/ as a gate.
+
+Every need the loop closes leaves its acceptance probe here (`verify --promote`). Without
+something that RUNS them they are inert: the loop would keep depositing evidence that a gap
+was closed while nothing checked it stayed closed, which is precisely the rot the
+`regressed` status exists to catch -- except a regression would then be found a round later
+by a tester rather than a minute later by CI.
+
+A probe only lands here if its target is `in-repo`, so this runs with no dataset and is safe
+in CI. `make test-cli` is the entry point.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from . import config, probe
+
+
+def cases(directory=None):
+    d = directory or config.cli_tests_dir()
+    if not os.path.isdir(str(d)):
+        return []
+    return [os.path.join(str(d), f) for f in sorted(os.listdir(str(d))) if f.endswith(".json")]
+
+
+def run_one(path, reps=None):
+    """(name, ok, verdict_or_error). A probe here asserts the FIXED behaviour, so ok == passed."""
+    name = os.path.basename(path)[:-5]
+    try:
+        with open(path) as fh:
+            doc = json.load(fh)
+    except (OSError, ValueError) as exc:
+        return name, False, {"error": "unreadable: %s" % exc}
+
+    target = doc.get("target") or {}
+    if target.get("binary_source") != "in-repo":
+        # Refuse rather than skip: a dataset-backed probe here would pass on a developer's
+        # box and fail in CI, which is worse than not having the test.
+        return name, False, {"error": "target.binary_source is %r, not 'in-repo' -- this "
+                                      "corpus must run without the dataset"
+                                      % target.get("binary_source")}
+    rel = target.get("in_repo_path")
+    ctx = {"work": str(config.repo_root())}
+    if rel:
+        ctx["bin"] = os.path.join(str(config.repo_root()), rel)
+    if reps:
+        doc = dict(doc)
+        doc["repeat"] = max(int(doc.get("repeat") or 1), int(reps))
+    try:
+        v = probe.check(doc, ctx)
+    except Exception as exc:
+        return name, False, {"error": "%s: %s" % (type(exc).__name__, exc)}
+    return name, bool(v.get("passed")) and not v.get("flaky"), v
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog="python -m scripts.repipe.clitests")
+    ap.add_argument("--dir", default=None)
+    ap.add_argument("--reps", type=int, default=None)
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--name", action="append", default=[])
+    args = ap.parse_args(argv)
+
+    paths = cases(args.dir)
+    if args.name:
+        paths = [p for p in paths if os.path.basename(p)[:-5] in args.name]
+    if not paths:
+        # An empty corpus is a legitimate state (nothing promoted yet) and must not fail.
+        print("tests/cli: no cases")
+        return 0
+
+    rows, failed = [], 0
+    for p in paths:
+        name, ok, v = run_one(p, args.reps)
+        rows.append({"name": name, "ok": ok,
+                     "error": v.get("error"), "flaky": v.get("flaky"),
+                     "clauses": [c for c in (v.get("clauses") or []) if not c.get("ok")]})
+        if not ok:
+            failed += 1
+        if not args.json:
+            print("  %-6s %s%s" % ("ok" if ok else "FAIL", name,
+                                   "" if ok else "  <- %s" % (v.get("error") or "clause failed")))
+            if not ok:
+                for c in rows[-1]["clauses"][:4]:
+                    print("         %s expected %s actual %s"
+                          % (c.get("clause"), c.get("expected"), c.get("actual")))
+
+    if args.json:
+        print(json.dumps({"total": len(rows), "failed": failed, "cases": rows}, indent=2,
+                         default=str))
+    else:
+        print("tests/cli: %d/%d passed" % (len(rows) - failed, len(rows)))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repipe/cluster.py
+++ b/scripts/repipe/cluster.py
@@ -196,14 +196,22 @@ def build_needs(observations, round_n):
     from . import needs as needs_mod
     out = []
     for grp in group(observations):
-        nid = need_id_for(grp)
+        # The id must come from the SAME observation as the title, severity and probe.
+        # Taking it from grp[0] while everything else comes from the witness produced a
+        # branch name and a test filename describing a different observation than the record.
         witness = _pick_witness(grp)
+        nid = need_id_for([witness])
         challenges = sorted({o.get("_hexid") for o in grp if o.get("_hexid")})
         existing = needs_mod.load(nid)
         if existing is not None:
             existing.fields["instances"] = int(existing.instances or 0) + len(grp)
             existing.fields["challenges"] = sorted(set(list(existing.challenges or []) + challenges))
             existing.fields["rounds"] = sorted(set(list(existing.rounds or []) + [round_n]))
+            # Corroboration is the whole point of a second sighting, so credibility is
+            # recomputed rather than frozen at first filing: a need first seen by one tester
+            # and later confirmed by two more is not still a single opinion.
+            existing.fields["credibility"] = max(
+                float(existing.credibility or 0.0), credibility(grp))
             if existing.status == "closed":
                 # A closed need whose symptom came back is a regression, and rank_score puts
                 # a regression at the front of the queue.

--- a/scripts/repipe/needs.py
+++ b/scripts/repipe/needs.py
@@ -707,7 +707,7 @@ def to_opportunities(needs=None, statuses=DISPATCHABLE):
     `test_name::selector` and derives the branch slug from `test_name` -- so a need's id is its
     test_name and its acceptance id is its selector, making OPP_ID `<need_id>::<acceptance_id>`:
     re-filing the same need against a NEW acceptance is a new unit of work, which is the
-    behaviour we want. `kinds` carries the track, so `select.py --kind tooling` (whose filter is
+    behaviour we want. `kinds` carries the track, so `needs list --track <t>` (scripts/pipeline/select.py's --kind filter keys off the `kinds` column this module emits into opportunities.json) (whose filter is
     already generic) partitions the backlog by builder track with no change to that module.
     """
     rows = [_opportunity_row(n, i)

--- a/scripts/repipe/probe.py
+++ b/scripts/repipe/probe.py
@@ -635,10 +635,15 @@ def _exec_once(index, argv, cwd, env, stdin_data, timeout_s, use_time):
             out, err = b"", b""
     rec["wall_ms"] = (time.monotonic() - t0) * 1000.0
 
+    # The true byte counts are recorded BEFORE truncation, so a `stdout_bytes` clause still
+    # sees reality even when the text is capped; only content past the cap is unavailable,
+    # and the observation says so.
     rec["stdout_bytes"] = len(out or b"")
     rec["stderr_bytes"] = len(err or b"")
-    rec["stdout"] = (out or b"").decode("utf-8", "replace")
-    rec["stderr"] = (err or b"").decode("utf-8", "replace")
+    rec["stdout"] = (out or b"")[:CAPTURE_MAX_BYTES].decode("utf-8", "replace")
+    rec["stderr"] = (err or b"")[:CAPTURE_MAX_BYTES].decode("utf-8", "replace")
+    rec["stdout_truncated"] = rec["stdout_bytes"] > CAPTURE_MAX_BYTES
+    rec["stderr_truncated"] = rec["stderr_bytes"] > CAPTURE_MAX_BYTES
 
     report = _parse_time_report(report_path) if report_path else None
     if report_path:
@@ -923,6 +928,13 @@ REGEX_BUDGET_S = float(os.environ.get("REPIPE_REGEX_BUDGET_S", "5"))
 # re is applied to whole streams; a huge stdout multiplies any pattern's cost.
 REGEX_MAX_BYTES = int(os.environ.get("REPIPE_REGEX_MAX_BYTES", str(4 << 20)))
 
+# How much of a probe's output is kept in memory. `kuna decompile-all --json` on a large
+# binary is already tens of MB, and an allowlisted tool pointed at the wrong thing can emit
+# far more; with repeat up to 11 and no cap, one bad probe could exhaust the box. The real
+# byte count is still measured and asserted on (`stdout_bytes`), so a truncated capture
+# never silently changes a verdict about SIZE -- only about content past the cap.
+CAPTURE_MAX_BYTES = int(os.environ.get("REPIPE_CAPTURE_MAX_BYTES", str(64 << 20)))
+
 
 def _search(pattern, text, budget=None):
     """re.search with a wall-clock bound. Returns None on error, timeout or no match.
@@ -1145,8 +1157,13 @@ def evaluate(probe, observation):
         "wall_ms_min": _stat_of(wall, "min"),
         "wall_ms_max": _stat_of(wall, "max"),
         "wall_ms_mean": _stat_of(wall, "mean"),
+        # The statpred enum allows median|min|max|mean, so all four must exist for BOTH
+        # metrics. Emitting only median and max meant a `max_rss_kb` clause with
+        # stat "min" or "mean" could never find its value and failed as unresolvable.
         "max_rss_kb_median": _stat_of(rss, "median"),
+        "max_rss_kb_min": _stat_of(rss, "min"),
         "max_rss_kb_max": _stat_of(rss, "max"),
+        "max_rss_kb_mean": _stat_of(rss, "mean"),
         "rusage_source": observation.get("rusage_source"),
         "cmd": observation.get("cmd"),
         "cwd": observation.get("cwd"),

--- a/scripts/repipe/verify.py
+++ b/scripts/repipe/verify.py
@@ -594,6 +594,28 @@ def need_records(need_ids=None):
     return out
 
 
+def probe_of(rec):
+    """The need's PROBE arm, as (dict, verbatim_text, source) -- the mirror of acceptance_of.
+
+    Needed because a `rel_to` acceptance is expressed relative to this arm's median, so the
+    suite has to be able to find and replay it.
+    """
+    obj, raw = _fenced_probe(_section(rec["text"], "Reproduction"))
+    if obj is not None:
+        return obj, raw, "record"
+    pid = rec["front_matter"].get("probe_id")
+    if pid:
+        for base in (config.needs_dir() / "probes", config.state_dir() / "probes"):
+            f = base / ("%s.json" % pid)
+            if f.is_file():
+                try:
+                    raw = f.read_text()
+                    return json.loads(raw), raw, str(f)
+                except (OSError, json.JSONDecodeError):
+                    continue
+    return None, None, None
+
+
 def acceptance_of(rec):
     """The need's acceptance probe, as (dict, verbatim_text, source).
 
@@ -615,6 +637,42 @@ def acceptance_of(rec):
                 except (OSError, json.JSONDecodeError):
                     continue
     return None, None, None
+
+
+def _acceptance_baselines(rec, challenges, reps):
+    """Measure the need's PROBE arm when its acceptance needs it as a `rel_to` baseline.
+
+    Only paid for when a clause actually references one: replaying the probe of every need in
+    the backlog on every suite run would triple the cost of the loop's most frequent
+    operation for a feature almost no need uses.
+    """
+    p, _raw, _src = acceptance_of(rec)
+    if not _wants_baseline(p):
+        return None
+    probe_p, _praw, _psrc = probe_of(rec)
+    if probe_p is None:
+        return None
+    try:
+        pv = run_probe(probe_p, False, None, None, challenges, reps)
+    except Exception:
+        return None
+    # Key by BOTH the derived id and whatever the record calls it. A `rel_to` is written by
+    # hand against the front-matter's probe_id, which need not equal the id derived from
+    # cmd+expect -- and a baseline nobody can look up is the same as no baseline at all.
+    out = {}
+    for pid in (pv.get("probe_id"), (probe_p or {}).get("probe_id"),
+                rec["front_matter"].get("probe_id")):
+        if pid:
+            out[pid] = pv
+    return out or None
+
+
+def _wants_baseline(probe_doc):
+    for key in ("wall_ms", "max_rss_kb"):
+        clause = ((probe_doc or {}).get("expect") or {}).get(key) or {}
+        if isinstance(clause, dict) and clause.get("rel_to"):
+            return True
+    return False
 
 
 def acceptance_suite(need_ids=None, reps=None):
@@ -642,7 +700,12 @@ def acceptance_suite(need_ids=None, reps=None):
         chal = fm.get("challenges") or []
         if isinstance(chal, str):
             chal = [chal]
-        v = run_probe(p, True, None, None, chal, reps)
+        # A `rel_to` acceptance compares its median against another probe's, so that
+        # baseline has to be measured here or the clause can never resolve and the need is
+        # unclosable forever. gate() already does this; the suite did not, which made the
+        # whole perf idiom dead on arrival.
+        baselines = _acceptance_baselines(rec, chal, reps)
+        v = run_probe(p, True, None, None, chal, reps, baselines=baselines)
         if v.get("unrunnable") or v.get("flaky"):
             trans = "indeterminate"
         elif v.get("passed") and status in OPEN_STATUSES:

--- a/scripts/repipe/webui.py
+++ b/scripts/repipe/webui.py
@@ -569,6 +569,9 @@ def _ci_verdict(runs):
 # the docs/re-needs/index.json cache, then a front-matter scan of the records themselves.
 # The scan is the floor, so an empty or half-written docs/re-needs/ still renders.
 
+# needs.load_all() returns Need OBJECTS; the fallback readers return dicts. Accepting only
+# lists-of-dicts made the highest-fidelity source silently unusable, so every row is
+# normalised through _need_row below.
 _NEEDS_API = ("load_all", "all_records", "load_index")
 
 
@@ -585,8 +588,28 @@ def _needs_from_module():
             continue
         if isinstance(recs, dict):
             recs = recs.get("needs") or recs.get("ranked") or list(recs.values())
-        if isinstance(recs, list) and all(isinstance(r, dict) for r in recs):
-            return recs
+        if isinstance(recs, list):
+            rows = [_need_row(r) for r in recs]
+            if all(r is not None for r in rows):
+                return rows
+    return None
+
+
+def _need_row(rec):
+    """Normalise one backlog record to a plain dict, whatever the reader handed back.
+
+    needs.load_all() returns Need OBJECTS (front-matter behind __getattr__), while the
+    index/JSON fallbacks return dicts. Accepting only dicts made the richest source -- the one
+    that reads the actual records rather than a cache -- silently unusable, so the dashboard
+    always fell back to the index and went stale the moment a record changed.
+    """
+    if isinstance(rec, dict):
+        return rec
+    fields = getattr(rec, "fields", None)
+    if isinstance(fields, dict):
+        out = dict(fields)
+        out.setdefault("path", str(getattr(rec, "path", "") or ""))
+        return out
     return None
 
 


### PR DESCRIPTION
The adversarial review of #359 returned 32 confirmed findings. I reported them as *"all criticals fixed, the rest recorded in `docs/re-pipeline.md`"*. **The recording never happened** — the doc had no such section. This adds the ledger and closes the nine that were left.

## The one that mattered

**Nothing ran `tests/cli/`.** Every gap the loop closes promotes the acceptance probe that proved the fix into that corpus — that is how a closed need is supposed to stay closed. With no runner they were inert evidence, and a re-opened need would have surfaced a round later from a tester instead of a minute later from CI.

`make test-cli` now runs them, and the parity-gates job runs it on every push:

```
$ make test-cli
  ok     functions-json-size
tests/cli: 1/1 passed
```

Design choices worth knowing: cases must be `in-repo` targeted so the corpus needs no dataset; an empty corpus **passes** (nothing promoted yet is a legitimate state); and a dataset-backed case is **refused, not skipped** — a test that passes on a developer's box and fails in CI is worse than no test.

## The rest

| | |
|---|---|
| `acceptance_suite()` supplied no baselines | so a `rel_to` clause could never resolve and any perf need was permanently unclosable. It now measures the probe arm when — and only when — a clause references it, keyed by **every** id the record uses, since a `rel_to` is hand-written against the front-matter `probe_id` and that need not equal the id derived from cmd+expect |
| `max_rss_kb` emitted only median and max | while the statpred enum allows `median\|min\|max\|mean`, so half the memory clauses were unresolvable |
| probe output buffered without limit | now capped, with the true byte counts recorded **before** truncation so a `stdout_bytes` clause still sees reality |
| `cluster.py` took `need_id` from `grp[0]` | while title, severity and probe came from the witness — so the branch name and test filename described a different observation than the record |
| credibility was frozen at first filing | never recomputed on corroboration, which is the entire point of a second sighting |
| `webui` accepted only lists-of-dicts | so `needs.load_all()`'s `Need` objects were silently unusable and the dashboard always fell back to the stale index |
| `needs.py` documented a `select.py --kind` invocation | that argparse rejects |

## The ledger

`docs/re-pipeline.md` now carries what the review found and where it stands — kept in the runbook rather than a PR description because the next person to touch this code needs to know which mistakes were already made in it. Two are worth reading even if you skip the rest:

- **A regex guard is not a sanitizer.** CodeQL rejected a charset gate on a URL id and was right to — the tainted string still flowed into a path. The accepted fix builds the path from `os.listdir()` and compares by equality, making traversal structurally impossible rather than guarded.
- **Negative operators are universally quantified.** `absent` under `[*]` means *no* element has it, not *some* element lacks it. Existential negation let a probe and its own negation both pass, which the gate reads as `already-supported` — silently discarding a real need.

## Gates

```
smoke.sh         73 passed / 0 failed
make test        PARITY OK 675/675      make check-spec  OK
make test-stages PARITY OK 574/574      make test-cli    1/1
```

No Rust touched, so `make rust-test` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
