### PR TITLE
feat(repipe): standing brief — be an interface, not an oracle

### DIFF
--- a/docs/re-pipeline.md
+++ b/docs/re-pipeline.md
@@ -174,6 +174,39 @@ Before any need is dispatched it is checked against `kuna catalog --json`: if an
 option closes it, it becomes `rejected` with `covered_by_option` — a default-flip candidate for
 the *other* pipeline, not new work here.
 
+## 4b. The standing brief: be an interface, not an oracle
+
+The corpus is deliberately hostile — 171 of its 250 challenges carry at least one obfuscation
+class, and 57 are code-virtualised. Hostile binaries are precisely where a decompiler's
+automatic answer is wrong, so the interesting question this loop asks is not "why did kuna
+guess wrong" but **"why could the agent not tell it the right answer"**.
+
+That is a standing instruction to both halves of the loop, and it is in both prompts:
+
+- **Testers** are told to file a missing *interface* whenever they think "kuna should have
+  known this" — because the useful form of that complaint is almost always "kuna should have
+  let me say so". Define a function boundary, override a jump table, declare a blob as data
+  with a type, steer structuring, fix a prototype, make a rename persist. They are told to
+  check `kuna catalog --json` first: an option that already exists is a discoverability
+  problem, not a missing interface, and that is worth knowing too.
+- **Builders** are told to *expose* before they invent. `kuna-console` registers ~37
+  intervention-shaped commands — `map function`, `override jumptable`, `force goto`,
+  `force datatype`, `parse line`, `retype`, `structure blocks` and the rest — and **none is
+  reachable from the `kuna` binary**. Three very different jobs hide behind "add an
+  interface": wiring something that already works (cheap, the common case), porting a
+  registered stub that answers `engine integration not yet ported` (real engine work, take
+  the `[PROPOSAL]` route), or adding a genuine new judgement call (that is a `phases.toml`
+  option, not a subcommand).
+
+Two rules keep the result usable by the thing it is for:
+
+**A durable assertion beats a one-shot flag.** The phase model is
+`assert(phase, anchor, type, value, strength)`, consulted on every re-run. An agent that
+renames forty functions and loses them on the next invocation has gained nothing.
+
+**Machine-readable in, machine-readable out.** Accept assertions as a file or repeatable
+flags; emit JSON beside the human form.
+
 ## 5. The builder — three tracks
 
 Getting the track wrong is the most likely way to waste a builder session.

--- a/scripts/repipe/render_tester_prompt.py
+++ b/scripts/repipe/render_tester_prompt.py
@@ -92,6 +92,20 @@ def _known_needs(limit=12):
     return "\n".join(lines)
 
 
+def _obfuscation_line(meta):
+    """What this challenge is actually doing to you, from the corpus labels.
+
+    Named rather than left abstract because "this binary is virtualised and string-encrypted"
+    changes which interface a tester should ask for: a VM wants control-flow structuring
+    control, encrypted strings want a way to define decoded data.
+    """
+    classes = (meta.get("obfuscation") or {}).get("classes") or []
+    if not classes:
+        return ("this one is not labelled as obfuscated, so a wrong answer here is a plain "
+                "bug rather than a defence")
+    return "this one is labelled " + ", ".join(c.lower() for c in classes)
+
+
 def _ida_line():
     if not config.ENABLE_IDA:
         return "- IDA is **not** available this round. kuna and the binutils are all you have."
@@ -115,6 +129,7 @@ def render(hexid, round_n, arena, out=None):
             .replace("{{TARGET}}", target)
             .replace("{{REPO}}", str(config.repo_root()))
             .replace("{{TIME_BUDGET}}", str(_time_budget_minutes(meta)))
+            .replace("{{OBFUSCATION}}", _obfuscation_line(meta))
             .replace("{{IDA_LINE}}", _ida_line())
             .replace("{{RECENTLY_SHIPPED}}", _recently_shipped())
             .replace("{{KNOWN_NEEDS}}", _known_needs()))

--- a/tools/repipe/builder_prompt.md
+++ b/tools/repipe/builder_prompt.md
@@ -81,6 +81,54 @@ Two standing requirements bite hardest here and are not optional:
   mechanism, "it does reach the output" is half the brief. It must also answer **would this
   produce WRONG output?** — by building the change and reading the diff, not by arguing.
 
+### When the need asks for an INTERFACE, expose — do not reinvent
+
+A large fraction of this backlog will be an agent asking to *tell kuna something* rather than
+asking kuna to guess better: define a function boundary, override a jump table, declare a
+blob as data, steer structuring, fix a prototype. Before you design anything, check whether
+the capability already exists one layer down and is simply unreachable.
+
+**It usually does.** `kuna-console`'s `register_decomp_commands` registers ~37
+intervention-shaped commands — `map function`, `map address`, `map param`, `map return`,
+`map label`, `override prototype`, `override flow`, `override jumptable`, `force goto`,
+`force datatype`, `force varnode`, `name varnode`, `rename`, `retype`, `type varnode`,
+`parse line`, `parse file`, `comment instruction`, `structure blocks`, `analyze range`,
+`global add`, `graph controlflow`, `callgraph build`, `dump` — and **none of them are
+reachable from the `kuna` binary**. `kuna decompile`'s generated script
+(`decompile.rs`) only ever emits `option` and `kassert` lines.
+
+So there are three very different jobs hiding behind "add an interface", and they cost
+wildly different amounts. Work out which one you are in **before** writing code:
+
+1. **It works in the console, it is just unexposed.** Wire it to the CLI. Cheap, high value,
+   and the common case. Verify by driving `decomp_dbg` directly first:
+   ```
+   printf 'load file BIN
+read symbols
+load function main
+<your command>
+quit
+'      | SLEIGHHOME=$PWD/specs decompiler/target/release/decomp_dbg
+   ```
+   If that works, your job is plumbing, not engine work.
+2. **It answers `engine integration not yet ported`.** The command is a registered stub —
+   `global add`, `dump` and `callgraph build` are confirmed examples. Porting it is real
+   engine work: scope it honestly and take the `[PROPOSAL]` route rather than half-porting it.
+3. **There is no decision point at all.** Then the right shape is usually a new
+   `phases.toml` option (Track `quality`) rather than a new subcommand, because you are
+   adding a *judgement call* to the pipeline, and those ship behind a named flag.
+
+Two design rules for anything in this family:
+
+- **A durable assertion beats a one-shot flag.** kuna's model is `assert(phase, anchor, type,
+  value, strength)` consulted on every (re-)run — not imperative mid-pipeline edits. An
+  interface that survives only inside one process is barely an interface: an agent that
+  renames forty functions and loses them on the next invocation has gained nothing. If you
+  cannot make it durable in one PR, say so in the record and ship the volatile version behind
+  an honest name.
+- **Machine-readable in, machine-readable out.** These are for agents. Accept the assertions
+  as a file or repeatable flags, and emit the result as JSON alongside the human form.
+
 ### Track `perf`
 
 Timing only. Measure with `scripts.pipeline.timeit`'s method (warmup + median over repeats),

--- a/tools/repipe/tester_prompt.md
+++ b/tools/repipe/tester_prompt.md
@@ -95,6 +95,33 @@ Also record, honestly:
 - **`minutes_lost`** — roughly how much of your time went to fighting kuna rather than the
   binary.
 
+## Ask for the interface you want, not just the answer
+
+This corpus is deliberately hostile — {{OBFUSCATION}} — and hostile binaries are exactly where
+a decompiler's automatic answer is wrong and an analyst's judgement has to override it. You
+are that analyst. So when kuna gets something wrong, the useful report is usually **not**
+"kuna should have known this"; it is **"kuna should have let me tell it"**.
+
+Concretely, when you find yourself thinking any of these, file it as a missing *interface*:
+
+- "there is obviously a function at 0x401230 and kuna did not find one" → you want to
+  **define a function boundary**
+- "that is a jump table, not an indirect call" → you want to **override a jump table**
+- "this blob is a string / an array of 32 structs, not code" → you want to **define data and
+  its type**
+- "this `goto` chain is really a loop and the structuring gave up" → you want to **steer
+  control-flow structuring**
+- "the prototype is wrong, it takes three arguments" → you want to **override a prototype**
+- "I worked out that `sub_401000` is `check_serial` and lost it on the next invocation" →
+  you want **renames that persist**
+
+kuna's design already anticipates this: its phase model exposes decision points as durable
+typed assertions (`--option NAME VALUE`, `--kassert`), and `kuna docs phases` explains the
+model. **Read `kuna catalog --json` before filing** — if an option already does what you want,
+that is not a missing interface, it is a discoverability problem, and saying so is still
+useful. Prefer asking for a *knob on an existing decision* over asking for a new heuristic:
+a knob you can drive beats a guess that is right more often.
+
 {{RECENTLY_SHIPPED}}
 
 {{KNOWN_NEEDS}}


### PR DESCRIPTION
The corpus is deliberately hostile — 171 of its 250 challenges carry at least one obfuscation class, 57 are code-virtualised. Hostile binaries are exactly where a decompiler's automatic answer is wrong, so the interesting question this loop asks is not *"why did kuna guess wrong"* but **"why could the agent not tell it the right answer?"**

That is now a standing instruction to both halves of the loop.

**Testers** file a missing *interface* whenever they catch themselves thinking "kuna should have known this" — because the useful form of that complaint is almost always "kuna should have let me say so". Define a function boundary, override a jump table, declare a blob as data with a type, steer structuring, fix a prototype, make a rename persist. They check `kuna catalog --json` first: an option that already exists is a *discoverability* problem, not a missing interface, and that is worth reporting too. The prompt now names the challenge's own obfuscation classes, because "this one is virtualised and string-encrypted" changes which interface is worth asking for.

**Builders** expose before they invent. `kuna-console` registers ~37 intervention-shaped commands — `map function`, `override jumptable`, `force goto`, `force datatype`, `parse line`, `retype`, `structure blocks` … — and **none is reachable from the `kuna` binary**. Three very different jobs hide behind "add an interface":

1. **it already works in the console** and is merely unexposed → wiring, the common case, verifiable in one `decomp_dbg` invocation before any code is written;
2. **it answers `engine integration not yet ported`** (`global add`, `dump`, `callgraph build` confirmed) → real engine work, `[PROPOSAL]` route, not a half-port;
3. **there is no decision point at all** → that is a `phases.toml` option, not a subcommand, because a new judgement call ships behind a named flag.

Two rules keep the result usable by the thing it is for:

- **A durable assertion beats a one-shot flag.** The model is `assert(phase, anchor, type, value, strength)`, consulted on every re-run. An agent that renames forty functions and loses them on the next invocation has gained nothing.
- **Machine-readable in, machine-readable out.** Assertions as a file or repeatable flags; JSON beside the human form.

`smoke.sh 71/71`, `make check-spec OK`. No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
