### PR TITLE
[AUTOMATED] fix(webui): the dashboard never showed either lane's state

### DIFF
--- a/scripts/repipe/webui.py
+++ b/scripts/repipe/webui.py
@@ -388,12 +388,20 @@ def _round_dirs(state_dir):
 
 
 def _lane_state(transitions, track, lane):
-    """Current state of one track: the destination of its last recorded transition."""
+    """Current state of one track: the destination of its last recorded transition.
+
+    captain.py names the field `machine`, not `track` -- `track` is accepted too so an
+    older transitions.jsonl still reads. Getting this wrong is silent: every lane renders
+    as "--" on a loop that is running perfectly, which is worse than an error because the
+    dashboard is what the operator trusts when the CLI is not in front of them.
+    """
+    def _is(t):
+        return (t.get("machine") or t.get("track")) == track
     for t in reversed(transitions):
-        if t.get("track") == track and t.get("to") in lane:
+        if _is(t) and t.get("to") in lane:
             return t["to"]
     for t in reversed(transitions):
-        if t.get("track") == track and t.get("to"):
+        if _is(t) and t.get("to"):
             return t["to"]
     return None
 
@@ -403,9 +411,14 @@ def _collect_rounds(state_dir):
     for num, path in _round_dirs(state_dir):
         meta = _read_json(path / "round.json", {}) or {}
         trans = _jsonl(path / "transitions.jsonl")
+        # captain.py's round.json is FLAT -- {"round","supervisor","test","build",...}.
+        # The nested {"tracks":{"test":{"state":...}}} shape is read first only so an
+        # older document still renders.
         tracks = meta.get("tracks") or {}
-        test_state = (tracks.get("test") or {}).get("state") or _lane_state(trans, "test", TEST_LANE)
-        build_state = (tracks.get("build") or {}).get("state") or _lane_state(trans, "build", BUILD_LANE)
+        test_state = ((tracks.get("test") or {}).get("state") or meta.get("test")
+                      or _lane_state(trans, "test", TEST_LANE))
+        build_state = ((tracks.get("build") or {}).get("state") or meta.get("build")
+                       or _lane_state(trans, "build", BUILD_LANE))
         acceptance = _read_json(path / "acceptance.json")
         slate = _read_json(path / "slate.json", []) or []
         if isinstance(slate, dict):


### PR DESCRIPTION
Both lane reads were against fields nothing writes:

  meta["tracks"]["test"]["state"]   captain.py's round.json is FLAT: {"round",
                                    "supervisor","test","build",...}
  transition["track"]               captain.py records the field as "machine"

So `test_state` and `build_state` were null for every round the loop has ever
run, and the round board rendered "--" for both lanes on a pipeline that was
working perfectly. `scripts/repipe/status.py` reads the same document correctly,
which is why the CLI showed `RUNNING / T_DEDUP / B_IDLE` while the dashboard --
the thing this pipeline was asked to provide -- showed nothing.

Both shapes are now read, the real one first, with the legacy nested/`track`
forms kept as fallbacks so an older transitions.jsonl still renders. Verified
live against round 2: `test T_PLAN | build B_IDLE`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcFmfZndNjgfqLQVBZCdkY