### PR TITLE
[AUTOMATED] fix(arena): the IDA reference arm has never worked, for two reasons

### DIFF
--- a/scripts/repipe/workspace.py
+++ b/scripts/repipe/workspace.py
@@ -225,12 +225,48 @@ _IDA_SETUP = '''
 # unix socket under TMPDIR (observed: /tmp/declib_server_<id>/decompiler.sock), so with the
 # default TMPDIR the server cannot start at all and every reference call fails with rc=1.
 DECLIB_SERVER_REGISTRY="$ARENA/.declib/servers"
-TMPDIR="$ARENA/.declib/tmp"
+
+# TMPDIR cannot live in the arena, and this is a hard limit rather than a preference.
+# declib binds an AF_UNIX socket at $TMPDIR/declib_server_<10 hex>/decompiler.sock -- 41
+# bytes of suffix -- and sun_path is 108 bytes. The arena root is already ~71
+# (.kuna-repipe/arena/<round>/<24-char hexid> under the repo), so even `$ARENA/t` computes
+# to 114 and bind(2) fails. The server then exits before registering, having logged nothing
+# past "Using headless interface", which is why this read for two rounds as "IDA is broken".
+# So: a short directory under the system temp, one per arena, cleaned with the round.
+# If codex's workspace-write sandbox refuses it, the reference call fails exactly as it does
+# today -- this cannot regress anything -- and the guard below says so in one line instead
+# of leaving an empty server log.
+TMPDIR="${TMPDIR:-/tmp}/kr-$(printf '%s' "$ARENA" | cksum | cut -d' ' -f1)"
+_SOCK_LEN=$(( ${#TMPDIR} + 41 ))
+if [ "$_SOCK_LEN" -gt 108 ]; then
+  echo "ida-decompile: TMPDIR=$TMPDIR makes the declib socket path ${_SOCK_LEN} bytes," \
+       "over the 108-byte AF_UNIX limit; set TMPDIR to something shorter" 1>&2
+fi
 XDG_STATE_HOME="$ARENA/.declib/state"
 XDG_CACHE_HOME="$ARENA/.declib/cache"
-export DECLIB_SERVER_REGISTRY TMPDIR XDG_STATE_HOME XDG_CACHE_HOME
+# XDG_CONFIG_HOME too, and this one is not optional: declib takes a lock on
+# $XDG_CONFIG_HOME/declib/DecLibConfig.lock at startup, and bwrap mounts $HOME read-only to
+# keep the tester away from credentials -- so without this every reference call died with
+#   Failed to start server: [Errno 30] Read-only file system:
+#   '/home/mahaloz/.config/declib/DecLibConfig.lock'
+# and the IDA comparison leg was silently unavailable for two whole rounds.
+XDG_CONFIG_HOME="$ARENA/.declib/config"
+export DECLIB_SERVER_REGISTRY TMPDIR XDG_STATE_HOME XDG_CACHE_HOME XDG_CONFIG_HOME
 mkdir -p "$ARENA/.declib/servers" "$ARENA/.declib/projects" "$TMPDIR" \
-         "$XDG_STATE_HOME" "$XDG_CACHE_HOME"
+         "$XDG_STATE_HOME" "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME/declib"
+# Seed the config from the operator's real one rather than letting declib regenerate a
+# default: it carries [headless_binary_paths] and [plugins_paths], and an empty config makes
+# the backend unresolvable -- a different failure with the same result. `save_location` is
+# rewritten so declib does not write back to the read-only original. Copy once; a rerun in a
+# live arena must not clobber whatever the round has already written.
+if [ ! -f "$XDG_CONFIG_HOME/declib/DecLibConfig.toml" ]; then
+  if [ -f "$HOME/.config/declib/DecLibConfig.toml" ]; then
+    sed "s|^save_location = .*|save_location = \"$XDG_CONFIG_HOME/declib/DecLibConfig.toml\"|" \
+        "$HOME/.config/declib/DecLibConfig.toml" > "$XDG_CONFIG_HOME/declib/DecLibConfig.toml"
+  else
+    : > "$XDG_CONFIG_HOME/declib/DecLibConfig.toml"
+  fi
+fi
 PROJDIR="$ARENA/.declib/projects"
 
 # `load` without an explicit --backend silently falls back to angr, which would make the


### PR DESCRIPTION
`ida-decompile` failed on every call in rounds 1 and 2 -- round 2's toolcall log
records 6 failures in 8 attempts -- so "compare against IDA", the reference leg
the design asks for and the source of the "kuna made testers leave N times this
round" metric, has been unavailable for the whole life of the loop. Two distinct
causes, both found by reading declib's own server log:

1. `[Errno 30] Read-only file system: ~/.config/declib/DecLibConfig.lock`.
   declib locks its config at startup; codex's workspace-write sandbox blocks
   writes outside the arena. XDG_STATE_HOME and XDG_CACHE_HOME were already
   redirected, XDG_CONFIG_HOME was not. It is now, and the config is SEEDED from
   the operator's real one with `save_location` rewritten -- letting declib
   regenerate a default instead would drop [headless_binary_paths] and make the
   backend unresolvable, a different failure with the same result.

2. The socket path exceeded the AF_UNIX limit. declib binds
   $TMPDIR/declib_server_<10 hex>/decompiler.sock -- 41 bytes of suffix -- and
   sun_path is 108. The shim pointed TMPDIR at $ARENA/.declib/tmp, and the arena
   root is already ~71 bytes, giving 124. Even `$ARENA/t` computes to 114: NO
   in-arena path can fit. bind(2) failed and the server exited having logged
   nothing past "Using headless interface", which is exactly why this read as
   "IDA is broken" rather than as a path-length bug. TMPDIR is now a short
   per-arena directory under the system temp, and a guard prints the computed
   length if it ever exceeds 108 again instead of leaving an empty server log.

The original comment blamed TMPDIR-in-/tmp for an earlier rc=1. That was almost
certainly cause 1 misattributed: the config lock fails regardless of TMPDIR.
Moving TMPDIR out of the arena cannot regress anything -- the arm is at 0% today.

Verified: the shim, run under bwrap with ~/.config/declib mounted read-only,
starts the server, resolves a function, and records the call in
notes/toolcalls.jsonl with exit/seconds/stdout accounting intact.
tools/repipe/smoke.sh 90/90.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcFmfZndNjgfqLQVBZCdkY