### PR TITLE
[AUTOMATED] fix(arena): the IDA shim's config seeding emitted invalid TOML

### DIFF
--- a/scripts/repipe/workspace.py
+++ b/scripts/repipe/workspace.py
@@ -260,13 +260,21 @@ mkdir -p "$ARENA/.declib/servers" "$ARENA/.declib/projects" "$TMPDIR" \
 # rewritten so declib does not write back to the read-only original. Copy once; a rerun in a
 # live arena must not clobber whatever the round has already written.
 if [ ! -f "$XDG_CONFIG_HOME/declib/DecLibConfig.toml" ]; then
+  # No backslash escapes here on purpose. This text is a Python string inside a Python
+  # string, so a `\\"` written in the generator collapses to a bare `"` by the time the
+  # shim is on disk -- which closed the sed expression and emitted
+  #   save_location = /path/to/file
+  # with the quotes gone, i.e. invalid TOML. Holding the quote in $_Q survives both passes.
+  _Q='"'
+  _SL="$XDG_CONFIG_HOME/declib/DecLibConfig.toml"
   if [ -f "$HOME/.config/declib/DecLibConfig.toml" ]; then
-    sed "s|^save_location = .*|save_location = \"$XDG_CONFIG_HOME/declib/DecLibConfig.toml\"|" \
-        "$HOME/.config/declib/DecLibConfig.toml" > "$XDG_CONFIG_HOME/declib/DecLibConfig.toml"
+    sed "s|^save_location = .*|save_location = $_Q$_SL$_Q|" \
+        "$HOME/.config/declib/DecLibConfig.toml" > "$_SL"
   else
-    : > "$XDG_CONFIG_HOME/declib/DecLibConfig.toml"
+    : > "$_SL"
   fi
 fi
+
 PROJDIR="$ARENA/.declib/projects"
 
 # `load` without an explicit --backend silently falls back to angr, which would make the


### PR DESCRIPTION
Found by the round-2 captain, reviewing the working tree before it built arenas:
"its sed line loses its backslash-escaped quotes when the shim text is emitted".
Correct, and it was already merged in #371.

The shim text is a Python string inside a Python string, so the `\"` written in
the generator collapses to a bare `"` on the way to disk. The emitted line was

  sed "s|^save_location = .*|save_location = "$XDG_CONFIG_HOME/.../DecLibConfig.toml"|"

where the inner quotes CLOSE the outer expression, so the substitution wrote

  save_location = /path/to/DecLibConfig.toml

with no quotes -- not valid TOML, and a bare path is not a TOML string. The
double-parse also made this invisible to inspection of the generator source: the
Python looked correctly escaped.

Fixed without any backslashes, by holding the quote character in a shell
variable, which survives both parses. Verified end to end: the shim now seeds a
config whose `save_location` is quoted, and declib parses it and starts the
server under bwrap with ~/.config/declib read-only.

Worth recording that the loop caught this. The captain read an uncommitted
working tree, spotted a defect in the tooling that builds its own arenas, and
wrote it down as something the next round must not inherit -- which is the
judgment step Level 4 existed to test.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcFmfZndNjgfqLQVBZCdkY