### PR TITLE
[AUTOMATED] feat(cli): --define-function — an agent-supplied function boundary

### DIFF
--- a/decompiler/crates/kuna-cli/src/decompile.rs
+++ b/decompiler/crates/kuna-cli/src/decompile.rs
@@ -37,6 +37,9 @@ pub struct DecompileArgs {
     pub regions: bool,
     pub options: Vec<(String, String)>,
     pub kasserts: Vec<String>,
+    /// `--define-function <start[-end][=name] | @file>` (repeatable): the
+    /// caller-declared function boundaries, lowered to `function bounds` lines.
+    pub func_decls: Vec<crate::funcdecl::FuncDecl>,
     pub decomp_dbg: Option<String>,
     pub sleighpath: Option<String>,
     /// Mach-O fat / universal slice override (`--slice <arch>`, e.g. `x86_64` /
@@ -117,6 +120,7 @@ fn build_script(
     out_path: &Path,
     options: &[(String, String)],
     kasserts: &[String],
+    func_decls: &[crate::funcdecl::FuncDecl],
     regions_path: Option<&Path>,
 ) -> String {
     let mut lines: Vec<String> = Vec::new();
@@ -144,6 +148,13 @@ fn build_script(
         lines.push(format!("option {name} {value}"));
     }
     lines.push("read symbols".into());
+    // `--define-function` AFTER the analysis commit and BEFORE the load: a
+    // caller-declared boundary is an assertion that outranks whatever discovery
+    // decided about the same address, and the load below is what consults the
+    // declared extent (`ConsoleProgram::declared_extent`).
+    for decl in func_decls {
+        lines.push(decl.console_line());
+    }
     if by_address {
         match EntrySelector::parse(target) {
             EntrySelector::SectionOffset { .. } | EntrySelector::SectionIndexOffset { .. } => {
@@ -475,6 +486,7 @@ fn decompile(args: &DecompileArgs) -> Result<DecompileOutcome, String> {
             &out_path,
             &args.options,
             &args.kasserts,
+            &args.func_decls,
             regions_path.as_deref(),
         );
 
@@ -798,6 +810,7 @@ pub fn main(argv: &[String]) -> i32 {
     let mut saw_language = false;
     let mut mode: Option<String> = None;
     let mut kasserts: Vec<String> = Vec::new();
+    let mut func_decls: Vec<crate::funcdecl::FuncDecl> = Vec::new();
     let mut decomp_dbg: Option<String> = None;
     let mut engine: Option<String> = None;
     let mut sleighpath: Option<String> = None;
@@ -855,6 +868,20 @@ pub fn main(argv: &[String]) -> i32 {
                     kasserts.push(v);
                 }
             }
+            "--define-function" => match take_value(argv, &mut i, "--define-function") {
+                Some(value) => match crate::funcdecl::parse_flag(&value) {
+                    Ok(decls) => {
+                        func_decls.extend(decls);
+                        forwarded.push("--define-function".into());
+                        forwarded.push(value);
+                    }
+                    Err(msg) => {
+                        eprintln!("error: {msg}");
+                        return 2;
+                    }
+                },
+                None => return 2,
+            },
             "--decomp-dbg" => decomp_dbg = take_value(argv, &mut i, "--decomp-dbg"),
             "--engine" => engine = take_value(argv, &mut i, "--engine"),
             "--sleighpath" => sleighpath = take_value(argv, &mut i, "--sleighpath"),
@@ -957,6 +984,7 @@ pub fn main(argv: &[String]) -> i32 {
         regions,
         options,
         kasserts,
+        func_decls,
         decomp_dbg,
         sleighpath,
         slice,
@@ -1319,6 +1347,55 @@ Decompilation complete
         assert_eq!(console_path("/odd \"name\"/a.out"), r#""/odd \"name\"/a.out""#);
     }
 
+    /// The declarations land AFTER `read symbols` and BEFORE the load: the commit
+    /// is what discovery writes, and the load is what reads the declared extent.
+    #[test]
+    fn build_script_declares_boundaries_between_read_symbols_and_the_load() {
+        let decls = crate::funcdecl::parse_flag("0x1400-0x1480=decrypt").expect("parses");
+        let script = build_script(
+            "/tmp/a.out",
+            "0x1400",
+            true,
+            None,
+            false,
+            Path::new("/tmp/kuna.c"),
+            &[],
+            &[],
+            &decls,
+            None,
+        );
+        let line = |needle: &str| {
+            script
+                .lines()
+                .position(|l| l == needle)
+                .unwrap_or_else(|| panic!("{needle:?} missing from:\n{script}"))
+        };
+        assert!(
+            line("read symbols")
+                < line("function bounds 0x1400 0x1480 as decrypt")
+                    && line("function bounds 0x1400 0x1480 as decrypt") < line("load addr 0x1400"),
+            "wrong order in:\n{script}"
+        );
+    }
+
+    /// No declarations ⇒ the script is byte-identical to what it always was.
+    #[test]
+    fn build_script_without_declarations_emits_no_boundary_lines() {
+        let script = build_script(
+            "/tmp/a.out",
+            "main",
+            false,
+            None,
+            false,
+            Path::new("/tmp/kuna.c"),
+            &[],
+            &[],
+            &[],
+            None,
+        );
+        assert!(!script.contains("function bounds"), "got:\n{script}");
+    }
+
     /// The whole script: a spaced binary path and a spaced output path must both
     /// reach the console as ONE argument each.  Unquoted, `load file` reads the
     /// tail as the filename and `openfile write` truncates a file at the split.
@@ -1331,6 +1408,7 @@ Decompilation complete
             None,
             false,
             Path::new("/tmp/out dir/kuna.c"),
+            &[],
             &[],
             &[],
             Some(Path::new("/tmp/out dir/kuna.txt")),
@@ -1362,6 +1440,7 @@ Decompilation complete
             Path::new("/tmp/kuna.c"),
             &[],
             &[],
+            &[],
             None,
         );
         assert!(
@@ -1380,6 +1459,7 @@ Decompilation complete
             None,
             false,
             Path::new("/tmp/kuna.c"),
+            &[],
             &[],
             &[],
             None,
@@ -1452,6 +1532,7 @@ Decompilation complete
             None,
             false,
             Path::new("/tmp/kuna.c"),
+            &[],
             &[],
             &[],
             None,

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -128,6 +128,12 @@ pub(crate) struct Args {
     /// for an unfiltered fast whole-binary run and 120 otherwise.
     pub(crate) max_fn_seconds: u64,
     pub(crate) options: Vec<(String, String)>,
+    /// `--define-function <start[-end][=name] | @file>` (repeatable): the
+    /// caller-declared function boundaries, applied by [`load_program`] right
+    /// after the analysis commit so they outrank discovery. Every surface that
+    /// loads through this struct honors them; only the surfaces that parse the
+    /// flag can be non-empty.
+    pub(crate) func_decls: Vec<crate::funcdecl::FuncDecl>,
     pub(crate) slice: Option<String>,
     pub(crate) target: Option<String>,
     pub(crate) sleighpath: Option<String>,
@@ -966,6 +972,9 @@ pub(crate) fn load_program(
     apply_runtime_options(&mut prog, &args.options)?;
     prog.commit_pending_analysis()
         .map_err(|e| format!("read symbols (analysis commit) failed: {}", e.explain()))?;
+    // AFTER the commit: a caller-declared boundary is an assertion that outranks
+    // whatever discovery decided about the same address.
+    crate::funcdecl::apply(&mut prog, &args.func_decls)?;
     Ok(prog)
 }
 
@@ -1758,6 +1767,7 @@ pub(crate) fn parse_args_with_filters(
     let mut no_vars = false;
     let mut max_fn_seconds: Option<u64> = None;
     let mut options: Vec<(String, String)> = Vec::new();
+    let mut func_decls: Vec<crate::funcdecl::FuncDecl> = Vec::new();
     let mut mode: Option<String> = None;
     let mut slice: Option<String> = None;
     let mut target: Option<String> = None;
@@ -1777,6 +1787,10 @@ pub(crate) fn parse_args_with_filters(
             "--addr" => {
                 let v = take(argv, &mut i, "--addr")?;
                 addrs.push(parse_entry_selector(&v)?);
+            }
+            "--define-function" => {
+                let v = take(argv, &mut i, "--define-function")?;
+                func_decls.extend(crate::funcdecl::parse_flag(&v)?);
             }
             "--max-fn-seconds" if cmd == "decompile-all" || cmd == "decompile-project" => {
                 let v = take(argv, &mut i, "--max-fn-seconds")?;
@@ -1897,7 +1911,19 @@ pub(crate) fn parse_args_with_filters(
     }
 
     Ok((
-        Args { binary, json, names, addrs, no_vars, max_fn_seconds, options, slice, target, sleighpath },
+        Args {
+            binary,
+            json,
+            names,
+            addrs,
+            no_vars,
+            max_fn_seconds,
+            options,
+            func_decls,
+            slice,
+            target,
+            sleighpath,
+        },
         filters,
     ))
 }
@@ -1938,7 +1964,7 @@ fn usage_decompile_all() {
          \x20                   [--no-vars] [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] \\\n\
          \x20                   [--filter REGEX] [--min-size N] [--max-size N] \\\n\
          \x20                   [--reachable-from <name|0xaddr>] [--sort addr|size|name] [--limit N] \\\n\
-         \x20                   [--summary] \\\n\
+         \x20                   [--summary] [--define-function S[-E][=N]|@FILE].. \\\n\
          \x20                   [--option N V].. [--slice ARCH] [--target T] [--sleighpath D]\n\
          \n\
          Decompile every CODE-backed function in one in-process load (load-once,\n\
@@ -1951,6 +1977,10 @@ fn usage_decompile_all() {
          2 MiB, and fast at 2 MiB or larger. Explicit --option values win.\n\
          An unfiltered run that discovers no function at all exits 1 with the\n\
          reason on stderr and in the document's run-level `error` field.\n\
+         \n\
+         --define-function <start[-end][=name] | @file> (repeatable) declares where a\n\
+         function starts and ends: start names an entry discovery missed, the\n\
+         exclusive end bounds its flow so it stops swallowing its neighbours.\n\
          \n\
          Triage (narrows the run BEFORE decompiling, so it is also what makes it\n\
          cheap): --filter REGEX matches the name or any alias; --min-size/--max-size\n\
@@ -1967,6 +1997,7 @@ fn usage_functions() {
         "usage: kuna functions <binary> [--json] [--summary] \\\n\
          \x20               [--filter REGEX] [--min-size N] [--max-size N] \\\n\
          \x20               [--reachable-from <name|0xaddr>] [--sort addr|size|name] [--limit N] \\\n\
+         \x20               [--define-function S[-E][=N]|@FILE].. \\\n\
          \x20               [--mode auto|reliable|aggressive|fast] [--slice ARCH] [--target T] [--sleighpath D]\n\
          \n\
          List every function kuna discovers in a binary as `<addr>\\t<name>` (or\n\
@@ -1984,6 +2015,8 @@ fn usage_functions() {
          Shares decompile-all's discovery policy, so the inventory always contains\n\
          every function a whole-binary run would decompile; on a non-x86-64 binary\n\
          that means a full prologue-pattern + gap-walk discovery pass.\n\
+         --define-function <start[-end][=name] | @file> (repeatable) declares an entry\n\
+         discovery missed and its exclusive extent; it enumerates like any other.\n\
          Discovering no function at all exits 1 with the reason on stderr and in\n\
          the document's `error` field (a packed image is named as such)."
     );

--- a/decompiler/crates/kuna-cli/src/decompile_project.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_project.rs
@@ -96,6 +96,7 @@ fn usage() {
     eprintln!(
         "usage: kuna decompile-project <binary> [-o|--output DIR] [--functions a,b,..] \\\n\
          \x20                   [--addr 0xVMA].. [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] \\\n\
+         \x20                   [--define-function S[-E][=N]|@FILE].. \\\n\
          \x20                   [--option N V].. [--slice ARCH] [--target T] [--sleighpath D]\n\
          \n\
          Decompile a whole binary in one in-process load and write a project folder\n\

--- a/decompiler/crates/kuna-cli/src/disassemble.rs
+++ b/decompiler/crates/kuna-cli/src/disassemble.rs
@@ -89,6 +89,10 @@ pub(crate) struct DisArgs {
     pub(crate) bytes: Option<u64>,
     pub(crate) json: bool,
     pub(crate) options: Vec<(String, String)>,
+    /// `--define-function <start[-end][=name] | @file>` (repeatable): declared
+    /// function boundaries, applied at load so `disassemble <name>` resolves a
+    /// name the image never carried and the walk stops at the declared end.
+    pub(crate) func_decls: Vec<crate::funcdecl::FuncDecl>,
     pub(crate) mode: Option<String>,
     pub(crate) slice: Option<String>,
     pub(crate) target: Option<String>,
@@ -170,6 +174,7 @@ pub(crate) fn render(args: &DisArgs) -> Result<String, String> {
         no_vars: true,
         max_fn_seconds: 0,
         options,
+        func_decls: args.func_decls.clone(),
         slice: args.slice.clone(),
         target: args.target.clone(),
         sleighpath: args.sleighpath.clone(),
@@ -445,6 +450,7 @@ pub(crate) fn parse_args(argv: &[String]) -> Result<DisArgs, String> {
     let mut bytes: Option<u64> = None;
     let mut json = false;
     let mut options: Vec<(String, String)> = Vec::new();
+    let mut func_decls: Vec<crate::funcdecl::FuncDecl> = Vec::new();
     let mut mode: Option<String> = None;
     let mut slice: Option<String> = None;
     let mut target: Option<String> = None;
@@ -466,6 +472,10 @@ pub(crate) fn parse_args(argv: &[String]) -> Result<DisArgs, String> {
                 i += 2;
             }
             "--mode" => mode = Some(take(argv, &mut i, "--mode")?),
+            "--define-function" => {
+                let v = take(argv, &mut i, "--define-function")?;
+                func_decls.extend(crate::funcdecl::parse_flag(&v)?);
+            }
             "--slice" => slice = Some(take(argv, &mut i, "--slice")?),
             "--target" => target = Some(take(argv, &mut i, "--target")?),
             "--sleighpath" => sleighpath = Some(take(argv, &mut i, "--sleighpath")?),
@@ -493,6 +503,7 @@ pub(crate) fn parse_args(argv: &[String]) -> Result<DisArgs, String> {
         bytes,
         json,
         options,
+        func_decls,
         mode,
         slice,
         target,
@@ -520,12 +531,16 @@ fn usage() {
     eprintln!(
         "usage: kuna disassemble <binary> <name|0xaddr|0xstart-0xend> [--addr] [--count N] \\\n\
          \x20                    [--bytes N] [--json] [--mode auto|reliable|aggressive|fast] \\\n\
+         \x20                    [--define-function S[-E][=N]|@FILE].. \\\n\
          \x20                    [--option N V].. [--slice ARCH] [--target T] [--sleighpath D]\n\
          \n\
          The target is a function name, an address (--addr for a bare hex one), or an\n\
          explicit range (0x1000-0x1040 / 0x1000..0x1040) for bytes no function owns.\n\
          A named function lists its whole extent; a raw address lists 64 bytes unless\n\
          --count / --bytes / a range says otherwise.\n\
+         \n\
+         --define-function <start[-end][=name] | @file> (repeatable) declares a\n\
+         boundary first, so a name the image never carried becomes a valid target.\n\
          \n\
          --json emits {{binary,target,start,end,count,bytes,truncated,instructions:\n\
          [{{address,address_hex,size,bytes,mnemonic,operands,text}}]}}; without it, a\n\

--- a/decompiler/crates/kuna-cli/src/funcdecl.rs
+++ b/decompiler/crates/kuna-cli/src/funcdecl.rs
@@ -1,0 +1,253 @@
+//! `--define-function` — telling kuna where a function starts and ends.
+//!
+//! # Why this exists
+//!
+//! Every function boundary kuna knows is one it *derived*: discovery finds the
+//! entries, and the extent is reconstructed as the address-contiguous clip
+//! `[entry, next_entry)` ([`kuna_console::funcextent`]) over an unbounded flow
+//! follow.  That is the right default and it is wrong exactly where reverse
+//! engineering is hard — an obfuscated, packed or hand-written image, where a
+//! missed entry silently merges two functions and a phantom entry invents one.
+//! Until this flag the `kuna` binary could not correct either: its generated
+//! console script emitted a fixed vocabulary (`load file` / `option` /
+//! `read symbols` / `load function|addr` / `kassert` / `decompile` / `print`),
+//! and "function F spans `[start,end)`" was not expressible anywhere in the
+//! engine (`docs/re-needs/no-cli-function-boundary-override.md`).
+//!
+//! # The declaration
+//!
+//! ```text
+//!   --define-function 0x1400[-0x1480][=name]
+//!   --define-function @bounds.txt
+//! ```
+//!
+//! `start` declares the entry (the `map function` recipe: a `FunctionSymbol` so
+//! call sites name it, and a name→address registration so it enumerates and
+//! resolves by name).  `end` is EXCLUSIVE and declares the extent, which bounds
+//! flow following for that function and replaces the clip the inventory reports.
+//! Both halves are optional in the sense that `end` may be omitted — a bare
+//! `--define-function 0x1400` asserts an entry and leaves the extent natural.
+//!
+//! The `@file` form is the durable half: an agent that has worked out the real
+//! boundaries of a packed image keeps them in a file and passes the same
+//! `@bounds.txt` to every later invocation.  kuna does not write the declarations
+//! back into the image, so durability is caller-carried by design — the file is
+//! the artifact, and it is plain text an agent can generate and diff.
+//!
+//! Both surfaces converge on the console `function bounds <start> [<end>] [as <name>]`
+//! command: the script path emits it, the in-process path calls the
+//! [`kuna_console::engine::ConsoleProgram::declare_function`] it is a wrapper for.
+
+use std::fmt::Write as _;
+
+/// One caller-declared function boundary.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct FuncDecl {
+    /// Entry VMA.
+    pub(crate) start: u64,
+    /// Exclusive end VMA; `None` leaves the extent unbounded.
+    pub(crate) end: Option<u64>,
+    /// The name to give the entry; `None` takes kuna's generated `sub_<addr>`.
+    pub(crate) name: Option<String>,
+}
+
+impl FuncDecl {
+    /// The declared byte extent, or `0` for "unbounded" (the engine-wide
+    /// `UNBOUNDED_SIZE` convention).
+    pub(crate) fn size(&self) -> u64 {
+        self.end.map(|end| end - self.start).unwrap_or(0)
+    }
+
+    /// The `function bounds` console line this declaration lowers to.
+    pub(crate) fn console_line(&self) -> String {
+        let mut line = format!("function bounds {:#x}", self.start);
+        if let Some(end) = self.end {
+            let _ = write!(line, " {end:#x}");
+        }
+        if let Some(name) = &self.name {
+            let _ = write!(line, " as {name}");
+        }
+        line
+    }
+}
+
+/// Parse one `--define-function` value: either a declaration or `@FILE`.
+///
+/// A file holds one declaration per line; blank lines and `#` comments are
+/// skipped, so an agent can annotate what it worked out.
+pub(crate) fn parse_flag(value: &str) -> Result<Vec<FuncDecl>, String> {
+    let Some(path) = value.strip_prefix('@') else {
+        return Ok(vec![parse_one(value)?]);
+    };
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("--define-function @{path}: {e}"))?;
+    let mut out = Vec::new();
+    for (n, line) in text.lines().enumerate() {
+        let line = line.split('#').next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+        out.push(parse_one(line).map_err(|e| format!("{path}:{}: {e}", n + 1))?);
+    }
+    Ok(out)
+}
+
+/// Parse `START[-END][=NAME]`, hex with or without a `0x` prefix.
+fn parse_one(spec: &str) -> Result<FuncDecl, String> {
+    let spec = spec.trim();
+    let (range, name) = match spec.split_once('=') {
+        Some((range, name)) if !name.trim().is_empty() => (range.trim(), Some(name.trim())),
+        Some((range, _)) => (range.trim(), None),
+        None => (spec, None),
+    };
+    // Split on the LAST '-': a range separator can never be the first character
+    // of a hex literal, but `0x-` cannot occur either, so the last one is the
+    // separator whenever there is a non-empty tail after it.
+    let (start, end) = match range.rsplit_once('-') {
+        Some((start, end)) if !start.trim().is_empty() && !end.trim().is_empty() => {
+            (start.trim(), Some(end.trim()))
+        }
+        _ => (range, None),
+    };
+    let start = parse_vma(start)
+        .ok_or_else(|| format!("--define-function {spec:?}: {start:?} is not a hex address"))?;
+    let end = match end {
+        None => None,
+        Some(end) => Some(
+            parse_vma(end)
+                .ok_or_else(|| format!("--define-function {spec:?}: {end:?} is not a hex address"))?,
+        ),
+    };
+    if let Some(end) = end {
+        if end <= start {
+            return Err(format!(
+                "--define-function {spec:?}: end {end:#x} must be above start {start:#x}"
+            ));
+        }
+    }
+    Ok(FuncDecl { start, end, name: name.map(str::to_string) })
+}
+
+/// A bare or `0x`-prefixed hexadecimal VMA.
+fn parse_vma(tok: &str) -> Option<u64> {
+    let tok = tok.trim();
+    let body = tok.strip_prefix("0x").or_else(|| tok.strip_prefix("0X")).unwrap_or(tok);
+    if body.is_empty() || !body.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    u64::from_str_radix(body, 16).ok()
+}
+
+/// Apply the declarations to a loaded program (the in-process surfaces).
+///
+/// Runs AFTER the analysis commit, so a declaration outranks whatever discovery
+/// decided about the same address — that is the whole point of the flag.
+pub(crate) fn apply(
+    prog: &mut kuna_console::engine::ConsoleProgram,
+    decls: &[FuncDecl],
+) -> Result<(), String> {
+    let Some(space) = prog.arch().manage().get_default_code_space().cloned() else {
+        if decls.is_empty() {
+            return Ok(());
+        }
+        return Err("--define-function: the loaded program has no default code space".into());
+    };
+    for decl in decls {
+        let addr = kuna_base::address::Address::new(std::rc::Rc::clone(&space), decl.start);
+        prog.declare_function(addr, decl.name.as_deref(), decl.size() as kuna_base::types::int4)
+            .map_err(|e| {
+                format!("--define-function {:#x}: {}", decl.start, e.explain())
+            })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn one(spec: &str) -> FuncDecl {
+        parse_flag(spec).expect("parses").pop().expect("one declaration")
+    }
+
+    #[test]
+    fn parses_start_end_and_name() {
+        assert_eq!(
+            one("0x1400-0x1480=decrypt"),
+            FuncDecl { start: 0x1400, end: Some(0x1480), name: Some("decrypt".into()) }
+        );
+    }
+
+    #[test]
+    fn end_and_name_are_each_optional() {
+        assert_eq!(one("0x1400"), FuncDecl { start: 0x1400, end: None, name: None });
+        assert_eq!(
+            one("0x1400-0x1480"),
+            FuncDecl { start: 0x1400, end: Some(0x1480), name: None }
+        );
+        assert_eq!(
+            one("0x1400=decrypt"),
+            FuncDecl { start: 0x1400, end: None, name: Some("decrypt".into()) }
+        );
+    }
+
+    #[test]
+    fn a_bare_hex_address_needs_no_prefix() {
+        assert_eq!(one("1400-1480"), FuncDecl { start: 0x1400, end: Some(0x1480), name: None });
+    }
+
+    #[test]
+    fn the_extent_is_end_exclusive() {
+        assert_eq!(one("0x1400-0x1480").size(), 0x80);
+        assert_eq!(one("0x1400").size(), 0);
+    }
+
+    /// An inverted or empty range is a caller error, not a silently-unbounded
+    /// function: a declaration kuna cannot honor must say so.
+    #[test]
+    fn an_end_at_or_below_the_start_is_rejected() {
+        assert!(parse_flag("0x1480-0x1400").is_err());
+        assert!(parse_flag("0x1400-0x1400").is_err());
+    }
+
+    #[test]
+    fn a_non_hex_token_is_rejected() {
+        assert!(parse_flag("main").is_err());
+        // A trailing `-` leaves an empty tail, so it is not a separator and the
+        // whole token must fail as hex rather than parse as a bare start.
+        assert!(parse_flag("0x1400-").is_err());
+    }
+
+    #[test]
+    fn lowers_to_the_console_command() {
+        assert_eq!(
+            one("0x1400-0x1480=decrypt").console_line(),
+            "function bounds 0x1400 0x1480 as decrypt"
+        );
+        assert_eq!(one("0x1400-0x1480").console_line(), "function bounds 0x1400 0x1480");
+        assert_eq!(one("0x1400").console_line(), "function bounds 0x1400");
+        // A name with no extent: `as` keys the name, so it cannot be read as the
+        // end address.
+        assert_eq!(one("0x1400=decrypt").console_line(), "function bounds 0x1400 as decrypt");
+    }
+
+    #[test]
+    fn a_file_holds_one_declaration_per_line_with_comments() {
+        let dir = std::env::temp_dir().join(format!("kuna-funcdecl-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let path = dir.join("bounds.txt");
+        std::fs::write(&path, "# worked out by hand\n0x1400-0x1480=decrypt\n\n0x1480-0x1500\n")
+            .expect("write");
+        let decls = parse_flag(&format!("@{}", path.display())).expect("parses");
+        assert_eq!(decls.len(), 2);
+        assert_eq!(decls[0].name.as_deref(), Some("decrypt"));
+        assert_eq!(decls[1].start, 0x1480);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_missing_file_is_an_error_naming_the_path() {
+        let err = parse_flag("@/nonexistent/kuna-bounds.txt").expect_err("refuses");
+        assert!(err.contains("/nonexistent/kuna-bounds.txt"), "got {err:?}");
+    }
+}

--- a/decompiler/crates/kuna-cli/src/main.rs
+++ b/decompiler/crates/kuna-cli/src/main.rs
@@ -4,6 +4,7 @@
 //!
 //! ```text
 //!   kuna decompile <binary> <func> [--addr] [--option NAME VALUE]... [--kassert ARGS]...
+//!                                 [--define-function <start[-end][=name] | @file>]...
 //!   kuna test [--all|--unittests|--datatests] [--name N]... [--baseline F]
 //!             [--save-baseline F] [--json] [--binary P] [--sleighpath D]
 //!   kuna catalog [--json|--markdown|--check] [--option NAME] [--tier T]
@@ -23,6 +24,7 @@ mod decompile_all;
 mod decompile_project;
 mod disassemble;
 mod fid;
+mod funcdecl;
 mod jsonfmt;
 mod output;
 mod paths;
@@ -87,14 +89,14 @@ fn usage() {
     eprintln!(
         "usage: kuna <decompile|decompile-all|decompile-project|functions|disassemble|xrefs|strings|unpack|docs|test|catalog|modes|specs|fid> ...\n\
          \n\
-         kuna decompile <binary> <func> [--addr] [--json] [--slice ARCH] [--language auto|c|rust] [--mode auto|reliable|aggressive|fast] [--option NAME VALUE]... [--kassert ARGS]...\n\
-         kuna decompile-all <binary> [--json] [--functions a,b,..] [--addr 0xVMA]... [--no-vars] [--language auto|c|rust] [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] [--option N V]...\n\
-         kuna decompile-project <binary> [-o DIR] [--functions a,b,..] [--addr 0xVMA]... [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] [--option N V]...\n\
-         kuna functions <binary> [--json] [--mode auto|reliable|aggressive|fast]\n\
+         kuna decompile <binary> <func> [--addr] [--json] [--slice ARCH] [--language auto|c|rust] [--mode auto|reliable|aggressive|fast] [--option NAME VALUE]... [--kassert ARGS]... [--define-function S[-E][=N]|@FILE]...\n\
+         kuna decompile-all <binary> [--json] [--functions a,b,..] [--addr 0xVMA]... [--no-vars] [--language auto|c|rust] [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] [--option N V]... [--define-function S[-E][=N]|@FILE]...\n\
+         kuna decompile-project <binary> [-o DIR] [--functions a,b,..] [--addr 0xVMA]... [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] [--option N V]... [--define-function S[-E][=N]|@FILE]...\n\
+         kuna functions <binary> [--json] [--mode auto|reliable|aggressive|fast] [--define-function S[-E][=N]|@FILE]...\n\
          kuna xrefs <binary> (--to <name|0xaddr> | --from <name|0xaddr>) [--json] [--kind call,jump,data,read,write] [--mode auto|reliable|aggressive|fast]\n\
          kuna unpack <binary> [-o OUT] [--json]\n\
          kuna strings <binary> [--json] [--min-length N] [--filter REGEX] [--encoding ascii|utf16|all] [--section NAME] [--no-xrefs]\n\
-         kuna disassemble <binary> <name|0xaddr|0xstart-0xend> [--addr] [--count N] [--bytes N] [--json] [--mode auto|reliable|aggressive|fast] [--option N V]... [--slice ARCH] [--target T] [--sleighpath D]\n\
+         kuna disassemble <binary> <name|0xaddr|0xstart-0xend> [--addr] [--count N] [--bytes N] [--json] [--mode auto|reliable|aggressive|fast] [--option N V]... [--define-function S[-E][=N]|@FILE]... [--slice ARCH] [--target T] [--sleighpath D]\n\
          kuna docs [<topic>] [--json] [--all]\n\
          kuna test [--all|--unittests|--datatests] [--name N]... [--baseline F] [--save-baseline F] [--json]\n\
          kuna catalog [--json|--markdown|--check] [--option NAME] [--tier transform|analysis|core]\n\

--- a/decompiler/crates/kuna-cli/src/strings.rs
+++ b/decompiler/crates/kuna-cli/src/strings.rs
@@ -168,6 +168,7 @@ fn attribute(
         no_vars: true,
         max_fn_seconds: 0,
         options,
+        func_decls: Vec::new(),
         slice: args.slice.clone(),
         target: args.target.clone(),
         sleighpath: args.sleighpath.clone(),

--- a/decompiler/crates/kuna-cli/src/xrefs.rs
+++ b/decompiler/crates/kuna-cli/src/xrefs.rs
@@ -106,6 +106,7 @@ fn query(args: &XrefArgs) -> Result<String, String> {
         no_vars: true,
         max_fn_seconds: 0,
         options,
+        func_decls: Vec::new(),
         slice: args.slice.clone(),
         target: args.target.clone(),
         sleighpath: args.sleighpath.clone(),

--- a/decompiler/crates/kuna-cli/tests/disassemble_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/disassemble_cli.rs
@@ -38,6 +38,9 @@ mod output;
 #[path = "../src/paths.rs"]
 mod paths;
 #[allow(dead_code)]
+#[path = "../src/funcdecl.rs"]
+mod funcdecl;
+#[allow(dead_code)]
 #[path = "../src/decompile.rs"]
 mod decompile;
 #[allow(dead_code)]

--- a/decompiler/crates/kuna-cli/tests/strings_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/strings_cli.rs
@@ -45,6 +45,9 @@ mod output;
 #[path = "../src/paths.rs"]
 mod paths;
 #[allow(dead_code)]
+#[path = "../src/funcdecl.rs"]
+mod funcdecl;
+#[allow(dead_code)]
 #[path = "../src/decompile.rs"]
 mod decompile;
 #[allow(dead_code)]

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -174,6 +174,19 @@ pub struct ConsoleProgram {
     /// objects — `optind`, `stdin`, `stdout`, `optarg` — live). Empty on the XML
     /// datatest path and for a relocatable object.
     loader_data_objects: Vec<(u64, String, u64)>,
+    /// (kuna) **Caller-declared function extents**, entry VMA → byte size — what
+    /// the console `function bounds <start> <end>` and the CLI
+    /// `kuna --define-function <start>-<end>` assert, and the only place kuna
+    /// carries "function F spans [start,end)" at all. (`map function` still
+    /// ignores its size argument; only these two surfaces write here.)
+    ///
+    /// Consulted by every later load of that entry (`load function`, `load addr`,
+    /// the whole-binary loop) so the declaration outlives the one command that
+    /// made it, and by [`crate::funcextent`] so the inventory reports what the
+    /// caller asserted rather than the address-contiguous clip it guesses.
+    /// Non-zero sizes only: a bare declaration with no extent leaves the entry
+    /// unbounded, which is the engine-wide `UNBOUNDED_SIZE` default.
+    declared_extents: BTreeMap<u64, int4>,
 }
 
 impl ConsoleProgram {
@@ -338,6 +351,16 @@ impl ConsoleProgram {
             &mut entries,
             &crate::funcextent::code_spans(&self.sections()),
         );
+        // A caller-declared extent is an assertion, not a guess: it outranks the
+        // clip everywhere the clip is reported (`declared_extents`).
+        if self.has_declared_extents() {
+            for entry in &mut entries {
+                let declared = self.declared_extent(entry.addr.get_offset());
+                if declared > 0 {
+                    entry.size = declared as u64;
+                }
+            }
+        }
         entries
     }
 
@@ -349,6 +372,10 @@ impl ConsoleProgram {
     /// [`crate::funcextent`].
     pub fn function_extent_at(&self, vma: u64) -> u64 {
         let entry = self.thumb_normalized(vma);
+        let declared = self.declared_extent(entry);
+        if declared > 0 {
+            return declared as u64;
+        }
         let entries: Vec<u64> = self
             .function_entries_canonical()
             .iter()
@@ -1042,6 +1069,81 @@ impl ConsoleProgram {
         });
     }
 
+    /// Record a caller-declared byte extent for the function entered at `vma`
+    /// (`declared_extents`); `size <= 0` clears it back to unbounded.
+    pub fn declare_extent(&mut self, vma: u64, size: int4) {
+        if size > 0 {
+            self.declared_extents.insert(vma, size);
+        } else {
+            self.declared_extents.remove(&vma);
+        }
+    }
+
+    /// The caller-declared byte extent of the function entered at `vma`, or
+    /// [`UNBOUNDED_SIZE`] when none was declared — the value every load of that
+    /// entry passes as the analysis-size bound.
+    pub fn declared_extent(&self, vma: u64) -> int4 {
+        self.declared_extents.get(&vma).copied().unwrap_or(UNBOUNDED_SIZE)
+    }
+
+    /// Is any function extent declared for this program?  Cheap enough to gate a
+    /// per-entry lookup in the inventory bulk pass.
+    pub fn has_declared_extents(&self) -> bool {
+        !self.declared_extents.is_empty()
+    }
+
+    /// Declare a function at `addr` — the in-process twin of the console
+    /// `map function <addr> [name]` command (`IfcMapfunction`), plus the extent
+    /// the console form cannot express on its own.
+    ///
+    /// Installs the `FunctionSymbol` (so a CALL here resolves to `name`),
+    /// registers the name→address entry (so `load function <name>` and the
+    /// whole-binary enumeration both see it), and records `size` as the entry's
+    /// declared extent (`0` = unbounded).
+    ///
+    /// An address that already carries a function symbol is RENAMED rather than
+    /// given a second one, but only when the caller named it: the symbol table
+    /// keys a function by address, so adding a second symbol there would leave
+    /// two names competing for one entry.  With no explicit name, an already-named
+    /// address keeps its name and only the extent is recorded.
+    pub fn declare_function(
+        &mut self,
+        addr: Address,
+        name: Option<&str>,
+        size: int4,
+    ) -> KunaResult<String> {
+        let explicit = name.map(str::to_string).filter(|n| !n.is_empty());
+        let name = match &explicit {
+            Some(n) => n.clone(),
+            None => self.arch().name_function(&addr),
+        };
+        let type_code = self.arch().types().get_type_code()?;
+        let min_size = self.arch().min_funcsymbol_size;
+        let num_spaces = self.arch().manage().num_spaces() as int4;
+        let arch = self.arch_mut();
+        let (scope, basename) =
+            arch.symboltab.find_create_scope_from_symbol_name(&name, "::", None, num_spaces)?;
+        let name = match arch.symboltab.find_function_across_scopes(&addr) {
+            Some((sym, _)) => match &explicit {
+                Some(_) => {
+                    arch.symboltab.rename_symbol(sym, &basename)?;
+                    name
+                }
+                // Nothing asked for: keep the name the image or the analysis gave
+                // this entry rather than overwriting it with `sub_<addr>`.
+                None => arch.symboltab.symbol(sym).get_display_name().to_string(),
+            },
+            None => {
+                arch.symboltab.add_function(scope, &addr, &basename, min_size, type_code)?;
+                name
+            }
+        };
+        let vma = addr.get_offset();
+        self.register_symbol(&name, addr);
+        self.declare_extent(vma, size);
+        Ok(name)
+    }
+
     /// (kuna) Build the `map addr`-shaped stack-symbol specs for the DWARF stack
     /// LOCALS parked on the function whose entry VMA is `func_addr` (DWARF subtask 3).
     ///
@@ -1633,6 +1735,7 @@ pub fn bootstrap_program(
         dwarf_locals: Vec::new(),
         analysis_image: None,
         loader_data_objects: Vec::new(),
+        declared_extents: BTreeMap::new(),
     };
     // C++ `conf->readLoaderSymbols("::")` (testfunction.cc:160 / consolemain.cc:104):
     // install the binaryimage symbols as FunctionSymbols so a CALL to one resolves
@@ -1869,6 +1972,7 @@ pub fn bootstrap_from_object(
         // here (it is unused below this point).
         analysis_image: Some((path.to_string(), bytes)),
         loader_data_objects,
+        declared_extents: BTreeMap::new(),
     };
     // conf->readLoaderSymbols("::"): install the ELF symbols as FunctionSymbols.
     // The deferred analysis commit at `read symbols` REQUIRES this to have run

--- a/decompiler/crates/kuna-console/src/ifacedecomp.rs
+++ b/decompiler/crates/kuna-console/src/ifacedecomp.rs
@@ -949,11 +949,14 @@ decomp_command!(
         }
         // Build the Funcdata + follow flow (C++ Funcdata + followFlow), seeding any
         // `override flow` facts stashed for this function before flow follows.
+        // A `function bounds` declaration for this entry bounds the follow;
+        // without one the extent is the natural (unbounded) one.
+        let declared = prog.declared_extent(entry.get_offset());
         let fd = build_and_follow_flow_with_override(
             prog.arch_mut(),
             &resolved_name,
             entry,
-            UNBOUNDED_SIZE,
+            declared,
             &flow_overrides,
         )
         .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
@@ -978,7 +981,7 @@ decomp_command!(
             .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
         // C++ Address offset = parse_machaddr(s,size,*dcp->conf->types) — the full
         // console address grammar over the engine spaces.
-        let (requested, _size) = parse_machaddr(prog, s, false).map_err(IfaceError::parse)?;
+        let (requested, parsed_size) = parse_machaddr(prog, s, false).map_err(IfaceError::parse)?;
         let in_default_space = requested
             .get_space()
             .zip(prog.arch().manage().get_default_code_space())
@@ -1021,8 +1024,20 @@ decomp_command!(
         }
         // The symbol-table addFunction is a later boundary; build the Funcdata
         // + follow flow directly (C++ addFunction + followFlow).
+        // `load addr [ram,<start>,<size>]` states the extent inline (C++
+        // `followFlow(offset, offset+size)`); an extent already declared for this
+        // entry by `map function` applies when the command carries none.  The
+        // parsed size is the address's own byte width when no `,<size>` was
+        // given, so only a size that exceeds it is a real bound.
+        let inline_size =
+            if parsed_size > requested.get_addr_size() { parsed_size } else { UNBOUNDED_SIZE };
+        let declared =
+            if inline_size > 0 { inline_size } else { prog.declared_extent(offset.get_offset()) };
+        if inline_size > 0 {
+            prog.declare_extent(offset.get_offset(), inline_size);
+        }
         let fd =
-            build_and_follow_flow_with_override(prog.arch_mut(), &name, offset, UNBOUNDED_SIZE, &flow_overrides)
+            build_and_follow_flow_with_override(prog.arch_mut(), &name, offset, declared, &flow_overrides)
                 .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
         dcp.fd = Some(fd);
         Ok(())

--- a/decompiler/crates/kuna-console/src/kuna_console.rs
+++ b/decompiler/crates/kuna-console/src/kuna_console.rs
@@ -1213,6 +1213,97 @@ impl IfaceCommandAction for IfcKunaFunctions {
     }
 }
 
+/// (kuna) `function bounds <start> [<end>] [as <name>]`: declare where a
+/// function starts and ends.
+///
+/// The one console primitive for "function F spans `[start,end)`", which kuna
+/// otherwise has nowhere to say: every extent is DERIVED (the address-contiguous
+/// clip in `funcextent`, and an unbounded flow follow), so on an obfuscated or
+/// packed image — where discovery is exactly what fails — the caller had no way
+/// to correct it (`docs/re-needs/no-cli-function-boundary-override.md`).
+///
+/// `start` registers the entry the way `map function` does, so it enumerates,
+/// resolves by name and names its call sites.  `end` is EXCLUSIVE and records
+/// the entry's declared extent, which bounds every later flow follow of it
+/// (`ConsoleProgram::declared_extent` -> `Funcdata::size` -> `FlowInfo::setRange`)
+/// and replaces the clip the inventory reports.  Both are plain integers in the
+/// default code space — no `parse_machaddr` size grammar, whose `[ram,a,n]` size
+/// is indistinguishable from the address width for a small `n` — and the name is
+/// keyed by `as` so a declaration that gives a name but no extent cannot have
+/// its name read as the end address.
+pub struct IfcKunaFunctionBounds;
+
+impl IfaceCommandAction for IfcKunaFunctionBounds {
+    fn execute(&self, status: &mut IfaceStatus, s: &mut CommandStream) -> IfaceResult<()> {
+        let start = read_vma(&s.read_token())
+            .ok_or_else(|| IfaceError::parse("Missing function start address"))?;
+        s.skip_ws();
+        let mut tok = s.read_token();
+        let mut end = None;
+        if !tok.is_empty() && tok != "as" {
+            end = Some(
+                read_vma(&tok)
+                    .ok_or_else(|| IfaceError::parse(format!("Bad end address {tok:?}")))?,
+            );
+            s.skip_ws();
+            tok = s.read_token();
+        }
+        let name = if tok == "as" {
+            s.skip_ws();
+            let name = s.read_token();
+            if name.is_empty() {
+                return Err(IfaceError::parse("Missing name after 'as'"));
+            }
+            Some(name)
+        } else if tok.is_empty() {
+            None
+        } else {
+            return Err(IfaceError::parse(format!("Unexpected token {tok:?} (expected 'as')")));
+        };
+        let size = match end {
+            None => 0,
+            Some(end) if end > start => (end - start) as kuna_base::types::int4,
+            Some(end) => {
+                return Err(IfaceError::parse(format!(
+                    "function bounds: end {end:#x} must be above start {start:#x}"
+                )))
+            }
+        };
+        let dcp = dcp_mut(status)?;
+        let prog = dcp
+            .conf
+            .as_mut()
+            .ok_or_else(|| IfaceError::execution("No load image present"))?;
+        let space = prog
+            .arch()
+            .manage()
+            .get_default_code_space()
+            .cloned()
+            .ok_or_else(|| IfaceError::execution("No default code space"))?;
+        let addr = kuna_base::address::Address::new(space, start);
+        let name = prog
+            .declare_function(addr, name.as_deref(), size)
+            .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
+        status.out(&format!("Declared {name} at {start:#x} spanning {size} bytes\n"));
+        Ok(())
+    }
+
+    fn module(&self) -> String {
+        DECOMPILE_MODULE.to_string()
+    }
+}
+
+/// Read a `0x`-prefixed-or-bare hexadecimal VMA token.  `function bounds` takes
+/// plain numbers rather than the console address grammar precisely so its size
+/// argument cannot be confused with an address width.
+fn read_vma(tok: &str) -> Option<u64> {
+    let body = tok.strip_prefix("0x").or_else(|| tok.strip_prefix("0X")).unwrap_or(tok);
+    if body.is_empty() || !body.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    u64::from_str_radix(body, 16).ok()
+}
+
 // ---------------------------------------------------------------------------
 // Registration — IfaceKunaCapability::registerCommands
 // ---------------------------------------------------------------------------
@@ -1245,6 +1336,9 @@ pub fn register_kuna_commands(status: &mut IfaceStatus) {
     status.register_com(Box::new(IfcKunaRegionTree), &["region", "tree"]);
     status.register_com(Box::new(IfcKunaRegionBlocks), &["region", "blocks"]);
     status.register_com(Box::new(IfcKunaRegionWalk), &["region", "walk"]);
+    // (kuna) Not a C++ command: the function-boundary override the `kuna` binary
+    // exposes as `--define-function`.
+    status.register_com(Box::new(IfcKunaFunctionBounds), &["function", "bounds"]);
 }
 
 /// Join tokens with single spaces — C++ `joinTokens(tokens,0,tokens.size())`.

--- a/decompiler/crates/kuna-console/src/kuna_console/tests.rs
+++ b/decompiler/crates/kuna-console/src/kuna_console/tests.rs
@@ -60,18 +60,19 @@ fn run_one(line: &str) -> String {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn registers_all_seventeen_kuna_commands() {
+fn registers_all_eighteen_kuna_commands() {
     // register_decomp_commands registers 105 (see ifacedecomp/tests.rs); the
-    // kuna capability adds 17: phase list/map/status/catalog (plus the four
+    // kuna capability adds 18: phase list/map/status/catalog (plus the four
     // deprecated `stage ...` alias registrations), kassert, restarts,
-    // pipeline, mode, quality, functions, region tree/blocks/walk.
+    // pipeline, mode, quality, functions, region tree/blocks/walk, and
+    // `function bounds`.
     let only_kuna = {
         let mut st = ConsoleCommands::into_status(vec![]);
         register_kuna_commands(&mut st);
         st.num_commands()
     };
-    assert_eq!(only_kuna, 17);
-    assert_eq!(console(&[]).num_commands(), 105 + 17);
+    assert_eq!(only_kuna, 18);
+    assert_eq!(console(&[]).num_commands(), 105 + 18);
 }
 
 #[test]

--- a/decompiler/crates/kuna-console/src/project.rs
+++ b/decompiler/crates/kuna-console/src/project.rs
@@ -180,11 +180,15 @@ pub fn decompile_targets(
         // was a silent no-op on every whole-binary surface. `discovered` is
         // dropped: each function is decompiled exactly once here, so there is no
         // later re-decompile to persist it for.
+        // A caller-declared extent (`function bounds` / `kuna --define-function`)
+        // bounds this function's flow follow; 0 — the usual case — is the natural,
+        // unbounded extent.
+        let declared = prog.declared_extent(address);
         match crate::decompile_step::decompile_one(
             prog.arch_mut(),
             &name,
             entry,
-            0, // UNBOUNDED: the function's natural flow extent
+            declared,
             &crate::decompile_step::DecompileSeed::plain(&mapped, &flow_ovr),
             &[],
         )

--- a/decompiler/crates/kuna-console/tests/verify_funcbounds.rs
+++ b/decompiler/crates/kuna-console/tests/verify_funcbounds.rs
@@ -1,0 +1,175 @@
+//! Declared function boundaries end-to-end — `docs/re-needs/no-cli-function-boundary-override.md`.
+//!
+//! Every function boundary kuna knows is one it DERIVED: discovery finds the
+//! entries and the extent is the address-contiguous clip `[entry, next_entry)`
+//! over an unbounded flow follow. On an obfuscated or packed image, where
+//! discovery is exactly what fails, a caller had no way to correct either half —
+//! "function F spans `[start,end)`" was not expressible anywhere in the engine.
+//!
+//! The two-state proof, on the real-ELF path (the XML datatest oracles never
+//! reach it):
+//!
+//!  - **no declaration** (today's default): the function at `0x13c9` follows flow
+//!    to its natural end and swallows the 25 leaf functions laid down after it.
+//!  - **`function bounds 0x13c9 0x1420 as stage1`**: the same address decompiles
+//!    to the ONE call inside the declared 87 bytes, reports 87 as its extent, and
+//!    answers to the declared name.
+//!
+//! Fixture: `kuna-analysis/tests/fixtures/aif_gap_x86_64` — a stripped x86-64 ELF
+//! whose `0x13c9` function calls `sub_1129` … `sub_1393` in sequence, so a bound
+//! that lands after the first call is trivially observable in the body.
+//!
+//! ## `.sla` precondition
+//!
+//! Bootstrapping needs the built x86 `.sla` under `specs/` (gitignored; `make
+//! specs`). When it is absent the bootstrap fails; the test prints that and
+//! returns early (a specs-less CI is a visible skip, never a false green).
+
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use kuna_base::address::Address;
+use kuna_console::decompile_step::{decompile_one, DecompileSeed};
+use kuna_console::engine::{bootstrap_from_object, ConsoleProgram};
+
+/// The merged blob's entry, and a bound just past its first (indirect) call.
+const ENTRY: u64 = 0x13c9;
+const DECLARED_END: u64 = 0x1420;
+/// The last of the 25 leaf calls the unbounded follow swallows — the witness that
+/// the bound really cut the flow rather than just relabelling the record.
+const PAST_THE_END: &str = "sub_1393";
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+/// Bootstrap the fixture. `None` ⇒ specs-less skip.
+fn load() -> Option<ConsoleProgram> {
+    let root = repo_root();
+    let spec_roots = vec![root.join("specs").to_str().unwrap().to_string()];
+    let bin = root.join("decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64");
+    let mut prog = match bootstrap_from_object(bin.to_str()?, "", &spec_roots) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "verify_funcbounds: skipping (bootstrap failed, build `.sla` with \
+                 `make specs`): {}",
+                e.explain()
+            );
+            return None;
+        }
+    };
+    prog.commit_pending_analysis().expect("analysis commit succeeds");
+    Some(prog)
+}
+
+fn code_addr(prog: &ConsoleProgram, vma: u64) -> Address {
+    let space = prog.arch().manage().get_default_code_space().expect("code space").clone();
+    Address::new(Rc::clone(&space), vma)
+}
+
+/// Decompile `ENTRY` under whatever extent the program has declared for it, and
+/// return its rendered C.
+fn body_at_entry(prog: &mut ConsoleProgram, name: &str) -> String {
+    let entry = code_addr(prog, ENTRY);
+    let declared = prog.declared_extent(ENTRY);
+    let step = decompile_one(
+        prog.arch_mut(),
+        name,
+        entry,
+        declared,
+        &DecompileSeed::plain(&[], &[]),
+        &[],
+    );
+    let fd = step.result.expect("the function decompiles");
+    kuna_decomp::decompile_drive::print_c(prog.arch_mut(), &fd)
+}
+
+/// The inventory extent kuna reports for `ENTRY`.
+fn reported_extent(prog: &ConsoleProgram) -> u64 {
+    prog.function_entries_canonical()
+        .iter()
+        .find(|e| e.addr.get_offset() == ENTRY)
+        .map(|e| e.size)
+        .expect("the entry is enumerated")
+}
+
+/// With nothing declared, both halves keep the derived answer — the default this
+/// feature must not disturb.
+#[test]
+fn an_undeclared_function_keeps_its_derived_extent_and_unbounded_flow() {
+    let Some(mut prog) = load() else { return };
+    assert_eq!(prog.declared_extent(ENTRY), 0, "nothing is declared yet");
+    // The derived clip: `.text` ends at 0x1673 and `_DT_FINI` is the first entry
+    // of the NEXT code section, so the section end wins over the neighbour.
+    assert_eq!(reported_extent(&prog), 0x1673 - ENTRY);
+    let body = body_at_entry(&mut prog, "sub_13c9");
+    assert!(
+        body.contains(PAST_THE_END),
+        "the unbounded follow must still reach {PAST_THE_END}, got:\n{body}"
+    );
+}
+
+/// A declared `[start,end)` bounds the flow follow, replaces the reported extent,
+/// and names the entry.
+#[test]
+fn a_declared_boundary_bounds_the_flow_and_the_reported_extent() {
+    let Some(mut prog) = load() else { return };
+    let addr = code_addr(&prog, ENTRY);
+    let name = prog
+        .declare_function(addr, Some("stage1"), (DECLARED_END - ENTRY) as i32)
+        .expect("the declaration is accepted");
+    assert_eq!(name, "stage1");
+    assert_eq!(prog.declared_extent(ENTRY), (DECLARED_END - ENTRY) as i32);
+    assert_eq!(reported_extent(&prog), DECLARED_END - ENTRY);
+
+    let body = body_at_entry(&mut prog, &name);
+    assert!(body.contains("stage1"), "the declared name renders, got:\n{body}");
+    assert!(
+        !body.contains(PAST_THE_END),
+        "flow past the declared end must be cut, got:\n{body}"
+    );
+}
+
+/// The declaration is what `load function <name>` and the enumeration resolve
+/// against, so an entry declared at an address the image never named is reachable
+/// by name afterwards.
+#[test]
+fn a_declared_entry_becomes_resolvable_by_name() {
+    let Some(mut prog) = load() else { return };
+    // 0x1500 is interior to the merged blob: discovery does not know it.
+    let interior = 0x1500u64;
+    assert!(prog.lookup_symbol("hidden_stage").is_none());
+    let before = prog.function_entries_canonical().len();
+    let addr = code_addr(&prog, interior);
+    prog.declare_function(addr, Some("hidden_stage"), 0x80).expect("declared");
+    assert_eq!(
+        prog.lookup_symbol("hidden_stage").map(|a| a.get_offset()),
+        Some(interior),
+        "the declared name resolves to its address"
+    );
+    assert_eq!(prog.function_entries_canonical().len(), before + 1);
+    // The neighbour's derived clip tightens against the new entry.
+    assert_eq!(reported_extent(&prog), interior - ENTRY);
+}
+
+/// Declaring an already-named entry without naming it keeps the name the image
+/// gave it: a boundary assertion must not silently rename `main` to `sub_<addr>`.
+#[test]
+fn an_unnamed_declaration_does_not_overwrite_an_existing_name() {
+    let Some(mut prog) = load() else { return };
+    let named = prog
+        .function_entries_canonical()
+        .iter()
+        .find(|e| e.name == "_DT_FINI")
+        .map(|e| e.addr.get_offset())
+        .expect("the fixture carries _DT_FINI");
+    let addr = code_addr(&prog, named);
+    let back = prog.declare_function(addr, None, 4).expect("declared");
+    assert_eq!(back, "_DT_FINI");
+    assert_eq!(prog.declared_extent(named), 4);
+    assert!(prog
+        .function_entries_canonical()
+        .iter()
+        .any(|e| e.addr.get_offset() == named && e.name == "_DT_FINI"));
+}

--- a/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
@@ -517,8 +517,22 @@ pub fn build_and_follow_flow_with_override_and_protos(
 /// clear, so the re-flow rebuilds the CALLIND straight as a direct CALL).
 #[allow(clippy::mutable_key_type)]
 fn follow_flow_on_fd(arch: &mut Architecture, fd: Funcdata) -> KunaResult<Funcdata> {
+    // C++ Funcdata::followFlow(baddr, eaddr): a function carrying a declared byte
+    // extent restricts flow to it; size 0 keeps the unbounded default the whole
+    // engine has used until now (`kuna_console::engine::UNBOUNDED_SIZE`), so this
+    // is inert for every caller that does not declare one. `eaddr` is INCLUSIVE
+    // (`FlowInfo::new_address` rejects `eaddr < to`), so the last in-body byte is
+    // `entry + size - 1`.
+    let range = (fd.get_size() > 0).then(|| fd.get_address().clone()).and_then(|start| {
+        let last = start.get_offset().checked_add(fd.get_size() as u64 - 1)?;
+        let space = Rc::clone(start.get_space()?);
+        Some((start.clone(), Address::new(space, last)))
+    });
     let env = ArchFlowEnv { arch: arch as *const Architecture };
     let mut flow = FlowInfo::new(fd, &env);
+    if let Some((baddr, eaddr)) = range {
+        flow.set_range(baddr, eaddr);
+    }
     // C++ Funcdata::followFlow (decompiler/cpp/funcdata_op.cc:765): after the
     // FlowInfo is constructed (and its range set), followFlow applies the global
     // flow options and the instruction bound.

--- a/decompiler/crates/kuna-decomp/src/p2_lift/flow.rs
+++ b/decompiler/crates/kuna-decomp/src/p2_lift/flow.rs
@@ -897,10 +897,15 @@ impl<'a, E: FlowEnvironment> FlowInfo<'a, E> {
         if (self.flags & flow_flags::ignore_outofbounds) == 0 {
             let msg = Self::out_of_bounds_message(fromaddr, toaddr);
             if (self.flags & flow_flags::error_outofbounds) == 0 {
-                // data.warning(msg, toaddr);  -- STUB(W4): warning store.
+                // (kuna) The C++ `data.warning`/`data.warningHeader` calls, no
+                // longer stubbed: the range is the whole entry-point space unless
+                // a caller declares a function extent, so this fires only under a
+                // declared boundary — and a declared end that cuts real flow must
+                // say so rather than silently truncating the body.
+                self.data.warning(&msg, toaddr);
                 if !self.has_out_of_bounds() {
                     self.flags |= flow_flags::outofbounds_present;
-                    // data.warningHeader("Function flows out of bounds");  -- STUB(W4)
+                    self.data.warning_header("Function flows out of bounds");
                 }
             } else {
                 return Err(KunaError::lowlevel(msg));

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,6 +43,51 @@ interactive prompts never pollute the output. `--option NAME VALUE` (repeatable)
 `--kassert "<args>"` flip phase-model sub-phase assertions per run; `--mode
 auto|reliable|aggressive|fast` applies an option preset (`docs/modes.md`).
 
+**`--define-function <start[-end][=name] | @file>`** (repeatable) tells kuna where a
+function starts and ends. Every boundary kuna knows is otherwise *derived* —
+discovery finds the entries, and the extent is the address-contiguous clip to the
+next one over an unbounded flow follow — which is the wrong answer on exactly the
+images where reverse engineering is hard. A missed entry merges two functions into
+one; a phantom one invents a function that is not there.
+
+```bash
+# an entry discovery missed: name it and decompile it
+kuna decompile ./packed.bin 0x4014a0 --addr --define-function 0x4014a0=stage2
+
+# two functions merged into one: say where the first really ends
+kuna decompile ./packed.bin --addr 0x4013c9 --define-function 0x4013c9-0x401420=stage1
+
+# keep the boundaries you worked out, and pass them to every later command
+cat > bounds.txt <<'EOF'
+# recovered by hand from the unpacked image
+0x4013c9-0x401420 = stage1
+0x401420-0x401500 = stage2
+EOF
+kuna functions ./packed.bin --json --define-function @bounds.txt
+```
+
+`start` declares the entry: it gets a function symbol (so call sites name it), it
+enumerates in `kuna functions`, and it resolves by name. `end` is **exclusive** and
+declares the extent: flow following stops there, so the body no longer swallows its
+neighbours, and the extent reported by `kuna functions --json` is the declared one
+rather than the clip. `=name` is optional and names the entry (an entry the image
+already named keeps its name unless you supply one); `end` is optional too — a bare
+`--define-function 0x4014a0` asserts an entry and leaves the extent natural.
+Addresses are hexadecimal with or without `0x`.
+
+A declared `end` that cuts real control flow is reported rather than silently
+truncating the body: the function carries a `WARNING: Function flows out of bounds`
+comment on its prototype and one at each cut edge. A correct boundary ends in a
+return and produces no warning, so that comment is the signal to widen the range.
+
+The `@file` form is the durable one: one declaration per line, `#` comments and
+blank lines skipped. kuna does not write boundaries back into the image, so the file
+is the artifact — generate it, diff it, and pass it to every invocation. The flag is
+accepted by `decompile`, `decompile-all`, `functions`, `decompile-project` and
+`disassemble`; a declaration is applied after analysis has had its say, so it
+overrides discovery rather than competing with it. The console spelling, for a
+hand-driven `decomp_dbg` session, is `function bounds <start> [<end>] [as <name>]`.
+
 **Paths containing spaces work (DIV-100).** This is the one surface that reaches the engine
 through a console *script* rather than an in-process call, and the console reads a
 filename with `s >> filename` — whitespace-delimited. An unquoted path with a space

--- a/docs/features/no-cli-function-boundary-override/pr_body.md
+++ b/docs/features/no-cli-function-boundary-override/pr_body.md
@@ -1,0 +1,145 @@
+## What was broken
+
+`docs/re-needs/no-cli-function-boundary-override.md` (severity **blocker**, track `tooling`, scope `large`):
+
+> The console has `map function <addr> [name] [nocode]` and `load addr <addr> [name]`, both
+> functional. The `kuna` binary can emit neither […] Worse, `function F spans [start,end)`
+> does not exist ANYWHERE — extent is derived in `kuna-console/src/funcextent.rs` as
+> `[entry, min(next_entry, section_end))` with no override […] On an obfuscated or packed
+> image, where discovery is exactly what fails, the agent has no lever.
+
+**1 instance**, captain-seeded, with an independent round-2 witness recorded in T_TRIAGE
+(`overlapping-anti-disassembly-sequence`: `kuna decompile … 0x80489e6 --addr` exiting 1 at an
+internal target). Round 1 hit the same wall three times.
+
+## The hypothesis was half wrong
+
+Filed hypothesis: *"the cheap half is exposure, the expensive half is the stubs."*
+
+- **START — upheld.** Declaring an entry really was pure exposure; `map function` works.
+- **END — overturned. No stub was involved.** It was inert *plumbing*. `Funcdata::size` is
+  threaded from `map function` / `load addr` / `decompile_one` all the way to
+  `Architecture::new_funcdata`, and `FlowInfo` carries a fully ported
+  `set_range` / `new_address` / `fallthru` / `handle_out_of_bounds` range machinery. The two
+  ends were simply never joined: every call site passed `UNBOUNDED_SIZE`, and
+  `follow_flow_on_fd` never called `set_range`. Joining them is ~10 lines in
+  `decompile_drive.rs`, not an engine port.
+
+## The mechanism
+
+`--define-function <start[-end][=name] | @file>`, repeatable, on `decompile`,
+`decompile-all`, `functions`, `decompile-project` and `disassemble`.
+
+```bash
+# two functions merged into one: say where the first really ends
+kuna decompile-all ./packed.bin --json --addr 0x13c9 --define-function 0x13c9-0x1420=stage1
+
+# keep what you worked out, and pass it to every later command
+kuna functions ./packed.bin --json --define-function @bounds.txt
+```
+
+- **`start`** declares the entry the way `map function` does — function symbol, name→address
+  registration — so it enumerates, resolves by name and names its call sites.
+- **`end` is exclusive** and records a *declared extent* in a new per-program store,
+  `ConsoleProgram::declared_extents`. That store is consulted by **every later load of that
+  entry** (`load function`, `load addr`, the whole-binary loop) and by `funcextent` when the
+  inventory reports a size. A declaration outlives the one command that made it — which is
+  what separates an interface from a one-shot flag. Cross-*process* durability is
+  caller-carried by design: the `@file` is the artifact.
+- Declarations are applied **after** the analysis commit, so they override discovery rather
+  than compete with it.
+- The console spelling is one new kuna-only command, `function bounds <start> [<end>] [as
+  <name>]`. It takes plain integers rather than the `parse_machaddr` grammar, whose
+  `[space,offset,size]` size is indistinguishable from the address width for a small size.
+
+### The failure mode this feature introduces, and the stub that hid it
+
+Refuting the mechanism against *wrongness* rather than against no-op turned up the real
+defect: a declared end that cuts real control flow produced a **silently empty body** with
+`error: null`. `FlowInfo::handle_out_of_bounds` computed the C++ `Function flow out of
+bounds` message and dropped it on the floor (a W4 stub). Un-stubbed to the two
+`Funcdata::warning` / `warning_header` calls the C++ makes:
+
+```c
+void chopped(void) // warn: Function flows out of bounds
+{ // warn: Function flow out of bounds: r0x000013d4 flows to r0x000013d4
+}
+```
+
+A correctly declared function ends in a return and never leaves its range, so that comment is
+the signal to widen the bound. The flow range is the whole entry-point space unless an extent
+is declared, so this fires only under a declared boundary.
+
+## The acceptance probe now passes
+
+The need had **no probe** in its front matter — one of the records the acceptance suite
+reports `unrunnable`. Both arms are now authored against `scripts/repipe/probe.py`'s schema
+with a pinned `target` block (in-repo fixture `aif_gap_x86_64`, sha256
+`1a592a85…fceeef`, 14408 bytes), so neither is a `{{BIN}}` substitution with `target: null`.
+
+| arm | on main `5fec5ff9` | on this branch |
+|---|---|---|
+| reproduction `p-83ce32ba278c` | **PASS** — exit 2, `error: unknown option --define-function` | n/a |
+| acceptance `a-88c4db106ade` | **FAIL** (same exit 2) | **PASS** |
+
+```
+python -m scripts.repipe.verify --need no-cli-function-boundary-override --json
+  counts {'total': 1, 'pass': 1, 'fail': 0, 'closed': 1, 'regressed': 0, 'indeterminate': 0}
+  passed True  flaky False  unrunnable False  transition closed
+```
+
+Promoted verbatim to `tests/cli/no-cli-function-boundary-override.json`.
+
+The A/B on one build, same address:
+
+| | name | size | body |
+|---|---|---|---|
+| no flag | `sub_13c9` | 682 | 54 lines, swallows 25 leaf callees through `sub_1393` |
+| `--define-function 0x13c9-0x1420=stage1` | `stage1` | 87 | the 1 call inside the declared extent |
+
+## Gates
+
+| gate | result |
+|---|---|
+| `make test` | **PARITY OK** — 675/675 assertions |
+| `make test-stages` | **PARITY OK** — 594/594 assertions |
+| `make rust-test` | green |
+| `make check-spec` | OK |
+| `kuna catalog --check` | OK |
+| acceptance probe | **PASS** |
+
+**Inertness, measured rather than asserted.** Both parity corpora are symbol-less bytechunks
+and never reach the real-ELF loader path, so they cannot see this change. Sweeping
+`decompile-all --json` over **all 73 real-ELF fixtures** in
+`kuna-analysis/tests/fixtures/`, main's release `kuna` vs this branch's: **0 differ**. Every
+byte of output is unchanged for a run that declares nothing.
+
+> **Note for whoever runs `make rust-test` next in a repipe worktree:** `verify_w10_proto_unlock`
+> fails spuriously unless `KUNA_DECOMP_TEST` is unset. The harness points that variable — which
+> the test reads as the *C++* oracle path — at a Rust `decomp_test_dbg`, so the test compares
+> Rust against Rust and reports "oracle signature drifted". CI does not set it.
+
+## Not closed (stated, not hidden)
+
+- `xrefs` and `strings` load through the same `Args` but do not accept the flag.
+- kuna never writes boundaries back into the image; the `@file` is the durable artifact.
+- Renaming is supported only as the `=NAME` half of a declaration — general rename/prototype
+  override is the separate open need `no-cli-rename-or-prototype-override`, and
+  `no-cli-data-code-override` / `no-cli-structuring-override` are likewise untouched.
+- **`analysis-generated-function-name` is NOT affected** — checked, since this branch touches
+  `kuna-cli/src/decompile.rs`. A *declared* name resolves as a selector here
+  (`kuna decompile <bin> stage1` works for an entry the image never named), but an
+  *analysis-generated* `sub_<addr>` selector already resolved on main for the same fixture,
+  and resolves identically with and without this change. Nothing here closes or moves that
+  need.
+
+## No option row, by design
+
+Per `docs/agents.md`, an option gates *anything that can change emitted C*. A CLI flag that
+only carries caller assertions cannot change output for a run that does not pass it — proven
+by the 73-fixture sweep above — so there is no `phases.toml` row, no `options.rs`
+registration, no catalog counter and no stages XML. Behaviour changes are described in prose
+in `docs/spec/00-overview.md` (the declared-boundary plane) and `docs/spec/02-lift-and-flow.md`
+(declared flow bounds and their diagnostics).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/no-cli-function-boundary-override/record.json
+++ b/docs/features/no-cli-function-boundary-override/record.json
@@ -1,0 +1,52 @@
+{
+  "slug": "no-cli-function-boundary-override",
+  "need_id": "no-cli-function-boundary-override",
+  "track": "tooling",
+  "scope": "large",
+  "round": 2,
+  "branch": "feat/re-no-cli-function-boundary-override",
+  "summary": "--define-function <start[-end][=name] | @file>: the caller-declared function boundary, on decompile / decompile-all / functions / decompile-project / disassemble, over a new console `function bounds` command and a per-program declared-extent store.",
+  "decisions": [
+    {
+      "what": "hypothesis UPHELD on the start half, OVERTURNED on the end half",
+      "detail": "The need's hypothesis was 'the cheap half is exposure, the expensive half is the stubs'. Declaring a START really was pure exposure. But no stub was involved in the END half: it was inert PLUMBING. Funcdata::size is threaded from map function / load addr / decompile_one all the way to Architecture::new_funcdata, and FlowInfo carries a fully ported set_range / new_address / fallthru / handle_out_of_bounds range machinery. The two ends were simply never joined -- every call site passed UNBOUNDED_SIZE and follow_flow_on_fd never called set_range. Joining them is ~10 lines in decompile_drive.rs, not an engine port."
+    },
+    {
+      "what": "a durable store, not a one-shot flag",
+      "detail": "ConsoleProgram::declared_extents (entry VMA -> byte size) is consulted by every later load of that entry -- load function, load addr, and the whole-binary loop -- and by funcextent when the inventory reports an extent. A declaration therefore outlives the one command that made it. Durability across PROCESSES is caller-carried by design: the @file form is the artifact, and kuna does not write boundaries back into the image."
+    },
+    {
+      "what": "the silent-truncation failure mode, found by refuting the mechanism rather than the no-op",
+      "detail": "A declared end that cuts real control flow produced an EMPTY body with error:null and no diagnostic -- the one failure mode the flag introduces was invisible. FlowInfo::handle_out_of_bounds computed the C++ 'Function flow out of bounds' message and dropped it (a W4 stub). Un-stubbed to the two Funcdata::warning / warning_header calls the C++ makes. The flow range is the whole entry-point space unless an extent is declared, so this fires only under a declared boundary."
+    },
+    {
+      "what": "read-only surfaces only; no engine default changes",
+      "detail": "No phases.toml row, no options.rs registration, no catalog counter, no stages XML: a CLI flag that only supplies caller assertions cannot change emitted C for a run that does not pass it. Proven, not asserted -- see inertness below."
+    }
+  ],
+  "inertness": {
+    "method": "decompile-all --json over every real-ELF fixture in kuna-analysis/tests/fixtures, main's release kuna vs this branch's, binary path normalized",
+    "fixtures": 73,
+    "differing": 0,
+    "note": "The two parity corpora are symbol-less bytechunks, so they never reach the real-ELF loader path; this sweep is what covers it."
+  },
+  "gates": {
+    "make test": "PARITY OK, 675/675 assertions",
+    "make test-stages": "PARITY OK, 594/594 assertions",
+    "make rust-test": "green (KUNA_DECOMP_TEST must be unset: the repipe harness points that C++-oracle variable at a Rust decomp_test_dbg, which makes verify_w10_proto_unlock compare Rust against Rust and fail spuriously)",
+    "make check-spec": "OK",
+    "kuna catalog --check": "OK"
+  },
+  "acceptance": {
+    "acceptance_id": "a-88c4db106ade",
+    "result": "PASS",
+    "promoted_to": "tests/cli/no-cli-function-boundary-override.json",
+    "reproduction_confirmed_on_main": "p-83ce32ba278c passes on main (5fec5ff9): exit 2, 'error: unknown option --define-function'; the acceptance fails there for the same reason"
+  },
+  "not_closed": [
+    "xrefs and strings load through the same Args but do not accept the flag (they pass an empty declaration list).",
+    "Cross-process durability is the @file, not state kuna owns; kuna never writes boundaries back into the image.",
+    "Renaming is only the =NAME half of a boundary declaration -- general rename/prototype override is no-cli-rename-or-prototype-override.",
+    "Data-vs-code and structuring overrides are the separate open needs no-cli-data-code-override and no-cli-structuring-override."
+  ]
+}

--- a/docs/re-needs/no-cli-function-boundary-override.md
+++ b/docs/re-needs/no-cli-function-boundary-override.md
@@ -4,6 +4,8 @@ title: an agent cannot tell kuna where a function starts or ends
 track: tooling
 status: open
 severity: blocker
+probe_id: p-83ce32ba278c
+acceptance_id: a-88c4db106ade
 hypothesis_status: upheld
 credibility: 1.0
 instances: 1
@@ -26,6 +28,134 @@ Every named CLI flag is rejected with `error: unknown option`, verified on the r
 
 ADVISORY. The cheap half is exposure, not implementation: most of these commands already work and only lack a path from the `kuna` binary. The expensive half is the stubs. A builder should measure which is which before choosing a design, and should NOT assume a `kuna console` passthrough is the right shape -- a scriptable console is a different product from a set of flags an agent can compose.
 
+## Probe
+
+Asserts the CURRENT bad behaviour: every named boundary flag is rejected, so the
+`kuna` binary has no lever at all. PASSes on the round-1 merge build (e5ac9c77).
+
+```json
+{
+  "schema": "re-probe/1",
+  "probe_id": "p-83ce32ba278c",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile-all",
+    "{{BIN}}",
+    "--json",
+    "--functions",
+    "stage1",
+    "--define-function",
+    "0x13c9-0x1420=stage1"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "binary_sha256": "1a592a85f424cc2db8953d5a38c86676bcee5e37b242b6fb6244a2c9fccfeeef",
+    "binary_size": 14408,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "selector": "0x13c9",
+    "selector_kind": "addr"
+  },
+  "expect": {
+    "exit_code": {
+      "ne": 0
+    },
+    "stderr_matches": [
+      "unknown option --define-function"
+    ]
+  },
+  "notes": "Current: no kuna surface can declare where a function starts or ends -- every named flag is rejected. The console has map function / load addr; the kuna binary can emit neither, and 'function F spans [start,end)' is not expressible anywhere in the engine."
+}
+```
+
+## Acceptance
+
+Asserts the DESIRED behaviour on the same command: `--define-function
+<start[-end][=name] | @file>` declares an entry discovery missed AND bounds its
+flow follow, so the extent kuna reports is the declared one and the body stops at
+the declared end instead of swallowing its neighbours.
+
+```json
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-88c4db106ade",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile-all",
+    "{{BIN}}",
+    "--json",
+    "--functions",
+    "stage1",
+    "--define-function",
+    "0x13c9-0x1420=stage1"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "binary_sha256": "1a592a85f424cc2db8953d5a38c86676bcee5e37b242b6fb6244a2c9fccfeeef",
+    "binary_size": 14408,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "selector": "0x13c9",
+    "selector_kind": "addr"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "functions[0].name",
+        "op": "eq",
+        "value": "stage1"
+      },
+      {
+        "path": "functions[0].address",
+        "op": "eq",
+        "value": 5065
+      },
+      {
+        "path": "functions[0].size",
+        "op": "eq",
+        "value": 87
+      },
+      {
+        "path": "functions[0].code",
+        "op": "contains",
+        "value": "stage1"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "not_contains",
+        "value": "sub_1393"
+      }
+    ]
+  },
+  "notes": "Desired: --define-function <start[-end][=name]|@file> declares both halves of a boundary. start names an entry discovery missed; end is exclusive and bounds the flow follow, so the extent is the declared 87 bytes and the body stops before the callees past 0x1420 (sub_1393 is the last of the 25 calls the unbounded 682-byte follow swallows). In-repo fixture, so it promotes verbatim."
+}
+```
+
 ## Decision log
 
 - seeded for round 2 from a source survey of the override surface, after round 1 showed testers hitting obfuscated images with no lever to correct kuna with. Not tester-filed: round 2 should confirm the demand.
+- round 2 T_TRIAGE (captain): track tooling / touches [kuna-cli/src, kuna-console/src/ifacedecomp.rs] / scope large CONFIRMED as filed; it was already dispatched this round and its builder died on the account 429 with no commits, so nothing here is re-litigated. What T_TRIAGE adds is the demand evidence the B_PLAN note said was missing: this need was captain-SEEDED with instances 1, and round 2's testers have now produced an independent witness -- overlapping-anti-disassembly-sequence records `kuna decompile ... 0x80489e6 --addr` exiting 1 at internal target 0x8048c49, a tester hitting exactly this wall while working a different challenge. The 'defer rather than approve' caution standing over its [PROPOSAL] is therefore weaker than when it was written.
+- round 2, builder: the hypothesis is upheld on the START half and OVERTURNED on the END half. Declaring a start really was pure exposure -- `map function` works, and `kuna decompile --addr` already reached an undiscovered entry. But "the expensive half is the stubs" is wrong: no stub was involved. The END half was inert PLUMBING. `Funcdata::size` is threaded from `map function`/`load addr`/`decompile_one` all the way to `Architecture::new_funcdata`, `FlowInfo` has a fully ported `set_range`/`new_address`/`handle_out_of_bounds` range machinery, and the two ends were simply never joined: every call site passed `UNBOUNDED_SIZE` and `follow_flow_on_fd` never called `set_range`. Closing it took ~10 lines in `decompile_drive.rs`, not an engine port.
+- shipped `--define-function <start[-end][=name] | @file>` on `decompile`, `decompile-all`, `functions`, `decompile-project` and `disassemble`, over one new kuna-only console command (`function bounds <start> [<end>] [as <name>]`) and one `ConsoleProgram::declared_extents` store consulted by every later load of that entry. NOT closed: `xrefs` and `strings` load through the same `Args` but do not accept the flag (they pass an empty declaration list), and durability is caller-carried (the `@file` is the artifact; kuna does not write boundaries back into the image).
+- a wrong declared end used to produce a silently EMPTY body: `FlowInfo::handle_out_of_bounds` computed the C++ "Function flow out of bounds" message and dropped it on the floor (a W4 stub), so the one failure mode the new flag introduces was invisible. Un-stubbed to the two `Funcdata::warning`/`warning_header` calls the C++ makes; the flow range is the whole entry-point space unless an extent is declared, so this fires only under a declared boundary and is inert everywhere else (measured: 69/69 real-ELF fixtures byte-identical to main).
+- deliberately out of scope, and left to `no-cli-rename-or-prototype-override`: renaming an entry is only supported here as the `=NAME` half of a boundary declaration.

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -604,6 +604,48 @@ console/parity paths never set one. It is not a hard wall around discovery,
 unprobed SLEIGH work, C rendering and variable extraction, assembly/JSON
 construction, total project time, or memory.
 
+(kuna) **Declared function boundaries.** Every function boundary the engine knows
+is derived: discovery supplies the entries, and the extent is the
+address-contiguous clip `[entry, next_entry)` over an unbounded flow follow
+(`decompiler/crates/kuna-console/src/funcextent.rs`). That is the wrong answer on
+exactly the images where reverse engineering is hard — obfuscated, packed or
+hand-written code, where a missed entry merges two functions and an invented one
+splits a body — so a caller can override both halves.
+
+The primitive is a **declared extent**, entry VMA → byte size, held per program in
+`decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::declared_extents)`
+and written by
+`decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::declare_function)`.
+Declaring also installs the `FunctionSymbol` and the name→address registration
+`map function` installs, so the entry enumerates, resolves by name and names its
+call sites; an address that already carries a function symbol is renamed rather
+than given a second one, and only when the caller supplied a name. The store is
+consulted by every later load of that entry — `load function`, `load addr`
+(`decompiler/crates/kuna-console/src/ifacedecomp.rs`) and the whole-binary loop
+(`decompiler/crates/kuna-console/src/project.rs (decompile_targets)`) — which pass
+it as the `Funcdata` size that bounds flow following (chapter
+[02 §2.1](02-lift-and-flow.md)), and by `funcextent` when the inventory reports an
+extent. A declaration therefore outlives the one command that made it, which is
+what separates an interface from a one-shot flag.
+
+Two surfaces reach it. The console command is `function bounds <start> [<end>]
+[as <name>]`
+(`decompiler/crates/kuna-console/src/kuna_console.rs (IfcKunaFunctionBounds)`),
+which takes plain integers rather than the `parse_machaddr` address grammar
+precisely because that grammar's `[space,offset,size]` size is indistinguishable
+from the address width for a small size, and keys the name with `as` so a
+declaration that gives a name but no extent cannot have its name read as the end
+address. The CLI flag is `--define-function <start[-end][=name] | @file>`
+(`decompiler/crates/kuna-cli/src/funcdecl.rs`), repeatable, honored by
+`decompile`, `decompile-all`, `functions`, `decompile-project` and `disassemble`.
+`end` is exclusive. The script surface emits the console command AFTER `read
+symbols` and BEFORE the load, and the in-process surfaces apply the declarations
+after `commit_pending_analysis`
+(`decompiler/crates/kuna-cli/src/decompile_all.rs (load_program)`): in both, a
+declaration is applied after discovery has had its say, because it is an assertion
+that outranks it. Durability is caller-carried — the `@file` form is the artifact,
+and kuna does not write boundaries back into the image.
+
 (kuna) **Load-time env bridges.** Seven loader gates are consumed *inside* the
 bootstrap — before any console `option` line can possibly run — so the option
 surface alone cannot deliver them; each is bridged through a process environment

--- a/docs/spec/02-lift-and-flow.md
+++ b/docs/spec/02-lift-and-flow.md
@@ -53,6 +53,31 @@ ops beyond the deepest internal branch time are dead and deleted
 (`delete_remaining_ops`). The op-creation and classification order here is
 observable — it fixes the SeqNum allocation every later phase keys on.
 
+**Declared flow bounds.** A function normally follows flow wherever the code
+goes: `FlowInfo`'s allowed range is initialized to the whole entry-point space, so
+the extent is discovered, not asserted. A `Funcdata` that carries a non-zero byte
+size instead restricts flow to `[entry, entry + size - 1]`
+(`decompile_drive.rs (follow_flow_on_fd)` calls `flow.rs (FlowInfo::set_range)`
+before op generation, the C++ `Funcdata::followFlow(baddr, eaddr)` shape). `eaddr`
+is inclusive, so the last in-body byte is `entry + size - 1`. A branch target
+outside the range is not followed (`flow.rs (FlowInfo::new_address)`), and
+fall-through stops when it would leave it (`flow.rs (FlowInfo::fallthru)`); both
+route through `flow.rs (FlowInfo::handle_out_of_bounds)`, which under the default
+flow options continues rather than failing the decompile — `errorreinterpreted`-style
+hard failure needs `error_outofbounds`.
+
+Continuing quietly would be the wrong contract for a *declared* bound, because the
+caller cannot otherwise tell a correct boundary from one that truncated the body:
+both just produce a shorter function. So the out-of-bounds handler emits the C++
+diagnostics — a `Funcdata::warning` at each cut edge and, once per function, the
+`Function flows out of bounds` `Funcdata::warning_header` — which the emitter
+renders as comments on the prototype and the offending statement. A correctly
+declared function ends in a return and never leaves its range, so a warning here
+means the declared end is wrong. Size 0 is the unbounded default every caller took
+until the boundary-declaration surface existed (chapter
+[00 §0.4](00-overview.md)) and leaves the range at the whole entry-point space, so
+both the bound and its diagnostics are inert for a run that declares nothing.
+
 **Decode scratch storage.** Every SLEIGH translation checks out a parser
 context from the engine-local pool
 (`decompiler/crates/kuna-sleigh/src/sleigh.rs (Sleigh::checkout_context)`).

--- a/tests/cli/no-cli-function-boundary-override.json
+++ b/tests/cli/no-cli-function-boundary-override.json
@@ -1,0 +1,65 @@
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-88c4db106ade",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile-all",
+    "{{BIN}}",
+    "--json",
+    "--functions",
+    "stage1",
+    "--define-function",
+    "0x13c9-0x1420=stage1"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "binary_sha256": "1a592a85f424cc2db8953d5a38c86676bcee5e37b242b6fb6244a2c9fccfeeef",
+    "binary_size": 14408,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "selector": "0x13c9",
+    "selector_kind": "addr"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "functions[0].name",
+        "op": "eq",
+        "value": "stage1"
+      },
+      {
+        "path": "functions[0].address",
+        "op": "eq",
+        "value": 5065
+      },
+      {
+        "path": "functions[0].size",
+        "op": "eq",
+        "value": 87
+      },
+      {
+        "path": "functions[0].code",
+        "op": "contains",
+        "value": "stage1"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "not_contains",
+        "value": "sub_1393"
+      }
+    ]
+  },
+  "notes": "Desired: --define-function <start[-end][=name]|@file> declares both halves of a boundary. start names an entry discovery missed; end is exclusive and bounds the flow follow, so the extent is the declared 87 bytes and the body stops before the callees past 0x1420 (sub_1393 is the last of the 25 calls the unbounded 682-byte follow swallows). In-repo fixture, so it promotes verbatim."
+}


### PR DESCRIPTION
## What was broken

`docs/re-needs/no-cli-function-boundary-override.md` (severity **blocker**, track `tooling`, scope `large`):

> The console has `map function <addr> [name] [nocode]` and `load addr <addr> [name]`, both
> functional. The `kuna` binary can emit neither […] Worse, `function F spans [start,end)`
> does not exist ANYWHERE — extent is derived in `kuna-console/src/funcextent.rs` as
> `[entry, min(next_entry, section_end))` with no override […] On an obfuscated or packed
> image, where discovery is exactly what fails, the agent has no lever.

**1 instance**, captain-seeded, with an independent round-2 witness recorded in T_TRIAGE
(`overlapping-anti-disassembly-sequence`: `kuna decompile … 0x80489e6 --addr` exiting 1 at an
internal target). Round 1 hit the same wall three times.

## The hypothesis was half wrong

Filed hypothesis: *"the cheap half is exposure, the expensive half is the stubs."*

- **START — upheld.** Declaring an entry really was pure exposure; `map function` works.
- **END — overturned. No stub was involved.** It was inert *plumbing*. `Funcdata::size` is
  threaded from `map function` / `load addr` / `decompile_one` all the way to
  `Architecture::new_funcdata`, and `FlowInfo` carries a fully ported
  `set_range` / `new_address` / `fallthru` / `handle_out_of_bounds` range machinery. The two
  ends were simply never joined: every call site passed `UNBOUNDED_SIZE`, and
  `follow_flow_on_fd` never called `set_range`. Joining them is ~10 lines in
  `decompile_drive.rs`, not an engine port.

## The mechanism

`--define-function <start[-end][=name] | @file>`, repeatable, on `decompile`,
`decompile-all`, `functions`, `decompile-project` and `disassemble`.

```bash
# two functions merged into one: say where the first really ends
kuna decompile-all ./packed.bin --json --addr 0x13c9 --define-function 0x13c9-0x1420=stage1

# keep what you worked out, and pass it to every later command
kuna functions ./packed.bin --json --define-function @bounds.txt
```

- **`start`** declares the entry the way `map function` does — function symbol, name→address
  registration — so it enumerates, resolves by name and names its call sites.
- **`end` is exclusive** and records a *declared extent* in a new per-program store,
  `ConsoleProgram::declared_extents`. That store is consulted by **every later load of that
  entry** (`load function`, `load addr`, the whole-binary loop) and by `funcextent` when the
  inventory reports a size. A declaration outlives the one command that made it — which is
  what separates an interface from a one-shot flag. Cross-*process* durability is
  caller-carried by design: the `@file` is the artifact.
- Declarations are applied **after** the analysis commit, so they override discovery rather
  than compete with it.
- The console spelling is one new kuna-only command, `function bounds <start> [<end>] [as
  <name>]`. It takes plain integers rather than the `parse_machaddr` grammar, whose
  `[space,offset,size]` size is indistinguishable from the address width for a small size.

### The failure mode this feature introduces, and the stub that hid it

Refuting the mechanism against *wrongness* rather than against no-op turned up the real
defect: a declared end that cuts real control flow produced a **silently empty body** with
`error: null`. `FlowInfo::handle_out_of_bounds` computed the C++ `Function flow out of
bounds` message and dropped it on the floor (a W4 stub). Un-stubbed to the two
`Funcdata::warning` / `warning_header` calls the C++ makes:

```c
void chopped(void) // warn: Function flows out of bounds
{ // warn: Function flow out of bounds: r0x000013d4 flows to r0x000013d4
}
```

A correctly declared function ends in a return and never leaves its range, so that comment is
the signal to widen the bound. The flow range is the whole entry-point space unless an extent
is declared, so this fires only under a declared boundary.

## The acceptance probe now passes

The need had **no probe** in its front matter — one of the records the acceptance suite
reports `unrunnable`. Both arms are now authored against `scripts/repipe/probe.py`'s schema
with a pinned `target` block (in-repo fixture `aif_gap_x86_64`, sha256
`1a592a85…fceeef`, 14408 bytes), so neither is a `{{BIN}}` substitution with `target: null`.

| arm | on main `5fec5ff9` | on this branch |
|---|---|---|
| reproduction `p-83ce32ba278c` | **PASS** — exit 2, `error: unknown option --define-function` | n/a |
| acceptance `a-88c4db106ade` | **FAIL** (same exit 2) | **PASS** |

```
python -m scripts.repipe.verify --need no-cli-function-boundary-override --json
  counts {'total': 1, 'pass': 1, 'fail': 0, 'closed': 1, 'regressed': 0, 'indeterminate': 0}
  passed True  flaky False  unrunnable False  transition closed
```

Promoted verbatim to `tests/cli/no-cli-function-boundary-override.json`.

The A/B on one build, same address:

| | name | size | body |
|---|---|---|---|
| no flag | `sub_13c9` | 682 | 54 lines, swallows 25 leaf callees through `sub_1393` |
| `--define-function 0x13c9-0x1420=stage1` | `stage1` | 87 | the 1 call inside the declared extent |

## Gates

| gate | result |
|---|---|
| `make test` | **PARITY OK** — 675/675 assertions |
| `make test-stages` | **PARITY OK** — 594/594 assertions |
| `make rust-test` | green |
| `make check-spec` | OK |
| `kuna catalog --check` | OK |
| acceptance probe | **PASS** |

**Inertness, measured rather than asserted.** Both parity corpora are symbol-less bytechunks
and never reach the real-ELF loader path, so they cannot see this change. Sweeping
`decompile-all --json` over **all 73 real-ELF fixtures** in
`kuna-analysis/tests/fixtures/`, main's release `kuna` vs this branch's: **0 differ**. Every
byte of output is unchanged for a run that declares nothing.

> **Note for whoever runs `make rust-test` next in a repipe worktree:** `verify_w10_proto_unlock`
> fails spuriously unless `KUNA_DECOMP_TEST` is unset. The harness points that variable — which
> the test reads as the *C++* oracle path — at a Rust `decomp_test_dbg`, so the test compares
> Rust against Rust and reports "oracle signature drifted". CI does not set it.

## Not closed (stated, not hidden)

- `xrefs` and `strings` load through the same `Args` but do not accept the flag.
- kuna never writes boundaries back into the image; the `@file` is the durable artifact.
- Renaming is supported only as the `=NAME` half of a declaration — general rename/prototype
  override is the separate open need `no-cli-rename-or-prototype-override`, and
  `no-cli-data-code-override` / `no-cli-structuring-override` are likewise untouched.
- **`analysis-generated-function-name` is NOT affected** — checked, since this branch touches
  `kuna-cli/src/decompile.rs`. A *declared* name resolves as a selector here
  (`kuna decompile <bin> stage1` works for an entry the image never named), but an
  *analysis-generated* `sub_<addr>` selector already resolved on main for the same fixture,
  and resolves identically with and without this change. Nothing here closes or moves that
  need.

## No option row, by design

Per `docs/agents.md`, an option gates *anything that can change emitted C*. A CLI flag that
only carries caller assertions cannot change output for a run that does not pass it — proven
by the 73-fixture sweep above — so there is no `phases.toml` row, no `options.rs`
registration, no catalog counter and no stages XML. Behaviour changes are described in prose
in `docs/spec/00-overview.md` (the declared-boundary plane) and `docs/spec/02-lift-and-flow.md`
(declared flow bounds and their diagnostics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
