### PR TITLE
[AUTOMATED] feat(cli): cli-mode-read-raw — a byte view for data addresses (kuna read / --as data)

### DIFF
--- a/decompiler/Cargo.lock
+++ b/decompiler/Cargo.lock
@@ -151,6 +151,7 @@ dependencies = [
  "kuna-base",
  "kuna-console",
  "kuna-decomp",
+ "kuna-sleigh",
  "object",
  "regex",
 ]

--- a/decompiler/crates/kuna-cli/Cargo.toml
+++ b/decompiler/crates/kuna-cli/Cargo.toml
@@ -25,6 +25,10 @@ kuna-base.workspace = true
 # `.fid` writer, and `object` re-opens the parsed image / `ObjectLoadImage`.
 kuna-console.workspace = true
 kuna-analysis.workspace = true
+# `kuna disassemble`/`kuna read` ask the loader which section an address is in
+# before choosing between the instruction listing and the hexdump; the flag bits
+# (`section_flags::CODE`/`DATA`) are the LoadImage vocabulary, not a local guess.
+kuna-sleigh.workspace = true
 # The workspace `object` is read_core+formats; `kuna fid build` additionally needs
 # the `ar` archive reader to unpack `.a` static libraries member-by-member, so the
 # `archive` feature is enabled here (additive — features unify, the rest of the

--- a/decompiler/crates/kuna-cli/src/disassemble.rs
+++ b/decompiler/crates/kuna-cli/src/disassemble.rs
@@ -1,9 +1,10 @@
 //! `kuna disassemble` — the instruction listing.
 //!
 //! ```text
-//!   kuna disassemble <binary> <name|0xaddr|0xstart-0xend> [--addr] [--count N]
-//!                    [--bytes N] [--json] [--mode MODE] [--option N V]..
-//!                    [--slice ARCH] [--target T] [--sleighpath D]
+//!   kuna disassemble <binary> <name|0xaddr|0xstart-0xend> [--addr] [--as VIEW]
+//!                    [--count N] [--bytes N] [--json] [--mode MODE]
+//!                    [--option N V].. [--slice ARCH] [--target T] [--sleighpath D]
+//!   kuna read <binary> <name|0xaddr|0xstart-0xend> ...   # the same, --as data
 //! ```
 //!
 //! The floor an RE agent falls back to when the ceiling gives way. Three
@@ -47,8 +48,26 @@
 //! Bytes that do not decode are not skipped and not guessed at: they are listed
 //! as `.byte 0x<nn>` rows, one byte at a time, so a listing that walked into
 //! data says so in place rather than silently stopping.
+//!
+//! ## Two views, because a data address is not an instruction stream
+//!
+//! Listing a data blob as instructions is worse than useless: an RE agent that
+//! asked kuna for the encoded globals at `0x100003f30` got `ADD byte ptr
+//! [RCX],AL` / `OR CL,byte ptr [RBX]` back — a decode of `00 01 02 03 ..` that is
+//! correct in the translator and a lie about the program. It went to `xxd`, which
+//! is the friction this view removes (`docs/re-needs/cli-mode-read-raw.md`).
+//!
+//! So the target picks its own rendering. `--as auto` (the default) asks the
+//! loader which section the start address is in: a section carrying `DATA`
+//! without `CODE` renders as a hexdump — address, bytes, ASCII gutter, and a
+//! contiguous `hex` string in `--json` — and says on stderr why it did.
+//! `--as code` and `--as data` override it in either direction, because a packer
+//! puts real code in `.data` and a compiler puts real data in `__TEXT`. Nothing
+//! about the decode changes: the same walk, the same bytes, a different view of
+//! them.
 
 use kuna_console::engine::ConsoleProgram;
+use kuna_sleigh::loadimage::section_flags;
 
 use crate::decompile::looks_like_addr;
 use crate::decompile_all::{load_program, mode_options_for_binary, Args, DriverDefaults};
@@ -73,8 +92,33 @@ const DEFAULT_WINDOW_BYTES: u64 = 64;
 /// address range is honored verbatim, however long.
 const DERIVED_INSTRUCTION_CAP: usize = 1024;
 
+/// The same safety stop for a byte listing nobody sized, in hexdump rows.
+const DERIVED_ROW_CAP: usize = DERIVED_INSTRUCTION_CAP;
+
+/// How many bytes one hexdump row covers — the `xxd` width an RE agent's eye is
+/// already calibrated to.
+const HEXDUMP_ROW_BYTES: usize = 16;
+
 /// The mnemonic given to a byte the translator would not decode.
 const BAD_BYTE_MNEMONIC: &str = ".byte";
+
+/// What to render at the target.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum View {
+    /// Decoded instructions.
+    Code,
+    /// The bytes themselves, as a hexdump.
+    Data,
+}
+
+/// `--as`: what the caller asked for, before the program gets a say.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum ViewRequest {
+    /// Let the loader's section flags choose ([`choose_view`]).
+    Auto,
+    Code,
+    Data,
+}
 
 /// The parsed command line.
 pub(crate) struct DisArgs {
@@ -83,6 +127,9 @@ pub(crate) struct DisArgs {
     pub(crate) spec: String,
     /// `--addr`: read `spec` as an address even when it is bare hex.
     pub(crate) by_address: bool,
+    /// `--as code|data|auto`. `None` is the command's own default — `Auto` for
+    /// `kuna disassemble`, `Data` for `kuna read`.
+    pub(crate) view: Option<ViewRequest>,
     /// `--count N`: stop after N instructions.
     pub(crate) count: Option<usize>,
     /// `--bytes N`: stop after N bytes.
@@ -107,6 +154,9 @@ struct Region {
     name: Option<String>,
     /// Was the stop derived from the inventory rather than asked for?
     derived: bool,
+    /// Did the target resolve to a discovered function entry? Such a target is
+    /// code by definition, whatever section it was linked into.
+    from_entry: bool,
 }
 
 /// One listed instruction.
@@ -133,17 +183,69 @@ impl Row {
     }
 
     fn hex(&self) -> String {
-        let mut s = String::with_capacity(self.bytes.len() * 2);
-        for b in &self.bytes {
-            s.push_str(&format!("{b:02x}"));
-        }
-        s
+        hex(&self.bytes)
     }
+}
+
+/// One hexdump row: up to [`HEXDUMP_ROW_BYTES`] bytes of the image.
+struct DataRow {
+    addr: u64,
+    bytes: Vec<u8>,
+}
+
+impl DataRow {
+    /// Contiguous lowercase hex — the spelling that pastes into another tool,
+    /// and the one `--json` reports (per row and, concatenated, for the span).
+    fn hex(&self) -> String {
+        hex(&self.bytes)
+    }
+
+    /// The same bytes space-separated (`xxd -g1`), for the human column, where a
+    /// 32-character run of hex is unreadable.
+    fn grouped(&self) -> String {
+        self.bytes.iter().map(|b| format!("{b:02x}")).collect::<Vec<_>>().join(" ")
+    }
+
+    /// The printable-ASCII gutter; every other byte is a `.`, `xxd`-style.
+    fn ascii(&self) -> String {
+        self.bytes
+            .iter()
+            .map(|&b| if (0x20..0x7f).contains(&b) { b as char } else { '.' })
+            .collect()
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// What the command produced: the document for stdout, plus the notes that
+/// belong on stderr. A note never enters the document, so `--json` stays
+/// machine-readable — it is repeated in the JSON's own `notes` array instead.
+pub(crate) struct Listing {
+    pub(crate) text: String,
+    pub(crate) notes: Vec<String>,
 }
 
 /// `kuna disassemble` entry point.
 pub fn run(argv: &[String]) -> i32 {
-    let args = match parse_args(argv) {
+    run_as(argv, ViewRequest::Auto)
+}
+
+/// `kuna read` entry point — the same query with the byte view as its default,
+/// so an agent that wants the bytes of a data address does not have to know that
+/// the command for it is spelled `disassemble`. An explicit `--as code` still
+/// wins, because the two spellings are one command.
+pub fn run_read(argv: &[String]) -> i32 {
+    run_as(argv, ViewRequest::Data)
+}
+
+fn run_as(argv: &[String], default_view: ViewRequest) -> i32 {
+    let mut args = match parse_args(argv) {
         Ok(a) => a,
         Err(e) => {
             eprintln!("error: {e}");
@@ -151,8 +253,14 @@ pub fn run(argv: &[String]) -> i32 {
             return 2;
         }
     };
+    args.view.get_or_insert(default_view);
     match render(&args) {
-        Ok(text) => crate::output::emit_with_status(&text, 0),
+        Ok(listing) => {
+            for note in &listing.notes {
+                eprintln!("note: {note}");
+            }
+            crate::output::emit_with_status(&listing.text, 0)
+        }
         Err(e) => {
             eprintln!("error: {e}");
             1
@@ -162,7 +270,7 @@ pub fn run(argv: &[String]) -> i32 {
 
 /// Load, resolve, walk, and render — the whole command, minus the stdout
 /// boundary, so the listing is testable without a subprocess.
-pub(crate) fn render(args: &DisArgs) -> Result<String, String> {
+pub(crate) fn render(args: &DisArgs) -> Result<Listing, String> {
     let options = mode_options_for_binary(args.mode.as_deref(), &args.binary, args.options.clone())?;
     // The inventory bundle: this surface enumerates entries to resolve a name
     // and to bound a function, and decompiles nothing.
@@ -192,12 +300,88 @@ pub(crate) fn render(args: &DisArgs) -> Result<String, String> {
             region.start, args.binary
         ));
     }
-    let (rows, truncated) = walk(&prog, &region, args.count);
-    Ok(if args.json {
-        format!("{}\n", dumps_indent2(&result_json(args, &region, &rows, truncated)))
+    let (view, notes) = choose_view(&prog, &region, args.view.unwrap_or(ViewRequest::Auto));
+    let text = match view {
+        View::Code => {
+            let (rows, truncated) = walk(&prog, &region, args.count);
+            if args.json {
+                format!("{}\n", dumps_indent2(&result_json(args, &region, &rows, truncated, &notes)))
+            } else {
+                render_text(&region, &rows, truncated)
+            }
+        }
+        View::Data => {
+            let (rows, truncated) = walk_data(&prog, &region, args.count);
+            if args.json {
+                format!(
+                    "{}\n",
+                    dumps_indent2(&data_result_json(args, &region, &rows, truncated, &notes))
+                )
+            } else {
+                render_data_text(&region, &rows, truncated)
+            }
+        }
+    };
+    Ok(Listing { text, notes })
+}
+
+// --- which view ---------------------------------------------------------------
+
+/// (kuna) The loader `section_flags` bits of the section containing `vma`.
+///
+/// `None` when no section covers it — which includes every loader that publishes
+/// no section table at all (the XML `<binaryimage>` corpus, a raw byte blob).
+/// There the byte view can only be asked for, never inferred, which is the right
+/// way round: an inference from missing evidence is a guess.
+fn section_flags_at(prog: &ConsoleProgram, vma: u64) -> Option<u32> {
+    prog.sections()
+        .into_iter()
+        .find(|(start, size, _)| vma >= *start && vma - start < *size)
+        .map(|(_, _, flags)| flags)
+}
+
+/// Decide between the instruction listing and the hexdump, and say why when the
+/// program — not the caller — made the choice.
+///
+/// `auto` believes the loader's own section classification and nothing else: a
+/// section the format marks as data and not as code (`.rdata`, `__TEXT,__const`,
+/// `.rodata`) holds bytes, so it is shown as bytes. A discovered function entry
+/// is code whatever section it was linked into, and an address in a section that
+/// carries `CODE` — or in no section the loader knows about — keeps the
+/// instruction listing it has always had.
+fn choose_view(prog: &ConsoleProgram, region: &Region, want: ViewRequest) -> (View, Vec<String>) {
+    let section = section_flags_at(prog, region.start);
+    let view = decide_view(want, region.from_entry, section);
+    let inferred = want == ViewRequest::Auto && view == View::Data;
+    let notes = if inferred {
+        vec![format!(
+            "0x{:x} is in a non-executable data section, so these are bytes, not \
+             instructions -- pass `--as code` to disassemble them anyway",
+            region.start
+        )]
     } else {
-        render_text(&region, &rows, truncated)
-    })
+        Vec::new()
+    };
+    (view, notes)
+}
+
+/// The decision itself, with the program's evidence already gathered: the
+/// caller's demand wins outright, a discovered entry is code wherever it was
+/// linked, and only a section the loader marks `DATA` without `CODE` flips the
+/// view. A loader that published no section covering the address (`None`) is
+/// silence, not evidence, and keeps the instruction listing.
+fn decide_view(want: ViewRequest, from_entry: bool, section: Option<u32>) -> View {
+    match want {
+        ViewRequest::Code => View::Code,
+        ViewRequest::Data => View::Data,
+        ViewRequest::Auto if from_entry => View::Code,
+        ViewRequest::Auto => match section {
+            Some(flags) if flags & section_flags::DATA != 0 && flags & section_flags::CODE == 0 => {
+                View::Data
+            }
+            _ => View::Code,
+        },
+    }
 }
 
 // --- the walk ----------------------------------------------------------------
@@ -258,6 +442,68 @@ fn walk(prog: &ConsoleProgram, region: &Region, count: Option<usize>) -> (Vec<Ro
     (rows, truncated)
 }
 
+/// Read the region's bytes forward from `region.start` into hexdump rows, until
+/// the region's end, the row budget, the derived-length cap, or memory that will
+/// not read.
+///
+/// A short read ends the listing rather than zero-filling it: the point of this
+/// view is that every byte it shows is a byte the image really holds.
+fn walk_data(prog: &ConsoleProgram, region: &Region, count: Option<usize>) -> (Vec<DataRow>, bool) {
+    let cap = if region.derived { Some(DERIVED_ROW_CAP) } else { None };
+    let mut rows: Vec<DataRow> = Vec::new();
+    let mut truncated = false;
+    let mut addr = region.start;
+    let mut raw: Vec<u8> = Vec::new();
+    loop {
+        if count.is_some_and(|n| rows.len() >= n) {
+            break;
+        }
+        if region.end.is_some_and(|end| addr >= end) {
+            break;
+        }
+        if cap.is_some_and(|c| rows.len() >= c) {
+            truncated = true;
+            break;
+        }
+        let want = match region.end {
+            Some(end) => (end - addr).min(HEXDUMP_ROW_BYTES as u64) as usize,
+            None => HEXDUMP_ROW_BYTES,
+        };
+        let got = read_upto(prog, addr, want, &mut raw);
+        if got == 0 {
+            break;
+        }
+        rows.push(DataRow { addr, bytes: raw[..got].to_vec() });
+        addr = addr.saturating_add(got as u64);
+        if got < want {
+            break;
+        }
+    }
+    (rows, truncated)
+}
+
+/// Read at most `want` bytes at `vma`, shortening at the first byte the image
+/// will not hand over — a mapped segment ends where it ends, which is far more
+/// often mid-row than on a 16-byte boundary. Returns how many were read.
+fn read_upto(prog: &ConsoleProgram, vma: u64, want: usize, out: &mut Vec<u8>) -> usize {
+    if want == 0 {
+        return 0;
+    }
+    if prog.read_bytes_into(vma, want, out) {
+        return want;
+    }
+    let mut one: Vec<u8> = Vec::new();
+    let mut got: Vec<u8> = Vec::with_capacity(want);
+    for i in 0..want {
+        if !prog.read_bytes_into(vma.saturating_add(i as u64), 1, &mut one) {
+            break;
+        }
+        got.push(one[0]);
+    }
+    *out = got;
+    out.len()
+}
+
 // --- target resolution -------------------------------------------------------
 
 /// Resolve the target operand into a start, a stop, and a display name.
@@ -285,29 +531,35 @@ fn resolve_region(prog: &ConsoleProgram, args: &DisArgs) -> Result<Region, Strin
         // Both bound the walk, so the tighter one wins — the same "first limit
         // reached" rule `--count` follows.
         let end = args.bytes.map_or(end, |n| end.min(start.saturating_add(n)));
-        return Ok(Region { start, end: Some(end), name: name_at(prog, start), derived: false });
+        return Ok(Region {
+            start,
+            end: Some(end),
+            name: name_at(prog, start),
+            derived: false,
+            from_entry: false,
+        });
     }
 
-    let (start, name) = if addressy {
+    let (start, name, from_entry) = if addressy {
         let addr = parse_addr(spec)?;
         // An ARM caller legitimately holds an odd `entry|1` Thumb address; the
         // inventory folds the mode bit, so resolve through it when it knows the
         // entry and list where the instructions actually are.
         match prog.find_entry_at(addr) {
-            Some(e) => (e.addr.get_offset(), Some(e.name)),
-            None => (addr, name_at(prog, addr)),
+            Some(e) => (e.addr.get_offset(), Some(e.name), true),
+            None => (addr, name_at(prog, addr), false),
         }
     } else if let Some(e) = prog.find_entry_by_name(spec) {
-        (e.addr.get_offset(), Some(e.name))
+        (e.addr.get_offset(), Some(e.name), true)
     } else if let Some(a) = prog.lookup_symbol(spec) {
         let addr = a.get_offset();
-        (addr, name_at(prog, addr).or_else(|| Some(spec.to_string())))
+        (addr, name_at(prog, addr).or_else(|| Some(spec.to_string())), false)
     } else if let Some((n, addr, _)) =
         prog.global_data_symbols().into_iter().find(|(n, _, _)| n == spec)
     {
-        (addr, Some(n))
+        (addr, Some(n), false)
     } else if let Ok(addr) = u64::from_str_radix(spec, 16) {
-        (addr, name_at(prog, addr))
+        (addr, name_at(prog, addr), false)
     } else {
         return Err(format!(
             "no symbol named {spec:?} in {} (and it is not an address; pass --addr \
@@ -317,14 +569,24 @@ fn resolve_region(prog: &ConsoleProgram, args: &DisArgs) -> Result<Region, Strin
     };
 
     Ok(match (args.bytes, args.count) {
-        (Some(n), _) => {
-            Region { start, end: Some(start.saturating_add(n)), name, derived: false }
-        }
-        (None, Some(_)) => Region { start, end: None, name, derived: false },
+        (Some(n), _) => Region {
+            start,
+            end: Some(start.saturating_add(n)),
+            name,
+            derived: false,
+            from_entry,
+        },
+        (None, Some(_)) => Region { start, end: None, name, derived: false, from_entry },
         (None, None) => {
             let extent = prog.function_extent_at(start);
             let span = if extent > 0 { extent } else { DEFAULT_WINDOW_BYTES };
-            Region { start, end: Some(start.saturating_add(span)), name, derived: true }
+            Region {
+                start,
+                end: Some(start.saturating_add(span)),
+                name,
+                derived: true,
+                from_entry,
+            }
         }
     })
 }
@@ -370,7 +632,13 @@ fn name_at(prog: &ConsoleProgram, vma: u64) -> Option<String> {
 ///
 /// `end` is one past the last instruction actually listed, not the requested
 /// stop, so a caller resuming a truncated listing has its next start in hand.
-fn result_json(args: &DisArgs, region: &Region, rows: &[Row], truncated: bool) -> Json {
+fn result_json(
+    args: &DisArgs,
+    region: &Region,
+    rows: &[Row],
+    truncated: bool,
+    notes: &[String],
+) -> Json {
     let end = rows.last().map_or(region.start, |r| r.addr + r.size);
     let instructions = Json::Array(
         rows.iter()
@@ -387,8 +655,63 @@ fn result_json(args: &DisArgs, region: &Region, rows: &[Row], truncated: bool) -
             })
             .collect(),
     );
-    Json::Object(vec![
+    let mut doc = envelope(args, region, end, rows.len(), truncated, notes, "code");
+    doc.push(("instructions".into(), instructions));
+    Json::Object(doc)
+}
+
+/// Build the `--as data` (`kuna read`) document: the same envelope, then the
+/// span's bytes as one contiguous hex string plus the hexdump rows.
+///
+/// `hex` is the whole span in one piece on purpose — an agent comparing kuna's
+/// answer with `xxd` or pasting a table into a decoder wants one token, not a
+/// re-join of N rows.
+fn data_result_json(
+    args: &DisArgs,
+    region: &Region,
+    rows: &[DataRow],
+    truncated: bool,
+    notes: &[String],
+) -> Json {
+    let end = rows.last().map_or(region.start, |r| r.addr + r.bytes.len() as u64);
+    let mut hex = String::new();
+    for r in rows {
+        hex.push_str(&r.hex());
+    }
+    let listed = Json::Array(
+        rows.iter()
+            .map(|r| {
+                Json::Object(vec![
+                    ("address".into(), Json::Number(r.addr.to_string())),
+                    ("address_hex".into(), Json::Str(format!("0x{:x}", r.addr))),
+                    ("size".into(), Json::Number(r.bytes.len().to_string())),
+                    ("bytes".into(), Json::Str(r.hex())),
+                    ("ascii".into(), Json::Str(r.ascii())),
+                ])
+            })
+            .collect(),
+    );
+    let mut doc = envelope(args, region, end, rows.len(), truncated, notes, "data");
+    doc.push(("hex".into(), Json::Str(hex)));
+    doc.push(("rows".into(), listed));
+    Json::Object(doc)
+}
+
+/// The keys both views share, in one order, so a consumer reads `start`/`end`/
+/// `count`/`bytes` the same way whichever view answered. `kind` says which one
+/// did; `count` is the number of listed entries (instructions, or hexdump rows).
+fn envelope(
+    args: &DisArgs,
+    region: &Region,
+    end: u64,
+    count: usize,
+    truncated: bool,
+    notes: &[String],
+    kind: &str,
+) -> Vec<(String, Json)> {
+    vec![
         ("binary".into(), Json::Str(args.binary.clone())),
+        ("kind".into(), Json::Str(kind.to_string())),
         (
             "target".into(),
             Json::Object(vec![
@@ -401,11 +724,11 @@ fn result_json(args: &DisArgs, region: &Region, rows: &[Row], truncated: bool) -
         ("start_hex".into(), Json::Str(format!("0x{:x}", region.start))),
         ("end".into(), Json::Number(end.to_string())),
         ("end_hex".into(), Json::Str(format!("0x{end:x}"))),
-        ("count".into(), Json::Number(rows.len().to_string())),
+        ("count".into(), Json::Number(count.to_string())),
         ("bytes".into(), Json::Number((end - region.start).to_string())),
         ("truncated".into(), Json::Bool(truncated)),
-        ("instructions".into(), instructions),
-    ])
+        ("notes".into(), Json::Array(notes.iter().cloned().map(Json::Str).collect())),
+    ]
 }
 
 /// The human surface: a `#` header naming what was listed, then one column-aligned
@@ -417,10 +740,7 @@ fn render_text(region: &Region, rows: &[Row], truncated: bool) -> String {
     use std::fmt::Write as _;
     let end = rows.last().map_or(region.start, |r| r.addr + r.size);
     let mut out = String::new();
-    let label = match &region.name {
-        Some(name) => format!("{name} @ 0x{:x}", region.start),
-        None => format!("0x{:x}", region.start),
-    };
+    let label = label(region);
     let plural = if rows.len() == 1 { "instruction" } else { "instructions" };
     let _ = writeln!(
         out,
@@ -441,11 +761,50 @@ fn render_text(region: &Region, rows: &[Row], truncated: bool) -> String {
     out
 }
 
+/// The human byte surface: `xxd -g1` with kuna's own address column — a `#`
+/// header naming the span, then address, sixteen space-separated bytes, and the
+/// printable-ASCII gutter. Space-separated because a 32-character run of hex is
+/// not readable; `--json` carries the contiguous spelling for the machine.
+fn render_data_text(region: &Region, rows: &[DataRow], truncated: bool) -> String {
+    use std::fmt::Write as _;
+    let end = rows.last().map_or(region.start, |r| r.addr + r.bytes.len() as u64);
+    let mut out = String::new();
+    let plural = if end - region.start == 1 { "byte" } else { "bytes" };
+    let _ = writeln!(
+        out,
+        "# {} {plural} at {} (0x{:x}..0x{end:x}){}",
+        end - region.start,
+        label(region),
+        region.start,
+        if truncated { " [truncated: --bytes N or a 0xstart-0xend range reads more]" } else { "" }
+    );
+    for r in rows {
+        let _ = writeln!(
+            out,
+            "{:<14}{:<49}|{}|",
+            format!("0x{:x}", r.addr),
+            r.grouped(),
+            r.ascii()
+        );
+    }
+    out
+}
+
+/// What to call the start address in a header: its name and address when the
+/// program has a name for it, the bare address otherwise.
+fn label(region: &Region) -> String {
+    match &region.name {
+        Some(name) => format!("{name} @ 0x{:x}", region.start),
+        None => format!("0x{:x}", region.start),
+    }
+}
+
 // --- argument parsing --------------------------------------------------------
 
 pub(crate) fn parse_args(argv: &[String]) -> Result<DisArgs, String> {
     let mut positional: Vec<String> = Vec::new();
     let mut by_address = false;
+    let mut view: Option<ViewRequest> = None;
     let mut count: Option<usize> = None;
     let mut bytes: Option<u64> = None;
     let mut json = false;
@@ -461,6 +820,7 @@ pub(crate) fn parse_args(argv: &[String]) -> Result<DisArgs, String> {
         let a = argv[i].as_str();
         match a {
             "--addr" => by_address = true,
+            "--as" => view = Some(parse_view(&take(argv, &mut i, "--as")?)?),
             "--json" => json = true,
             "--count" => count = Some(parse_positive(&take(argv, &mut i, a)?, a)? as usize),
             "--bytes" => bytes = Some(parse_positive(&take(argv, &mut i, a)?, a)?),
@@ -499,6 +859,7 @@ pub(crate) fn parse_args(argv: &[String]) -> Result<DisArgs, String> {
         binary,
         spec,
         by_address,
+        view,
         count,
         bytes,
         json,
@@ -509,6 +870,15 @@ pub(crate) fn parse_args(argv: &[String]) -> Result<DisArgs, String> {
         target,
         sleighpath,
     })
+}
+
+fn parse_view(value: &str) -> Result<ViewRequest, String> {
+    match value {
+        "auto" => Ok(ViewRequest::Auto),
+        "code" => Ok(ViewRequest::Code),
+        "data" => Ok(ViewRequest::Data),
+        other => Err(format!("--as takes code|data|auto, got {other:?}")),
+    }
 }
 
 fn parse_positive(value: &str, flag: &str) -> Result<u64, String> {
@@ -529,8 +899,9 @@ fn take(argv: &[String], i: &mut usize, flag: &str) -> Result<String, String> {
 
 fn usage() {
     eprintln!(
-        "usage: kuna disassemble <binary> <name|0xaddr|0xstart-0xend> [--addr] [--count N] \\\n\
-         \x20                    [--bytes N] [--json] [--mode auto|reliable|aggressive|fast] \\\n\
+        "usage: kuna disassemble|read <binary> <name|0xaddr|0xstart-0xend> [--addr] \\\n\
+         \x20                    [--as code|data|auto] [--count N] [--bytes N] [--json] \\\n\
+         \x20                    [--mode auto|reliable|aggressive|fast] \\\n\
          \x20                    [--define-function S[-E][=N]|@FILE].. \\\n\
          \x20                    [--option N V].. [--slice ARCH] [--target T] [--sleighpath D]\n\
          \n\
@@ -539,12 +910,18 @@ fn usage() {
          A named function lists its whole extent; a raw address lists 64 bytes unless\n\
          --count / --bytes / a range says otherwise.\n\
          \n\
+         --as picks the view. `code` decodes instructions, `data` prints a hexdump,\n\
+         and `auto` (the default for `disassemble`) reads bytes when the address is\n\
+         in a non-executable data section. `kuna read` is the same command with\n\
+         `--as data` as its default.\n\
+         \n\
          --define-function <start[-end][=name] | @file> (repeatable) declares a\n\
          boundary first, so a name the image never carried becomes a valid target.\n\
          \n\
-         --json emits {{binary,target,start,end,count,bytes,truncated,instructions:\n\
-         [{{address,address_hex,size,bytes,mnemonic,operands,text}}]}}; without it, a\n\
-         header line and one address / bytes / text row per instruction."
+         --json emits {{binary,kind,target,start,end,count,bytes,truncated,notes}} plus\n\
+         instructions:[{{address,address_hex,size,bytes,mnemonic,operands,text}}] in the\n\
+         code view, or hex + rows:[{{address,address_hex,size,bytes,ascii}}] in the data\n\
+         view; without it, a header line and one row per instruction or 16 bytes."
     );
 }
 
@@ -571,6 +948,33 @@ mod tests {
     #[test]
     fn bytes_render_as_contiguous_lowercase_hex() {
         assert_eq!(row(0, &[0x48, 0x89, 0xe5], "MOV", "RBP,RSP").hex(), "4889e5");
+    }
+
+    #[test]
+    fn a_data_row_spells_its_bytes_three_ways() {
+        let r = DataRow { addr: 0x1000, bytes: (0u8..16).collect() };
+        assert_eq!(r.hex(), "000102030405060708090a0b0c0d0e0f");
+        assert_eq!(r.grouped(), "00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f");
+        assert_eq!(r.ascii(), "................");
+        let text = DataRow { addr: 0, bytes: b"kuna \x7f\"\\".to_vec() };
+        assert_eq!(text.ascii(), "kuna .\"\\", "0x7f is not printable; 0x20 and quotes are");
+    }
+
+    #[test]
+    fn the_view_flag_takes_three_spellings_and_nothing_else() {
+        assert_eq!(parse_view("auto"), Ok(ViewRequest::Auto));
+        assert_eq!(parse_view("code"), Ok(ViewRequest::Code));
+        assert_eq!(parse_view("data"), Ok(ViewRequest::Data));
+        assert!(parse_view("hex").is_err());
+        let argv: Vec<String> =
+            ["a.out", "0x1000", "--addr", "--as", "data"].iter().map(|s| s.to_string()).collect();
+        assert_eq!(parse_args(&argv).unwrap().view, Some(ViewRequest::Data));
+        // Unspecified stays unspecified, so each entry point can default it.
+        assert_eq!(parse_args(&["a.out".into(), "main".into()]).unwrap().view, None);
+        assert!(
+            parse_args(&["a.out".into(), "main".into(), "--as".into(), "asm".into()]).is_err(),
+            "an unknown view is a usage error"
+        );
     }
 
     #[test]
@@ -616,7 +1020,13 @@ mod tests {
 
     #[test]
     fn the_header_names_the_target_and_the_extent() {
-        let region = Region { start: 0x1000, end: Some(0x1004), name: Some("main".into()), derived: true };
+        let region = Region {
+            start: 0x1000,
+            end: Some(0x1004),
+            name: Some("main".into()),
+            derived: true,
+            from_entry: true,
+        };
         let rows = vec![row(0x1000, &[0x55], "PUSH", "RBP"), row(0x1001, &[0x48, 0x89, 0xe5], "MOV", "RBP,RSP")];
         let text = render_text(&region, &rows, false);
         let mut lines = text.lines();
@@ -626,5 +1036,58 @@ mod tests {
         );
         assert_eq!(lines.next().unwrap(), "0x1000        55                    PUSH RBP");
         assert!(render_text(&region, &rows, true).contains("[truncated:"));
+    }
+
+    #[test]
+    fn the_byte_header_counts_bytes_and_the_rows_are_xxd_shaped() {
+        let region = Region {
+            start: 0x400915,
+            end: Some(0x400925),
+            name: Some("s_400915".into()),
+            derived: false,
+            from_entry: false,
+        };
+        let rows = vec![DataRow { addr: 0x400915, bytes: b"Username: \0\x01\x02\x03\x04\x05".to_vec() }];
+        let text = render_data_text(&region, &rows, false);
+        let mut lines = text.lines();
+        assert_eq!(
+            lines.next().unwrap(),
+            "# 16 bytes at s_400915 @ 0x400915 (0x400915..0x400925)"
+        );
+        assert_eq!(
+            lines.next().unwrap(),
+            "0x400915      55 73 65 72 6e 61 6d 65 3a 20 00 01 02 03 04 05  |Username: ......|"
+        );
+        assert!(render_data_text(&region, &rows, true).contains("[truncated:"));
+    }
+
+    /// An explicit `--as` is the caller's, and `auto` only ever flips on the
+    /// loader's own classification — never on an entry, never on silence.
+    #[test]
+    fn the_view_choice_believes_the_caller_then_the_section_flags() {
+        let data = section_flags::DATA | section_flags::READONLY;
+        let code = section_flags::CODE | section_flags::READONLY;
+        use ViewRequest::{Auto, Code as WantCode, Data as WantData};
+        for (want, from_entry, flags, expect) in [
+            (Auto, false, Some(data), View::Data),
+            (Auto, false, Some(code), View::Code),
+            // A section marked BOTH (a Mach-O `__text` carrying data attributes)
+            // is code: the executable bit is the stronger claim.
+            (Auto, false, Some(data | code), View::Code),
+            // A discovered function is code wherever it was linked.
+            (Auto, true, Some(data), View::Code),
+            // No section covering the address: silence, not evidence.
+            (Auto, false, None, View::Code),
+            // The caller outranks all of it, in either direction.
+            (WantCode, false, Some(data), View::Code),
+            (WantData, true, Some(code), View::Data),
+            (WantData, false, None, View::Data),
+        ] {
+            assert_eq!(
+                decide_view(want, from_entry, flags),
+                expect,
+                "{want:?} / from_entry {from_entry} / flags {flags:?}"
+            );
+        }
     }
 }

--- a/decompiler/crates/kuna-cli/src/main.rs
+++ b/decompiler/crates/kuna-cli/src/main.rs
@@ -60,6 +60,7 @@ fn main() -> ExitCode {
         "unpack" => unpack::run(rest),
         "strings" => strings::run(rest),
         "disassemble" => disassemble::run(rest),
+        "read" => disassemble::run_read(rest),
         "xrefs" => xrefs::run(rest),
         "-V" | "--version" | "version" => {
             // Release CI bakes the repo-derived MAJOR.MINOR (docs/release.md)
@@ -87,7 +88,7 @@ fn main() -> ExitCode {
 
 fn usage() {
     eprintln!(
-        "usage: kuna <decompile|decompile-all|decompile-project|functions|disassemble|xrefs|strings|unpack|docs|test|catalog|modes|specs|fid> ...\n\
+        "usage: kuna <decompile|decompile-all|decompile-project|functions|disassemble|read|xrefs|strings|unpack|docs|test|catalog|modes|specs|fid> ...\n\
          \n\
          kuna decompile <binary> <func> [--addr] [--json] [--slice ARCH] [--language auto|c|rust] [--mode auto|reliable|aggressive|fast] [--option NAME VALUE]... [--kassert ARGS]... [--define-function S[-E][=N]|@FILE]...\n\
          kuna decompile-all <binary> [--json] [--functions a,b,..] [--addr 0xVMA]... [--no-vars] [--language auto|c|rust] [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] [--option N V]... [--define-function S[-E][=N]|@FILE]...\n\
@@ -96,7 +97,8 @@ fn usage() {
          kuna xrefs <binary> (--to <name|0xaddr> | --from <name|0xaddr>) [--json] [--kind call,jump,data,read,write] [--mode auto|reliable|aggressive|fast]\n\
          kuna unpack <binary> [-o OUT] [--json]\n\
          kuna strings <binary> [--json] [--min-length N] [--filter REGEX] [--encoding ascii|utf16|all] [--section NAME] [--no-xrefs]\n\
-         kuna disassemble <binary> <name|0xaddr|0xstart-0xend> [--addr] [--count N] [--bytes N] [--json] [--mode auto|reliable|aggressive|fast] [--option N V]... [--define-function S[-E][=N]|@FILE]... [--slice ARCH] [--target T] [--sleighpath D]\n\
+         kuna disassemble <binary> <name|0xaddr|0xstart-0xend> [--addr] [--as code|data|auto] [--count N] [--bytes N] [--json] [--mode auto|reliable|aggressive|fast] [--option N V]... [--define-function S[-E][=N]|@FILE]... [--slice ARCH] [--target T] [--sleighpath D]\n\
+         kuna read <binary> <name|0xaddr|0xstart-0xend> [--addr] [--bytes N] [--count N] [--json]   # the hexdump view of the same target\n\
          kuna docs [<topic>] [--json] [--all]\n\
          kuna test [--all|--unittests|--datatests] [--name N]... [--baseline F] [--save-baseline F] [--json]\n\
          kuna catalog [--json|--markdown|--check] [--option NAME] [--tier transform|analysis|core]\n\

--- a/decompiler/crates/kuna-cli/tests/disassemble_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/disassemble_cli.rs
@@ -87,13 +87,18 @@ fn is_specs_skip(message: &str) -> bool {
         || message.contains("Could not discover")
 }
 
-/// Drive the command in-process, exactly as `main.rs` will: parse the argv, then
+/// Drive the command in-process, exactly as `main.rs` does: parse the argv, then
 /// render. `None` is the missing-`.sla` skip.
 fn listing(argv: &[&str]) -> Option<String> {
+    rendered(argv).map(|(text, _)| text)
+}
+
+/// The same, keeping the notes the command would have put on stderr.
+fn rendered(argv: &[&str]) -> Option<(String, Vec<String>)> {
     let argv: Vec<String> = argv.iter().map(|s| (*s).to_string()).collect();
     let args = disassemble::parse_args(&argv).unwrap_or_else(|e| panic!("{argv:?}: {e}"));
     match disassemble::render(&args) {
-        Ok(text) => Some(text),
+        Ok(l) => Some((l.text, l.notes)),
         Err(e) if is_specs_skip(&e) => {
             eprintln!("skipping: {e}");
             None
@@ -142,6 +147,19 @@ fn as_u64(v: &Json) -> u64 {
     }
 }
 
+/// The `rows` array of a `--as data` document (the byte view's `instructions`).
+fn listed_rows(doc: &str) -> Vec<Vec<(String, Json)>> {
+    let pairs = parse_doc(doc);
+    let Json::Array(items) = field(&pairs, "rows") else { panic!("rows must be an array") };
+    items
+        .iter()
+        .map(|i| match i {
+            Json::Object(o) => o.clone(),
+            other => panic!("a row must be an object, got {other:?}"),
+        })
+        .collect()
+}
+
 fn instructions(doc: &str) -> Vec<Vec<(String, Json)>> {
     match field(&parse_doc(doc), "instructions") {
         Json::Array(items) => items
@@ -185,11 +203,14 @@ fn the_json_document_is_valid_and_carries_every_documented_field() {
         return;
     };
     let pairs = parse_doc(&doc);
-    for key in
-        ["binary", "target", "start", "start_hex", "end", "end_hex", "count", "bytes", "truncated", "instructions"]
-    {
+    for key in [
+        "binary", "kind", "target", "start", "start_hex", "end", "end_hex", "count", "bytes",
+        "truncated", "notes", "instructions",
+    ] {
         let _ = field(&pairs, key);
     }
+    assert_eq!(as_str(field(&pairs, "kind")), "code");
+    assert_eq!(field(&pairs, "notes"), &Json::Array(Vec::new()), "a code listing has nothing to say");
     assert_eq!(as_u64(field(&pairs, "start")), 0x40071d);
     assert_eq!(as_str(field(&pairs, "start_hex")), "0x40071d");
     let Json::Object(target) = field(&pairs, "target") else { panic!("target must be an object") };
@@ -254,7 +275,8 @@ fn an_explicit_range_lists_exactly_that_span() {
 }
 
 /// `--bytes N` is the other way to bound a region — the one an agent reaches for
-/// with a size in hand (a 197-byte decrypted payload, a 0x28-byte blob).
+/// with a size in hand (a 197-byte decrypted payload, a 0x28-byte blob). On a
+/// data address it bounds the byte view, which is the one `auto` picks there.
 #[test]
 fn bytes_bounds_the_listing_and_works_on_data() {
     let Some(doc) = listing(&[&fauxware(), "0x400915", "--addr", "--bytes", "16", "--json"]) else {
@@ -262,9 +284,18 @@ fn bytes_bounds_the_listing_and_works_on_data() {
     };
     let pairs = parse_doc(&doc);
     assert_eq!(as_u64(field(&pairs, "start")), 0x400915);
-    let end = as_u64(field(&pairs, "end"));
-    assert!(end >= 0x400925, "fewer than 16 bytes listed (end 0x{end:x}):\n{doc}");
-    assert!(!instructions(&doc).is_empty(), "a data address produced no rows:\n{doc}");
+    assert_eq!(as_u64(field(&pairs, "end")), 0x400925, "--bytes 16 is exactly 16 bytes:\n{doc}");
+    assert_eq!(as_str(field(&pairs, "kind")), "data", ".rodata is not an instruction stream");
+    assert!(!listed_rows(&doc).is_empty(), "a data address produced no rows:\n{doc}");
+
+    // Forced back to code, the same request is the instruction walk it always was.
+    let Some(code) =
+        listing(&[&fauxware(), "0x400915", "--addr", "--bytes", "16", "--as", "code", "--json"])
+    else {
+        return;
+    };
+    assert_eq!(as_str(field(&parse_doc(&code), "kind")), "code");
+    assert!(!instructions(&code).is_empty(), "--as code produced no instructions:\n{code}");
 }
 
 /// A named function lists its whole extent by default — the same clip
@@ -331,7 +362,8 @@ fn each_row_carries_its_own_bytes_contiguously() {
 /// byte that will not decode.
 #[test]
 fn undecodable_bytes_are_listed_in_place_and_a_string_symbol_resolves() {
-    let Some(doc) = listing(&[&fauxware(), "s_400915", "--bytes", "24", "--json"]) else {
+    let Some(doc) = listing(&[&fauxware(), "s_400915", "--bytes", "24", "--as", "code", "--json"])
+    else {
         return;
     };
     let pairs = parse_doc(&doc);
@@ -362,6 +394,94 @@ fn the_derived_cap_never_bounds_an_explicit_request() {
         return;
     };
     assert_eq!(instructions(&doc).len(), 1200, "--count above the cap was clipped");
+}
+
+// --- the byte view -----------------------------------------------------------
+
+/// The need this view closes: an agent inspecting the encoded globals at a data
+/// address got instructions back and left kuna for `xxd`
+/// (`docs/re-needs/cli-mode-read-raw.md`). Now the span comes back as one
+/// contiguous hex string, per-row bytes, and an ASCII gutter — and `auto` picks
+/// it without being asked, because `.rodata` is not an instruction stream.
+#[test]
+fn a_data_range_answers_with_its_bytes() {
+    let Some((doc, notes)) = rendered(&[&fauxware(), "0x400915-0x400925", "--json"]) else {
+        return;
+    };
+    let pairs = parse_doc(&doc);
+    assert_eq!(as_str(field(&pairs, "kind")), "data");
+    assert_eq!(as_u64(field(&pairs, "start")), 0x400915);
+    assert_eq!(as_u64(field(&pairs, "end")), 0x400925, "a byte view honors the end exactly");
+    assert_eq!(as_u64(field(&pairs, "bytes")), 16);
+    // objdump -s -j .rodata: "Username: " then a NUL then "Passw".
+    assert_eq!(as_str(field(&pairs, "hex")), "557365726e616d653a20005061737377");
+    // ...and the note that explains the view is on the record, not just on stderr.
+    assert_eq!(notes.len(), 1, "the inferred view must say so: {notes:?}");
+    assert!(notes[0].contains("non-executable"), "{notes:?}");
+    let Json::Array(carried) = field(&pairs, "notes") else { panic!("notes must be an array") };
+    assert_eq!(carried.len(), 1, "the JSON carries the same note the stderr does");
+
+    let rows = listed_rows(&doc);
+    assert_eq!(rows.len(), 1, "16 bytes is one row");
+    assert_eq!(as_str(field(&rows[0], "address_hex")), "0x400915");
+    assert_eq!(as_u64(field(&rows[0], "size")), 16);
+    assert_eq!(as_str(field(&rows[0], "ascii")), "Username: .Passw", "the gutter is printable-only");
+}
+
+/// `hex` is the whole span in one piece, and the rows are exactly that string
+/// cut into sixteens — a caller may use either and never both.
+#[test]
+fn the_span_hex_is_the_rows_joined() {
+    let Some(doc) = listing(&[&fauxware(), "0x4008c8", "--addr", "--bytes", "40", "--json"]) else {
+        return;
+    };
+    let pairs = parse_doc(&doc);
+    let rows = listed_rows(&doc);
+    assert_eq!(rows.len(), 3, "40 bytes is two full rows and a short one");
+    let joined: String = rows.iter().map(|r| as_str(field(r, "bytes")).to_string()).collect();
+    assert_eq!(as_str(field(&pairs, "hex")), joined);
+    assert_eq!(joined.len(), 80, "40 bytes is 80 hex characters");
+    for r in &rows {
+        assert_eq!(as_str(field(r, "bytes")).len() as u64, as_u64(field(r, "size")) * 2);
+    }
+    assert_eq!(as_u64(field(&rows[2], "size")), 8, "the last row is the remainder");
+}
+
+/// A code address stays code under `auto`, and `--as data` reads its bytes on
+/// demand — a packer puts real code in `.data` and the caller outranks the flags.
+#[test]
+fn the_view_is_the_callers_to_override() {
+    let Some((auto, notes)) = rendered(&[&fauxware(), "main", "--count", "1", "--json"]) else {
+        return;
+    };
+    assert_eq!(as_str(field(&parse_doc(&auto), "kind")), "code");
+    assert!(notes.is_empty(), "nothing was inferred, so nothing is said: {notes:?}");
+
+    let Some((forced, notes)) = rendered(&[&fauxware(), "main", "--bytes", "4", "--as", "data", "--json"])
+    else {
+        return;
+    };
+    let pairs = parse_doc(&forced);
+    assert_eq!(as_str(field(&pairs, "kind")), "data");
+    // objdump -d: main opens 55 48 89 e5.
+    assert_eq!(as_str(field(&pairs, "hex")), "554889e5");
+    assert!(notes.is_empty(), "an explicit --as is not explained back at the caller: {notes:?}");
+}
+
+/// The human byte surface is `xxd -g1` with kuna's address column.
+#[test]
+fn the_human_byte_surface_is_a_hexdump() {
+    let Some(text) = listing(&[&fauxware(), "0x400915", "--addr", "--bytes", "16"]) else {
+        return;
+    };
+    let mut lines = text.lines();
+    assert_eq!(lines.next().unwrap(), "# 16 bytes at s_400915 @ 0x400915 (0x400915..0x400925)");
+    assert_eq!(
+        lines.next().unwrap(),
+        "0x400915      55 73 65 72 6e 61 6d 65 3a 20 00 50 61 73 73 77  |Username: .Passw|"
+    );
+    assert!(lines.next().is_none(), "16 bytes is one row:\n{text}");
+    assert!(!text.contains('{'), "the human surface emitted JSON:\n{text}");
 }
 
 // --- the human surface -------------------------------------------------------
@@ -398,7 +518,7 @@ fn an_unmapped_address_fails_with_a_reason() {
         [fauxware(), "0xdeadbeef000".into(), "--addr".into()].into_iter().collect();
     let args = disassemble::parse_args(&argv).expect("a well-formed command line");
     match disassemble::render(&args) {
-        Ok(text) => panic!("an unmapped address must not produce a listing:\n{text}"),
+        Ok(l) => panic!("an unmapped address must not produce a listing:\n{}", l.text),
         Err(e) if is_specs_skip(&e) => eprintln!("skipping: {e}"),
         Err(e) => {
             assert!(e.contains("no bytes mapped"), "{e}");
@@ -413,7 +533,7 @@ fn an_unresolvable_name_fails_with_a_reason() {
     let argv: Vec<String> = [fauxware(), "no_such_symbol_here".into()].into_iter().collect();
     let args = disassemble::parse_args(&argv).expect("a well-formed command line");
     match disassemble::render(&args) {
-        Ok(text) => panic!("an unresolvable name must not produce a listing:\n{text}"),
+        Ok(l) => panic!("an unresolvable name must not produce a listing:\n{}", l.text),
         Err(e) if is_specs_skip(&e) => eprintln!("skipping: {e}"),
         Err(e) => {
             assert!(e.contains("no symbol named"), "{e}");
@@ -446,7 +566,7 @@ fn an_inverted_range_is_rejected() {
     let argv: Vec<String> = [fauxware(), "0x400680-0x400664".into()].into_iter().collect();
     let args = disassemble::parse_args(&argv).expect("a well-formed command line");
     match disassemble::render(&args) {
-        Ok(text) => panic!("an inverted range must not produce a listing:\n{text}"),
+        Ok(l) => panic!("an inverted range must not produce a listing:\n{}", l.text),
         Err(e) if is_specs_skip(&e) => eprintln!("skipping: {e}"),
         Err(e) => assert!(e.contains("empty range"), "{e}"),
     }
@@ -493,6 +613,50 @@ fn the_cli_exits_zero_and_prints_instructions() {
     assert_eq!(code, 0, "{stderr}");
     assert!(stdout.contains("PUSH RBP"), "{stdout}");
     assert!(stdout.contains("CALL 0x400510"), "{stdout}");
+}
+
+/// `kuna read` is the same command with the byte view as its default, so an
+/// agent that wants the bytes at an address does not have to know they are
+/// spelled `disassemble`. Through the binary, because the alias IS the dispatch.
+#[test]
+fn the_read_alias_prints_bytes_and_explains_nothing() {
+    if !dispatch_wired() {
+        return;
+    }
+    let (stdout, stderr, code) = run_kuna(&["read", &fauxware(), "main", "--bytes", "4"]);
+    if is_specs_skip(&stderr) {
+        eprintln!("skipping: {stderr}");
+        return;
+    }
+    assert_eq!(code, 0, "{stderr}");
+    assert!(stdout.contains("55 48 89 e5"), "{stdout}");
+    assert!(!stdout.contains("PUSH RBP"), "`read` must not disassemble:\n{stdout}");
+    // The view was asked for, not inferred, so there is nothing to explain.
+    assert!(!stderr.contains("note:"), "{stderr}");
+
+    // ...and the caller can still ask for instructions through it.
+    let (stdout, _, code) = run_kuna(&["read", &fauxware(), "main", "--count", "1", "--as", "code"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("PUSH RBP"), "--as code must win over the alias default:\n{stdout}");
+}
+
+/// The inferred view puts its reason on **stderr**, so `--json` stdout stays a
+/// document a caller can pipe straight into a parser.
+#[test]
+fn an_inferred_byte_view_explains_itself_on_stderr() {
+    if !dispatch_wired() {
+        return;
+    }
+    let (stdout, stderr, code) =
+        run_kuna(&["disassemble", &fauxware(), "0x400915-0x400925", "--json"]);
+    if is_specs_skip(&stderr) {
+        eprintln!("skipping: {stderr}");
+        return;
+    }
+    assert_eq!(code, 0, "{stderr}");
+    assert!(stderr.contains("non-executable data section"), "{stderr}");
+    assert!(stdout.trim_start().starts_with('{'), "stdout must be the document alone:\n{stdout}");
+    assert!(stdout.contains("557365726e616d653a20005061737377"), "{stdout}");
 }
 
 /// Usage errors are exit 2 with the usage block, never a silent empty listing.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -519,7 +519,7 @@ A target nothing references is exit `0` with `count: 0` — an answer, not a
 failure. A name that resolves to nothing is exit `1` with the reason on stderr; a
 malformed command line is exit `2` with the usage block.
 
-## `kuna disassemble` — instructions, when the pseudocode is not enough
+## `kuna disassemble` / `kuna read` — instructions or bytes, when the pseudocode is not enough
 
 ```bash
 kuna disassemble ./a.out main                    # a function, whole extent
@@ -527,6 +527,8 @@ kuna disassemble ./a.out main --json             # machine-readable
 kuna disassemble ./stripped.bin 0x8049850 --addr # a raw address
 kuna disassemble ./a.out 0x1140-0x11a0           # an explicit range
 kuna disassemble ./a.out 0x2010 --addr --bytes 64  # bytes no function owns
+kuna read ./a.out 0x100003f30 --addr --bytes 96  # a hexdump of a data address
+kuna disassemble ./packed.bin 0x2010 --addr --as code   # decode data as code anyway
 ```
 
 The floor to fall back to when the ceiling gives way. Every RE agent that asked
@@ -544,9 +546,9 @@ The target is a **name**, an **address**, or a **range**:
 | `0x8049850` (`--addr` for bare hex) | That function's extent if the address is a discovered entry; otherwise 64 bytes from exactly there. |
 | `0x1140-0x11a0`, `0x1140..0x11a0` | Exactly that half-open span — the direct replacement for `objdump -d --start-address=.. --stop-address=..`. |
 
-`--count N` stops after N instructions and `--bytes N` after N bytes; either
+`--count N` stops after N listed entries and `--bytes N` after N bytes; either
 overrides the derived extent, and a listing stops at whichever limit it reaches
-first. Also accepted: `--json` plus the shared `--mode`, `--option N V`,
+first. Also accepted: `--as`, `--json`, plus the shared `--mode`, `--option N V`,
 `--slice`, `--target`, `--sleighpath`.
 
 ```
@@ -569,21 +571,66 @@ space between mnemonic and operands — the same spelling `kuna xrefs` puts in i
 JSON. `--json` emits
 
 ```json
-{"binary": "...", "target": {"name","address","address_hex"},
+{"binary": "...", "kind": "code", "target": {"name","address","address_hex"},
  "start": N, "start_hex": "0x..", "end": N, "end_hex": "0x..",
- "count": N, "bytes": N, "truncated": false,
+ "count": N, "bytes": N, "truncated": false, "notes": [],
  "instructions": [{"address","address_hex","size","bytes","mnemonic","operands","text"}]}
 ```
 
 `bytes` on a row is that instruction's own bytes as contiguous lowercase hex
 (`"4889e5"`); `end` is one past the last instruction actually listed, so a
-truncated listing hands back the address to resume from.
+truncated listing hands back the address to resume from. `kind` is `"code"` here
+and `"data"` in the byte view below.
 
 Bytes the translator will not decode are listed in place as `.byte 0x<nn>` rows,
 one byte each, and the walk continues — a listing that ran into inline data says
-so where it happened instead of stopping silently. That is what makes the command
-usable on a **data** address: point it at a blob, a jump table, or a decrypted
-payload dumped to a file, and it prints what is there.
+so where it happened instead of stopping silently.
+
+### The byte view
+
+An instruction listing is the wrong answer for a data address, and for a while it
+was the only one on offer. An agent that asked kuna for the encoded globals at
+`0x100003f30` got `ADD byte ptr [RCX],AL` / `OR CL,byte ptr [RBX]` — a correct
+decode of `00 01 02 03 ..` and a lie about the program — and left for `xxd`.
+
+So the target picks its own rendering, and `--as` overrides it:
+
+| `--as` | What is listed |
+|---|---|
+| `auto` (default for `disassemble`) | Instructions, unless the start address is in a section the loader marks as data and not as code (`.rdata`, `.rodata`, `__TEXT,__const`) — then bytes, with the reason on **stderr**. A discovered function entry is always code, wherever it was linked. |
+| `code` | Instructions, whatever the section says. A packer puts real code in `.data`. |
+| `data` (default for `kuna read`) | Bytes, whatever the section says. |
+
+`kuna read` is the same command with `--as data` as its default — the spelling to
+reach for when what you want is the bytes, not a view of them as instructions.
+
+```
+$ kuna read ./crackme 0x100003f30 --addr --bytes 96
+# 96 bytes at 0x100003f30 (0x100003f30..0x100003f90)
+0x100003f30   00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f  |................|
+0x100003f40   10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10  |................|
+0x100003f50   20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20  |                |
+0x100003f60   25 73 00 43 72 61 63 6b 6d 65 20 4c 65 76 65 6c  |%s.Crackme Level|
+```
+
+Sixteen bytes a row, space-separated, with the printable-ASCII gutter — `xxd -g1`
+with kuna's own address column, so the two are diffable. `--json` replaces
+`instructions` with the contiguous span and its rows:
+
+```json
+{"binary": "...", "kind": "data", "target": {...},
+ "start": N, "start_hex": "0x..", "end": N, "end_hex": "0x..",
+ "count": N, "bytes": N, "truncated": false, "notes": ["..."],
+ "hex": "000102030405060708090a0b0c0d0e0f",
+ "rows": [{"address","address_hex","size","bytes","ascii"}]}
+```
+
+`hex` is the whole span in one piece and `rows[].bytes` is that same string cut
+into sixteens — use either, never both. `count` is the number of listed entries
+in both views (instructions, or hexdump rows); `bytes` is the span. A byte view
+honors the requested end exactly, where an instruction listing overshoots to the
+end of the instruction that straddles it. `notes` carries anything the command
+would have said on stderr, so a `--json` caller never has to read two streams.
 
 A listing whose length nobody asked for is capped at 1024 instructions, flagged
 `truncated` and marked in the header. The extent is only an upper bound — clipped

--- a/docs/features/cli-mode-read-raw/pr_body.md
+++ b/docs/features/cli-mode-read-raw/pr_body.md
@@ -1,0 +1,95 @@
+## The need
+
+`docs/re-needs/cli-mode-read-raw.md` (major, 1 instance, round 2, challenge `653d88600f4238b24302b0ec`):
+
+> **No CLI mode to read raw bytes from data addresses**
+> The new disassemble command returned raw instruction bytes, but there is no analogous data/hexdump mode; strings discarded non-printable constants.
+
+The tester wanted the encoded globals at `0x100003f30` — the `00..0f`, repeated `0x10`
+and repeated `0x20` vectors an initializer indexes. kuna answered with
+`ADD byte ptr [RCX],AL` / `OR CL,byte ptr [RBX]`: a correct decode of `00 01 02 03 ..`
+and a lie about the program. They left for `xxd -g1 -s 0x3f30 -l 96`.
+
+The companion need `disassembling-non-executable-rdata` is the same gap seen from the
+other side — `disassemble` decoding a PE `.rdata` range into `SBB`/`POP`/`PUSH`/`JNC`
+with nothing saying the range is non-executable.
+
+## The mechanism
+
+`kuna disassemble` becomes one command with **two renderings of one walk**, selected by
+`--as code|data|auto`:
+
+- **`auto`** (the default) asks the loader which section holds the start address. A
+  section carrying `DATA` without `CODE` (`.rdata`, `.rodata`, `__TEXT,__const`) holds
+  bytes, so it is shown as bytes — and the reason goes on **stderr**, so `--json` stdout
+  stays one document.
+- **`code`** and **`data`** override it in either direction. A packer puts real code in
+  `.data`; a compiler puts real data in `__TEXT`.
+- **`kuna read`** is the same command with `--as data` as its default — the spelling to
+  reach for when what you want is the bytes.
+
+Two exceptions keep the inference honest: a target that resolved to a **discovered
+function entry** is code wherever it was linked and is never reclassified, and an address
+in **no section the loader published** (the XML `<binaryimage>` corpus, a raw blob) is
+silence rather than evidence and keeps the instruction listing.
+
+The byte view is `xxd -g1` with kuna's address column, and its `--json` carries the span
+as one contiguous hex string alongside the per-row cut:
+
+```
+$ kuna read ./crackme0x04 0x100003f30 --addr --bytes 96
+# 96 bytes at 0x100003f30 (0x100003f30..0x100003f90)
+0x100003f30   00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f  |................|
+0x100003f40   10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10  |................|
+0x100003f50   20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20  |                |
+0x100003f60   25 73 00 43 72 61 63 6b 6d 65 20 4c 65 76 65 6c  |%s.Crackme Level|
+```
+
+Both views share one envelope (`binary, kind, target, start, end, count, bytes,
+truncated, notes`), so a consumer reads the same keys whichever answered; `kind` says
+which did.
+
+**Nothing about the decode changed.** No `phases.toml` row, no `options.rs`
+registration, no catalog counter, no stages XML, no DIV row: a rendering choice inside a
+read-only query surface cannot change emitted C.
+
+## The acceptance probe
+
+`a-ecb7f35d39aa` fails on `cb357826` and passes here:
+
+```
+$ kuna disassemble .../crackme0x04 0x100003f30-0x100003f40 --addr --json
+{ "kind": "data", ..., "hex": "000102030405060708090a0b0c0d0e0f", ... }
+```
+
+`scripts.repipe.verify --need cli-mode-read-raw` reports **PASS / transition `closed`**.
+
+Promoted to `tests/cli/cli-mode-read-raw.json`, re-pointed from the dataset crackme
+(CI has no dataset) at the in-repo Mach-O fixture `macho_imports`, whose
+`__TEXT,__cstring` at `0x1000005ee` is the same shape: data linked inside an executable
+segment. `make test-cli` is 15/15.
+
+The companion need's acceptance (`a-c42440103c7d`, a stderr warning on a non-executable
+range) also passes as a side effect — one surface answered both, as its triage note
+predicted. Its record is left for the captain to transition.
+
+## Gates
+
+| Gate | Result |
+|---|---|
+| `make test` | PARITY OK — 675/675 assertions |
+| `make test-stages` | PARITY OK — 597/597 assertions |
+| `make rust-test` | green — 5,296 passed / 1 failed / 38 ignored. The single failure is `verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip`, the known repipe-harness artifact: the loop exports `KUNA_DECOMP_TEST` pointing at a **Rust** `decomp_test_dbg`, so that test compares Rust against Rust. Re-run with it unset: 4/4 pass. |
+| `make check-spec` | OK |
+| `make test-cli` | 15/15 |
+| `kuna catalog --check` | catalog OK |
+| `kuna disassemble` suite | 96/96 (`cargo test -p kuna-cli --test disassemble_cli`) |
+
+**Sweep for the wrongness this could introduce** — a *code* target flipped to the byte
+view: every discovered entry (capped at 40/image) of all 73 binary fixtures under
+`kuna-analysis/tests/fixtures` + `tests/hang-repro`, through `disassemble --addr --count 1
+--json`. **1,299 entries answered `kind: "code"`; 0 flipped.** The 17 non-answers are the
+pre-existing unmapped-entry exit-1 path (an ET_REL undefined extern at a synthetic address,
+a `0x0` entry), which fails before view selection is reached.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/cli-mode-read-raw/record.json
+++ b/docs/features/cli-mode-read-raw/record.json
@@ -1,0 +1,64 @@
+{
+  "slug": "cli-mode-read-raw",
+  "need_id": "cli-mode-read-raw",
+  "track": "tooling",
+  "scope": "small",
+  "round": 2,
+  "branch": "feat/re-cli-mode-read-raw",
+  "summary": "kuna disassemble gains a byte view (--as code|data|auto, plus the `kuna read` spelling): a data address answers with a hexdump, an ASCII gutter and the span as one contiguous hex string, instead of a decode of .rodata into ADD/OR rows.",
+  "decisions": [
+    {
+      "what": "hypothesis UPHELD, but the remedy is a view on the existing walk, not a new memory-range surface",
+      "detail": "The need's hypothesis -- 'raw-byte exposure was implemented only for decoded instructions, not as a general memory-range view' -- is right about the gap. It is wrong about the cost: the walk already resolves names, addresses and explicit ranges, already reads the image's own bytes (ConsoleProgram::read_bytes_into), and already bounds itself with --count/--bytes/an extent. The only thing missing was a second RENDERING of what it already had. So this is one branch in render(), not a new command with its own target grammar -- which is also why `kuna read` could be a 3-line alias rather than a parallel implementation."
+    },
+    {
+      "what": "the view is INFERRED by default, not flag-gated, because the tester never knew to ask",
+      "detail": "A --as data that must be typed would have left the recorded symptom intact: the agent asked `disassemble 0x100003f30` and believed the ADD/OR rows. So `auto` consults the loader's own section classification -- DATA without CODE, kuna_sleigh::loadimage::section_flags -- and flips. Two guards keep the inference from being a guess: a target that resolved to a discovered function entry is code wherever it was linked (packed code in .data still decodes), and an address in NO published section is silence, not evidence, and keeps the instruction listing -- which is what leaves the XML <binaryimage> corpus and raw blobs untouched."
+    },
+    {
+      "what": "the note goes on stderr AND in the JSON, never in the stdout document",
+      "detail": "The one thing a rendering switch must not do is break the machine surface. render() returns a Listing { text, notes }; run() prints the notes to stderr and the document to stdout through the existing emit_with_status boundary (DIV-89). --json stdout is therefore still exactly one JSON value, and a JSON-only caller still sees the note in the document's own `notes` array. An explicit --as is the caller's decision and is not narrated back at them -- only an INFERRED flip is explained."
+    },
+    {
+      "what": "one surface closed a second, separately-filed need",
+      "detail": "`disassembling-non-executable-rdata` (a-c42440103c7d) asks for a stderr warning when a non-executable range is decoded as code. The auto-flip note satisfies it verbatim; its acceptance now PASSES on the PE dataset binary. Its record is left open for the captain to transition -- closing another need's record is not this worker's call. The round-2 T_DEDUP note predicted exactly this ('one subcommand plausibly answers both')."
+    },
+    {
+      "what": "no option, no stages XML, no catalog counter, no DIV row",
+      "detail": "A rendering choice inside a read-only query surface cannot change emitted C: nothing here is committed into the engine, no decompilation runs, and the diff is confined to kuna-cli/src/{disassemble.rs,main.rs} plus its Cargo edge. The kuna-decomp engine is untouched, which is also why this collides with neither builder live this wave."
+    }
+  ],
+  "inertness": {
+    "method": "no engine source is touched at all (git diff --stat: kuna-cli/src/disassemble.rs, kuna-cli/src/main.rs, kuna-cli/Cargo.toml, Cargo.lock, docs, tests), so emitted C cannot move; the parity gates confirm it",
+    "note": "The failure mode this change COULD have introduced is the opposite one -- a code target wrongly flipped to the byte view -- so the sweep below asks that question instead of the emitted-C one."
+  },
+  "sweep": {
+    "question": "does auto ever answer `data` for an address that is a real function entry?",
+    "method": "every discovered entry (capped at 40 per image) of every binary fixture under kuna-analysis/tests/fixtures and tests/hang-repro, through `kuna disassemble <f> <addr> --addr --count 1 --json`, asserting kind == \"code\"",
+    "result": "1,299 entries across 73 binary fixtures answered kind=\"code\"; 0 flipped to the byte view. The 17 non-answers are the PRE-EXISTING unmapped-entry exit-1 path (an ET_REL undefined extern at a synthetic address, a 0x0 entry) -- vma_bytes_mapped fails before view selection is ever reached, so they are unchanged by this PR."
+  },
+  "gates": {
+    "make test": "PARITY OK, 675/675 assertions",
+    "make test-stages": "PARITY OK, 597/597 assertions",
+    "make rust-test": "green \u2014 5,296 passed / 1 failed / 38 ignored. The single failure is `verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip`, the known repipe-harness artifact: the loop exports `KUNA_DECOMP_TEST` pointing at a **Rust** `decomp_test_dbg`, so that test compares Rust against Rust. Re-run with it unset: 4/4 pass.",
+    "make check-spec": "OK (lenient mode)",
+    "make test-cli": "15/15",
+    "kuna catalog --check": "catalog OK",
+    "cargo test -p kuna-cli --test disassemble_cli": "96/96"
+  },
+  "acceptance": {
+    "acceptance_id": "a-ecb7f35d39aa",
+    "result": "PASS",
+    "transition": "closed",
+    "promoted_to": "tests/cli/cli-mode-read-raw.json",
+    "promotion_note": "verify --promote refused (target.binary_source is 'dataset'; CI has no dataset). Re-pointed by hand at the in-repo Mach-O fixture macho_imports, whose __TEXT,__cstring at 0x1000005ee is the same shape -- data linked inside an executable segment -- and asserts `kind` as well as the span hex, because the regression to guard is not wrong bytes but no bytes.",
+    "reproduction_confirmed_on_main": "the acceptance FAILS on cb357826 on stdout_matches: the 16 bytes come back as per-instruction `0001`/`0203`/`0405` rows, never as one contiguous 000102..0f",
+    "side_effect": "disassembling-non-executable-rdata (a-c42440103c7d) also PASSES now; record left open for the captain"
+  },
+  "not_closed": [
+    "`strings` still discards non-printable constants -- the second half of the tester's sentence. A byte view answers 'show me these bytes', not 'inventory every constant table in the image'; that is strings-inventory-omits-statically.",
+    "There is no TYPED data view (read this as u32[8] / a pointer table / a C string). The hexdump plus the ASCII gutter is the floor, not the ceiling.",
+    "No caller-supplied data-vs-code ASSERTION: --as is per-invocation and does not durably tell the engine that a range is data. That is the still-open no-cli-data-code-override.",
+    "The section test is per-section, so a data blob inside a CODE section (an x86 jump table in .text, an ARM literal pool) still lists as instructions unless --as data is asked for. That is correct here -- the loader has no evidence to the contrary -- but it is a real remaining gap."
+  ]
+}

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -222,6 +222,29 @@ Four front-ends drive one engine assembly:
   (`decompiler/crates/kuna-wasm/src/classify.rs`), which a name test cannot do:
   loader names are demangled (`CellClass::Cell_Coord`) and symbol-table names are
   not.
+
+  (kuna) **The listing surfaces read the same section flags to choose a view.**
+  `kuna disassemble` and its `kuna read` spelling
+  (`decompiler/crates/kuna-cli/src/disassemble.rs (render)`) are one command with
+  two renderings of one walk: decoded instructions, or the bytes as a hexdump
+  with an ASCII gutter and, under `--json`, the span as one contiguous hex
+  string. `--as code|data|auto` selects, and `auto` — the default for
+  `disassemble`, where `read` defaults to `data` — decides from the loader's own
+  classification of the section holding the start address
+  (`decompiler/crates/kuna-cli/src/disassemble.rs (decide_view)`): a section
+  carrying `DATA` without `CODE`
+  (`decompiler/crates/kuna-sleigh/src/loadimage.rs (section_flags)`) holds bytes,
+  so it is shown as bytes. Two exceptions keep the inference honest. A target that
+  resolved to a discovered function entry is code wherever it was linked, so it is
+  never reclassified; and an address in no section the loader published — the XML
+  `<binaryimage>` corpus, a raw blob — is silence rather than evidence and keeps
+  the instruction listing. Only an inferred flip is explained, on stderr and in
+  the JSON `notes`, so `--json` stdout stays one document; an explicit `--as` is
+  the caller's decision and is not narrated back at them. This exists because the
+  instruction view alone is a wrong answer that reads like a right one: `.rdata`
+  and `__TEXT,__const` decode perfectly well into `ADD`/`OR` rows that describe
+  nothing in the program, which is what sent two RE-loop testers to `xxd` and
+  `objdump -s` (`docs/re-needs/cli-mode-read-raw.md`).
 - **`kuna_ghidra`** (`decompiler/crates/kuna-ghidra/src/bin/kuna_ghidra.rs`) —
   the ghidra-mode process front-end: the stock Ghidra GUI spawns it as its
   decompiler core and talks the burst-framed stdin/stdout protocol

--- a/tests/cli/cli-mode-read-raw.json
+++ b/tests/cli/cli-mode-read-raw.json
@@ -1,0 +1,55 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "disassemble",
+    "{{BIN}}",
+    "0x1000005ee-0x1000005fe",
+    "--addr",
+    "--json"
+  ],
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/macho_imports",
+    "binary_sha256": "0394e1be81c4ccdfb28a50cf5dba55a6d95a692cd5504f2305a8f139e8f86675",
+    "binary_size": 16688,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/macho_imports",
+    "selector": "0x1000005ee-0x1000005fe",
+    "selector_kind": "addr"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "stdout_matches": [
+      "25640a000000010000001c0000000100"
+    ],
+    "json": [
+      {
+        "path": "kind",
+        "op": "eq",
+        "value": "data"
+      },
+      {
+        "path": "hex",
+        "op": "eq",
+        "value": "25640a000000010000001c0000000100"
+      },
+      {
+        "path": "bytes",
+        "op": "eq",
+        "value": 16
+      },
+      {
+        "path": "rows[0].ascii",
+        "op": "eq",
+        "value": "%d.............."
+      }
+    ]
+  },
+  "notes": "The acceptance asserted the same span hex on the dataset crackme0x04; CI has no dataset, so it is re-pointed at the in-repo Mach-O fixture, whose __TEXT,__cstring is the same shape: data inside an executable segment, which is what made the original read back as ADD/OR. `kind` is asserted too -- the regression to guard is not wrong bytes but no bytes, the range decoded as code again."
+}


### PR DESCRIPTION
## The need

`docs/re-needs/cli-mode-read-raw.md` (major, 1 instance, round 2, challenge `653d88600f4238b24302b0ec`):

> **No CLI mode to read raw bytes from data addresses**
> The new disassemble command returned raw instruction bytes, but there is no analogous data/hexdump mode; strings discarded non-printable constants.

The tester wanted the encoded globals at `0x100003f30` — the `00..0f`, repeated `0x10`
and repeated `0x20` vectors an initializer indexes. kuna answered with
`ADD byte ptr [RCX],AL` / `OR CL,byte ptr [RBX]`: a correct decode of `00 01 02 03 ..`
and a lie about the program. They left for `xxd -g1 -s 0x3f30 -l 96`.

The companion need `disassembling-non-executable-rdata` is the same gap seen from the
other side — `disassemble` decoding a PE `.rdata` range into `SBB`/`POP`/`PUSH`/`JNC`
with nothing saying the range is non-executable.

## The mechanism

`kuna disassemble` becomes one command with **two renderings of one walk**, selected by
`--as code|data|auto`:

- **`auto`** (the default) asks the loader which section holds the start address. A
  section carrying `DATA` without `CODE` (`.rdata`, `.rodata`, `__TEXT,__const`) holds
  bytes, so it is shown as bytes — and the reason goes on **stderr**, so `--json` stdout
  stays one document.
- **`code`** and **`data`** override it in either direction. A packer puts real code in
  `.data`; a compiler puts real data in `__TEXT`.
- **`kuna read`** is the same command with `--as data` as its default — the spelling to
  reach for when what you want is the bytes.

Two exceptions keep the inference honest: a target that resolved to a **discovered
function entry** is code wherever it was linked and is never reclassified, and an address
in **no section the loader published** (the XML `<binaryimage>` corpus, a raw blob) is
silence rather than evidence and keeps the instruction listing.

The byte view is `xxd -g1` with kuna's address column, and its `--json` carries the span
as one contiguous hex string alongside the per-row cut:

```
$ kuna read ./crackme0x04 0x100003f30 --addr --bytes 96
# 96 bytes at 0x100003f30 (0x100003f30..0x100003f90)
0x100003f30   00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f  |................|
0x100003f40   10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10  |................|
0x100003f50   20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20  |                |
0x100003f60   25 73 00 43 72 61 63 6b 6d 65 20 4c 65 76 65 6c  |%s.Crackme Level|
```

Both views share one envelope (`binary, kind, target, start, end, count, bytes,
truncated, notes`), so a consumer reads the same keys whichever answered; `kind` says
which did.

**Nothing about the decode changed.** No `phases.toml` row, no `options.rs`
registration, no catalog counter, no stages XML, no DIV row: a rendering choice inside a
read-only query surface cannot change emitted C.

## The acceptance probe

`a-ecb7f35d39aa` fails on `cb357826` and passes here:

```
$ kuna disassemble .../crackme0x04 0x100003f30-0x100003f40 --addr --json
{ "kind": "data", ..., "hex": "000102030405060708090a0b0c0d0e0f", ... }
```

`scripts.repipe.verify --need cli-mode-read-raw` reports **PASS / transition `closed`**.

Promoted to `tests/cli/cli-mode-read-raw.json`, re-pointed from the dataset crackme
(CI has no dataset) at the in-repo Mach-O fixture `macho_imports`, whose
`__TEXT,__cstring` at `0x1000005ee` is the same shape: data linked inside an executable
segment. `make test-cli` is 15/15.

The companion need's acceptance (`a-c42440103c7d`, a stderr warning on a non-executable
range) also passes as a side effect — one surface answered both, as its triage note
predicted. Its record is left for the captain to transition.

## Gates

| Gate | Result |
|---|---|
| `make test` | PARITY OK — 675/675 assertions |
| `make test-stages` | PARITY OK — 597/597 assertions |
| `make rust-test` | green — 5,296 passed / 1 failed / 38 ignored. The single failure is `verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip`, the known repipe-harness artifact: the loop exports `KUNA_DECOMP_TEST` pointing at a **Rust** `decomp_test_dbg`, so that test compares Rust against Rust. Re-run with it unset: 4/4 pass. |
| `make check-spec` | OK |
| `make test-cli` | 15/15 |
| `kuna catalog --check` | catalog OK |
| `kuna disassemble` suite | 96/96 (`cargo test -p kuna-cli --test disassemble_cli`) |

**Sweep for the wrongness this could introduce** — a *code* target flipped to the byte
view: every discovered entry (capped at 40/image) of all 73 binary fixtures under
`kuna-analysis/tests/fixtures` + `tests/hang-repro`, through `disassemble --addr --count 1
--json`. **1,299 entries answered `kind: "code"`; 0 flipped.** The 17 non-answers are the
pre-existing unmapped-entry exit-1 path (an ET_REL undefined extern at a synthetic address,
a `0x0` entry), which fails before view selection is reached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
