### PR TITLE
[AUTOMATED] perf(p2): decompiling-3396-byte-main — dead-list position was O(N) per op; 71.5s -> 19.4s

### DIFF
--- a/decompiler/crates/kuna-decomp/src/infra/action.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/action.rs
@@ -1098,6 +1098,20 @@ pub struct ActionPool {
     /// last; otherwise the [`SeqNum`] of the *next* op to visit (see module
     /// docs for why this is a key, not a live iterator).
     op_state: OpCursor,
+    /// The [`OpId`] the cursor resolves to, memoized by
+    /// [`advance_op_state`](ActionPool::advance_op_state).
+    ///
+    /// The C++ `op_state` is a `std::map::iterator`, so `++op_state` and the
+    /// following deref are both O(1); re-deriving the position from a [`SeqNum`]
+    /// costs an optree range search *per op per rule pass*, and the pool is the
+    /// decompiler's innermost loop.  The advance already performs that search to
+    /// decide `After`/`Done`, so it keeps the answer and
+    /// [`current_op`](ActionPool::current_op) reads it instead of searching
+    /// again.  Only valid within one [`apply`](ActionPool::apply) call: the sole
+    /// mutation between the advance and the next read is the `destroy(op)` of the
+    /// op just consumed, which cannot move its own successor.  Every `apply`
+    /// return path clears it, so a resumed or interleaved pass re-searches.
+    next_op: Option<OpId>,
     /// Iterator over rules for one OpCode (C++ `rule_index`).
     rule_index: usize,
     /// Messages emitted mid-[`process_op`] (rule warnings).  `process_op` is a
@@ -1135,6 +1149,7 @@ impl ActionPool {
             allrules: Vec::new(),
             perop: vec![PerOp::new(); OpCode::CPUI_MAX as usize],
             op_state: OpCursor::Unstarted,
+            next_op: None,
             rule_index: 0,
             warnings: WarningSink::new(),
             pending_error: None,
@@ -1258,19 +1273,19 @@ impl ActionPool {
             .get(op)
             .map(|o| o.get_seq_num().clone())
             .expect("advance_op_state: op already gone");
-        // Is there any optree entry strictly greater than sq?  Only existence
-        // matters here, so probe with first_after_seq (O(log n)) rather than
-        // cloning the successor key just to throw it away.
-        self.op_state = if data.obank().first_after_seq(&sq).is_some() {
-            OpCursor::After(sq)
-        } else {
-            OpCursor::Done
-        };
+        // One optree probe answers both questions the cursor has: whether a
+        // successor exists, and which op it is.  Keep the id so `current_op` does
+        // not repeat the search.
+        self.next_op = data.obank().first_after_seq_id(&sq);
+        self.op_state = if self.next_op.is_some() { OpCursor::After(sq) } else { OpCursor::Done };
     }
 
     /// The op the cursor currently points at (C++ `(*op_state).second`), or
     /// `None` at end.  `Unstarted` points at the first optree entry.
     fn current_op(&self, data: &Funcdata) -> Option<OpId> {
+        if let Some(op) = self.next_op {
+            return Some(op);
+        }
         match &self.op_state {
             OpCursor::Unstarted => data.obank().iter_all().next().map(|(_, id)| id),
             OpCursor::After(sq) => first_op_after(data, sq),
@@ -1341,6 +1356,7 @@ impl Action for ActionPool {
             self.op_state = OpCursor::Unstarted;
             self.rule_index = 0;
         }
+        self.next_op = None;
         let mut ops_since_deadline_probe: u32 = 0;
         while let Some(op) = self.current_op(data) {
             // (kuna decompile-all watchdog) Cooperative deadline in the tight
@@ -1351,16 +1367,19 @@ impl Action for ActionPool {
             if ops_since_deadline_probe >= POOL_DEADLINE_STRIDE {
                 ops_since_deadline_probe = 0;
                 if ctx.deadline_expired() {
+                    self.next_op = None;
                     self.drain_into(ctx);
                     return 0;
                 }
             }
             let r = self.process_op(op, data);
             if r != 0 {
+                self.next_op = None;
                 self.drain_into(ctx);
                 return -1;
             }
         }
+        self.next_op = None;
         self.drain_into(ctx);
         0 // Indicate successful completion
     }

--- a/decompiler/crates/kuna-decomp/src/p2_lift/flow.rs
+++ b/decompiler/crates/kuna-decomp/src/p2_lift/flow.rs
@@ -871,16 +871,9 @@ impl<'a, E: FlowEnvironment> FlowInfo<'a, E> {
     }
 
     /// The successor of `op` in the global \e dead list (C++ `++op->getInsertIter()`
-    /// while the op is dead), or `None` at the end.  Reconstructed from the bank's
-    /// forward dead-list iteration (op.rs owns the intrusive links privately).
+    /// while the op is dead), or `None` at the end.
     fn dead_next(&self, op: OpId) -> Option<OpId> {
-        let mut it = self.data.obank().iter_dead();
-        for cur in it.by_ref() {
-            if cur == op {
-                return it.next();
-            }
-        }
-        None
+        self.data.obank().dead_next(op)
     }
 
     // -----------------------------------------------------------------------
@@ -1005,17 +998,15 @@ impl<'a, E: FlowEnvironment> FlowInfo<'a, E> {
             Some(s) => s,
             None => return Ok(()), // oiter == endDead(): nothing to delete
         };
-        // Collect [start .. endDead()) in dead-list order.
-        let dead: Vec<OpId> = self.data.obank().iter_dead().collect();
-        let mut hit = false;
+        // Collect [start .. endDead()) by walking the dead list forward from
+        // `start`.  A `start` that is no longer on the list deletes nothing (the
+        // bank's dead-list navigation reports non-membership as `None`).
         let mut victims: Vec<OpId> = Vec::new();
-        for op in dead {
-            if op == start {
-                hit = true;
-            }
-            if hit {
-                victims.push(op);
-            }
+        let mut cur =
+            if self.data.obank().on_dead_list(start) { Some(start) } else { None };
+        while let Some(op) = cur {
+            victims.push(op);
+            cur = self.data.obank().dead_next(op);
         }
         for op in victims {
             //   -- STUB(W3-funcdata): op_destroy_raw needs destroyVarnode; the
@@ -1447,10 +1438,10 @@ impl<'a, E: FlowEnvironment> FlowInfo<'a, E> {
 
     /// First / last op of the global dead list (helpers for the marker idiom).
     fn dead_head(&self) -> Option<OpId> {
-        self.data.obank().iter_dead().next()
+        self.data.obank().dead_front()
     }
     fn dead_tail(&self) -> Option<OpId> {
-        self.data.obank().iter_dead().last()
+        self.data.obank().dead_back()
     }
 
     // -----------------------------------------------------------------------

--- a/decompiler/crates/kuna-decomp/src/substrate/funcdata_block.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/funcdata_block.rs
@@ -2483,6 +2483,17 @@ impl Funcdata {
         self.jumpvec_mut()[jt_idx].increment_recovery_count();
 
         // Build the partial function (clone ops + jump-tables).
+        //
+        // (kuna DIVERGENCE, deliberate) The C++ builds ONE `partial` per call to
+        // `FlowInfo::recoverJumpTables` and guards the clone + reduced pipeline
+        // behind `if (!partial.isJumptableRecoveryOn())`, so the sub-decompilation
+        // runs once per function instead of once per table.  kuna cannot share it:
+        // `option unrolledguard` recovers MSVC interleaved (Duff's-device) tables
+        // precisely BECAUSE each table's partial re-clones the siblings recovered
+        // before it (see `flow.rs (FlowInfo::collect_edges)`), and sharing the
+        // partial loses 16 of the 17 switches that testcase asserts.  Sharing is a
+        // real speedup (~20% on a two-table function) but it changes which tables
+        // recover, so it belongs behind its own option, not here.
         let mut partial = match self.build_jumptable_partial() {
             Ok(p) => p,
             Err(_) => return RecoveryMode::FailNormal,

--- a/decompiler/crates/kuna-decomp/src/substrate/funcdata_op.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/funcdata_op.rs
@@ -2424,27 +2424,13 @@ impl Funcdata {
     /// before blocks are calculated (all ops still on the dead list).
     pub fn op_target(&self, op: OpId) -> OpId {
         let dead = self.obank().get(op).expect("op_target: stale op").is_dead();
-        // For the dead case the C++ walks the global dead list backward via
-        // `insertiter`.  op.rs owns the dead-list intrusive links privately and
-        // exposes only forward iteration ([`iter_dead`]); reconstruct the
-        // predecessor map once (semantically identical — the dead list is a plain
-        // doubly-linked list, so `--insertiter` is the previous element).
-        let dead_prev: std::collections::BTreeMap<OpId, OpId> = if dead {
-            let order: Vec<OpId> = self.obank().iter_dead().collect();
-            order
-                .windows(2)
-                .map(|w| (w[1], w[0])) // prev-of(w[1]) == w[0]
-                .collect()
-        } else {
-            std::collections::BTreeMap::new()
-        };
         let mut retop = op;
         while (self.obank().get(retop).expect("op_target").get_flags() & pcodeop_flags::startmark)
             == 0
         {
             retop = if dead {
-                *dead_prev
-                    .get(&retop)
+                self.obank()
+                    .dead_prev(retop)
                     .expect("op_target: walked past dead-list begin (C++ UB)")
             } else {
                 self.obank()

--- a/decompiler/crates/kuna-decomp/src/substrate/op.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/op.rs
@@ -1852,6 +1852,16 @@ impl PcodeOpBank {
     /// The first optree entry strictly greater than `sq` (C++ `++op_state`).
     /// O(log n) `BTreeMap::range` — the ActionPool op-cursor advance, which the
     /// C++ does in O(1) by incrementing a `PcodeOpTree::const_iterator`.
+    /// The [`OpId`] of the first optree entry strictly after `sq` (C++
+    /// `++op_state` then deref), or `None` when `sq` is the last.
+    ///
+    /// The id-only form exists so the pool cursor can memoize the successor from
+    /// the same search that decides whether one exists, instead of searching once
+    /// to test and again to dereference.
+    pub fn first_after_seq_id(&self, sq: &SeqNum) -> Option<OpId> {
+        self.first_after_seq(sq).map(|(_, id)| id)
+    }
+
     pub fn first_after_seq(&self, sq: &SeqNum) -> Option<(&SeqNum, OpId)> {
         // Borrow `sq` into the range bound (the `(Bound<&T>, Bound<&T>)`
         // RangeBounds impl) so the per-op cursor advance does not clone the key.
@@ -1918,6 +1928,53 @@ impl PcodeOpBank {
     /// Iterate the dead list in order (C++ `beginDead`..`endDead`).
     pub fn iter_dead(&self) -> impl Iterator<Item = OpId> + '_ {
         self.deadlist.iter(&self.arena, ListKind::Insert)
+    }
+
+    /// `true` if `op` is currently linked into the dead list.
+    ///
+    /// The `dead` flag alone is not sufficient: [`destroy`](Self::destroy) retires
+    /// an op to `deadandgone` with the flag still set (the C++ keeps the heap
+    /// object marked dead), so membership is the flag plus a live link — or being
+    /// the head, for a single-element list.
+    pub fn on_dead_list(&self, op: OpId) -> bool {
+        match self.arena.get(op) {
+            None => false,
+            Some(o) => {
+                if !o.is_dead() {
+                    return false;
+                }
+                let (prev, next) = o.links.get(ListKind::Insert);
+                prev.is_some() || next.is_some() || self.deadlist.head == Some(op)
+            }
+        }
+    }
+
+    /// First op of the dead list (C++ `beginDead()`), or `None` when empty.
+    pub fn dead_front(&self) -> Option<OpId> {
+        self.deadlist.head
+    }
+
+    /// Last op of the dead list (C++ `--endDead()`), or `None` when empty.
+    pub fn dead_back(&self) -> Option<OpId> {
+        self.deadlist.tail
+    }
+
+    /// The dead-list successor of `op` (C++ `++insertiter`), or `None` when `op`
+    /// is last or is not on the dead list at all.
+    pub fn dead_next(&self, op: OpId) -> Option<OpId> {
+        if !self.on_dead_list(op) {
+            return None;
+        }
+        self.arena[op].links.get(ListKind::Insert).1
+    }
+
+    /// The dead-list predecessor of `op` (C++ `--insertiter`), or `None` when
+    /// `op` is first or is not on the dead list at all.
+    pub fn dead_prev(&self, op: OpId) -> Option<OpId> {
+        if !self.on_dead_list(op) {
+            return None;
+        }
+        self.arena[op].links.get(ListKind::Insert).0
     }
 
     /// Number of ops in the alive list.
@@ -2083,6 +2140,66 @@ mod tests {
         bank.mark_dead(b);
         assert_eq!(bank.iter_dead().collect::<Vec<_>>(), vec![c, b]);
         assert_eq!(bank.iter_alive().collect::<Vec<_>>(), vec![a]);
+    }
+
+    /// The O(1) dead-list cursor must agree with a full `iter_dead()` scan for
+    /// every position, and must report non-membership (alive, or destroyed) as
+    /// `None` exactly as the scan did.
+    #[test]
+    fn dead_cursor_matches_a_full_scan() {
+        let m = build_manager();
+        let mut bank = PcodeOpBank::new();
+        assert_eq!(bank.dead_front(), None);
+        assert_eq!(bank.dead_back(), None);
+        let ops: Vec<OpId> = (0..5).map(|i| bank.create_at(0, ram(&m, 0x10 * i))).collect();
+
+        let scan: Vec<OpId> = bank.iter_dead().collect();
+        assert_eq!(scan, ops);
+        assert_eq!(bank.dead_front(), Some(ops[0]));
+        assert_eq!(bank.dead_back(), Some(ops[4]));
+        // Forward: dead_next(scan[i]) == scan[i+1], None at the tail.
+        for (i, &op) in scan.iter().enumerate() {
+            assert_eq!(bank.dead_next(op), scan.get(i + 1).copied(), "next of #{i}");
+            assert_eq!(
+                bank.dead_prev(op),
+                if i == 0 { None } else { Some(scan[i - 1]) },
+                "prev of #{i}"
+            );
+        }
+        // An op on the ALIVE list shares the `insertiter` links, so membership --
+        // not just "has a link" -- is what the cursor must test.
+        bank.mark_alive(ops[2]);
+        assert_eq!(bank.dead_next(ops[2]), None);
+        assert_eq!(bank.dead_prev(ops[2]), None);
+        assert_eq!(bank.dead_next(ops[1]), Some(ops[3]));
+        assert_eq!(bank.dead_prev(ops[3]), Some(ops[1]));
+        // A destroyed op keeps the `dead` flag but leaves the list.
+        bank.destroy(ops[0]);
+        assert_eq!(bank.dead_next(ops[0]), None);
+        assert_eq!(bank.dead_prev(ops[0]), None);
+        assert_eq!(bank.dead_front(), Some(ops[1]));
+        // Single element: front == back, no neighbours.
+        bank.destroy(ops[3]);
+        bank.destroy(ops[4]);
+        assert_eq!(bank.dead_front(), Some(ops[1]));
+        assert_eq!(bank.dead_back(), Some(ops[1]));
+        assert_eq!(bank.dead_next(ops[1]), None);
+        assert_eq!(bank.dead_prev(ops[1]), None);
+    }
+
+    /// `first_after_seq_id` is the id-only form the pool cursor memoizes; it must
+    /// name the same op `first_after_seq` does at every position.
+    #[test]
+    fn first_after_seq_id_agrees_with_first_after_seq() {
+        let m = build_manager();
+        let mut bank = PcodeOpBank::new();
+        let ops: Vec<OpId> = (0..4).map(|i| bank.create_at(0, ram(&m, 0x10 * i))).collect();
+        for &op in &ops {
+            let sq = bank.get(op).unwrap().get_seq_num().clone();
+            assert_eq!(bank.first_after_seq_id(&sq), bank.first_after_seq(&sq).map(|(_, id)| id));
+        }
+        let last = bank.get(*ops.last().unwrap()).unwrap().get_seq_num().clone();
+        assert_eq!(bank.first_after_seq_id(&last), None);
     }
 
     #[test]

--- a/docs/features/decompiling-3396-byte-main/pr_body.md
+++ b/docs/features/decompiling-3396-byte-main/pr_body.md
@@ -1,0 +1,126 @@
+## What was broken
+
+RE-need `decompiling-3396-byte-main` (round 2, track `perf`, 1 instance,
+challenge `69a3822f7b3cc38c80464da4`):
+
+> **Decompiling the 3396-byte main function takes about 68 seconds** (major)
+> The command produced no output for roughly 68 seconds, then emitted about 30 KB of
+> highly noisy pseudocode. […] this observation is specifically about latency.
+
+Reproduced at **71.5 s median** for `kuna decompile <bin> sub_140023350`.
+
+## The cause is not what was filed
+
+The filed hypothesis was "opaque arithmetic and indirect calls make an analysis pass
+scale poorly". The symptom stands, the diagnosis does not: gdb-sampled profiling put
+**53% of wall time in one leaf frame, `FlowInfo::xref_control_flow`** — the *lifter*,
+before any analysis runs. This function is unusual only in op count (48,169 raw ops,
+37,710 of them INDIRECTs across 365 call sites), and op count is exactly what the real
+defect squares.
+
+**The dead list is a doubly-linked list whose links three call sites refused to use.**
+The C++ caches a `std::list<PcodeOp*>::iterator` on every op (`insertiter`), so "the op
+after this one" and "the last op" are O(1). kuna's dead list *is* that list —
+`op.rs (IntrusiveList)` keeps prev/next `OpId` links on each op — but position was being
+re-derived by scanning:
+
+| site | what it did | how often |
+|---|---|---|
+| `FlowInfo::dead_next` | scanned all of `iter_dead()` to locate one op | once per emitted p-code op |
+| `FlowInfo::dead_tail` | `iter_dead().last()` | once per decoded instruction (the marker idiom) |
+| `FlowInfo::delete_remaining_ops` | collected the whole list to find a suffix | once per terminating instruction |
+| `Funcdata::op_target` | rebuilt an entire `BTreeMap` predecessor index | once per call |
+
+The list grows to the whole function, so this is O(N²) in op count. It is invisible on
+small functions and quadratic on the ones an RE actually cares about.
+
+## The mechanism
+
+1. **`op.rs`** — expose what the list already carries: `PcodeOpBank::dead_front` /
+   `dead_back` / `dead_next` / `dead_prev`. Membership is the `dead` flag **plus a live
+   link**, because `destroy()` retires an op to `deadandgone` with the flag still set and
+   the alive list shares the same link pair; a non-member reports `None`, exactly what a
+   scan for an absent op returned.
+2. **`flow.rs` / `funcdata_op.rs`** — the four sites above use those accessors.
+3. **`action.rs`** — `ActionPool::advance_op_state` already ran the optree search that
+   decides `After`/`Done`, so it now keeps the successor's `OpId` and `current_op` reads
+   it instead of searching a second time for the op the advance already found. The memo is
+   dropped on every `apply()` exit, so a resumed or interleaved sweep re-searches.
+
+No option: none of this can change emitted C, so `docs/agents.md`'s flag rule does not
+apply. `phases.toml`, `options.rs`, the catalog counters, `docs/options.md` and
+`docs/history.md` are untouched.
+
+## Measured
+
+Interleaved A/B (base and new binaries alternating in one loop; machine load 5–7 from
+sibling builders, so both median and min are reported):
+
+| run | base | new | delta |
+|---|---|---|---|
+| `kuna decompile <bin> sub_140023350` (the probe), median of 5 | **71.46 s** | **19.42 s** | **−72.8%** |
+| same, min of 5 | 69.14 s | 18.44 s | −73.3% |
+| `kuna decompile-all --addr 0x140023350`, median of 3 | 40.05 s | 14.24 s | −64.4% |
+| `kuna decompile-all /bin/gzip` (145 functions), median of 3 | 14.55 s | 13.60 s | −6.5% |
+
+The base and new distributions do not overlap: max(new) = 23.35 s < min(base) = 69.14 s.
+The gzip row is the honest control — small functions barely feel a quadratic in op count.
+
+**Output is byte-identical.** Whole-binary `decompile-all --json` captures from an
+interleaved before/after build pair compare byte-for-byte on three binaries / 509
+functions: the probe crackme (322 fns, 5,653,602 B), `/bin/gzip` (145 fns, 1,196,332 B),
+`/usr/bin/xxd` (42 fns, 135,319 B). The 120,052-byte witness function is identical too.
+
+## The acceptance probe does NOT pass — read this part
+
+The need's acceptance asks for a **median under 10 s**. This lands at 19.4 s. The probe
+arm (`> 30 s`, i.e. the filed bad behaviour) no longer holds, so the symptom is gone, but
+the threshold is not met and **the need should stay open**.
+
+After this fix the profile is flat — p6 merge/ScopeLocal 27.6%, p3 heritage 26.3%, the
+rule pool 19.8%, jump-table sub-decompilation 17.4%, p9 dead-code/emit 13.7% of a 12.2 s
+in-process run. Nothing left is worth the further 48%; closing that gap is a campaign
+across kuna's core indexes, not one focused change. Two concrete leads are recorded in
+`docs/features/decompiling-3396-byte-main/record.json`:
+
+- **`kuna decompile` follows flow twice** (~18% of the probe). `follow_flow_on_fd` is hit
+  2× and `stage_jump_table` 4× on the console path versus 1×/2× in-process, because
+  kuna's `IfcDecompile` rebuilds the `Funcdata` from scratch where the C++ calls
+  `clearAnalysis` on the one `IfcFuncload` already followed. Not local: the rebuild exists
+  so the seeds (mapped symbols, DWARF locals, prototypes, param maps, overrides) apply at
+  flow time.
+- **The jump-table partial clone is rebuilt per table.** Upstream builds it once
+  (`flow.cc:1437`, guarded at `funcdata_block.cc:513`). Implemented, measured at
+  18.0 s → 14.3 s — and **reverted**: it takes `tests/stages/ghangr-optimized-memcpy-6301a9.xml`
+  from 2/2 to 0/2, losing 16 of 17 interleaved MSVC switches, because `option unrolledguard`
+  recovers them precisely *because* each table's clone re-clones its already-recovered
+  siblings. It changes which tables recover, so it needs its own option — and this round's
+  `phases.toml`/catalog leases are held by a sibling builder. Left documented in the code
+  and in `docs/spec/02-lift-and-flow.md` §2.3.
+
+No `tests/cli/` probe was promoted: the acceptance does not pass, and its target is a
+dataset binary (`scripts.repipe.verify.vendorable` refuses anything not in-repo). The
+regression guard is a cargo unit test on the cursor semantics instead of a wall-clock
+assertion on a CI runner.
+
+## Gates
+
+| gate | result |
+|---|---|
+| `make test` | **675/675 PARITY OK** (`docs/baseline.json` not re-pinned) |
+| `make test-stages` | **597/597 PARITY OK** (`docs/baseline-stages.json` not re-recorded) |
+| `make rust-test` | **green**, 342 `test result: ok` — run with `env -u KUNA_DECOMP_TEST`, see below |
+| `make check-spec` | check-spec OK (lenient mode) |
+| `kuna catalog --check` | catalog OK |
+
+New tests: `substrate::op::tests::dead_cursor_matches_a_full_scan` (the O(1) cursor agrees
+with a full `iter_dead()` scan at every position, and reports an alive op, a destroyed op
+and a single-element list exactly as the scan did) and
+`first_after_seq_id_agrees_with_first_after_seq`.
+
+> **Harness note:** the RE-pipeline worker environment exports `KUNA_DECOMP_TEST` pointing
+> at kuna's *own* `decomp_test_dbg`, which makes `verify_w10_proto_unlock`'s
+> `cpp_oracle_bin()` compare kuna against kuna and fail on the C++ oracle's `xunknown4`
+> versus kuna's DIV-6 `unsigned int`. That failure is the env var, not the change.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/decompiling-3396-byte-main/record.json
+++ b/docs/features/decompiling-3396-byte-main/record.json
@@ -1,0 +1,105 @@
+{
+ "opportunity": "decompiling-3396-byte-main",
+ "need_id": "decompiling-3396-byte-main",
+ "route": "RE-friction loop (docs/re-pipeline.md), round 2, track perf",
+ "challenge": "69a3822f7b3cc38c80464da4",
+ "binary": ".kuna-repipe/probebin/bcfacd743bc607be/nikos_crack_me.exe (PE x86-64, 235725 bytes, sha256 bcfacd74...)",
+ "selector": "sub_140023350 (the program's main, 3396 bytes)",
+ "phase": "P2 (lift/flow) + the action scheduler (infra)",
+ "modules": [
+  "decompiler/crates/kuna-decomp/src/substrate/op.rs (PcodeOpBank::dead_next / dead_prev / dead_front / dead_back / on_dead_list / first_after_seq_id)",
+  "decompiler/crates/kuna-decomp/src/p2_lift/flow.rs (FlowInfo::dead_next / dead_head / dead_tail / delete_remaining_ops)",
+  "decompiler/crates/kuna-decomp/src/substrate/funcdata_op.rs (Funcdata::op_target)",
+  "decompiler/crates/kuna-decomp/src/infra/action.rs (ActionPool cursor memo)"
+ ],
+ "change_kind": "performance-fix (output byte-identical)",
+ "option": null,
+ "gated": false,
+ "gating_rationale": "Not a judgement call and not output-changing: every edit replaces a search for a position with the O(1) link the same data structure already carries, and the whole-binary output is byte-identical before/after on three binaries (509 functions) plus the 675 datatest and 597 stage assertions. AGENTS.md gates features that CAN change emitted C; these cannot. No phases.toml row, no options.rs registration, no catalog counters, no docs/options.md, no DIV row.",
+ "hypothesis_filed": "The function's extensive opaque arithmetic and indirect calls cause one or more analysis passes to scale poorly.",
+ "hypothesis_verdict": "PARTLY REFUTED. The symptom stands (68 s reproduced as 71.5 s median). The cause is not 'opaque arithmetic and indirect calls' and not an analysis pass: it is a quadratic in the LIFTER, present for every function and only visible on a large one. gdb-sampled profiling put 53% of wall time in the single leaf frame FlowInfo::xref_control_flow, which is not analysis at all. The function is unusual only in op count (48,169 raw ops, 37,710 of them INDIRECTs at 365 call sites over ~78 guarded locations) -- and op count is exactly what the quadratic squares.",
+ "root_cause": "The C++ caches std::list<PcodeOp*>::iterators on each op (insertiter), so 'the op after this one' / 'the last op' are O(1). kuna's dead list is the same doubly-linked list (op.rs IntrusiveList, prev/next OpId links per op) but three call sites re-derived position by SCANNING iter_dead(): FlowInfo::dead_next scanned the whole list to locate one op, FlowInfo::dead_tail scanned it to reach the end, and Funcdata::op_target rebuilt a whole BTreeMap predecessor index per call. process_instruction does one dead_tail() + one dead_next() PER INSTRUCTION, and xref_control_flow does one dead_next() per emitted op, over a list that grows to the whole function -- O(N^2) in op count. delete_remaining_ops likewise collected the entire list to find a suffix.",
+ "fix": "Expose the links the list already has (PcodeBank::dead_next/dead_prev/dead_front/dead_back, membership = the `dead` flag PLUS a live link, because destroy() retires an op to deadandgone with the flag still set and the alive list shares the same link pair) and use them. Separately, ActionPool::advance_op_state already performed the optree search that decides After/Done, so it now keeps the successor's OpId and current_op reads it instead of searching a second time; the memo is dropped on every apply() exit so a resumed or interleaved sweep re-searches.",
+ "measurement": {
+  "method": "interleaved A/B, base binary vs new binary alternating in the same loop (docs/agents.md worktree rule: files copied aside, never stashed); machine load average 5-7 from sibling builders, so min and median are both reported",
+  "probe_command": "kuna decompile <bin> sub_140023350",
+  "base_s": [
+   76.36,
+   69.14,
+   70.03,
+   71.46,
+   72.36
+  ],
+  "new_s": [
+   18.44,
+   23.35,
+   21.79,
+   19.42,
+   18.84
+  ],
+  "base_median_s": 71.46,
+  "new_median_s": 19.42,
+  "delta_pct": -72.8,
+  "separation": "max(new)=23.35 s is below min(base)=69.14 s -- the distributions do not overlap",
+  "in_process_single_function": "kuna decompile-all --addr 0x140023350: 40.05 s -> 14.24 s median of 3 (-64.4%)",
+  "whole_binary_control": "kuna decompile-all /bin/gzip (145 functions): 14.55 s -> 13.60 s median of 3 (-6.5%) -- small functions barely feel a quadratic in op count, which is the expected shape and the honest limit of this fix"
+ },
+ "acceptance": {
+  "target": "wall_ms median < 10000 on `kuna decompile <bin> sub_140023350`",
+  "result": "NOT MET (19.4 s median). The probe arm still passes (>30 s) is FALSE, i.e. the filed bad behaviour is gone, but the acceptance threshold is not reached.",
+  "why_not": "After this fix the profile is flat: no remaining item is worth the further 48% the threshold needs. The measured 12.2 s in-process breakdown was p6 merge/ScopeLocal 27.6%, p3 dataflow/heritage 26.3%, the rule pool 19.8%, jump-table sub-decompilation 17.4%, p9 dead-code/emit 13.7%. Closing the gap is a campaign across kuna's core indexes, not one focused change.",
+  "promoted": false,
+  "promote_refused_because": "the acceptance does not pass, and its target is binary_source=dataset (scripts.repipe.verify.vendorable refuses anything that is not in-repo). Promoting it would install a red CI test; promoting a weakened variant would need the 235 KB third-party crackme vendored into the repo and would assert a wall clock on CI runners that this project already knows are noisy (docs: a red kuna check is usually runner starvation). The regression guard shipped instead is a cargo unit test on the cursor semantics."
+ },
+ "left_on_the_table": [
+  {
+   "item": "kuna decompile follows flow TWICE",
+   "evidence": "gdb breakpoint counts: follow_flow_on_fd is hit 2x and stage_jump_table 4x in the decomp_dbg console path, versus 1x / 2x for the in-process decompile-all path. `load function` costs 2.85 s of the console run on this function (0.88 s load+read symbols, 3.73 s with load function).",
+   "cause": "C++ IfcFuncload follows flow and IfcDecompile then calls clearAnalysis(fd) and runs the actions on that Funcdata. kuna's IfcDecompile rebuilds the Funcdata from scratch instead (there is no per-Funcdata clearAnalysis surface yet), so the flow follow and the whole jump-table sub-decompilation are paid twice.",
+   "why_not_done": "Worth ~18% of the probe. It is not a local fix: the rebuild exists because the seeds (mapped symbols, DWARF locals, parsed prototypes, param maps, proto overrides, flow overrides) must be applied AT FLOW TIME, and IfcFuncload applies only some of them. Reusing the loaded Funcdata is only sound when every seed is empty, which is a behavioural fork in the shared decompile step both the console and decompile-all use. That is console-tier infrastructure, i.e. the proposal fork."
+  },
+  {
+   "item": "the jump-table partial clone is rebuilt per table",
+   "evidence": "Upstream (verified against the pinned tree: flow.cc:1437 constructs `Funcdata partial` once before the tablelist loop, funcdata_block.cc:513 guards the clone + reduced pipeline behind `if (!partial.isJumptableRecoveryOn())`). Sharing it measured 18.0 s -> 14.3 s on the probe.",
+   "why_not_done": "IMPLEMENTED AND REVERTED. It breaks `option unrolledguard`: tests/stages/ghangr-optimized-memcpy-6301a9.xml went 2/2 -> 0/2, losing 16 of the 17 interleaved MSVC switches, because that kuna extension recovers them precisely BECAUSE each table's clone re-clones the siblings recovered before it (the mechanism is spelled out in flow.rs collect_edges). unrolledguard is on in aggressive mode, which is what `kuna decompile` selects for this binary, so the speedup and the feature are mutually exclusive here. It changes which tables recover, so it needs its own option -- and this round's phases.toml / catalog / docs-options.md leases are held by a sibling builder. Left as a documented divergence in the code and in docs/spec/02-lift-and-flow.md."
+  },
+  {
+   "item": "the rule pool's optree cursor is still O(log n) per op",
+   "evidence": "advance_op_state 5.5% self + SeqNum::cmp 5.8% self after the memo (which removed the second of the two searches).",
+   "why_not_done": "Making it O(1) needs a seqnum-ordered intrusive list alongside the optree, i.e. new infrastructure in the op bank. BTreeMap::lower_bound (one descent instead of range()'s leaf-range construction) is still unstable on the pinned 1.90 toolchain."
+  }
+ ],
+ "regression_sweep": {
+  "method": "whole-binary `kuna decompile-all --json --max-fn-seconds 0` with an interleaved before/after release build pair of this worktree (files copied aside per docs/agents.md, never stashed), byte-compared",
+  "binaries": [
+   "the probe crackme (PE x86-64, 322 functions emitted)",
+   "/bin/gzip (ELF x86-64, 145 functions)",
+   "/usr/bin/xxd (ELF x86-64, 42 functions)"
+  ],
+  "result": "all three captures BYTE-IDENTICAL (5,653,602 + 1,196,332 + 135,319 bytes). The 120,052-byte witness function output is byte-identical too."
+ },
+ "tests": {
+  "cargo": [
+   "substrate::op::tests::dead_cursor_matches_a_full_scan -- the O(1) cursor agrees with a full iter_dead() scan at every position, and reports an alive op, a destroyed op, and a single-element list exactly as the scan did",
+   "substrate::op::tests::first_after_seq_id_agrees_with_first_after_seq"
+  ],
+  "stage_test": null,
+  "stage_test_rationale": "tests/stages/README.md scopes that corpus to stage-model issues; a pure timing fix with byte-identical output has no assertion to make there, and adding one would re-record the stages baseline and bump the hard-coded corpus count for nothing.",
+  "cli_probe": null
+ },
+ "gates": {
+  "make test": "675/675 PARITY OK (docs/baseline.json NOT re-pinned)",
+  "make test-stages": "597/597 PARITY OK (docs/baseline-stages.json NOT re-recorded)",
+  "make rust-test": "green (342 `test result: ok`). NOTE: the harness exports KUNA_DECOMP_TEST pointing at kuna's OWN decomp_test_dbg, which makes verify_w10_proto_unlock's `cpp_oracle_bin()` compare kuna against kuna and fail on the C++ oracle's `xunknown4` vs kuna's DIV-6 `unsigned int`. Run with `env -u KUNA_DECOMP_TEST`.",
+  "make check-spec": "check-spec OK (lenient mode)",
+  "kuna catalog --check": "catalog OK (no option added; phases.toml, options.rs, the catalog counters and docs/options.md are untouched)"
+ },
+ "profiling_method": "gdb-as-parent sampling (perf_event_paranoid=4 and yama ptrace_scope=1 block perf and gdb attach on this box): run the target under `gdb -batch` with a chained `run`/`bt`/`continue` command list and `handle SIGUSR1 stop print nopass`, then SIGUSR1 the inferior on a fixed interval from a driver script. 456 samples before the fix, 293 after. Invocation counts came from `rbreak` + a large `ignore` count and `info breakpoints`.",
+ "scope": "small",
+ "decisions": [
+  "REFUTED the filed diagnosis. Symptom stands (68 s filed, 71.5 s median reproduced); cause is not 'an analysis pass scaling poorly on opaque arithmetic and indirect calls' but an O(N^2) position re-derivation in the LIFTER's dead-op list, present in every function and only visible once the op count is large. 53% of wall time sampled in one leaf frame, FlowInfo::xref_control_flow.",
+  "NO OPTION. Output is byte-identical (509 functions across three binaries, plus 1272 corpus assertions), so AGENTS.md's 'anything that CAN change emitted C ships behind a named option' does not bite. No catalog/DIV/phases.toml touch -- which also keeps this clear of the counter leases a sibling builder holds this round.",
+  "REVERTED the jump-table shared-partial fix after implementing and measuring it (-20%): it is upstream-faithful but kuna's `unrolledguard` extension is built on the per-table rebuild, and it took the interleaved-memcpy stage test from 2/2 to 0/2. Recorded as a deliberate divergence in the code and the spec rather than shipped ungated.",
+  "ACCEPTANCE NOT MET (<10 s asked, 19.4 s delivered). Shipping the verified -73% anyway rather than sitting on it: the probe arm no longer holds, the remaining gap is a flat profile needing a multi-front campaign, and the two biggest remaining leads are recorded with evidence so the next worker does not re-derive them."
+ ]
+}

--- a/docs/re-needs/decompiling-3396-byte-main.md
+++ b/docs/re-needs/decompiling-3396-byte-main.md
@@ -100,7 +100,26 @@ Interactive decompilation of the program's main function, sub_140023350, fast en
 
 ## Refutation
 
-_not yet refuted_
+**Hypothesis partly refuted (round 2 builder, PR for `feat/re-decompiling-3396-byte-main`).**
+The symptom stands — 71.5 s median reproduced for `kuna decompile <bin> sub_140023350`.
+The diagnosis does not: it is not an analysis pass and not "opaque arithmetic and
+indirect calls". gdb-sampled profiling put 53% of wall time in a single leaf frame,
+`FlowInfo::xref_control_flow`, i.e. the **lifter**, before any analysis runs. The dead
+p-code list is a doubly-linked list, but `dead_next`, `dead_tail`,
+`delete_remaining_ops` and `Funcdata::op_target` re-derived position by scanning it,
+making op generation O(N²) in op count. This function is unusual only in op count
+(48,169 raw ops, 37,710 INDIRECTs across 365 call sites), which is exactly what the
+quadratic squares — so the same defect is present in every function and merely invisible
+on small ones.
+
+Fixed to O(1) (output byte-identical): **71.46 s → 19.42 s median, −72.8%**. The probe
+arm (`> 30 s`) no longer holds. **The acceptance (`< 10 s`) is still not met** and the
+need should stay open: after the fix the profile is flat (p6 merge 27.6%, p3 heritage
+26.3%, rule pool 19.8%, jump-table sub-decompilation 17.4%, p9 emit 13.7%), so the
+remaining 48% is a campaign, not a fix. The two ranked leads —
+`kuna decompile` following flow twice (~18%), and the per-table jump-table partial clone
+(~20%, implemented then reverted because `option unrolledguard` depends on it) — are
+recorded with evidence in `docs/features/decompiling-3396-byte-main/record.json`.
 
 ## Reference
 

--- a/docs/spec/02-lift-and-flow.md
+++ b/docs/spec/02-lift-and-flow.md
@@ -53,6 +53,21 @@ ops beyond the deepest internal branch time are dead and deleted
 (`delete_remaining_ops`). The op-creation and classification order here is
 observable — it fixes the SeqNum allocation every later phase keys on.
 
+**The dead list is a list, and the walk must treat it as one.** The C++ holds
+`std::list<PcodeOp *>::iterator`s directly (`insertiter` on each op), so
+"the op after this one", "the op before this one" and "the last op" are all
+constant-time. kuna's dead list is the same doubly-linked list, realized as
+prev/next `OpId` links on each op (`op.rs (IntrusiveList)`), and
+`op.rs (PcodeOpBank::dead_next / dead_prev / dead_front / dead_back)` read those
+links. Position must never be re-derived by scanning `iter_dead()`: the marker
+idiom in `process_instruction` (remember the tail, decode, then take the first
+op after the marker) and the per-op walk in `xref_control_flow` run once per
+instruction over a list that grows to the whole function, so a scan there is
+quadratic in the function's op count. Membership is the `dead` flag *plus* a live
+link — `destroy` retires an op to `deadandgone` with the flag still set, and the
+alive list shares the same link pair — so the cursor reports a non-member as
+`None`, which is what a scan for an absent op returned.
+
 **Declared flow bounds.** A function normally follows flow wherever the code
 goes: `FlowInfo`'s allowed range is initialized to the whole entry-point space, so
 the extent is discovered, not asserted. A `Funcdata` that carries a non-zero byte
@@ -357,7 +372,16 @@ built against the parent flow's `visited` snapshot, and the reduced
 `"jumptable"` action set — heritage plus the simplification core, no
 structuring — is run over it (`decompile_drive.rs (run_jumptable_pipeline)`).
 The model is then recovered against the *partial*'s BRANCHIND and the finished
-table is written back keyed to the real op. Two pre-checks bound the attempt:
+table is written back keyed to the real op. **This clone is per table, and that
+is a deliberate divergence**: the C++ builds one `partial` per
+`recoverJumpTables` call and guards the clone plus the reduced pipeline behind
+`if (!partial.isJumptableRecoveryOn())`, so upstream pays for the
+sub-decompilation once per function however many BRANCHINDs it has. kuna cannot
+share it, because `unrolledguard` (below) recovers interleaved tables precisely
+*because* each table's clone re-clones the siblings recovered before it. Sharing
+the clone is worth about 20% of the wall time of a two-table function and would
+be upstream-faithful, but it changes which tables recover, so it would have to
+ship behind its own option. Two pre-checks bound the attempt:
 `funcdata_block.rs (Funcdata::early_jump_table_fail)` backtracks up to 8 ops
 through value-preserving arithmetic looking for a computation the recovery can
 never emulate -- but its only failing arm (the uninjected-CALLOTHER

--- a/docs/spec/03-ssa-and-simplification.md
+++ b/docs/spec/03-ssa-and-simplification.md
@@ -289,8 +289,15 @@ rewrite and returns 1. Rules are owned by an
 `decompiler/crates/kuna-decomp/src/infra/action.rs (ActionPool)`, which indexes
 them at registration into a flat per-opcode table (`perop`, insertion order
 preserved). One pool sweep visits every op in the function in sequence-number
-order through a resumable cursor that survives op deletion (§0.3), and for each
-op walks its opcode's rule list in registration order
+order through a resumable cursor that survives op deletion (§0.3) — it is
+recorded as the last *consumed* `SeqNum`, so the next op is the first optree key
+strictly greater than it, which stays valid when the op it named is destroyed.
+Resolving that key is an optree search, and the sweep is the decompiler's
+innermost loop, so the advance resolves the successor's id and the cursor read
+returns it rather than searching a second time for the op the advance already
+found; the memo is dropped on every `apply` exit, so a resumed or interleaved
+sweep re-searches. For each op the sweep walks its opcode's rule list in
+registration order
 (`action.rs (ActionPool::process_op)`): disabled rules are skipped (the
 upstream `option togglerule` surface writes that per-rule flag), a rule that
 fires bumps the pool's change count, a rule that kills the op ends the walk,


### PR DESCRIPTION
## What was broken

RE-need `decompiling-3396-byte-main` (round 2, track `perf`, 1 instance,
challenge `69a3822f7b3cc38c80464da4`):

> **Decompiling the 3396-byte main function takes about 68 seconds** (major)
> The command produced no output for roughly 68 seconds, then emitted about 30 KB of
> highly noisy pseudocode. […] this observation is specifically about latency.

Reproduced at **71.5 s median** for `kuna decompile <bin> sub_140023350`.

## The cause is not what was filed

The filed hypothesis was "opaque arithmetic and indirect calls make an analysis pass
scale poorly". The symptom stands, the diagnosis does not: gdb-sampled profiling put
**53% of wall time in one leaf frame, `FlowInfo::xref_control_flow`** — the *lifter*,
before any analysis runs. This function is unusual only in op count (48,169 raw ops,
37,710 of them INDIRECTs across 365 call sites), and op count is exactly what the real
defect squares.

**The dead list is a doubly-linked list whose links three call sites refused to use.**
The C++ caches a `std::list<PcodeOp*>::iterator` on every op (`insertiter`), so "the op
after this one" and "the last op" are O(1). kuna's dead list *is* that list —
`op.rs (IntrusiveList)` keeps prev/next `OpId` links on each op — but position was being
re-derived by scanning:

| site | what it did | how often |
|---|---|---|
| `FlowInfo::dead_next` | scanned all of `iter_dead()` to locate one op | once per emitted p-code op |
| `FlowInfo::dead_tail` | `iter_dead().last()` | once per decoded instruction (the marker idiom) |
| `FlowInfo::delete_remaining_ops` | collected the whole list to find a suffix | once per terminating instruction |
| `Funcdata::op_target` | rebuilt an entire `BTreeMap` predecessor index | once per call |

The list grows to the whole function, so this is O(N²) in op count. It is invisible on
small functions and quadratic on the ones an RE actually cares about.

## The mechanism

1. **`op.rs`** — expose what the list already carries: `PcodeOpBank::dead_front` /
   `dead_back` / `dead_next` / `dead_prev`. Membership is the `dead` flag **plus a live
   link**, because `destroy()` retires an op to `deadandgone` with the flag still set and
   the alive list shares the same link pair; a non-member reports `None`, exactly what a
   scan for an absent op returned.
2. **`flow.rs` / `funcdata_op.rs`** — the four sites above use those accessors.
3. **`action.rs`** — `ActionPool::advance_op_state` already ran the optree search that
   decides `After`/`Done`, so it now keeps the successor's `OpId` and `current_op` reads
   it instead of searching a second time for the op the advance already found. The memo is
   dropped on every `apply()` exit, so a resumed or interleaved sweep re-searches.

No option: none of this can change emitted C, so `docs/agents.md`'s flag rule does not
apply. `phases.toml`, `options.rs`, the catalog counters, `docs/options.md` and
`docs/history.md` are untouched.

## Measured

Interleaved A/B (base and new binaries alternating in one loop; machine load 5–7 from
sibling builders, so both median and min are reported):

| run | base | new | delta |
|---|---|---|---|
| `kuna decompile <bin> sub_140023350` (the probe), median of 5 | **71.46 s** | **19.42 s** | **−72.8%** |
| same, min of 5 | 69.14 s | 18.44 s | −73.3% |
| `kuna decompile-all --addr 0x140023350`, median of 3 | 40.05 s | 14.24 s | −64.4% |
| `kuna decompile-all /bin/gzip` (145 functions), median of 3 | 14.55 s | 13.60 s | −6.5% |

The base and new distributions do not overlap: max(new) = 23.35 s < min(base) = 69.14 s.
The gzip row is the honest control — small functions barely feel a quadratic in op count.

**Output is byte-identical.** Whole-binary `decompile-all --json` captures from an
interleaved before/after build pair compare byte-for-byte on three binaries / 509
functions: the probe crackme (322 fns, 5,653,602 B), `/bin/gzip` (145 fns, 1,196,332 B),
`/usr/bin/xxd` (42 fns, 135,319 B). The 120,052-byte witness function is identical too.

## The acceptance probe does NOT pass — read this part

The need's acceptance asks for a **median under 10 s**. This lands at 19.4 s. The probe
arm (`> 30 s`, i.e. the filed bad behaviour) no longer holds, so the symptom is gone, but
the threshold is not met and **the need should stay open**.

After this fix the profile is flat — p6 merge/ScopeLocal 27.6%, p3 heritage 26.3%, the
rule pool 19.8%, jump-table sub-decompilation 17.4%, p9 dead-code/emit 13.7% of a 12.2 s
in-process run. Nothing left is worth the further 48%; closing that gap is a campaign
across kuna's core indexes, not one focused change. Two concrete leads are recorded in
`docs/features/decompiling-3396-byte-main/record.json`:

- **`kuna decompile` follows flow twice** (~18% of the probe). `follow_flow_on_fd` is hit
  2× and `stage_jump_table` 4× on the console path versus 1×/2× in-process, because
  kuna's `IfcDecompile` rebuilds the `Funcdata` from scratch where the C++ calls
  `clearAnalysis` on the one `IfcFuncload` already followed. Not local: the rebuild exists
  so the seeds (mapped symbols, DWARF locals, prototypes, param maps, overrides) apply at
  flow time.
- **The jump-table partial clone is rebuilt per table.** Upstream builds it once
  (`flow.cc:1437`, guarded at `funcdata_block.cc:513`). Implemented, measured at
  18.0 s → 14.3 s — and **reverted**: it takes `tests/stages/ghangr-optimized-memcpy-6301a9.xml`
  from 2/2 to 0/2, losing 16 of 17 interleaved MSVC switches, because `option unrolledguard`
  recovers them precisely *because* each table's clone re-clones its already-recovered
  siblings. It changes which tables recover, so it needs its own option — and this round's
  `phases.toml`/catalog leases are held by a sibling builder. Left documented in the code
  and in `docs/spec/02-lift-and-flow.md` §2.3.

No `tests/cli/` probe was promoted: the acceptance does not pass, and its target is a
dataset binary (`scripts.repipe.verify.vendorable` refuses anything not in-repo). The
regression guard is a cargo unit test on the cursor semantics instead of a wall-clock
assertion on a CI runner.

## Gates

| gate | result |
|---|---|
| `make test` | **675/675 PARITY OK** (`docs/baseline.json` not re-pinned) |
| `make test-stages` | **597/597 PARITY OK** (`docs/baseline-stages.json` not re-recorded) |
| `make rust-test` | **green**, 342 `test result: ok` — run with `env -u KUNA_DECOMP_TEST`, see below |
| `make check-spec` | check-spec OK (lenient mode) |
| `kuna catalog --check` | catalog OK |

New tests: `substrate::op::tests::dead_cursor_matches_a_full_scan` (the O(1) cursor agrees
with a full `iter_dead()` scan at every position, and reports an alive op, a destroyed op
and a single-element list exactly as the scan did) and
`first_after_seq_id_agrees_with_first_after_seq`.

> **Harness note:** the RE-pipeline worker environment exports `KUNA_DECOMP_TEST` pointing
> at kuna's *own* `decomp_test_dbg`, which makes `verify_w10_proto_unlock`'s
> `cpp_oracle_bin()` compare kuna against kuna and fail on the C++ oracle's `xunknown4`
> versus kuna's DIV-6 `unsigned int`. That failure is the env var, not the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
