### PR TITLE
[AUTOMATED] fix(analysis): pe-function-inventory-labels — name a virtual method after the function, not its vftable

### DIFF
--- a/decompiler/crates/kuna-analysis/src/analyzers/rtti/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/rtti/mod.rs
@@ -30,11 +30,18 @@
 //! `<Class>::vftable` base it reads each pointer-width slot (an **absolute VA on both
 //! arches** — vftable slots are NOT the `IBO32` displacements the COL/RTTI graph uses),
 //! bounding the array at the first NULL / non-`.text` slot. For each surviving slot it
-//! emits a virtual-method **function** [`SymFact`] named `<Class>::vftable_<i>` (the
+//! emits a virtual-method **function** [`SymFact`] named `<Class>::vfunc_<i>` (the
 //! MSVC metadata carries the class name but not per-method names, so the slot index is
 //! the disambiguator), and marks the slot array read-only ([`AnalysisOutput::readonly`]).
 //! So the virtual dispatch — `(**(code **)*plVar1)()`, an unnamed `DAT_*` vtable slot
-//! before — now resolves to a named function (`Box::vftable_0` = `Box::area`).
+//! before — now resolves to a named function (`Box::vfunc_0` = `Box::area`).
+//!
+//! The slot-index name is `vfunc_<i>` and NOT `vftable_<i>`: a routine must not be named
+//! after the data object that points at it. Under multiple inheritance an MSVC class
+//! really does own several vftables, so `<Class>::vftable_<i>` reads as "this class's
+//! i-th vftable" — which made a function inventory claim that hundreds of bytes of
+//! `std::basic_stringbuf` code were vtable objects. `vfunc_<i>` names the callee, and
+//! the vftable data object keeps the unindexed `<Class>::vftable` label.
 //!
 //! # x86 vs x64 — the one place a port goes wrong (§3.1f)
 //!
@@ -290,7 +297,7 @@ fn emit_for_col(
             kind: SymKind::Data,
         });
         // R3: walk the vftable's slots, naming each virtual-method function
-        // `<Class>::vftable_<i>` and marking the slot array read-only. The virtual
+        // `<Class>::vfunc_<i>` and marking the slot array read-only. The virtual
         // dispatch (an unnamed `DAT_*` slot before) now resolves to a named function.
         if let Some(vt) = walk_vftable(img, rk, text, vftable_base) {
             emit_vftable_methods(&self_class, &vt, rk, out);
@@ -320,13 +327,21 @@ fn emit_type_descriptor_label(class: &str, td_addr: u64, out: &mut AnalysisOutpu
     });
 }
 
+/// The name a recovered virtual method takes: `<Class>::vfunc_<i>` for slot `i` of the
+/// class's vftable. Deliberately NOT `<Class>::vftable_<i>` — that spells the data
+/// object, and a class under multiple inheritance genuinely owns several vftables, so
+/// the indexed form reads as "vftable number i" rather than "the function in slot i".
+fn vfunc_name(class: &str, slot: usize) -> String {
+    format!("{class}::vfunc_{slot}")
+}
+
 /// Emit the per-slot virtual-method facts for a recovered vftable (R3):
-///   - one `Function` [`SymFact`] per slot, named `<Class>::vftable_<i>` at the slot's
+///   - one `Function` [`SymFact`] per slot, named [`vfunc_name`] at the slot's
 ///     target VA (the virtual method the dispatch jumps to);
 ///   - the slot array's VMA range as read-only ([`AnalysisOutput::readonly`]).
 /// The `SymFact{Function}` commit is an idempotent ADD (`find_function`-gated), so a
 /// slot target that already carries a real `.symtab`/import name keeps it; only a
-/// never-symboled virtual method takes the `<Class>::vftable_<i>` name.
+/// never-symboled virtual method takes the `<Class>::vfunc_<i>` name.
 fn emit_vftable_methods(
     class: &str,
     vt: &vftable::VfTable,
@@ -336,7 +351,7 @@ fn emit_vftable_methods(
     for (i, &fn_addr) in vt.slots.iter().enumerate() {
         out.symbols.push(SymFact {
             addr: fn_addr,
-            name: format!("{class}::vftable_{i}"),
+            name: vfunc_name(class, i),
             kind: SymKind::Function,
         });
     }
@@ -382,6 +397,24 @@ mod tests {
         let p = RttiPass;
         assert_eq!(p.id(), "rtti");
         assert_eq!(p.phase(), Phase::P1);
+    }
+
+    /// A recovered virtual method is named after the FUNCTION in the slot, never after
+    /// the vftable data object that points at it: an inventory that labels an executable
+    /// range `<Class>::vftable_<i>` claims a routine is a vtable, and under multiple
+    /// inheritance a class really does own several vftables, so the indexed `vftable_`
+    /// form is ambiguous rather than merely ugly.
+    #[test]
+    fn virtual_method_is_named_after_the_function_not_the_table() {
+        assert_eq!(vfunc_name("Box", 0), "Box::vfunc_0");
+        assert_eq!(vfunc_name("std::basic_stringbuf", 11), "std::basic_stringbuf::vfunc_11");
+        for slot in [0usize, 1, 11] {
+            let n = vfunc_name("std::bad_alloc", slot);
+            assert!(
+                !n.contains("vftable"),
+                "a virtual-method function name must not spell the vftable data object: {n}"
+            );
+        }
     }
 
     #[test]

--- a/decompiler/crates/kuna-analysis/src/analyzers/rtti/vftable.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/rtti/vftable.rs
@@ -28,9 +28,11 @@
 //! (`None`): a real polymorphic class has at least one virtual method.
 //!
 //! Each surviving slot VA is a virtual-method **function** the pass names
-//! `<Class>::vftable_<i>` (the MSVC metadata graph carries the class name in the
+//! `<Class>::vfunc_<i>` (the MSVC metadata graph carries the class name in the
 //! RTTI0 `TypeDescriptor` but NOT per-method names, so the slot index is the faithful
 //! disambiguator — the documented scope vs Ghidra's script-tier method demangling).
+//! The `vfunc_` stem, not `vftable_`: the slot's target is code, and the vftable data
+//! object at `base` is what carries the unindexed `<Class>::vftable` label.
 
 use object::read::{Object, ObjectSection};
 use object::SectionKind;

--- a/decompiler/crates/kuna-analysis/tests/fixtures/README.md
+++ b/decompiler/crates/kuna-analysis/tests/fixtures/README.md
@@ -601,13 +601,15 @@ as `.?AU…`; both `V`/`U` recover the bare name).
 walked from its `Box::vftable` base (`VfTableModel.getVfTableCount`), bounding the slot
 array at the first NULL / non-`.text` slot. The Box vftable holds exactly one slot —
 `Box::area` (`return side*side;`, the pinned slot-0 target above: `0x140001040` x64 /
-`0x401030` x86) — which R3 names `Box::vftable_0` (a `SymKind::Function`) and marks the
+`0x401030` x86) — which R3 names `Box::vfunc_0` (a `SymKind::Function`) and marks the
 slot array read-only. The slots are **absolute VAs on both arches** (NOT the `IBO32`
 displacements the COL/RTTI inter-struct refs use): the x64 vftable cell at `0x140002010`
 holds the full 8-byte `0x140001040`, the x86 cell at `0x40200c` the 4-byte `0x401030`.
-`kuna-console/tests/verify_rtti.rs` asserts `Box::vftable_0` exists AND a function symbol
+`kuna-console/tests/verify_rtti.rs` asserts `Box::vfunc_0` exists AND a function symbol
 resolves at the slot-0 target VA (the virtual dispatch now points at a named method),
-absent with `rtti off`.
+absent with `rtti off`. The slot function's stem is `vfunc_`, never `vftable_`: only the
+table data object wears a `vftable` name, so a function inventory never reports an
+executable range as a vtable.
 
 ## Mach-O (Apple) fixtures — the multi-format loader (PR-6+7, the Mach-O headline)
 

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -998,7 +998,7 @@ impl ConsoleProgram {
     /// (kuna) The basename of the FunctionSymbol installed at code-space VMA `vma`, or
     /// `None` if no function is mapped there. Resolves across scopes
     /// (`find_function_across_scopes`, the no-return/FID arm's resolver), so it sees a
-    /// namespaced virtual-method function (e.g. `Box::vftable_0` in scope `Box`).
+    /// namespaced virtual-method function (e.g. `Box::vfunc_0` in scope `Box`).
     ///
     /// The verification hook for the MSVC-RTTI **vftable** e2e (R3): a vtable slot's
     /// target VA should now resolve to a named virtual method — the virtual dispatch
@@ -1461,6 +1461,9 @@ fn is_generic_placeholder_name(name: &str) -> bool {
 /// table SLOT is, not what the function is called, so a real symbol at the same
 /// address must outrank them — `fmt_arm`'s `0x4c0` reports
 /// `__do_global_dtors_aux` with `_FINI_0` as an alias, not the reverse.
+///
+/// A recovered virtual method named by its VTABLE SLOT INDEX is the same kind of
+/// name and is treated the same way ([`is_vtable_slot_name`]).
 fn is_structural_entry_name(name: &str) -> bool {
     name == "_DT_INIT"
         || name == "_DT_FINI"
@@ -1468,6 +1471,34 @@ fn is_structural_entry_name(name: &str) -> bool {
             .strip_prefix("_INIT_")
             .or_else(|| name.strip_prefix("_FINI_"))
             .is_some_and(|i| !i.is_empty() && i.bytes().all(|b| b.is_ascii_digit()))
+        || is_vtable_slot_name(name)
+}
+
+/// (kuna, `pe-function-inventory-labels`) Is `name` a virtual method the RTTI passes
+/// could only name by its vtable SLOT INDEX — `<Class>::vfunc_<i>` (MSVC `rtti`) or
+/// `<Class>::vtable_<i>` (Itanium `itaniumrtti`)?
+///
+/// Neither metadata graph records per-method names, only the class name, so the slot
+/// index is all those passes have. That makes the name structural in exactly the sense
+/// `_FINI_<i>` is: it says which SLOT the function occupies, not what the function is
+/// called. A real method name recovered at the same address must therefore outrank it —
+/// on a Windows PE the `std::basic_streambuf` thunks carry both, and the length
+/// tie-break alone decided it, so `showmanyc` reported as `std::basic_stringbuf::vfunc_5`
+/// while its one-byte-shorter neighbour `uflow` kept its real name.
+///
+/// The unindexed `<Class>::vftable` / `<Class>::vtable` labels are DATA symbols and never
+/// reach this ranking; the digit test excludes descriptive suffixes such as
+/// `Widget::vtable_for_Drawable` as well.
+fn is_vtable_slot_name(name: &str) -> bool {
+    let Some((class, slot)) = name.rsplit_once("::") else {
+        return false;
+    };
+    if class.is_empty() {
+        return false;
+    }
+    slot.strip_prefix("vfunc_")
+        .or_else(|| slot.strip_prefix("vtable_"))
+        .is_some_and(|i| !i.is_empty() && i.bytes().all(|b| b.is_ascii_digit()))
 }
 
 /// (kuna, issue #197) How informative is `name`?  Smaller sorts first when
@@ -1484,7 +1515,9 @@ fn is_structural_entry_name(name: &str) -> bool {
 ///    at `0x40`, and the reported mingw-PE pair is `_pre_c_init`+`pre_c_init`.
 ///    The unprefixed name is the one a reader wants.
 /// 4. **Shorter**, then **lexicographic** — so the choice is total and stable
-///    run to run rather than dependent on symbol-stream order.
+///    run to run rather than dependent on symbol-stream order.  This is a tie-break
+///    between names of equal standing ONLY; a difference in kind must be caught by a
+///    tier above it, or a one-character length accident decides the report.
 fn entry_name_rank(name: &str) -> (bool, bool, bool, usize) {
     (
         is_generic_placeholder_name(name),
@@ -2795,3 +2828,64 @@ impl LoadImage for NullLoad {
 /// function's natural extent), mirroring the C++ `IfcFuncload` / `IfcAddrrangeLoad`
 /// unbounded follow.
 pub const UNBOUNDED_SIZE: int4 = 0;
+
+#[cfg(test)]
+mod tests {
+    use super::{entry_name_rank, is_vtable_slot_name};
+
+    /// Which of an entry's names `function_entries_canonical` reports.
+    fn wins<'a>(a: &'a str, b: &'a str) -> &'a str {
+        if entry_name_rank(a).cmp(&entry_name_rank(b)).then_with(|| a.cmp(b)).is_le() {
+            a
+        } else {
+            b
+        }
+    }
+
+    /// (kuna, `pe-function-inventory-labels`) A vtable-slot-index name is structural:
+    /// a real method name at the same address outranks it however long that name is.
+    /// Before, only the length tie-break separated them, so which name a PE inventory
+    /// reported turned on a one-character accident — `std::basic_streambuf::showmanyc`
+    /// lost to `std::basic_stringbuf::vfunc_5` while the shorter `uflow` next door kept
+    /// its own name.
+    #[test]
+    fn a_real_method_name_outranks_its_vtable_slot_index() {
+        for (real, slot) in [
+            ("std::basic_streambuf::showmanyc", "std::basic_stringbuf::vfunc_5"),
+            ("std::basic_streambuf::uflow", "std::basic_stringbuf::vfunc_7"),
+            ("Shape::perimeter", "Circle::vtable_2"),
+            // The real name being much the longer of the two is the whole point.
+            ("Widget::an_extremely_long_method_name", "Widget::vfunc_0"),
+        ] {
+            assert_eq!(wins(real, slot), real, "{real} must outrank {slot}");
+        }
+    }
+
+    /// The slot name still beats an engine placeholder — it is structural, not useless.
+    #[test]
+    fn a_vtable_slot_index_still_outranks_a_placeholder() {
+        for placeholder in ["sub_140002c2c", "FUN_140002c2c", "func_140002c2c"] {
+            assert_eq!(wins("std::bad_alloc::vfunc_0", placeholder), "std::bad_alloc::vfunc_0");
+        }
+    }
+
+    /// Only `<Class>::v{func,table}_<digits>` is a slot name. The unindexed labels are
+    /// DATA symbols, and a descriptive suffix names a base subobject, not a slot.
+    #[test]
+    fn only_an_indexed_slot_name_is_structural() {
+        assert!(is_vtable_slot_name("Box::vfunc_0"));
+        assert!(is_vtable_slot_name("std::basic_stringbuf::vtable_11"));
+        for not_a_slot in [
+            "Box::vftable",
+            "Box::vtable",
+            "Widget::vtable_for_Drawable",
+            "Box::vfunc_",
+            "Box::vfunc_1a",
+            "vfunc_0",
+            "::vfunc_0",
+            "vtable_3",
+        ] {
+            assert!(!is_vtable_slot_name(not_a_slot), "{not_a_slot} is not a slot name");
+        }
+    }
+}

--- a/decompiler/crates/kuna-console/tests/verify_rtti.rs
+++ b/decompiler/crates/kuna-console/tests/verify_rtti.rs
@@ -21,7 +21,7 @@
 //!                                          `Box::RTTI_Complete_Object_Locator`, the
 //!                                          vftable `Box::vftable`, AND each vftable
 //!                                          slot a named virtual-method function
-//!                                          `Box::vftable_0` (R3, at the slot's target
+//!                                          `Box::vfunc_0` (R3, at the slot's target
 //!                                          VA) — so the virtual dispatch resolves to
 //!                                          a named method and `Box`/`Shape` surface
 //!                                          as recovered C++ class names.
@@ -32,7 +32,9 @@
 //! On top of the class names, `rtti` R3 walks each vftable from its
 //! `<Class>::vftable` base (`VfTableModel.getVfTableCount`), bounding the slot array
 //! at the first NULL / non-`.text` slot, and names each slot's target a virtual-method
-//! function `<Class>::vftable_<i>` + marks the slot array read-only. The Box vftable
+//! function `<Class>::vfunc_<i>` + marks the slot array read-only. The `vfunc_` stem is
+//! load-bearing: only the vftable DATA object wears a `vftable` name, so a function
+//! inventory never reports an executable range as a vtable. The Box vftable
 //! here has exactly one slot — `Box::area` (`side*side`) — at the pinned target VMA
 //! (`0x140001040` x64 / `0x401030` x86). The slots are absolute VAs on BOTH arches
 //! (NOT the `IBO32` displacements the COL/RTTI graph uses).
@@ -133,19 +135,31 @@ fn assert_recovered(prog: &ConsoleProgram, box_area_vma: u64) {
     );
 
     // R3 — vftable discovery + per-slot virtual-method naming. The Box vftable has
-    // one slot (`Box::area`); R3 names it `Box::vftable_0`. The name must exist in
+    // one slot (`Box::area`); R3 names it `Box::vfunc_0`. The name must exist in
     // the symbol table AND a function symbol must be installed AT the slot's target
     // VA — the virtual dispatch `(**(code **)*p)()` now points at a NAMED function
-    // (`Box::vftable_0`), not a bare `DAT_*` slot.
+    // (`Box::vfunc_0`), not a bare `DAT_*` slot.
     assert!(
-        prog.has_symbol_named("Box::vftable_0"),
-        "rtti on: the first Box vftable slot must be named Box::vftable_0 (R3)"
+        prog.has_symbol_named("Box::vfunc_0"),
+        "rtti on: the first Box vftable slot must be named Box::vfunc_0 (R3)"
     );
     assert_eq!(
         prog.function_named_at(box_area_vma).as_deref(),
-        Some("vftable_0"),
+        Some("vfunc_0"),
         "rtti on: the vftable slot's target VA {box_area_vma:#x} must resolve to the \
          named virtual-method function (R3 — the virtual dispatch is now named)"
+    );
+    // A recovered ROUTINE is never named after the vftable data object: the only
+    // `vftable` symbol is the unindexed label on the table itself. `<Class>::vftable_<i>`
+    // told a function inventory that executable code was a vtable object.
+    assert!(
+        !prog.has_symbol_named("Box::vftable_0"),
+        "the virtual method must not be named Box::vftable_0 — that spells the data object"
+    );
+    assert_ne!(
+        prog.function_named_at(box_area_vma).as_deref(),
+        Some("vftable_0"),
+        "rtti on: the function at {box_area_vma:#x} must not carry a vftable_<i> name"
     );
 }
 
@@ -159,6 +173,7 @@ fn assert_absent(prog: &ConsoleProgram, box_area_vma: u64) {
         "Box::RTTI_Complete_Object_Locator",
         "Box::vftable",
         "Box::vftable_0",
+        "Box::vfunc_0",
     ] {
         assert!(
             !prog.has_symbol_named(name),
@@ -166,10 +181,10 @@ fn assert_absent(prog: &ConsoleProgram, box_area_vma: u64) {
         );
     }
     // The vftable slot is an unnamed `DAT_*`/undiscovered slot with the option off:
-    // no `vftable_*` virtual-method function is installed at its target VA.
+    // no `vfunc_*` virtual-method function is installed at its target VA.
     assert_ne!(
         prog.function_named_at(box_area_vma).as_deref(),
-        Some("vftable_0"),
+        Some("vfunc_0"),
         "rtti off: the vftable slot target must NOT be a named virtual method"
     );
 }

--- a/docs/features/pe-function-inventory-labels/pr_body.md
+++ b/docs/features/pe-function-inventory-labels/pr_body.md
@@ -1,0 +1,110 @@
+## What was broken
+
+RE-friction need `pe-function-inventory-labels` (round 2, challenge `6547b4d50f4238b24302b588`,
+1 instance, severity major). The tester wanted *"a trustworthy function inventory for triaging
+the PE"* and reported:
+
+> The inventory includes executable ranges named `std::bad_alloc::vftable_1` and numerous
+> `std::basic_stringbuf::vftable_N` entries as functions, including ranges hundreds of bytes
+> long. These names are data-symbol aliases and misleadingly classify routines as vtable
+> objects.
+
+10 entries on that PE, from `0x140001040` (32 B) to `0x140001de0` (496 B).
+
+## The filed hypothesis is overturned; the symptom stands
+
+The hypothesis was *"public data aliases near code addresses are winning the canonical-name
+selection"*. No data symbol is involved. `<Class>::vftable_<i>` is a name **kuna synthesises**:
+the MSVC RTTI pass (R3, `analyzers/rtti/mod.rs::emit_vftable_methods`) walks each recovered
+vftable and emits a `SymFact{Function}` at the address each slot **points at** — the virtual
+method, not the table. All 10 entries are genuine `.text` routines and classifying them as
+functions is correct.
+
+The name is what is wrong, and not merely cosmetically: an MSVC class under multiple
+inheritance genuinely owns several vftables, so `<Class>::vftable_<i>` collides with the
+natural reading *"this class's i-th vftable"*. The need's STOP clause — stop if the fix changes
+function DISCOVERY rather than labelling — does not fire: which addresses the pass creates is
+untouched.
+
+## Mechanism
+
+**1. The slot function is named after the function.** `<Class>::vftable_<i>` →
+`<Class>::vfunc_<i>`. Only the table itself keeps a `vftable` name, and it keeps the unindexed
+`<Class>::vftable` Data label it always had.
+
+**2. A slot-index name is structural, so a real method name outranks it.** The rename alone was
+a *net regression* on one function, and only the whole-corpus sweep found it.
+`entry_name_rank`'s tiers are `(placeholder, structural, leading-underscore, LENGTH)`, so
+between a recovered method name and a synthetic slot name the reported name was decided by a
+one-character length accident:
+
+| address | before this PR | after rename only | after both changes |
+|---|---|---|---|
+| `0x140002c2c` | `std::basic_streambuf::showmanyc` (30) | **`std::basic_stringbuf::vfunc_5`** (29) | `std::basic_streambuf::showmanyc` |
+| `0x140002c32` | `std::basic_streambuf::uflow` (27) | `std::basic_streambuf::uflow` | `std::basic_streambuf::uflow` |
+
+The fix is not to pick a longer word. A slot-index name is structural in exactly the sense the
+existing `_FINI_<i>` tier already documents — *it says which slot the function occupies, not
+what the function is called* — so `<Class>::vfunc_<i>` (MSVC) and `<Class>::vtable_<i>`
+(Itanium) now sort into that tier, and a real method name outranks them at any length. They
+still beat `sub_`/`FUN_` placeholders, which lose a tier earlier.
+
+## The acceptance probe now passes
+
+```
+$ python -m scripts.repipe.verify --need pe-function-inventory-labels
+acceptance suite  sha 74118fd
+  PASS   closed         open           pe-function-inventory-labels
+total=1 pass=1 fail=0 closed=1 regressed=0 indeterminate=0
+```
+
+`"name": "[^"]*::vftable_[0-9]+"` count on the recorded PE: **10 → 0**.
+
+Promoted to `tests/cli/pe-function-inventory-labels.json`, re-pointed off the dataset PE onto
+the in-repo `msvc_rtti_x64.exe`, which carried the identical defect (`Box::vftable_0`) — CI has
+no dataset. The acceptance is a single `stdout_absent` clause, which a dead `rtti` pass would
+also satisfy, so the promoted probe adds a positive `"name": "Box::vfunc_0"` clause and pins
+`--mode aggressive` instead of relying on auto's 500 KiB threshold to turn the gate on.
+
+## Sweep
+
+`kuna functions --json --mode aggressive` over **19 targets** — all 9 in-repo PE fixtures, all 8
+C++/ELF fixtures including the stripped Itanium-RTTI `.so`, the `fauxware`/`aif_gap` controls,
+and the recorded dataset PE — plus `kuna decompile-all --json` over the 9 PE fixtures.
+
+- 3 files changed, 50 lines; **residual after normalising `::vftable_<i>` → `::vfunc_<i>`: 0**.
+  Every changed line anywhere is exactly that one name.
+- The ELF half of the rank predicate is **measured-inert**: `itaniumrtti_x86_64.so` is stripped,
+  so its 26 `<Class>::vtable_<i>` entries only ever face `sub_<addr>` placeholders, which
+  already lose at tier 1. It is carried by unit tests, not by a fixture.
+
+No speed measurement: no pass, decode or analysis step was added or removed. The rtti change is
+one format string; the ranking change adds one `rsplit_once` + prefix test per `(name, entry)`
+pair inside an inventory sort that already compares those strings.
+
+## Gates
+
+| Gate | Result |
+|---|---|
+| `make test` | **PARITY OK**, 675/675 assertions |
+| `make test-stages` | **PARITY OK**, 600/600 assertions |
+| `make rust-test` | green — 5,317 tests over 343 suites |
+| `make check-spec` | `check-spec OK` |
+| `kuna catalog --check` | `catalog OK: documents exactly the registered kuna options` |
+| `python -m scripts.repipe.clitests` | 17/17 |
+| new unit tests | 3 in `kuna-console::engine`, 1 in `kuna-analysis::rtti`, `verify_rtti.rs` updated |
+
+Tooling track: no option, no `phases.toml` row, no catalog counter, no `tests/stages` case — so
+no counter or file lease was taken.
+
+## Left for a follow-up (recorded in the need)
+
+The MSVC pass has no defining-class attribution, so a slot shared by a base and its derivatives
+is named once per class and the canonical pick among them is arbitrary
+(`std::bad_alloc::vfunc_0` canonical over `std::exception::vfunc_0` on lexicographic order
+alone). The Itanium sibling already attributes an inherited slot to the class that *defines*
+it. The Itanium pass's own `vtable_<i>` stem carries the same naming defect and was left alone
+deliberately: renaming it edits the `itaniumrtti` row in `phases.toml`, which is leased to
+another builder this round.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/pe-function-inventory-labels/record.json
+++ b/docs/features/pe-function-inventory-labels/record.json
@@ -1,0 +1,72 @@
+{
+  "opportunity": "repipe:6547b4d50f4238b24302b588::pe-function-inventory-labels",
+  "need_id": "pe-function-inventory-labels",
+  "track": "tooling",
+  "round": 2,
+  "test_name": "repipe round 2, challenge 6547b4d50f4238b24302b588",
+  "binary": "kuna-re-dataset/challenges/6547b4d50f4238b24302b588/bin/trappy attack.exe",
+  "selector": null,
+  "func_addr": null,
+  "option": null,
+  "flag": null,
+  "element_id": null,
+  "change_kind": "correctness-fix",
+  "source_decompiler": "kuna",
+  "inspiration": "repipe round 2 need pe-function-inventory-labels; the rank tier it reuses is kuna's own issue-#197 canonical-entry model",
+  "default_on": true,
+  "div": null,
+  "scope": "small",
+  "files": [
+    "decompiler/crates/kuna-analysis/src/analyzers/rtti/mod.rs",
+    "decompiler/crates/kuna-analysis/src/analyzers/rtti/vftable.rs",
+    "decompiler/crates/kuna-console/src/engine.rs",
+    "decompiler/crates/kuna-console/tests/verify_rtti.rs",
+    "decompiler/crates/kuna-analysis/tests/fixtures/README.md",
+    "tests/cli/pe-function-inventory-labels.json",
+    "docs/spec/01-program-prep.md",
+    "docs/re-needs/pe-function-inventory-labels.md"
+  ],
+  "parity": "OK",
+  "gates": {
+    "make test": "PARITY OK 675/675",
+    "make test-stages": "PARITY OK 600/600",
+    "make check-spec": "OK",
+    "kuna catalog --check": "catalog OK",
+    "tests/cli": "17/17",
+    "make rust-test": "green (5,317 tests, 343 suites; run with KUNA_DECOMP_TEST unset -- the repipe worker exports it at kuna's own decomp_test_dbg, which makes the C++-oracle cross-checks in verify_w10_* compare kuna against itself and fail spuriously. kuna-decomp depends on neither crate this PR touches)"
+  },
+  "probe_flip": {
+    "probe_still_passes": false,
+    "acceptance_passes": true,
+    "vftable_named_functions_before": 10,
+    "vftable_named_functions_after": 0
+  },
+  "promoted_probe": {
+    "path": "tests/cli/pe-function-inventory-labels.json",
+    "retargeted_from": "dataset bin/trappy attack.exe (10 vftable_<i>-named routines, 0x140001040/32B .. 0x140001de0/496B)",
+    "retargeted_to": "decompiler/crates/kuna-analysis/tests/fixtures/msvc_rtti_x64.exe (Box::vftable_0 at 0x140001040)",
+    "why": "CI has no dataset; the vendored MSVC RTTI PE reproduces the identical defect, verified before the fix",
+    "strengthened": "the acceptance is a single stdout_absent clause, which a dead rtti pass would also satisfy, so the promoted probe adds a positive `\"name\": \"Box::vfunc_0\"` clause and pins --mode aggressive rather than relying on auto's 500 KiB threshold to turn the rtti gate on"
+  },
+  "speed_method": "not measured: no pass, decode or analysis step was added or removed. The rtti change is one format string; the ranking change adds one rsplit_once + prefix test per (name, entry) pair inside an inventory sort that already compares strings",
+  "sweep": {
+    "targets": 19,
+    "surface": "kuna functions --json --mode aggressive over every in-repo PE fixture (9) + every C++/ELF fixture incl. the stripped Itanium-RTTI .so (8) + fauxware/aif_gap controls, plus the recorded dataset PE; kuna decompile-all --json over the 9 PE fixtures on the first arm",
+    "changed_files": 3,
+    "changed_lines": 50,
+    "residual_after_normalising_vftable_i_to_vfunc_i": 0,
+    "note": "every changed line in the final arm is exactly one name: `::vftable_<i>` -> `::vfunc_<i>`. Nothing else moved anywhere, on any target, in either surface",
+    "elf_arm_inert": "itaniumrtti_x86_64.so is stripped, so its 26 `<Class>::vtable_<i>` entries only ever compete with `sub_<addr>` placeholders, which already lose at rank tier 1. The `vtable_` half of the rank predicate is therefore measured-inert on every in-repo ELF today and is covered by unit tests only",
+    "regression_caught": "the FIRST arm (rename only) had a 4-line residual, and it was a real regression the rename introduced: at 0x140002c2c the canonical name flipped from the recovered `std::basic_streambuf::showmanyc` to `std::basic_stringbuf::vfunc_5`, because entry_name_rank's last tier is name LENGTH and vfunc_5 is one character shorter than vftable_5. That is what added the ranking change; the residual is 0 with it in"
+  },
+  "decisions": [
+    "The filed hypothesis -- 'public data aliases near code addresses are winning the canonical-name selection for discovered function entries' -- is OVERTURNED, and the need's hypothesis_status is updated to match. No data symbol is involved. `<Class>::vftable_<i>` is a name kuna SYNTHESISES in the rtti pass (R3, analyzers/rtti/mod.rs::emit_vftable_methods) and attaches to the address a vftable slot POINTS AT -- the virtual method, not the table. All 10 flagged entries are genuine .text routines and their classification as functions is correct.",
+    "What is wrong is only the name, and it is wrong in a way that is not cosmetic: an MSVC class compiled under multiple inheritance really does own several vftables, so `<Class>::vftable_<i>` collides with the natural reading 'this class's i-th vftable'. On the recorded PE that made 496 bytes of std::basic_stringbuf code read as a vtable object. Renamed to `<Class>::vfunc_<i>`; only the table itself keeps the unindexed `<Class>::vftable` Data label.",
+    "The captain's STOP clause (stop if correcting this changes function DISCOVERY rather than labelling) does not fire. The rtti pass does create functions -- SymFact{Function} runs add_function when find_function misses -- but which addresses it creates is untouched. Discovery is byte-identical: the sweep's only diff is the name string.",
+    "Tooling track, so per docs/agents.md no option, no phases.toml row, no catalog counter and no tests/stages case. None were touched and no counter lease was taken -- which also means no collision with the phases.toml/docs/options.md leases held this round.",
+    "The rename ALONE was a net regression on one function, and only the sweep found it. entry_name_rank's tiers are (placeholder, structural, leading-underscore, LENGTH), so between a real method name and a synthetic slot name the report was decided by a one-character length accident: `std::basic_streambuf::showmanyc` (30) beat `std::basic_stringbuf::vftable_5` (31) and lost to `vfunc_5` (29), while its neighbour `uflow` (27) kept its name either way. The fix is not to pick a longer word: a slot-index name is STRUCTURAL in exactly the sense the existing `_FINI_<i>` tier documents -- it says which slot the function occupies, not what the function is called -- so it now sorts into that tier and a real method name outranks it at any length.",
+    "The rank predicate covers the Itanium sibling's `<Class>::vtable_<i>` as well as `<Class>::vfunc_<i>`: same defect, same one predicate. It is measured-inert on every in-repo ELF (the itaniumrtti fixture is stripped, so those names only face `sub_` placeholders, which already lose a tier earlier) and is carried by unit tests. The Itanium pass's own `vtable_<i>` STEM was left alone deliberately -- renaming it edits the itaniumrtti row in phases.toml, which quotes `Shape::vtable_2`, and phases.toml is leased to another builder this round. Worth a follow-up need.",
+    "A slot-index name still outranks `sub_`/`FUN_` placeholders: it is structural, not uninformative. `std::bad_alloc::vfunc_0` stays canonical over `sub_140001060`, which is checked by a unit test.",
+    "Second defect found, NOT fixed here, recorded in the need's Refutation for a follow-up: the MSVC pass has no defining-class attribution, so a slot shared by a base and its derivatives is named once per class and the canonical pick among them is arbitrary (`std::bad_alloc::vfunc_0` canonical over `std::exception::vfunc_0` purely on lexicographic order). The Itanium sibling already attributes an inherited slot to the class that DEFINES it; the MSVC one does not."
+  ]
+}

--- a/docs/re-needs/pe-function-inventory-labels.md
+++ b/docs/re-needs/pe-function-inventory-labels.md
@@ -6,7 +6,7 @@ status: open
 severity: major
 probe_id: p-8e912566d7ea
 acceptance_id: a-d6666365cbb6
-hypothesis_status: inconclusive
+hypothesis_status: overturned
 credibility: 0.7
 instances: 1
 challenges: [6547b4d50f4238b24302b588]
@@ -96,7 +96,27 @@ A trustworthy function inventory for triaging the PE.
 
 ## Refutation
 
-_not yet refuted_
+**Hypothesis OVERTURNED (round 2 builder `b-r2-pe-function-inve`); the symptom stands.**
+
+The name is not a data-symbol alias winning canonical-name selection. `<Class>::vftable_<i>`
+is a name kuna SYNTHESISES, and it is attached to a genuine function. The `rtti` pass (R3,
+`decompiler/crates/kuna-analysis/src/analyzers/rtti/mod.rs`) walks each recovered vftable and
+emits, per slot, a `SymFact{Function}` **at the address the slot points at** — the virtual
+method itself, not the table. All 10 flagged entries on `trappy attack.exe` are real
+`.text` routines (0x140001040/32B … 0x140001de0/496B), and the classification as functions is
+correct. What was wrong was only the name: it spells the data object that points at the code,
+and since an MSVC class under multiple inheritance really does own several vftables, the
+indexed form reads as "this class's i-th vftable" rather than "the function in slot i".
+
+Two consequences for the fix: nothing about function DISCOVERY changes (the captain's STOP
+clause does not fire — this is pure labelling), and no option is needed.
+
+Adjacent, NOT fixed here and worth a separate need: the MSVC pass has no defining-class
+attribution, so a slot shared by a base and its derivatives gets one name per class
+(`std::bad_alloc::vfunc_0` with `std::exception::vfunc_0` / `std::bad_array_new_length::vfunc_0`
+as aliases; the canonical pick is arbitrary). The Itanium sibling already solves this; the MSVC
+one does not. Its function symbols also still use the `vtable_<i>` stem and carry the same
+naming defect, left alone here because correcting it edits `phases.toml`, leased this round.
 
 ## Reference
 

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -1030,7 +1030,17 @@ every other binary's pass list is byte-identical to before the pass existed):
   CompleteObjectLocator, validate the COL→RTTI3→RTTI2→RTTI1→RTTI0 reachability
   chain (x86 raw-VA vs x64 image-base-relative refs behind a refkind dispatch), and
   label `<Class>::vftable` / `RTTI_*` with the class names demangled by the
-  existing MSVC arm.
+  existing MSVC arm. From each recovered `<Class>::vftable` base the pass then walks
+  the slot array (`vftable.rs`), bounded at the first NULL or non-`.text` slot, and
+  emits one **function** symbol per surviving slot at the address it points at. That
+  symbol is named `<Class>::vfunc_<i>` — the class name comes from the RTTI0
+  `TypeDescriptor` and the slot index is the only disambiguator MSVC metadata offers,
+  since it records no per-method names. The stem is `vfunc_`, not `vftable_`, because
+  the name lands on *code*: a class compiled under multiple inheritance genuinely owns
+  more than one vftable, so an indexed `<Class>::vftable_<i>` reads as that class's
+  i-th table and made `kuna functions` report hundreds of bytes of executable
+  `std::basic_stringbuf` code as vtable objects. Only the table itself wears a
+  `vftable` name, and it is unindexed.
 - **(kuna) Itanium RTTI** (`itaniumrtti`, ELF-only, default-off;
   `decompiler/crates/kuna-analysis/src/analyzers/rtti/kuna_itaniumrtti.rs`): the
   GCC/Clang counterpart of the pass above, and a capability with **no Ghidra

--- a/tests/cli/pe-function-inventory-labels.json
+++ b/tests/cli/pe-function-inventory-labels.json
@@ -1,0 +1,38 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json",
+    "--mode",
+    "aggressive"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/msvc_rtti_x64.exe",
+    "binary_sha256": "8fc43a64b980043382bfc68754298b4533a0a97489ce2b35bf66174ad207325b",
+    "binary_size": 3584,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/msvc_rtti_x64.exe"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "\"name\": \"Box::vfunc_0\""
+    ],
+    "stdout_absent": [
+      "\"name\": \"[^\"]*::vftable_[0-9]+\""
+    ]
+  },
+  "notes": "Promoted acceptance of pe-function-inventory-labels, re-pointed off the dataset PE onto the in-repo MSVC RTTI fixture, which reproduces it (CI has no dataset). rtti names each vftable slot's TARGET -- a function -- and used to call it `<Class>::vftable_<i>`, so `kuna functions` called executable ranges vtables. Now `vfunc_<i>`. --mode aggressive pins the rtti gate on."
+}


### PR DESCRIPTION
## What was broken

RE-friction need `pe-function-inventory-labels` (round 2, challenge `6547b4d50f4238b24302b588`,
1 instance, severity major). The tester wanted *"a trustworthy function inventory for triaging
the PE"* and reported:

> The inventory includes executable ranges named `std::bad_alloc::vftable_1` and numerous
> `std::basic_stringbuf::vftable_N` entries as functions, including ranges hundreds of bytes
> long. These names are data-symbol aliases and misleadingly classify routines as vtable
> objects.

10 entries on that PE, from `0x140001040` (32 B) to `0x140001de0` (496 B).

## The filed hypothesis is overturned; the symptom stands

The hypothesis was *"public data aliases near code addresses are winning the canonical-name
selection"*. No data symbol is involved. `<Class>::vftable_<i>` is a name **kuna synthesises**:
the MSVC RTTI pass (R3, `analyzers/rtti/mod.rs::emit_vftable_methods`) walks each recovered
vftable and emits a `SymFact{Function}` at the address each slot **points at** — the virtual
method, not the table. All 10 entries are genuine `.text` routines and classifying them as
functions is correct.

The name is what is wrong, and not merely cosmetically: an MSVC class under multiple
inheritance genuinely owns several vftables, so `<Class>::vftable_<i>` collides with the
natural reading *"this class's i-th vftable"*. The need's STOP clause — stop if the fix changes
function DISCOVERY rather than labelling — does not fire: which addresses the pass creates is
untouched.

## Mechanism

**1. The slot function is named after the function.** `<Class>::vftable_<i>` →
`<Class>::vfunc_<i>`. Only the table itself keeps a `vftable` name, and it keeps the unindexed
`<Class>::vftable` Data label it always had.

**2. A slot-index name is structural, so a real method name outranks it.** The rename alone was
a *net regression* on one function, and only the whole-corpus sweep found it.
`entry_name_rank`'s tiers are `(placeholder, structural, leading-underscore, LENGTH)`, so
between a recovered method name and a synthetic slot name the reported name was decided by a
one-character length accident:

| address | before this PR | after rename only | after both changes |
|---|---|---|---|
| `0x140002c2c` | `std::basic_streambuf::showmanyc` (30) | **`std::basic_stringbuf::vfunc_5`** (29) | `std::basic_streambuf::showmanyc` |
| `0x140002c32` | `std::basic_streambuf::uflow` (27) | `std::basic_streambuf::uflow` | `std::basic_streambuf::uflow` |

The fix is not to pick a longer word. A slot-index name is structural in exactly the sense the
existing `_FINI_<i>` tier already documents — *it says which slot the function occupies, not
what the function is called* — so `<Class>::vfunc_<i>` (MSVC) and `<Class>::vtable_<i>`
(Itanium) now sort into that tier, and a real method name outranks them at any length. They
still beat `sub_`/`FUN_` placeholders, which lose a tier earlier.

## The acceptance probe now passes

```
$ python -m scripts.repipe.verify --need pe-function-inventory-labels
acceptance suite  sha 74118fd
  PASS   closed         open           pe-function-inventory-labels
total=1 pass=1 fail=0 closed=1 regressed=0 indeterminate=0
```

`"name": "[^"]*::vftable_[0-9]+"` count on the recorded PE: **10 → 0**.

Promoted to `tests/cli/pe-function-inventory-labels.json`, re-pointed off the dataset PE onto
the in-repo `msvc_rtti_x64.exe`, which carried the identical defect (`Box::vftable_0`) — CI has
no dataset. The acceptance is a single `stdout_absent` clause, which a dead `rtti` pass would
also satisfy, so the promoted probe adds a positive `"name": "Box::vfunc_0"` clause and pins
`--mode aggressive` instead of relying on auto's 500 KiB threshold to turn the gate on.

## Sweep

`kuna functions --json --mode aggressive` over **19 targets** — all 9 in-repo PE fixtures, all 8
C++/ELF fixtures including the stripped Itanium-RTTI `.so`, the `fauxware`/`aif_gap` controls,
and the recorded dataset PE — plus `kuna decompile-all --json` over the 9 PE fixtures.

- 3 files changed, 50 lines; **residual after normalising `::vftable_<i>` → `::vfunc_<i>`: 0**.
  Every changed line anywhere is exactly that one name.
- The ELF half of the rank predicate is **measured-inert**: `itaniumrtti_x86_64.so` is stripped,
  so its 26 `<Class>::vtable_<i>` entries only ever face `sub_<addr>` placeholders, which
  already lose at tier 1. It is carried by unit tests, not by a fixture.

No speed measurement: no pass, decode or analysis step was added or removed. The rtti change is
one format string; the ranking change adds one `rsplit_once` + prefix test per `(name, entry)`
pair inside an inventory sort that already compares those strings.

## Gates

| Gate | Result |
|---|---|
| `make test` | **PARITY OK**, 675/675 assertions |
| `make test-stages` | **PARITY OK**, 600/600 assertions |
| `make rust-test` | green — 5,317 tests over 343 suites |
| `make check-spec` | `check-spec OK` |
| `kuna catalog --check` | `catalog OK: documents exactly the registered kuna options` |
| `python -m scripts.repipe.clitests` | 17/17 |
| new unit tests | 3 in `kuna-console::engine`, 1 in `kuna-analysis::rtti`, `verify_rtti.rs` updated |

Tooling track: no option, no `phases.toml` row, no catalog counter, no `tests/stages` case — so
no counter or file lease was taken.

## Left for a follow-up (recorded in the need)

The MSVC pass has no defining-class attribution, so a slot shared by a base and its derivatives
is named once per class and the canonical pick among them is arbitrary
(`std::bad_alloc::vfunc_0` canonical over `std::exception::vfunc_0` on lexicographic order
alone). The Itanium sibling already attributes an inherited slot to the class that *defines*
it. The Itanium pass's own `vtable_<i>` stem carries the same naming defect and was left alone
deliberately: renaming it edits the `itaniumrtti` row in `phases.toml`, which is leased to
another builder this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
