### PR TITLE
[AUTOMATED] fix(console): decompiling-3396-byte-main — follow the function's flow once, not twice

### DIFF
--- a/decompiler/crates/kuna-console/src/decompile_step.rs
+++ b/decompiler/crates/kuna-console/src/decompile_step.rs
@@ -120,12 +120,31 @@ pub fn decompile_one(
     seed: &DecompileSeed<'_>,
     proto_overrides: &[(Address, PrototypePieces)],
 ) -> DecompileStep {
+    decompile_one_prefollowed(arch, name, entry, size, seed, proto_overrides, None)
+}
+
+/// [`decompile_one`], but able to adopt an already-followed `Funcdata` for the
+/// FIRST drive instead of following the same flow a second time (see
+/// `kuna_decomp::decompile_drive::decompile_func_full_with_override_dyn_prefollowed`).
+///
+/// Only the first drive can adopt it: the format-string re-decompile installs
+/// new per-call-site prototype overrides, which are consumed AT FLOW TIME, so
+/// that second pass always re-follows.
+pub fn decompile_one_prefollowed(
+    arch: &mut Architecture,
+    name: &str,
+    entry: Address,
+    size: int4,
+    seed: &DecompileSeed<'_>,
+    proto_overrides: &[(Address, PrototypePieces)],
+    prefollowed: Option<Funcdata>,
+) -> DecompileStep {
     let formatstring_enabled = arch.analysis_formatstring;
     let saved_readonlypropagate = arch.readonlypropagate;
     if formatstring_enabled {
         arch.readonlypropagate = true;
     }
-    let mut result = kuna_decomp::decompile_drive::decompile_func_full_with_override_dyn(
+    let mut result = kuna_decomp::decompile_drive::decompile_func_full_with_override_dyn_prefollowed(
         arch,
         name,
         // Cloned so `entry` survives for the conditional re-decompile below
@@ -140,6 +159,7 @@ pub fn decompile_one(
         seed.flow_overrides,
         proto_overrides,
         seed.mapped_params,
+        prefollowed,
     );
     let mut discovered: Vec<(Address, PrototypePieces)> = Vec::new();
     if formatstring_enabled {

--- a/decompiler/crates/kuna-console/src/ifacedecomp.rs
+++ b/decompiler/crates/kuna-console/src/ifacedecomp.rs
@@ -163,6 +163,52 @@ pub struct IfaceDecompData {
         String,
         Vec<(kuna_base::types::int4, String, kuna_decomp::fspec::ParameterPieces)>,
     >,
+    /// (kuna) What the last `load function` / `load addr` followed, so the very
+    /// next `decompile` can adopt that IR instead of following the same flow a
+    /// second time.  See [`PristineFlow`].
+    pub pristine_flow: Option<PristineFlow>,
+    /// (kuna) How many times a `decompile` adopted the loaded IR instead of
+    /// re-following the flow.  Observability only -- nothing reads it to make a
+    /// decision; it is what lets a test assert the fast path was actually taken
+    /// rather than only that the output did not change.
+    pub adopted_flows: u64,
+}
+
+/// (kuna) The provenance stamp of the `Funcdata` currently in `dcp.fd`, recorded
+/// by `load function` / `load addr` right after their flow follow.
+///
+/// C++ `IfcDecompile` re-runs the actions on the `Funcdata` `IfcFuncload` built
+/// (`clearAnalysis` + `perform`), so upstream follows the flow ONCE.  The kuna
+/// console rebuilds the IR instead, because the seeds a decompile is given --
+/// `map addr` symbols and DWARF locals, `type varnode` usepoint symbols, `map
+/// hash` dynamic symbols, a `parse line` prototype, `map param` storage locks,
+/// `override prototype` facts -- are consumed AT FLOW TIME and `load function`
+/// applies none of them.  So the rebuild is not gratuitous; it is what makes
+/// those console facts take effect.
+///
+/// It is also pure waste whenever there are no such facts, which is every
+/// `kuna decompile <bin> <fn>`: the lift, the block build and the per-jump-table
+/// sub-decompilation all run twice.  This stamp is what lets `decompile` prove
+/// the waste case: it records the identity the flow was followed under, and the
+/// console command counter at that moment, so a `decompile` that runs as the
+/// very next command with every seed still empty can adopt the IR verbatim.
+///
+/// The `command_seq` check is deliberately the whole invalidation story.  Any
+/// command in between -- an `option` that changes a flow-time decision, a
+/// `kassert`, a `map`/`override`/`parse`, another `load` -- advances the counter
+/// and the stamp stops matching, so no command needs its own invalidation hook
+/// and none can be forgotten.
+pub struct PristineFlow {
+    /// `IfaceStatus::command_seq` as of the `load` that followed this flow.
+    pub command_seq: u64,
+    /// The name the flow was followed under.
+    pub name: String,
+    /// The entry the flow was followed from.
+    pub entry: kuna_base::address::Address,
+    /// The declared byte extent the follow was bounded by (0 = unbounded).
+    pub size: kuna_base::types::int4,
+    /// The flow overrides seeded before the follow.
+    pub flow_overrides: Vec<(kuna_base::address::Address, kuna_base::types::uint4)>,
 }
 
 impl IfaceData for IfaceDecompData {
@@ -906,6 +952,7 @@ decomp_command!(
         // Idempotent, and a no-op for every real name.
         let funcname =
             kuna_decomp::kuna_symbolnamebound::bound_scope_path(&s.read_token(), "::").into_owned();
+        let command_seq = status.command_seq;
         let dcp = dcp_mut(status)?;
         if dcp.conf.is_none() {
             return Err(IfaceError::execution("No image loaded"));
@@ -952,6 +999,7 @@ decomp_command!(
         // A `function bounds` declaration for this entry bounds the follow;
         // without one the extent is the natural (unbounded) one.
         let declared = prog.declared_extent(entry.get_offset());
+        let entry_stamp = entry.clone();
         let fd = build_and_follow_flow_with_override(
             prog.arch_mut(),
             &resolved_name,
@@ -960,6 +1008,15 @@ decomp_command!(
             &flow_overrides,
         )
         .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
+        // (kuna) Stamp the follow so an immediately-following `decompile` can adopt
+        // this IR rather than following the same flow again (see `PristineFlow`).
+        dcp.pristine_flow = Some(PristineFlow {
+            command_seq,
+            name: resolved_name,
+            entry: entry_stamp,
+            size: declared,
+            flow_overrides,
+        });
         dcp.fd = Some(fd);
         Ok(())
     }
@@ -970,6 +1027,7 @@ decomp_command!(
     /// <addr> [name]`).
     IfcAddrrangeLoad,
     fn execute(&self, status: &mut IfaceStatus, s: &mut CommandStream) -> IfaceResult<()> {
+        let command_seq = status.command_seq;
         let dcp = dcp_mut(status)?;
         if dcp.conf.is_none() {
             return Err(IfaceError::execution("No binary loaded"));
@@ -1036,9 +1094,19 @@ decomp_command!(
         if inline_size > 0 {
             prog.declare_extent(offset.get_offset(), inline_size);
         }
+        let entry_stamp = offset.clone();
+        let name_stamp = name.clone();
         let fd =
             build_and_follow_flow_with_override(prog.arch_mut(), &name, offset, declared, &flow_overrides)
                 .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
+        // (kuna) Same follow stamp as `load function` (see `PristineFlow`).
+        dcp.pristine_flow = Some(PristineFlow {
+            command_seq,
+            name: name_stamp,
+            entry: entry_stamp,
+            size: declared,
+            flow_overrides,
+        });
         dcp.fd = Some(fd);
         Ok(())
     }
@@ -1659,6 +1727,7 @@ decomp_command!(
     /// drive once it lands.
     IfcDecompile,
     fn execute(&self, status: &mut IfaceStatus, _s: &mut CommandStream) -> IfaceResult<()> {
+        let command_seq = status.command_seq;
         // Read the per-function values + take the program out so the engine work
         // borrows neither `status` nor `dcp` while the console output is written.
         let (name, has_no_code, proc_started, entry, size, mut mapped_symbols, usepoint_symbols, dynamic_symbols, pending_proto, all_pending_protos, mut prog) = {
@@ -1715,6 +1784,7 @@ decomp_command!(
         // call site (C++ `coreaction.cc:2385` `fc->copy(otherfunc->getFuncProto())`).
         // Functions without a declared prototype (or whose symbol is absent) are
         // unaffected — the default-model recovery still applies there.
+        let all_pending_protos_empty = all_pending_protos.is_empty();
         for pieces in all_pending_protos {
             prog.arch_mut().set_function_prototype_pieces(&pieces.name.clone(), pieces);
         }
@@ -1775,11 +1845,75 @@ decomp_command!(
         // drive (decompile_drive::decompile_func) installs the `decompile` root,
         // resets it, and runs the 252-pass perform loop to completion.
         //
+        // (kuna) Adopt the IR `load function` / `load addr` already followed, when
+        // this `decompile` is provably the same flow follow repeated.  Upstream
+        // never repeats it (`IfcDecompile` re-runs the actions on `IfcFuncload`'s
+        // Funcdata); kuna rebuilds because the seeds below are consumed at flow
+        // time and the load applies none of them — so the rebuild is required
+        // exactly when some seed is non-empty, and pure waste when none is.  Every
+        // seed the drive would apply before/at flow time is checked, plus the
+        // command counter (see `PristineFlow`), so anything at all between the two
+        // commands falls back to the rebuild.
+        let prefollowed = {
+            let dcp = dcp_mut(status)?;
+            let seeds_empty = mapped_symbols.is_empty()
+                && usepoint_symbols.is_empty()
+                && dynamic_symbols.is_empty()
+                && pending_proto.is_none()
+                && all_pending_protos_empty
+                && mapped_params.is_empty()
+                && proto_overrides.is_empty();
+            let stamp_matches = matches!(&dcp.pristine_flow, Some(p)
+                if p.command_seq + 1 == command_seq
+                    && p.name == name
+                    && p.entry == entry
+                    && p.size == size
+                    && p.flow_overrides == flow_overrides);
+            // The IR must also have been followed under the SAME architecture
+            // configuration the drive will run with, because a `Funcdata` snapshots
+            // the per-function flags into its ArchSeam handle when it is BUILT (see
+            // `docs/spec/00-overview.md` §0.5) -- a flag flipped afterwards is
+            // invisible to it.  Three things move between the load and the drive:
+            //
+            //  * `formatstring` turns read-only propagation on around the drive so
+            //    the printf format constant can be READ (on ARM it is a PC-relative
+            //    literal-pool load that only folds with `fillin_read_only`).  The
+            //    loaded IR snapshotted the flag OFF, so adopting it renders
+            //    `printf((char *)(dat_52c + 0x51c), ...)` -- the format string never
+            //    resolves and the varargs never get typed.
+            //  * the watchdog arms its per-function deadline inside the drive
+            //    (`kuna_fn_budget` is `None` on every console path).
+            //  * ghidra mode stages name/dynamic/prototype-model recommendations that
+            //    the drive takes; a follow that ran while they were still parked is
+            //    not the same follow.
+            let same_config = !prog.arch().analysis_formatstring
+                && prog.arch().kuna_fn_budget.is_none()
+                && prog.arch().kuna_pending_name_recs.is_empty()
+                && prog.arch().kuna_pending_dyn_recs.is_empty()
+                && prog.arch().kuna_pending_proto_model.is_none();
+            if seeds_empty && stamp_matches && same_config {
+                dcp.adopted_flows += 1;
+                dcp.fd.take()
+            } else {
+                None
+            }
+        };
+        // The recipe that rebuilds what was just handed over, for the failure arm
+        // below.  A drive that aborts (the GH-6904 LOSS-131 stub path) leaves the
+        // console expected to still hold an un-decompiled `dcp.fd` for a following
+        // `print C`; adopting the IR moves it into the drive, which consumes it, so
+        // the error arm re-follows the SAME name/entry/size/overrides `load
+        // function` used.  Only reached when a decompile fails, i.e. never on a
+        // healthy run and never on the parity corpora.
+        let adopted_recipe = prefollowed.as_ref().and_then(|_| {
+            dcp_mut(status).ok().and_then(|dcp| dcp.pristine_flow.take())
+        });
+        dcp_mut(status)?.pristine_flow = None;
         // (DIV-66) Routed through the SHARED step so this console command and the
         // whole-binary loop (`project::decompile_targets`) run the identical
         // pipeline — including the FormatStringAnalyzer half-B override /
         // re-decompile loop, which used to live only here.
-        let step = crate::decompile_step::decompile_one(
+        let step = crate::decompile_step::decompile_one_prefollowed(
             prog.arch_mut(),
             &name,
             entry,
@@ -1793,6 +1927,7 @@ decomp_command!(
                 mapped_params: &mapped_params,
             },
             &proto_overrides,
+            prefollowed,
         );
         let result = step.result;
         if !step.discovered.is_empty() {
@@ -1808,6 +1943,22 @@ decomp_command!(
                 .push((callpoint, pieces));
         }
         // Restore the program (and the fresh Funcdata on success) regardless.
+        if result.is_err() {
+            // Re-follow the adopted IR so the console is left holding the same
+            // un-decompiled `dcp.fd` the rebuild path would have left (see
+            // `adopted_recipe`).  `None` whenever nothing was adopted.
+            if let Some(recipe) = &adopted_recipe {
+                if let Ok(fd) = build_and_follow_flow_with_override(
+                    prog.arch_mut(),
+                    &recipe.name,
+                    recipe.entry.clone(),
+                    recipe.size,
+                    &recipe.flow_overrides,
+                ) {
+                    dcp_mut(status)?.fd = Some(fd);
+                }
+            }
+        }
         let dcp = dcp_mut(status)?;
         dcp.conf = Some(prog);
         match result {

--- a/decompiler/crates/kuna-console/src/interface.rs
+++ b/decompiler/crates/kuna-console/src/interface.rs
@@ -844,6 +844,15 @@ pub struct IfaceStatus {
 
     /// The input behavior (C++ virtual `readLine`/`pushScript`/...).
     source: Box<dyn LineSource>,
+
+    /// (kuna) How many commands this session has dispatched, incremented just
+    /// before each `execute`.  A command that wants to know whether it runs
+    /// *immediately* after another one compares stamps: `load function` records
+    /// this counter and `decompile` adopts its already-followed IR only when the
+    /// counter advanced by exactly one, so any command in between (an `option`,
+    /// a `map`, a `kassert`) silently invalidates the reuse rather than needing
+    /// its own invalidation hook.
+    pub command_seq: u64,
 }
 
 /// An open bulk-output redirect (`openfile`/`openfile append`).
@@ -881,6 +890,7 @@ impl IfaceStatus {
             comlist: Vec::new(),
             datamap: BTreeMap::new(),
             source,
+            command_seq: 0,
         }
     }
 
@@ -1180,6 +1190,7 @@ impl IfaceStatus {
             &mut self.comlist[first].action,
             Box::new(DummyAction),
         );
+        self.command_seq = self.command_seq.wrapping_add(1);
         let res = action.execute(self, &mut is);
         self.comlist[first].action = action;
         res?;

--- a/decompiler/crates/kuna-console/tests/verify_flowreuse.rs
+++ b/decompiler/crates/kuna-console/tests/verify_flowreuse.rs
@@ -1,0 +1,211 @@
+//! End-to-end gate for the **adopted flow follow**: `kuna decompile` drives the
+//! console with `load function <fn>` and then `decompile`, and each of those used
+//! to follow the same function's flow from scratch — lift, block build, and the
+//! per-jump-table sub-decompilation, all twice.
+//!
+//! Upstream never pays that: C++ `IfcFuncload` follows flow once and
+//! `IfcDecompile` re-runs the actions on *that* `Funcdata` after
+//! `Architecture::clearAnalysis` (`ifacedecomp.cc:889`). The kuna console rebuilds
+//! instead because the facts a decompile is seeded with — `map addr` symbols and
+//! DWARF locals, `type varnode` usepoint symbols, `map hash` dynamic symbols, a
+//! `parse line` prototype, `map param` storage locks, `override prototype` facts —
+//! are consumed AT FLOW TIME and `load function` applies none of them. So the
+//! rebuild is required exactly when one of those is present, and pure waste when
+//! none is, which is every plain `kuna decompile <bin> <fn>`.
+//!
+//! `IfcDecompile` now adopts the loaded IR when it can prove the rebuild would
+//! repeat the same follow (`kuna_console::ifacedecomp::PristineFlow`). The
+//! properties asserted here are the two that matter:
+//!
+//! 1. **The fast path fires** on the plain `load function` → `decompile` pair
+//!    (`IfaceDecompData::adopted_flows`), and does NOT fire when anything at all
+//!    ran in between or when a seed is present.
+//! 2. **It changes nothing**: the C rendered through the adopting path is
+//!    byte-identical to the C rendered through the rebuilding path.
+//!
+//! ## `.sla` precondition
+//!
+//! Like the sibling gates, bootstrapping needs the built per-arch `.sla` under
+//! `specs/` (gitignored; `make specs`). When it is absent the bootstrap fails;
+//! the test prints that and returns early (a specs-less CI is a visible skip,
+//! never a false green).
+
+use std::path::PathBuf;
+
+use kuna_console::engine::{bootstrap_from_object, ConsoleProgram};
+use kuna_console::ifacedecomp::{
+    execute, register_decomp_commands, IfaceDecompData, DECOMPILE_MODULE,
+};
+use kuna_console::ifaceterm::ConsoleCommands;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+/// Bootstrap the x86-64 `fmt` fixture and run the analysis commit.  `None` is a
+/// visible specs-less skip.
+fn load() -> Option<ConsoleProgram> {
+    load_fixture("fmt_x86_64")
+}
+
+fn load_fixture(name: &str) -> Option<ConsoleProgram> {
+    let root = repo_root();
+    let spec_roots = vec![root.join("specs").to_str().unwrap().to_string()];
+    let bin = root
+        .join("decompiler/crates/kuna-analysis/tests/fixtures")
+        .join(name)
+        .to_str()?
+        .to_string();
+    let mut prog = match bootstrap_from_object(&bin, "", &spec_roots) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "verify_flowreuse[{name}]: skipping (bootstrap failed, build `.sla` \
+                 with `make specs`): {}",
+                e.explain()
+            );
+            return None;
+        }
+    };
+    prog.commit_pending_analysis().expect("analysis commit succeeds");
+    Some(prog)
+}
+
+/// Drive the console with `cmds` and return `(rendered C, adoption count)`.
+fn drive(cmds: &[&str]) -> Option<(String, u64)> {
+    drive_on("fmt_x86_64", cmds)
+}
+
+fn drive_on(fixture: &str, cmds: &[&str]) -> Option<(String, u64)> {
+    drive_with(fixture, &[], cmds)
+}
+
+fn drive_with(fixture: &str, options: &[(&str, &str)], cmds: &[&str]) -> Option<(String, u64)> {
+    let mut prog = load_fixture(fixture)?;
+    for (name, value) in options {
+        prog.arch_mut().set_kuna_option(name, value).expect("option flips");
+    }
+    let cmds: Vec<String> = cmds.iter().map(|s| s.to_string()).collect();
+    let count = cmds.len();
+    let mut status = ConsoleCommands::into_status(cmds);
+    register_decomp_commands(&mut status);
+    {
+        let data = status.get_data_mut(DECOMPILE_MODULE).unwrap();
+        let dcp = data.as_any_mut().downcast_mut::<IfaceDecompData>().unwrap();
+        dcp.conf = Some(prog);
+    }
+    for _ in 0..count {
+        execute(&mut status);
+    }
+    let adopted = {
+        let data = status.get_data_mut(DECOMPILE_MODULE).unwrap();
+        data.as_any_mut().downcast_mut::<IfaceDecompData>().unwrap().adopted_flows
+    };
+    // Without a `decomp_dbg`-style `openfile` redirect the bulk `print C` output
+    // lands in the same buffer as the command notices, so drop the transcript and
+    // keep the C (the `verify_decompile_all_parity` precedent).
+    let text = status
+        .optr
+        .rsplit_once("Decompilation complete\n")
+        .unwrap_or_else(|| panic!("console decompile did not complete:\n{}", status.optr))
+        .1
+        .to_string();
+    Some((text.trim_matches('\n').to_string(), adopted))
+}
+
+/// Property 1 + 2 together: the plain pair adopts, an `echo` in between does not,
+/// and both render the same C.  `echo` is chosen deliberately — it is the most
+/// inert command the console has, so what suppresses the adoption is the command
+/// counter itself and not any state the command touched.
+#[test]
+fn adopting_the_loaded_flow_renders_the_same_c_as_rebuilding_it() {
+    let Some((adopted_c, adopted_n)) =
+        drive(&["load function main", "decompile", "print C"])
+    else {
+        return;
+    };
+    let (rebuilt_c, rebuilt_n) =
+        drive(&["load function main", "echo x", "decompile", "print C"]).expect("second load");
+
+    assert_eq!(adopted_n, 1, "the plain load/decompile pair must adopt the loaded IR");
+    assert_eq!(rebuilt_n, 0, "a command in between must fall back to the rebuild");
+    assert_eq!(
+        adopted_c, rebuilt_c,
+        "adopting the loaded IR must render byte-identical C"
+    );
+    assert!(adopted_c.contains("printf("), "the fixture renders a printf call:\n{adopted_c}");
+}
+
+/// `load addr` stamps its follow the same way `load function` does.
+#[test]
+fn load_addr_also_adopts() {
+    let Some((c, n)) = drive(&["load function main", "decompile", "print C"]) else { return };
+    let Some(prog) = load() else { return };
+    let entry = prog
+        .function_entries_canonical()
+        .into_iter()
+        .find(|e| e.name == "main")
+        .expect("the fixture exports main");
+    drop(prog);
+    let cmd = format!("load addr 0x{:x} main", entry.addr.get_offset());
+    let (c2, n2) = drive(&[&cmd, "decompile", "print C"]).expect("load addr drive");
+    assert_eq!(n, 1);
+    assert_eq!(n2, 1, "`load addr` must stamp its follow too");
+    assert_eq!(c, c2, "the two entry surfaces render the same C");
+}
+
+/// The stamp is single-use: a second `decompile` of the same function has no
+/// pristine IR to adopt (the first one consumed it and left a decompiled
+/// `Funcdata` in its place), so it must re-follow.
+#[test]
+fn a_second_decompile_does_not_adopt() {
+    let Some((_, n)) = drive(&[
+        "load function main",
+        "decompile",
+        "decompile",
+        "print C",
+    ]) else {
+        return;
+    };
+    assert_eq!(n, 1, "the stamp is single-use; a second decompile must rebuild");
+}
+
+/// The SEED guard, isolated from the command-counter guard: a `-g` binary parks
+/// DWARF stack locals on the function, and `IfcDecompile` re-seeds them into the
+/// rebuilt IR's `ScopeLocal` — a fact consumed at flow time that `load function`
+/// never applied.  Nothing runs between the load and the decompile here, so the
+/// counter guard passes and it is the seed guard alone that must force the
+/// rebuild.  The rendered C is the proof it matters: the DWARF names survive.
+#[test]
+fn dwarf_locals_are_a_flow_time_seed_that_forces_the_rebuild() {
+    let Some((c, n)) =
+        drive_on("dwarfstructs_x86_64", &["load function main", "decompile", "print C"])
+    else {
+        return;
+    };
+    assert_eq!(n, 0, "DWARF locals are a flow-time seed; they must force the rebuild");
+    assert!(!c.is_empty(), "the DWARF fixture still renders C:\n{c}");
+}
+
+/// The ARCHITECTURE-CONFIG guard, and the reason it exists.  A `Funcdata`
+/// snapshots the per-function flags into its ArchSeam handle when it is BUILT, so
+/// a flag flipped afterwards is invisible to it.  `formatstring` flips exactly
+/// one — read-only propagation, turned on around the drive so the printf format
+/// constant can be READ — which the loaded IR snapshotted OFF.  Adopting it there
+/// leaves `printf((char *)(dat_… + …), …)`: the format string never resolves and
+/// the varargs never get typed.  So `formatstring` must force the rebuild.
+#[test]
+fn formatstring_forces_the_rebuild() {
+    let Some((c, n)) = drive_with(
+        "fmt_x86_64",
+        &[("formatstring", "on")],
+        &["load function main", "decompile", "print C"],
+    ) else {
+        return;
+    };
+    assert_eq!(n, 0, "formatstring moves an arch flag around the drive; it must rebuild");
+    assert!(
+        c.contains("printf(\"%d %s"),
+        "the format string must still resolve with formatstring on:\n{c}"
+    );
+}

--- a/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
@@ -864,6 +864,54 @@ pub fn decompile_func_full_with_override_dyn(
     proto_overrides: &[(Address, crate::fspec::PrototypePieces)],
     mapped_params: &[(int4, String, crate::fspec::ParameterPieces)],
 ) -> KunaResult<Funcdata> {
+    decompile_func_full_with_override_dyn_prefollowed(
+        arch,
+        name,
+        funcaddr,
+        size,
+        mapped_symbols,
+        usepoint_symbols,
+        dynamic_symbols,
+        pending_proto,
+        flow_overrides,
+        proto_overrides,
+        mapped_params,
+        None,
+    )
+}
+
+/// [`decompile_func_full_with_override_dyn`], but able to adopt a `Funcdata`
+/// whose flow has **already been followed** instead of following it again.
+///
+/// The console runs `load function <name>` and then `decompile`, and each of
+/// those followed the flow of the same function from scratch -- so a `kuna
+/// decompile` paid the whole lift, including the per-jump-table
+/// sub-decompilation, twice.  C++ has no such duplication: `IfcFuncload`
+/// follows flow once and `IfcDecompile` re-runs the actions on *that*
+/// `Funcdata` after `Architecture::clearAnalysis` (ifacedecomp.cc:889).
+///
+/// `prefollowed` is the caller's already-followed IR.  It is adopted verbatim,
+/// so the caller is responsible for having followed flow with the SAME name,
+/// entry, size, flow overrides and prototype overrides this call would have used
+/// -- see `kuna_console::ifacedecomp` (`PristineFlow`), which only offers one
+/// when every seed below is empty and nothing has run in between.  `None`
+/// restores the build-and-follow behaviour every other caller has.
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::mutable_key_type)]
+pub fn decompile_func_full_with_override_dyn_prefollowed(
+    arch: &mut Architecture,
+    name: &str,
+    funcaddr: Address,
+    size: int4,
+    mapped_symbols: &[(String, std::rc::Rc<crate::dtype::Datatype>, Address, kuna_base::types::uint4)],
+    usepoint_symbols: &[(String, std::rc::Rc<crate::dtype::Datatype>, Address, kuna_base::types::uint4, Address, bool)],
+    dynamic_symbols: &[crate::database::DynamicSymbolSpec],
+    pending_proto: Option<&crate::fspec::PrototypePieces>,
+    flow_overrides: &[(Address, kuna_base::types::uint4)],
+    proto_overrides: &[(Address, crate::fspec::PrototypePieces)],
+    mapped_params: &[(int4, String, crate::fspec::ParameterPieces)],
+    prefollowed: Option<Funcdata>,
+) -> KunaResult<Funcdata> {
     // (kuna decompile-all watchdog) Arm the per-function deadline from the
     // driver-set budget (`kuna decompile-all --max-fn-seconds N` sets
     // `kuna_fn_budget`; every other path leaves it `None`, so this is a `None`
@@ -881,14 +929,17 @@ pub fn decompile_func_full_with_override_dyn(
         // Kept for the parked-prototype lookup below (the flow build consumes the
         // address).
         let entry_addr = funcaddr.clone();
-        let mut fd = build_and_follow_flow_with_override_and_protos(
-            arch,
-            name,
-            funcaddr,
-            size,
-            flow_overrides,
-            proto_overrides,
-        )?;
+        let mut fd = match prefollowed {
+            Some(fd) => fd,
+            None => build_and_follow_flow_with_override_and_protos(
+                arch,
+                name,
+                funcaddr,
+                size,
+                flow_overrides,
+                proto_overrides,
+            )?,
+        };
         // The prototype the function is decompiled *against*. Two sources, in
         // precedence order:
         //

--- a/docs/features/decompiling-3396-byte-main/pr_body.md
+++ b/docs/features/decompiling-3396-byte-main/pr_body.md
@@ -110,8 +110,12 @@ follows) for 8.5 s of the 18.8 s run. It now runs twice.
 
 ## The acceptance probe still does NOT pass, and the reason is now measured
 
-Acceptance `a-53d616afcb6a` asks for a median under 10,000 ms. This PR does not
-reach it, and no further redundancy removal can:
+Acceptance `a-53d616afcb6a` asks for a median under 10,000 ms. On the final build
+`scripts.repipe.verify` measures **14,437 ms** (the interleaved A/B median is
+15,317 ms), so the `wall_ms` clause fails while `exit_code` passes. **The need
+stays open and the probe is deliberately not promoted** — promoting it would
+commit a red test. This PR does not reach the bar, and no further redundancy
+removal can:
 
 - The **action pipeline plus emit alone is ~8.8 s**, and `load file` + `read
   symbols` is another 0.75 s. That is a ~9.6 s floor before a single jump table is
@@ -160,10 +164,21 @@ structural leads (the per-table partial rebuild, blocked because kuna's
 |---|---|
 | `make test` | **PARITY OK** — 675/675, `docs/baseline.json` untouched |
 | `make test-stages` | **PARITY OK** — 600/600, `docs/baseline-stages.json` untouched |
-| `make rust-test` | RUSTTEST |
+| `make rust-test` | **green** — 344 test binaries, 5,322 tests, 0 failed \* |
 | `make test-cli` | tests/cli: **17/17 passed** |
 | `make check-spec` | check-spec OK |
 | `kuna catalog --check` | catalog OK (no option added) |
+| `repipe.mergecheck` | merge guards clean — 0 rejects vs `origin/main` |
+
+\* The first `make rust-test` reported one failure —
+`verify_w10_proto_unlock::…_no_tied_roundtrip`, *"oracle promote_compare
+signature drifted"*. It is not this change. That assertion is guarded by
+`cpp_oracle_bin()`, which falls back to the removed `decompiler/cpp/decomp_test_dbg`
+and is normally skipped — but the repipe worker environment exports
+`KUNA_DECOMP_TEST` pointing at the worktree's own *modern* `decomp_test_dbg`, so
+the "C++ oracle" arm activates and asserts the pre-DIV-6 `xunknown4` rendering
+against a realtypes build. `env -u KUNA_DECOMP_TEST` → 4/4 pass; the row above is
+a full re-run with it unset.
 
 ## Whole-surface regression sweep
 

--- a/docs/features/decompiling-3396-byte-main/pr_body.md
+++ b/docs/features/decompiling-3396-byte-main/pr_body.md
@@ -57,23 +57,42 @@ It is a pure-performance seam: the adopted `Funcdata` is the one the rebuild wou
 have produced, so the emitted C is byte-identical either way. No option, no
 `phases.toml` row, no catalog counter, no DIV — nothing here can change emitted C.
 
-Guard 2 is not hypothetical. The first cut had it missing and
-`verify_decompile_all_parity` caught it: with `--option formatstring on` the ARM
-fixture rendered `printf((char *)(dat_52c + 0x51c), a0, *a1)` instead of
-`printf("%d %s\n", a0, (char *)*a1)`, because `formatstring` turns read-only
-propagation on *around* the drive so the PC-relative literal-pool format constant
-can be read, and the adopted IR had snapshotted the flag off.
+Guard 2 is not hypothetical, and it was re-verified rather than assumed. A build
+with `same_config` forced true renders, for `fmt_arm::main` under `--option
+formatstring on`:
+
+```c
+printf((char *)(dat_52c + 0x51c),a0,*a1);   // guard 2 removed
+printf("%d %s\n",a0,(char *)*a1);           // shipping
+```
+
+`formatstring` turns read-only propagation on *around* the drive so the
+PC-relative literal-pool format constant can be read, and the adopted IR had
+snapshotted the flag off. It is ARM-specific — the same A/B on `fmt_x86_64` and
+`fmt_aarch64` is byte-identical — so a sweep without an ARM literal-pool case
+would have missed it.
 
 ## Measurement
 
-`kuna decompile <crackme> sub_140023350`, interleaved A/B, same worktree, base
-binary and new binary alternating in one loop:
+`kuna decompile <crackme> sub_140023350`, **interleaved** A/B — one loop
+alternating the two arms per iteration, so both see the same machine load (three
+sibling builders were running; load average 8–24 across the measurement). The two
+arms are builds of this same worktree differing only in the adoption guard, chosen
+per run via `KUNA_DECOMP_DBG`, so the driver, the generated script and the loaded
+image are identical between them.
 
-| | median | min |
-|---|---|---|
-| base (`origin/main`) | BASE_MEDIAN | BASE_MIN |
-| this PR | NEW_MEDIAN | NEW_MIN |
-| | **DELTA_PCT** | |
+| 7 pairs | median | min | max |
+|---|---|---|---|
+| base (adoption off ≡ `origin/main`) | 19,703 ms | 18,537 ms | 21,103 ms |
+| this PR | **15,317 ms** | 13,967 ms | 18,929 ms |
+| delta | **−22.26 %** | −24.66 % | |
+
+Paired mean −20.58 % ± 7.80 (sd) over 7 pairs → **7 σ**, and ≥20 % on the median,
+the min and the paired mean — past both bars the perf track sets. A single-arm
+before/after would not have been trustworthy here: the *same* binary measured
+14.6 s and 18.9 s hours apart on this box.
+
+The C emitted by the two arms on the witness is byte-identical (`cmp`).
 
 Where it goes, from `Instant`-instrumented builds of the same tree:
 
@@ -139,14 +158,28 @@ structural leads (the per-table partial rebuild, blocked because kuna's
 
 | gate | result |
 |---|---|
-| `make test` | **PARITY OK** (675/675, `docs/baseline.json` untouched) |
-| `make test-stages` | **PARITY OK** (`docs/baseline-stages.json` untouched) |
+| `make test` | **PARITY OK** — 675/675, `docs/baseline.json` untouched |
+| `make test-stages` | **PARITY OK** — 600/600, `docs/baseline-stages.json` untouched |
 | `make rust-test` | RUSTTEST |
+| `make test-cli` | tests/cli: **17/17 passed** |
 | `make check-spec` | check-spec OK |
 | `kuna catalog --check` | catalog OK (no option added) |
 
-Whole-surface regression sweep — `kuna decompile <bin> <addr> --addr` run under
-the base binary and this one and byte-compared, stdout **and** stderr **and** exit
-code, over every function of three binaries: SWEEPLINE.
+## Whole-surface regression sweep
+
+`kuna decompile <bin> <fn>` run under both arms and byte-compared (stdout and exit
+code) over **218 functions in 20 binaries** — x86-64, i386, aarch64, ARM, ARM
+Thumb, Cortex-M, RISC-V 64; ELF exe/PIE/`.so` and PE32+ — with DWARF, stripped and
+C++-mangled cases among them.
+
+**218 compared, 0 diffs.** And, measured separately with a third instrumented
+build, **203 of the 218 actually took the adopt path**; the other 15 are the seed
+guard firing as designed (DWARF stack locals, parsed prototypes, the PE CRT) and
+are byte-identical through the fallback arm.
+
+That second number is the one worth stating, because the obvious way to get it is
+wrong: `kuna` pipes the child `decomp_dbg`'s stdout *and* stderr and only surfaces
+them on failure, so an `eprintln!` marker is swallowed and a naive count reads
+**0 adoptions on a run that adopted 203 times**.
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/decompiling-3396-byte-main/pr_body.md
+++ b/docs/features/decompiling-3396-byte-main/pr_body.md
@@ -1,126 +1,144 @@
 ## What was broken
 
-RE-need `decompiling-3396-byte-main` (round 2, track `perf`, 1 instance,
-challenge `69a3822f7b3cc38c80464da4`):
+RE-need `decompiling-3396-byte-main` (round 2, `perf`, 1 instance, challenge
+`69a3822f7b3cc38c80464da4`). A tester reverse-engineering a PE crackme reported:
 
-> **Decompiling the 3396-byte main function takes about 68 seconds** (major)
-> The command produced no output for roughly 68 seconds, then emitted about 30 KB of
-> highly noisy pseudocode. […] this observation is specifically about latency.
+> **Decompiling the 3396-byte main function takes about 68 seconds.** The command
+> produced no output for roughly 68 seconds, then emitted about 30 KB of highly
+> noisy pseudocode. […] this observation is specifically about latency.
 
-Reproduced at **71.5 s median** for `kuna decompile <bin> sub_140023350`.
+Attempt 1 (#380, merged) removed an O(N²) dead-list position scan in the lifter
+and took the witness from 71.46 s to 19.42 s. The acceptance bar is a **median
+under 10 s**, so the need stayed open.
 
-## The cause is not what was filed
+## What this PR changes
 
-The filed hypothesis was "opaque arithmetic and indirect calls make an analysis pass
-scale poorly". The symptom stands, the diagnosis does not: gdb-sampled profiling put
-**53% of wall time in one leaf frame, `FlowInfo::xref_control_flow`** — the *lifter*,
-before any analysis runs. This function is unusual only in op count (48,169 raw ops,
-37,710 of them INDIRECTs across 365 call sites), and op count is exactly what the real
-defect squares.
+`kuna decompile <bin> <fn>` drives the console with `load function <fn>` and then
+`decompile`, and **each of those followed the same function's flow from scratch** —
+the whole lift, the block build, and the per-jump-table sub-decompilation, twice.
 
-**The dead list is a doubly-linked list whose links three call sites refused to use.**
-The C++ caches a `std::list<PcodeOp*>::iterator` on every op (`insertiter`), so "the op
-after this one" and "the last op" are O(1). kuna's dead list *is* that list —
-`op.rs (IntrusiveList)` keeps prev/next `OpId` links on each op — but position was being
-re-derived by scanning:
+Upstream never pays that: C++ `IfcFuncload` follows the flow once and
+`IfcDecompile` re-runs the action pipeline on *that* `Funcdata` after
+`Architecture::clearAnalysis` (`ifacedecomp.cc:889`). kuna rebuilds instead
+because the facts a decompile is seeded with are consumed **at flow time** and
+`load function` applies none of them: `map address` symbols and DWARF stack
+locals, `type varnode` usepoint symbols, `map hash` dynamic symbols, a `parse
+line extern` prototype, `map param` storage locks, `override prototype` call-site
+overrides. So the rebuild is *required* exactly when one of those exists — and
+pure waste when none does, which is every plain `kuna decompile`.
 
-| site | what it did | how often |
+`decompile` now **adopts** the loaded IR when it can prove the rebuild would
+repeat the same follow. Three independent guards must all hold
+(`kuna-console/src/ifacedecomp.rs`, `PristineFlow`):
+
+1. **Every flow-time seed is empty** — any one present means the loaded IR was
+   followed without it.
+2. **The architecture is configured as it was at the load** — a `Funcdata`
+   snapshots the per-function flags into its ArchSeam handle when it is *built*,
+   so a flag flipped afterwards is invisible to it. `formatstring`, the watchdog
+   budget and ghidra-mode's staged recommendations all move between the load and
+   the drive, and each refuses adoption.
+3. **`decompile` is the immediately next command** — `load function` records
+   `IfaceStatus::command_seq` and `decompile` requires it to have advanced by
+   exactly one, with the same name, entry, declared extent and flow overrides.
+   The counter is the whole invalidation story on purpose: an `option`, a
+   `kassert`, a `map`, a second `load` — anything at all — advances it, so no
+   command needs its own invalidation hook and none can be forgotten.
+
+It is a pure-performance seam: the adopted `Funcdata` is the one the rebuild would
+have produced, so the emitted C is byte-identical either way. No option, no
+`phases.toml` row, no catalog counter, no DIV — nothing here can change emitted C.
+
+Guard 2 is not hypothetical. The first cut had it missing and
+`verify_decompile_all_parity` caught it: with `--option formatstring on` the ARM
+fixture rendered `printf((char *)(dat_52c + 0x51c), a0, *a1)` instead of
+`printf("%d %s\n", a0, (char *)*a1)`, because `formatstring` turns read-only
+propagation on *around* the drive so the PC-relative literal-pool format constant
+can be read, and the adopted IR had snapshotted the flag off.
+
+## Measurement
+
+`kuna decompile <crackme> sub_140023350`, interleaved A/B, same worktree, base
+binary and new binary alternating in one loop:
+
+| | median | min |
 |---|---|---|
-| `FlowInfo::dead_next` | scanned all of `iter_dead()` to locate one op | once per emitted p-code op |
-| `FlowInfo::dead_tail` | `iter_dead().last()` | once per decoded instruction (the marker idiom) |
-| `FlowInfo::delete_remaining_ops` | collected the whole list to find a suffix | once per terminating instruction |
-| `Funcdata::op_target` | rebuilt an entire `BTreeMap` predecessor index | once per call |
+| base (`origin/main`) | BASE_MEDIAN | BASE_MIN |
+| this PR | NEW_MEDIAN | NEW_MIN |
+| | **DELTA_PCT** | |
 
-The list grows to the whole function, so this is O(N²) in op count. It is invisible on
-small functions and quadratic on the ones an RE actually cares about.
+Where it goes, from `Instant`-instrumented builds of the same tree:
 
-## The mechanism
+| stage | before | after |
+|---|---|---|
+| `load file` + `read symbols` | 0.75 s | 0.75 s |
+| flow follow #1 (`load function`) | 4.95 s | **0 s** |
+| flow follow #2 (`decompile`) | 4.33 s | 4.33 s |
+| action pipeline + emit | ~8.8 s | ~8.8 s |
 
-1. **`op.rs`** — expose what the list already carries: `PcodeOpBank::dead_front` /
-   `dead_back` / `dead_next` / `dead_prev`. Membership is the `dead` flag **plus a live
-   link**, because `destroy()` retires an op to `deadandgone` with the flag still set and
-   the alive list shares the same link pair; a non-member reports `None`, exactly what a
-   scan for an absent op returned.
-2. **`flow.rs` / `funcdata_op.rs`** — the four sites above use those accessors.
-3. **`action.rs`** — `ActionPool::advance_op_state` already ran the optree search that
-   decides `After`/`Done`, so it now keeps the successor's `OpId` and `current_op` reads
-   it instead of searching a second time for the op the advance already found. The memo is
-   dropped on every `apply()` exit, so a resumed or interleaved sweep re-searches.
+Both follows were dominated by the jump-table sub-decompilation: the function has
+2 tables, each staging a 68,370-op partial clone (~0.25 s) plus a reduced
+"jumptable" pipeline over it (~1.7 s), and that ran **4 times** (2 tables × 2
+follows) for 8.5 s of the 18.8 s run. It now runs twice.
 
-No option: none of this can change emitted C, so `docs/agents.md`'s flag rule does not
-apply. `phases.toml`, `options.rs`, the catalog counters, `docs/options.md` and
-`docs/history.md` are untouched.
+## The acceptance probe still does NOT pass, and the reason is now measured
 
-## Measured
+Acceptance `a-53d616afcb6a` asks for a median under 10,000 ms. This PR does not
+reach it, and no further redundancy removal can:
 
-Interleaved A/B (base and new binaries alternating in one loop; machine load 5–7 from
-sibling builders, so both median and min are reported):
+- The **action pipeline plus emit alone is ~8.8 s**, and `load file` + `read
+  symbols` is another 0.75 s. That is a ~9.6 s floor before a single jump table is
+  touched. Even deleting *all* remaining jump-table work lands at ~10.6 s.
+- The residue is not a bug, it is **scaling**. The witness is not a 3396-byte
+  function: `kuna functions` derives sizes from the gap to the next entry, and the
+  PE's own `.pdata` `RUNTIME_FUNCTION` says `0x140023350..0x14002dbe0` — **43,152
+  bytes**, with `sub_140024094` and `sub_14002bb5c` being mid-function labels. The
+  flow follow is correct; there is no overrun.
+- Measured on `/bin/bash` (`--mode aggressive`, `decompile-all --addr`, load cost
+  subtracted), pipeline time against function size:
 
-| run | base | new | delta |
-|---|---|---|---|
-| `kuna decompile <bin> sub_140023350` (the probe), median of 5 | **71.46 s** | **19.42 s** | **−72.8%** |
-| same, min of 5 | 69.14 s | 18.44 s | −73.3% |
-| `kuna decompile-all --addr 0x140023350`, median of 3 | 40.05 s | 14.24 s | −64.4% |
-| `kuna decompile-all /bin/gzip` (145 functions), median of 3 | 14.55 s | 13.60 s | −6.5% |
+  | size | alive ops | INDIRECT | MULTIEQUAL | varnodes | pipeline |
+  |---|---|---|---|---|---|
+  | 5,248 B | 3,233 | 1,004 | 1,047 | 4,715 | 1.6 s |
+  | 9,184 B | 8,937 | 4,098 | 2,558 | 13,934 | 9.6 s |
+  | 13,488 B | 30,697 | 17,142 | 9,714 | 49,382 | 30.7 s |
 
-The base and new distributions do not overlap: max(new) = 23.35 s < min(base) = 69.14 s.
-The gzip row is the honest control — small functions barely feel a quadratic in op count.
+  The **IR itself** is superlinear in function size (ops ∝ size^~2.4, driven by
+  INDIRECT: calls × heritaged locations, both O(size)), and pipeline time is
+  ∝ ops^~1.5-2 on top of that. Closing the last 4 s is a constant-factor campaign
+  across the rule pool, p6 merge, p5 infertypes, p3 heritage and p9 emit — a flat
+  ~24/18/14/12/10 % split with no single hot spot — not another focused fix.
 
-**Output is byte-identical.** Whole-binary `decompile-all --json` captures from an
-interleaved before/after build pair compare byte-for-byte on three binaries / 509
-functions: the probe crackme (322 fns, 5,653,602 B), `/bin/gzip` (145 fns, 1,196,332 B),
-`/usr/bin/xxd` (42 fns, 135,319 B). The 120,052-byte witness function is identical too.
+The full residue map, the profile that produced it, and the two remaining
+structural leads (the per-table partial rebuild, blocked because kuna's
+`unrolledguard` extension depends on it; and the O(log n) rule-pool cursor) are in
+`docs/features/decompiling-3396-byte-main/record.json`.
 
-## The acceptance probe does NOT pass — read this part
+## Tests
 
-The need's acceptance asks for a **median under 10 s**. This lands at 19.4 s. The probe
-arm (`> 30 s`, i.e. the filed bad behaviour) no longer holds, so the symptom is gone, but
-the threshold is not met and **the need should stay open**.
+`decompiler/crates/kuna-console/tests/verify_flowreuse.rs` — 5 cases:
 
-After this fix the profile is flat — p6 merge/ScopeLocal 27.6%, p3 heritage 26.3%, the
-rule pool 19.8%, jump-table sub-decompilation 17.4%, p9 dead-code/emit 13.7% of a 12.2 s
-in-process run. Nothing left is worth the further 48%; closing that gap is a campaign
-across kuna's core indexes, not one focused change. Two concrete leads are recorded in
-`docs/features/decompiling-3396-byte-main/record.json`:
-
-- **`kuna decompile` follows flow twice** (~18% of the probe). `follow_flow_on_fd` is hit
-  2× and `stage_jump_table` 4× on the console path versus 1×/2× in-process, because
-  kuna's `IfcDecompile` rebuilds the `Funcdata` from scratch where the C++ calls
-  `clearAnalysis` on the one `IfcFuncload` already followed. Not local: the rebuild exists
-  so the seeds (mapped symbols, DWARF locals, prototypes, param maps, overrides) apply at
-  flow time.
-- **The jump-table partial clone is rebuilt per table.** Upstream builds it once
-  (`flow.cc:1437`, guarded at `funcdata_block.cc:513`). Implemented, measured at
-  18.0 s → 14.3 s — and **reverted**: it takes `tests/stages/ghangr-optimized-memcpy-6301a9.xml`
-  from 2/2 to 0/2, losing 16 of 17 interleaved MSVC switches, because `option unrolledguard`
-  recovers them precisely *because* each table's clone re-clones its already-recovered
-  siblings. It changes which tables recover, so it needs its own option — and this round's
-  `phases.toml`/catalog leases are held by a sibling builder. Left documented in the code
-  and in `docs/spec/02-lift-and-flow.md` §2.3.
-
-No `tests/cli/` probe was promoted: the acceptance does not pass, and its target is a
-dataset binary (`scripts.repipe.verify.vendorable` refuses anything not in-repo). The
-regression guard is a cargo unit test on the cursor semantics instead of a wall-clock
-assertion on a CI runner.
+- the plain `load function` → `decompile` pair adopts (`adopted_flows == 1`) and
+  renders **byte-identical** C to the same pair with an inert `echo` in between
+  (which does not adopt);
+- `load addr` stamps its follow the same way;
+- a second `decompile` does not adopt (the stamp is single-use);
+- DWARF stack locals — a flow-time seed present with *nothing* running in
+  between — force the rebuild, isolating the seed guard from the counter guard;
+- `formatstring` forces the rebuild, and the format string still resolves.
 
 ## Gates
 
 | gate | result |
 |---|---|
-| `make test` | **675/675 PARITY OK** (`docs/baseline.json` not re-pinned) |
-| `make test-stages` | **597/597 PARITY OK** (`docs/baseline-stages.json` not re-recorded) |
-| `make rust-test` | **green**, 342 `test result: ok` — run with `env -u KUNA_DECOMP_TEST`, see below |
-| `make check-spec` | check-spec OK (lenient mode) |
-| `kuna catalog --check` | catalog OK |
+| `make test` | **PARITY OK** (675/675, `docs/baseline.json` untouched) |
+| `make test-stages` | **PARITY OK** (`docs/baseline-stages.json` untouched) |
+| `make rust-test` | RUSTTEST |
+| `make check-spec` | check-spec OK |
+| `kuna catalog --check` | catalog OK (no option added) |
 
-New tests: `substrate::op::tests::dead_cursor_matches_a_full_scan` (the O(1) cursor agrees
-with a full `iter_dead()` scan at every position, and reports an alive op, a destroyed op
-and a single-element list exactly as the scan did) and
-`first_after_seq_id_agrees_with_first_after_seq`.
-
-> **Harness note:** the RE-pipeline worker environment exports `KUNA_DECOMP_TEST` pointing
-> at kuna's *own* `decomp_test_dbg`, which makes `verify_w10_proto_unlock`'s
-> `cpp_oracle_bin()` compare kuna against kuna and fail on the C++ oracle's `xunknown4`
-> versus kuna's DIV-6 `unsigned int`. That failure is the env var, not the change.
+Whole-surface regression sweep — `kuna decompile <bin> <addr> --addr` run under
+the base binary and this one and byte-compared, stdout **and** stderr **and** exit
+code, over every function of three binaries: SWEEPLINE.
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/decompiling-3396-byte-main/pr_body.md
+++ b/docs/features/decompiling-3396-byte-main/pr_body.md
@@ -20,19 +20,27 @@ the whole lift, the block build, and the per-jump-table sub-decompilation, twice
 Upstream never pays that: C++ `IfcFuncload` follows the flow once and
 `IfcDecompile` re-runs the action pipeline on *that* `Funcdata` after
 `Architecture::clearAnalysis` (`ifacedecomp.cc:889`). kuna rebuilds instead
-because the facts a decompile is seeded with are consumed **at flow time** and
-`load function` applies none of them: `map address` symbols and DWARF stack
-locals, `type varnode` usepoint symbols, `map hash` dynamic symbols, a `parse
-line extern` prototype, `map param` storage locks, `override prototype` call-site
-overrides. So the rebuild is *required* exactly when one of those exists — and
-pure waste when none does, which is every plain `kuna decompile`.
+because a decompile is seeded with facts `load function` never applied, and two of
+them are consumed **at flow time**: `override prototype` call-site overrides
+(`FlowInfo::build_call_specs`) and the parsed callee prototypes re-parked on their
+global `FunctionSymbol` before the drive. The other five — `map address` symbols
+and DWARF stack locals, `type varnode` usepoint symbols, `map hash` dynamic
+symbols, a `parse line extern` prototype, `map param` storage locks — the drive
+re-seeds *after* the follow, so they would survive an adoption; they are held to
+the same bar anyway (below). So the rebuild is *required* when a flow-time fact
+exists, and pure waste when no fact exists at all — which is every plain `kuna
+decompile`.
 
 `decompile` now **adopts** the loaded IR when it can prove the rebuild would
 repeat the same follow. Three independent guards must all hold
 (`kuna-console/src/ifacedecomp.rs`, `PristineFlow`):
 
-1. **Every flow-time seed is empty** — any one present means the loaded IR was
-   followed without it.
+1. **Every seed is empty** — flow-time or re-seeded alike. Holding the re-seeded
+   ones to the same bar makes the guard one question ("did the console learn
+   anything about this function?") instead of a per-seed judgement a later seed
+   could be forgotten from. It costs coverage only where kuna already has symbols:
+   in the sweep below 203 of 218 functions adopt, and the 15 that do not are the
+   DWARF-local and parsed-prototype cases.
 2. **The architecture is configured as it was at the load** — a `Funcdata`
    snapshots the per-function flags into its ArchSeam handle when it is *built*,
    so a flag flipped afterwards is invisible to it. `formatstring`, the watchdog
@@ -72,8 +80,8 @@ Where it goes, from `Instant`-instrumented builds of the same tree:
 | stage | before | after |
 |---|---|---|
 | `load file` + `read symbols` | 0.75 s | 0.75 s |
-| flow follow #1 (`load function`) | 4.95 s | **0 s** |
-| flow follow #2 (`decompile`) | 4.33 s | 4.33 s |
+| flow follow #1 (`load function`) | 4.95 s | 4.95 s |
+| flow follow #2 (`decompile`) | 4.33 s | **0 s** (adopted) |
 | action pipeline + emit | ~8.8 s | ~8.8 s |
 
 Both follows were dominated by the jump-table sub-decompilation: the function has

--- a/docs/features/decompiling-3396-byte-main/pr_body.md
+++ b/docs/features/decompiling-3396-byte-main/pr_body.md
@@ -81,16 +81,19 @@ arms are builds of this same worktree differing only in the adoption guard, chos
 per run via `KUNA_DECOMP_DBG`, so the driver, the generated script and the loaded
 image are identical between them.
 
-| 7 pairs | median | min | max |
-|---|---|---|---|
-| base (adoption off ≡ `origin/main`) | 19,703 ms | 18,537 ms | 21,103 ms |
-| this PR | **15,317 ms** | 13,967 ms | 18,929 ms |
-| delta | **−22.26 %** | −24.66 % | |
+Measured twice — once before the rebase on a loaded box, once after it on a
+quieter one, with both arms rebuilt from the rebased tree each time:
 
-Paired mean −20.58 % ± 7.80 (sd) over 7 pairs → **7 σ**, and ≥20 % on the median,
-the min and the paired mean — past both bars the perf track sets. A single-arm
-before/after would not have been trustworthy here: the *same* binary measured
-14.6 s and 18.9 s hours apart on this box.
+| | pairs | base median | this PR median | delta | paired mean ± sd |
+|---|---|---|---|---|---|
+| pre-rebase | 7 | 19,703 ms | 15,317 ms | **−22.26 %** | −20.58 % ± 7.80 |
+| **on the rebased tree** | 5 | 18,601 ms | **14,348 ms** | **−22.86 %** | −22.89 % ± 1.92 |
+
+The second is 26 σ, per-pair range −21.0 % to −25.0 %, and ≥20 % on median, min
+and paired mean alike — past both bars the perf track sets. The interleaving is
+not ceremony: the *same* binary measured 14.6 s and 18.9 s hours apart on this
+box, so a single-arm before/after here would have been indistinguishable from the
+machine.
 
 The C emitted by the two arms on the witness is byte-identical (`cmp`).
 
@@ -111,8 +114,8 @@ follows) for 8.5 s of the 18.8 s run. It now runs twice.
 ## The acceptance probe still does NOT pass, and the reason is now measured
 
 Acceptance `a-53d616afcb6a` asks for a median under 10,000 ms. On the final build
-`scripts.repipe.verify` measures **14,437 ms** (the interleaved A/B median is
-15,317 ms), so the `wall_ms` clause fails while `exit_code` passes. **The need
+`scripts.repipe.verify` measures **14,437 ms** (the interleaved A/B median on the
+rebased tree is 14,348 ms), so the `wall_ms` clause fails while `exit_code` passes. **The need
 stays open and the probe is deliberately not promoted** — promoting it would
 commit a red test. This PR does not reach the bar, and no further redundancy
 removal can:
@@ -163,9 +166,9 @@ structural leads (the per-table partial rebuild, blocked because kuna's
 | gate | result |
 |---|---|
 | `make test` | **PARITY OK** — 675/675, `docs/baseline.json` untouched |
-| `make test-stages` | **PARITY OK** — 600/600, `docs/baseline-stages.json` untouched |
-| `make rust-test` | **green** — 344 test binaries, 5,322 tests, 0 failed \* |
-| `make test-cli` | tests/cli: **17/17 passed** |
+| `make test-stages` | **PARITY OK** — 603/603, `docs/baseline-stages.json` untouched |
+| `make rust-test` | **green** — 345 test binaries, 5,335 tests, 0 failed \* |
+| `make test-cli` | tests/cli: **18/18 passed** |
 | `make check-spec` | check-spec OK |
 | `kuna catalog --check` | catalog OK (no option added) |
 | `repipe.mergecheck` | merge guards clean — 0 rejects vs `origin/main` |
@@ -187,7 +190,7 @@ code) over **218 functions in 20 binaries** — x86-64, i386, aarch64, ARM, ARM
 Thumb, Cortex-M, RISC-V 64; ELF exe/PIE/`.so` and PE32+ — with DWARF, stripped and
 C++-mangled cases among them.
 
-**218 compared, 0 diffs.** And, measured separately with a third instrumented
+**218 compared, 0 diffs**, plus 119 more re-swept on the rebased tree — also 0. And, measured separately with a third instrumented
 build, **203 of the 218 actually took the adopt path**; the other 15 are the seed
 guard firing as designed (DWARF stack locals, parsed prototypes, the PE CRT) and
 are byte-identical through the fallback arm.

--- a/docs/features/decompiling-3396-byte-main/proposal.md
+++ b/docs/features/decompiling-3396-byte-main/proposal.md
@@ -1,0 +1,53 @@
+# RESUME BRIEF — this is not a design proposal, it is a salvaged implementation
+
+Written by the captain, round 2 wave 8. Read this before anything else; the
+`IMPLEMENTATION MODE` line in your prompt points here.
+
+## What already exists on this branch
+
+Wave 7's builder implemented the fix and was **SIGKILLed (rc=137) mid `make rust-test`** at
+15:30:23Z on 2026-09-04, before it could open a PR. The captain committed its worktree as
+`679f4a70` (also tagged `salvage/r2w7-decompiling-3396`) and deleted the worktree. Nothing
+was pushed.
+
+The commit makes `kuna decompile <bin> <fn>` stop following the same function's flow twice —
+`load function` and `decompile` each rebuilt the whole lift, block build and per-jump-table
+sub-decompilation from scratch. 8 files: `kuna-console` `decompile_step.rs` /
+`ifacedecomp.rs` / `interface.rs`, `kuna-decomp/src/infra/decompile_drive.rs`, a new
+`kuna-console/tests/verify_flowreuse.rs` (211 lines), `docs/spec/00-overview.md`, and a
+drafted `pr_body.md`. This is **attempt 2**: attempt 1 (#380, merged) removed the O(N²)
+dead-list scan and took the witness 71.5s -> 19.4s; the acceptance bar is a median under
+10s, so the need stayed open.
+
+**Assume none of it is verified.** No gate is known to have passed on it.
+
+## What is left for you
+
+1. Rebase onto `main` (now `3411f35c`; the branch was cut at `74118fd7`). `git merge-tree`
+   reported **no conflicts** as of this brief.
+2. Build, then re-derive the evidence yourself: acceptance
+   `verify --need decompiling-3396-byte-main --json` (currently FAIL on the `wall_ms`
+   clause alone — median 19299 ms against a `< 10000` bar; `exit_code` already passes),
+   the four gates, and an interleaved min-of-N timing, never a single run on a loaded box.
+3. Read the existing diff critically. Reusing a followed flow across `load function` and
+   `decompile` is a correctness question, not only a speed one: the facts a decompile is
+   seeded with (`map address` symbols, DWARF stack locals, `type varnode` usepoints,
+   `map hash` dynamic symbols) are consumed **at flow time**, which is why kuna rebuilt.
+   Convince yourself the reuse path cannot silently drop one of them — a wrong decompile
+   that is 3x faster fails this need, and `verify_flowreuse.rs` is wave 7's own test, so it
+   is not independent evidence.
+
+## Two hazards that are specific to this branch
+
+- **Your branch is `feat/re-decompiling-3396-w8`, deliberately NOT
+  `feat/re-decompiling-3396-byte-main`.** That older name still exists on `origin` pointing
+  at `0e8ce0eb`, the already-merged head of PR #380, which is not an ancestor of anything
+  you have; `open_pr.sh` pushes without `--force`, so pushing the old name would be
+  rejected non-fast-forward. Do not rename the branch back.
+- **The gate that killed wave 7.** Two builders died together in `make rust-test` in
+  separate worktrees; OOM can be neither confirmed nor excluded on this box. Cap cargo
+  parallelism (`CARGO_BUILD_JOBS`), keep `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0
+  CARGO_PROFILE_TEST_DEBUG=0`, and **commit your worktree before starting any long gate** —
+  a commit is the only thing that survived last time. A foreground bash call also caps at
+  600s, which `make test` and a CI-waiting `open_pr.sh --merge` both exceed; run those
+  detached with an rc file and poll.

--- a/docs/features/decompiling-3396-byte-main/record.json
+++ b/docs/features/decompiling-3396-byte-main/record.json
@@ -1,139 +1,195 @@
 {
- "opportunity": "decompiling-3396-byte-main",
- "need_id": "decompiling-3396-byte-main",
- "route": "RE-friction loop (docs/re-pipeline.md), round 2, track perf -- ATTEMPT 2",
- "challenge": "69a3822f7b3cc38c80464da4",
- "binary": ".kuna-repipe/probebin/bcfacd743bc607be/nikos_crack_me.exe (PE x86-64, 235725 bytes)",
- "selector": "sub_140023350",
- "scope": "small",
- "attempt": 2,
- "prior_attempt": {
-  "pr": 380,
-  "summary": "dead-list position was re-derived by scanning; 71.46 s -> 19.42 s (-72.8%), acceptance not met",
-  "record": "preserved verbatim under `attempt_1` below"
- },
- "phase": "console/drive tier (kuna-console `ifacedecomp`/`interface`/`decompile_step`, kuna-decomp `infra/decompile_drive`)",
- "modules": [
-  "decompiler/crates/kuna-console/src/ifacedecomp.rs (PristineFlow, IfcFuncload, IfcAddrrangeLoad, IfcDecompile)",
-  "decompiler/crates/kuna-console/src/interface.rs (IfaceStatus::command_seq)",
-  "decompiler/crates/kuna-console/src/decompile_step.rs (decompile_one_prefollowed)",
-  "decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs (decompile_func_full_with_override_dyn_prefollowed)"
- ],
- "change_kind": "performance-fix (output byte-identical)",
- "option": null,
- "gated": false,
- "gating_rationale": "Not a judgement call and cannot change emitted C: the adopted Funcdata is the one the rebuild would have produced, and the three guards refuse adoption whenever it would not be. Byte-identical over 187 whole-surface console decompiles, the 675 datatest assertions and the 597 stage assertions. No phases.toml row, no options.rs registration, no catalog counters, no docs/options.md, no DIV row -- which also keeps this clear of the counter and phases.toml leases a sibling builder holds this round.",
- "hypothesis_filed": "The function's extensive opaque arithmetic and indirect calls cause one or more analysis passes to scale poorly.",
- "hypothesis_verdict": "REFUTED AGAIN, and differently from attempt 1. It is not an analysis pass, and it is not the lifter quadratic attempt 1 fixed either. Two facts overturn the framing: (1) `kuna decompile` follows the SAME flow twice (`load function` then `decompile`), and both follows are ~93% jump-table sub-decompilation -- 8.5 s of an 18.8 s run spent staging 2 tables four times over; (2) the witness is NOT a 3396-byte function. `kuna functions` derives sizes from the gap to the next entry; the PE's own .pdata RUNTIME_FUNCTION says 0x140023350..0x14002dbe0 = 43,152 bytes, and `sub_140024094` / `sub_14002bb5c` are mid-function labels. The flow follow is CORRECT and there is no overrun -- the function really is 43 KB with 68,370 raw ops. The need's own title is built on the wrong size.",
- "root_cause": "C++ `IfcFuncload` follows flow once and `IfcDecompile` re-runs the actions on THAT Funcdata after `Architecture::clearAnalysis` (ifacedecomp.cc:889). kuna's `IfcDecompile` rebuilds the Funcdata from scratch, because every fact a decompile is seeded with -- `map address` symbols and DWARF stack locals, `type varnode` usepoint symbols, `map hash` dynamic symbols, a `parse line extern` prototype, `map param` storage locks, `override prototype` call-site overrides -- is consumed AT FLOW TIME and `load function` applies none of them. So the rebuild is required exactly when one of those exists, and pure waste when none does, which is every plain `kuna decompile <bin> <fn>`.",
- "fix": "`IfcDecompile` adopts the loaded IR when it can prove the rebuild would repeat the same follow. `load function`/`load addr` stamp the follow (`PristineFlow`: name, entry, declared extent, flow overrides, and the console command counter); `decompile` adopts only when (a) every flow-time seed above is empty, (b) the architecture is configured as it was at the load, and (c) the stamp's command counter advanced by exactly one. (c) is deliberately the whole invalidation story: any command at all -- an `option`, a `kassert`, a `map`, a second `load` -- advances the counter, so no command needs its own invalidation hook and none can be forgotten. The adopted Funcdata is threaded into the drive through a new `..._prefollowed` variant, so every line after the flow follow is the same code.",
- "the_guard_the_suite_caught": "The first cut had guard (b) missing and `verify_decompile_all_parity` failed: with `--option formatstring on` the ARM fixture rendered `printf((char *)(dat_52c + 0x51c),a0,*a1)` instead of `printf(\"%d %s\\n\",a0,(char *)*a1)`. `decompile_one` turns `readonlypropagate` ON around the drive so the PC-relative literal-pool format constant can be READ -- but a Funcdata snapshots the per-function flags into its ArchSeam handle when it is BUILT, and the adopted IR had snapshotted the flag OFF. Guard (b) now refuses adoption for `formatstring`, the watchdog budget, and ghidra mode's staged recommendations, and `verify_flowreuse::formatstring_forces_the_rebuild` pins it.",
- "profiling_method": "gdb-as-parent SIGUSR1 sampling (perf_event_paranoid=4, yama ptrace_scope=1 -- neither perf nor gdb attach works on this box), 400 + 500 samples, plus `Instant`-instrumented builds printing per-stage wall time and IR sizes. The sampler's kill loop is bounded, so its samples cover only the first N intervals of the run; the phase split below comes from the instrumented build, not the sampler.",
- "measurement": {},
- "residue_map": {
-  "method": "Instant-instrumented release build of this same worktree, `kuna decompile <crackme> sub_140023350` under the aggressive preset the CLI selects for a 235 KB binary",
-  "before_18_8s": {
-   "load file + read symbols": "0.75 s",
-   "flow follow #1 (load function)": "4.95 s (4.52 s of it 2x stage_jump_table)",
-   "flow follow #2 (decompile)": "4.33 s (4.01 s of it 2x stage_jump_table)",
-   "action pipeline + emit": "~8.8 s"
+  "opportunity": "decompiling-3396-byte-main",
+  "need_id": "decompiling-3396-byte-main",
+  "route": "RE-friction loop (docs/re-pipeline.md), round 2, track perf -- ATTEMPT 2",
+  "challenge": "69a3822f7b3cc38c80464da4",
+  "binary": ".kuna-repipe/probebin/bcfacd743bc607be/nikos_crack_me.exe (PE x86-64, 235725 bytes)",
+  "selector": "sub_140023350",
+  "scope": "small",
+  "attempt": 2,
+  "prior_attempt": {
+    "pr": 380,
+    "summary": "dead-list position was re-derived by scanning; 71.46 s -> 19.42 s (-72.8%), acceptance not met",
+    "record": "preserved verbatim under `attempt_1` below"
   },
-  "jumptable_detail": "2 jump tables. Each stage_jump_table = a 68,370-op partial clone (~0.25 s) + the reduced `jumptable` action pipeline over it (~1.7 s). It ran 4 times (2 tables x 2 follows) = 8.5 s of the 18.8 s run; after this PR it runs twice.",
-  "main_pipeline_profile_500_samples": {
-   "ActionPool (rule pool)": "24.4%",
-   "p6 merge (with_covermerge / ActionMergeRequired / merge_addr_tied)": "18.4%",
-   "p5 infertypes": "14.0%",
-   "p3 heritage": "11.6%",
-   "p9 ActionDeadCode": "9.6%",
-   "p8 structure": "~4%",
-   "note": "flat -- no remaining hot spot, and no remaining quadratic in a single pass"
-  },
-  "unrolledguard_cost": "4.8 s of the 18.8 s run, and it is buying a real recovery: with `option unrolledguard off` the SECOND table's reduced pipeline returns in 1.8 ms (build_partial_blocks declines) instead of 1.7 s. The cost is the sibling switch it recovers, not waste."
- },
- "why_the_acceptance_cannot_be_reached_by_removing_redundancy": {
-  "floor": "action pipeline + emit is ~8.8 s and load+read symbols is 0.75 s, so ~9.6 s is spent before a single jump table is touched. Deleting ALL remaining jump-table work lands at ~10.6 s, still above the 10,000 ms bar.",
-  "the_witness_is_43KB_not_3396B": "PE .pdata RUNTIME_FUNCTION 0x23350..0x2dbe0 = 43,152 bytes. `kuna functions` reports 3396 because it derives size from the gap to the next discovered entry, and `sub_140024094` / `sub_14002bb5c` are mid-function labels inside the same .pdata range. Confirmed by parsing the exception directory directly. A `--define-function 0x140023350-0x140024093` run finishes in 1.35 s but ERRORS (`Could not find op at target address: (ram,0x1400249fa)`) precisely because a real switch target lies past the fake boundary.",
-  "scaling_law": {
-   "method": "/bin/bash, `kuna decompile-all --addr <fn> --json --mode aggressive`, load cost (~3.4 s) subtracted; op/varnode counts from an instrumented build",
-   "rows": [
-    {
-     "size_bytes": 5248,
-     "alive_ops": 3233,
-     "indirect": 1004,
-     "multiequal": 1047,
-     "varnodes": 4715,
-     "pipeline_s": 1.6
-    },
-    {
-     "size_bytes": 9184,
-     "alive_ops": 8937,
-     "indirect": 4098,
-     "multiequal": 2558,
-     "varnodes": 13934,
-     "pipeline_s": 9.6
-    },
-    {
-     "size_bytes": 13488,
-     "alive_ops": 30697,
-     "indirect": 17142,
-     "multiequal": 9714,
-     "varnodes": 49382,
-     "pipeline_s": 30.7
-    },
-    {
-     "size_bytes": 14432,
-     "alive_ops": 21806,
-     "indirect": 8284,
-     "multiequal": 7067,
-     "varnodes": 31596,
-     "pipeline_s": 17.7
-    }
-   ],
-   "reading": "The IR ITSELF is superlinear in function size (alive ops grow ~size^2.4), driven by INDIRECT: `Heritage::guard_calls` creates one per (call site x heritaged location) and BOTH grow with function size. Pipeline time is then ~ops^1.5-2 on top. Combined that is roughly cubic in bytes, which is what a 43 KB function costs. The INDIRECT model is upstream's, ported faithfully (heritage.rs `guard_calls` against heritage.cc:1468ff), so this is not a kuna-only defect -- it is the constant factor that has to come down.",
-   "consequence": "closing the last ~4 s is a constant-factor campaign across the rule pool, p6 merge, p5 infertypes, p3 heritage and p9 emit -- five fronts at 24/18/14/12/10 % with no hot spot -- not another focused fix."
-  }
- },
- "left_on_the_table": [
-  {
-   "item": "the jump-table partial is rebuilt per table",
-   "worth": "~2.0 s of the post-PR 14 s run (1 of the 2 remaining stagings)",
-   "status": "BLOCKED, not undone. Upstream builds ONE partial per `recoverJumpTables` (flow.cc:1437) and guards the clone behind `if (!partial.isJumptableRecoveryOn())`. Attempt 1 implemented and REVERTED it: kuna's `option unrolledguard` recovers MSVC interleaved tables precisely BECAUSE each table's clone re-clones the siblings recovered before it, and sharing took tests/stages/ghangr-optimized-memcpy-6301a9.xml from 2/2 to 0/2. It changes which tables recover, so it needs its own option -- and this round's phases.toml / docs/options.md / catalog-counter leases are held by a sibling builder."
-  },
-  {
-   "item": "`Funcdata::early_jump_table_fail` collects the whole dead list",
-   "worth": "small (a 68,370-element Vec per BRANCHIND considered, a handful of times)",
-   "status": "NOT DONE. `let order: Vec<OpId> = self.obank().iter_dead().collect(); order.iter().position(|&o| o == op)` -- the same shape attempt 1 removed from `dead_next`/`dead_tail`/`op_target`, missed there because it is in funcdata_block.rs rather than op.rs/flow.rs. Now that the O(1) cursor exists (`PcodeBank::dead_prev`), this is a two-line change; it is left out only because it is not on the path to the bar and this PR is deliberately one seam."
-  },
-  {
-   "item": "the rule pool's optree cursor is still O(log n) per op",
-   "worth": "~9% of the pipeline (`advance_op_state` 9.2% inclusive, `SeqNum::cmp` 4.4% self)",
-   "status": "NOT DONE, unchanged from attempt 1. Making it O(1) needs a seqnum-ordered intrusive list alongside the optree; `BTreeMap::lower_bound` is still unstable on the pinned toolchain."
-  },
-  {
-   "item": "`Funcdata::bb_ops` allocates a Vec per call",
-   "worth": "~10% of the pipeline (4.6% self + the `Vec::from_iter` it feeds at 5.2%)",
-   "status": "NOT DONE. Every caller that only iterates could walk the intrusive block link instead; output-identical but it touches many call sites."
-  }
- ],
- "regression_sweep": {},
- "tests": {
-  "cargo": [
-   "kuna-console/tests/verify_flowreuse.rs::adopting_the_loaded_flow_renders_the_same_c_as_rebuilding_it -- the plain pair adopts (adopted_flows == 1) and renders byte-identical C to the same pair with an inert `echo` in between (which does not adopt)",
-   "kuna-console/tests/verify_flowreuse.rs::load_addr_also_adopts -- `load addr` stamps its follow too, and the two entry surfaces render the same C",
-   "kuna-console/tests/verify_flowreuse.rs::a_second_decompile_does_not_adopt -- the stamp is single-use",
-   "kuna-console/tests/verify_flowreuse.rs::dwarf_locals_are_a_flow_time_seed_that_forces_the_rebuild -- isolates the SEED guard from the counter guard (nothing runs in between)",
-   "kuna-console/tests/verify_flowreuse.rs::formatstring_forces_the_rebuild -- isolates the ARCH-CONFIG guard, and asserts the format string still resolves"
+  "phase": "console/drive tier (kuna-console `ifacedecomp`/`interface`/`decompile_step`, kuna-decomp `infra/decompile_drive`)",
+  "modules": [
+    "decompiler/crates/kuna-console/src/ifacedecomp.rs (PristineFlow, IfcFuncload, IfcAddrrangeLoad, IfcDecompile)",
+    "decompiler/crates/kuna-console/src/interface.rs (IfaceStatus::command_seq)",
+    "decompiler/crates/kuna-console/src/decompile_step.rs (decompile_one_prefollowed)",
+    "decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs (decompile_func_full_with_override_dyn_prefollowed)"
   ],
-  "stage_test": null,
-  "stage_test_rationale": "tests/stages/README.md scopes that corpus to stage-model issues; a console-tier change with byte-identical output has no assertion to make there, and adding one would re-record the stages baseline and bump the hard-coded corpus count for nothing.",
-  "cli_probe": null
- },
- "gates": {},
- "decisions": [
-  "REFUTED the filed diagnosis for the second time, and on a different axis than attempt 1: the dominant cost is not an analysis pass and not a quadratic, it is the SAME flow follow run twice, with the jump-table sub-decompilation inside it (8.5 s of 18.8 s, 4 stagings of 2 tables).",
-  "OVERTURNED the need's own premise: `sub_140023350` is NOT 3396 bytes. `kuna functions` derives size from the gap to the next entry; the PE .pdata says 43,152. The flow follow is correct and there is no overrun -- which is why bounding it (`--define-function`) finishes in 1.35 s but ERRORS on a real switch target past the fake boundary. Anyone reading this need's title should know the number in it is a kuna reporting artifact, and the neighbouring `pe-function-inventory-labels` need is the place that belongs.",
-  "NO OPTION. Output is byte-identical (187 console decompiles over 3 binaries plus 1272 corpus assertions), so AGENTS.md's `anything that CAN change emitted C ships behind a named option` does not bite -- and it keeps this clear of the phases.toml / docs/options.md / catalog-counter leases a sibling builder holds this round.",
-  "SHIPPED ONE SEAM, not three. The other identified wins (`early_jump_table_fail`'s list collect, the rule-pool cursor, `bb_ops`) are recorded rather than bundled: none of them reaches the bar either, and a perf PR whose output must be proven byte-identical is worth keeping to one reviewable mechanism.",
-  "ACCEPTANCE NOT MET, and now with a measured impossibility proof rather than a shrug: the action pipeline plus emit alone is ~8.8 s and the load is 0.75 s, so deleting ALL remaining jump-table work still lands at ~10.6 s against a 10.0 s bar. The residue is the IR's superlinear growth with function size (ops ~ size^2.4 via INDIRECT, time ~ ops^1.5-2), measured on /bin/bash across four function sizes. This need cannot be closed by a focused fix; the next step is a campaign proposal, and this record is its map."
- ]
+  "change_kind": "performance-fix (output byte-identical)",
+  "option": null,
+  "gated": false,
+  "gating_rationale": "Not a judgement call and cannot change emitted C: the adopted Funcdata is the one the rebuild would have produced, and the three guards refuse adoption whenever it would not be. Verified byte-identical over 218 whole-surface `kuna decompile` runs across 20 binaries and 8 arch/format combinations (203 of which took the adopt path), the 675 datatest assertions and the 600 stage assertions. No phases.toml row, no options.rs registration, no catalog counters, no docs/options.md, no DIV row -- which also keeps this clear of the counter and phases.toml leases a sibling builder holds this round.",
+  "hypothesis_filed": "The function's extensive opaque arithmetic and indirect calls cause one or more analysis passes to scale poorly.",
+  "hypothesis_verdict": "REFUTED AGAIN, and differently from attempt 1. It is not an analysis pass, and it is not the lifter quadratic attempt 1 fixed either. Two facts overturn the framing: (1) `kuna decompile` follows the SAME flow twice (`load function` then `decompile`), and both follows are ~93% jump-table sub-decompilation -- 8.5 s of an 18.8 s run spent staging 2 tables four times over; (2) the witness is NOT a 3396-byte function. `kuna functions` derives sizes from the gap to the next entry; the PE's own .pdata RUNTIME_FUNCTION says 0x140023350..0x14002dbe0 = 43,152 bytes, and `sub_140024094` / `sub_14002bb5c` are mid-function labels. The flow follow is CORRECT and there is no overrun -- the function really is 43 KB with 68,370 raw ops. The need's own title is built on the wrong size.",
+  "root_cause": "C++ `IfcFuncload` follows flow once and `IfcDecompile` re-runs the actions on THAT Funcdata after `Architecture::clearAnalysis` (ifacedecomp.cc:889). kuna's `IfcDecompile` rebuilds the Funcdata from scratch. Two of the facts a decompile is seeded with are genuinely consumed AT FLOW TIME and `load function` applies neither: `override prototype` call-site overrides (`FlowInfo::build_call_specs`) and the parsed callee prototypes re-parked on their global FunctionSymbol before the drive. The other five -- `map address` symbols and DWARF stack locals, `type varnode` usepoint symbols, `map hash` dynamic symbols, a `parse line extern` prototype for the function itself, `map param` storage locks -- the drive re-seeds onto the Funcdata AFTER the follow (`seed_mapped_symbols` / `seed_usepoint_symbols` / `seed_dynamic_symbols` / `apply_locked_prototype_with_model` / `apply_mapped_params`), so they would survive an adoption. (Attempt 2's first draft asserted all seven were flow-time; reading the drive body refuted that. The guard still requires all seven empty -- see `decisions` -- but the rationale is conservatism, not necessity.) So the rebuild is required when a flow-time fact exists, and pure waste when no fact exists at all, which is every plain `kuna decompile <bin> <fn>`.",
+  "fix": "`IfcDecompile` adopts the loaded IR when it can prove the rebuild would repeat the same follow. `load function`/`load addr` stamp the follow (`PristineFlow`: name, entry, declared extent, flow overrides, and the console command counter); `decompile` adopts only when (a) every flow-time seed above is empty, (b) the architecture is configured as it was at the load, and (c) the stamp's command counter advanced by exactly one. (c) is deliberately the whole invalidation story: any command at all -- an `option`, a `kassert`, a `map`, a second `load` -- advances the counter, so no command needs its own invalidation hook and none can be forgotten. The adopted Funcdata is threaded into the drive through a new `..._prefollowed` variant, so every line after the flow follow is the same code.",
+  "the_guard_the_suite_caught": "GUARD 2 (arch config) is load-bearing, and attempt 2 reproduced that independently rather than taking wave 7's word for it: a build with `same_config` forced true renders `printf((char *)(dat_52c + 0x51c),a0,*a1)` for `fmt_arm::main` under `--option formatstring on`, where the shipping build renders `printf(\"%d %s\\n\",a0,(char *)*a1)`. `decompile_one` turns `readonlypropagate` ON around the drive so the PC-relative literal-pool format constant can be READ, but a Funcdata snapshots the per-function flags into its ArchSeam handle when it is BUILT, and the adopted IR had snapshotted the flag OFF. It is ARM-specific: the same A/B on `fmt_x86_64` and `fmt_aarch64` is byte-identical, so a sweep without an ARM literal-pool case would have missed it entirely. `verify_flowreuse::formatstring_forces_the_rebuild` pins it.",
+  "profiling_method": "gdb-as-parent SIGUSR1 sampling (perf_event_paranoid=4, yama ptrace_scope=1 -- neither perf nor gdb attach works on this box), 400 + 500 samples, plus `Instant`-instrumented builds printing per-stage wall time and IR sizes. The sampler's kill loop is bounded, so its samples cover only the first N intervals of the run; the phase split below comes from the instrumented build, not the sampler. || ATTEMPT 2 RE-PROFILE (independent, not inherited): gdb-as-parent with a Python stop-event loop (`run`; on each SIGUSR1 stop take `thread apply all bt 70`, `continue`), driven by an external `pkill -USR1 -x <uniquely-named copy of the binary>` loop at 20 ms. Two traps cost a whole sampling run each: (1) `handle SIGUSR1 stop noprint nopass` never stops -- `noprint` IMPLIES `nostop` in gdb, so it must be `stop print nopass`; (2) `kuna decompile` (without `--json`) FORKS `decomp_dbg` and waits, so 99% of the parent's samples are `__GI___poll` and gdb does not follow the child. Profile the in-process `kuna decompile <bin> <fn> --json` path instead -- same drive, one process. 1,053 usable samples.",
+  "measurement": {
+    "method": "Interleaved min-of-N: ONE loop alternating base and new arms per iteration so both see the same machine load (the box was running 3 sibling builders, load average 8-24 across the run). Arms are two builds of THIS worktree differing only in the adoption guard -- the base arm is the same source with `if false && seeds_empty && ...`, i.e. behaviourally origin/main for this path -- selected per run through the `KUNA_DECOMP_DBG` binary override, so the `kuna` driver, the script it generates and the loaded image are byte-identical between arms.",
+    "command": "kuna decompile <crackme> sub_140023350",
+    "pairs": 7,
+    "base_median_ms": 19703,
+    "base_min_ms": 18537,
+    "base_max_ms": 21103,
+    "new_median_ms": 15317,
+    "new_min_ms": 13967,
+    "new_max_ms": 18929,
+    "median_delta_pct": -22.26,
+    "min_delta_pct": -24.66,
+    "paired_mean_delta_pct": -20.58,
+    "paired_sd_pct": 7.8,
+    "significance": "paired t = 20.58 / (7.80/sqrt(7)) = 7.0 sigma, and the effect is >=20% on the median, min and paired mean -- past both bars the perf track sets. The one weak pair (-3.9%) is the first after warmup; the other six span -18.8% to -27.4%.",
+    "acceptance_ms_bar": 10000,
+    "acceptance_result": "FAIL on `wall_ms` alone; `exit_code` passes. 15,317 ms median against a <10,000 ms bar. `scripts.repipe.verify` measured 14,586 ms on a quieter moment of the same build -- still 46% over the bar. The need stays open.",
+    "output_identity": "the C emitted by the two arms on the witness is byte-identical (`cmp`)"
+  },
+  "residue_map": {
+    "method": "Instant-instrumented release build of this same worktree, `kuna decompile <crackme> sub_140023350` under the aggressive preset the CLI selects for a 235 KB binary",
+    "before_18_8s": {
+      "load file + read symbols": "0.75 s",
+      "flow follow #1 (load function)": "4.95 s (4.52 s of it 2x stage_jump_table)",
+      "flow follow #2 (decompile)": "4.33 s (4.01 s of it 2x stage_jump_table)",
+      "action pipeline + emit": "~8.8 s"
+    },
+    "jumptable_detail": "2 jump tables. Each stage_jump_table = a 68,370-op partial clone (~0.25 s) + the reduced `jumptable` action pipeline over it (~1.7 s). It ran 4 times (2 tables x 2 follows) = 8.5 s of the 18.8 s run; after this PR it runs twice.",
+    "main_pipeline_profile_500_samples": {
+      "ActionPool (rule pool)": "24.4%",
+      "p6 merge (with_covermerge / ActionMergeRequired / merge_addr_tied)": "18.4%",
+      "p5 infertypes": "14.0%",
+      "p3 heritage": "11.6%",
+      "p9 ActionDeadCode": "9.6%",
+      "p8 structure": "~4%",
+      "note": "flat -- no remaining hot spot, and no remaining quadratic in a single pass"
+    },
+    "unrolledguard_cost": "4.8 s of the 18.8 s run, and it is buying a real recovery: with `option unrolledguard off` the SECOND table's reduced pipeline returns in 1.8 ms (build_partial_blocks declines) instead of 1.7 s. The cost is the sibling switch it recovers, not waste.",
+    "attempt_2_profile_after_the_flow_reuse": {
+      "method": "1,053 gdb samples of `kuna decompile <crackme> sub_140023350 --json` on this branch's build; percentages are inclusive, of the whole run",
+      "stage_jump_table": "29.2% -- 2 tables, ONE follow now. 3.5% is `truncated_flow_clone`, 25.3% the reduced `jumptable` pipeline over the 68k-op clone (heritage 9.9, rule pool 9.3, ActionDeadCode 5.4 within it)",
+      "main action pipeline + emit": "60.4%",
+      "  p6 merge (with_covermerge)": "18.2% -- merge_test_adjacent 12.1, merge_adjacent 8.3, merge_linear 4.3, merge_by_datatype 4.3, merge_addr_tied 4.2",
+      "  rule pool (ActionPool)": "10.4%",
+      "  p3 heritage": "10.1% -- place_multiequals 4.1, guard 3.5 (guard_calls 2.8), rename 3.1",
+      "  symbol-container lookups": "~11% -- ScopeLocal::query_container_for_link 7.0, Database::find_container 4.9, RangeMap::find_subsorts 3.7 (overlapping)",
+      "  p5 infertypes": "6.0%",
+      "  p9 ActionDeadCode": "5.8%",
+      "load + analysis": "~10% -- load_program 5.7, commit_pending_analysis 5.0, sleigh one_instruction 5.5, listing 2.8",
+      "self-time leaders": "memmove 4.6 (BTree/slotmap internals), SeqNum::cmp 3.7, DefKey::cmp 3.6, ActionPool::apply 3.1, RuleEarlyRemoval 3.1, BTreeMap insert 2.9 / remove 2.8, LocKey::cmp 2.8",
+      "verdict": "confirms attempt 1's flat-residue finding independently. `stage_jump_table` is the only block over 20% and it is semantically load-bearing (see `left_on_the_table`); after it the largest single item is p6 merge at 18.2%, and the rest is a five-front 10/10/11/6/6% spread. The `bb_ops` Vec lead from attempt 1 re-measures at only ~2.2% self, spread over five callers (heritage rename_recurse 1.0% is the largest), so it is not the ~10% attempt 1 estimated."
+    }
+  },
+  "why_the_acceptance_cannot_be_reached_by_removing_redundancy": {
+    "floor": "action pipeline + emit is ~8.8 s and load+read symbols is 0.75 s, so ~9.6 s is spent before a single jump table is touched. Deleting ALL remaining jump-table work lands at ~10.6 s, still above the 10,000 ms bar.",
+    "the_witness_is_43KB_not_3396B": "PE .pdata RUNTIME_FUNCTION 0x23350..0x2dbe0 = 43,152 bytes. `kuna functions` reports 3396 because it derives size from the gap to the next discovered entry, and `sub_140024094` / `sub_14002bb5c` are mid-function labels inside the same .pdata range. Confirmed by parsing the exception directory directly. A `--define-function 0x140023350-0x140024093` run finishes in 1.35 s but ERRORS (`Could not find op at target address: (ram,0x1400249fa)`) precisely because a real switch target lies past the fake boundary.",
+    "scaling_law": {
+      "method": "/bin/bash, `kuna decompile-all --addr <fn> --json --mode aggressive`, load cost (~3.4 s) subtracted; op/varnode counts from an instrumented build",
+      "rows": [
+        {
+          "size_bytes": 5248,
+          "alive_ops": 3233,
+          "indirect": 1004,
+          "multiequal": 1047,
+          "varnodes": 4715,
+          "pipeline_s": 1.6
+        },
+        {
+          "size_bytes": 9184,
+          "alive_ops": 8937,
+          "indirect": 4098,
+          "multiequal": 2558,
+          "varnodes": 13934,
+          "pipeline_s": 9.6
+        },
+        {
+          "size_bytes": 13488,
+          "alive_ops": 30697,
+          "indirect": 17142,
+          "multiequal": 9714,
+          "varnodes": 49382,
+          "pipeline_s": 30.7
+        },
+        {
+          "size_bytes": 14432,
+          "alive_ops": 21806,
+          "indirect": 8284,
+          "multiequal": 7067,
+          "varnodes": 31596,
+          "pipeline_s": 17.7
+        }
+      ],
+      "reading": "The IR ITSELF is superlinear in function size (alive ops grow ~size^2.4), driven by INDIRECT: `Heritage::guard_calls` creates one per (call site x heritaged location) and BOTH grow with function size. Pipeline time is then ~ops^1.5-2 on top. Combined that is roughly cubic in bytes, which is what a 43 KB function costs. The INDIRECT model is upstream's, ported faithfully (heritage.rs `guard_calls` against heritage.cc:1468ff), so this is not a kuna-only defect -- it is the constant factor that has to come down.",
+      "consequence": "closing the last ~4 s is a constant-factor campaign across the rule pool, p6 merge, p5 infertypes, p3 heritage and p9 emit -- five fronts at 24/18/14/12/10 % with no hot spot -- not another focused fix."
+    }
+  },
+  "left_on_the_table": [
+    {
+      "item": "the jump-table partial is rebuilt per table",
+      "worth": "~2.0 s of the post-PR 14 s run (1 of the 2 remaining stagings)",
+      "status": "BLOCKED, not undone. Upstream builds ONE partial per `recoverJumpTables` (flow.cc:1437) and guards the clone behind `if (!partial.isJumptableRecoveryOn())`. Attempt 1 implemented and REVERTED it: kuna's `option unrolledguard` recovers MSVC interleaved tables precisely BECAUSE each table's clone re-clones the siblings recovered before it, and sharing took tests/stages/ghangr-optimized-memcpy-6301a9.xml from 2/2 to 0/2. It changes which tables recover, so it needs its own option -- and this round's phases.toml / docs/options.md / catalog-counter leases are held by a sibling builder."
+    },
+    {
+      "item": "`Funcdata::early_jump_table_fail` collects the whole dead list",
+      "worth": "small (a 68,370-element Vec per BRANCHIND considered, a handful of times)",
+      "status": "NOT DONE. `let order: Vec<OpId> = self.obank().iter_dead().collect(); order.iter().position(|&o| o == op)` -- the same shape attempt 1 removed from `dead_next`/`dead_tail`/`op_target`, missed there because it is in funcdata_block.rs rather than op.rs/flow.rs. Now that the O(1) cursor exists (`PcodeBank::dead_prev`), this is a two-line change; it is left out only because it is not on the path to the bar and this PR is deliberately one seam."
+    },
+    {
+      "item": "the rule pool's optree cursor is still O(log n) per op",
+      "worth": "~9% of the pipeline (`advance_op_state` 9.2% inclusive, `SeqNum::cmp` 4.4% self)",
+      "status": "NOT DONE, unchanged from attempt 1. Making it O(1) needs a seqnum-ordered intrusive list alongside the optree; `BTreeMap::lower_bound` is still unstable on the pinned toolchain."
+    },
+    {
+      "item": "`Funcdata::bb_ops` allocates a Vec per call",
+      "worth": "~10% of the pipeline (4.6% self + the `Vec::from_iter` it feeds at 5.2%)",
+      "status": "NOT DONE. Every caller that only iterates could walk the intrusive block link instead; output-identical but it touches many call sites."
+    }
+  ],
+  "regression_sweep": {
+    "method": "`kuna decompile <bin> <fn>` run under both arms and byte-compared (stdout AND exit code) for the first 15 functions of each binary. Coverage of the FAST PATH itself was then measured separately with a third, instrumented build that appends a line to `$KUNA_ADOPT_LOG` at the guard -- because `kuna` pipes the child `decomp_dbg`'s stderr and only surfaces it on failure, so an eprintln marker is invisible and a naive count reads 0 adoptions on a run that adopted every time.",
+    "binaries": 20,
+    "architectures": "x86-64, i386, aarch64, ARM, ARM Thumb, Cortex-M, RISC-V 64; ELF exe/PIE/.so and PE32+",
+    "functions_compared": 218,
+    "functions_that_took_the_adopt_path": 203,
+    "diffs": 0,
+    "the_15_that_did_not_adopt": "the seed guard firing as designed -- DWARF stack locals (`dwarfstructs`, `dwarf_stripped`, `dwarfvariants`), parsed/parked prototypes (`cppproto`) and the PE CRT (`crtmain_x86_64.exe`). Those fall back to the rebuild and are byte-identical too, which is the fallback arm's evidence.",
+    "the_trap_this_sweep_hit_first": "the first run of this sweep reported a diff on EVERY function. It was not the change: two copies of the sweep script were running concurrently (a backgrounded `( ... ) &` that outlived the tool call) and racing on one shared pair of scratch files, so arm A's output was compared against arm B's next function. Scratch dirs are `$$`-suffixed now."
+  },
+  "tests": {
+    "cargo": [
+      "kuna-console/tests/verify_flowreuse.rs::adopting_the_loaded_flow_renders_the_same_c_as_rebuilding_it -- the plain pair adopts (adopted_flows == 1) and renders byte-identical C to the same pair with an inert `echo` in between (which does not adopt)",
+      "kuna-console/tests/verify_flowreuse.rs::load_addr_also_adopts -- `load addr` stamps its follow too, and the two entry surfaces render the same C",
+      "kuna-console/tests/verify_flowreuse.rs::a_second_decompile_does_not_adopt -- the stamp is single-use",
+      "kuna-console/tests/verify_flowreuse.rs::dwarf_locals_are_a_flow_time_seed_that_forces_the_rebuild -- isolates the SEED guard from the counter guard (nothing runs in between)",
+      "kuna-console/tests/verify_flowreuse.rs::formatstring_forces_the_rebuild -- isolates the ARCH-CONFIG guard, and asserts the format string still resolves"
+    ],
+    "stage_test": null,
+    "stage_test_rationale": "tests/stages/README.md scopes that corpus to stage-model issues; a console-tier change with byte-identical output has no assertion to make there, and adding one would re-record the stages baseline and bump the hard-coded corpus count for nothing.",
+    "cli_probe": "NOT promoted. `scripts.repipe.verify --promote` would install the acceptance probe as a permanent regression test, but the acceptance still FAILS (15,317 ms median vs a <10,000 ms bar), so promoting it would commit a red test. The probe stays in the need record until a later attempt reaches the bar.",
+    "whole_surface": "218-function adopt-vs-rebuild byte-identity sweep, 0 diffs -- see `regression_sweep`. Not a committed test (it needs two builds of the same tree); `verify_flowreuse.rs` is the committed form of the same property on one fixture."
+  },
+  "gates": {
+    "make test": "PARITY OK -- 675/675 assertions, docs/baseline.json untouched",
+    "make test-stages": "PARITY OK -- 600/600 assertions, docs/baseline-stages.json untouched",
+    "make check-spec": "check-spec OK",
+    "kuna catalog --check": "catalog OK: documents exactly the registered kuna options (no option added)",
+    "make test-cli": "tests/cli: 17/17 passed",
+    "make rust-test": "PENDING(rerun)",
+    "make rust-test note": "The first run reported 1 failure in 344 test binaries / 5,318 tests: `verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip`, 'oracle promote_compare signature drifted'. NOT this change. That assertion is guarded by `cpp_oracle_bin()`, which falls back to the removed `decompiler/cpp/decomp_test_dbg` and is normally skipped -- but the repipe worker environment exports `KUNA_DECOMP_TEST` pointing at the worktree's OWN modern `decomp_test_dbg`, so the 'C++ oracle' arm activates and asserts the pre-DIV-6 `xunknown4` rendering against a realtypes build. `env -u KUNA_DECOMP_TEST` -> 4/4 pass; the gate below is a full re-run with it unset."
+  },
+  "decisions": [
+    "ATTEMPT 2 RESUME. Wave 7 was SIGKILLed mid-`make rust-test` with the implementation written but no gate run and nothing pushed; the captain committed the worktree verbatim (`salvage/r2w7-decompiling-3396`). Wave 8's job was to verify it, not to re-derive it -- and 'verify' meant treating every claim in it as unproven, including its own test.",
+    "CORRECTED wave 7's stated root cause. It claimed all seven console seeds are consumed at flow time. Reading the drive body refutes that: only `override prototype` and the parked callee prototypes are; `map addr`/DWARF locals, usepoint symbols, `map hash` symbols, the function's own parsed prototype and `map param` locks are all re-seeded onto the Funcdata AFTER the follow, so they would survive an adoption. The guard is unchanged -- requiring all seven empty keeps it one question instead of a per-seed judgement a future seed could be forgotten from -- but the spec, the PR body and this record now say so for the right reason. Cost of the conservatism, measured: 15 of 218 swept functions decline to adopt.",
+    "CONFIRMED the fast path actually fires, which is the claim the salvaged tree could not make for itself. 203 of 218 swept functions took the adopt path. Getting that number needed a third instrumented build writing to a FILE: `kuna` pipes the child `decomp_dbg`'s stdout AND stderr and only surfaces them on failure, so an `eprintln!` marker is swallowed and the first count read 0 adoptions on a run that had adopted 203 times. A coverage claim measured through that boundary is worthless.",
+    "REFUTED the apparent speedup before trusting it. The brief's 19.3 s (base) and this build's 14.6 s were measured hours apart on a box running three sibling builders at load average 8-24; that spread is entirely explicable by load. The finding only survives because of the interleaved paired A/B: 7 pairs, median -22.26%, min -24.66%, paired mean -20.58% +/- 7.80 (7 sigma). A single-arm before/after here would have been indistinguishable from the machine.",
+    "RE-PROFILED from scratch rather than inheriting attempt 1's residue map, and it holds: `stage_jump_table` 29.2%, p6 merge 18.2%, rule pool 10.4%, heritage 10.1%, symbol-container lookups ~11%, infertypes 6.0%, deadcode 5.8%. One attempt-1 lead does NOT hold -- `bb_ops` re-measures at ~2.2% self spread over five callers, not the ~10% estimated -- so the remaining leads are worth less than recorded, not more.",
+    "REFUTED the filed diagnosis for the second time, and on a different axis than attempt 1: the dominant cost is not an analysis pass and not a quadratic, it is the SAME flow follow run twice, with the jump-table sub-decompilation inside it (8.5 s of 18.8 s, 4 stagings of 2 tables).",
+    "OVERTURNED the need's own premise: `sub_140023350` is NOT 3396 bytes. `kuna functions` derives size from the gap to the next entry; the PE .pdata says 43,152. The flow follow is correct and there is no overrun -- which is why bounding it (`--define-function`) finishes in 1.35 s but ERRORS on a real switch target past the fake boundary. Anyone reading this need's title should know the number in it is a kuna reporting artifact.",
+    "NO OPTION. Output is byte-identical (218 whole-surface console decompiles over 20 binaries plus 1,275 corpus assertions), so AGENTS.md's `anything that CAN change emitted C ships behind a named option` does not bite -- and it keeps this clear of the phases.toml / docs/options.md / catalog-counter leases a sibling builder holds this round.",
+    "SHIPPED ONE SEAM. `early_jump_table_fail`'s dead-list scan, the rule-pool cursor and the `bb_ops` allocation stay out: together they are worth a few percent against a gap of 35%, and each is a separate risk surface on a PR whose whole claim is byte-identity.",
+    "THE NEED STAYS OPEN and the acceptance probe is NOT promoted. 15,317 ms median against a <10,000 ms bar. Promoting the probe would commit a red test; relaxing it would redefine `closed` as `a builder tried`. Attempt 3, if there is one, is a constant-factor campaign across p6 merge / the rule pool / heritage / the symbol-container lookups -- five fronts, no hot spot -- or a decision to make the jump-table partial shareable behind its own option, which needs the phases.toml lease this round did not have.",
+    "ACCEPTANCE NOT MET, and now with a measured impossibility proof rather than a shrug: the action pipeline plus emit alone is ~8.8 s and the load is 0.75 s, so deleting ALL remaining jump-table work still lands at ~10.6 s against a 10.0 s bar. The residue is the IR's superlinear growth with function size (ops ~ size^2.4 via INDIRECT, time ~ ops^1.5-2), measured on /bin/bash across four function sizes. This need cannot be closed by a focused fix; the next step is a campaign proposal, and this record is its map."
+  ]
 }

--- a/docs/features/decompiling-3396-byte-main/record.json
+++ b/docs/features/decompiling-3396-byte-main/record.json
@@ -46,7 +46,21 @@
     "significance": "paired t = 20.58 / (7.80/sqrt(7)) = 7.0 sigma, and the effect is >=20% on the median, min and paired mean -- past both bars the perf track sets. The one weak pair (-3.9%) is the first after warmup; the other six span -18.8% to -27.4%.",
     "acceptance_ms_bar": 10000,
     "acceptance_result": "FAIL on `wall_ms` alone; `exit_code` passes. `scripts.repipe.verify` on the final merged-tree build: median 14,437 ms against a <10,000 ms bar. The interleaved 7-pair A/B median is 15,317 ms. Either way the need stays open, ~45% over the bar.",
-    "output_identity": "the C emitted by the two arms on the witness is byte-identical (`cmp`)"
+    "output_identity": "the C emitted by the two arms on the witness is byte-identical (`cmp`)",
+    "confirmation_on_the_rebased_tree": {
+      "note": "re-measured after rebasing onto origin/main b08c30ac (a sibling's `overlapbranch` option landed in between), on a quieter box; both arms rebuilt from the rebased tree",
+      "pairs": 5,
+      "base_median_ms": 18601,
+      "base_min_ms": 18224,
+      "new_median_ms": 14348,
+      "new_min_ms": 13984,
+      "median_delta_pct": -22.86,
+      "min_delta_pct": -23.26,
+      "paired_mean_delta_pct": -22.89,
+      "paired_sd_pct": 1.92,
+      "significance": "paired t = 22.89 / (1.92/sqrt(5)) = 26.6 sigma; per-pair range -21.0% to -25.0%",
+      "identity_recheck": "119 further functions over 10 binaries swept adopt-vs-rebuild on the rebased tree: 0 diffs"
+    }
   },
   "residue_map": {
     "method": "Instant-instrumented release build of this same worktree, `kuna decompile <crackme> sub_140023350` under the aggressive preset the CLI selects for a 235 KB binary",
@@ -171,14 +185,15 @@
     "whole_surface": "218-function adopt-vs-rebuild byte-identity sweep, 0 diffs -- see `regression_sweep`. Not a committed test (it needs two builds of the same tree); `verify_flowreuse.rs` is the committed form of the same property on one fixture."
   },
   "gates": {
-    "make test": "PARITY OK -- 675/675 assertions, docs/baseline.json untouched",
-    "make test-stages": "PARITY OK -- 600/600 assertions, docs/baseline-stages.json untouched",
+    "make test": "PARITY OK -- 675/675 assertions, docs/baseline.json untouched (re-run after the rebase)",
+    "make test-stages": "PARITY OK -- 603/603 assertions, docs/baseline-stages.json untouched (re-run after the rebase)",
+    "make rust-test": "green -- 345 test binaries, 5,335 tests, 0 failed (re-run after the rebase, with `env -u KUNA_DECOMP_TEST`; see note)",
     "make check-spec": "check-spec OK",
+    "make test-cli": "tests/cli: 18/18 passed",
     "kuna catalog --check": "catalog OK: documents exactly the registered kuna options (no option added)",
-    "make test-cli": "tests/cli: 17/17 passed",
-    "make rust-test": "green -- 344 test binaries, 5,322 tests, 0 failed (run with `env -u KUNA_DECOMP_TEST`; see note)",
+    "repipe.mergecheck": "merge guards clean -- 0 rejects against origin/main; counters re-derived and agree (137 settables, tiers 32/55/50, 231 corpus files, next ElementId 4139)",
     "make rust-test note": "The first run reported 1 failure in 344 test binaries / 5,318 tests: `verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip`, 'oracle promote_compare signature drifted'. NOT this change. That assertion is guarded by `cpp_oracle_bin()`, which falls back to the removed `decompiler/cpp/decomp_test_dbg` and is normally skipped -- but the repipe worker environment exports `KUNA_DECOMP_TEST` pointing at the worktree's OWN modern `decomp_test_dbg`, so the 'C++ oracle' arm activates and asserts the pre-DIV-6 `xunknown4` rendering against a realtypes build. `env -u KUNA_DECOMP_TEST` -> 4/4 pass; the line above is a full re-run with it unset.",
-    "mergecheck": "merge guards clean -- 0 rejects against origin/main; shared counters re-derived and agree (136 settables, 230 corpus files, next ElementId 4138); docs/baseline.json byte-identical to origin/main"
+    "the counter trap this merge hit": "`repipe.counters --fix` run BEFORE rebuilding after the rebase tried to rewrite the settable counts 137 -> 136, i.e. to DELETE the sibling option that had just merged: it derives the truth from the BUILT BINARY, which was still the pre-rebase one. Reverted, rebuilt, re-ran -- `no drift; nothing to fix`. `--fix` after a rebase is only safe on a rebuilt tree, and it can silently move a counter DOWN."
   },
   "decisions": [
     "ATTEMPT 2 RESUME. Wave 7 was SIGKILLed mid-`make rust-test` with the implementation written but no gate run and nothing pushed; the captain committed the worktree verbatim (`salvage/r2w7-decompiling-3396`). Wave 8's job was to verify it, not to re-derive it -- and 'verify' meant treating every claim in it as unproven, including its own test.",

--- a/docs/features/decompiling-3396-byte-main/record.json
+++ b/docs/features/decompiling-3396-byte-main/record.json
@@ -45,7 +45,7 @@
     "paired_sd_pct": 7.8,
     "significance": "paired t = 20.58 / (7.80/sqrt(7)) = 7.0 sigma, and the effect is >=20% on the median, min and paired mean -- past both bars the perf track sets. The one weak pair (-3.9%) is the first after warmup; the other six span -18.8% to -27.4%.",
     "acceptance_ms_bar": 10000,
-    "acceptance_result": "FAIL on `wall_ms` alone; `exit_code` passes. 15,317 ms median against a <10,000 ms bar. `scripts.repipe.verify` measured 14,586 ms on a quieter moment of the same build -- still 46% over the bar. The need stays open.",
+    "acceptance_result": "FAIL on `wall_ms` alone; `exit_code` passes. `scripts.repipe.verify` on the final merged-tree build: median 14,437 ms against a <10,000 ms bar. The interleaved 7-pair A/B median is 15,317 ms. Either way the need stays open, ~45% over the bar.",
     "output_identity": "the C emitted by the two arms on the witness is byte-identical (`cmp`)"
   },
   "residue_map": {
@@ -176,8 +176,9 @@
     "make check-spec": "check-spec OK",
     "kuna catalog --check": "catalog OK: documents exactly the registered kuna options (no option added)",
     "make test-cli": "tests/cli: 17/17 passed",
-    "make rust-test": "PENDING(rerun)",
-    "make rust-test note": "The first run reported 1 failure in 344 test binaries / 5,318 tests: `verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip`, 'oracle promote_compare signature drifted'. NOT this change. That assertion is guarded by `cpp_oracle_bin()`, which falls back to the removed `decompiler/cpp/decomp_test_dbg` and is normally skipped -- but the repipe worker environment exports `KUNA_DECOMP_TEST` pointing at the worktree's OWN modern `decomp_test_dbg`, so the 'C++ oracle' arm activates and asserts the pre-DIV-6 `xunknown4` rendering against a realtypes build. `env -u KUNA_DECOMP_TEST` -> 4/4 pass; the gate below is a full re-run with it unset."
+    "make rust-test": "green -- 344 test binaries, 5,322 tests, 0 failed (run with `env -u KUNA_DECOMP_TEST`; see note)",
+    "make rust-test note": "The first run reported 1 failure in 344 test binaries / 5,318 tests: `verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip`, 'oracle promote_compare signature drifted'. NOT this change. That assertion is guarded by `cpp_oracle_bin()`, which falls back to the removed `decompiler/cpp/decomp_test_dbg` and is normally skipped -- but the repipe worker environment exports `KUNA_DECOMP_TEST` pointing at the worktree's OWN modern `decomp_test_dbg`, so the 'C++ oracle' arm activates and asserts the pre-DIV-6 `xunknown4` rendering against a realtypes build. `env -u KUNA_DECOMP_TEST` -> 4/4 pass; the line above is a full re-run with it unset.",
+    "mergecheck": "merge guards clean -- 0 rejects against origin/main; shared counters re-derived and agree (136 settables, 230 corpus files, next ElementId 4138); docs/baseline.json byte-identical to origin/main"
   },
   "decisions": [
     "ATTEMPT 2 RESUME. Wave 7 was SIGKILLed mid-`make rust-test` with the implementation written but no gate run and nothing pushed; the captain committed the worktree verbatim (`salvage/r2w7-decompiling-3396`). Wave 8's job was to verify it, not to re-derive it -- and 'verify' meant treating every claim in it as unproven, including its own test.",

--- a/docs/features/decompiling-3396-byte-main/record.json
+++ b/docs/features/decompiling-3396-byte-main/record.json
@@ -1,105 +1,139 @@
 {
  "opportunity": "decompiling-3396-byte-main",
  "need_id": "decompiling-3396-byte-main",
- "route": "RE-friction loop (docs/re-pipeline.md), round 2, track perf",
+ "route": "RE-friction loop (docs/re-pipeline.md), round 2, track perf -- ATTEMPT 2",
  "challenge": "69a3822f7b3cc38c80464da4",
- "binary": ".kuna-repipe/probebin/bcfacd743bc607be/nikos_crack_me.exe (PE x86-64, 235725 bytes, sha256 bcfacd74...)",
- "selector": "sub_140023350 (the program's main, 3396 bytes)",
- "phase": "P2 (lift/flow) + the action scheduler (infra)",
+ "binary": ".kuna-repipe/probebin/bcfacd743bc607be/nikos_crack_me.exe (PE x86-64, 235725 bytes)",
+ "selector": "sub_140023350",
+ "scope": "small",
+ "attempt": 2,
+ "prior_attempt": {
+  "pr": 380,
+  "summary": "dead-list position was re-derived by scanning; 71.46 s -> 19.42 s (-72.8%), acceptance not met",
+  "record": "preserved verbatim under `attempt_1` below"
+ },
+ "phase": "console/drive tier (kuna-console `ifacedecomp`/`interface`/`decompile_step`, kuna-decomp `infra/decompile_drive`)",
  "modules": [
-  "decompiler/crates/kuna-decomp/src/substrate/op.rs (PcodeOpBank::dead_next / dead_prev / dead_front / dead_back / on_dead_list / first_after_seq_id)",
-  "decompiler/crates/kuna-decomp/src/p2_lift/flow.rs (FlowInfo::dead_next / dead_head / dead_tail / delete_remaining_ops)",
-  "decompiler/crates/kuna-decomp/src/substrate/funcdata_op.rs (Funcdata::op_target)",
-  "decompiler/crates/kuna-decomp/src/infra/action.rs (ActionPool cursor memo)"
+  "decompiler/crates/kuna-console/src/ifacedecomp.rs (PristineFlow, IfcFuncload, IfcAddrrangeLoad, IfcDecompile)",
+  "decompiler/crates/kuna-console/src/interface.rs (IfaceStatus::command_seq)",
+  "decompiler/crates/kuna-console/src/decompile_step.rs (decompile_one_prefollowed)",
+  "decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs (decompile_func_full_with_override_dyn_prefollowed)"
  ],
  "change_kind": "performance-fix (output byte-identical)",
  "option": null,
  "gated": false,
- "gating_rationale": "Not a judgement call and not output-changing: every edit replaces a search for a position with the O(1) link the same data structure already carries, and the whole-binary output is byte-identical before/after on three binaries (509 functions) plus the 675 datatest and 597 stage assertions. AGENTS.md gates features that CAN change emitted C; these cannot. No phases.toml row, no options.rs registration, no catalog counters, no docs/options.md, no DIV row.",
+ "gating_rationale": "Not a judgement call and cannot change emitted C: the adopted Funcdata is the one the rebuild would have produced, and the three guards refuse adoption whenever it would not be. Byte-identical over 187 whole-surface console decompiles, the 675 datatest assertions and the 597 stage assertions. No phases.toml row, no options.rs registration, no catalog counters, no docs/options.md, no DIV row -- which also keeps this clear of the counter and phases.toml leases a sibling builder holds this round.",
  "hypothesis_filed": "The function's extensive opaque arithmetic and indirect calls cause one or more analysis passes to scale poorly.",
- "hypothesis_verdict": "PARTLY REFUTED. The symptom stands (68 s reproduced as 71.5 s median). The cause is not 'opaque arithmetic and indirect calls' and not an analysis pass: it is a quadratic in the LIFTER, present for every function and only visible on a large one. gdb-sampled profiling put 53% of wall time in the single leaf frame FlowInfo::xref_control_flow, which is not analysis at all. The function is unusual only in op count (48,169 raw ops, 37,710 of them INDIRECTs at 365 call sites over ~78 guarded locations) -- and op count is exactly what the quadratic squares.",
- "root_cause": "The C++ caches std::list<PcodeOp*>::iterators on each op (insertiter), so 'the op after this one' / 'the last op' are O(1). kuna's dead list is the same doubly-linked list (op.rs IntrusiveList, prev/next OpId links per op) but three call sites re-derived position by SCANNING iter_dead(): FlowInfo::dead_next scanned the whole list to locate one op, FlowInfo::dead_tail scanned it to reach the end, and Funcdata::op_target rebuilt a whole BTreeMap predecessor index per call. process_instruction does one dead_tail() + one dead_next() PER INSTRUCTION, and xref_control_flow does one dead_next() per emitted op, over a list that grows to the whole function -- O(N^2) in op count. delete_remaining_ops likewise collected the entire list to find a suffix.",
- "fix": "Expose the links the list already has (PcodeBank::dead_next/dead_prev/dead_front/dead_back, membership = the `dead` flag PLUS a live link, because destroy() retires an op to deadandgone with the flag still set and the alive list shares the same link pair) and use them. Separately, ActionPool::advance_op_state already performed the optree search that decides After/Done, so it now keeps the successor's OpId and current_op reads it instead of searching a second time; the memo is dropped on every apply() exit so a resumed or interleaved sweep re-searches.",
- "measurement": {
-  "method": "interleaved A/B, base binary vs new binary alternating in the same loop (docs/agents.md worktree rule: files copied aside, never stashed); machine load average 5-7 from sibling builders, so min and median are both reported",
-  "probe_command": "kuna decompile <bin> sub_140023350",
-  "base_s": [
-   76.36,
-   69.14,
-   70.03,
-   71.46,
-   72.36
-  ],
-  "new_s": [
-   18.44,
-   23.35,
-   21.79,
-   19.42,
-   18.84
-  ],
-  "base_median_s": 71.46,
-  "new_median_s": 19.42,
-  "delta_pct": -72.8,
-  "separation": "max(new)=23.35 s is below min(base)=69.14 s -- the distributions do not overlap",
-  "in_process_single_function": "kuna decompile-all --addr 0x140023350: 40.05 s -> 14.24 s median of 3 (-64.4%)",
-  "whole_binary_control": "kuna decompile-all /bin/gzip (145 functions): 14.55 s -> 13.60 s median of 3 (-6.5%) -- small functions barely feel a quadratic in op count, which is the expected shape and the honest limit of this fix"
+ "hypothesis_verdict": "REFUTED AGAIN, and differently from attempt 1. It is not an analysis pass, and it is not the lifter quadratic attempt 1 fixed either. Two facts overturn the framing: (1) `kuna decompile` follows the SAME flow twice (`load function` then `decompile`), and both follows are ~93% jump-table sub-decompilation -- 8.5 s of an 18.8 s run spent staging 2 tables four times over; (2) the witness is NOT a 3396-byte function. `kuna functions` derives sizes from the gap to the next entry; the PE's own .pdata RUNTIME_FUNCTION says 0x140023350..0x14002dbe0 = 43,152 bytes, and `sub_140024094` / `sub_14002bb5c` are mid-function labels. The flow follow is CORRECT and there is no overrun -- the function really is 43 KB with 68,370 raw ops. The need's own title is built on the wrong size.",
+ "root_cause": "C++ `IfcFuncload` follows flow once and `IfcDecompile` re-runs the actions on THAT Funcdata after `Architecture::clearAnalysis` (ifacedecomp.cc:889). kuna's `IfcDecompile` rebuilds the Funcdata from scratch, because every fact a decompile is seeded with -- `map address` symbols and DWARF stack locals, `type varnode` usepoint symbols, `map hash` dynamic symbols, a `parse line extern` prototype, `map param` storage locks, `override prototype` call-site overrides -- is consumed AT FLOW TIME and `load function` applies none of them. So the rebuild is required exactly when one of those exists, and pure waste when none does, which is every plain `kuna decompile <bin> <fn>`.",
+ "fix": "`IfcDecompile` adopts the loaded IR when it can prove the rebuild would repeat the same follow. `load function`/`load addr` stamp the follow (`PristineFlow`: name, entry, declared extent, flow overrides, and the console command counter); `decompile` adopts only when (a) every flow-time seed above is empty, (b) the architecture is configured as it was at the load, and (c) the stamp's command counter advanced by exactly one. (c) is deliberately the whole invalidation story: any command at all -- an `option`, a `kassert`, a `map`, a second `load` -- advances the counter, so no command needs its own invalidation hook and none can be forgotten. The adopted Funcdata is threaded into the drive through a new `..._prefollowed` variant, so every line after the flow follow is the same code.",
+ "the_guard_the_suite_caught": "The first cut had guard (b) missing and `verify_decompile_all_parity` failed: with `--option formatstring on` the ARM fixture rendered `printf((char *)(dat_52c + 0x51c),a0,*a1)` instead of `printf(\"%d %s\\n\",a0,(char *)*a1)`. `decompile_one` turns `readonlypropagate` ON around the drive so the PC-relative literal-pool format constant can be READ -- but a Funcdata snapshots the per-function flags into its ArchSeam handle when it is BUILT, and the adopted IR had snapshotted the flag OFF. Guard (b) now refuses adoption for `formatstring`, the watchdog budget, and ghidra mode's staged recommendations, and `verify_flowreuse::formatstring_forces_the_rebuild` pins it.",
+ "profiling_method": "gdb-as-parent SIGUSR1 sampling (perf_event_paranoid=4, yama ptrace_scope=1 -- neither perf nor gdb attach works on this box), 400 + 500 samples, plus `Instant`-instrumented builds printing per-stage wall time and IR sizes. The sampler's kill loop is bounded, so its samples cover only the first N intervals of the run; the phase split below comes from the instrumented build, not the sampler.",
+ "measurement": {},
+ "residue_map": {
+  "method": "Instant-instrumented release build of this same worktree, `kuna decompile <crackme> sub_140023350` under the aggressive preset the CLI selects for a 235 KB binary",
+  "before_18_8s": {
+   "load file + read symbols": "0.75 s",
+   "flow follow #1 (load function)": "4.95 s (4.52 s of it 2x stage_jump_table)",
+   "flow follow #2 (decompile)": "4.33 s (4.01 s of it 2x stage_jump_table)",
+   "action pipeline + emit": "~8.8 s"
+  },
+  "jumptable_detail": "2 jump tables. Each stage_jump_table = a 68,370-op partial clone (~0.25 s) + the reduced `jumptable` action pipeline over it (~1.7 s). It ran 4 times (2 tables x 2 follows) = 8.5 s of the 18.8 s run; after this PR it runs twice.",
+  "main_pipeline_profile_500_samples": {
+   "ActionPool (rule pool)": "24.4%",
+   "p6 merge (with_covermerge / ActionMergeRequired / merge_addr_tied)": "18.4%",
+   "p5 infertypes": "14.0%",
+   "p3 heritage": "11.6%",
+   "p9 ActionDeadCode": "9.6%",
+   "p8 structure": "~4%",
+   "note": "flat -- no remaining hot spot, and no remaining quadratic in a single pass"
+  },
+  "unrolledguard_cost": "4.8 s of the 18.8 s run, and it is buying a real recovery: with `option unrolledguard off` the SECOND table's reduced pipeline returns in 1.8 ms (build_partial_blocks declines) instead of 1.7 s. The cost is the sibling switch it recovers, not waste."
  },
- "acceptance": {
-  "target": "wall_ms median < 10000 on `kuna decompile <bin> sub_140023350`",
-  "result": "NOT MET (19.4 s median). The probe arm still passes (>30 s) is FALSE, i.e. the filed bad behaviour is gone, but the acceptance threshold is not reached.",
-  "why_not": "After this fix the profile is flat: no remaining item is worth the further 48% the threshold needs. The measured 12.2 s in-process breakdown was p6 merge/ScopeLocal 27.6%, p3 dataflow/heritage 26.3%, the rule pool 19.8%, jump-table sub-decompilation 17.4%, p9 dead-code/emit 13.7%. Closing the gap is a campaign across kuna's core indexes, not one focused change.",
-  "promoted": false,
-  "promote_refused_because": "the acceptance does not pass, and its target is binary_source=dataset (scripts.repipe.verify.vendorable refuses anything that is not in-repo). Promoting it would install a red CI test; promoting a weakened variant would need the 235 KB third-party crackme vendored into the repo and would assert a wall clock on CI runners that this project already knows are noisy (docs: a red kuna check is usually runner starvation). The regression guard shipped instead is a cargo unit test on the cursor semantics."
+ "why_the_acceptance_cannot_be_reached_by_removing_redundancy": {
+  "floor": "action pipeline + emit is ~8.8 s and load+read symbols is 0.75 s, so ~9.6 s is spent before a single jump table is touched. Deleting ALL remaining jump-table work lands at ~10.6 s, still above the 10,000 ms bar.",
+  "the_witness_is_43KB_not_3396B": "PE .pdata RUNTIME_FUNCTION 0x23350..0x2dbe0 = 43,152 bytes. `kuna functions` reports 3396 because it derives size from the gap to the next discovered entry, and `sub_140024094` / `sub_14002bb5c` are mid-function labels inside the same .pdata range. Confirmed by parsing the exception directory directly. A `--define-function 0x140023350-0x140024093` run finishes in 1.35 s but ERRORS (`Could not find op at target address: (ram,0x1400249fa)`) precisely because a real switch target lies past the fake boundary.",
+  "scaling_law": {
+   "method": "/bin/bash, `kuna decompile-all --addr <fn> --json --mode aggressive`, load cost (~3.4 s) subtracted; op/varnode counts from an instrumented build",
+   "rows": [
+    {
+     "size_bytes": 5248,
+     "alive_ops": 3233,
+     "indirect": 1004,
+     "multiequal": 1047,
+     "varnodes": 4715,
+     "pipeline_s": 1.6
+    },
+    {
+     "size_bytes": 9184,
+     "alive_ops": 8937,
+     "indirect": 4098,
+     "multiequal": 2558,
+     "varnodes": 13934,
+     "pipeline_s": 9.6
+    },
+    {
+     "size_bytes": 13488,
+     "alive_ops": 30697,
+     "indirect": 17142,
+     "multiequal": 9714,
+     "varnodes": 49382,
+     "pipeline_s": 30.7
+    },
+    {
+     "size_bytes": 14432,
+     "alive_ops": 21806,
+     "indirect": 8284,
+     "multiequal": 7067,
+     "varnodes": 31596,
+     "pipeline_s": 17.7
+    }
+   ],
+   "reading": "The IR ITSELF is superlinear in function size (alive ops grow ~size^2.4), driven by INDIRECT: `Heritage::guard_calls` creates one per (call site x heritaged location) and BOTH grow with function size. Pipeline time is then ~ops^1.5-2 on top. Combined that is roughly cubic in bytes, which is what a 43 KB function costs. The INDIRECT model is upstream's, ported faithfully (heritage.rs `guard_calls` against heritage.cc:1468ff), so this is not a kuna-only defect -- it is the constant factor that has to come down.",
+   "consequence": "closing the last ~4 s is a constant-factor campaign across the rule pool, p6 merge, p5 infertypes, p3 heritage and p9 emit -- five fronts at 24/18/14/12/10 % with no hot spot -- not another focused fix."
+  }
  },
  "left_on_the_table": [
   {
-   "item": "kuna decompile follows flow TWICE",
-   "evidence": "gdb breakpoint counts: follow_flow_on_fd is hit 2x and stage_jump_table 4x in the decomp_dbg console path, versus 1x / 2x for the in-process decompile-all path. `load function` costs 2.85 s of the console run on this function (0.88 s load+read symbols, 3.73 s with load function).",
-   "cause": "C++ IfcFuncload follows flow and IfcDecompile then calls clearAnalysis(fd) and runs the actions on that Funcdata. kuna's IfcDecompile rebuilds the Funcdata from scratch instead (there is no per-Funcdata clearAnalysis surface yet), so the flow follow and the whole jump-table sub-decompilation are paid twice.",
-   "why_not_done": "Worth ~18% of the probe. It is not a local fix: the rebuild exists because the seeds (mapped symbols, DWARF locals, parsed prototypes, param maps, proto overrides, flow overrides) must be applied AT FLOW TIME, and IfcFuncload applies only some of them. Reusing the loaded Funcdata is only sound when every seed is empty, which is a behavioural fork in the shared decompile step both the console and decompile-all use. That is console-tier infrastructure, i.e. the proposal fork."
+   "item": "the jump-table partial is rebuilt per table",
+   "worth": "~2.0 s of the post-PR 14 s run (1 of the 2 remaining stagings)",
+   "status": "BLOCKED, not undone. Upstream builds ONE partial per `recoverJumpTables` (flow.cc:1437) and guards the clone behind `if (!partial.isJumptableRecoveryOn())`. Attempt 1 implemented and REVERTED it: kuna's `option unrolledguard` recovers MSVC interleaved tables precisely BECAUSE each table's clone re-clones the siblings recovered before it, and sharing took tests/stages/ghangr-optimized-memcpy-6301a9.xml from 2/2 to 0/2. It changes which tables recover, so it needs its own option -- and this round's phases.toml / docs/options.md / catalog-counter leases are held by a sibling builder."
   },
   {
-   "item": "the jump-table partial clone is rebuilt per table",
-   "evidence": "Upstream (verified against the pinned tree: flow.cc:1437 constructs `Funcdata partial` once before the tablelist loop, funcdata_block.cc:513 guards the clone + reduced pipeline behind `if (!partial.isJumptableRecoveryOn())`). Sharing it measured 18.0 s -> 14.3 s on the probe.",
-   "why_not_done": "IMPLEMENTED AND REVERTED. It breaks `option unrolledguard`: tests/stages/ghangr-optimized-memcpy-6301a9.xml went 2/2 -> 0/2, losing 16 of the 17 interleaved MSVC switches, because that kuna extension recovers them precisely BECAUSE each table's clone re-clones the siblings recovered before it (the mechanism is spelled out in flow.rs collect_edges). unrolledguard is on in aggressive mode, which is what `kuna decompile` selects for this binary, so the speedup and the feature are mutually exclusive here. It changes which tables recover, so it needs its own option -- and this round's phases.toml / catalog / docs-options.md leases are held by a sibling builder. Left as a documented divergence in the code and in docs/spec/02-lift-and-flow.md."
+   "item": "`Funcdata::early_jump_table_fail` collects the whole dead list",
+   "worth": "small (a 68,370-element Vec per BRANCHIND considered, a handful of times)",
+   "status": "NOT DONE. `let order: Vec<OpId> = self.obank().iter_dead().collect(); order.iter().position(|&o| o == op)` -- the same shape attempt 1 removed from `dead_next`/`dead_tail`/`op_target`, missed there because it is in funcdata_block.rs rather than op.rs/flow.rs. Now that the O(1) cursor exists (`PcodeBank::dead_prev`), this is a two-line change; it is left out only because it is not on the path to the bar and this PR is deliberately one seam."
   },
   {
    "item": "the rule pool's optree cursor is still O(log n) per op",
-   "evidence": "advance_op_state 5.5% self + SeqNum::cmp 5.8% self after the memo (which removed the second of the two searches).",
-   "why_not_done": "Making it O(1) needs a seqnum-ordered intrusive list alongside the optree, i.e. new infrastructure in the op bank. BTreeMap::lower_bound (one descent instead of range()'s leaf-range construction) is still unstable on the pinned 1.90 toolchain."
+   "worth": "~9% of the pipeline (`advance_op_state` 9.2% inclusive, `SeqNum::cmp` 4.4% self)",
+   "status": "NOT DONE, unchanged from attempt 1. Making it O(1) needs a seqnum-ordered intrusive list alongside the optree; `BTreeMap::lower_bound` is still unstable on the pinned toolchain."
+  },
+  {
+   "item": "`Funcdata::bb_ops` allocates a Vec per call",
+   "worth": "~10% of the pipeline (4.6% self + the `Vec::from_iter` it feeds at 5.2%)",
+   "status": "NOT DONE. Every caller that only iterates could walk the intrusive block link instead; output-identical but it touches many call sites."
   }
  ],
- "regression_sweep": {
-  "method": "whole-binary `kuna decompile-all --json --max-fn-seconds 0` with an interleaved before/after release build pair of this worktree (files copied aside per docs/agents.md, never stashed), byte-compared",
-  "binaries": [
-   "the probe crackme (PE x86-64, 322 functions emitted)",
-   "/bin/gzip (ELF x86-64, 145 functions)",
-   "/usr/bin/xxd (ELF x86-64, 42 functions)"
-  ],
-  "result": "all three captures BYTE-IDENTICAL (5,653,602 + 1,196,332 + 135,319 bytes). The 120,052-byte witness function output is byte-identical too."
- },
+ "regression_sweep": {},
  "tests": {
   "cargo": [
-   "substrate::op::tests::dead_cursor_matches_a_full_scan -- the O(1) cursor agrees with a full iter_dead() scan at every position, and reports an alive op, a destroyed op, and a single-element list exactly as the scan did",
-   "substrate::op::tests::first_after_seq_id_agrees_with_first_after_seq"
+   "kuna-console/tests/verify_flowreuse.rs::adopting_the_loaded_flow_renders_the_same_c_as_rebuilding_it -- the plain pair adopts (adopted_flows == 1) and renders byte-identical C to the same pair with an inert `echo` in between (which does not adopt)",
+   "kuna-console/tests/verify_flowreuse.rs::load_addr_also_adopts -- `load addr` stamps its follow too, and the two entry surfaces render the same C",
+   "kuna-console/tests/verify_flowreuse.rs::a_second_decompile_does_not_adopt -- the stamp is single-use",
+   "kuna-console/tests/verify_flowreuse.rs::dwarf_locals_are_a_flow_time_seed_that_forces_the_rebuild -- isolates the SEED guard from the counter guard (nothing runs in between)",
+   "kuna-console/tests/verify_flowreuse.rs::formatstring_forces_the_rebuild -- isolates the ARCH-CONFIG guard, and asserts the format string still resolves"
   ],
   "stage_test": null,
-  "stage_test_rationale": "tests/stages/README.md scopes that corpus to stage-model issues; a pure timing fix with byte-identical output has no assertion to make there, and adding one would re-record the stages baseline and bump the hard-coded corpus count for nothing.",
+  "stage_test_rationale": "tests/stages/README.md scopes that corpus to stage-model issues; a console-tier change with byte-identical output has no assertion to make there, and adding one would re-record the stages baseline and bump the hard-coded corpus count for nothing.",
   "cli_probe": null
  },
- "gates": {
-  "make test": "675/675 PARITY OK (docs/baseline.json NOT re-pinned)",
-  "make test-stages": "597/597 PARITY OK (docs/baseline-stages.json NOT re-recorded)",
-  "make rust-test": "green (342 `test result: ok`). NOTE: the harness exports KUNA_DECOMP_TEST pointing at kuna's OWN decomp_test_dbg, which makes verify_w10_proto_unlock's `cpp_oracle_bin()` compare kuna against kuna and fail on the C++ oracle's `xunknown4` vs kuna's DIV-6 `unsigned int`. Run with `env -u KUNA_DECOMP_TEST`.",
-  "make check-spec": "check-spec OK (lenient mode)",
-  "kuna catalog --check": "catalog OK (no option added; phases.toml, options.rs, the catalog counters and docs/options.md are untouched)"
- },
- "profiling_method": "gdb-as-parent sampling (perf_event_paranoid=4 and yama ptrace_scope=1 block perf and gdb attach on this box): run the target under `gdb -batch` with a chained `run`/`bt`/`continue` command list and `handle SIGUSR1 stop print nopass`, then SIGUSR1 the inferior on a fixed interval from a driver script. 456 samples before the fix, 293 after. Invocation counts came from `rbreak` + a large `ignore` count and `info breakpoints`.",
- "scope": "small",
+ "gates": {},
  "decisions": [
-  "REFUTED the filed diagnosis. Symptom stands (68 s filed, 71.5 s median reproduced); cause is not 'an analysis pass scaling poorly on opaque arithmetic and indirect calls' but an O(N^2) position re-derivation in the LIFTER's dead-op list, present in every function and only visible once the op count is large. 53% of wall time sampled in one leaf frame, FlowInfo::xref_control_flow.",
-  "NO OPTION. Output is byte-identical (509 functions across three binaries, plus 1272 corpus assertions), so AGENTS.md's 'anything that CAN change emitted C ships behind a named option' does not bite. No catalog/DIV/phases.toml touch -- which also keeps this clear of the counter leases a sibling builder holds this round.",
-  "REVERTED the jump-table shared-partial fix after implementing and measuring it (-20%): it is upstream-faithful but kuna's `unrolledguard` extension is built on the per-table rebuild, and it took the interleaved-memcpy stage test from 2/2 to 0/2. Recorded as a deliberate divergence in the code and the spec rather than shipped ungated.",
-  "ACCEPTANCE NOT MET (<10 s asked, 19.4 s delivered). Shipping the verified -73% anyway rather than sitting on it: the probe arm no longer holds, the remaining gap is a flat profile needing a multi-front campaign, and the two biggest remaining leads are recorded with evidence so the next worker does not re-derive them."
+  "REFUTED the filed diagnosis for the second time, and on a different axis than attempt 1: the dominant cost is not an analysis pass and not a quadratic, it is the SAME flow follow run twice, with the jump-table sub-decompilation inside it (8.5 s of 18.8 s, 4 stagings of 2 tables).",
+  "OVERTURNED the need's own premise: `sub_140023350` is NOT 3396 bytes. `kuna functions` derives size from the gap to the next entry; the PE .pdata says 43,152. The flow follow is correct and there is no overrun -- which is why bounding it (`--define-function`) finishes in 1.35 s but ERRORS on a real switch target past the fake boundary. Anyone reading this need's title should know the number in it is a kuna reporting artifact, and the neighbouring `pe-function-inventory-labels` need is the place that belongs.",
+  "NO OPTION. Output is byte-identical (187 console decompiles over 3 binaries plus 1272 corpus assertions), so AGENTS.md's `anything that CAN change emitted C ships behind a named option` does not bite -- and it keeps this clear of the phases.toml / docs/options.md / catalog-counter leases a sibling builder holds this round.",
+  "SHIPPED ONE SEAM, not three. The other identified wins (`early_jump_table_fail`'s list collect, the rule-pool cursor, `bb_ops`) are recorded rather than bundled: none of them reaches the bar either, and a perf PR whose output must be proven byte-identical is worth keeping to one reviewable mechanism.",
+  "ACCEPTANCE NOT MET, and now with a measured impossibility proof rather than a shrug: the action pipeline plus emit alone is ~8.8 s and the load is 0.75 s, so deleting ALL remaining jump-table work still lands at ~10.6 s against a 10.0 s bar. The residue is the IR's superlinear growth with function size (ops ~ size^2.4 via INDIRECT, time ~ ops^1.5-2), measured on /bin/bash across four function sizes. This need cannot be closed by a focused fix; the next step is a campaign proposal, and this record is its map."
  ]
 }

--- a/docs/re-needs/decompiling-3396-byte-main.md
+++ b/docs/re-needs/decompiling-3396-byte-main.md
@@ -121,6 +121,31 @@ remaining 48% is a campaign, not a fix. The two ranked leads —
 (~20%, implemented then reverted because `option unrolledguard` depends on it) — are
 recorded with evidence in `docs/features/decompiling-3396-byte-main/record.json`.
 
+**Attempt 2 (round 2 wave 8, branch `feat/re-decompiling-3396-w8`).** The symptom
+still stands and the acceptance is still unmet: **14,437 ms** against the
+`< 10,000 ms` bar. What attempt 2 removed is the *second* flow follow — `kuna
+decompile` drives the console with `load function` then `decompile`, and each of
+those followed the same function's flow from scratch, jump-table
+sub-decompilation included. Interleaved 7-pair A/B: **19,703 ms -> 15,317 ms
+median, -22.3%** (min -24.7%, paired mean -20.6% +/- 7.8, ~7 sigma), output
+byte-identical over 218 whole-surface decompiles across 20 binaries (203 of which
+took the new fast path).
+
+Two things attempt 3 should inherit rather than rediscover:
+
+- **The residue is confirmed flat, on a fresh profile.** `stage_jump_table` 29.2%
+  (the only block over 20%, and semantically load-bearing — `unrolledguard`
+  depends on each table's clone re-cloning its siblings), p6 merge 18.2%, rule
+  pool 10.4%, heritage 10.1%, symbol-container lookups ~11%, infertypes 6.0%,
+  dead code 5.8%. One attempt-1 lead does NOT survive re-measurement: `bb_ops` is
+  ~2.2% self spread over five callers, not ~10%.
+- **Measuring this need is harder than fixing it.** `kuna decompile` (without
+  `--json`) forks `decomp_dbg` and pipes both its streams, so a stderr marker is
+  invisible and gdb does not follow the child — profile the in-process `--json`
+  path and instrument to a file. And this box runs sibling builders at load
+  average 8-24, where the same binary measures 14.6 s and 18.9 s hours apart; only
+  an interleaved paired A/B means anything.
+
 ## Reference
 
 _none recorded_

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -1008,7 +1008,9 @@ built. Two consequences:
   reuses the same `Funcdata`, `decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
   (refollow_flow)`). Options must therefore be in effect before the function is
   built — which the console guarantees by rebuilding a fresh `Funcdata` on every
-  `decompile` command.
+  `decompile` command, *except* when `decompile` adopts the IR `load function`
+  already followed (§0.8), and that adoption is refused the moment any command at
+  all — an `option` among them — has run since the load.
 
 ## 0.6 The schedule
 
@@ -1106,7 +1108,7 @@ study summarized in `docs/history.md`; every row below is re-verified against th
 | (angr) P2 → P2, lowered switch | detect-then-restart, two halves | a comparison cascade recognized as a compiler-lowered switch after simplification | the recovered cascade record, in a store shared by both halves | detect in fullloop writes + requests restart, install in mainloop (before heritage) reads on the restarted run — `decompiler/crates/kuna-decomp/src/p2_lift/kuna_loweredswitch.rs (ActionLowerSwitchDetect, ActionLowerSwitchInstall)` |
 | P5 → P2, determined branch | in-loop re-entry | constant folding decides a conditional branch, removing a CFG edge | the simplified ops themselves | `decompiler/crates/kuna-decomp/src/p3_dataflow/coreaction_early.rs (ActionDeterminedBranch)`, inside mainloop |
 | (kuna/angr) P7/P8 structuring fallback | degraded re-run | the region structurer cannot collapse the graph to a single root | nothing; `sblocks` is re-seeded clean | `decompiler/crates/kuna-decomp/src/p8_structure/blockaction.rs (ActionBlockStructure)` falls back to `CollapseStructure` after `decompiler/crates/kuna-decomp/src/p8_structure/region_structurer.rs (run_region_structurer)` declines |
-| P0 → everything, the outer loop | knowledge-store re-run | an operator/agent writes an assertion (`option`, `kassert`, override) and re-decompiles | the entire P0 store | `decompiler/crates/kuna-decomp/src/p0_knowledge/kuna_assert.rs (Dispatch)`; the console rebuilds the IR per `decompile`, re-seeding stashed facts — `decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs (decompile_func_full_with_override_dyn)` |
+| P0 → everything, the outer loop | knowledge-store re-run | an operator/agent writes an assertion (`option`, `kassert`, override) and re-decompiles | the entire P0 store | `decompiler/crates/kuna-decomp/src/p0_knowledge/kuna_assert.rs (Dispatch)`; the console rebuilds the IR per `decompile`, re-seeding stashed facts — `decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs (decompile_func_full_with_override_dyn)` (§0.8 is when the rebuild is skipped) |
 
 **Not implemented in kuna** (theory-only, kept for the record): the upstream
 jump-table *size-mismatch* restart — `matchModel` finding the recovered model's
@@ -1127,7 +1129,67 @@ engine-owned restart log
 (`decompiler/crates/kuna-decomp/src/p0_knowledge/kuna_restartlog.rs (RestartLog)`),
 because a function that silently decompiles twice is otherwise invisible.
 
-## 0.8 Reading order
+## 0.8 One flow follow per decompile
+
+The console has two commands that build IR for a function, and a `kuna decompile
+<bin> <fn>` runs both: `load function <fn>` (or `load addr`), then `decompile`.
+Upstream follows the flow once — C++ `IfcFuncload` follows it, and `IfcDecompile`
+re-runs the action pipeline on *that* `Funcdata` after
+`Architecture::clearAnalysis`. kuna's `decompile` instead builds a fresh
+`Funcdata` and follows the flow again, because the facts a decompile is seeded
+with are consumed AT FLOW TIME and `load function` applies none of them:
+
+- `map address` symbols and the function's DWARF stack locals, seeded into the
+  rebuilt `ScopeLocal`;
+- `type varnode %REG(pc)` usepoint-scoped symbols, and `map hash` dynamic symbols;
+- a `parse line extern` prototype, and every other parsed prototype re-parked on
+  its global `FunctionSymbol` so a call site can copy it;
+- `map param` storage locks, and `override prototype` call-site overrides, which
+  `FlowInfo::build_call_specs` consumes as it builds the call specs.
+
+So the rebuild is *required* exactly when one of those facts exists, and pure
+waste when none does — which is every plain `kuna decompile`. The waste is not
+small: the second follow repeats the whole lift, the block build, and the
+jump-table sub-decompilation (§0.7), which on a large switch-heavy function is the
+single most expensive thing the run does.
+
+`decompile` therefore **adopts** the loaded IR when it can prove the rebuild would
+repeat the same follow
+(`decompiler/crates/kuna-console/src/ifacedecomp.rs (PristineFlow)`, consumed
+through `decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
+(decompile_func_full_with_override_dyn_prefollowed)`). Two independent guards must
+both hold:
+
+- **Every flow-time seed above is empty.** Any one of them present means the
+  loaded IR was followed without it, so adopting would silently drop it.
+- **The architecture is configured as it was at the load.** A `Funcdata`
+  snapshots the per-function flags into its ArchSeam handle when it is *built*
+  (§0.5), so a flag flipped afterwards is invisible to it. Three things move
+  between the load and the drive and therefore refuse adoption: `formatstring`,
+  which turns read-only propagation on around the drive so the printf format
+  constant can be read (adopting there leaves `printf((char *)(dat_… + …), …)`,
+  the format string unresolved); the watchdog's per-function budget, armed inside
+  the drive; and ghidra mode's staged name/dynamic/prototype-model
+  recommendations.
+- **The `decompile` is the immediately next command.** `load function` records the
+  console's command counter
+  (`decompiler/crates/kuna-console/src/interface.rs (IfaceStatus::command_seq)`)
+  and `decompile` requires it to have advanced by exactly one, along with the same
+  name, entry, declared extent and flow overrides. The counter is the whole
+  invalidation story on purpose: an `option` that changes a flow-time decision, a
+  `kassert`, a `map`, a second `load` — anything at all — advances it, so no
+  command needs its own invalidation hook and none can be forgotten.
+
+Adoption is a pure-performance seam: the adopted `Funcdata` is the one the rebuild
+would have produced, so the emitted C is byte-identical either way, and
+`decompiler/crates/kuna-console/tests/verify_flowreuse.rs` asserts exactly that
+(plus that the fast path is really taken, via `IfaceDecompData::adopted_flows`).
+The one place the two paths differ is the failure arm: a drive that aborts
+consumes the adopted IR, where the rebuild path left the loaded `Funcdata`
+untouched for a following `print C`, so the error arm re-follows the recorded
+name/entry/size/overrides to put it back.
+
+## 0.9 Reading order
 
 The folder taxonomy is the *artifact* order, not the execution order. Source
 under `decompiler/crates/kuna-decomp/src` is arranged as `substrate` (the IR

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -1136,19 +1136,25 @@ The console has two commands that build IR for a function, and a `kuna decompile
 Upstream follows the flow once — C++ `IfcFuncload` follows it, and `IfcDecompile`
 re-runs the action pipeline on *that* `Funcdata` after
 `Architecture::clearAnalysis`. kuna's `decompile` instead builds a fresh
-`Funcdata` and follows the flow again, because the facts a decompile is seeded
-with are consumed AT FLOW TIME and `load function` applies none of them:
+`Funcdata` and follows the flow again, because a decompile is seeded with facts
+that `load function` never applied — and some of them are consumed AT FLOW TIME,
+so re-seeding them onto an already-followed IR would be too late:
 
-- `map address` symbols and the function's DWARF stack locals, seeded into the
-  rebuilt `ScopeLocal`;
-- `type varnode %REG(pc)` usepoint-scoped symbols, and `map hash` dynamic symbols;
-- a `parse line extern` prototype, and every other parsed prototype re-parked on
-  its global `FunctionSymbol` so a call site can copy it;
-- `map param` storage locks, and `override prototype` call-site overrides, which
-  `FlowInfo::build_call_specs` consumes as it builds the call specs.
+- `override prototype` call-site overrides, which `FlowInfo::build_call_specs`
+  consumes as it builds the call specs, and every `parse line` prototype re-parked
+  on its global `FunctionSymbol` before the drive (a callee prototype the follow
+  resolves against). These two are the genuinely flow-time seeds.
+- `override flow` facts, likewise consumed at flow time — but `load function`
+  seeds these too, from the same store, so the two follows agree on them.
+- `map address` symbols and DWARF stack locals, `type varnode %REG(pc)` usepoint
+  symbols, `map hash` dynamic symbols, a `parse line extern` prototype for the
+  function itself, and `map param` storage locks. The drive re-seeds all of these
+  onto the `Funcdata` *after* the follow, so they do not require a re-follow —
+  they are nonetheless required absent below, because "no facts at all" is the
+  condition that is cheap to prove and impossible to get subtly wrong.
 
-So the rebuild is *required* exactly when one of those facts exists, and pure
-waste when none does — which is every plain `kuna decompile`. The waste is not
+So the rebuild is *required* when a flow-time fact exists, and pure waste when no
+fact exists at all — which is every plain `kuna decompile`. The waste is not
 small: the second follow repeats the whole lift, the block build, and the
 jump-table sub-decompilation (§0.7), which on a large switch-heavy function is the
 single most expensive thing the run does.
@@ -1160,8 +1166,11 @@ through `decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
 (decompile_func_full_with_override_dyn_prefollowed)`). Two independent guards must
 both hold:
 
-- **Every flow-time seed above is empty.** Any one of them present means the
-  loaded IR was followed without it, so adopting would silently drop it.
+- **Every seed above is empty**, flow-time or re-seeded alike. A flow-time seed
+  present means the loaded IR was followed without it, so adopting would silently
+  drop it; the re-seeded ones are held to the same bar deliberately, so the guard
+  is one question ("did the console learn anything about this function?") rather
+  than a per-seed judgement that a later seed could be forgotten from.
 - **The architecture is configured as it was at the load.** A `Funcdata`
   snapshots the per-function flags into its ArchSeam handle when it is *built*
   (§0.5), so a flag flipped afterwards is invisible to it. Three things move


### PR DESCRIPTION
## What was broken

RE-need `decompiling-3396-byte-main` (round 2, `perf`, 1 instance, challenge
`69a3822f7b3cc38c80464da4`). A tester reverse-engineering a PE crackme reported:

> **Decompiling the 3396-byte main function takes about 68 seconds.** The command
> produced no output for roughly 68 seconds, then emitted about 30 KB of highly
> noisy pseudocode. […] this observation is specifically about latency.

Attempt 1 (#380, merged) removed an O(N²) dead-list position scan in the lifter
and took the witness from 71.46 s to 19.42 s. The acceptance bar is a **median
under 10 s**, so the need stayed open.

## What this PR changes

`kuna decompile <bin> <fn>` drives the console with `load function <fn>` and then
`decompile`, and **each of those followed the same function's flow from scratch** —
the whole lift, the block build, and the per-jump-table sub-decompilation, twice.

Upstream never pays that: C++ `IfcFuncload` follows the flow once and
`IfcDecompile` re-runs the action pipeline on *that* `Funcdata` after
`Architecture::clearAnalysis` (`ifacedecomp.cc:889`). kuna rebuilds instead
because a decompile is seeded with facts `load function` never applied, and two of
them are consumed **at flow time**: `override prototype` call-site overrides
(`FlowInfo::build_call_specs`) and the parsed callee prototypes re-parked on their
global `FunctionSymbol` before the drive. The other five — `map address` symbols
and DWARF stack locals, `type varnode` usepoint symbols, `map hash` dynamic
symbols, a `parse line extern` prototype, `map param` storage locks — the drive
re-seeds *after* the follow, so they would survive an adoption; they are held to
the same bar anyway (below). So the rebuild is *required* when a flow-time fact
exists, and pure waste when no fact exists at all — which is every plain `kuna
decompile`.

`decompile` now **adopts** the loaded IR when it can prove the rebuild would
repeat the same follow. Three independent guards must all hold
(`kuna-console/src/ifacedecomp.rs`, `PristineFlow`):

1. **Every seed is empty** — flow-time or re-seeded alike. Holding the re-seeded
   ones to the same bar makes the guard one question ("did the console learn
   anything about this function?") instead of a per-seed judgement a later seed
   could be forgotten from. It costs coverage only where kuna already has symbols:
   in the sweep below 203 of 218 functions adopt, and the 15 that do not are the
   DWARF-local and parsed-prototype cases.
2. **The architecture is configured as it was at the load** — a `Funcdata`
   snapshots the per-function flags into its ArchSeam handle when it is *built*,
   so a flag flipped afterwards is invisible to it. `formatstring`, the watchdog
   budget and ghidra-mode's staged recommendations all move between the load and
   the drive, and each refuses adoption.
3. **`decompile` is the immediately next command** — `load function` records
   `IfaceStatus::command_seq` and `decompile` requires it to have advanced by
   exactly one, with the same name, entry, declared extent and flow overrides.
   The counter is the whole invalidation story on purpose: an `option`, a
   `kassert`, a `map`, a second `load` — anything at all — advances it, so no
   command needs its own invalidation hook and none can be forgotten.

It is a pure-performance seam: the adopted `Funcdata` is the one the rebuild would
have produced, so the emitted C is byte-identical either way. No option, no
`phases.toml` row, no catalog counter, no DIV — nothing here can change emitted C.

Guard 2 is not hypothetical, and it was re-verified rather than assumed. A build
with `same_config` forced true renders, for `fmt_arm::main` under `--option
formatstring on`:

```c
printf((char *)(dat_52c + 0x51c),a0,*a1);   // guard 2 removed
printf("%d %s\n",a0,(char *)*a1);           // shipping
```

`formatstring` turns read-only propagation on *around* the drive so the
PC-relative literal-pool format constant can be read, and the adopted IR had
snapshotted the flag off. It is ARM-specific — the same A/B on `fmt_x86_64` and
`fmt_aarch64` is byte-identical — so a sweep without an ARM literal-pool case
would have missed it.

## Measurement

`kuna decompile <crackme> sub_140023350`, **interleaved** A/B — one loop
alternating the two arms per iteration, so both see the same machine load (three
sibling builders were running; load average 8–24 across the measurement). The two
arms are builds of this same worktree differing only in the adoption guard, chosen
per run via `KUNA_DECOMP_DBG`, so the driver, the generated script and the loaded
image are identical between them.

Measured twice — once before the rebase on a loaded box, once after it on a
quieter one, with both arms rebuilt from the rebased tree each time:

| | pairs | base median | this PR median | delta | paired mean ± sd |
|---|---|---|---|---|---|
| pre-rebase | 7 | 19,703 ms | 15,317 ms | **−22.26 %** | −20.58 % ± 7.80 |
| **on the rebased tree** | 5 | 18,601 ms | **14,348 ms** | **−22.86 %** | −22.89 % ± 1.92 |

The second is 26 σ, per-pair range −21.0 % to −25.0 %, and ≥20 % on median, min
and paired mean alike — past both bars the perf track sets. The interleaving is
not ceremony: the *same* binary measured 14.6 s and 18.9 s hours apart on this
box, so a single-arm before/after here would have been indistinguishable from the
machine.

The C emitted by the two arms on the witness is byte-identical (`cmp`).

Where it goes, from `Instant`-instrumented builds of the same tree:

| stage | before | after |
|---|---|---|
| `load file` + `read symbols` | 0.75 s | 0.75 s |
| flow follow #1 (`load function`) | 4.95 s | 4.95 s |
| flow follow #2 (`decompile`) | 4.33 s | **0 s** (adopted) |
| action pipeline + emit | ~8.8 s | ~8.8 s |

Both follows were dominated by the jump-table sub-decompilation: the function has
2 tables, each staging a 68,370-op partial clone (~0.25 s) plus a reduced
"jumptable" pipeline over it (~1.7 s), and that ran **4 times** (2 tables × 2
follows) for 8.5 s of the 18.8 s run. It now runs twice.

## The acceptance probe still does NOT pass, and the reason is now measured

Acceptance `a-53d616afcb6a` asks for a median under 10,000 ms. On the final build
`scripts.repipe.verify` measures **14,437 ms** (the interleaved A/B median on the
rebased tree is 14,348 ms), so the `wall_ms` clause fails while `exit_code` passes. **The need
stays open and the probe is deliberately not promoted** — promoting it would
commit a red test. This PR does not reach the bar, and no further redundancy
removal can:

- The **action pipeline plus emit alone is ~8.8 s**, and `load file` + `read
  symbols` is another 0.75 s. That is a ~9.6 s floor before a single jump table is
  touched. Even deleting *all* remaining jump-table work lands at ~10.6 s.
- The residue is not a bug, it is **scaling**. The witness is not a 3396-byte
  function: `kuna functions` derives sizes from the gap to the next entry, and the
  PE's own `.pdata` `RUNTIME_FUNCTION` says `0x140023350..0x14002dbe0` — **43,152
  bytes**, with `sub_140024094` and `sub_14002bb5c` being mid-function labels. The
  flow follow is correct; there is no overrun.
- Measured on `/bin/bash` (`--mode aggressive`, `decompile-all --addr`, load cost
  subtracted), pipeline time against function size:

  | size | alive ops | INDIRECT | MULTIEQUAL | varnodes | pipeline |
  |---|---|---|---|---|---|
  | 5,248 B | 3,233 | 1,004 | 1,047 | 4,715 | 1.6 s |
  | 9,184 B | 8,937 | 4,098 | 2,558 | 13,934 | 9.6 s |
  | 13,488 B | 30,697 | 17,142 | 9,714 | 49,382 | 30.7 s |

  The **IR itself** is superlinear in function size (ops ∝ size^~2.4, driven by
  INDIRECT: calls × heritaged locations, both O(size)), and pipeline time is
  ∝ ops^~1.5-2 on top of that. Closing the last 4 s is a constant-factor campaign
  across the rule pool, p6 merge, p5 infertypes, p3 heritage and p9 emit — a flat
  ~24/18/14/12/10 % split with no single hot spot — not another focused fix.

The full residue map, the profile that produced it, and the two remaining
structural leads (the per-table partial rebuild, blocked because kuna's
`unrolledguard` extension depends on it; and the O(log n) rule-pool cursor) are in
`docs/features/decompiling-3396-byte-main/record.json`.

## Tests

`decompiler/crates/kuna-console/tests/verify_flowreuse.rs` — 5 cases:

- the plain `load function` → `decompile` pair adopts (`adopted_flows == 1`) and
  renders **byte-identical** C to the same pair with an inert `echo` in between
  (which does not adopt);
- `load addr` stamps its follow the same way;
- a second `decompile` does not adopt (the stamp is single-use);
- DWARF stack locals — a flow-time seed present with *nothing* running in
  between — force the rebuild, isolating the seed guard from the counter guard;
- `formatstring` forces the rebuild, and the format string still resolves.

## Gates

| gate | result |
|---|---|
| `make test` | **PARITY OK** — 675/675, `docs/baseline.json` untouched |
| `make test-stages` | **PARITY OK** — 603/603, `docs/baseline-stages.json` untouched |
| `make rust-test` | **green** — 345 test binaries, 5,335 tests, 0 failed \* |
| `make test-cli` | tests/cli: **18/18 passed** |
| `make check-spec` | check-spec OK |
| `kuna catalog --check` | catalog OK (no option added) |
| `repipe.mergecheck` | merge guards clean — 0 rejects vs `origin/main` |

\* The first `make rust-test` reported one failure —
`verify_w10_proto_unlock::…_no_tied_roundtrip`, *"oracle promote_compare
signature drifted"*. It is not this change. That assertion is guarded by
`cpp_oracle_bin()`, which falls back to the removed `decompiler/cpp/decomp_test_dbg`
and is normally skipped — but the repipe worker environment exports
`KUNA_DECOMP_TEST` pointing at the worktree's own *modern* `decomp_test_dbg`, so
the "C++ oracle" arm activates and asserts the pre-DIV-6 `xunknown4` rendering
against a realtypes build. `env -u KUNA_DECOMP_TEST` → 4/4 pass; the row above is
a full re-run with it unset.

## Whole-surface regression sweep

`kuna decompile <bin> <fn>` run under both arms and byte-compared (stdout and exit
code) over **218 functions in 20 binaries** — x86-64, i386, aarch64, ARM, ARM
Thumb, Cortex-M, RISC-V 64; ELF exe/PIE/`.so` and PE32+ — with DWARF, stripped and
C++-mangled cases among them.

**218 compared, 0 diffs**, plus 119 more re-swept on the rebased tree — also 0. And, measured separately with a third instrumented
build, **203 of the 218 actually took the adopt path**; the other 15 are the seed
guard firing as designed (DWARF stack locals, parsed prototypes, the PE CRT) and
are byte-identical through the fallback arm.

That second number is the one worth stating, because the obvious way to get it is
wrong: `kuna` pipes the child `decomp_dbg`'s stdout *and* stderr and only surfaces
them on failure, so an `eprintln!` marker is swallowed and a naive count reads
**0 adoptions on a run that adopted 203 times**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
