### PR TITLE
[AUTOMATED] docs(re-pipeline): an empty already-supported bucket is not a broken gate

### DIFF
--- a/docs/re-pipeline.md
+++ b/docs/re-pipeline.md
@@ -135,7 +135,7 @@ python3 -m scripts.repipe.verify --gate --round 1 --json
 |---|---|
 | `admitted` | real, reproducible, not already possible |
 | `not-reproducible` | the probe does not fire — noise, or environment |
-| `already-supported` | the acceptance already passes: **the tester was wrong.** Kept as a ledger — if this bucket is ever empty, the gate is broken |
+| `already-supported` | the acceptance already passes: **the tester was wrong.** Kept as a ledger — but see the caveat below before reading an empty bucket as a broken gate |
 | `flaky` | the repeats disagreed. A flaky probe is not evidence |
 | `unrunnable` | malformed, or the target's sha256 does not match — a probe pointed at the wrong file **refuses** rather than returning a confident false verdict |
 
@@ -517,6 +517,39 @@ guard) and it caught this one. **Do not soften it to "absent means not required"
 diagnostic to reach for first is `gh pr view <n> --json mergeable,mergeStateStatus`:
 `CONFLICTING`/`DIRTY` explains an absent suite far more often than anything about the
 workflow file does.
+
+## An empty `already-supported` bucket does not mean the gate is broken
+
+Round 1's success criteria say "≥2 rejected as `already-supported`/`user-error` — if this
+is zero, the gate is not working". Round 2 reported **zero** and the gate was fine. The
+criterion has been quietly obsoleted, by a change made here after round 1.
+
+A gate result carrying `reasons: ['probe-fail', 'acceptance-pass']` looks like
+already-supported — the bad behaviour is gone *and* the desired behaviour works. It usually
+is not. Round 2's one such record:
+
+```
+probe.expect      {"stdout_matches": ["sub_418fb0\\(\\)"]}
+acceptance.expect {"stdout_absent":  ["sub_418fb0\\(\\)"]}
+```
+
+Those are **exact polarity inverses on the same regex**. `probe-fail` and `acceptance-pass`
+are one fact — `sub_418fb0()` is absent — reported twice. Relabelling it `already-supported`
+would assert kuna does the desired thing, when all that was observed is the symptom's
+absence. `not-reproducible` is the correct, weaker claim, and the gate's existing precedence
+(probe first) already produces it.
+
+The obsolescence is self-inflicted and worth naming: the tester brief now says *assert the
+symptom's absence, not the fix's spelling*, which was the right fix for round 1's
+over-specified acceptances — and it **manufactures negation-shaped arm pairs**. 11 of round
+2's 22 observations have that shape. The better the acceptances get by that rule, the closer
+the `already-supported` bucket goes to zero, because a negation pair can never populate it.
+
+So: judge the gate by whether it refutes anything at all — `not-reproducible` plus
+`already-supported` together — and read a zero in either bucket alone as uninformative. A
+proposal to flip the precedence for these pairs was written and **rejected** in review for
+exactly this reason; do not re-litigate it without first checking whether the two arms are
+independent or complementary.
 
 ## Machinery reference
 


### PR DESCRIPTION
Round 1's criterion says a zero here means the gate is not working. Round 2 reported
zero and the gate was fine, because the criterion was obsoleted by a change made
after round 1 -- by me, in the tester brief.

A result with reasons ['probe-fail','acceptance-pass'] looks like already-supported.
Round 2's one such record has probe `stdout_matches ["sub_418fb0\\(\\)"]` against
acceptance `stdout_absent ["sub_418fb0\\(\\)"]` -- exact polarity inverses on the
same regex, so the two reasons are ONE fact reported twice. Calling that
already-supported would assert kuna does the desired thing when only the symptom's
absence was observed; not-reproducible is the correct weaker claim and the existing
precedence already yields it.

The cause is self-inflicted: the brief now says assert the symptom's ABSENCE rather
than the fix's spelling, which was right for round 1's over-specified acceptances and
which manufactures negation-shaped pairs -- 11 of round 2's 22 observations have that
shape. The better acceptances get by that rule, the closer this bucket goes to zero.

I had recorded the opposite conclusion earlier in this round and proposed flipping the
precedence; that proposal was rejected in review and the reasoning is written down here
so it is not re-litigated.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcFmfZndNjgfqLQVBZCdkY