### PR TITLE
[AUTOMATED] feat(cli): no-cli-rename-or-prototype-override — --assert, one override plane an agent states facts through

### DIFF
--- a/decompiler/crates/kuna-cli/src/assertdecl.rs
+++ b/decompiler/crates/kuna-cli/src/assertdecl.rs
@@ -1,0 +1,474 @@
+//! `--assert` — the text syntax of the override plane.
+//!
+//! # Why this exists
+//!
+//! `rename`, `retype`, `map param`, `map return`, `map address`,
+//! `comment instruction` and `parse line extern` are all functional in the
+//! console, and until this flag not one of them was reachable from the `kuna`
+//! binary: the generated console script emitted only `option`, `kassert`,
+//! `function bounds` and `decompile`.  For an agent that is the difference
+//! between reading a decompilation once and actually working through one — a
+//! rename it cannot state is a rename it does not have
+//! (`docs/re-needs/no-cli-rename-or-prototype-override.md`).
+//!
+//! # The flag
+//!
+//! ```text
+//!   --assert 'prototype authenticate int authenticate(char *user,char *pass)'
+//!   --assert 'type v2 char[16]'
+//!   --assert 'name v2 credbuf'
+//!   --assert @notes/overrides.kuna
+//! ```
+//!
+//! Repeatable, and `@FILE` holds one directive per line with `#` comments — the
+//! `--define-function` file contract verbatim, because that is what makes an
+//! override durable across invocations.  kuna does not write assertions back
+//! into the image: the file is the artifact, and it is plain text an agent can
+//! generate, diff and version.
+//!
+//! This module owns the SYNTAX only.  The vocabulary, where each directive lands
+//! in the pipeline and what "applied" means for it live in
+//! [`kuna_console::assertions`], which both the in-process surfaces and the
+//! generated console script go through.
+//!
+//! # Console lowering
+//!
+//! `kuna decompile`'s text surface drives `decomp_dbg`, so each directive also
+//! has to be expressible as console lines ([`ConsoleForm`]).  The two surfaces
+//! emit the same facts in the same order; they differ only in whether the engine
+//! is reached in-process or through a script.
+
+use kuna_console::assertions::{Body, Directive};
+
+/// Where a directive's console line goes in the generated script.
+///
+/// The slots are forced, not stylistic: an `option` must precede `read symbols`
+/// (the analysis commit), a `map param` needs a loaded function, and a `rename`
+/// of a local needs a function that has already been decompiled — before that
+/// the console answers `No symbol named: v2`, which is exactly the bug that makes
+/// today's `--kassert p9 naming-policy` a silent no-op.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Slot {
+    /// After `read symbols`, before `load function`.
+    Program,
+    /// After `load function`, before the first `decompile`.
+    Function,
+    /// After the first `decompile` (forcing a second one).
+    Symbol,
+}
+
+/// One directive rendered for the console script.
+pub(crate) struct ConsoleForm {
+    pub(crate) slot: Slot,
+    pub(crate) line: String,
+}
+
+/// Parse one `--assert` value: either a directive or `@FILE`.
+pub(crate) fn parse_flag(value: &str) -> Result<Vec<Directive>, String> {
+    let Some(path) = value.strip_prefix('@') else {
+        return Ok(vec![parse_one(value)?]);
+    };
+    let text = std::fs::read_to_string(path).map_err(|e| format!("--assert @{path}: {e}"))?;
+    let mut out = Vec::new();
+    for (n, line) in text.lines().enumerate() {
+        let line = strip_comment(line);
+        if line.is_empty() {
+            continue;
+        }
+        out.push(parse_one(line).map_err(|e| format!("{path}:{}: {e}", n + 1))?);
+    }
+    Ok(out)
+}
+
+/// A `#` starts a comment, so an agent can annotate what it worked out.  Only at
+/// the start of a token: a `#` inside a `comment` directive's text is text.
+fn strip_comment(line: &str) -> &str {
+    match line.find(" #") {
+        Some(at) => line[..at].trim(),
+        None => line.trim().strip_prefix('#').map(|_| "").unwrap_or(line.trim()),
+    }
+}
+
+/// Split `<func>::<operand>` into its two halves.  Unqualified means "the
+/// function under decompile"; a C++ name is split at its LAST `::`, so
+/// `ns::cls::fn::v2` qualifies `v2` with `ns::cls::fn`.
+fn split_qualifier(tok: &str) -> (Option<String>, String) {
+    match tok.rsplit_once("::") {
+        Some((func, operand)) if !func.is_empty() && !operand.is_empty() => {
+            (Some(func.to_string()), operand.to_string())
+        }
+        _ => (None, tok.to_string()),
+    }
+}
+
+/// Normalise a storage operand to the console's machine-address syntax.
+///
+/// Storage is spelled the way the console spells it — `%RDI`, `[register,0x38,8]`,
+/// `[stack,-0x18,8]`, `s0x10` — because that is the grammar the engine parses
+/// (`parse_machaddr`).  A bare register NAME is the one spelling an agent will
+/// reach for and the one the console rejects outright (`RDI` reads as the space
+/// shortcut `R`, "Bad address: R"), so it is rewritten to `%RDI` here: a token
+/// that starts with a letter and carries no `0x` cannot be any of the other
+/// forms.
+fn normalize_storage(tok: &str) -> String {
+    let bare_name = tok.starts_with(|c: char| c.is_ascii_alphabetic())
+        && !tok.contains("0x")
+        && !tok.contains("0X")
+        && tok.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
+    if bare_name {
+        format!("%{tok}")
+    } else {
+        tok.to_string()
+    }
+}
+
+/// A bare or `0x`-prefixed hexadecimal VMA (the `--define-function` convention).
+fn parse_vma(tok: &str) -> Option<u64> {
+    let tok = tok.trim();
+    let body = tok.strip_prefix("0x").or_else(|| tok.strip_prefix("0X")).unwrap_or(tok);
+    if body.is_empty() || !body.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    u64::from_str_radix(body, 16).ok()
+}
+
+/// Split off the leading whitespace-delimited token, returning `(token, rest)`.
+fn take_token(s: &str) -> (&str, &str) {
+    let s = s.trim_start();
+    match s.find(char::is_whitespace) {
+        Some(at) => (&s[..at], s[at..].trim_start()),
+        None => (s, ""),
+    }
+}
+
+/// Parse one directive line.
+pub(crate) fn parse_one(spec: &str) -> Result<Directive, String> {
+    let raw = spec.trim().to_string();
+    let (keyword, rest) = take_token(&raw);
+    let bad = |what: &str| format!("--assert {raw:?}: {what}");
+    let body = match keyword {
+        "function" => {
+            let decls = crate::funcdecl::parse_flag(rest)
+                .map_err(|e| format!("--assert {raw:?}: {}", e.trim_start_matches("--define-function ")))?;
+            let decl = decls.into_iter().next().ok_or_else(|| bad("missing <start>"))?;
+            Body::Function { start: decl.start, end: decl.end, name: decl.name }
+        }
+        "typedef" => {
+            if rest.is_empty() {
+                return Err(bad("typedef needs a C declaration"));
+            }
+            Body::Typedef { decl: rest.to_string() }
+        }
+        "prototype" => {
+            let (func, decl) = take_token(rest);
+            if func.is_empty() || decl.is_empty() {
+                return Err(bad("prototype needs <func> then a C declaration"));
+            }
+            Body::Prototype { func: func.to_string(), decl: decl.to_string() }
+        }
+        "data" => {
+            let (addr, decl) = take_token(rest);
+            let addr = parse_vma(addr).ok_or_else(|| bad("data needs a hex <addr>"))?;
+            if decl.is_empty() {
+                return Err(bad("data needs a C type declaration naming the symbol"));
+            }
+            Body::Data { addr, decl: decl.to_string() }
+        }
+        "param" => {
+            let (index, rest) = take_token(rest);
+            let (func, index) = split_qualifier(index);
+            let index: i32 = index.parse().map_err(|_| bad("param needs a decimal index"))?;
+            let (storage, decl) = take_token(rest);
+            if storage.is_empty() || decl.is_empty() {
+                return Err(bad("param needs <i> <storage> then a C type declaration"));
+            }
+            Body::Param {
+                func,
+                index,
+                storage: normalize_storage(storage),
+                decl: decl.to_string(),
+            }
+        }
+        "return" => {
+            let (storage, decl) = take_token(rest);
+            let (func, storage) = split_qualifier(storage);
+            if storage.is_empty() || decl.is_empty() {
+                return Err(bad("return needs <storage> then a C type declaration"));
+            }
+            Body::Return { func, storage: normalize_storage(&storage), decl: decl.to_string() }
+        }
+        "comment" => {
+            let (addr, text) = take_token(rest);
+            let (func, addr) = split_qualifier(addr);
+            let addr = parse_vma(&addr).ok_or_else(|| bad("comment needs a hex <addr>"))?;
+            if text.is_empty() {
+                return Err(bad("comment needs text"));
+            }
+            Body::Comment { func, addr, text: text.to_string() }
+        }
+        "name" => {
+            let (symbol, newname) = take_token(rest);
+            let (func, symbol) = split_qualifier(symbol);
+            let (newname, tail) = take_token(newname);
+            if symbol.is_empty() || newname.is_empty() {
+                return Err(bad("name needs <symbol> <newname>"));
+            }
+            if !tail.is_empty() {
+                return Err(bad("name takes exactly <symbol> <newname>"));
+            }
+            Body::Name { func, symbol, newname: newname.to_string() }
+        }
+        "type" => {
+            let (symbol, decl) = take_token(rest);
+            let (func, symbol) = split_qualifier(symbol);
+            if symbol.is_empty() || decl.is_empty() {
+                return Err(bad("type needs <symbol> then a C type"));
+            }
+            Body::Type { func, symbol, decl: decl.to_string() }
+        }
+        "" => return Err("--assert: empty directive".into()),
+        other => {
+            return Err(format!(
+                "--assert {raw:?}: unknown directive {other:?} (want one of \
+                 function, typedef, prototype, data, param, return, comment, name, type)"
+            ))
+        }
+    };
+    Ok(Directive { raw, body })
+}
+
+/// The console line(s) a directive lowers to, and the script slot they belong
+/// in.  `None` for a directive with no console spelling.
+pub(crate) fn console_form(d: &Directive) -> Option<ConsoleForm> {
+    let (slot, line) = match &d.body {
+        Body::Function { start, end, name } => {
+            let mut line = format!("function bounds {start:#x}");
+            if let Some(end) = end {
+                line.push_str(&format!(" {end:#x}"));
+            }
+            if let Some(name) = name {
+                line.push_str(&format!(" as {name}"));
+            }
+            (Slot::Program, line)
+        }
+        Body::Typedef { decl } => (Slot::Program, format!("parse line {}", semicolon(decl))),
+        Body::Prototype { func: _, decl } => {
+            (Slot::Program, format!("parse line extern {}", semicolon(decl)))
+        }
+        Body::Data { addr, decl } => (Slot::Program, format!("map address {addr:#x} {decl}")),
+        Body::Param { index, storage, decl, .. } => {
+            (Slot::Function, format!("map param {index} {storage} {decl}"))
+        }
+        Body::Return { storage, decl, .. } => {
+            (Slot::Function, format!("map return {storage} {decl}"))
+        }
+        Body::Comment { addr, text, .. } => {
+            (Slot::Function, format!("comment instruction {addr:#x} {text}"))
+        }
+        Body::Name { symbol, newname, .. } => (Slot::Symbol, format!("rename {symbol} {newname}")),
+        Body::Type { symbol, decl, .. } => (Slot::Symbol, format!("retype {symbol} {decl}")),
+    };
+    Some(ConsoleForm { slot, line })
+}
+
+fn semicolon(decl: &str) -> String {
+    let decl = decl.trim();
+    if decl.ends_with(';') {
+        decl.to_string()
+    } else {
+        format!("{decl};")
+    }
+}
+
+/// Does any directive need the script's second `decompile`?
+pub(crate) fn needs_second_pass(directives: &[Directive]) -> bool {
+    directives
+        .iter()
+        .filter_map(console_form)
+        .any(|form| form.slot == Slot::Symbol)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn one(spec: &str) -> Directive {
+        parse_one(spec).expect("parses")
+    }
+
+    #[test]
+    fn the_three_directives_of_the_acceptance_probe() {
+        assert_eq!(
+            one("prototype authenticate int4 authenticate(char *user,char *pass)").body,
+            Body::Prototype {
+                func: "authenticate".into(),
+                decl: "int4 authenticate(char *user,char *pass)".into()
+            }
+        );
+        assert_eq!(
+            one("type v2 char[16]").body,
+            Body::Type { func: None, symbol: "v2".into(), decl: "char[16]".into() }
+        );
+        assert_eq!(
+            one("name v2 credbuf").body,
+            Body::Name { func: None, symbol: "v2".into(), newname: "credbuf".into() }
+        );
+    }
+
+    #[test]
+    fn a_directive_may_name_the_function_it_binds_to() {
+        assert_eq!(
+            one("name authenticate::v2 credbuf").body,
+            Body::Name {
+                func: Some("authenticate".into()),
+                symbol: "v2".into(),
+                newname: "credbuf".into()
+            }
+        );
+        // A C++ name is split at its LAST `::`, so the qualifier keeps its own.
+        assert_eq!(
+            one("type ns::cls::run::v2 char[8]").body,
+            Body::Type {
+                func: Some("ns::cls::run".into()),
+                symbol: "v2".into(),
+                decl: "char[8]".into()
+            }
+        );
+    }
+
+    #[test]
+    fn param_and_return_carry_storage_and_a_type() {
+        assert_eq!(
+            one("param 0 RDI char *user").body,
+            Body::Param {
+                func: None,
+                index: 0,
+                storage: "%RDI".into(),
+                decl: "char *user".into()
+            }
+        );
+        assert_eq!(
+            one("return main::RAX int4").body,
+            Body::Return {
+                func: Some("main".into()),
+                storage: "%RAX".into(),
+                decl: "int4".into()
+            }
+        );
+    }
+
+    #[test]
+    fn addresses_are_hex_with_or_without_the_prefix() {
+        assert_eq!(
+            one("data 0x601040 char *sneaky").body,
+            Body::Data { addr: 0x601040, decl: "char *sneaky".into() }
+        );
+        assert_eq!(
+            one("comment 400699 open the file").body,
+            Body::Comment { func: None, addr: 0x400699, text: "open the file".into() }
+        );
+    }
+
+    #[test]
+    fn function_is_the_define_function_spelling() {
+        assert_eq!(
+            one("function 0x1400-0x1480=decrypt").body,
+            Body::Function { start: 0x1400, end: Some(0x1480), name: Some("decrypt".into()) }
+        );
+    }
+
+    /// A directive kuna cannot honor must say so rather than be dropped: an
+    /// accepted-and-inert assertion is the failure mode this plane exists to end.
+    #[test]
+    fn a_malformed_directive_is_rejected_naming_itself() {
+        for spec in [
+            "",
+            "rename v2 buf",
+            "name v2",
+            "name v2 buf extra",
+            "type v2",
+            "data notahex int4 x",
+            "param x RDI int4",
+            "prototype authenticate",
+            "comment 0x400699",
+        ] {
+            let err = parse_one(spec).expect_err("refuses");
+            assert!(err.starts_with("--assert"), "got {err:?} for {spec:?}");
+        }
+    }
+
+    #[test]
+    fn directives_lower_to_their_console_commands() {
+        let lowered = |spec: &str| {
+            let d = one(spec);
+            let f = console_form(&d).expect("has a console form");
+            (f.slot, f.line)
+        };
+        assert_eq!(
+            lowered("prototype authenticate int4 authenticate(char *u,char *p)"),
+            (Slot::Program, "parse line extern int4 authenticate(char *u,char *p);".into())
+        );
+        assert_eq!(
+            lowered("typedef struct pt { int x; int y; };"),
+            (Slot::Program, "parse line struct pt { int x; int y; };".into())
+        );
+        assert_eq!(
+            lowered("data 0x601040 char *sneaky"),
+            (Slot::Program, "map address 0x601040 char *sneaky".into())
+        );
+        assert_eq!(
+            lowered("param 0 RDI char *user"),
+            (Slot::Function, "map param 0 %RDI char *user".into())
+        );
+        assert_eq!(
+            lowered("return RAX int4"),
+            (Slot::Function, "map return %RAX int4".into())
+        );
+        assert_eq!(
+            lowered("comment 0x400699 open the file"),
+            (Slot::Function, "comment instruction 0x400699 open the file".into())
+        );
+        assert_eq!(lowered("type v2 char[16]"), (Slot::Symbol, "retype v2 char[16]".into()));
+        assert_eq!(lowered("name v2 credbuf"), (Slot::Symbol, "rename v2 credbuf".into()));
+        assert_eq!(
+            lowered("function 0x1400-0x1480=decrypt"),
+            (Slot::Program, "function bounds 0x1400 0x1480 as decrypt".into())
+        );
+    }
+
+    /// The second `decompile` is emitted ONLY for a symbol-scoped directive, so
+    /// every other invocation keeps its current cost.
+    #[test]
+    fn only_a_symbol_scoped_directive_forces_a_second_pass() {
+        assert!(!needs_second_pass(&[one("prototype f int4 f(void)")]));
+        assert!(!needs_second_pass(&[one("param 0 RDI int4 a")]));
+        assert!(needs_second_pass(&[one("name v2 buf")]));
+        assert!(needs_second_pass(&[one("prototype f int4 f(void)"), one("type v2 char[4]")]));
+    }
+
+    #[test]
+    fn a_file_holds_one_directive_per_line_with_comments() {
+        let dir = std::env::temp_dir().join(format!("kuna-assertdecl-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let path = dir.join("overrides.kuna");
+        std::fs::write(
+            &path,
+            "# worked out by hand\nname v2 credbuf\n\ntype v2 char[16] # the read buffer\n",
+        )
+        .expect("write");
+        let directives = parse_flag(&format!("@{}", path.display())).expect("parses");
+        assert_eq!(directives.len(), 2);
+        assert_eq!(directives[0].raw, "name v2 credbuf");
+        assert_eq!(
+            directives[1].body,
+            Body::Type { func: None, symbol: "v2".into(), decl: "char[16]".into() }
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_missing_file_is_an_error_naming_the_path() {
+        let err = parse_flag("@/nonexistent/kuna-asserts.txt").expect_err("refuses");
+        assert!(err.contains("/nonexistent/kuna-asserts.txt"), "got {err:?}");
+    }
+}

--- a/decompiler/crates/kuna-cli/src/decompile.rs
+++ b/decompiler/crates/kuna-cli/src/decompile.rs
@@ -1569,6 +1569,7 @@ Decompilation complete
             &[],
             &[],
             &decls,
+            &[],
             None,
         );
         let line = |needle: &str| {
@@ -1585,6 +1586,116 @@ Decompilation complete
         );
     }
 
+    /// The assertion slots, which are forced rather than stylistic: a parsed
+    /// prototype must precede the load, a `map param` needs the loaded function,
+    /// and a `rename` of a LOCAL needs a function that has already been
+    /// decompiled — before that the console answers `No symbol named: v2`, which
+    /// is exactly the bug that makes `--kassert p9 naming-policy` inert today.
+    #[test]
+    fn build_script_puts_each_assertion_in_its_own_slot() {
+        let directives: Vec<_> = [
+            "prototype authenticate int4 authenticate(char *u)",
+            "param 0 RDI char *u",
+            "name v2 credbuf",
+        ]
+        .iter()
+        .map(|spec| crate::assertdecl::parse_one(spec).expect("parses"))
+        .collect();
+        let script = build_script(
+            "/tmp/a.out",
+            "authenticate",
+            false,
+            None,
+            false,
+            Path::new("/tmp/kuna.c"),
+            LISTING,
+            &[],
+            &[],
+            &[],
+            &directives,
+            None,
+        );
+        let line = |needle: &str| {
+            script
+                .lines()
+                .position(|l| l == needle)
+                .unwrap_or_else(|| panic!("{needle:?} missing from:\n{script}"))
+        };
+        assert!(line("read symbols") < line("parse line extern int4 authenticate(char *u);"));
+        assert!(
+            line("parse line extern int4 authenticate(char *u);")
+                < line("load function authenticate")
+        );
+        assert!(line("load function authenticate") < line("map param 0 %RDI char *u"));
+        assert!(line("map param 0 %RDI char *u") < line("decompile"));
+        assert!(line("decompile") < line("rename v2 credbuf"));
+        // The symbol-scoped directive forces a SECOND decompile after it.
+        assert_eq!(
+            script.lines().filter(|l| *l == "decompile").count(),
+            2,
+            "a symbol-scoped directive needs a second pass:\n{script}"
+        );
+        assert!(line("rename v2 credbuf") < script.lines().count());
+    }
+
+    /// Without a symbol-scoped directive there is no second `decompile`, so an
+    /// assertion an agent passes never doubles the cost of a run that does not
+    /// need it.
+    #[test]
+    fn build_script_emits_one_decompile_without_a_symbol_scoped_assertion() {
+        let directives = vec![crate::assertdecl::parse_one("data 0x601048 char *pw")
+            .expect("parses")];
+        let script = build_script(
+            "/tmp/a.out",
+            "main",
+            false,
+            None,
+            false,
+            Path::new("/tmp/kuna.c"),
+            LISTING,
+            &[],
+            &[],
+            &[],
+            &directives,
+            None,
+        );
+        assert_eq!(script.lines().filter(|l| *l == "decompile").count(), 1, "{script}");
+        assert!(script.contains("map address 0x601048 char *pw"), "{script}");
+    }
+
+    /// The transcript reader is what gives the human surface a report at all: a
+    /// console diagnostic under a directive's echo is that directive's rejection,
+    /// and a clean echo is an application.
+    #[test]
+    fn assertion_outcomes_read_the_console_diagnostic_under_each_echo() {
+        let directives: Vec<_> = ["name v2 credbuf", "type v9 char[4]"]
+            .iter()
+            .map(|spec| crate::assertdecl::parse_one(spec).expect("parses"))
+            .collect();
+        let transcript = "\
+[decomp]> decompile
+Decompiling authenticate
+[decomp]> rename v2 credbuf
+[decomp]> retype v9 char[4]
+Execution error: No symbol named: v9
+[decomp]> decompile
+";
+        let report = super::assertion_outcomes(transcript, &directives);
+        assert_eq!(report[0].status, "applied");
+        assert_eq!(report[1].status, "rejected");
+        assert_eq!(report[1].detail.as_deref(), Some("No symbol named: v9"));
+    }
+
+    /// A script that never reached a directive did not apply it, and saying so is
+    /// the difference between a report and a guess.
+    #[test]
+    fn an_unreached_directive_is_rejected_not_assumed_applied() {
+        let directives = vec![crate::assertdecl::parse_one("name v2 buf").expect("parses")];
+        let report = super::assertion_outcomes("[decomp]> load file /tmp/a.out\n", &directives);
+        assert_eq!(report[0].status, "rejected");
+        assert!(report[0].detail.as_deref().unwrap_or_default().contains("did not reach"));
+    }
+
     /// No declarations ⇒ the script is byte-identical to what it always was.
     #[test]
     fn build_script_without_declarations_emits_no_boundary_lines() {
@@ -1596,6 +1707,7 @@ Decompilation complete
             false,
             Path::new("/tmp/kuna.c"),
             LISTING,
+            &[],
             &[],
             &[],
             &[],
@@ -1617,6 +1729,7 @@ Decompilation complete
             false,
             Path::new("/tmp/out dir/kuna.c"),
             LISTING,
+            &[],
             &[],
             &[],
             &[],
@@ -1648,6 +1761,7 @@ Decompilation complete
             false,
             Path::new("/tmp/kuna.c"),
             LISTING,
+            &[],
             &[],
             &[],
             &[],
@@ -1723,6 +1837,7 @@ Decompilation complete
             &[],
             &[],
             &[],
+            &[],
             None,
         );
         let (before, after) = script.split_once("read symbols").expect("read symbols");
@@ -1756,6 +1871,7 @@ Decompilation complete
             false,
             Path::new("/tmp/kuna.c"),
             LISTING,
+            &[],
             &[],
             &[],
             &[],
@@ -1830,6 +1946,7 @@ Decompilation complete
             false,
             Path::new("/tmp/kuna.c"),
             LISTING,
+            &[],
             &[],
             &[],
             &[],

--- a/decompiler/crates/kuna-cli/src/decompile.rs
+++ b/decompiler/crates/kuna-cli/src/decompile.rs
@@ -40,6 +40,12 @@ pub struct DecompileArgs {
     /// `--define-function <start[-end][=name] | @file>` (repeatable): the
     /// caller-declared function boundaries, lowered to `function bounds` lines.
     pub func_decls: Vec<crate::funcdecl::FuncDecl>,
+    /// `--assert <directive> | @FILE` (repeatable): the caller-supplied
+    /// assertions, lowered to console lines at the slots `build_script`
+    /// documents (`crate::assertdecl`).
+    pub assertions: Vec<kuna_console::assertions::Directive>,
+    /// `--assert-strict`: a rejected directive makes the run exit non-zero.
+    pub assert_strict: bool,
     pub decomp_dbg: Option<String>,
     pub sleighpath: Option<String>,
     /// Mach-O fat / universal slice override (`--slice <arch>`, e.g. `x86_64` /
@@ -122,6 +128,7 @@ fn build_script(
     options: &[(String, String)],
     kasserts: &[String],
     func_decls: &[crate::funcdecl::FuncDecl],
+    assertions: &[kuna_console::assertions::Directive],
     regions_path: Option<&Path>,
 ) -> String {
     let mut lines: Vec<String> = Vec::new();
@@ -155,6 +162,14 @@ fn build_script(
     for decl in func_decls {
         lines.push(decl.console_line());
     }
+    // (kuna `--assert`) The PROGRAM-scoped directives -- a parsed type, a
+    // declared prototype, a named global -- go here, after the analysis commit
+    // and before the selection, so the function is loaded against them.
+    for form in assertions.iter().filter_map(crate::assertdecl::console_form) {
+        if form.slot == crate::assertdecl::Slot::Program {
+            lines.push(form.line);
+        }
+    }
     if by_address {
         match EntrySelector::parse(target) {
             EntrySelector::SectionOffset { .. } | EntrySelector::SectionIndexOffset { .. } => {
@@ -172,10 +187,30 @@ fn build_script(
     } else {
         lines.push(format!("load function {target}"));
     }
+    // FUNCTION-scoped directives need a loaded function and are consumed at flow
+    // time, so they precede the first `decompile`.
+    for form in assertions.iter().filter_map(crate::assertdecl::console_form) {
+        if form.slot == crate::assertdecl::Slot::Function {
+            lines.push(form.line);
+        }
+    }
     for ka in kasserts {
         lines.push(format!("kassert {ka}"));
     }
     lines.push("decompile".into());
+    // SYMBOL-scoped directives name a LOCAL, which does not exist until a
+    // decompile has produced it (`rename v2 buf` before the first one answers
+    // `No symbol named: v2`), so they run between two decompiles. The second
+    // `decompile` is emitted ONLY when there is such a directive, so every other
+    // invocation keeps its current cost.
+    if crate::assertdecl::needs_second_pass(assertions) {
+        for form in assertions.iter().filter_map(crate::assertdecl::console_form) {
+            if form.slot == crate::assertdecl::Slot::Symbol {
+                lines.push(form.line);
+            }
+        }
+        lines.push("decompile".into());
+    }
     let out_display = out_path.display().to_string();
     lines.push(format!("openfile write {}", console_path(&out_display)));
     lines.push("print C".into());
@@ -419,6 +454,76 @@ fn find_pipeline_failure(out: &str) -> Option<(String, String)> {
     None
 }
 
+/// Recover one [`Outcome`](kuna_console::assertions::Outcome) per `--assert`
+/// directive from the `decomp_dbg` transcript.
+///
+/// The console's exception grammar is byte-faithful and load-bearing
+/// (`ifacedecomp::execute`, and [`CONSOLE_DIAGNOSTICS`] already parses it): a
+/// command that raised prints exactly one diagnostic prefix and the session
+/// continues.  So a directive is `applied` unless a diagnostic follows the echo
+/// of the console line it lowered to — which is the only signal this surface
+/// has, since the C comes back through a file redirect and not the transcript.
+///
+/// A directive whose echo is absent entirely (the script never got that far —
+/// the load failed) is reported as rejected rather than silently applied.
+fn assertion_outcomes(
+    out: &str,
+    directives: &[kuna_console::assertions::Directive],
+) -> Vec<kuna_console::assertions::Outcome> {
+    use kuna_console::assertions::Outcome;
+    directives
+        .iter()
+        .map(|directive| {
+            let (kind, phase, subphase) = directive.body.coords();
+            let detail = match crate::assertdecl::console_form(directive) {
+                Some(form) => command_failure(out, &form.line),
+                None => Some("no console spelling for this directive".to_string()),
+            };
+            Outcome {
+                directive: directive.raw.clone(),
+                kind,
+                phase,
+                subphase,
+                status: if detail.is_none() { "applied" } else { "rejected" },
+                detail,
+            }
+        })
+        .collect()
+}
+
+/// The diagnostic the console printed for the command `line`, or `None` when it
+/// ran clean.  `Some` for a command whose echo never appears at all — a script
+/// that stopped early did not apply it.
+fn command_failure(out: &str, line: &str) -> Option<String> {
+    let mut in_command = false;
+    let mut seen = false;
+    for raw in out.lines() {
+        let trimmed = raw.trim();
+        let text = console_text(trimmed);
+        if trimmed.starts_with(CONSOLE_PROMPT) {
+            in_command = text == line;
+            seen |= in_command;
+            continue;
+        }
+        if !in_command || text.is_empty() {
+            continue;
+        }
+        for prefix in CONSOLE_DIAGNOSTICS {
+            if let Some(reason) = text.strip_prefix(prefix) {
+                let reason = reason.trim();
+                if !reason.is_empty() {
+                    return Some(reason.to_string());
+                }
+            }
+        }
+    }
+    if seen {
+        None
+    } else {
+        Some("the console script did not reach this directive".into())
+    }
+}
+
 /// A unique temp path under the system temp dir (no external dep; mirrors
 /// `tempfile.NamedTemporaryFile(delete=False)`'s role — a private scratch file we
 /// delete in the `finally`).
@@ -440,6 +545,8 @@ struct DecompileOutcome {
     c: String,
     regions: Option<String>,
     failure: Option<String>,
+    /// One row per `--assert` directive, recovered from the transcript.
+    assertions: Vec<kuna_console::assertions::Outcome>,
 }
 
 /// Run the decompile and return its [`DecompileOutcome`].
@@ -519,6 +626,7 @@ fn decompile(args: &DecompileArgs) -> Result<DecompileOutcome, String> {
             &args.options,
             &args.kasserts,
             &args.func_decls,
+            &args.assertions,
             regions_path.as_deref(),
         );
 
@@ -732,6 +840,7 @@ fn decompile(args: &DecompileArgs) -> Result<DecompileOutcome, String> {
                     ),
                     regions: None,
                     failure: None,
+                    assertions: assertion_outcomes(&stdout_text, &args.assertions),
                 });
             }
             return Err((
@@ -766,7 +875,12 @@ fn decompile(args: &DecompileArgs) -> Result<DecompileOutcome, String> {
             }
             regions_text = Some(trim_newlines(&buf));
         }
-        Ok(DecompileOutcome { c: c_text, regions: regions_text, failure })
+        Ok(DecompileOutcome {
+            c: c_text,
+            regions: regions_text,
+            failure,
+            assertions: assertion_outcomes(&stdout_text, &args.assertions),
+        })
     };
 
     let mut result = attempt(&base);
@@ -811,11 +925,15 @@ pub fn run(args: &DecompileArgs) -> i32 {
             // survived (DIV-45): a closed reader is not evidence the decompile
             // worked.  Emitting first keeps the stdout-then-stderr order.
             let written = crate::output::emit(&text);
+            // A rejected assertion is reported and the run continues;
+            // `--assert-strict` makes it the verdict.
+            let rejected = decompile_all::report_rejected_assertions(&out.assertions);
             let status = match out.failure {
                 Some(msg) => {
                     eprintln!("error: {msg}");
                     1
                 }
+                None if args.assert_strict && rejected => 1,
                 None => 0,
             };
             match written {
@@ -854,6 +972,8 @@ pub fn main(argv: &[String]) -> i32 {
     let mut mode: Option<String> = None;
     let mut kasserts: Vec<String> = Vec::new();
     let mut func_decls: Vec<crate::funcdecl::FuncDecl> = Vec::new();
+    let mut assertions: Vec<kuna_console::assertions::Directive> = Vec::new();
+    let mut assert_strict = false;
     let mut decomp_dbg: Option<String> = None;
     let mut engine: Option<String> = None;
     let mut sleighpath: Option<String> = None;
@@ -925,6 +1045,24 @@ pub fn main(argv: &[String]) -> i32 {
                 },
                 None => return 2,
             },
+            "--assert" => match take_value(argv, &mut i, "--assert") {
+                Some(value) => match crate::assertdecl::parse_flag(&value) {
+                    Ok(parsed) => {
+                        assertions.extend(parsed);
+                        forwarded.push("--assert".into());
+                        forwarded.push(value);
+                    }
+                    Err(msg) => {
+                        eprintln!("error: {msg}");
+                        return 2;
+                    }
+                },
+                None => return 2,
+            },
+            "--assert-strict" => {
+                assert_strict = true;
+                forwarded.push("--assert-strict".into());
+            }
             "--decomp-dbg" => decomp_dbg = take_value(argv, &mut i, "--decomp-dbg"),
             "--engine" => engine = take_value(argv, &mut i, "--engine"),
             "--sleighpath" => sleighpath = take_value(argv, &mut i, "--sleighpath"),
@@ -1028,6 +1166,8 @@ pub fn main(argv: &[String]) -> i32 {
         options,
         kasserts,
         func_decls,
+        assertions,
+        assert_strict,
         decomp_dbg,
         sleighpath,
         slice,
@@ -1111,7 +1251,13 @@ fn run_json(req: &JsonRequest) -> i32 {
     let (text, failure) = match decompile_json(&args, req.target) {
         Ok(answered) => answered,
         Err(message) => (
-            decompile_all::render_result_json(&args.binary, &[], &args.options, Some(&message)),
+            decompile_all::render_result_json(
+                &args.binary,
+                &[],
+                &args.options,
+                Some(&message),
+                &[],
+            ),
             Some(message),
         ),
     };
@@ -1150,20 +1296,26 @@ fn decompile_json(args: &AllArgs, target: &str) -> Result<(String, Option<String
     }
 
     let funcs = decompile_all::decompile_entries(&mut prog, args, targets);
-    let failure = funcs.iter().find_map(|f| {
+    let assertions = prog.assertion_outcomes();
+    let mut failure = funcs.iter().find_map(|f| {
         f.error.as_ref().map(|reason| {
             format!("decompilation failed for {} in {}: {reason}", f.name, args.binary)
         })
     });
-    Ok((
-        decompile_all::render_result_json(
-            &args.binary,
-            &funcs,
-            &args.options,
-            failure.as_deref(),
-        ),
-        failure,
-    ))
+    // A rejected assertion is reported and the run continues; `--assert-strict`
+    // makes it the run's verdict (see `report_rejected_assertions`).
+    let rejected = decompile_all::report_rejected_assertions(&assertions);
+    let text = decompile_all::render_result_json(
+        &args.binary,
+        &funcs,
+        &args.options,
+        failure.as_deref(),
+        &assertions,
+    );
+    if failure.is_none() && args.assert_strict && rejected {
+        failure = Some(format!("--assert directive rejected in {}", args.binary));
+    }
+    Ok((text, failure))
 }
 
 #[cfg(test)]

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -1760,7 +1760,7 @@ mod provenance_json_tests {
             object_location: None,
         };
 
-        let rendered = dumps_indent2(&result_json("fixture", &[function], "c-language", None, None));
+        let rendered = dumps_indent2(&result_json("fixture", &[function], "c-language", None, None, &[]));
         assert!(rendered.contains("\"address\": 4198400"));
         assert!(rendered.contains("\"code\": \"int f(int x)\\n{\\n  return x;\\n}\""));
         assert!(rendered.contains("\"line_mappings\": ["));

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -134,6 +134,14 @@ pub(crate) struct Args {
     /// loads through this struct honors them; only the surfaces that parse the
     /// flag can be non-empty.
     pub(crate) func_decls: Vec<crate::funcdecl::FuncDecl>,
+    /// `--assert <directive> | @FILE` (repeatable): the caller-supplied
+    /// assertions, installed by [`load_program`] right after the analysis commit
+    /// and dispatched by the decompile loop (`kuna_console::assertions`). Empty
+    /// for every invocation that passed none.
+    pub(crate) assertions: Vec<kuna_console::assertions::Directive>,
+    /// `--assert-strict`: a rejected directive makes the run exit non-zero
+    /// instead of being reported and continuing.
+    pub(crate) assert_strict: bool,
     pub(crate) slice: Option<String>,
     pub(crate) target: Option<String>,
     pub(crate) sleighpath: Option<String>,
@@ -650,11 +658,20 @@ pub fn run(argv: &[String]) -> i32 {
                     &args.options,
                     discovery_error.as_deref(),
                     filters.narrows().then_some(run.discovered),
+                    &run.assertions,
                 )
             } else {
                 render_c(&run.funcs)
             };
-            emit_with_discovery_error(&text, discovery_error.as_deref())
+            // A rejected assertion is reported and the run continues (an agent
+            // batching forty renames against a re-decompiled binary must not lose
+            // all forty to one stale name); `--assert-strict` makes it fatal.
+            let rejected = report_rejected_assertions(&run.assertions);
+            let status = emit_with_discovery_error(&text, discovery_error.as_deref());
+            if status == 0 && args.assert_strict && rejected {
+                return 1;
+            }
+            status
         }
         Err(e) => {
             eprintln!("error: {e}");
@@ -665,6 +682,26 @@ pub fn run(argv: &[String]) -> i32 {
 
 /// Emit `text`, then report a discovery failure (stdout before stderr, as
 /// `kuna decompile` orders them) and answer with the run's verdict.
+/// Report every rejected assertion on stderr, and say whether there was one.
+///
+/// The human surface has no `assertions[]` to read, and a directive that was
+/// silently dropped is the failure mode this plane exists to end -- so a
+/// rejection is always spoken, on both surfaces.
+pub(crate) fn report_rejected_assertions(
+    outcomes: &[kuna_console::assertions::Outcome],
+) -> bool {
+    let mut any = false;
+    for outcome in outcomes.iter().filter(|o| o.status == "rejected") {
+        any = true;
+        eprintln!(
+            "warning: --assert {:?} rejected: {}",
+            outcome.directive,
+            outcome.detail.as_deref().unwrap_or("no reason given")
+        );
+    }
+    any
+}
+
 fn emit_with_discovery_error(text: &str, discovery_error: Option<&str>) -> i32 {
     let status = crate::output::emit_with_status(text, i32::from(discovery_error.is_some()));
     if let Some(message) = discovery_error {
@@ -773,6 +810,8 @@ fn run_summary(args: &Args, filters: &Filters) -> i32 {
 struct AllRun {
     funcs: Vec<FuncResult>,
     discovered: usize,
+    /// One row per `--assert` directive: what became of it.
+    assertions: Vec<kuna_console::assertions::Outcome>,
 }
 
 /// Load + analyze the binary once, narrow the target list, then decompile what
@@ -789,7 +828,8 @@ fn decompile_all(args: &Args, filters: &Filters) -> Result<AllRun, String> {
     } else {
         targets
     };
-    Ok(AllRun { funcs: decompile_entries(&mut prog, args, targets), discovered })
+    let funcs = decompile_entries(&mut prog, args, targets);
+    Ok(AllRun { funcs, discovered, assertions: prog.assertion_outcomes() })
 }
 
 /// Arm the per-function watchdog and run the decompile loop over `targets` — the
@@ -999,6 +1039,14 @@ pub(crate) fn load_program(
     // AFTER the commit: a caller-declared boundary is an assertion that outranks
     // whatever discovery decided about the same address.
     crate::funcdecl::apply(&mut prog, &args.func_decls)?;
+    // The `--assert` plane, same slot and for the same reason: a caller-declared
+    // fact outranks whatever discovery decided about it. The program-scoped
+    // directives take effect here; the function- and symbol-scoped ones are
+    // dispatched by the decompile loop (`kuna_console::assertions`).
+    if !args.assertions.is_empty() {
+        prog.set_assertions(args.assertions.clone());
+        kuna_console::assertions::apply_program_scoped(&mut prog);
+    }
     Ok(prog)
 }
 
@@ -1427,8 +1475,9 @@ pub(crate) fn render_result_json(
     funcs: &[FuncResult],
     options: &[(String, String)],
     error: Option<&str>,
+    assertions: &[kuna_console::assertions::Outcome],
 ) -> String {
-    render_selected_json(binary, funcs, options, error, None)
+    render_selected_json(binary, funcs, options, error, None, assertions)
 }
 
 /// [`render_result_json`] plus the inventory `total` a NARROWED whole-binary run
@@ -1445,9 +1494,13 @@ pub(crate) fn render_selected_json(
     options: &[(String, String)],
     error: Option<&str>,
     total: Option<usize>,
+    assertions: &[kuna_console::assertions::Outcome],
 ) -> String {
     let language = last_option_value(options, "setlanguage").unwrap_or("c-language");
-    format!("{}\n", dumps_indent2(&result_json(binary, funcs, language, error, total)))
+    format!(
+        "{}\n",
+        dumps_indent2(&result_json(binary, funcs, language, error, total, assertions))
+    )
 }
 
 /// The `functions --json` document.
@@ -1510,6 +1563,7 @@ fn result_json(
     language: &str,
     error: Option<&str>,
     total: Option<usize>,
+    assertions: &[kuna_console::assertions::Outcome],
 ) -> Json {
     let functions = Json::Array(
         funcs
@@ -1561,7 +1615,35 @@ fn result_json(
         "error".to_string(),
         error_json(error),
     ), ("functions".to_string(), functions)]);
+    // (kuna `--assert`) One row per caller-supplied assertion, in the order the
+    // caller gave them: what it was, where in the phase model it wrote, and
+    // whether it landed. Always present (`[]` when none were passed) so an agent
+    // can read it unconditionally — an assertion whose fate is unreported is an
+    // assertion an agent has to verify by eye, which is the whole problem.
+    fields.push(("assertions".to_string(), assertions_json(assertions)));
     Json::Object(fields)
+}
+
+/// The per-directive report (`kuna_console::assertions::Outcome`).
+fn assertions_json(outcomes: &[kuna_console::assertions::Outcome]) -> Json {
+    Json::Array(
+        outcomes
+            .iter()
+            .map(|o| {
+                Json::Object(vec![
+                    ("directive".into(), Json::Str(o.directive.clone())),
+                    ("kind".into(), Json::Str(o.kind.to_string())),
+                    ("phase".into(), Json::Str(o.phase.to_string())),
+                    ("subphase".into(), Json::Str(o.subphase.to_string())),
+                    ("status".into(), Json::Str(o.status.to_string())),
+                    (
+                        "detail".into(),
+                        o.detail.clone().map(Json::Str).unwrap_or(Json::Null),
+                    ),
+                ])
+            })
+            .collect(),
+    )
 }
 
 fn line_mapping_json(mapping: &LineMapping) -> Json {
@@ -1792,6 +1874,8 @@ pub(crate) fn parse_args_with_filters(
     let mut max_fn_seconds: Option<u64> = None;
     let mut options: Vec<(String, String)> = Vec::new();
     let mut func_decls: Vec<crate::funcdecl::FuncDecl> = Vec::new();
+    let mut assertions: Vec<kuna_console::assertions::Directive> = Vec::new();
+    let mut assert_strict = false;
     let mut mode: Option<String> = None;
     let mut slice: Option<String> = None;
     let mut target: Option<String> = None;
@@ -1816,6 +1900,11 @@ pub(crate) fn parse_args_with_filters(
                 let v = take(argv, &mut i, "--define-function")?;
                 func_decls.extend(crate::funcdecl::parse_flag(&v)?);
             }
+            "--assert" => {
+                let v = take(argv, &mut i, "--assert")?;
+                assertions.extend(crate::assertdecl::parse_flag(&v)?);
+            }
+            "--assert-strict" => assert_strict = true,
             "--max-fn-seconds" if cmd == "decompile-all" || cmd == "decompile-project" => {
                 let v = take(argv, &mut i, "--max-fn-seconds")?;
                 max_fn_seconds = Some(
@@ -1944,6 +2033,8 @@ pub(crate) fn parse_args_with_filters(
             max_fn_seconds,
             options,
             func_decls,
+            assertions,
+            assert_strict,
             slice,
             target,
             sleighpath,
@@ -2202,10 +2293,10 @@ mod discovery_tests {
             failed.contains("\"error\": \"no functions discovered in fixture\""),
             "{failed}"
         );
-        let decompiled = render_result_json("fixture", &[], &[], Some("boom"));
+        let decompiled = render_result_json("fixture", &[], &[], Some("boom"), &[]);
         assert!(decompiled.contains("\"error\": \"boom\""), "{decompiled}");
         assert!(
-            render_result_json("fixture", &[], &[], None).contains("\"error\": null")
+            render_result_json("fixture", &[], &[], None, &[]).contains("\"error\": null")
         );
     }
 
@@ -2217,8 +2308,8 @@ mod discovery_tests {
             ("setlanguage".into(), "rust-language".into()),
             ("setlanguage".into(), "c-language".into()),
         ];
-        assert!(render_result_json("f", &[], &options, None).contains("\"c-language\""));
-        assert!(render_result_json("f", &[], &[], None).contains("\"c-language\""));
+        assert!(render_result_json("f", &[], &options, None, &[]).contains("\"c-language\""));
+        assert!(render_result_json("f", &[], &[], None, &[]).contains("\"c-language\""));
     }
 }
 

--- a/decompiler/crates/kuna-cli/src/disassemble.rs
+++ b/decompiler/crates/kuna-cli/src/disassemble.rs
@@ -283,6 +283,8 @@ pub(crate) fn render(args: &DisArgs) -> Result<Listing, String> {
         max_fn_seconds: 0,
         options,
         func_decls: args.func_decls.clone(),
+        assertions: Vec::new(),
+        assert_strict: false,
         slice: args.slice.clone(),
         target: args.target.clone(),
         sleighpath: args.sleighpath.clone(),

--- a/decompiler/crates/kuna-cli/src/main.rs
+++ b/decompiler/crates/kuna-cli/src/main.rs
@@ -24,6 +24,7 @@ mod decompile_all;
 mod decompile_project;
 mod disassemble;
 mod fid;
+mod assertdecl;
 mod funcdecl;
 mod jsonfmt;
 mod output;
@@ -90,9 +91,9 @@ fn usage() {
     eprintln!(
         "usage: kuna <decompile|decompile-all|decompile-project|functions|disassemble|read|xrefs|strings|unpack|docs|test|catalog|modes|specs|fid> ...\n\
          \n\
-         kuna decompile <binary> <func> [--addr] [--json] [--slice ARCH] [--language auto|c|rust] [--mode auto|reliable|aggressive|fast] [--option NAME VALUE]... [--kassert ARGS]... [--define-function S[-E][=N]|@FILE]...\n\
-         kuna decompile-all <binary> [--json] [--functions a,b,..] [--addr 0xVMA]... [--no-vars] [--language auto|c|rust] [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] [--option N V]... [--define-function S[-E][=N]|@FILE]...\n\
-         kuna decompile-project <binary> [-o DIR] [--functions a,b,..] [--addr 0xVMA]... [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] [--option N V]... [--define-function S[-E][=N]|@FILE]...\n\
+         kuna decompile <binary> <func> [--addr] [--json] [--slice ARCH] [--language auto|c|rust] [--mode auto|reliable|aggressive|fast] [--option NAME VALUE]... [--kassert ARGS]... [--define-function S[-E][=N]|@FILE]... [--assert DIRECTIVE|@FILE]...\n\
+         kuna decompile-all <binary> [--json] [--functions a,b,..] [--addr 0xVMA]... [--no-vars] [--language auto|c|rust] [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] [--option N V]... [--define-function S[-E][=N]|@FILE]... [--assert DIRECTIVE|@FILE]...\n\
+         kuna decompile-project <binary> [-o DIR] [--functions a,b,..] [--addr 0xVMA]... [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] [--option N V]... [--define-function S[-E][=N]|@FILE]... [--assert DIRECTIVE|@FILE]...\n\
          kuna functions <binary> [--json] [--mode auto|reliable|aggressive|fast] [--define-function S[-E][=N]|@FILE]...\n\
          kuna xrefs <binary> (--to <name|0xaddr> | --from <name|0xaddr>) [--json] [--kind call,jump,data,read,write] [--mode auto|reliable|aggressive|fast]\n\
          kuna unpack <binary> [-o OUT] [--json]\n\

--- a/decompiler/crates/kuna-cli/src/strings.rs
+++ b/decompiler/crates/kuna-cli/src/strings.rs
@@ -169,6 +169,8 @@ fn attribute(
         max_fn_seconds: 0,
         options,
         func_decls: Vec::new(),
+        assertions: Vec::new(),
+        assert_strict: false,
         slice: args.slice.clone(),
         target: args.target.clone(),
         sleighpath: args.sleighpath.clone(),

--- a/decompiler/crates/kuna-cli/src/xrefs.rs
+++ b/decompiler/crates/kuna-cli/src/xrefs.rs
@@ -107,6 +107,8 @@ fn query(args: &XrefArgs) -> Result<String, String> {
         max_fn_seconds: 0,
         options,
         func_decls: Vec::new(),
+        assertions: Vec::new(),
+        assert_strict: false,
         slice: args.slice.clone(),
         target: args.target.clone(),
         sleighpath: args.sleighpath.clone(),

--- a/decompiler/crates/kuna-cli/tests/disassemble_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/disassemble_cli.rs
@@ -38,6 +38,9 @@ mod output;
 #[path = "../src/paths.rs"]
 mod paths;
 #[allow(dead_code)]
+#[path = "../src/assertdecl.rs"]
+mod assertdecl;
+
 #[path = "../src/funcdecl.rs"]
 mod funcdecl;
 #[allow(dead_code)]

--- a/decompiler/crates/kuna-cli/tests/strings_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/strings_cli.rs
@@ -45,6 +45,9 @@ mod output;
 #[path = "../src/paths.rs"]
 mod paths;
 #[allow(dead_code)]
+#[path = "../src/assertdecl.rs"]
+mod assertdecl;
+
 #[path = "../src/funcdecl.rs"]
 mod funcdecl;
 #[allow(dead_code)]

--- a/decompiler/crates/kuna-console/src/assertions.rs
+++ b/decompiler/crates/kuna-console/src/assertions.rs
@@ -1,0 +1,581 @@
+//! `--assert` — the one override plane an agent states facts through.
+//!
+//! # Why this exists
+//!
+//! Everything kuna knows about a program it *derived*. That is the right default
+//! and it is wrong exactly where reverse engineering is hard, and until this
+//! module the `kuna` binary had almost no lever to correct it: `rename`,
+//! `retype`, `map param`, `map return`, `map address`, `comment instruction` and
+//! `parse line extern` all work in the console and none of them was reachable
+//! from `kuna` (`docs/re-needs/no-cli-rename-or-prototype-override.md`).  A
+//! rename that does not survive the process that made it is not an interface.
+//!
+//! # The directive
+//!
+//! One line-oriented vocabulary, keyed by INTENT rather than by phase — an agent
+//! should not have to know that renaming is P9 to rename something:
+//!
+//! ```text
+//!   prototype <func> <C declaration>       parse line extern    P4 prototype-source
+//!   param [<func>::]<i> <storage> <decl>   map param            P4 prototype-source
+//!   return [<func>::]<storage> <decl>      map return           P4 prototype-source
+//!   name [<func>::]<symbol> <newname>      rename               P9 naming-policy
+//!   type [<func>::]<symbol> <C type>       retype               P5 type-propagation
+//!   typedef <C declaration>                parse line           P5
+//!   data <addr> <C typedeclaration>        map address          P5 const-pointer
+//!   comment [<func>::]<addr> <text>        comment instruction  P9
+//!   function <start>[-<end>][=<name>]      function bounds      P1  (= --define-function)
+//! ```
+//!
+//! [`Directive`] is the parsed form; the CLI's `assertdecl` module owns the text
+//! syntax and the `@FILE` contract, exactly as `funcdecl` does for
+//! `--define-function`.  Every directive produces exactly one [`Outcome`], so a
+//! caller can report each one's fate machine-readably instead of scraping a
+//! console transcript.
+//!
+//! # Where a directive lands
+//!
+//! The ordering is not cosmetic; it is what makes the plane work at all.
+//!
+//! * **Program-scoped** (`function`, `typedef`, `prototype`, `data`) is applied
+//!   by [`apply_program_scoped`] right after the analysis commit, so a declared
+//!   fact outranks whatever discovery decided.
+//! * **Function-scoped** (`param`, `return`, `comment`) is turned into decompile
+//!   SEEDS by [`function_seed`] — the facts the drive consumes at flow time.
+//! * **Symbol-scoped** (`name`, `type`) can only be applied AFTER a decompile:
+//!   a local like `v2` does not exist until one has run (`rename v2 buf` before
+//!   the first decompile answers `No symbol named: v2`, which is precisely the
+//!   bug that makes today's `--kassert p9 naming-policy` inert).  So
+//!   [`apply_symbol_scoped`] runs on the first pass's `Funcdata` and the caller
+//!   decompiles a second time with the mutated scope carried across — the same
+//!   shape the console's `decompile` / `rename` / `decompile` sequence has.
+//!
+//! A directive that names no function binds to the function being decompiled.
+//! That is unambiguous for `kuna decompile`, which selects exactly one; on a
+//! whole-binary run it would silently mean "every function that happens to have a
+//! `v2`", so it is REJECTED there with a detail telling the caller to qualify it
+//! `<func>::<symbol>`.  Rejecting is the point: a directive that is accepted and
+//! does nothing is worse than an error.
+
+use std::rc::Rc;
+
+use kuna_base::address::Address;
+use kuna_base::types::{int4, uint4};
+use kuna_decomp::dtype::Datatype;
+use kuna_decomp::fspec::{ParameterPieces, PrototypePieces};
+use kuna_decomp::funcdata::Funcdata;
+
+use crate::engine::ConsoleProgram;
+use crate::grammar::DataOrg;
+
+/// One parsed assertion.  `raw` is the caller's own text, echoed back in the
+/// [`Outcome`] so a report row is greppable against the command line that made
+/// it.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Directive {
+    pub raw: String,
+    pub body: Body,
+}
+
+/// The directive vocabulary (see the module docs for the text syntax).
+#[derive(Clone, Debug, PartialEq)]
+pub enum Body {
+    /// `function <start>[-<end>][=<name>]` — the `--define-function` alias.
+    Function { start: u64, end: Option<u64>, name: Option<String> },
+    /// `typedef <C declaration>` — intern a type so later directives can name it.
+    Typedef { decl: String },
+    /// `prototype <func> <C declaration>` — the function's signature.
+    Prototype { func: String, decl: String },
+    /// `data <addr> <C typedeclaration>` — a named, typed global.
+    Data { addr: u64, decl: String },
+    /// `param [<func>::]<i> <storage> <C typedeclaration>` — a locked input.
+    Param { func: Option<String>, index: int4, storage: String, decl: String },
+    /// `return [<func>::]<storage> <C typedeclaration>` — a locked return.
+    Return { func: Option<String>, storage: String, decl: String },
+    /// `comment [<func>::]<addr> <text>` — a comment at an instruction.
+    Comment { func: Option<String>, addr: u64, text: String },
+    /// `name [<func>::]<symbol> <newname>` — rename a local.
+    Name { func: Option<String>, symbol: String, newname: String },
+    /// `type [<func>::]<symbol> <C type>` — retype a local.
+    Type { func: Option<String>, symbol: String, decl: String },
+}
+
+/// What became of one directive.  `status` is `applied` or `rejected`; a
+/// rejection always carries a `detail` naming the reason.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Outcome {
+    pub directive: String,
+    pub kind: &'static str,
+    pub phase: &'static str,
+    pub subphase: &'static str,
+    pub status: &'static str,
+    pub detail: Option<String>,
+}
+
+impl Body {
+    /// `(kind, phase, sub-phase)` — the phase-model coordinates a directive
+    /// writes at, reported so an agent can correlate a rejection with
+    /// `kuna catalog` / `docs/phases.md`.
+    pub fn coords(&self) -> (&'static str, &'static str, &'static str) {
+        match self {
+            Body::Function { .. } => ("function", "P1", "function-boundary"),
+            Body::Typedef { .. } => ("typedef", "P5", "type-propagation"),
+            Body::Prototype { .. } => ("prototype", "P4", "prototype-source"),
+            Body::Data { .. } => ("data", "P5", "const-pointer"),
+            Body::Param { .. } => ("param", "P4", "prototype-source"),
+            Body::Return { .. } => ("return", "P4", "prototype-source"),
+            Body::Comment { .. } => ("comment", "P9", "external-refinement"),
+            Body::Name { .. } => ("name", "P9", "naming-policy"),
+            Body::Type { .. } => ("type", "P5", "type-propagation"),
+        }
+    }
+
+    /// The function this directive names, when it names one.
+    fn qualifier(&self) -> Option<&str> {
+        match self {
+            Body::Prototype { func, .. } => Some(func.as_str()),
+            Body::Param { func, .. }
+            | Body::Return { func, .. }
+            | Body::Comment { func, .. }
+            | Body::Name { func, .. }
+            | Body::Type { func, .. } => func.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Is this directive applied per-function (rather than once per program)?
+    fn is_function_scoped(&self) -> bool {
+        matches!(
+            self,
+            Body::Param { .. }
+                | Body::Return { .. }
+                | Body::Comment { .. }
+                | Body::Name { .. }
+                | Body::Type { .. }
+        )
+    }
+
+    /// Is this directive one that can only be applied to an already-decompiled
+    /// function (because the symbol it names does not exist before)?
+    fn is_symbol_scoped(&self) -> bool {
+        matches!(self, Body::Name { .. } | Body::Type { .. })
+    }
+}
+
+impl Directive {
+    fn applied(&self) -> Outcome {
+        let (kind, phase, subphase) = self.body.coords();
+        Outcome {
+            directive: self.raw.clone(),
+            kind,
+            phase,
+            subphase,
+            status: "applied",
+            detail: None,
+        }
+    }
+
+    fn rejected(&self, detail: impl Into<String>) -> Outcome {
+        let (kind, phase, subphase) = self.body.coords();
+        Outcome {
+            directive: self.raw.clone(),
+            kind,
+            phase,
+            subphase,
+            status: "rejected",
+            detail: Some(detail.into()),
+        }
+    }
+}
+
+/// Does this directive bind to the function named `name`?
+///
+/// A qualified directive binds only to the function it names.  An unqualified
+/// one binds to the single function under decompile, which is why `single` (the
+/// run selected exactly one function) is required for it: see the module docs.
+fn binds_to(body: &Body, name: &str, single: bool) -> bool {
+    match body.qualifier() {
+        Some(func) => func == name,
+        None => single,
+    }
+}
+
+/// The console-side data organisation of the loaded program.
+fn data_org(prog: &ConsoleProgram) -> DataOrg {
+    let (addr_size, word_size) = prog.arch().data_org();
+    DataOrg { addr_size, word_size }
+}
+
+/// Build an [`Address`] in the program's default code space.
+fn code_addr(prog: &ConsoleProgram, vma: u64) -> Option<Address> {
+    let space = prog.arch().manage().get_default_code_space().cloned()?;
+    Some(Address::new(space, vma))
+}
+
+/// Parse a storage token (`%RDI`, `[stack,-0x18,8]`, `s0x10`) through the
+/// console's own machine-address grammar, so `--assert` and the console spell
+/// storage the same way.
+fn parse_storage(prog: &ConsoleProgram, tok: &str) -> Result<Address, String> {
+    let mut s = crate::interface::CommandStream::new(tok);
+    crate::ifacedecomp::parse_machaddr(prog, &mut s, false).map(|(addr, _size)| addr)
+}
+
+/// Apply the program-scoped directives (`function`, `typedef`, `prototype`,
+/// `data`) and record an [`Outcome`] for each.
+///
+/// Called right after the analysis commit — a caller-declared fact outranks
+/// discovery — and before any function is selected.  The function- and
+/// symbol-scoped directives are left for the decompile loop and are given a
+/// placeholder outcome that the loop overwrites; one that is never reached keeps
+/// it, which is how "you asked about a function this run did not decompile"
+/// becomes a report row instead of silence.
+pub fn apply_program_scoped(prog: &mut ConsoleProgram) {
+    let directives = prog.assertions().to_vec();
+    for (i, directive) in directives.iter().enumerate() {
+        if directive.body.is_function_scoped() {
+            let outcome = directive.rejected(
+                "no decompiled function matched this directive (name it as \
+                 <func>::<operand>, or select the function)",
+            );
+            prog.set_assertion_outcome(i, outcome);
+            continue;
+        }
+        let outcome = match apply_one_program_scoped(prog, &directive.body) {
+            Ok(()) => directive.applied(),
+            Err(detail) => directive.rejected(detail),
+        };
+        prog.set_assertion_outcome(i, outcome);
+    }
+}
+
+fn apply_one_program_scoped(prog: &mut ConsoleProgram, body: &Body) -> Result<(), String> {
+    match body {
+        Body::Function { start, end, name } => {
+            let addr = code_addr(prog, *start)
+                .ok_or_else(|| "the loaded program has no default code space".to_string())?;
+            let size = end.map(|e| e - *start).unwrap_or(0) as int4;
+            prog.declare_function(addr, name.as_deref(), size)
+                .map(|_| ())
+                .map_err(|e| e.explain().to_string())
+        }
+        Body::Typedef { decl } => {
+            let org = data_org(prog);
+            let text = with_semicolon(decl);
+            crate::grammar::parse_c(&text, prog.arch().types(), org, |_| Ok(()))
+                .map_err(|e| e.explain().to_string())
+        }
+        Body::Prototype { func, decl } => apply_prototype(prog, func, decl),
+        Body::Data { addr, decl } => apply_data(prog, *addr, decl),
+        // Handled by the decompile loop.
+        _ => Err("internal: not a program-scoped directive".into()),
+    }
+}
+
+/// C declarations are parsed as a statement; accept the caller's text with or
+/// without the terminating `;`.
+fn with_semicolon(decl: &str) -> String {
+    let decl = decl.trim();
+    if decl.ends_with(';') {
+        decl.to_string()
+    } else {
+        format!("{decl};")
+    }
+}
+
+/// `prototype <func> <C declaration>` — the in-process twin of `parse line
+/// extern <decl>` (`IfcParseLine`'s `setPrototype` branch).
+///
+/// The parsed pieces are parked in two places, because two different consumers
+/// read them: on the function's own `FunctionSymbol` (where a CALLER's
+/// `ActionDefaultParams` finds them, so a call to this function renders typed),
+/// and in the program's pending-prototype store (where the function's OWN
+/// decompile finds them, since the drive rebuilds the `Funcdata` and the
+/// symbol-table link does not survive that).
+///
+/// The `<func>` operand is authoritative over the name inside the declaration:
+/// it says *which* function this signature describes, so `prototype sub_1400
+/// int handler(char *)` binds to `sub_1400`.
+fn apply_prototype(prog: &mut ConsoleProgram, func: &str, decl: &str) -> Result<(), String> {
+    use std::cell::RefCell;
+    let org = data_org(prog);
+    let text = format!("extern {}", with_semicolon(decl));
+    let captured: RefCell<Option<PrototypePieces>> = RefCell::new(None);
+    crate::grammar::parse_c(&text, prog.arch().types(), org, |pieces| {
+        *captured.borrow_mut() = Some(pieces);
+        Ok(())
+    })
+    .map_err(|e| e.explain().to_string())?;
+    let mut pieces = captured
+        .into_inner()
+        .ok_or_else(|| "not a function declaration".to_string())?;
+    pieces.name = func.to_string();
+    prog.arch_mut().set_function_prototype_pieces(func, pieces.clone());
+    apply_prototype_to_symbol(prog, &pieces);
+    prog.set_pending_prototype(func, pieces);
+    Ok(())
+}
+
+/// Lock the parsed prototype onto the named `FunctionSymbol` by retyping it to
+/// the prototype-bearing `TypeCode` (C++ `Architecture::setPrototype`).  A
+/// missing symbol is a no-op: the pending store above still carries the fact for
+/// the function's own decompile.
+fn apply_prototype_to_symbol(prog: &mut ConsoleProgram, pieces: &PrototypePieces) {
+    let arch = prog.arch_mut();
+    let Some(scope) = arch.symboltab.get_global_scope() else {
+        return;
+    };
+    let Some(sid) = arch.symboltab.query_function_by_name(scope, &pieces.name) else {
+        return;
+    };
+    if let Ok(tc) = arch.types().get_type_code_proto(pieces) {
+        let _ = arch.symboltab.retype_symbol(sid, tc);
+    }
+}
+
+/// `data <addr> <C typedeclaration>` — the in-process twin of the global branch
+/// of `map address` (`IfcMapaddress`): a named, typed, name+type-locked global
+/// mapped at `addr`, so a load through that address renders by name.
+fn apply_data(prog: &mut ConsoleProgram, vma: u64, decl: &str) -> Result<(), String> {
+    use kuna_decomp::varnode::varnode_flags;
+    let org = data_org(prog);
+    let addr = code_addr(prog, vma)
+        .ok_or_else(|| "the loaded program has no default code space".to_string())?;
+    let (ct, name) = crate::grammar::parse_type(decl, prog.arch().types(), org)
+        .map_err(|e| e.explain().to_string())?;
+    if name.is_empty() {
+        return Err("a data declaration must name the symbol".into());
+    }
+    let inherit = prog.arch().symboltab.get_property(&addr);
+    let flags = varnode_flags::namelock | varnode_flags::typelock | inherit;
+    let num_spaces = prog.arch().manage().num_spaces() as int4;
+    let arch = prog.arch_mut();
+    let (scope, basename) = arch
+        .symboltab
+        .find_create_scope_from_symbol_name(&name, "::", None, num_spaces)
+        .map_err(|e| e.explain().to_string())?;
+    let invalid = Address::new_invalid();
+    let (sym, _entry) = arch
+        .symboltab
+        .add_symbol_mapped(scope, &basename, ct, &addr, &invalid)
+        .map_err(|e| e.explain().to_string())?;
+    arch.symboltab.set_attribute(sym, flags);
+    Ok(())
+}
+
+/// The function-scoped facts a decompile of `name` must be seeded with.
+///
+/// `param` and `return` are consumed at flow time (they are the prototype the
+/// function is decompiled against), so they cannot be applied afterwards;
+/// `comment` is program state and is written here too, since it is keyed by the
+/// owning function's entry.
+#[derive(Default)]
+pub struct FunctionSeed {
+    /// `map param` storage locks, in the drive's `mapped_params` shape.
+    pub mapped_params: Vec<(int4, String, ParameterPieces)>,
+    /// The prototype this function is decompiled against (`prototype`, plus the
+    /// output storage a `return` directive locks).
+    pub pending_proto: Option<PrototypePieces>,
+}
+
+/// Build the [`FunctionSeed`] for the function `name` entered at `entry`, and
+/// record an outcome for every directive that bound to it.
+///
+/// `single` says the run selected exactly one function, which is what lets an
+/// unqualified directive bind (see the module docs).
+pub fn function_seed(
+    prog: &mut ConsoleProgram,
+    name: &str,
+    entry: &Address,
+    single: bool,
+) -> FunctionSeed {
+    let directives = prog.assertions().to_vec();
+    let mut seed = FunctionSeed {
+        pending_proto: prog.pending_prototype(name).cloned(),
+        ..Default::default()
+    };
+    for (i, directive) in directives.iter().enumerate() {
+        if directive.body.is_symbol_scoped() || !directive.body.is_function_scoped() {
+            continue;
+        }
+        if !binds_to(&directive.body, name, single) {
+            continue;
+        }
+        let outcome = match seed_one(prog, &directive.body, name, entry, &mut seed) {
+            Ok(()) => directive.applied(),
+            Err(detail) => directive.rejected(detail),
+        };
+        prog.set_assertion_outcome(i, outcome);
+    }
+    seed
+}
+
+fn seed_one(
+    prog: &mut ConsoleProgram,
+    body: &Body,
+    name: &str,
+    entry: &Address,
+    seed: &mut FunctionSeed,
+) -> Result<(), String> {
+    use kuna_decomp::fspec::parameter_pieces_flags;
+    let org = data_org(prog);
+    match body {
+        Body::Param { index, storage, decl, .. } => {
+            let addr = parse_storage(prog, storage)?;
+            let (ct, pname) = crate::grammar::parse_type(decl, prog.arch().types(), org)
+                .map_err(|e| e.explain().to_string())?;
+            let piece = ParameterPieces {
+                addr,
+                type_: Some(ct),
+                flags: parameter_pieces_flags::TYPELOCK | parameter_pieces_flags::NAMELOCK,
+            };
+            seed.mapped_params.push((*index, pname, piece));
+            Ok(())
+        }
+        Body::Return { storage, decl, .. } => {
+            let addr = parse_storage(prog, storage)?;
+            let (ct, _) = crate::grammar::parse_type(decl, prog.arch().types(), org)
+                .map_err(|e| e.explain().to_string())?;
+            let piece = ParameterPieces {
+                addr,
+                type_: Some(ct),
+                flags: parameter_pieces_flags::TYPELOCK,
+            };
+            // The output-only pieces `map return` parks: explicit storage, and
+            // the declared type as the return type (without which the model's
+            // `assignMap` has no output to work with — see
+            // `FuncProto::seed_locked_from_pieces`).
+            let proto = seed.pending_proto.get_or_insert_with(|| PrototypePieces {
+                name: name.to_string(),
+                first_var_arg_slot: -1,
+                ..Default::default()
+            });
+            proto.outtype = piece.type_.clone();
+            proto.output_storage = Some(piece);
+            Ok(())
+        }
+        Body::Comment { addr, text, .. } => {
+            let at = code_addr(prog, *addr)
+                .ok_or_else(|| "the loaded program has no default code space".to_string())?;
+            let arch = prog.arch_mut();
+            let ctype = arch.print().instruction_comment_flags();
+            arch.commentdb.add_comment(ctype, entry, &at, text);
+            Ok(())
+        }
+        _ => Err("internal: not a function-scoped directive".into()),
+    }
+}
+
+/// Are there symbol-scoped directives bound to `name`?  The second decompile
+/// pass exists only for these, so every run without one keeps its current cost.
+pub fn has_symbol_scoped(prog: &ConsoleProgram, name: &str, single: bool) -> bool {
+    prog.assertions()
+        .iter()
+        .any(|d| d.body.is_symbol_scoped() && binds_to(&d.body, name, single))
+}
+
+/// Apply the symbol-scoped directives (`name`, `type`) to the first pass's
+/// `Funcdata`, and return whether any of them took.
+///
+/// The caller re-decompiles when this returns `true`, carrying the mutated local
+/// scope across as `mapped_symbols` — the console's `decompile` / `rename` /
+/// `decompile` sequence, which is the only order in which these can work: the
+/// local a directive names does not exist until a decompile has produced it.
+///
+/// Directives are applied in the order the caller gave them, so
+/// `type v2 char[16]` followed by `name v2 credbuf` means what it reads like
+/// (the reverse order would leave the second directive naming a symbol the first
+/// had already renamed).
+pub fn apply_symbol_scoped(
+    prog: &mut ConsoleProgram,
+    fd: &mut Funcdata,
+    name: &str,
+    single: bool,
+) -> bool {
+    let directives = prog.assertions().to_vec();
+    let mut applied_any = false;
+    for (i, directive) in directives.iter().enumerate() {
+        if !directive.body.is_symbol_scoped() || !binds_to(&directive.body, name, single) {
+            continue;
+        }
+        let outcome = match apply_one_symbol_scoped(prog, fd, &directive.body) {
+            Ok(()) => {
+                applied_any = true;
+                directive.applied()
+            }
+            Err(detail) => directive.rejected(detail),
+        };
+        prog.set_assertion_outcome(i, outcome);
+    }
+    applied_any
+}
+
+fn apply_one_symbol_scoped(
+    prog: &ConsoleProgram,
+    fd: &mut Funcdata,
+    body: &Body,
+) -> Result<(), String> {
+    use kuna_decomp::database::symbol_category;
+    use kuna_decomp::varnode::varnode_flags;
+    let (symbol, retype) = match body {
+        Body::Name { symbol, .. } => (symbol.as_str(), None),
+        Body::Type { symbol, decl, .. } => {
+            let org = data_org(prog);
+            let parsed = crate::grammar::parse_type(decl, prog.arch().types(), org)
+                .map_err(|e| e.explain().to_string())?;
+            (symbol.as_str(), Some(parsed))
+        }
+        _ => return Err("internal: not a symbol-scoped directive".into()),
+    };
+    let found = fd
+        .get_scope_local()
+        .map(|lm| lm.query_by_name(symbol))
+        .unwrap_or_default();
+    match found.len() {
+        0 => return Err(format!("No symbol named: {symbol}")),
+        1 => {}
+        n => return Err(format!("More than one symbol named: {symbol} ({n})")),
+    }
+    let sym = found[0];
+    // A parameter's storage is model-derived; locking its name or type locks the
+    // input side of the prototype too (C++ `IfcRename`/`IfcRetype`).
+    let is_param = fd
+        .get_scope_local()
+        .map(|lm| lm.symbol_category(sym) == symbol_category::FUNCTION_PARAMETER)
+        .unwrap_or(false);
+    if is_param {
+        fd.get_func_proto_mut().set_input_lock(true);
+    }
+    let lm = fd
+        .get_scope_local_mut()
+        .ok_or_else(|| "Function has no local scope".to_string())?;
+    match (body, retype) {
+        (Body::Name { newname, .. }, _) => {
+            lm.rename_symbol(sym, newname).map_err(|e| e.explain().to_string())?;
+            lm.set_attribute(sym, varnode_flags::namelock | varnode_flags::typelock);
+        }
+        (Body::Type { .. }, Some((ct, newname))) => {
+            lm.retype_symbol(sym, ct).map_err(|e| e.explain().to_string())?;
+            lm.set_attribute(sym, varnode_flags::typelock);
+            if !newname.is_empty() && newname != symbol {
+                lm.rename_symbol(sym, &newname).map_err(|e| e.explain().to_string())?;
+                lm.set_attribute(sym, varnode_flags::namelock);
+            }
+        }
+        _ => unreachable!("symbol-scoped directive kinds are exhausted above"),
+    }
+    Ok(())
+}
+
+/// The outcome of a directive nothing claimed -- the load never reached the
+/// surface that applies it.  Reported rather than dropped, because a silently
+/// ignored assertion is the failure mode this plane exists to end.
+pub fn unclaimed(directive: &Directive) -> Outcome {
+    directive.rejected("not reached by this run")
+}
+
+/// The mutated local scope of the first pass, in the shape the second decompile
+/// re-seeds it from (`IfcDecompile` carries the same specs across its own IR
+/// rebuild).
+pub fn carried_symbols(fd: &Funcdata) -> Vec<(String, Rc<Datatype>, Address, uint4)> {
+    fd.mapped_symbol_specs()
+}

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -187,6 +187,21 @@ pub struct ConsoleProgram {
     /// Non-zero sizes only: a bare declaration with no extent leaves the entry
     /// unbounded, which is the engine-wide `UNBOUNDED_SIZE` default.
     declared_extents: BTreeMap<u64, int4>,
+    /// (kuna `--assert`) The caller-supplied assertions this program was loaded
+    /// with, in the order they were given -- the one override plane an agent
+    /// states facts through (`crate::assertions`).  Empty for every invocation
+    /// that passed none, which is what keeps the plane free.
+    assertions: Vec<crate::assertions::Directive>,
+    /// One slot per [`Self::assertions`] entry: what became of that directive.
+    /// `None` until something claims it, so a directive no surface reached is
+    /// still distinguishable from one that was applied.
+    assertion_outcomes: Vec<Option<crate::assertions::Outcome>>,
+    /// Prototypes parked by an `assert prototype <func> <decl>` directive, keyed
+    /// by function name -- the in-process twin of the console's
+    /// `IfaceDecompData::pending_prototypes` (`parse line extern`).  Consulted by
+    /// the decompile loop, because the drive rebuilds the `Funcdata` and the
+    /// symbol-table prototype link does not survive that rebuild.
+    pending_prototypes: BTreeMap<String, kuna_decomp::fspec::PrototypePieces>,
 }
 
 impl ConsoleProgram {
@@ -1092,6 +1107,53 @@ impl ConsoleProgram {
         !self.declared_extents.is_empty()
     }
 
+    // --- the `--assert` override plane (see `crate::assertions`) -------------
+
+    /// Install the caller's assertions.  One outcome slot is reserved per
+    /// directive so the report keeps the caller's own order however the
+    /// directives are later dispatched.
+    pub fn set_assertions(&mut self, directives: Vec<crate::assertions::Directive>) {
+        self.assertion_outcomes = vec![None; directives.len()];
+        self.assertions = directives;
+    }
+
+    /// The installed assertions, in the order they were given.
+    pub fn assertions(&self) -> &[crate::assertions::Directive] {
+        &self.assertions
+    }
+
+    /// Record what became of the `i`-th directive.
+    pub fn set_assertion_outcome(&mut self, i: usize, outcome: crate::assertions::Outcome) {
+        if let Some(slot) = self.assertion_outcomes.get_mut(i) {
+            *slot = Some(outcome);
+        }
+    }
+
+    /// The per-directive report, one row per installed assertion.
+    pub fn assertion_outcomes(&self) -> Vec<crate::assertions::Outcome> {
+        self.assertions
+            .iter()
+            .zip(self.assertion_outcomes.iter())
+            .map(|(directive, outcome)| {
+                outcome.clone().unwrap_or_else(|| crate::assertions::unclaimed(directive))
+            })
+            .collect()
+    }
+
+    /// Park a prototype for `func` (an `assert prototype` directive).
+    pub fn set_pending_prototype(
+        &mut self,
+        func: &str,
+        pieces: kuna_decomp::fspec::PrototypePieces,
+    ) {
+        self.pending_prototypes.insert(func.to_string(), pieces);
+    }
+
+    /// The prototype parked for `func`, if any.
+    pub fn pending_prototype(&self, func: &str) -> Option<&kuna_decomp::fspec::PrototypePieces> {
+        self.pending_prototypes.get(func)
+    }
+
     /// Declare a function at `addr` — the in-process twin of the console
     /// `map function <addr> [name]` command (`IfcMapfunction`), plus the extent
     /// the console form cannot express on its own.
@@ -1769,6 +1831,9 @@ pub fn bootstrap_program(
         analysis_image: None,
         loader_data_objects: Vec::new(),
         declared_extents: BTreeMap::new(),
+        assertions: Vec::new(),
+        assertion_outcomes: Vec::new(),
+        pending_prototypes: BTreeMap::new(),
     };
     // C++ `conf->readLoaderSymbols("::")` (testfunction.cc:160 / consolemain.cc:104):
     // install the binaryimage symbols as FunctionSymbols so a CALL to one resolves
@@ -2006,6 +2071,9 @@ pub fn bootstrap_from_object(
         analysis_image: Some((path.to_string(), bytes)),
         loader_data_objects,
         declared_extents: BTreeMap::new(),
+        assertions: Vec::new(),
+        assertion_outcomes: Vec::new(),
+        pending_prototypes: BTreeMap::new(),
     };
     // conf->readLoaderSymbols("::"): install the ELF symbols as FunctionSymbols.
     // The deferred analysis commit at `read symbols` REQUIRES this to have run

--- a/decompiler/crates/kuna-console/src/ifacedecomp.rs
+++ b/decompiler/crates/kuna-console/src/ifacedecomp.rs
@@ -319,7 +319,7 @@ fn engine_unavailable(entry: &str) -> IfaceError {
 /// `{...}` form errs (the join-space console syntax is unported).  `ignorecolon`
 /// controls whether `:` is a separator in the offset token (false: included,
 /// matching the C++ default).
-fn parse_machaddr(
+pub(crate) fn parse_machaddr(
     prog: &ConsoleProgram,
     s: &mut CommandStream,
     ignorecolon: bool,

--- a/decompiler/crates/kuna-console/src/lib.rs
+++ b/decompiler/crates/kuna-console/src/lib.rs
@@ -26,6 +26,7 @@ pub mod project;
 pub mod funcextent;
 pub mod codedata;
 pub mod kuna_console;
+pub mod assertions;
 pub mod grammar;
 pub mod rulecompile;
 pub mod unify;

--- a/decompiler/crates/kuna-console/src/project.rs
+++ b/decompiler/crates/kuna-console/src/project.rs
@@ -92,6 +92,9 @@ pub fn decompile_targets(
     want_provenance: bool,
 ) -> Vec<FuncResult> {
     let mut out = Vec::with_capacity(targets.len());
+    // (kuna `--assert`) An unqualified directive binds to "the function under
+    // decompile", which is only unambiguous when the run selected exactly one.
+    let single_target = targets.len() == 1;
     for FunctionEntry {
         name,
         addr: entry,
@@ -184,16 +187,63 @@ pub fn decompile_targets(
         // bounds this function's flow follow; 0 — the usual case — is the natural,
         // unbounded extent.
         let declared = prog.declared_extent(address);
-        match crate::decompile_step::decompile_one(
+        // (kuna `--assert`) The caller-declared facts this function is decompiled
+        // AGAINST: a `prototype`/`param`/`return` directive is consumed at flow
+        // time, so it has to be seeded here rather than applied afterwards. Every
+        // field is empty for a run that passed no directive, which is what makes
+        // the plane free (`crate::assertions`).
+        let seed = crate::assertions::function_seed(prog, &name, &entry, single_target);
+        let step = crate::decompile_step::decompile_one(
             prog.arch_mut(),
             &name,
-            entry,
+            entry.clone(),
             declared,
-            &crate::decompile_step::DecompileSeed::plain(&mapped, &flow_ovr),
+            &crate::decompile_step::DecompileSeed {
+                mapped_symbols: &mapped,
+                usepoint_symbols: &[],
+                dynamic_symbols: &[],
+                pending_proto: seed.pending_proto.as_ref(),
+                flow_overrides: &flow_ovr,
+                mapped_params: &seed.mapped_params,
+            },
             &[],
-        )
-        .result
-        {
+        );
+        // (kuna `--assert`) The symbol-scoped second pass. `name`/`type` name a
+        // LOCAL, and a local does not exist until a decompile has produced it --
+        // so the only order in which they can work is decompile, mutate the local
+        // scope, decompile again with the mutation carried across (exactly the
+        // console's `decompile` / `rename` / `decompile` sequence). Emitted only
+        // when such a directive actually bound to this function, so every other
+        // invocation keeps its current cost.
+        let result = match step.result {
+            Ok(mut fd)
+                if crate::assertions::has_symbol_scoped(prog, &name, single_target) =>
+            {
+                if crate::assertions::apply_symbol_scoped(prog, &mut fd, &name, single_target) {
+                    let carried = crate::assertions::carried_symbols(&fd);
+                    crate::decompile_step::decompile_one(
+                        prog.arch_mut(),
+                        &name,
+                        entry,
+                        declared,
+                        &crate::decompile_step::DecompileSeed {
+                            mapped_symbols: &carried,
+                            usepoint_symbols: &[],
+                            dynamic_symbols: &[],
+                            pending_proto: seed.pending_proto.as_ref(),
+                            flow_overrides: &flow_ovr,
+                            mapped_params: &seed.mapped_params,
+                        },
+                        &[],
+                    )
+                    .result
+                } else {
+                    Ok(fd)
+                }
+            }
+            other => other,
+        };
+        match result {
             Ok(fd) => {
                 // Render + extract under `catch_unwind`: the decompile drive only
                 // guards the pipeline (decompile_drive.rs), so a fail-fast invariant

--- a/decompiler/crates/kuna-console/tests/verify_assertplane.rs
+++ b/decompiler/crates/kuna-console/tests/verify_assertplane.rs
@@ -1,0 +1,362 @@
+//! The `--assert` override plane end-to-end — `docs/re-needs/no-cli-rename-or-prototype-override.md`.
+//!
+//! `rename`, `retype`, `map param`, `map return`, `map address`, `comment
+//! instruction` and `parse line extern` all work in the console, and none of
+//! them was reachable from the `kuna` binary. This drives the in-process path
+//! `kuna decompile --json` / `decompile-all` take, and asserts for every
+//! directive that **the emitted C changed** — not that the command returned Ok.
+//!
+//! That distinction is the whole point. `override prototype` has printed
+//! "Successfully added override" and changed nothing since it was ported, and it
+//! got there by being reviewed on its return value. A directive that is accepted
+//! and inert is worse than one that errors, because an agent cannot tell.
+//!
+//! Fixture: `kuna-analysis/tests/fixtures/fauxware` — a small unstripped x86-64
+//! ELF whose `authenticate` has an 8-byte stack buffer (`v2`), two pointer
+//! parameters and a call to a named global (`sneaky`), so every directive has
+//! something observable to move.
+//!
+//! ## `.sla` precondition
+//!
+//! Bootstrapping needs the built x86 `.sla` under `specs/` (gitignored; `make
+//! specs`). When it is absent the bootstrap fails; the test prints that and
+//! returns early (a specs-less CI is a visible skip, never a false green).
+
+use std::path::PathBuf;
+
+use kuna_console::assertions::{self, Body, Directive, Outcome};
+use kuna_console::engine::{bootstrap_from_object, ConsoleProgram, EntrySelector};
+use kuna_console::project::decompile_targets;
+
+const TARGET: &str = "authenticate";
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+/// Bootstrap the fixture and run the analysis commit.  `None` ⇒ specs-less skip.
+fn load() -> Option<ConsoleProgram> {
+    let root = repo_root();
+    let spec_roots = vec![root.join("specs").to_str().unwrap().to_string()];
+    let bin = root.join("decompiler/crates/kuna-analysis/tests/fixtures/fauxware");
+    let mut prog = match bootstrap_from_object(bin.to_str()?, "", &spec_roots) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "verify_assertplane: skipping (bootstrap failed, build `.sla` with \
+                 `make specs`): {}",
+                e.explain()
+            );
+            return None;
+        }
+    };
+    prog.commit_pending_analysis().expect("analysis commit");
+    Some(prog)
+}
+
+fn directive(spec: &str, body: Body) -> Directive {
+    Directive { raw: spec.to_string(), body }
+}
+
+/// Decompile `authenticate` under `directives`, returning `(C, report)`.
+fn decompile_with(directives: Vec<Directive>) -> Option<(String, Vec<Outcome>)> {
+    let mut prog = load()?;
+    if !directives.is_empty() {
+        prog.set_assertions(directives);
+        assertions::apply_program_scoped(&mut prog);
+    }
+    let entry = prog
+        .resolve_entry(&EntrySelector::Name(TARGET.to_string()))
+        .expect("fauxware has an `authenticate`");
+    let funcs = decompile_targets(&mut prog, vec![entry], false, false, false);
+    let code = funcs[0].code.clone().unwrap_or_default();
+    Some((code, prog.assertion_outcomes()))
+}
+
+/// Every outcome is `applied`; panics naming the offender otherwise.
+fn all_applied(report: &[Outcome]) {
+    for outcome in report {
+        assert_eq!(
+            outcome.status, "applied",
+            "{:?} was rejected: {:?}",
+            outcome.directive, outcome.detail
+        );
+    }
+}
+
+/// The un-asserted baseline every case below is measured against.
+#[test]
+fn the_baseline_names_nothing_the_directives_name() {
+    let Some((code, report)) = decompile_with(Vec::new()) else { return };
+    assert!(report.is_empty(), "no directives ⇒ no report rows");
+    assert!(code.contains("char v2 [8]"), "baseline lost its 8-byte buffer:\n{code}");
+    assert!(!code.contains("credbuf"), "baseline already names credbuf:\n{code}");
+    assert!(code.contains("sneaky"), "baseline lost the named global:\n{code}");
+}
+
+/// `prototype` + `type` + `name` — the acceptance probe's three directives, and
+/// the need's own headline: an agent states the signature, a local's type and a
+/// local's name in one invocation and all three land in the C.
+#[test]
+fn prototype_type_and_name_all_reach_the_emitted_c() {
+    let Some((code, report)) = decompile_with(vec![
+        directive(
+            "prototype authenticate int4 authenticate(char *user,char *pass)",
+            Body::Prototype {
+                func: TARGET.into(),
+                decl: "int4 authenticate(char *user,char *pass)".into(),
+            },
+        ),
+        directive(
+            "type v2 char[16]",
+            Body::Type { func: None, symbol: "v2".into(), decl: "char[16]".into() },
+        ),
+        directive(
+            "name v2 credbuf",
+            Body::Name { func: None, symbol: "v2".into(), newname: "credbuf".into() },
+        ),
+    ]) else {
+        return;
+    };
+    all_applied(&report);
+    assert!(
+        code.contains("authenticate(char *user,char *pass)"),
+        "the declared signature did not reach the C:\n{code}"
+    );
+    assert!(code.contains("char credbuf [16];"), "the retype+rename did not land:\n{code}");
+    assert!(!code.contains("char v2 [8]"), "the original buffer survived:\n{code}");
+}
+
+/// A directive is applied in the order it was given: `type` then `name` retypes
+/// and then renames, where the reverse order leaves the second naming a symbol
+/// the first already renamed away.  The rejection is reported, not swallowed.
+#[test]
+fn directive_order_is_the_callers_order_and_a_miss_is_reported() {
+    let Some((code, report)) = decompile_with(vec![
+        directive(
+            "name v2 credbuf",
+            Body::Name { func: None, symbol: "v2".into(), newname: "credbuf".into() },
+        ),
+        directive(
+            "type v2 char[16]",
+            Body::Type { func: None, symbol: "v2".into(), decl: "char[16]".into() },
+        ),
+    ]) else {
+        return;
+    };
+    assert_eq!(report[0].status, "applied");
+    assert_eq!(report[1].status, "rejected");
+    assert_eq!(report[1].detail.as_deref(), Some("No symbol named: v2"));
+    // The rename still took, so the run is not all-or-nothing: an agent batching
+    // forty renames against a re-decompiled binary does not lose the other 39.
+    assert!(code.contains("credbuf"), "the applied half was rolled back:\n{code}");
+}
+
+/// `param` — a locked input storage and name (`map param`).
+#[test]
+fn param_locks_the_input_storage_and_name() {
+    let Some((code, report)) = decompile_with(vec![directive(
+        "param 0 %RDI char *username",
+        Body::Param {
+            func: None,
+            index: 0,
+            storage: "%RDI".into(),
+            decl: "char *username".into(),
+        },
+    )]) else {
+        return;
+    };
+    all_applied(&report);
+    assert!(
+        code.contains("authenticate(char *username)"),
+        "the locked parameter did not reach the signature:\n{code}"
+    );
+}
+
+/// `return` — a locked return storage and type (`map return`).
+///
+/// This is also the regression for the abort below: the directive parks pieces
+/// that carry output storage, and before the fix those aborted the process.
+#[test]
+fn return_locks_the_output_storage_and_type() {
+    let Some((code, report)) = decompile_with(vec![directive(
+        "return %RAX int4",
+        Body::Return { func: None, storage: "%RAX".into(), decl: "int4".into() },
+    )]) else {
+        return;
+    };
+    all_applied(&report);
+    assert!(
+        code.starts_with("int4 authenticate") || code.starts_with("int authenticate"),
+        "the locked return type did not reach the signature:\n{code}"
+    );
+}
+
+/// `typedef` interns a type, and `type` can then name it — the pair is what lets
+/// an agent describe a structure kuna never saw.
+#[test]
+fn a_typedef_is_nameable_by_a_later_type_directive() {
+    let Some((code, report)) = decompile_with(vec![
+        directive(
+            "typedef struct creds { char raw[16]; };",
+            Body::Typedef { decl: "struct creds { char raw[16]; };".into() },
+        ),
+        directive(
+            "type v2 creds",
+            Body::Type { func: None, symbol: "v2".into(), decl: "creds".into() },
+        ),
+    ]) else {
+        return;
+    };
+    all_applied(&report);
+    assert!(code.contains("creds v2;"), "the interned struct did not type the local:\n{code}");
+    assert!(code.contains("v2.raw"), "the struct fields did not render:\n{code}");
+}
+
+/// `data` — a named, typed global (`map address`), observable at the call that
+/// passes it.
+#[test]
+fn data_renames_the_global_at_its_use() {
+    let Some((code, report)) = decompile_with(vec![directive(
+        "data 0x601048 char *shadowpw",
+        Body::Data { addr: 0x601048, decl: "char *shadowpw".into() },
+    )]) else {
+        return;
+    };
+    all_applied(&report);
+    assert!(code.contains("shadowpw"), "the declared global did not reach the C:\n{code}");
+    assert!(!code.contains("sneaky"), "the loader name survived the declaration:\n{code}");
+}
+
+/// `comment` — an agent's own note, rendered into the C at the instruction.
+#[test]
+fn comment_reaches_the_emitted_c() {
+    let Some((code, report)) = decompile_with(vec![directive(
+        "comment 0x400699 open the credentials file",
+        Body::Comment {
+            func: None,
+            addr: 0x400699,
+            text: "open the credentials file".into(),
+        },
+    )]) else {
+        return;
+    };
+    all_applied(&report);
+    assert!(
+        code.contains("/* open the credentials file */"),
+        "the comment did not reach the C:\n{code}"
+    );
+}
+
+/// `function` — the `--define-function` spelling, carried by the same plane.
+#[test]
+fn function_declares_a_bounded_entry() {
+    let Some(mut prog) = load() else { return };
+    prog.set_assertions(vec![directive(
+        "function 0x400664-0x400680=authstub",
+        Body::Function { start: 0x400664, end: Some(0x400680), name: Some("authstub".into()) },
+    )]);
+    assertions::apply_program_scoped(&mut prog);
+    all_applied(&prog.assertion_outcomes());
+    let entry = prog
+        .resolve_entry(&EntrySelector::Name("authstub".to_string()))
+        .expect("the declared name resolves");
+    assert_eq!(entry.addr.get_offset(), 0x400664);
+    let funcs = decompile_targets(&mut prog, vec![entry], true, false, false);
+    assert_eq!(funcs[0].name, "authstub");
+    assert_eq!(funcs[0].size, 0x1c, "the declared extent is what the record reports");
+}
+
+/// An unqualified symbol-scoped directive cannot bind on a multi-function run —
+/// it would silently mean "every function that happens to have a `v2`" — so it is
+/// rejected with a detail that says how to write it instead.  A qualified one
+/// binds to exactly the function it names.
+#[test]
+fn a_multi_function_run_needs_the_directive_to_name_its_function() {
+    let Some(mut prog) = load() else { return };
+    prog.set_assertions(vec![
+        directive(
+            "name v2 credbuf",
+            Body::Name { func: None, symbol: "v2".into(), newname: "credbuf".into() },
+        ),
+        directive(
+            "name authenticate::v2 credbuf",
+            Body::Name {
+                func: Some(TARGET.into()),
+                symbol: "v2".into(),
+                newname: "credbuf".into(),
+            },
+        ),
+    ]);
+    assertions::apply_program_scoped(&mut prog);
+    let targets: Vec<_> = ["authenticate", "main"]
+        .iter()
+        .map(|n| prog.resolve_entry(&EntrySelector::Name(n.to_string())).expect("resolves"))
+        .collect();
+    let funcs = decompile_targets(&mut prog, targets, true, false, false);
+    let report = prog.assertion_outcomes();
+    assert_eq!(report[0].status, "rejected", "an unqualified directive bound anyway");
+    assert!(
+        report[0].detail.as_deref().unwrap_or_default().contains("<func>::<operand>"),
+        "the rejection does not say how to qualify it: {:?}",
+        report[0].detail
+    );
+    assert_eq!(report[1].status, "applied");
+    let authenticate = funcs.iter().find(|f| f.name == "authenticate").expect("decompiled");
+    assert!(
+        authenticate.code.as_deref().unwrap_or_default().contains("credbuf"),
+        "the qualified directive did not reach its function"
+    );
+}
+
+/// A `map return`-shaped prototype — explicit output storage and NO declared
+/// return type — used to abort the process (`outtype null`,
+/// `ParamListStandardOut::assignMap`) the moment its function was decompiled, so
+/// the one console command an agent would reach for to fix a return value killed
+/// the session.  The declared type is the return type.
+#[test]
+fn output_only_prototype_pieces_do_not_abort_the_drive() {
+    use kuna_decomp::fspec::{parameter_pieces_flags, ParameterPieces, PrototypePieces};
+    let Some(mut prog) = load() else { return };
+    let entry = prog
+        .resolve_entry(&EntrySelector::Name(TARGET.to_string()))
+        .expect("fauxware has an `authenticate`");
+    let int4 = prog
+        .arch()
+        .types()
+        .get_base(4, kuna_decomp::dtype::type_metatype::TYPE_INT)
+        .expect("int4");
+    let rax = prog
+        .arch()
+        .manage()
+        .get_space_by_name("register")
+        .map(|s| kuna_base::address::Address::new(std::rc::Rc::clone(s), 0))
+        .expect("x86-64 has a register space");
+    let pieces = PrototypePieces {
+        name: TARGET.to_string(),
+        first_var_arg_slot: -1,
+        output_storage: Some(ParameterPieces {
+            addr: rax,
+            type_: Some(int4),
+            flags: parameter_pieces_flags::TYPELOCK,
+        }),
+        ..Default::default()
+    };
+    let addr = entry.addr.clone();
+    let step = kuna_console::decompile_step::decompile_one(
+        prog.arch_mut(),
+        TARGET,
+        addr,
+        0,
+        &kuna_console::decompile_step::DecompileSeed {
+            mapped_symbols: &[],
+            usepoint_symbols: &[],
+            dynamic_symbols: &[],
+            pending_proto: Some(&pieces),
+            flow_overrides: &[],
+            mapped_params: &[],
+        },
+        &[],
+    );
+    assert!(step.result.is_ok(), "an output-only prototype aborted the drive");
+}

--- a/decompiler/crates/kuna-decomp/src/p4_calls/fspec.rs
+++ b/decompiler/crates/kuna-decomp/src/p4_calls/fspec.rs
@@ -5623,6 +5623,20 @@ impl FuncProto {
             self.set_output_lock(false);
             return Ok(());
         }
+        // (kuna) A `map return <addr> <type>` parks OUTPUT-ONLY pieces: explicit
+        // storage, and no `outtype` because the directive declares no separate
+        // return type. But `assignParameterStorage` dereferences `outtype`
+        // unconditionally, so those pieces aborted the process the moment the
+        // function was decompiled. The declared type IS the return type — adopt it
+        // and the model has something to assign against, after which `set_pieces`
+        // replaces the derived storage with the explicit one as before.
+        if pieces.outtype.is_none() {
+            if let Some(declared) = pieces.output_storage.as_ref().and_then(|p| p.type_.clone()) {
+                let mut typed = pieces.clone();
+                typed.outtype = Some(declared);
+                return self.set_pieces(&typed, Some(defaultfp), typefactory, manager);
+            }
+        }
         self.set_pieces(pieces, Some(defaultfp), typefactory, manager)
     }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -88,6 +88,92 @@ accepted by `decompile`, `decompile-all`, `functions`, `decompile-project` and
 overrides discovery rather than competing with it. The console spelling, for a
 hand-driven `decomp_dbg` session, is `function bounds <start> [<end>] [as <name>]`.
 
+**`--assert <directive> | @file`** (repeatable) is the other half: where
+`--define-function` tells kuna where a function *is*, `--assert` tells it what
+anything *is*. Everything kuna knows it derived, and until this flag the only
+levers the `kuna` binary offered were `--option` and `--kassert` — the console has
+carried `rename`, `retype`, `map param`, `map return`, `map address`,
+`comment instruction` and `parse line extern` all along, unreachable.
+
+```bash
+kuna decompile ./a.out authenticate --json \
+  --assert 'prototype authenticate int authenticate(char *user,char *pass)' \
+  --assert 'type v2 char[16]' \
+  --assert 'name v2 credbuf'
+```
+
+```text
+- unsigned long authenticate(char *a0,char *a1)     - char v2 [8];
++ int authenticate(char *user,char *pass)           + char credbuf [16];
+```
+
+One directive per `--assert`, keyed by intent rather than by phase:
+
+| directive | what it states |
+|---|---|
+| `prototype <func> <C declaration>` | the function's signature (parameter names included) |
+| `param [<func>::]<i> <storage> <C typedecl>` | the storage and type of one input |
+| `return [<func>::]<storage> <C typedecl>` | the storage and type of the return value |
+| `name [<func>::]<symbol> <newname>` | rename a local |
+| `type [<func>::]<symbol> <C type>` | retype a local |
+| `typedef <C declaration>` | intern a `struct`/`union`/`enum`/`typedef` so `type` can name it |
+| `data <addr> <C typedeclaration>` | a named, typed global at an address |
+| `comment [<func>::]<addr> <text>` | a comment rendered into the C at that instruction |
+| `function <start>[-<end>][=<name>]` | the `--define-function` spelling, on this plane |
+
+Storage is a register name (`RDI`), the console's `%RDI`, or its address grammar
+(`[stack,-0x18,8]`). Addresses are hexadecimal with or without `0x`. A C type may
+be anything the console's `parse line` accepts, including a `typedef` you asserted
+earlier in the same run.
+
+**Every directive's fate is reported.** `--json` grows an `assertions` array — one
+row per directive, in the order you gave them, carrying the directive text, its
+phase and sub-phase, `applied` or `rejected`, and a reason:
+
+```json
+{"directive": "name v9 credbuf", "kind": "name", "phase": "P9",
+ "subphase": "naming-policy", "status": "rejected",
+ "detail": "No symbol named: v9"}
+```
+
+A rejection is also printed on stderr, on both surfaces. It is **not** fatal by
+default — a batch of forty renames against a re-decompiled binary must not lose the
+other thirty-nine to one stale name — and `--assert-strict` makes any rejection
+exit non-zero.
+
+**Order matters, and so does scoping.** Directives are applied in the order given:
+`type v2 char[16]` then `name v2 credbuf` retypes and then renames, where the
+reverse leaves the second naming a symbol the first renamed away. `name` and
+`type` name a *local*, which does not exist until the function has been decompiled
+once, so kuna decompiles it twice — but only when such a directive is present, so
+nothing else pays for it. A directive that names no function binds to the function
+being decompiled; on a run that decompiles more than one (`decompile-all`,
+`decompile-project`) it is rejected rather than applied to every function that
+happens to have a `v2`, so qualify it:
+
+```bash
+kuna decompile-all ./a.out --json --assert 'name authenticate::v2 credbuf'
+```
+
+The `@file` form is the durable one, exactly as for `--define-function`: one
+directive per line, `#` comments and blank lines skipped, and the file is the
+artifact — kuna does not write assertions back into the image.
+
+```bash
+cat > overrides.kuna <<'EOF'
+# worked out from the strings and the xrefs
+prototype sub_401200 int check_license(char *key,int len)
+name sub_401200::v3 keylen
+type sub_401200::v2 char[32]
+data 0x601048 char *expected_key
+EOF
+kuna decompile ./a.out sub_401200 --json --assert @overrides.kuna
+```
+
+Accepted by `decompile`, `decompile-all`, `decompile-project` and `functions`.
+The console spellings, for a hand-driven `decomp_dbg` session, are the commands in
+the table's second column.
+
 **Paths containing spaces work (DIV-100).** This is the one surface that reaches the engine
 through a console *script* rather than an in-process call, and the console reads a
 filename with `s >> filename` — whitespace-delimited. An unquoted path with a space

--- a/docs/features/no-cli-rename-or-prototype-override/pr_body.md
+++ b/docs/features/no-cli-rename-or-prototype-override/pr_body.md
@@ -1,0 +1,111 @@
+## What is broken
+
+Three backlog records, all severity **major**, all filed in round 2, say the same thing about
+three different subjects — an agent can read a kuna decompilation but cannot correct one.
+
+> `rename`, `retype`, `map param`, `map return`, `override prototype` and `parse line extern ...`
+> are all functional in the console and none is reachable from `kuna`. [...] For an agent, a
+> rename that does not persist is the difference between reading a decompilation once and
+> actually working through one.
+> — `no-cli-rename-or-prototype-override`, instances 1, rounds [2]
+
+`no-cli-data-code-override` (instances 1) and `no-cli-structuring-override` (instances 1) are
+the same wall for data/code ranges and for the CFG. The captain dispatched this need as the
+family's **one design**, with three standing instructions: cover all three siblings, answer the
+cheap/expensive question as a table, and file the acceptance probe this need has never had.
+
+This PR is that design. **It changes no source file** — the diff is the proposal, its record,
+and the need's new `## Acceptance` section.
+
+## What was measured
+
+Everything in the proposal's tables was measured by driving `decomp_dbg` directly at
+`e3db5512` on in-repo fixtures. "Reaches C" means the *printed C changed*, not that the command
+returned Ok — which turned out to be the distinction that matters.
+
+- **11 console commands reach emitted C today** and only lack a path from the `kuna` binary.
+  `parse line extern int4 authenticate(char *user,char *pass);` renames both parameters through
+  the whole body; `override flow 0x4006aa branch` turns a CALL into a tail-call and restructures
+  the function; `map param 0 [register,0x38,8] char *username` rewrites the signature.
+- **The shared Hypothesis is overturned on its second half.** "The expensive half is the stubs"
+  assumes engine ports are missing. They are not: `Override::insert_force_goto`,
+  `Funcdata::install_jump_table`, `Override::insert_deadcode_delay`, `Symbol::set_isolated` and
+  `FuncProto::set_input_lock/set_output_lock` are all already in `kuna-decomp`, and the stub
+  message blaming `parse_machaddr`/`parse_C` is stale — both are implemented and in use. Same
+  finding, same shape, as `no-cli-function-boundary-override`.
+- **The real expensive half is two shipped commands that lie**, which no source reading finds:
+  `map return` **panics the process** (`outtype null`, `p4_calls/fspec.rs:2624`), and
+  `override prototype` prints `Successfully added override` and changes nothing — measured on
+  both a direct known callee and an indirect call.
+- **Two further CLI-level defects, in no need:** `kuna decompile --kassert "p9 naming-policy v2
+  buf"` exits 0 and does nothing (the assertion is emitted before the first `decompile`, so the
+  local does not exist yet and the error goes into a discarded transcript), and `--kassert` is
+  rejected outright alongside `--json`.
+
+## The mechanism
+
+`--assert <directive> | @FILE`, repeatable, on `decompile` / `decompile-all` /
+`decompile-project` — one intent-keyed vocabulary (`prototype`, `param`, `return`, `name`,
+`type`, `data`, `label`, `readonly`, `volatile`, `flow`, `goto`, `jumptable`, …) lowering onto
+the console commands that already work, with an `assertions[]` array in every `--json` reporting
+each directive as `applied` or `rejected` with a reason. The `@FILE` contract is `--define-
+function`'s (#374) verbatim, because that is what makes an override durable across runs.
+
+The in-process half is largely already built: `decompile_step::DecompileSeed` is the shared
+"console-only facts" carrier whose slices the whole-binary loop leaves empty, and
+`decompile_one` already contains a decompile → adjust → re-decompile loop. Staged as A (this
+need) / B (`no-cli-data-code-override`) / C (`no-cli-structuring-override`), so the siblings
+collapse into a directive-table row and a stub to wire rather than each burning a builder.
+
+## The acceptance probe
+
+`verify --acceptance-suite` reported this need **`unrunnable`** before this branch — "no
+acceptance probe on the record or in the probe store" — so nothing built on it could ever have
+been closed by `B_DONE`. It now carries `a-a58fc408288b`:
+
+```
+kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/fauxware authenticate --json \
+  --assert 'prototype authenticate int4 authenticate(char *user,char *pass)' \
+  --assert 'type v2 char[16]' \
+  --assert 'name v2 credbuf'
+```
+
+asserting `assertions` has 3 rows all `applied`, and that the C contains
+`authenticate(char *user,char *pass)` and `char credbuf [16];` and no longer contains
+`char v2 [8]`.
+
+It is **runnable and failing**, which is exactly right for an unimplemented acceptance:
+
+```
+passed: false  unrunnable: false
+  exit_code   expected {"eq": 0}   actual 2       (error: unknown option --assert)
+  stdout_is_json   expected true   actual false
+  json[0..6]  <stdout is not JSON>
+```
+
+Its target C is not aspirational — it was produced end-to-end by `decomp_dbg` at `e3db5512`,
+on that same in-repo fixture, by the exact console script Stage A would generate:
+
+```
+int4 authenticate(char *user,char *pass) // return-dupe x2
+{
+  char credbuf [16]; // stack - 0x18
+  int4 v1; // eax
+  ...
+```
+
+The engine already produces the acceptance output. Stage A is the path to it.
+
+## Gates
+
+No source file changed, so no gate can move: the diff is `docs/features/no-cli-rename-or-
+prototype-override/{proposal.md,record.json,pr_body.md}`, `docs/re-needs/no-cli-rename-or-
+prototype-override.md` and the regenerated `docs/re-needs/index.json`.
+
+- `python -m scripts.repipe.needs reindex` — 35 needs indexed, clean round-trip
+- `python -m scripts.repipe.verify --acceptance-suite --need no-cli-rename-or-prototype-override`
+  — `unrunnable: false`, `passed: false` (was `unrunnable: true` at `e3db5512`)
+- `kuna catalog --json` swept for a covering option: 137 rows, none matching
+  rename/retype/prototype-override — not a default-flip candidate
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/no-cli-rename-or-prototype-override/pr_body.md
+++ b/docs/features/no-cli-rename-or-prototype-override/pr_body.md
@@ -1,111 +1,148 @@
-## What is broken
+## What was broken
 
-Three backlog records, all severity **major**, all filed in round 2, say the same thing about
-three different subjects — an agent can read a kuna decompilation but cannot correct one.
+> `rename`, `retype`, `map param`, `map return`, `override prototype` and
+> `parse line extern ...` are all functional in the console and none is reachable from
+> `kuna`. [...] For an agent, a rename that does not persist is the difference between
+> reading a decompilation once and actually working through one.
+>
+> — `docs/re-needs/no-cli-rename-or-prototype-override.md` (severity major, instances 1, rounds [2])
 
-> `rename`, `retype`, `map param`, `map return`, `override prototype` and `parse line extern ...`
-> are all functional in the console and none is reachable from `kuna`. [...] For an agent, a
-> rename that does not persist is the difference between reading a decompilation once and
-> actually working through one.
-> — `no-cli-rename-or-prototype-override`, instances 1, rounds [2]
+Everything kuna knows about a program it *derived*. The console has carried the commands
+that correct each derivation all along; the `kuna` binary's generated script emitted a fixed
+vocabulary — `option`, `read symbols`, `load`, `kassert`, `function bounds`, `decompile` —
+and nothing else. `--kassert` exists but only its `Option` and `Rename` arms do real work,
+and the `Rename` one is a **silent no-op from the CLI**: it is emitted before the first
+`decompile`, so the local it names does not exist yet and `No symbol named: v2` goes into a
+transcript the CLI discards. `--kassert` is also refused outright with `--json`, so for an
+agent consuming machine-readable output the override surface did not exist at all.
 
-`no-cli-data-code-override` (instances 1) and `no-cli-structuring-override` (instances 1) are
-the same wall for data/code ranges and for the CFG. The captain dispatched this need as the
-family's **one design**, with three standing instructions: cover all three siblings, answer the
-cheap/expensive question as a table, and file the acceptance probe this need has never had.
-
-This PR is that design. **It changes no source file** — the diff is the proposal, its record,
-and the need's new `## Acceptance` section.
-
-## What was measured
-
-Everything in the proposal's tables was measured by driving `decomp_dbg` directly at
-`e3db5512` on in-repo fixtures. "Reaches C" means the *printed C changed*, not that the command
-returned Ok — which turned out to be the distinction that matters.
-
-- **11 console commands reach emitted C today** and only lack a path from the `kuna` binary.
-  `parse line extern int4 authenticate(char *user,char *pass);` renames both parameters through
-  the whole body; `override flow 0x4006aa branch` turns a CALL into a tail-call and restructures
-  the function; `map param 0 [register,0x38,8] char *username` rewrites the signature.
-- **The shared Hypothesis is overturned on its second half.** "The expensive half is the stubs"
-  assumes engine ports are missing. They are not: `Override::insert_force_goto`,
-  `Funcdata::install_jump_table`, `Override::insert_deadcode_delay`, `Symbol::set_isolated` and
-  `FuncProto::set_input_lock/set_output_lock` are all already in `kuna-decomp`, and the stub
-  message blaming `parse_machaddr`/`parse_C` is stale — both are implemented and in use. Same
-  finding, same shape, as `no-cli-function-boundary-override`.
-- **The real expensive half is two shipped commands that lie**, which no source reading finds:
-  `map return` **panics the process** (`outtype null`, `p4_calls/fspec.rs:2624`), and
-  `override prototype` prints `Successfully added override` and changes nothing — measured on
-  both a direct known callee and an indirect call.
-- **Two further CLI-level defects, in no need:** `kuna decompile --kassert "p9 naming-policy v2
-  buf"` exits 0 and does nothing (the assertion is emitted before the first `decompile`, so the
-  local does not exist yet and the error goes into a discarded transcript), and `--kassert` is
-  rejected outright alongside `--json`.
+This is Stage A of the approved proposal (`docs/features/no-cli-rename-or-prototype-override/proposal.md`).
 
 ## The mechanism
 
-`--assert <directive> | @FILE`, repeatable, on `decompile` / `decompile-all` /
-`decompile-project` — one intent-keyed vocabulary (`prototype`, `param`, `return`, `name`,
-`type`, `data`, `label`, `readonly`, `volatile`, `flow`, `goto`, `jumptable`, …) lowering onto
-the console commands that already work, with an `assertions[]` array in every `--json` reporting
-each directive as `applied` or `rejected` with a reason. The `@FILE` contract is `--define-
-function`'s (#374) verbatim, because that is what makes an override durable across runs.
+`--assert <directive> | @FILE`, repeatable, on `decompile`, `decompile-all`,
+`decompile-project` and `functions`.
 
-The in-process half is largely already built: `decompile_step::DecompileSeed` is the shared
-"console-only facts" carrier whose slices the whole-binary loop leaves empty, and
-`decompile_one` already contains a decompile → adjust → re-decompile loop. Staged as A (this
-need) / B (`no-cli-data-code-override`) / C (`no-cli-structuring-override`), so the siblings
-collapse into a directive-table row and a stub to wire rather than each burning a builder.
-
-## The acceptance probe
-
-`verify --acceptance-suite` reported this need **`unrunnable`** before this branch — "no
-acceptance probe on the record or in the probe store" — so nothing built on it could ever have
-been closed by `B_DONE`. It now carries `a-a58fc408288b`:
-
-```
-kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/fauxware authenticate --json \
-  --assert 'prototype authenticate int4 authenticate(char *user,char *pass)' \
+```bash
+kuna decompile ./a.out authenticate --json \
+  --assert 'prototype authenticate int authenticate(char *user,char *pass)' \
   --assert 'type v2 char[16]' \
   --assert 'name v2 credbuf'
 ```
 
-asserting `assertions` has 3 rows all `applied`, and that the C contains
-`authenticate(char *user,char *pass)` and `char credbuf [16];` and no longer contains
-`char v2 [8]`.
-
-It is **runnable and failing**, which is exactly right for an unimplemented acceptance:
-
-```
-passed: false  unrunnable: false
-  exit_code   expected {"eq": 0}   actual 2       (error: unknown option --assert)
-  stdout_is_json   expected true   actual false
-  json[0..6]  <stdout is not JSON>
+```text
+- unsigned long authenticate(char *a0,char *a1)     - char v2 [8];
++ int authenticate(char *user,char *pass)           + char credbuf [16];
 ```
 
-Its target C is not aspirational — it was produced end-to-end by `decomp_dbg` at `e3db5512`,
-on that same in-repo fixture, by the exact console script Stage A would generate:
+Nine directives, keyed by **intent** rather than by phase — an agent should not have to know
+that renaming is P9 to rename something — each lowering to the console command that already
+implements it:
 
-```
-int4 authenticate(char *user,char *pass) // return-dupe x2
-{
-  char credbuf [16]; // stack - 0x18
-  int4 v1; // eax
-  ...
-```
+| directive | lowers to | writes at |
+|---|---|---|
+| `function <start>[-<end>][=<name>]` | `function bounds` | P1 (the `--define-function` spelling) |
+| `typedef <C declaration>` | `parse line` | P5 type-propagation |
+| `prototype <func> <C declaration>` | `parse line extern` | P4 prototype-source |
+| `data <addr> <C typedeclaration>` | `map address` | P5 const-pointer |
+| `param [<func>::]<i> <storage> <C typedecl>` | `map param` | P4 prototype-source |
+| `return [<func>::]<storage> <C typedecl>` | `map return` | P4 prototype-source |
+| `comment [<func>::]<addr> <text>` | `comment instruction` | P9 external-refinement |
+| `name [<func>::]<symbol> <newname>` | `rename` | P9 naming-policy |
+| `type [<func>::]<symbol> <C type>` | `retype` | P5 type-propagation |
 
-The engine already produces the acceptance output. Stage A is the path to it.
+**Machine-readable in, machine-readable out.** Every `--json` document grows an `assertions`
+array — one row per directive, in the caller's order, carrying the directive text, its phase
+and sub-phase, `applied` or `rejected`, and a reason. A rejection is also spoken on stderr on
+both surfaces, is non-fatal by default (a batch of forty renames against a re-decompiled
+binary must not lose the other thirty-nine to one stale name), and `--assert-strict` makes it
+the run's verdict.
+
+**Three slots, and the ordering is forced rather than stylistic.** Program-scoped directives
+are applied right after the analysis commit, for the same reason a declared boundary is: an
+assertion outranks discovery. Function-scoped ones become decompile seeds, because a
+prototype fact is consumed at flow time. Symbol-scoped ones (`name`, `type`) can only run
+*between two decompiles* — the local they name does not exist until one has produced it,
+which is exactly the bug that makes `--kassert p9 naming-policy` inert today. The second pass
+is emitted only when such a directive bound to the function, so **every run without one costs
+what it did before**. An unqualified directive on a multi-function run is rejected with a
+detail naming the `<func>::<operand>` form rather than applied to every function that happens
+to have a `v2`.
+
+`@FILE` is the durable form, the `--define-function` contract verbatim: kuna does not write
+assertions back into the image, so the file is the artifact.
+
+## Also fixed: `map return` aborted the process
+
+`map return <addr> <type>` killed the whole console the moment its function was decompiled —
+`outtype null`, `ParamListStandardOut::assignMap`. It parks OUTPUT-ONLY `PrototypePieces`
+(explicit storage, no declared return type) and `assignParameterStorage` dereferences
+`outtype` unconditionally. `FuncProto::seed_locked_from_pieces` already special-cased
+`outtype: None && output_storage: None`; the `Some` case fell through to the abort. The
+declared type *is* the return type. Fixed at the engine seam so every caller gets it, with a
+regression test that drives the drive with output-only pieces directly.
+
+## The filed hypothesis is overturned
+
+> ADVISORY. The cheap half is exposure [...] The expensive half is the stubs.
+
+The cheap half is **much larger** than filed — 11 console commands were measured reaching
+emitted C. The expensive half is **not** the stubs, whose engine entry points are all already
+ported: it was two *shipped* commands that lie. One (`map return`) is fixed here. The other
+(`override prototype`) is residue, and the proposal's own diagnosis of it (*"the `queryCall`
+consume is stubbed OR `applyPrototype` is wired — one is stale"*) is itself wrong: reading
+the whole chain, every link is present and looks correct — store, re-seed, install on the
+fresh `Funcdata`, `build_override_proto` builds a real locked `FuncProto` — and the C still
+does not change (re-measured on this branch: `strcmp` at `0x400689`, 2 params → 3, no
+change). Time-boxed per the dispatch; the `prototype` directive lowers to `parse line
+extern`, which is measured working and is what the acceptance asserts, so nothing shipped
+here depends on it. Per-call-site prototype override is worth its own need.
+
+`hypothesis_status` on the need record is reconciled from `upheld` to `overturned`, matching
+its `record.json` and the proposal's verdict.
+
+## Acceptance
+
+`a-a58fc408288b` — FAILED at `e3db5512` (`exit_code 2`, `error: unknown option --assert`),
+**PASS** here, all seven clauses. Promoted verbatim to
+`tests/cli/no-cli-rename-or-prototype-override.json` (in-repo fixture, so CI needs no
+dataset).
+
+## Every directive's test asserts the emitted C CHANGED
+
+Not that the command returned Ok — reviewing on the return value is how `override prototype`
+got shipped broken. `crates/kuna-console/tests/verify_assertplane.rs`, 11 tests, each a diff
+against the un-asserted baseline: prototype (signature + parameter names), param (locked
+input), return (locked output), name+type (`char v2 [8]` → `char credbuf [16]`), typedef+type
+(`creds v2;` / `v2.raw`), data (`sneaky` → `shadowpw` at the call), comment (`/* ... */` in
+the body), function (`authstub`, 28 bytes), plus directive ordering, the multi-function
+qualification rule, and the `map return` abort. `assertdecl` adds 9 syntax tests and
+`decompile.rs` 4 more for the script slots and the transcript reader.
+
+`label` (`map label`) is deliberately **not** shipped: it has no observable effect on emitted
+C on any fixture tried, so no test could satisfy that rule, and shipping it would have made
+this PR an instance of the failure mode it exists to close. Recorded as residue.
 
 ## Gates
 
-No source file changed, so no gate can move: the diff is `docs/features/no-cli-rename-or-
-prototype-override/{proposal.md,record.json,pr_body.md}`, `docs/re-needs/no-cli-rename-or-
-prototype-override.md` and the regenerated `docs/re-needs/index.json`.
+| gate | result |
+|---|---|
+| `make test` | **PARITY OK**, 675/675 |
+| `make test-stages` | **PARITY OK**, 603/603 |
+| `make rust-test` | green |
+| `make check-spec` | OK |
+| `kuna catalog --check` | OK |
+| `verify --need no-cli-rename-or-prototype-override` | acceptance **PASS** |
 
-- `python -m scripts.repipe.needs reindex` — 35 needs indexed, clean round-trip
-- `python -m scripts.repipe.verify --acceptance-suite --need no-cli-rename-or-prototype-override`
-  — `unrunnable: false`, `passed: false` (was `unrunnable: true` at `e3db5512`)
-- `kuna catalog --json` swept for a covering option: 137 rows, none matching
-  rename/retype/prototype-override — not a default-flip candidate
+No `phases.toml` row, no `options.rs` registration, no catalog counter, no `docs/options.md`
+regeneration, no DIV row and no `tests/stages/` case: a flag that only carries caller
+assertions cannot change emitted C for a run that does not pass one, and the tooling track
+scopes the stages corpus away from it. The parity corpora are structurally unaffected —
+symbol-less bytechunks driven by XML, with no CLI in the loop.
+
+**Deferred, not skipped:** the P4/P5/P9 `exposure` prose in `phases.toml`. That file was
+leased by `b-r2-ppc64-localentry` for this whole wave (captain dispatch item 2). It is prose,
+no gate reads it. Stage B (`no-cli-data-code-override`) and Stage C
+(`no-cli-structuring-override`) stay parked as their own needs and their own PRs.
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/no-cli-rename-or-prototype-override/proposal.md
+++ b/docs/features/no-cli-rename-or-prototype-override/proposal.md
@@ -1,0 +1,351 @@
+# `--assert`: one override plane for the whole no-cli-* family
+
+**Needs covered:** `no-cli-rename-or-prototype-override` (the dispatched one),
+`no-cli-data-code-override`, `no-cli-structuring-override`.
+**Track:** tooling. **Scope:** large. **Base:** `e3db5512`.
+
+## 1. The problem
+
+Three backlog records say the same thing about three different subjects:
+
+> `rename`, `retype`, `map param`, `map return`, `override prototype` and `parse line extern ...`
+> are all functional in the console and none is reachable from `kuna`.
+> — `no-cli-rename-or-prototype-override` (severity major, instances 1, rounds [2])
+
+> `map address <addr> <typedeclaration>`, `parse line`, `type varnode`, `readonly <addr+size>`
+> and `volatile <addr+size>` all work in the console and none is reachable from `kuna`.
+> — `no-cli-data-code-override` (severity major, instances 1, rounds [2])
+
+> Of the four structuring overrides `phases.toml` advertises in its own `exposure` fields,
+> three are `engine_unavailable` stubs [...] and the fourth, `override flow`, works but is
+> console-only.
+> — `no-cli-structuring-override` (severity major, instances 1, rounds [2])
+
+All three were captain-seeded from a source survey and each has picked up an independent
+tester witness since: `keyboard-callback-uses-undefined` (an agent that could state a
+callback's prototype would not need kuna to infer R9D/R8D), the three-sighting "kuna will
+not tell me about data" family (653d8860 x2 + 69a3822f), and round 1's `switch(0)`.
+
+The delivery vehicle now exists. `no-cli-function-boundary-override` closed via #374, which
+shipped `kuna decompile --define-function <start[-end][=name] | @file>`: an agent-supplied
+fact, injected from the `kuna` binary, carried in a plain-text file the agent owns, honored
+by both the script surface and the in-process surface. This proposal is that shape,
+generalised once, for everything else an agent needs to tell kuna.
+
+## 2. The cheap/expensive question, answered by measurement
+
+The captain asked for this as a table. Every row was measured at `e3db5512` by driving
+`decomp_dbg` directly on in-repo fixtures (`fauxware`, `aif_gap_x86_64`) — not read off the
+source. "Reaches C?" means *the emitted C actually changed*, which is a strictly harder
+question than "the command returned Ok".
+
+### Already works in the console — the job is a path from `kuna`
+
+| Console command | Named by | Reaches C? | Measured evidence |
+|---|---|---|---|
+| `rename <sym> <new>` | rename | **yes** | `char v2 [8]` → `char credbuf [16]` after `rename`+`retype` |
+| `retype <sym> <type>` | rename | **yes** | same run; the array widened and the frame re-laid out |
+| `map param <i> <addr> <decl>` | rename | **yes** | `authenticate(char *a0,char *a1)` → `authenticate(char *username)` |
+| `parse line extern <decl>` | rename | **yes** | → `int4 authenticate(char *user,char *pass)`, names bound through the body |
+| `parse line typedef/struct/enum` | data | n/a | interns the type; `verify_w10_union_truncation.rs` exercises it |
+| `map address <addr> <decl>` | data | **yes** | `strcmp(a1,sneaky)` → `strcmp(a1,shadowpw)`, retyped |
+| `type varnode <vn> <decl>` | data | (usepoint) | live; needs the `[space,offset,size]` varnode syntax, not a bare address |
+| `readonly <addr> <size>` | data | not observed | accepted ("Successfully marked range as readonly"); no fold on the fixture tried |
+| `volatile <addr> <size>` | data | not observed | accepted |
+| `override flow <addr> <kind>` | structuring | **yes** | `override flow 0x4006aa branch` turned the CALL into a tail-call and restructured |
+| `map label <name> <addr>` | — | n/a | accepted |
+| `comment instruction <addr> <text>` | — | n/a | accepted |
+| `map function` / `load addr` | boundary | **yes** | already exposed as `--define-function` (#374) |
+
+### Broken in the console — a fix, then a path
+
+| Console command | What actually happens | Cost |
+|---|---|---|
+| `map return <addr> <decl>` | **panics the process**: `outtype null`, `p4_calls/fspec.rs:2624` in `assign_map_standard_out`. Reproduces standalone, first command after `load function`. | small: the parked `PrototypePieces` is output-only and carries `outtype: None` where `assign_map_standard_out` unwraps it |
+| `override prototype <addr> <decl>` | prints `Successfully added override` and **changes nothing** — measured on a direct known callee (`strcmp` at `0x400689`, 2→3 params) and on an indirect call (`CALL RDX` at `0x1405` in `aif_gap` `stage1`). Its own doc comment says the `FlowInfo::queryCall` consume is stubbed; `flow.rs:2152` says `applyPrototype` is wired. One of the two is stale. | medium: find which, then either wire the consume or fix the store |
+
+### `engine_unavailable` stubs — and the hypothesis they were filed under
+
+The records' shared Hypothesis says *"The expensive half is the stubs."* **That is overturned,
+exactly as it was on the boundary need.** Every engine entry point the stubs name is already
+ported in `kuna-decomp`:
+
+| Stub command | Engine entry it names | Ported? |
+|---|---|---|
+| `force goto` | `Override::insertForceGoto` | `p0_knowledge/overrides.rs:256` `insert_force_goto` |
+| `override jumptable` | `Funcdata::installJumpTable` | `substrate/funcdata_block.rs:1724` `install_jump_table` |
+| `deadcode delay` | `Override::insertDeadcodeDelay` | `p0_knowledge/overrides.rs:265` `insert_deadcode_delay` |
+| `isolate` | `Symbol::setIsolated` | `p0_knowledge/database.rs:834` `set_isolated` |
+| `prototype lock/unlock` | `FuncProto::setInput/OutputLock` | `p4_calls/fspec.rs:5204/5242` |
+| `global add`/`remove` | `ScopeGlobal` range add | `ScopeGlobal` exists; the range call needs checking |
+| `name varnode` | `Funcdata::nameRecommend` | not checked |
+| `structure blocks` | `BlockGraph` structuring | genuinely large — **out of scope** |
+| `analyze range` | `ValueSetSolver` | genuinely large — **out of scope** |
+
+The stub message ("`Architecture print/types/loader/context + parse_machaddr/parse_C grammars
+are a later W-item`") is stale on its face: `parse_machaddr` is implemented at
+`ifacedecomp.rs:322` and `parse_c` at `grammar.rs:2292`, and both are used by the commands
+that work. These are **inert plumbing**, the same finding #374 recorded, not engine ports.
+
+### The `kassert` plane, which was meant to carry all of this
+
+`P9 external-refinement`'s own `exposure` in `phases.toml` reads *"the console itself; kassert
+(kuna) is the uniform writer"*. Today:
+
+| `kassert` sub-phase | Dispatch arm | State at `e3db5512` |
+|---|---|---|
+| `naming-policy` | `Rename` | implemented — but **a silent no-op from the CLI** (below) |
+| (option-backed sub-phases) | `Option` | works |
+| `prototype-source` | `ProtoLock` | `engine_unavailable` |
+| `type-propagation` | `Retype` | `engine_unavailable` |
+| `flow-classification` | `FlowOverride` | `engine_unavailable` — *while `override flow` works* |
+| `edge-virtualization` | `ForceGoto` | `engine_unavailable` |
+| `switch-model` | `MultistageJump` | `engine_unavailable` |
+| `merge-aggressiveness` | `Isolate` | `engine_unavailable` |
+| `dead-definition-gate` | `DeadcodeDelay` | `engine_unavailable` |
+| `code-data-partition`, `const-pointer` | `Unroutable` | routed to their native command |
+
+Two CLI-level facts make `--kassert` unusable as it stands, both measured:
+
+- `kuna decompile <bin> authenticate --kassert "p9 naming-policy v2 buf"` **exits 0 and changes
+  nothing.** `build_script` emits `kassert` between `load function` and the *first* `decompile`,
+  and a local like `v2` does not exist until a decompile has run, so the arm throws
+  `No symbol named: v2` into a transcript the CLI discards. The one working assertion arm is
+  dead on the one surface that can reach it.
+- `kuna decompile ... --json --kassert ...` → `error: --kassert is not supported with --json`.
+  The override surface and the machine-readable surface are mutually exclusive, which for an
+  agent means the override surface does not exist.
+
+**Verdict on the shared Hypothesis: `hypothesis_status` should move to `overturned` on all
+three records.** The cheap half is much larger than filed (11 commands reach emitted C today),
+and the expensive half is not "the stubs" — it is two *shipped* commands that lie (`map
+return` panics, `override prototype` no-ops) plus one CLI ordering bug that makes the working
+assertion arm inert.
+
+## 3. The mechanism
+
+### `--assert <directive> | @FILE`, repeatable
+
+One flag, one line-oriented vocabulary, on every surface that loads a program. Each directive
+is one line; `@FILE` holds many, with `#` comments — the `--define-function` file contract
+verbatim, because that is what makes an override durable across invocations. kuna does not
+write assertions back into the image; the file is the artifact, and it is text an agent can
+generate, diff and version.
+
+```text
+kuna decompile ./a.out authenticate --json \
+  --assert 'prototype authenticate int4 authenticate(char *user,char *pass)' \
+  --assert 'type v2 char[16]' \
+  --assert 'name v2 credbuf'
+
+kuna decompile-all ./packed.bin --json --assert @notes/overrides.kuna
+```
+
+The vocabulary is **intent-keyed, not phase-keyed**. An agent should not have to know that
+renaming is P9 to rename something; `--kassert <phase> <subphase>` stays as the raw writer and
+is documented as such.
+
+| Directive | Lowers to | Phase / sub-phase | Stage |
+|---|---|---|---|
+| `function <start>[-<end>][=<name>]` | `function bounds` | P1 | **shipped** (alias of `--define-function`) |
+| `prototype <func> <C declaration>` | `parse line extern <decl>;` | P4 prototype-source | A |
+| `param <i> <storage> <C typedecl>` | `map param` | P4 prototype-source | A |
+| `return <storage> <C typedecl>` | `map return` | P4 prototype-source | A |
+| `name <symbol> <newname>` | `rename` | P9 naming-policy | A |
+| `type <symbol> <C type>` | `retype` | P5 type-propagation | A |
+| `typedef <C declaration>` | `parse line` | P5 | A |
+| `data <addr> <C typedecl>` | `map address` | P5 const-pointer | A |
+| `label <addr> <name>` | `map label` | P9 | A |
+| `comment <addr> <text>` | `comment instruction` | P9 | A |
+| `readonly <addr>+<size>` | `readonly` | P1 code-data-partition | B |
+| `volatile <addr>+<size>` | `volatile` | P1 code-data-partition | B |
+| `global <addr>+<size>` | `global add` *(stub to wire)* | P1 code-data-partition | B |
+| `flow <addr> branch\|call\|callreturn\|return` | `override flow` | P2 flow-classification | C |
+| `goto <branch> <target>` | `force goto` *(stub to wire)* | P7 edge-virtualization | C |
+| `jumptable <addr> <case>..` | `override jumptable` *(stub to wire)* | P2 switch-model | C |
+| `isolate <symbol>` | `isolate` *(stub to wire)* | P6 merge-aggressiveness | C |
+| `deadcode-delay <space> <n>` | `deadcode delay` *(stub to wire)* | P3 dead-definition-gate | C |
+
+Deliberately **not** in the plane: `structure blocks` and `analyze range`. Both are real engine
+ports (`BlockGraph` structuring, `ValueSetSolver`) and `no-cli-structuring-override` should
+record them as a residue rather than have this design half-port them.
+
+### Machine-readable in, machine-readable out
+
+Every surface's `--json` grows one array, and every directive produces exactly one row:
+
+```json
+"assertions": [
+  {"directive": "prototype authenticate int4 authenticate(char *user,char *pass)",
+   "kind": "prototype", "phase": "P4", "subphase": "prototype-source",
+   "status": "applied", "detail": null},
+  {"directive": "name v9 credbuf", "kind": "name", "phase": "P9",
+   "subphase": "naming-policy", "status": "rejected",
+   "detail": "No symbol named: v9"}
+]
+```
+
+`status` is `applied` or `rejected`; a rejection also goes to stderr on the human surface.
+A rejected directive is **not** fatal by default (an agent batching forty renames against a
+re-decompiled binary must not lose all forty to one stale name), but `--assert-strict` makes
+any rejection exit non-zero. `--kassert`'s `--json` prohibition is lifted and its arms report
+into the same array, so `kassert list` and the JSON agree.
+
+### Where each directive is applied
+
+The ordering is not cosmetic — it was measured, and getting it wrong is how this design fails
+silently.
+
+Script surface (`kuna decompile`, which forks `decomp_dbg` with a generated script):
+
+```text
+load file BIN
+option ...                     # must precede `read symbols` (analysis commit)
+read symbols
+function bounds ...            # existing --define-function slot
+parse line / typedef / data / label / readonly / volatile / global / comment
+load function TARGET
+prototype (parse line extern) / param / return / flow / goto / jumptable
+decompile                      # pass 1 -- materialises the local symbols
+name / type / isolate          # symbol-scoped: `rename v2` fails before pass 1
+decompile                      # pass 2, only emitted when a symbol-scoped directive exists
+print C
+```
+
+The two-pass shape is forced: `rename v2 buf` before the first `decompile` returns
+`No symbol named: v2` (measured), which is precisely the bug that makes today's
+`--kassert p9 naming-policy` inert. The second `decompile` is emitted **only** when a
+symbol-scoped directive is present, so every existing invocation keeps its current cost.
+
+In-process surface (`decompile-all`, `decompile-project`, WASM): the plumbing is already
+built. `kuna_console::decompile_step::DecompileSeed` is the shared "console-only facts"
+carrier and the whole-binary loop passes empty slices for every field this plane needs —
+`mapped_symbols` (`data`), `usepoint_symbols` (`type varnode`), `dynamic_symbols`,
+`pending_proto` (`prototype`), `flow_overrides` (`flow`), `mapped_params` (`param`). Stage A
+fills them from the parsed directives. `decompile_step::decompile_one` **already** contains a
+decompile → adjust → re-decompile loop (the `formatstring` half-B override loop), so the
+symbol-scoped second pass has precedent in the exact function that needs it.
+
+### Why not a `kuna console` passthrough
+
+The captain's caution stands and the measurements support it. A passthrough would ship
+`map return`'s panic and `override prototype`'s silent no-op straight to agents, would expose
+37 commands of which ~14 are stubs, and would have no place to put the `assertions[]` report.
+A typed vocabulary is what lets a directive be *rejected* with a reason instead of throwing an
+unstructured console diagnostic into a discarded transcript.
+
+## 4. The plan
+
+Each stage is one PR, each closes one need, each is independently shippable.
+
+**Stage A — `no-cli-rename-or-prototype-override` (the dispatched need).**
+1. `kuna-cli/src/assertdecl.rs`: the directive parser + `@FILE`, modelled line-for-line on
+   `funcdecl.rs`. Unit tests per directive, per malformation.
+2. Fix `map return`'s `outtype null` panic; add a `kuna-console` regression test.
+3. Diagnose `override prototype`'s no-op — the store side or the `queryCall` consume — and fix
+   or, if it is a genuine engine port, record it as Stage-A residue on the need rather than
+   silently shipping a directive that lies.
+4. Script surface: emit the directives at the slots above, including the conditional second
+   `decompile`; parse the transcript back into `assertions[]`.
+5. In-process surface: fill `DecompileSeed`; add the symbol-scoped second pass to
+   `decompile_one`.
+6. `--assert` on `decompile`, `decompile-all`, `decompile-project`; lift the
+   `--kassert`+`--json` prohibition; `assertions[]` in every `--json`.
+7. `docs/cli.md`, the owning `docs/spec/` chapter, and `phases.toml`'s `exposure` prose for
+   P4/P5/P9 (no new `settable` row — a CLI surface cannot change emitted C on its own, and the
+   tooling track forbids one).
+8. Acceptance `a-a58fc408288b` passes; promote to `tests/cli/`.
+
+**Stage B — `no-cli-data-code-override`.** `readonly`/`volatile`/`global`/`data` directives;
+wire the `global add`/`global remove` stubs onto `ScopeGlobal`; find a fixture where a
+`readonly` range demonstrably folds (none of the ones tried here does) and file that need's
+acceptance probe against it.
+
+**Stage C — `no-cli-structuring-override`.** `flow` (works today), then wire `force goto`,
+`override jumptable`, `isolate` and `deadcode delay` onto their ported engine entries, and fill
+the matching `kassert` Dispatch arms. Update the `exposure` fields for the sub-phases whose
+overrides stop being stubs. Record `structure blocks` and `analyze range` as residue.
+
+Stage A is the load-bearing one: it builds the parser, the report, the ordering and the
+`DecompileSeed` fill that B and C only extend. That is why the captain's "one design, three
+needs" instruction is the right call — B and C collapse to a directive table row each plus a
+stub to wire.
+
+## 5. Risk and speed
+
+**Speed.** Zero on every existing invocation: no directives means no extra console lines, no
+second `decompile`, and an empty `assertions[]`. With a symbol-scoped directive the function is
+decompiled twice — a bounded ~2x on one function, opt-in, and the same cost shape the
+`formatstring` loop already pays. No pipeline pass is added, so `make test` / `make test-stages`
+are structurally unaffected.
+
+**Risk, ranked.**
+1. *`override prototype` is a genuine engine gap, not a bug.* Then the `prototype` directive
+   must lower to `parse line extern` only (which is measured working for the loaded function)
+   and per-call-site prototype override becomes Stage-A residue. The acceptance probe is
+   written against `parse line extern` for exactly this reason and is unaffected.
+2. *Transcript-scraping the script surface is brittle.* `assertions[]` on the forked path is
+   derived from console diagnostics. Mitigation: the console prefixes are documented as
+   byte-faithful and load-bearing (`ifacedecomp::execute`), and `decompile.rs` already parses
+   them (`CONSOLE_DIAGNOSTICS`, `arch_failure_reason`).
+3. *A directive that is accepted and does nothing.* The failure mode of this whole family —
+   `override prototype` is already an instance, and it is worse than an error. Every directive
+   must ship with a test that asserts the emitted C **changed**, not that the command returned
+   Ok. Reviewing on "did it return Ok" is how `override prototype` got here.
+4. *Symbol names are unstable across runs.* `name v2 credbuf` binds to a generated name that a
+   later kuna version may number differently ([[kuna-entry-name-rank-length]] is the same
+   hazard one layer over). Mitigation: `name`/`type` also accept a storage form
+   (`name [stack,-0x18,8] credbuf`), which is stable; the generated-name form stays as the
+   convenient one.
+5. *Blast radius.* Nothing here runs unless a directive is passed, so the parity corpora — which
+   are symbol-less bytechunks driven by XML, with no CLI in the loop — cannot be affected.
+
+## 6. Acceptance
+
+Filed on the need at `a-a58fc408288b`, and runnable: `verify --acceptance-suite` reported it
+`unrunnable` before this branch and now reports `passed: false` with a real clause list
+(`exit_code` 2, `error: unknown option --assert`).
+
+```
+kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/fauxware authenticate --json \
+  --assert 'prototype authenticate int4 authenticate(char *user,char *pass)' \
+  --assert 'type v2 char[16]' \
+  --assert 'name v2 credbuf'
+```
+
+asserting `assertions` has 3 rows all `applied`, and that the C contains
+`authenticate(char *user,char *pass)` and `char credbuf [16];` and no longer contains
+`char v2 [8]`.
+
+The target C is not aspirational. This is `decomp_dbg` at `e3db5512`, on the same in-repo
+fixture, driven by the exact console script Stage A would generate:
+
+```text
+load file .../fauxware
+read symbols
+parse line extern int4 authenticate(char *user,char *pass);
+load function authenticate
+decompile
+retype v2 char[16]
+rename v2 credbuf
+decompile
+print C
+--------------------------------------------------
+int4 authenticate(char *user,char *pass) // return-dupe x2
+{
+  char credbuf [16]; // stack - 0x18
+  int4 v1; // eax
+
+  credbuf[8] = '\0';
+  v1 = strcmp(pass,sneaky);
+  ...
+```
+
+The engine already produces the acceptance output. Stage A is the path to it.
+
+Sibling acceptance probes are **not** filed here. `no-cli-structuring-override`'s can be
+written today against the measured `override flow 0x4006aa branch` result;
+`no-cli-data-code-override`'s cannot, because no in-repo fixture tried here shows an
+observable `readonly`/`volatile` effect, and filing an acceptance probe whose target was never
+measured is the mistake this proposal exists to avoid. Stage B's first task is to find that
+fixture.

--- a/docs/features/no-cli-rename-or-prototype-override/record.json
+++ b/docs/features/no-cli-rename-or-prototype-override/record.json
@@ -7,11 +7,9 @@
   "acceptance_id": "a-a58fc408288b",
   "instances": 1,
   "scope": "large",
-  "proposal": true,
+  "proposal": false,
   "covers_needs": [
-    "no-cli-rename-or-prototype-override",
-    "no-cli-data-code-override",
-    "no-cli-structuring-override"
+    "no-cli-rename-or-prototype-override"
   ],
   "option": null,
   "flag": null,
@@ -20,9 +18,9 @@
   "tier": "driver",
   "change_kind": "capability-add",
   "default_on": null,
-  "owning_file": "docs/features/no-cli-rename-or-prototype-override/proposal.md",
+  "owning_file": "decompiler/crates/kuna-cli/src/assertdecl.rs",
   "spec_chapter": "docs/spec/00-overview.md",
-  "parity": "untouched (no code change on this branch)",
+  "parity": "make test PARITY OK 675/675; make test-stages PARITY OK 603/603. Structurally unaffected: both corpora are symbol-less bytechunks driven by XML with no CLI in the loop, and nothing on this branch runs unless a --assert directive is passed.",
   "root_cause_class": "absent-capability",
   "hypothesis_status": "OVERTURNED",
   "filed_hypothesis": "ADVISORY. The cheap half is exposure, not implementation: most of these commands already work and only lack a path from the `kuna` binary. The expensive half is the stubs.",
@@ -37,9 +35,16 @@
     "DESIGN -- THE IN-PROCESS HALF IS ALREADY BUILT, which is what makes this affordable. kuna_console::decompile_step::DecompileSeed is the shared 'console-only facts' carrier and the whole-binary loop passes empty slices for exactly the fields this plane needs: mapped_symbols (data), usepoint_symbols (type varnode), dynamic_symbols, pending_proto (prototype), flow_overrides (flow), mapped_params (param). And decompile_one ALREADY contains a decompile -> adjust -> re-decompile loop (the formatstring half-B override loop), so the symbol-scoped second pass has precedent in the exact function that needs it.",
     "REJECTED -- a `kuna console` passthrough or a --script flag. The captain's caution is upheld by the measurements: a passthrough would ship map return's panic and override prototype's silent no-op straight to agents, expose 37 commands of which ~14 are stubs, and leave nowhere to put the assertions[] report. A typed vocabulary is what lets a directive be REJECTED with a reason instead of throwing an unstructured diagnostic into a discarded transcript.",
     "OUT OF SCOPE AND RECORDED AS RESIDUE: `structure blocks` (BlockGraph structuring) and `analyze range` (ValueSetSolver) are genuine engine ports. no-cli-structuring-override should carry them as residue rather than have this design half-port them.",
-    "ACCEPTANCE FILED AND GROUNDED. a-a58fc408288b was written only after its target C was produced end-to-end by decomp_dbg at e3db5512, on the same in-repo fixture, driven by the exact console script Stage A would generate. verify --acceptance-suite reported this need `unrunnable` before this branch and now reports passed:false with a real clause list (exit_code 2, 'unknown option --assert'). Sibling probes were deliberately NOT filed: no-cli-data-code-override's would have to assert a readonly/volatile effect, and no fixture tried here shows one -- filing a probe whose target was never measured is the exact mistake this proposal argues against."
+    "ACCEPTANCE FILED AND GROUNDED. a-a58fc408288b was written only after its target C was produced end-to-end by decomp_dbg at e3db5512, on the same in-repo fixture, driven by the exact console script Stage A would generate. verify --acceptance-suite reported this need `unrunnable` before this branch and now reports passed:false with a real clause list (exit_code 2, 'unknown option --assert'). Sibling probes were deliberately NOT filed: no-cli-data-code-override's would have to assert a readonly/volatile effect, and no fixture tried here shows one -- filing a probe whose target was never measured is the exact mistake this proposal argues against.",
+    "IMPLEMENTED AS STAGE A. `--assert <directive> | @FILE`, repeatable, on decompile / decompile-all / decompile-project / functions. Nine directives shipped: function, typedef, prototype, data, param, return, comment, name, type. The syntax lives in kuna-cli/src/assertdecl.rs (modelled line-for-line on funcdecl.rs, per the dispatch); the vocabulary and the engine-side application live in kuna-console/src/assertions.rs, because the symbol-scoped half has to run inside the decompile loop and the CLI cannot reach there.",
+    "SCOPE NARROWED FROM THE PROPOSAL TABLE ON PURPOSE, one directive: `label` (map label). It is accepted by the console and changes no emitted C on any fixture tried, so it cannot satisfy the standing rule that every directive ship with a test asserting the C CHANGED. Shipping it would have made this PR an instance of the exact failure mode it exists to close. Recorded as residue instead.",
+    "STORAGE OPERANDS ARE NORMALISED, which the proposal did not anticipate. A bare register name is the spelling an agent reaches for and the one the console rejects outright: `map param 0 RDI ...` answers 'Bad address: R', because parse_machaddr reads the first character as an address-space shortcut. assertdecl rewrites a bare identifier to the console's `%RDI` (a token that starts with a letter and carries no 0x cannot be any of the other forms), so both spellings work and the console's own `[stack,-0x18,8]` grammar is untouched.",
+    "map return's PANIC IS FIXED AT THE ENGINE SEAM, not in the console command, so every caller gets it. FuncProto::seed_locked_from_pieces already special-cased `outtype: None && output_storage: None` (the C++-mangled-name case) but fell through to set_pieces for `outtype: None && output_storage: Some`, which is exactly what map return parks -- and ParamListStandardOut::assignMap dereferences proto.outtype unconditionally. The declared type IS the return type: adopt it. Verified by the standalone console script that used to abort, and by a regression test that drives the drive with output-only pieces directly.",
+    "OVERRIDE PROTOTYPE IS RESIDUE, and the proposal's diagnosis of it is itself wrong. It predicted 'the FlowInfo::queryCall consume is stubbed OR flow.rs:2152's applyPrototype is wired -- one of the two is stale'. Reading the whole chain on this branch: IfcProtooverride stashes into pending_proto_overrides, IfcDecompile re-seeds it, build_and_follow_flow_with_override_and_protos installs it on the fresh Funcdata's localoverride before flow, FlowInfo::build_call_specs finds it and calls ArchFlowEnv::build_override_proto, and that (decompile_drive.rs:325) builds a real locked FuncProto and copies it onto the call spec. Every link is present and looks correct, and the emitted C still does not change (re-measured on this branch: strcmp at 0x400689, 2 params -> 3, no change). So the defect is somewhere neither the proposal nor a source read located, and it is a need of its own. Time-boxed per the captain's dispatch item 4; the `prototype` directive lowers to `parse line extern`, which is measured working and is what the acceptance asserts, so nothing shipped here depends on it.",
+    "THE TWO --kassert DEFECTS ARE NOT FIXED, deliberately. --assert supersedes both: it is the intent-keyed writer an agent should reach for, it reports into assertions[], and it works with --json. Fixing the raw phase-keyed writer's ordering bug and lifting its --json prohibition became optional cleanup rather than a gap an agent can feel, so they are residue on the need rather than scope here.",
+    "PHASES.TOML EXPOSURE PROSE DEFERRED: file:phases.toml was leased by b-r2-ppc64-localentry for the whole wave (captain dispatch item 2). It is prose, no gate reads it, and this PR adds no settable row -- so no catalog counters, no docs/options.md regeneration and no DIV row either."
   ],
-  "mechanism": "`--assert <directive> | @FILE`, repeatable, on decompile / decompile-all / decompile-project. A new kuna-cli/src/assertdecl.rs parses a line-oriented intent-keyed vocabulary (prototype/param/return/name/type/typedef/data/label/comment, then readonly/volatile/global, then flow/goto/jumptable/isolate/deadcode-delay) modelled line-for-line on funcdecl.rs. The script surface emits each directive at its measured slot -- program-scope after `read symbols`, function-scope after `load function`, symbol-scope after a first `decompile` with a conditional second `decompile` -- and scrapes the byte-faithful console diagnostics back into an `assertions[]` array. The in-process surface fills DecompileSeed's already-present but always-empty slices and adds the symbol-scoped second pass to decompile_one.",
+  "mechanism": "`--assert <directive> | @FILE` (repeatable) on decompile / decompile-all / decompile-project / functions, plus `--assert-strict`. kuna-cli/src/assertdecl.rs owns the syntax (nine directives, the @FILE contract copied from funcdecl.rs, storage normalisation) and the console lowering with its three script slots. kuna-console/src/assertions.rs owns the vocabulary and the engine-side application, over two new ConsoleProgram stores (assertions + one outcome slot per directive, and a pending-prototype map). Program-scoped directives are applied after the analysis commit in decompile_all::load_program, for the same reason a declared boundary is. Function-scoped ones become DecompileSeed fields (pending_proto, mapped_params) because a prototype fact is consumed at flow time. Symbol-scoped ones (name/type) run between two decompiles inside project::decompile_targets -- the local they name does not exist until a decompile has produced it -- with the first pass's mutated local scope carried across as mapped_symbols; the second pass is emitted only when such a directive bound, so no other run pays for it. The script surface emits the same facts at the same three slots and recovers each directive's fate from the console's byte-faithful diagnostic grammar.",
   "measurements": {
     "method": "drove decompiler/target/release/decomp_dbg directly at e3db5512 with SLEIGHHOME=$PWD/specs, one command per line on stdin, on the in-repo fixtures fauxware (c2d90645, 8776 bytes) and aif_gap_x86_64 (1a592a85, 14408 bytes); every 'reaches C' verdict is a diff of the printed C, never a return code",
     "commands_probed": 22,
@@ -47,12 +52,13 @@
     "engine_unavailable_stubs": 9,
     "stubs_whose_engine_entry_is_already_ported": 5,
     "shipped_commands_found_broken": 2,
-    "cli_level_defects_found": 2
+    "cli_level_defects_found": 2,
+    "implementation_note": "every shipped directive was re-measured end-to-end on this branch, on BOTH surfaces, as a diff of the emitted C: prototype (signature + parameter names), param (locked input), return (locked output), name+type (char v2 [8] -> char credbuf [16]), typedef+type (creds v2 / v2.raw), data (sneaky -> shadowpw at the call), comment (/* ... */ in the body), function (authstub, 28 bytes)"
   },
   "stages": [
-    "A (this need): the symbol and prototype plane -- parser, map return panic fix, override prototype diagnosis, two-pass script, DecompileSeed fill, assertions[] JSON, --kassert/--json prohibition lifted, docs/cli.md + spec + phases.toml exposure prose, acceptance a-a58fc408288b + tests/cli promotion",
-    "B (no-cli-data-code-override): readonly/volatile/global/data directives; wire the global add/remove stubs onto ScopeGlobal; find a fixture where a readonly range demonstrably folds and file that need's acceptance against it",
-    "C (no-cli-structuring-override): flow (works today) then wire force goto / override jumptable / isolate / deadcode delay onto their ported engine entries, fill the matching kassert Dispatch arms, update the affected subphase exposure fields, record structure blocks and analyze range as residue"
+    "A (this need, SHIPPED): --assert with function/typedef/prototype/data/param/return/comment/name/type, the three-slot ordering, the conditional symbol-scoped second pass, assertions[] on every --json, --assert-strict, the map return outtype-null fix, docs/cli.md + docs/spec/00-overview.md, acceptance a-a58fc408288b promoted to tests/cli/",
+    "B (no-cli-data-code-override, PARKED): readonly/volatile/global directives; wire the global add/remove stubs onto ScopeGlobal; find a fixture where a readonly range demonstrably folds and file that need's acceptance against it. `data` shipped in A because it was measured changing emitted C.",
+    "C (no-cli-structuring-override, PARKED): flow (works today) then wire force goto / override jumptable / isolate / deadcode delay onto their ported engine entries, fill the matching kassert Dispatch arms, record structure blocks and analyze range as residue"
   ],
   "speed": "zero on every existing invocation -- no directives means no extra console lines, no second decompile and an empty assertions[]. With a symbol-scoped directive the target function is decompiled twice: a bounded ~2x on one function, opt-in, and the same cost shape the formatstring half-B loop already pays. No pipeline pass is added.",
   "risks": [
@@ -65,5 +71,12 @@
   "gates": {
     "note": "no source file was changed on this branch; the diff is the proposal, the record and the need's new Acceptance section",
     "acceptance": "a-a58fc408288b runnable and FAILING at e3db5512 (exit_code 2, 'error: unknown option --assert') -- correct for an unimplemented acceptance"
-  }
+  },
+  "stage": "A (implemented)",
+  "residue": [
+    "override prototype <addr> <decl> is accepted and inert; the whole store->consume chain is present and looks correct, so this needs its own diagnosis (per-call-site prototype override only -- a function's OWN prototype is covered by `assert prototype`)",
+    "label (map label): no observable effect on emitted C, so no directive shipped for it",
+    "--kassert p9 naming-policy is inert from the CLI (emitted before the first decompile) and --kassert is still refused with --json; superseded by --assert",
+    "phases.toml P4/P5/P9 exposure prose (lease held by another builder this wave)"
+  ]
 }

--- a/docs/features/no-cli-rename-or-prototype-override/record.json
+++ b/docs/features/no-cli-rename-or-prototype-override/record.json
@@ -1,0 +1,69 @@
+{
+  "slug": "no-cli-rename-or-prototype-override",
+  "need_id": "no-cli-rename-or-prototype-override",
+  "track": "tooling",
+  "opportunity": "re-need:no-cli-rename-or-prototype-override",
+  "probe_id": null,
+  "acceptance_id": "a-a58fc408288b",
+  "instances": 1,
+  "scope": "large",
+  "proposal": true,
+  "covers_needs": [
+    "no-cli-rename-or-prototype-override",
+    "no-cli-data-code-override",
+    "no-cli-structuring-override"
+  ],
+  "option": null,
+  "flag": null,
+  "element_id": null,
+  "phase": null,
+  "tier": "driver",
+  "change_kind": "capability-add",
+  "default_on": null,
+  "owning_file": "docs/features/no-cli-rename-or-prototype-override/proposal.md",
+  "spec_chapter": "docs/spec/00-overview.md",
+  "parity": "untouched (no code change on this branch)",
+  "root_cause_class": "absent-capability",
+  "hypothesis_status": "OVERTURNED",
+  "filed_hypothesis": "ADVISORY. The cheap half is exposure, not implementation: most of these commands already work and only lack a path from the `kuna` binary. The expensive half is the stubs.",
+  "decisions": [
+    "THE FIRST HALF OF THE HYPOTHESIS IS UPHELD AND LARGER THAN FILED. 11 console commands were measured reaching emitted C at e3db5512 on in-repo fixtures: rename, retype, map param, parse line extern, parse line typedef/struct, map address, map label, type varnode, readonly, volatile, override flow. Two of them are worth quoting as evidence -- `parse line extern int4 authenticate(char *user,char *pass);` renames both parameters through the whole body, and `override flow 0x4006aa branch` turns a CALL into a tail-call and restructures the function. This is exposure work.",
+    "THE SECOND HALF IS OVERTURNED -- the same way it was overturned on no-cli-function-boundary-override, and for the same reason. 'The expensive half is the stubs' assumes the stubs need engine ports. Every engine entry point they name is already ported in kuna-decomp: Override::insert_force_goto (p0_knowledge/overrides.rs:256), Funcdata::install_jump_table (substrate/funcdata_block.rs:1724), Override::insert_deadcode_delay (overrides.rs:265), Symbol::set_isolated (database.rs:834), FuncProto::set_input_lock/set_output_lock (p4_calls/fspec.rs:5204/5242). The stub message blames 'parse_machaddr/parse_C grammars are a later W-item', but parse_machaddr is implemented at ifacedecomp.rs:322 and parse_c at grammar.rs:2292, and both are used by commands that work. These are inert plumbing, not ports.",
+    "THE ACTUAL EXPENSIVE HALF IS TWO SHIPPED COMMANDS THAT LIE, which no reading of the source would have found. (1) `map return <addr> <typedecl>` PANICS the whole console process -- `outtype null`, p4_calls/fspec.rs:2624 in assign_map_standard_out -- reproduced standalone as the first command after `load function`. (2) `override prototype <addr> <decl>` prints 'Successfully added override' and changes nothing, measured on a direct known callee (strcmp at 0x400689, 2 params -> 3) AND on an indirect call (CALL RDX at 0x1405 in aif_gap stage1). Its own doc comment says the FlowInfo::queryCall consume is stubbed while flow.rs:2152 says applyPrototype is wired; one is stale.",
+    "A THIRD DEFECT, CLI-SIDE AND NOT IN ANY NEED: the one kassert arm that is fully implemented is dead on the one surface that can reach it. `kuna decompile <bin> authenticate --kassert 'p9 naming-policy v2 buf'` exits 0 and changes nothing, because build_script emits kassert between `load function` and the FIRST `decompile`, and a local like v2 does not exist until a decompile has run. The arm throws 'No symbol named: v2' into a transcript the CLI discards. This forces the two-pass script shape in the design and is the single most important ordering fact measured here.",
+    "AND A FOURTH: `--kassert` is rejected outright when combined with `--json` ('error: --kassert is not supported with --json'). For an agent consuming machine-readable output the existing override surface therefore does not exist at all.",
+    "DESIGN -- ONE PLANE, `--assert <directive> | @FILE` (repeatable), intent-keyed rather than phase-keyed. An agent should not have to know renaming is P9 to rename something; --kassert stays as the raw phase-keyed writer. The @FILE contract is copied verbatim from --define-function (#374) because that is what makes an override durable across invocations: kuna does not write assertions back into the image, the file is the artifact.",
+    "DESIGN -- MACHINE-READABLE OUT. Every --json surface grows an `assertions[]` array, one row per directive, status applied|rejected with a reason. A rejection is non-fatal by default (an agent batching forty renames must not lose all forty to one stale name) with --assert-strict to opt in. The --kassert/--json prohibition is lifted so the two report into the same array.",
+    "DESIGN -- THE IN-PROCESS HALF IS ALREADY BUILT, which is what makes this affordable. kuna_console::decompile_step::DecompileSeed is the shared 'console-only facts' carrier and the whole-binary loop passes empty slices for exactly the fields this plane needs: mapped_symbols (data), usepoint_symbols (type varnode), dynamic_symbols, pending_proto (prototype), flow_overrides (flow), mapped_params (param). And decompile_one ALREADY contains a decompile -> adjust -> re-decompile loop (the formatstring half-B override loop), so the symbol-scoped second pass has precedent in the exact function that needs it.",
+    "REJECTED -- a `kuna console` passthrough or a --script flag. The captain's caution is upheld by the measurements: a passthrough would ship map return's panic and override prototype's silent no-op straight to agents, expose 37 commands of which ~14 are stubs, and leave nowhere to put the assertions[] report. A typed vocabulary is what lets a directive be REJECTED with a reason instead of throwing an unstructured diagnostic into a discarded transcript.",
+    "OUT OF SCOPE AND RECORDED AS RESIDUE: `structure blocks` (BlockGraph structuring) and `analyze range` (ValueSetSolver) are genuine engine ports. no-cli-structuring-override should carry them as residue rather than have this design half-port them.",
+    "ACCEPTANCE FILED AND GROUNDED. a-a58fc408288b was written only after its target C was produced end-to-end by decomp_dbg at e3db5512, on the same in-repo fixture, driven by the exact console script Stage A would generate. verify --acceptance-suite reported this need `unrunnable` before this branch and now reports passed:false with a real clause list (exit_code 2, 'unknown option --assert'). Sibling probes were deliberately NOT filed: no-cli-data-code-override's would have to assert a readonly/volatile effect, and no fixture tried here shows one -- filing a probe whose target was never measured is the exact mistake this proposal argues against."
+  ],
+  "mechanism": "`--assert <directive> | @FILE`, repeatable, on decompile / decompile-all / decompile-project. A new kuna-cli/src/assertdecl.rs parses a line-oriented intent-keyed vocabulary (prototype/param/return/name/type/typedef/data/label/comment, then readonly/volatile/global, then flow/goto/jumptable/isolate/deadcode-delay) modelled line-for-line on funcdecl.rs. The script surface emits each directive at its measured slot -- program-scope after `read symbols`, function-scope after `load function`, symbol-scope after a first `decompile` with a conditional second `decompile` -- and scrapes the byte-faithful console diagnostics back into an `assertions[]` array. The in-process surface fills DecompileSeed's already-present but always-empty slices and adds the symbol-scoped second pass to decompile_one.",
+  "measurements": {
+    "method": "drove decompiler/target/release/decomp_dbg directly at e3db5512 with SLEIGHHOME=$PWD/specs, one command per line on stdin, on the in-repo fixtures fauxware (c2d90645, 8776 bytes) and aif_gap_x86_64 (1a592a85, 14408 bytes); every 'reaches C' verdict is a diff of the printed C, never a return code",
+    "commands_probed": 22,
+    "reach_emitted_c": 11,
+    "engine_unavailable_stubs": 9,
+    "stubs_whose_engine_entry_is_already_ported": 5,
+    "shipped_commands_found_broken": 2,
+    "cli_level_defects_found": 2
+  },
+  "stages": [
+    "A (this need): the symbol and prototype plane -- parser, map return panic fix, override prototype diagnosis, two-pass script, DecompileSeed fill, assertions[] JSON, --kassert/--json prohibition lifted, docs/cli.md + spec + phases.toml exposure prose, acceptance a-a58fc408288b + tests/cli promotion",
+    "B (no-cli-data-code-override): readonly/volatile/global/data directives; wire the global add/remove stubs onto ScopeGlobal; find a fixture where a readonly range demonstrably folds and file that need's acceptance against it",
+    "C (no-cli-structuring-override): flow (works today) then wire force goto / override jumptable / isolate / deadcode delay onto their ported engine entries, fill the matching kassert Dispatch arms, update the affected subphase exposure fields, record structure blocks and analyze range as residue"
+  ],
+  "speed": "zero on every existing invocation -- no directives means no extra console lines, no second decompile and an empty assertions[]. With a symbol-scoped directive the target function is decompiled twice: a bounded ~2x on one function, opt-in, and the same cost shape the formatstring half-B loop already pays. No pipeline pass is added.",
+  "risks": [
+    "override prototype may be a genuine engine gap rather than a bug; the prototype directive then lowers to `parse line extern` only (measured working) and per-call-site override becomes Stage-A residue. The acceptance probe is written against parse line extern for exactly this reason and is unaffected.",
+    "transcript-scraping the forked script surface for assertions[] is brittle; mitigated by the console prefixes being documented byte-faithful and already parsed by decompile.rs (CONSOLE_DIAGNOSTICS, arch_failure_reason).",
+    "a directive that is accepted and does nothing is the failure mode of this whole family -- override prototype is already an instance. Every directive must ship with a test that asserts the emitted C CHANGED, not that the command returned Ok.",
+    "generated symbol names are unstable across runs, so `name v2 credbuf` can silently bind to the wrong local on a later kuna; mitigated by also accepting a stable storage form.",
+    "blast radius is nil: nothing runs unless a directive is passed, and the parity corpora are symbol-less bytechunks driven by XML with no CLI in the loop."
+  ],
+  "gates": {
+    "note": "no source file was changed on this branch; the diff is the proposal, the record and the need's new Acceptance section",
+    "acceptance": "a-a58fc408288b runnable and FAILING at e3db5512 (exit_code 2, 'error: unknown option --assert') -- correct for an unimplemented acceptance"
+  }
+}

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -376,7 +376,7 @@
       "status": "open",
       "severity": "major",
       "probe_id": null,
-      "acceptance_id": null,
+      "acceptance_id": "a-a58fc408288b",
       "hypothesis_status": "upheld",
       "credibility": 1.0,
       "instances": 1,

--- a/docs/re-needs/no-cli-rename-or-prototype-override.md
+++ b/docs/re-needs/no-cli-rename-or-prototype-override.md
@@ -5,13 +5,13 @@ track: tooling
 status: open
 severity: major
 acceptance_id: a-a58fc408288b
-hypothesis_status: upheld
+hypothesis_status: overturned
 credibility: 1.0
 instances: 1
 rounds: [2]
 first_seen_round: 2
-attempts: 0
-touches: [decompiler/crates/kuna-cli/src, decompiler/crates/kuna-console/src/kuna_console.rs]
+attempts: 1
+touches: [decompiler/crates/kuna-cli/src, decompiler/crates/kuna-console/src/assertions.rs]
 scope: large
 ---
 
@@ -122,3 +122,38 @@ ADVISORY. The cheap half is exposure, not implementation: most of these commands
 - round 2 T_TRIAGE (captain): track tooling / touches [kuna-cli/src, kuna-console/src/kuna_console.rs] / scope large CONFIRMED. New this tick: keyboard-callback-uses-undefined is a tester-filed demand witness for it -- an agent that could state a callback's prototype would not need kuna to infer R9D/R8D at all. Still waits behind the function-boundary proposal for the delivery vehicle.
 - round 2 wave 9 B_PLAN (captain): DISPATCHED as the override family's one design, because the delivery vehicle this need was waiting behind now EXISTS -- no-cli-function-boundary-override closed via #374 (`kuna decompile --define-function`), an agent-supplied fact injected from the `kuna` binary. Three standing instructions for the builder. (1) Design ONE override plane that covers this need AND its two siblings (no-cli-data-code-override, no-cli-structuring-override); the captain will not approve three separate large designs, and a unified proposal lets the siblings collapse into it rather than each burning a builder. (2) Answer the Hypothesis's cheap/expensive question as a table: for every command named in the Symptom, whether it already works in the console and only lacks a `kuna` path, or is an `engine_unavailable` stub. (3) The proposal MUST define a concrete `acceptance` probe for this need. It has none today (`verify --acceptance-suite` reports it unrunnable), so nothing built on it could ever be closed by B_DONE, and a design that leaves it unrunnable is not approvable.
 - round 2 B_PLAN (builder): filed the acceptance probe this need lacked, `a-a58fc408288b`. Its target C was measured end-to-end through `decomp_dbg` before the probe was written (`parse line extern` + `retype` + `rename` on the in-repo `fauxware` fixture), so the probe asserts an output the engine demonstrably already produces -- what is missing is only the path from the `kuna` binary.
+- round 2 B_DONE (builder): SHIPPED as `kuna --assert <directive> | @FILE`, Stage A of the
+  approved proposal. Nine directives -- function, typedef, prototype, data, param, return,
+  comment, name, type -- each lowering to the console command that already implements it,
+  each with a test that asserts the emitted C CHANGED rather than that the command returned
+  Ok. Acceptance `a-a58fc408288b` PASS; promoted verbatim to
+  `tests/cli/no-cli-rename-or-prototype-override.json`.
+- round 2 B_DONE: `hypothesis_status` reconciled to `overturned`, matching this need's
+  `record.json` and the proposal's own verdict (the frontmatter still said `upheld`). The
+  cheap half is much LARGER than filed -- 11 console commands were measured reaching emitted
+  C -- and the expensive half is not "the stubs": it is two shipped commands that lied.
+  `map return` is fixed here (it parked output-only `PrototypePieces`, and
+  `ParamListStandardOut::assignMap` dereferences `outtype` unconditionally, so the command
+  aborted the process the moment its function was decompiled).
+- round 2 B_DONE: **Stage-A residue, three items, none of them blocking.**
+  (1) `override prototype <addr> <decl>` is still accepted-and-inert, re-measured on this
+  branch (`strcmp` at `0x400689`, 2 params -> 3: no change). The store and the consume are
+  BOTH present and look correct -- `IfcProtooverride` stashes into `pending_proto_overrides`,
+  `IfcDecompile` re-seeds it, `build_and_follow_flow_with_override_and_protos` installs it on
+  the fresh `Funcdata`, and `ArchFlowEnv::build_override_proto` (decompile_drive.rs:325)
+  builds a real `FuncProto` from the pieces -- so the proposal's "one of the two is stale" is
+  itself wrong and the defect is somewhere else in that chain. Time-boxed per the captain's
+  dispatch: the `prototype` directive lowers to `parse line extern` (measured working, and
+  what the acceptance asserts), so per-CALL-SITE prototype override is the residue, not the
+  function's own prototype. Worth its own need.
+  (2) `label` is not shipped: `map label` has no observable effect on emitted C on any
+  fixture tried, so it cannot satisfy the standing "the test asserts the C changed" rule.
+  (3) The two CLI-level `--kassert` defects this need's proposal recorded (the `naming-policy`
+  arm emitted before the first `decompile` and therefore inert; `--kassert` rejected outright
+  with `--json`) are NOT fixed. `--assert` supersedes both -- it is the intent-keyed writer,
+  it reports into `assertions[]`, and it works with `--json` -- so fixing the raw phase-keyed
+  writer is optional cleanup rather than a gap an agent can feel.
+- round 2 B_DONE: the P4/P5/P9 `exposure` prose in `phases.toml` is DEFERRED, not skipped by
+  choice: `file:phases.toml` was held by `b-r2-ppc64-localentry` for this whole wave. It is
+  prose, no gate reads it, and this PR adds no settable row (so no catalog counters and no
+  DIV row either).

--- a/docs/re-needs/no-cli-rename-or-prototype-override.md
+++ b/docs/re-needs/no-cli-rename-or-prototype-override.md
@@ -4,6 +4,7 @@ title: an agent cannot rename or retype anything, or force a prototype
 track: tooling
 status: open
 severity: major
+acceptance_id: a-a58fc408288b
 hypothesis_status: upheld
 credibility: 1.0
 instances: 1
@@ -22,6 +23,95 @@ scope: large
 
 Every named CLI flag is rejected with `error: unknown option`, verified on the round-1 merge build; the stubs are verified by driving `decomp_dbg` directly and reading back `engine integration not yet ported`.
 
+## Acceptance
+
+Asserts the DESIRED behaviour: an agent states three facts kuna cannot be told
+today -- the function's prototype, a local's type and a local's name -- on one
+`kuna decompile --json` invocation, and all three land in the emitted C while the
+run reports each one's fate as machine-readable JSON. FAILS at e3db5512: every
+`--assert` is rejected with `error: unknown option`.
+
+```json
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-a58fc408288b",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "authenticate",
+    "--json",
+    "--assert",
+    "prototype authenticate int4 authenticate(char *user,char *pass)",
+    "--assert",
+    "type v2 char[16]",
+    "--assert",
+    "name v2 credbuf"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "binary_sha256": "c2d90645a45e99221593547e55c601a901b80f807ae96f94c60a7661df0b3e0b",
+    "binary_size": 8776,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "selector": "authenticate",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "assertions",
+        "op": "len_eq",
+        "value": 3
+      },
+      {
+        "path": "assertions[0].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "assertions[1].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "assertions[2].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "contains",
+        "value": "authenticate(char *user,char *pass)"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "contains",
+        "value": "char credbuf [16];"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "not_contains",
+        "value": "char v2 [8]"
+      }
+    ]
+  },
+  "notes": "Desired: `--assert <directive>|@FILE` (repeatable), the one override plane. Three directives -- `prototype` (a C signature, lowering to `parse line extern`), `type` (`retype`) and `name` (`rename`) -- land in the emitted C, and each one's fate is reported in a machine-readable `assertions[]`. The asserted C was measured end-to-end through decomp_dbg at e3db5512. In-repo fixture: promotes verbatim."
+}
+```
+
 ## Hypothesis
 
 ADVISORY. The cheap half is exposure, not implementation: most of these commands already work and only lack a path from the `kuna` binary. The expensive half is the stubs. A builder should measure which is which before choosing a design, and should NOT assume a `kuna console` passthrough is the right shape -- a scriptable console is a different product from a set of flags an agent can compose.
@@ -31,3 +121,4 @@ ADVISORY. The cheap half is exposure, not implementation: most of these commands
 - seeded for round 2 from a source survey of the override surface, after round 1 showed testers hitting obfuscated images with no lever to correct kuna with. Not tester-filed: round 2 should confirm the demand.
 - round 2 T_TRIAGE (captain): track tooling / touches [kuna-cli/src, kuna-console/src/kuna_console.rs] / scope large CONFIRMED. New this tick: keyboard-callback-uses-undefined is a tester-filed demand witness for it -- an agent that could state a callback's prototype would not need kuna to infer R9D/R8D at all. Still waits behind the function-boundary proposal for the delivery vehicle.
 - round 2 wave 9 B_PLAN (captain): DISPATCHED as the override family's one design, because the delivery vehicle this need was waiting behind now EXISTS -- no-cli-function-boundary-override closed via #374 (`kuna decompile --define-function`), an agent-supplied fact injected from the `kuna` binary. Three standing instructions for the builder. (1) Design ONE override plane that covers this need AND its two siblings (no-cli-data-code-override, no-cli-structuring-override); the captain will not approve three separate large designs, and a unified proposal lets the siblings collapse into it rather than each burning a builder. (2) Answer the Hypothesis's cheap/expensive question as a table: for every command named in the Symptom, whether it already works in the console and only lacks a `kuna` path, or is an `engine_unavailable` stub. (3) The proposal MUST define a concrete `acceptance` probe for this need. It has none today (`verify --acceptance-suite` reports it unrunnable), so nothing built on it could ever be closed by B_DONE, and a design that leaves it unrunnable is not approvable.
+- round 2 B_PLAN (builder): filed the acceptance probe this need lacked, `a-a58fc408288b`. Its target C was measured end-to-end through `decomp_dbg` before the probe was written (`parse line extern` + `retype` + `rename` on the in-repo `fauxware` fixture), so the probe asserts an output the engine demonstrably already produces -- what is missing is only the path from the `kuna` binary.

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -702,6 +702,66 @@ declaration is applied after discovery has had its say, because it is an asserti
 that outranks it. Durability is caller-carried — the `@file` form is the artifact,
 and kuna does not write boundaries back into the image.
 
+(kuna) **Caller assertions (`--assert`).** Declared boundaries are one fact an
+agent can state; the assertion plane is the rest of them. Everything the engine
+knows about a program it derived, and the console has long carried the commands
+that correct each derivation — `rename`, `retype`, `map param`, `map return`,
+`map address`, `comment instruction`, `parse line` — while none of them was
+reachable from the `kuna` binary, whose generated script emitted a fixed
+vocabulary (`option`, `read symbols`, `load`, `kassert`, `function bounds`,
+`decompile`).
+
+A **directive** is one line of an intent-keyed vocabulary — an agent does not have
+to know that renaming is P9 to rename something — parsed by
+`decompiler/crates/kuna-cli/src/assertdecl.rs` and applied by
+`decompiler/crates/kuna-console/src/assertions.rs`:
+
+| directive | lowers to | writes at |
+|---|---|---|
+| `function <start>[-<end>][=<name>]` | `function bounds` | P1, the `--define-function` spelling |
+| `typedef <C declaration>` | `parse line` | P5 type-propagation |
+| `prototype <func> <C declaration>` | `parse line extern` | P4 prototype-source |
+| `data <addr> <C typedeclaration>` | `map address` | P5 const-pointer |
+| `param [<func>::]<i> <storage> <C typedeclaration>` | `map param` | P4 prototype-source |
+| `return [<func>::]<storage> <C typedeclaration>` | `map return` | P4 prototype-source |
+| `comment [<func>::]<addr> <text>` | `comment instruction` | P9 external-refinement |
+| `name [<func>::]<symbol> <newname>` | `rename` | P9 naming-policy |
+| `type [<func>::]<symbol> <C type>` | `retype` | P5 type-propagation |
+
+Three application points, and the ordering between them is forced rather than
+stylistic. **Program-scoped** directives (`function`, `typedef`, `prototype`,
+`data`) are applied right after the analysis commit
+(`ConsoleProgram::set_assertions` + `assertions::apply_program_scoped`, called
+from `decompiler/crates/kuna-cli/src/decompile_all.rs (load_program)`), for the
+same reason a declared boundary is: an assertion outranks discovery.
+**Function-scoped** directives (`param`, `return`, `comment`) become decompile
+SEEDS (`assertions::function_seed`), because a prototype fact is consumed at flow
+time and cannot be applied afterwards. **Symbol-scoped** directives (`name`,
+`type`) can only be applied to an already-decompiled function — the local they
+name does not exist until a decompile has produced it — so
+`decompiler/crates/kuna-console/src/project.rs (decompile_targets)` decompiles,
+applies them to the first pass's `Funcdata` (`assertions::apply_symbol_scoped`),
+and decompiles again with the mutated local scope carried across as
+`mapped_symbols`. That second pass is emitted only when such a directive bound to
+the function, so every run without one costs exactly what it did before. The
+script surface (`decompiler/crates/kuna-cli/src/decompile.rs (build_script)`)
+emits the same facts at the same three slots, with the same conditional second
+`decompile`.
+
+A directive that names no function binds to the function being decompiled, which
+is unambiguous only when the run selected exactly one; on a whole-binary run it
+would silently mean *every* function that happens to have a `v2`, so it is
+rejected there with a detail naming the `<func>::<operand>` form. Rejecting is the
+design: every directive produces exactly one row in the run's report
+(`ConsoleProgram::assertion_outcomes`, serialized as the `assertions` array of
+every `--json` document and spoken on stderr on the human surface), because a
+directive that is accepted and does nothing is worse for an agent than one that
+errors. `--assert-strict` turns any rejection into a non-zero exit; without it a
+rejection is reported and the run continues, so a batch of forty renames against a
+re-decompiled binary does not lose the other thirty-nine to one stale name.
+Durability is caller-carried, as it is for boundaries: `--assert @FILE` is the
+artifact.
+
 (kuna) **Load-time env bridges.** Seven loader gates are consumed *inside* the
 bootstrap — before any console `option` line can possibly run — so the option
 surface alone cannot deliver them; each is bridged through a process environment

--- a/tests/cli/no-cli-rename-or-prototype-override.json
+++ b/tests/cli/no-cli-rename-or-prototype-override.json
@@ -1,0 +1,78 @@
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-a58fc408288b",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "authenticate",
+    "--json",
+    "--assert",
+    "prototype authenticate int4 authenticate(char *user,char *pass)",
+    "--assert",
+    "type v2 char[16]",
+    "--assert",
+    "name v2 credbuf"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "binary_sha256": "c2d90645a45e99221593547e55c601a901b80f807ae96f94c60a7661df0b3e0b",
+    "binary_size": 8776,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "selector": "authenticate",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "assertions",
+        "op": "len_eq",
+        "value": 3
+      },
+      {
+        "path": "assertions[0].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "assertions[1].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "assertions[2].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "contains",
+        "value": "authenticate(char *user,char *pass)"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "contains",
+        "value": "char credbuf [16];"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "not_contains",
+        "value": "char v2 [8]"
+      }
+    ]
+  },
+  "notes": "Desired: `--assert <directive>|@FILE` (repeatable), the one override plane. Three directives -- `prototype` (a C signature, lowering to `parse line extern`), `type` (`retype`) and `name` (`rename`) -- land in the emitted C, and each one's fate is reported in a machine-readable `assertions[]`. The asserted C was measured end-to-end through decomp_dbg at e3db5512. In-repo fixture: promotes verbatim."
+}


### PR DESCRIPTION
## What was broken

> `rename`, `retype`, `map param`, `map return`, `override prototype` and
> `parse line extern ...` are all functional in the console and none is reachable from
> `kuna`. [...] For an agent, a rename that does not persist is the difference between
> reading a decompilation once and actually working through one.
>
> — `docs/re-needs/no-cli-rename-or-prototype-override.md` (severity major, instances 1, rounds [2])

Everything kuna knows about a program it *derived*. The console has carried the commands
that correct each derivation all along; the `kuna` binary's generated script emitted a fixed
vocabulary — `option`, `read symbols`, `load`, `kassert`, `function bounds`, `decompile` —
and nothing else. `--kassert` exists but only its `Option` and `Rename` arms do real work,
and the `Rename` one is a **silent no-op from the CLI**: it is emitted before the first
`decompile`, so the local it names does not exist yet and `No symbol named: v2` goes into a
transcript the CLI discards. `--kassert` is also refused outright with `--json`, so for an
agent consuming machine-readable output the override surface did not exist at all.

This is Stage A of the approved proposal (`docs/features/no-cli-rename-or-prototype-override/proposal.md`).

## The mechanism

`--assert <directive> | @FILE`, repeatable, on `decompile`, `decompile-all`,
`decompile-project` and `functions`.

```bash
kuna decompile ./a.out authenticate --json \
  --assert 'prototype authenticate int authenticate(char *user,char *pass)' \
  --assert 'type v2 char[16]' \
  --assert 'name v2 credbuf'
```

```text
- unsigned long authenticate(char *a0,char *a1)     - char v2 [8];
+ int authenticate(char *user,char *pass)           + char credbuf [16];
```

Nine directives, keyed by **intent** rather than by phase — an agent should not have to know
that renaming is P9 to rename something — each lowering to the console command that already
implements it:

| directive | lowers to | writes at |
|---|---|---|
| `function <start>[-<end>][=<name>]` | `function bounds` | P1 (the `--define-function` spelling) |
| `typedef <C declaration>` | `parse line` | P5 type-propagation |
| `prototype <func> <C declaration>` | `parse line extern` | P4 prototype-source |
| `data <addr> <C typedeclaration>` | `map address` | P5 const-pointer |
| `param [<func>::]<i> <storage> <C typedecl>` | `map param` | P4 prototype-source |
| `return [<func>::]<storage> <C typedecl>` | `map return` | P4 prototype-source |
| `comment [<func>::]<addr> <text>` | `comment instruction` | P9 external-refinement |
| `name [<func>::]<symbol> <newname>` | `rename` | P9 naming-policy |
| `type [<func>::]<symbol> <C type>` | `retype` | P5 type-propagation |

**Machine-readable in, machine-readable out.** Every `--json` document grows an `assertions`
array — one row per directive, in the caller's order, carrying the directive text, its phase
and sub-phase, `applied` or `rejected`, and a reason. A rejection is also spoken on stderr on
both surfaces, is non-fatal by default (a batch of forty renames against a re-decompiled
binary must not lose the other thirty-nine to one stale name), and `--assert-strict` makes it
the run's verdict.

**Three slots, and the ordering is forced rather than stylistic.** Program-scoped directives
are applied right after the analysis commit, for the same reason a declared boundary is: an
assertion outranks discovery. Function-scoped ones become decompile seeds, because a
prototype fact is consumed at flow time. Symbol-scoped ones (`name`, `type`) can only run
*between two decompiles* — the local they name does not exist until one has produced it,
which is exactly the bug that makes `--kassert p9 naming-policy` inert today. The second pass
is emitted only when such a directive bound to the function, so **every run without one costs
what it did before**. An unqualified directive on a multi-function run is rejected with a
detail naming the `<func>::<operand>` form rather than applied to every function that happens
to have a `v2`.

`@FILE` is the durable form, the `--define-function` contract verbatim: kuna does not write
assertions back into the image, so the file is the artifact.

## Also fixed: `map return` aborted the process

`map return <addr> <type>` killed the whole console the moment its function was decompiled —
`outtype null`, `ParamListStandardOut::assignMap`. It parks OUTPUT-ONLY `PrototypePieces`
(explicit storage, no declared return type) and `assignParameterStorage` dereferences
`outtype` unconditionally. `FuncProto::seed_locked_from_pieces` already special-cased
`outtype: None && output_storage: None`; the `Some` case fell through to the abort. The
declared type *is* the return type. Fixed at the engine seam so every caller gets it, with a
regression test that drives the drive with output-only pieces directly.

## The filed hypothesis is overturned

> ADVISORY. The cheap half is exposure [...] The expensive half is the stubs.

The cheap half is **much larger** than filed — 11 console commands were measured reaching
emitted C. The expensive half is **not** the stubs, whose engine entry points are all already
ported: it was two *shipped* commands that lie. One (`map return`) is fixed here. The other
(`override prototype`) is residue, and the proposal's own diagnosis of it (*"the `queryCall`
consume is stubbed OR `applyPrototype` is wired — one is stale"*) is itself wrong: reading
the whole chain, every link is present and looks correct — store, re-seed, install on the
fresh `Funcdata`, `build_override_proto` builds a real locked `FuncProto` — and the C still
does not change (re-measured on this branch: `strcmp` at `0x400689`, 2 params → 3, no
change). Time-boxed per the dispatch; the `prototype` directive lowers to `parse line
extern`, which is measured working and is what the acceptance asserts, so nothing shipped
here depends on it. Per-call-site prototype override is worth its own need.

`hypothesis_status` on the need record is reconciled from `upheld` to `overturned`, matching
its `record.json` and the proposal's verdict.

## Acceptance

`a-a58fc408288b` — FAILED at `e3db5512` (`exit_code 2`, `error: unknown option --assert`),
**PASS** here, all seven clauses. Promoted verbatim to
`tests/cli/no-cli-rename-or-prototype-override.json` (in-repo fixture, so CI needs no
dataset).

## Every directive's test asserts the emitted C CHANGED

Not that the command returned Ok — reviewing on the return value is how `override prototype`
got shipped broken. `crates/kuna-console/tests/verify_assertplane.rs`, 11 tests, each a diff
against the un-asserted baseline: prototype (signature + parameter names), param (locked
input), return (locked output), name+type (`char v2 [8]` → `char credbuf [16]`), typedef+type
(`creds v2;` / `v2.raw`), data (`sneaky` → `shadowpw` at the call), comment (`/* ... */` in
the body), function (`authstub`, 28 bytes), plus directive ordering, the multi-function
qualification rule, and the `map return` abort. `assertdecl` adds 9 syntax tests and
`decompile.rs` 4 more for the script slots and the transcript reader.

`label` (`map label`) is deliberately **not** shipped: it has no observable effect on emitted
C on any fixture tried, so no test could satisfy that rule, and shipping it would have made
this PR an instance of the failure mode it exists to close. Recorded as residue.

## Gates

| gate | result |
|---|---|
| `make test` | **PARITY OK**, 675/675 |
| `make test-stages` | **PARITY OK**, 603/603 |
| `make rust-test` | green |
| `make check-spec` | OK |
| `kuna catalog --check` | OK |
| `verify --need no-cli-rename-or-prototype-override` | acceptance **PASS** |

No `phases.toml` row, no `options.rs` registration, no catalog counter, no `docs/options.md`
regeneration, no DIV row and no `tests/stages/` case: a flag that only carries caller
assertions cannot change emitted C for a run that does not pass one, and the tooling track
scopes the stages corpus away from it. The parity corpora are structurally unaffected —
symbol-less bytechunks driven by XML, with no CLI in the loop.

**Deferred, not skipped:** the P4/P5/P9 `exposure` prose in `phases.toml`. That file was
leased by `b-r2-ppc64-localentry` for this whole wave (captain dispatch item 2). It is prose,
no gate reads it. Stage B (`no-cli-data-code-override`) and Stage C
(`no-cli-structuring-override`) stay parked as their own needs and their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)