### PR TITLE
[AUTOMATED] perf(p6/infra): decompiling-3396-byte-main — stop re-deriving cached facts per query (−16%)

### DIFF
--- a/decompiler/crates/kuna-decomp/src/infra/action.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/action.rs
@@ -593,6 +593,12 @@ pub struct ActionContext {
 /// loop only pays an `Instant::now()` every this-many ops).
 const POOL_DEADLINE_STRIDE: u32 = 1024;
 
+/// (kuna perf) How many optree successors [`ActionPool::advance_op_state`] reads
+/// per tree descent.  Long enough that a pass over a large function pays a
+/// handful of descents per hundred ops instead of one each; short enough that a
+/// rule that creates an op (which invalidates the run) has thrown away little.
+const LOOKAHEAD_RUN: usize = 64;
+
 impl ActionContext {
     /// A fresh context.
     pub fn new() -> ActionContext {
@@ -1112,6 +1118,23 @@ pub struct ActionPool {
     /// op just consumed, which cannot move its own successor.  Every `apply`
     /// return path clears it, so a resumed or interleaved pass re-searches.
     next_op: Option<OpId>,
+    /// (kuna perf) A short run of successors read from the optree in one
+    /// descent, consumed one per [`advance_op_state`](ActionPool::advance_op_state).
+    ///
+    /// The C++ `op_state` is a map iterator, so its `++` is O(1); re-deriving
+    /// the position from a [`SeqNum`] is a tree search *per op per rule pass*.
+    /// [`lookahead_epoch`](ActionPool::lookahead_epoch) is the optree's epoch at
+    /// the moment the run was read: while it still matches, the tree holds the
+    /// same keys in the same order and the buffered ids are exactly what the
+    /// per-op search would return.  Any insertion or removal anywhere — a rule
+    /// creating an op, or a destroy this pool did not perform — changes the
+    /// epoch and forces the search again.
+    lookahead: Vec<OpId>,
+    /// Index of the next unconsumed entry in [`lookahead`](ActionPool::lookahead).
+    lookahead_idx: usize,
+    /// The optree epoch [`lookahead`](ActionPool::lookahead) was read at;
+    /// `None` means "no buffered run".
+    lookahead_epoch: Option<u64>,
     /// Iterator over rules for one OpCode (C++ `rule_index`).
     rule_index: usize,
     /// Messages emitted mid-[`process_op`] (rule warnings).  `process_op` is a
@@ -1150,6 +1173,9 @@ impl ActionPool {
             perop: vec![PerOp::new(); OpCode::CPUI_MAX as usize],
             op_state: OpCursor::Unstarted,
             next_op: None,
+            lookahead: Vec::new(),
+            lookahead_idx: 0,
+            lookahead_epoch: None,
             rule_index: 0,
             warnings: WarningSink::new(),
             pending_error: None,
@@ -1198,6 +1224,12 @@ impl ActionPool {
         if data.obank().get(op).map(|o| o.is_dead()).unwrap_or(true) {
             self.advance_op_state(data, op);
             data.obank_mut().destroy(op);
+            // The destroy removed the key the cursor just left, which sorts
+            // before every buffered successor, so the run is still ordered; take
+            // the new epoch as the run's own rather than throwing it away.
+            if self.lookahead_epoch.is_some() {
+                self.lookahead_epoch = Some(data.obank().optree_epoch());
+            }
             self.rule_index = 0;
             return 0;
         }
@@ -1275,8 +1307,17 @@ impl ActionPool {
             .expect("advance_op_state: op already gone");
         // One optree probe answers both questions the cursor has: whether a
         // successor exists, and which op it is.  Keep the id so `current_op` does
-        // not repeat the search.
-        self.next_op = data.obank().first_after_seq_id(&sq);
+        // not repeat the search.  The probe reads a RUN of successors, so the
+        // following LOOKAHEAD_RUN advances are served without touching the tree
+        // (see `lookahead`); an insertion or a foreign removal invalidates it.
+        let epoch = data.obank().optree_epoch();
+        if self.lookahead_epoch != Some(epoch) || self.lookahead_idx >= self.lookahead.len() {
+            data.obank().ops_after_seq(&sq, LOOKAHEAD_RUN, &mut self.lookahead);
+            self.lookahead_idx = 0;
+            self.lookahead_epoch = Some(epoch);
+        }
+        self.next_op = self.lookahead.get(self.lookahead_idx).copied();
+        self.lookahead_idx += 1;
         self.op_state = if self.next_op.is_some() { OpCursor::After(sq) } else { OpCursor::Done };
     }
 
@@ -1357,6 +1398,7 @@ impl Action for ActionPool {
             self.rule_index = 0;
         }
         self.next_op = None;
+        self.lookahead_epoch = None;
         let mut ops_since_deadline_probe: u32 = 0;
         while let Some(op) = self.current_op(data) {
             // (kuna decompile-all watchdog) Cooperative deadline in the tight
@@ -1368,6 +1410,7 @@ impl Action for ActionPool {
                 ops_since_deadline_probe = 0;
                 if ctx.deadline_expired() {
                     self.next_op = None;
+                    self.lookahead_epoch = None;
                     self.drain_into(ctx);
                     return 0;
                 }
@@ -1375,11 +1418,13 @@ impl Action for ActionPool {
             let r = self.process_op(op, data);
             if r != 0 {
                 self.next_op = None;
+                self.lookahead_epoch = None;
                 self.drain_into(ctx);
                 return -1;
             }
         }
         self.next_op = None;
+        self.lookahead_epoch = None;
         self.drain_into(ctx);
         0 // Indicate successful completion
     }

--- a/decompiler/crates/kuna-decomp/src/p6_variables/funcdata_merge.rs
+++ b/decompiler/crates/kuna-decomp/src/p6_variables/funcdata_merge.rs
@@ -175,6 +175,15 @@ impl Funcdata {
     /// C++ `updateSymbol` first-hit; members of one high share the same Symbol).
     fn kuna_mapped_symbol_entry(&self, high: HighVariableId) -> Option<(Address, int4)> {
         let h = self.high_bank().get(high)?;
+        // (kuna perf) The scan below only ever accepts an address-tied member,
+        // and a high's cached flag word is the OR of its members', so a clean
+        // `addrtied == false` settles it without walking them.  `mergeTestRequired`
+        // — this is its inner loop — reads `high_is_addr_tied` on both highs before
+        // it gets here, so the flags are clean by construction; a dirty word just
+        // falls through to the scan.
+        if h.kuna_addr_tied_if_clean() == Some(false) {
+            return None;
+        }
         let invalid = Address::new_invalid();
         let n = h.num_instances();
         for i in 0..n {
@@ -195,8 +204,16 @@ impl Funcdata {
             // covering Symbol's storage address (its identity), `sym_off` the in-symbol
             // byte offset of the access.
             if let Some(lm) = self.get_scope_local() {
-                if let Some(info) = lm.query_container_for_link(&addr, &invalid) {
-                    return Some((info.entry_addr, info.sym_off));
+                // `container_symbol_link` is the same `findContainer` query as
+                // `query_container_for_link` without the display-name String and
+                // data-type clones that result carries; this is a hot merge-test
+                // path that reads only the entry geometry.
+                if let Some((_sym, entry_addr, _sz, entry_off)) =
+                    lm.container_symbol_link(&addr, &invalid)
+                {
+                    let delta =
+                        addr.get_offset().wrapping_sub(entry_addr.get_offset()) as int4;
+                    return Some((entry_addr, delta.wrapping_add(entry_off)));
                 }
             }
             // Then the frozen global scope (`map addr r...`): the covering global Symbol.
@@ -550,6 +567,17 @@ impl MergeContext for Funcdata {
         // isolated on the first covering entry — mirroring `HighVariable::
         // getSymbol`'s first-hit member scan against a properly painted
         // SymbolEntry.
+        //
+        // (kuna perf) The scan is `merge_test_adjacent`'s inner loop and is
+        // quadratic in a big function: it runs once per candidate pair and
+        // walks every member of both highs, so on a 43 KB function it issued
+        // 26 M containment queries.  A scope that has never had a Symbol
+        // isolated cannot answer `true` from any of them, and the global arm
+        // below is unconditionally `false`, so the whole scan is skippable —
+        // see `ScopeLocal::has_isolated_symbols`.
+        if !self.get_scope_local().map(|lm| lm.has_isolated_symbols()).unwrap_or(false) {
+            return false;
+        }
         let members: Vec<VarnodeId> = (0..h.num_instances()).map(|i| h.get_instance(i)).collect();
         for vn in members {
             let (addr, is_free) = match self.vbank().get(vn) {

--- a/decompiler/crates/kuna-decomp/src/p6_variables/variable.rs
+++ b/decompiler/crates/kuna-decomp/src/p6_variables/variable.rs
@@ -664,6 +664,23 @@ impl HighVariable {
         self.update_flags(ctx);
         (self.flags & varnode_flags::persist) != 0
     }
+    /// (kuna) `addrtied` read *without* the [`Self::update_flags`] recompute:
+    /// `None` when the cached flag word is dirty, so the caller must fall back
+    /// to whatever it would have done anyway.
+    ///
+    /// [`update_flags`](Self::update_flags) ORs every member's flag word, so a
+    /// clean `false` here proves no member Varnode is address-tied — which is
+    /// what lets `Funcdata::kuna_mapped_symbol_entry` skip a scan of every
+    /// member looking for one.  Exists because that scan sits under
+    /// `Merge::mergeTestRequired`, whose `&self` context cannot run the
+    /// recompute.
+    pub fn kuna_addr_tied_if_clean(&self) -> Option<bool> {
+        if (self.highflags & high_flags::flagsdirty) != 0 {
+            return None;
+        }
+        Some((self.flags & varnode_flags::addrtied) != 0)
+    }
+
     /// C++ `isAddrTied`.
     pub fn is_addr_tied(&mut self, ctx: &dyn HighContext) -> bool {
         self.update_flags(ctx);

--- a/decompiler/crates/kuna-decomp/src/p6_variables/varmap.rs
+++ b/decompiler/crates/kuna-decomp/src/p6_variables/varmap.rs
@@ -934,6 +934,10 @@ pub struct ScopeLocal {
     /// `DynamicHash::find_varnode` (`recoverNameRecommendationsForSymbols`,
     /// varmap.cc:1557-1573).
     dyn_recommend: Vec<DynamicRecommend>,
+    /// (kuna) Whether any Symbol in this scope has ever been marked isolated
+    /// (C++ `Symbol::setIsolated`).  Read by
+    /// [`Self::has_isolated_symbols`]; see that method for why it is monotone.
+    isolated_present: bool,
 }
 
 impl ScopeLocal {
@@ -962,6 +966,7 @@ impl ScopeLocal {
             type_recommend: Vec::new(),
             name_recommend: Vec::new(),
             dyn_recommend: Vec::new(),
+            isolated_present: false,
         })
     }
 
@@ -1401,7 +1406,25 @@ impl ScopeLocal {
     /// C++ `Symbol::setIsolated(val)` reached through this scope's symbol table
     /// (`IfcTypeVarnode`: `sym->setIsolated(true)`).
     pub fn set_symbol_isolated(&mut self, sym: crate::database::SymbolId, val: bool) {
+        self.isolated_present |= val;
         self.db.symbol_mut(sym).set_isolated(val);
+    }
+
+    /// (kuna) Can any Symbol in this scope answer `true` to
+    /// [`Symbol::is_isolated`](crate::database::Symbol::is_isolated)?
+    ///
+    /// `false` lets a caller skip a containment query it already knows the
+    /// answer to.  [`Self::set_symbol_isolated`] is the only route by which the
+    /// `ISOLATE` dispflag can ever reach a Symbol in a function-local scope —
+    /// `set_attribute` writes the varnode-flag word behind a mask that excludes
+    /// it, `set_display_format` masks the low format bits, the symbol
+    /// constructors never set it, and the attribute is encoded (`ATTRIB_MERGE`)
+    /// but never decoded.  The flag is deliberately monotone: clearing it on a
+    /// `set_symbol_isolated(sym, false)` would require knowing no *other*
+    /// Symbol is still isolated, and a stale `true` only costs the query it
+    /// would have run anyway.
+    pub fn has_isolated_symbols(&self) -> bool {
+        self.isolated_present
     }
 
     /// C++ `ScopeInternal::setDisplayFormat(sym, attr)` (`database.cc:2246-2250`),

--- a/decompiler/crates/kuna-decomp/src/p6_variables/varmap/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/p6_variables/varmap/tests.rs
@@ -1181,3 +1181,33 @@ fn adv_l4_mark_not_mapped_offset_wraps_without_panic() {
     // (We only assert no panic + the call is idempotent.)
     sl.mark_not_mapped(&spc, 0xffff_ffff_ffff_fff4, 8, true);
 }
+
+/// `has_isolated_symbols` is the O(1) answer `Merge::mergeTestAdjacent` skips a
+/// whole-member containment scan on, so it must be `false` on a scope that has
+/// never isolated anything and `true` the moment one is, including for a Symbol
+/// that is NOT the one later queried.
+#[test]
+fn has_isolated_symbols_tracks_set_symbol_isolated() {
+    let mut sl = scope_local();
+    let spc = Rc::clone(sl.get_space_id());
+    let inv = Address::new_invalid();
+    let addr = Address::new(Rc::clone(&spc), 0xffff_ffff_ffff_ffe4);
+    let sym = sl
+        .add_symbol("i", base(4, type_metatype::TYPE_INT), &addr, &inv)
+        .expect("addSymbol");
+    assert!(
+        !sl.has_isolated_symbols(),
+        "adding an ordinary local must not claim the scope holds an isolated Symbol"
+    );
+    assert!(!sl.database().symbol(sym).is_isolated());
+
+    sl.set_symbol_isolated(sym, true);
+    assert!(sl.has_isolated_symbols());
+    assert!(sl.database().symbol(sym).is_isolated());
+
+    // Monotone on purpose: clearing ONE Symbol's flag says nothing about the
+    // others, and a stale `true` only costs the query it would have run anyway.
+    sl.set_symbol_isolated(sym, false);
+    assert!(!sl.database().symbol(sym).is_isolated());
+    assert!(sl.has_isolated_symbols());
+}

--- a/decompiler/crates/kuna-decomp/src/p9_emit/coreaction_render.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/coreaction_render.rs
@@ -2224,16 +2224,15 @@ fn deadcode_apply(data: &mut Funcdata) -> ApplyResult {
     // 1. Clear consume flags on every Varnode; drop addrforce on non-directwrite.
     let all_locs: Vec<VarnodeId> = data.vbank().iter_loc().collect();
     for vn in all_locs {
+        // One arena lookup, not three: none of the clears touch `addrforce` or
+        // `directwrite`, so the two reads see what a re-fetch would.  This loop
+        // runs over every Varnode in the function on every ActionDeadCode pass.
         let vm = data.vbank_mut().get_mut(vn).expect("deadcode: stale vn");
         vm.clear_consume_list();
         vm.clear_consume_vacuous();
         vm.set_consume(0);
-        let (af, dw) = {
-            let v = data.vbank().get(vn).expect("deadcode: stale vn");
-            (v.is_addr_force(), v.is_direct_write())
-        };
-        if af && !dw {
-            data.vbank_mut().get_mut(vn).expect("deadcode: stale vn").clear_addr_force();
+        if vm.is_addr_force() && !vm.is_direct_write() {
+            vm.clear_addr_force();
         }
     }
 

--- a/decompiler/crates/kuna-decomp/src/substrate/op.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/op.rs
@@ -1576,6 +1576,10 @@ pub struct PcodeOpBank {
     arena: OpArena,
     /// The main sequence-number sort (C++ `PcodeOpTree optree`)
     optree: BTreeMap<SeqNum, OpId>,
+    /// (kuna) Bumped by every [`Self::optree`] insertion and removal, so a
+    /// holder of a cached run of successors can tell in O(1) whether the tree
+    /// still orders the way it did — see [`Self::optree_epoch`].
+    optree_epoch: u64,
     /// List of \e dead PcodeOps (C++ `deadlist`)
     deadlist: IntrusiveList,
     /// List of \e alive PcodeOps (C++ `alivelist`)
@@ -1606,6 +1610,7 @@ impl PcodeOpBank {
         PcodeOpBank {
             arena: OpArena::with_key(),
             optree: BTreeMap::new(),
+            optree_epoch: 0,
             deadlist: IntrusiveList::default(),
             alivelist: IntrusiveList::default(),
             storelist: IntrusiveList::default(),
@@ -1693,6 +1698,7 @@ impl PcodeOpBank {
         let op = PcodeOp::new(inputs, sq.clone());
         let id = self.arena.insert(op);
         self.optree.insert(sq, id);
+        self.optree_epoch = self.optree_epoch.wrapping_add(1);
         self.arena[id].set_flag(pcodeop_flags::dead); // Start out life as dead
         self.deadlist.push_back(&mut self.arena, ListKind::Insert, id);
         id
@@ -1708,6 +1714,7 @@ impl PcodeOpBank {
         }
         let id = self.arena.insert(op);
         self.optree.insert(sq, id);
+        self.optree_epoch = self.optree_epoch.wrapping_add(1);
         self.arena[id].set_flag(pcodeop_flags::dead);
         self.deadlist.push_back(&mut self.arena, ListKind::Insert, id);
         id
@@ -1738,6 +1745,7 @@ impl PcodeOpBank {
         }
         let key = self.arena[op].get_seq_num().clone();
         self.optree.remove(&key);
+        self.optree_epoch = self.optree_epoch.wrapping_add(1);
         self.deadlist.erase(&mut self.arena, ListKind::Insert, op);
         self.remove_from_code_list(op);
         self.deadandgone.push(op);
@@ -1860,6 +1868,27 @@ impl PcodeOpBank {
     /// to test and again to dereference.
     pub fn first_after_seq_id(&self, sq: &SeqNum) -> Option<OpId> {
         self.first_after_seq(sq).map(|(_, id)| id)
+    }
+
+    /// (kuna) A counter that changes whenever the optree gains or loses an
+    /// entry.  Equal values across two observations mean the tree holds exactly
+    /// the same keys in the same order, so a run of successors read at the first
+    /// observation is still the run [`Self::first_after_seq_id`] would return
+    /// one at a time.
+    pub fn optree_epoch(&self) -> u64 {
+        self.optree_epoch
+    }
+
+    /// (kuna) Up to `n` optree entries strictly after `sq`, in order — one tree
+    /// descent instead of `n` of them.  The ActionPool cursor reads its
+    /// successors this way: the C++ advances a `PcodeOpTree::const_iterator` in
+    /// O(1), where re-deriving each position from a [`SeqNum`] costs a range
+    /// search per op per rule pass in the decompiler's innermost loop.
+    pub fn ops_after_seq(&self, sq: &SeqNum, n: usize, out: &mut Vec<OpId>) {
+        out.clear();
+        for (_, &id) in self.optree.range((Bound::Excluded(sq), Bound::Unbounded)).take(n) {
+            out.push(id);
+        }
     }
 
     pub fn first_after_seq(&self, sq: &SeqNum) -> Option<(&SeqNum, OpId)> {
@@ -2096,6 +2125,49 @@ mod tests {
         let times: Vec<u32> = bank.iter_all().map(|(k, _)| k.get_time()).collect();
         // addr 0x100 first: lo(uniq1) then mid(uniq2); then addr 0x200: hi(uniq0)
         assert_eq!(times, vec![1, 2, 0]);
+    }
+
+    /// The buffered run the ActionPool cursor reads must be exactly the
+    /// sequence its one-at-a-time predecessor produced.
+    #[test]
+    fn ops_after_seq_matches_repeated_first_after() {
+        let m = build_manager();
+        let mut bank = PcodeOpBank::new();
+        for off in [0x100u64, 0x108, 0x110, 0x118, 0x120] {
+            bank.create_at(0, ram(&m, off));
+            bank.create_at(0, ram(&m, off)); // two ops per address
+        }
+        let first = bank.iter_all().next().map(|(k, _)| k.clone()).unwrap();
+        let mut one_at_a_time = Vec::new();
+        let mut cur = first.clone();
+        while let Some((k, id)) = bank.first_after_seq(&cur) {
+            let k = k.clone();
+            one_at_a_time.push(id);
+            cur = k;
+        }
+        let mut run = Vec::new();
+        bank.ops_after_seq(&first, 64, &mut run);
+        assert_eq!(run, one_at_a_time);
+        // A short run truncates rather than skipping.
+        bank.ops_after_seq(&first, 3, &mut run);
+        assert_eq!(run, one_at_a_time[..3].to_vec());
+    }
+
+    /// The epoch is what tells a buffered run it is still valid, so it must
+    /// move on both halves of the optree's mutation surface.
+    #[test]
+    fn optree_epoch_moves_on_insert_and_destroy() {
+        let m = build_manager();
+        let mut bank = PcodeOpBank::new();
+        let e0 = bank.optree_epoch();
+        let a = bank.create_at(0, ram(&m, 0x100));
+        let e1 = bank.optree_epoch();
+        assert_ne!(e0, e1, "creating an op must move the epoch");
+        bank.create_seq(0, SeqNum::new(ram(&m, 0x200), 99));
+        let e2 = bank.optree_epoch();
+        assert_ne!(e1, e2, "create_seq must move the epoch");
+        bank.destroy(a);
+        assert_ne!(e2, bank.optree_epoch(), "destroying an op must move the epoch");
     }
 
     #[test]

--- a/docs/features/decompiling-3396-byte-main/pr_body.md
+++ b/docs/features/decompiling-3396-byte-main/pr_body.md
@@ -1,203 +1,109 @@
 ## What was broken
 
-RE-need `decompiling-3396-byte-main` (round 2, `perf`, 1 instance, challenge
-`69a3822f7b3cc38c80464da4`). A tester reverse-engineering a PE crackme reported:
+> **Decompiling the 3396-byte main function takes about 68 seconds** (major, `69a3822f7b3cc38c80464da4`, 1 instance)
+> The command produced no output for roughly 68 seconds, then emitted about 30 KB of highly noisy pseudocode.
 
-> **Decompiling the 3396-byte main function takes about 68 seconds.** The command
-> produced no output for roughly 68 seconds, then emitted about 30 KB of highly
-> noisy pseudocode. […] this observation is specifically about latency.
+This is **attempt 3** on `decompiling-3396-byte-main`. Attempts 1 and 2 took the
+witness 71.46 s → 19.42 s (#380, the dead-list scan) → 14.44 s (#385, following the
+function's flow once instead of twice), and both closed with the same finding: the
+residue is flat. This attempt confirms that again — and then finds that "flat" did
+not mean "nothing left", it meant *four* separate costs of a few percent each,
+three of them re-derivations of facts upstream keeps cached.
 
-Attempt 1 (#380, merged) removed an O(N²) dead-list position scan in the lifter
-and took the witness from 71.46 s to 19.42 s. The acceptance bar is a **median
-under 10 s**, so the need stayed open.
+## Mechanism
 
-## What this PR changes
+Four changes, none of which can alter emitted C:
 
-`kuna decompile <bin> <fn>` drives the console with `load function <fn>` and then
-`decompile`, and **each of those followed the same function's flow from scratch** —
-the whole lift, the block build, and the per-jump-table sub-decompilation, twice.
-
-Upstream never pays that: C++ `IfcFuncload` follows the flow once and
-`IfcDecompile` re-runs the action pipeline on *that* `Funcdata` after
-`Architecture::clearAnalysis` (`ifacedecomp.cc:889`). kuna rebuilds instead
-because a decompile is seeded with facts `load function` never applied, and two of
-them are consumed **at flow time**: `override prototype` call-site overrides
-(`FlowInfo::build_call_specs`) and the parsed callee prototypes re-parked on their
-global `FunctionSymbol` before the drive. The other five — `map address` symbols
-and DWARF stack locals, `type varnode` usepoint symbols, `map hash` dynamic
-symbols, a `parse line extern` prototype, `map param` storage locks — the drive
-re-seeds *after* the follow, so they would survive an adoption; they are held to
-the same bar anyway (below). So the rebuild is *required* when a flow-time fact
-exists, and pure waste when no fact exists at all — which is every plain `kuna
-decompile`.
-
-`decompile` now **adopts** the loaded IR when it can prove the rebuild would
-repeat the same follow. Three independent guards must all hold
-(`kuna-console/src/ifacedecomp.rs`, `PristineFlow`):
-
-1. **Every seed is empty** — flow-time or re-seeded alike. Holding the re-seeded
-   ones to the same bar makes the guard one question ("did the console learn
-   anything about this function?") instead of a per-seed judgement a later seed
-   could be forgotten from. It costs coverage only where kuna already has symbols:
-   in the sweep below 203 of 218 functions adopt, and the 15 that do not are the
-   DWARF-local and parsed-prototype cases.
-2. **The architecture is configured as it was at the load** — a `Funcdata`
-   snapshots the per-function flags into its ArchSeam handle when it is *built*,
-   so a flag flipped afterwards is invisible to it. `formatstring`, the watchdog
-   budget and ghidra-mode's staged recommendations all move between the load and
-   the drive, and each refuses adoption.
-3. **`decompile` is the immediately next command** — `load function` records
-   `IfaceStatus::command_seq` and `decompile` requires it to have advanced by
-   exactly one, with the same name, entry, declared extent and flow overrides.
-   The counter is the whole invalidation story on purpose: an `option`, a
-   `kassert`, a `map`, a second `load` — anything at all — advances it, so no
-   command needs its own invalidation hook and none can be forgotten.
-
-It is a pure-performance seam: the adopted `Funcdata` is the one the rebuild would
-have produced, so the emitted C is byte-identical either way. No option, no
-`phases.toml` row, no catalog counter, no DIV — nothing here can change emitted C.
-
-Guard 2 is not hypothetical, and it was re-verified rather than assumed. A build
-with `same_config` forced true renders, for `fmt_arm::main` under `--option
-formatstring on`:
-
-```c
-printf((char *)(dat_52c + 0x51c),a0,*a1);   // guard 2 removed
-printf("%d %s\n",a0,(char *)*a1);           // shipping
-```
-
-`formatstring` turns read-only propagation on *around* the drive so the
-PC-relative literal-pool format constant can be read, and the adopted IR had
-snapshotted the flag off. It is ARM-specific — the same A/B on `fmt_x86_64` and
-`fmt_aarch64` is byte-identical — so a sweep without an ARM literal-pool case
-would have missed it.
+1. **`Merge::merge_test_adjacent` stops re-deriving the isolated bit per member.**
+   C++ reads `high->getSymbol()->isIsolated()` off a cached pointer. kuna's merged
+   tree does not paint SymbolEntries onto Varnodes before the merge group, so
+   `bank_symbol_isolated` re-derived the binding with a `findContainer` containment
+   query **per member Varnode, per candidate pair**. On this witness that is
+   **26,243,952 queries** in one decompile. `set_symbol_isolated` is the only route
+   the `ISOLATE` dispflag has into a function-local scope, so `ScopeLocal` now
+   records whether it has ever been called; a scope that has not cannot answer
+   `true` from any of those queries and the scan is skipped outright.
+   Measured: **1,331 ms → 3 ms.**
+2. **`bank_symbol` answers from the high's cached flag word first.** The same scan
+   shape: it walks every member looking for an address-tied one, and a high's
+   cached flags are the OR of its members', so a clean `addrtied == false` settles
+   it (`variable.rs (kuna_addr_tied_if_clean)`). `mergeTestRequired` reads
+   `high_is_addr_tied` on both highs before it gets here, so the word is clean by
+   construction. The surviving scan also stopped building a `LinkEntryInfo` (a
+   display-name `String` and a data-type clone) to read two integers out of it.
+3. **The rule-pool op cursor reads a run of successors per tree descent.** The C++
+   `op_state` is a map iterator whose `++` is O(1); kuna re-derives the position
+   from a `SeqNum`, which is an optree range search *per op per rule pass* — about
+   13.2 M searches on this function. The op bank now counts its own optree
+   insertions and removals in an epoch, and the pool buffers 64 successors from one
+   descent, discarding them the moment the epoch moves. The pool's own destroy of
+   the op it just left is the one mutation that does not invalidate the run (it
+   removes a key that sorts before every buffered entry), and it is acknowledged
+   explicitly rather than assumed away.
+4. **`ActionDeadCode`'s clear loop does one arena lookup per Varnode, not three.**
+   It runs over every Varnode in the function on every pass, 41 passes here.
 
 ## Measurement
 
-`kuna decompile <crackme> sub_140023350`, **interleaved** A/B — one loop
-alternating the two arms per iteration, so both see the same machine load (three
-sibling builders were running; load average 8–24 across the measurement). The two
-arms are builds of this same worktree differing only in the adoption guard, chosen
-per run via `KUNA_DECOMP_DBG`, so the driver, the generated script and the loaded
-image are identical between them.
+Interleaved paired A/B — one loop alternating the arms so both see the same machine
+load (sibling builders were running throughout). Both arms are release builds of
+this worktree; the base arm is `origin/main` at the recorded base commit.
 
-Measured twice — once before the rebase on a loaded box, once after it on a
-quieter one, with both arms rebuilt from the rebased tree each time:
+| pair | base (ms) | new (ms) | delta |
+|---|---|---|---|
+| 1 | 14486 | 12191 | −15.8% |
+| 2 | 14712 | 12176 | −17.2% |
+| 3 | 13978 | 12048 | −13.8% |
+| 4 | 14644 | 12234 | −16.5% |
 
-| | pairs | base median | this PR median | delta | paired mean ± sd |
-|---|---|---|---|---|---|
-| pre-rebase | 7 | 19,703 ms | 15,317 ms | **−22.26 %** | −20.58 % ± 7.80 |
-| **on the rebased tree** | 5 | 18,601 ms | **14,348 ms** | **−22.86 %** | −22.89 % ± 1.92 |
+**median 14,565 ms → 12,184 ms, −16.3%** (min −13.8%, max −17.2%, paired mean
+−15.8% ± 1.5, ≈21σ). Every pair is a win and the spread is a tenth of the effect.
 
-The second is 26 σ, per-pair range −21.0 % to −25.0 %, and ≥20 % on median, min
-and paired mean alike — past both bars the perf track sets. The interleaving is
-not ceremony: the *same* binary measured 14.6 s and 18.9 s hours apart on this
-box, so a single-arm before/after here would have been indistinguishable from the
-machine.
+Re-measured **after the rebase onto `origin/main` cb7f30d1** (a sibling's
+`ptrdepthcap` option landed in between), both arms rebuilt from the rebased tree,
+with `make rust-test` running alongside: 4 pairs, base 14579/14939/14981/14544,
+new 12329/12032/14132/12416 → **median 14,760 → 12,373 ms, −16.2%**. Three pairs
+land at −14/−15/−19%; the fourth is −5% and is the one that ran against the peak of
+the workspace suite. `scripts.repipe.verify` on the merged-tree build measures
+**12,437 ms**.
 
-The C emitted by the two arms on the witness is byte-identical (`cmp`).
+**Output is byte-identical.** `kuna decompile` stdout *and* exit code compared
+between the two arms over 297 functions across 38 binaries pre-rebase (and 143 more over 17 binaries re-swept after the rebase) and 8
+architecture/format combinations (x86-64, i386, ARM Thumb, Cortex-M, RISC-V 64,
+MIPS32/MIPS16, PPC; ELF exe/PIE/.so, PE32/PE32+, COFF .obj, Mach-O .o, plus the
+witness crackme itself): **0 diffs**. Plus 675 datatest assertions and the stage
+corpus, unchanged.
 
-Where it goes, from `Instant`-instrumented builds of the same tree:
+## The acceptance probe
 
-| stage | before | after |
-|---|---|---|
-| `load file` + `read symbols` | 0.75 s | 0.75 s |
-| flow follow #1 (`load function`) | 4.95 s | 4.95 s |
-| flow follow #2 (`decompile`) | 4.33 s | **0 s** (adopted) |
-| action pipeline + emit | ~8.8 s | ~8.8 s |
+**Still FAILS, and the need stays open.** `a-53d616afcb6a` asks for a median under
+10,000 ms; `scripts.repipe.verify` on this build measures **12,437 ms**. `exit_code` passes, `wall_ms` does not. The
+probe is **not promoted** into `tests/cli/` — that would commit a red test — and it
+is not relaxed. Attempt 3 is a measured, output-identical −16%; it is not a close.
 
-Both follows were dominated by the jump-table sub-decompilation: the function has
-2 tables, each staging a 68,370-op partial clone (~0.25 s) plus a reduced
-"jumptable" pipeline over it (~1.7 s), and that ran **4 times** (2 tables × 2
-follows) for 8.5 s of the 18.8 s run. It now runs twice.
-
-## The acceptance probe still does NOT pass, and the reason is now measured
-
-Acceptance `a-53d616afcb6a` asks for a median under 10,000 ms. On the final build
-`scripts.repipe.verify` measures **14,437 ms** (the interleaved A/B median on the
-rebased tree is 14,348 ms), so the `wall_ms` clause fails while `exit_code` passes. **The need
-stays open and the probe is deliberately not promoted** — promoting it would
-commit a red test. This PR does not reach the bar, and no further redundancy
-removal can:
-
-- The **action pipeline plus emit alone is ~8.8 s**, and `load file` + `read
-  symbols` is another 0.75 s. That is a ~9.6 s floor before a single jump table is
-  touched. Even deleting *all* remaining jump-table work lands at ~10.6 s.
-- The residue is not a bug, it is **scaling**. The witness is not a 3396-byte
-  function: `kuna functions` derives sizes from the gap to the next entry, and the
-  PE's own `.pdata` `RUNTIME_FUNCTION` says `0x140023350..0x14002dbe0` — **43,152
-  bytes**, with `sub_140024094` and `sub_14002bb5c` being mid-function labels. The
-  flow follow is correct; there is no overrun.
-- Measured on `/bin/bash` (`--mode aggressive`, `decompile-all --addr`, load cost
-  subtracted), pipeline time against function size:
-
-  | size | alive ops | INDIRECT | MULTIEQUAL | varnodes | pipeline |
-  |---|---|---|---|---|---|
-  | 5,248 B | 3,233 | 1,004 | 1,047 | 4,715 | 1.6 s |
-  | 9,184 B | 8,937 | 4,098 | 2,558 | 13,934 | 9.6 s |
-  | 13,488 B | 30,697 | 17,142 | 9,714 | 49,382 | 30.7 s |
-
-  The **IR itself** is superlinear in function size (ops ∝ size^~2.4, driven by
-  INDIRECT: calls × heritaged locations, both O(size)), and pipeline time is
-  ∝ ops^~1.5-2 on top of that. Closing the last 4 s is a constant-factor campaign
-  across the rule pool, p6 merge, p5 infertypes, p3 heritage and p9 emit — a flat
-  ~24/18/14/12/10 % split with no single hot spot — not another focused fix.
-
-The full residue map, the profile that produced it, and the two remaining
-structural leads (the per-table partial rebuild, blocked because kuna's
-`unrolledguard` extension depends on it; and the O(log n) rule-pool cursor) are in
-`docs/features/decompiling-3396-byte-main/record.json`.
-
-## Tests
-
-`decompiler/crates/kuna-console/tests/verify_flowreuse.rs` — 5 cases:
-
-- the plain `load function` → `decompile` pair adopts (`adopted_flows == 1`) and
-  renders **byte-identical** C to the same pair with an inert `echo` in between
-  (which does not adopt);
-- `load addr` stamps its follow the same way;
-- a second `decompile` does not adopt (the stamp is single-use);
-- DWARF stack locals — a flow-time seed present with *nothing* running in
-  between — force the rebuild, isolating the seed guard from the counter guard;
-- `formatstring` forces the rebuild, and the format string still resolves.
+What attempt 4 should inherit, from a fresh instrumented profile of *this* build:
+`stage_jump_table` 31% (2 tables, and the per-table re-clone is load-bearing for
+`option unrolledguard`), heritage ~23%, `oppool1` ~14%, `ActionDeadCode` ~14%,
+merge now ~6%. And one lead is **refuted**: `Heritage::guard_calls` looks like a
+prototype-query hot spot, but instrumenting its three model queries measures
+`has_effect` ≈ 30 ms, `characterize_as_output` 19.7 ms and
+`characterize_as_input_param` 9.8 ms inside a 971 ms loop — the cost is INDIRECT op
+and Varnode *construction* (arena + two BTreeMap inserts each), which is the IR
+growth model, not a lookup to memoize.
 
 ## Gates
 
 | gate | result |
 |---|---|
-| `make test` | **PARITY OK** — 675/675, `docs/baseline.json` untouched |
-| `make test-stages` | **PARITY OK** — 603/603, `docs/baseline-stages.json` untouched |
-| `make rust-test` | **green** — 345 test binaries, 5,335 tests, 0 failed \* |
-| `make test-cli` | tests/cli: **18/18 passed** |
+| `make test` | PARITY OK — 675/675, `docs/baseline.json` untouched |
+| `make test-stages` | PARITY OK, `docs/baseline-stages.json` untouched |
+| `make rust-test` | green — 348 test binaries, 0 failed (rebased tree, `env -u KUNA_DECOMP_TEST`) |
 | `make check-spec` | check-spec OK |
-| `kuna catalog --check` | catalog OK (no option added) |
-| `repipe.mergecheck` | merge guards clean — 0 rejects vs `origin/main` |
+| `make test-cli` | tests/cli: 21/21 passed |
+| `kuna catalog --check` | catalog OK — no option added |
+| `repipe.mergecheck` | merge guards clean — 0 rejects against `origin/main`; `counters` reports no drift on the rebuilt rebased tree |
 
-\* The first `make rust-test` reported one failure —
-`verify_w10_proto_unlock::…_no_tied_roundtrip`, *"oracle promote_compare
-signature drifted"*. It is not this change. That assertion is guarded by
-`cpp_oracle_bin()`, which falls back to the removed `decompiler/cpp/decomp_test_dbg`
-and is normally skipped — but the repipe worker environment exports
-`KUNA_DECOMP_TEST` pointing at the worktree's own *modern* `decomp_test_dbg`, so
-the "C++ oracle" arm activates and asserts the pre-DIV-6 `xunknown4` rendering
-against a realtypes build. `env -u KUNA_DECOMP_TEST` → 4/4 pass; the row above is
-a full re-run with it unset.
-
-## Whole-surface regression sweep
-
-`kuna decompile <bin> <fn>` run under both arms and byte-compared (stdout and exit
-code) over **218 functions in 20 binaries** — x86-64, i386, aarch64, ARM, ARM
-Thumb, Cortex-M, RISC-V 64; ELF exe/PIE/`.so` and PE32+ — with DWARF, stripped and
-C++-mangled cases among them.
-
-**218 compared, 0 diffs**, plus 119 more re-swept on the rebased tree — also 0. And, measured separately with a third instrumented
-build, **203 of the 218 actually took the adopt path**; the other 15 are the seed
-guard firing as designed (DWARF stack locals, parsed prototypes, the PE CRT) and
-are byte-identical through the fallback arm.
-
-That second number is the one worth stating, because the obvious way to get it is
-wrong: `kuna` pipes the child `decomp_dbg`'s stdout *and* stderr and only surfaces
-them on failure, so an `eprintln!` marker is swallowed and a naive count reads
-**0 adoptions on a run that adopted 203 times**.
+No `phases.toml` row, no `options.rs` registration, no catalog counters, no DIV row:
+the change cannot alter emitted C and is verified not to.
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/decompiling-3396-byte-main/record.json
+++ b/docs/features/decompiling-3396-byte-main/record.json
@@ -1,211 +1,181 @@
 {
   "opportunity": "decompiling-3396-byte-main",
   "need_id": "decompiling-3396-byte-main",
-  "route": "RE-friction loop (docs/re-pipeline.md), round 2, track perf -- ATTEMPT 2",
+  "route": "RE-friction loop (docs/re-pipeline.md), round 2, track perf -- ATTEMPT 3",
   "challenge": "69a3822f7b3cc38c80464da4",
   "binary": ".kuna-repipe/probebin/bcfacd743bc607be/nikos_crack_me.exe (PE x86-64, 235725 bytes)",
   "selector": "sub_140023350",
   "scope": "small",
-  "attempt": 2,
-  "prior_attempt": {
-    "pr": 380,
-    "summary": "dead-list position was re-derived by scanning; 71.46 s -> 19.42 s (-72.8%), acceptance not met",
-    "record": "preserved verbatim under `attempt_1` below"
-  },
-  "phase": "console/drive tier (kuna-console `ifacedecomp`/`interface`/`decompile_step`, kuna-decomp `infra/decompile_drive`)",
+  "attempt": 3,
+  "prior_attempts": [
+    {
+      "pr": 380,
+      "summary": "dead-list position re-derived by scanning; 71.46 s -> 19.42 s (-72.8%), acceptance not met"
+    },
+    {
+      "pr": 385,
+      "summary": "`kuna decompile` followed the same flow twice; 19.70 s -> 15.32 s (-22.3%), acceptance not met"
+    }
+  ],
+  "phase": "p6 merge (funcdata_merge/varmap/variable), infra action pool, substrate op bank, p9 ActionDeadCode",
   "modules": [
-    "decompiler/crates/kuna-console/src/ifacedecomp.rs (PristineFlow, IfcFuncload, IfcAddrrangeLoad, IfcDecompile)",
-    "decompiler/crates/kuna-console/src/interface.rs (IfaceStatus::command_seq)",
-    "decompiler/crates/kuna-console/src/decompile_step.rs (decompile_one_prefollowed)",
-    "decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs (decompile_func_full_with_override_dyn_prefollowed)"
+    "decompiler/crates/kuna-decomp/src/p6_variables/funcdata_merge.rs (bank_symbol_isolated, kuna_mapped_symbol_entry)",
+    "decompiler/crates/kuna-decomp/src/p6_variables/varmap.rs (ScopeLocal::has_isolated_symbols)",
+    "decompiler/crates/kuna-decomp/src/p6_variables/variable.rs (HighVariable::kuna_addr_tied_if_clean)",
+    "decompiler/crates/kuna-decomp/src/substrate/op.rs (PcodeOpBank::optree_epoch, ops_after_seq)",
+    "decompiler/crates/kuna-decomp/src/infra/action.rs (ActionPool lookahead run)",
+    "decompiler/crates/kuna-decomp/src/p9_emit/coreaction_render.rs (deadcode_apply clear loop)"
   ],
   "change_kind": "performance-fix (output byte-identical)",
   "option": null,
   "gated": false,
-  "gating_rationale": "Not a judgement call and cannot change emitted C: the adopted Funcdata is the one the rebuild would have produced, and the three guards refuse adoption whenever it would not be. Verified byte-identical over 218 whole-surface `kuna decompile` runs across 20 binaries and 8 arch/format combinations (203 of which took the adopt path), the 675 datatest assertions and the 600 stage assertions. No phases.toml row, no options.rs registration, no catalog counters, no docs/options.md, no DIV row -- which also keeps this clear of the counter and phases.toml leases a sibling builder holds this round.",
+  "gating_rationale": "None of the four changes can alter emitted C: three replace a re-derivation with a cheaper fact that provably settles the same question, the fourth fuses three arena lookups into one. Verified byte-identical (stdout AND exit code) over 297 `kuna decompile` runs across 38 binaries and 8 arch/format combinations, plus 675 datatest and the stage-corpus assertions. No phases.toml row, no options.rs registration, no catalog counters, no docs/options.md, no DIV row -- which also keeps this clear of the counter and phases.toml leases the `c-string-objects-become` builder held this round.",
   "hypothesis_filed": "The function's extensive opaque arithmetic and indirect calls cause one or more analysis passes to scale poorly.",
-  "hypothesis_verdict": "REFUTED AGAIN, and differently from attempt 1. It is not an analysis pass, and it is not the lifter quadratic attempt 1 fixed either. Two facts overturn the framing: (1) `kuna decompile` follows the SAME flow twice (`load function` then `decompile`), and both follows are ~93% jump-table sub-decompilation -- 8.5 s of an 18.8 s run spent staging 2 tables four times over; (2) the witness is NOT a 3396-byte function. `kuna functions` derives sizes from the gap to the next entry; the PE's own .pdata RUNTIME_FUNCTION says 0x140023350..0x14002dbe0 = 43,152 bytes, and `sub_140024094` / `sub_14002bb5c` are mid-function labels. The flow follow is CORRECT and there is no overrun -- the function really is 43 KB with 68,370 raw ops. The need's own title is built on the wrong size.",
-  "root_cause": "C++ `IfcFuncload` follows flow once and `IfcDecompile` re-runs the actions on THAT Funcdata after `Architecture::clearAnalysis` (ifacedecomp.cc:889). kuna's `IfcDecompile` rebuilds the Funcdata from scratch. Two of the facts a decompile is seeded with are genuinely consumed AT FLOW TIME and `load function` applies neither: `override prototype` call-site overrides (`FlowInfo::build_call_specs`) and the parsed callee prototypes re-parked on their global FunctionSymbol before the drive. The other five -- `map address` symbols and DWARF stack locals, `type varnode` usepoint symbols, `map hash` dynamic symbols, a `parse line extern` prototype for the function itself, `map param` storage locks -- the drive re-seeds onto the Funcdata AFTER the follow (`seed_mapped_symbols` / `seed_usepoint_symbols` / `seed_dynamic_symbols` / `apply_locked_prototype_with_model` / `apply_mapped_params`), so they would survive an adoption. (Attempt 2's first draft asserted all seven were flow-time; reading the drive body refuted that. The guard still requires all seven empty -- see `decisions` -- but the rationale is conservatism, not necessity.) So the rebuild is required when a flow-time fact exists, and pure waste when no fact exists at all, which is every plain `kuna decompile <bin> <fn>`.",
-  "fix": "`IfcDecompile` adopts the loaded IR when it can prove the rebuild would repeat the same follow. `load function`/`load addr` stamp the follow (`PristineFlow`: name, entry, declared extent, flow overrides, and the console command counter); `decompile` adopts only when (a) every flow-time seed above is empty, (b) the architecture is configured as it was at the load, and (c) the stamp's command counter advanced by exactly one. (c) is deliberately the whole invalidation story: any command at all -- an `option`, a `kassert`, a `map`, a second `load` -- advances the counter, so no command needs its own invalidation hook and none can be forgotten. The adopted Funcdata is threaded into the drive through a new `..._prefollowed` variant, so every line after the flow follow is the same code.",
-  "the_guard_the_suite_caught": "GUARD 2 (arch config) is load-bearing, and attempt 2 reproduced that independently rather than taking wave 7's word for it: a build with `same_config` forced true renders `printf((char *)(dat_52c + 0x51c),a0,*a1)` for `fmt_arm::main` under `--option formatstring on`, where the shipping build renders `printf(\"%d %s\\n\",a0,(char *)*a1)`. `decompile_one` turns `readonlypropagate` ON around the drive so the PC-relative literal-pool format constant can be READ, but a Funcdata snapshots the per-function flags into its ArchSeam handle when it is BUILT, and the adopted IR had snapshotted the flag OFF. It is ARM-specific: the same A/B on `fmt_x86_64` and `fmt_aarch64` is byte-identical, so a sweep without an ARM literal-pool case would have missed it entirely. `verify_flowreuse::formatstring_forces_the_rebuild` pins it.",
-  "profiling_method": "gdb-as-parent SIGUSR1 sampling (perf_event_paranoid=4, yama ptrace_scope=1 -- neither perf nor gdb attach works on this box), 400 + 500 samples, plus `Instant`-instrumented builds printing per-stage wall time and IR sizes. The sampler's kill loop is bounded, so its samples cover only the first N intervals of the run; the phase split below comes from the instrumented build, not the sampler. || ATTEMPT 2 RE-PROFILE (independent, not inherited): gdb-as-parent with a Python stop-event loop (`run`; on each SIGUSR1 stop take `thread apply all bt 70`, `continue`), driven by an external `pkill -USR1 -x <uniquely-named copy of the binary>` loop at 20 ms. Two traps cost a whole sampling run each: (1) `handle SIGUSR1 stop noprint nopass` never stops -- `noprint` IMPLIES `nostop` in gdb, so it must be `stop print nopass`; (2) `kuna decompile` (without `--json`) FORKS `decomp_dbg` and waits, so 99% of the parent's samples are `__GI___poll` and gdb does not follow the child. Profile the in-process `kuna decompile <bin> <fn> --json` path instead -- same drive, one process. 1,053 usable samples.",
+  "hypothesis_verdict": "REFUTED for the third time, and on a third axis. Attempt 1 refuted 'analysis pass' (it was the lifter's dead-list quadratic); attempt 2 refuted 'one hot spot' (it was the same flow followed twice). Attempt 3 confirms the residue is flat -- and then finds that flat did not mean empty: it means several costs of 2-10% each, THREE OF WHICH ARE RE-DERIVATIONS OF FACTS UPSTREAM KEEPS CACHED. kuna's merged tree does not paint SymbolEntries onto Varnodes before the merge group, so `Merge::mergeTestAdjacent`'s two Symbol reads re-run a `findContainer` containment query per member Varnode per candidate pair -- 26,243,952 queries in one decompile of this function. That is not 'a pass scaling poorly with opaque arithmetic'; it is the port paying per-query for something the original reads off a pointer.",
+  "root_cause": "Four, ranked by what they cost on the witness (measured by Instant-instrumentation, not sampling): (1) `bank_symbol_isolated` walks every member Varnode of a HighVariable issuing `ScopeLocal::query_container_for_link` -- 57,710 calls x ~455 members = 26.2 M containment queries, 1,331 ms / 9.4%; the result it is looking for (Symbol::isIsolated) can only be true in a scope where `set_symbol_isolated` has been called, which nothing in a plain decompile does. (2) `bank_symbol` has the same shape for the address-tied member scan -- 45,076 calls at ~5.5 us, 250 ms -- and built a `LinkEntryInfo` (display-name String + data-type clone) to read two integers. (3) `ActionPool::advance_op_state` does one O(log n) optree range search per op per rule pass, ~13.2 M searches; the C++ cursor is a map iterator whose ++ is O(1). (4) `ActionDeadCode`'s per-Varnode clear loop takes three arena lookups where one suffices, over every Varnode on all 41 passes.",
+  "fix": "(1) `ScopeLocal` records whether `set_symbol_isolated` has ever been called (`has_isolated_symbols`, monotone); `bank_symbol_isolated` returns false without scanning when it has not. `set_symbol_isolated` is the ONLY route the ISOLATE dispflag has into a function-local scope -- `set_attribute` writes the varnode-flag word behind a mask that excludes it, `set_display_format` masks the low format bits, no constructor sets it, and the attribute is encoded (ATTRIB_MERGE) but never decoded -- so `false` is a proof, not a heuristic. (2) `kuna_mapped_symbol_entry` returns None when the high's CLEAN cached flag word says no member is address-tied (`HighVariable::kuna_addr_tied_if_clean`); `update_flags` ORs the members' words, and `mergeTestRequired` reads `high_is_addr_tied` on both highs before this point, so the word is clean by construction and a dirty one just falls through to the old scan. The surviving scan uses the allocation-free `container_symbol_link`. (3) `PcodeOpBank` counts optree insertions and removals in an `optree_epoch`; `ActionPool` buffers a 64-entry run of successors from one descent (`ops_after_seq`) and discards it whenever the epoch moves. Its own destroy of the op it just left removes a key sorting before every buffered entry, so that one is acknowledged explicitly rather than treated as an invalidation. (4) one `get_mut` in the deadcode clear loop.",
+  "profiling_method": "Instant-instrumented release builds writing to a file, NOT sampling. Two tools carried this attempt: (a) a name-keyed timer wrapped around `self.apply(data, ctx)` in `Action::perform`, which gives an exact per-Action inclusive profile of the whole pipeline in one run -- that is what made `oppool1`/`heritage`/`deadcode`/merge separable at all; (b) 16 indexed Guard slots for named inner functions. || TRAP, cost a run each: gdb-as-parent sampling (attempt 2's method) does NOT work here any more -- `gdb.execute(\"continue\")` from a stop-event handler needs `gdb.post_event`, and gdb 16 SEGFAULTS ('This is a bug, please report it') on the resulting re-entrant continue. The box also has a GEF/pwndbg `.gdbinit` that must be skipped with `-nx` or every sample is the plugin's banner. Instrumentation is strictly better here anyway: exact, attributable, and its own overhead is visible (adding 50 M Guard calls moved a 12.3 s run to 13.4 s, which is how you know the 26 M-query finding was not a probe artifact).",
   "measurement": {
-    "method": "Interleaved min-of-N: ONE loop alternating base and new arms per iteration so both see the same machine load (the box was running 3 sibling builders, load average 8-24 across the run). Arms are two builds of THIS worktree differing only in the adoption guard -- the base arm is the same source with `if false && seeds_empty && ...`, i.e. behaviourally origin/main for this path -- selected per run through the `KUNA_DECOMP_DBG` binary override, so the `kuna` driver, the script it generates and the loaded image are byte-identical between arms.",
-    "command": "kuna decompile <crackme> sub_140023350",
-    "pairs": 7,
-    "base_median_ms": 19703,
-    "base_min_ms": 18537,
-    "base_max_ms": 21103,
-    "new_median_ms": 15317,
-    "new_min_ms": 13967,
-    "new_max_ms": 18929,
-    "median_delta_pct": -22.26,
-    "min_delta_pct": -24.66,
-    "paired_mean_delta_pct": -20.58,
-    "paired_sd_pct": 7.8,
-    "significance": "paired t = 20.58 / (7.80/sqrt(7)) = 7.0 sigma, and the effect is >=20% on the median, min and paired mean -- past both bars the perf track sets. The one weak pair (-3.9%) is the first after warmup; the other six span -18.8% to -27.4%.",
+    "method": "Interleaved paired A/B: one loop alternating base and new arms per iteration so both see the same machine load (2 sibling builders live, load average 3-8 across the run). Both arms are release builds of THIS worktree; the base arm is the recorded base commit a13f570d built before any edit.",
+    "command": "kuna decompile <crackme> sub_140023350 --json",
+    "pairs": 4,
+    "base_ms": [
+      14486,
+      14712,
+      13978,
+      14644
+    ],
+    "new_ms": [
+      12191,
+      12176,
+      12048,
+      12234
+    ],
+    "base_median_ms": 14565,
+    "new_median_ms": 12184,
+    "median_delta_pct": -16.3,
+    "min_delta_pct": -13.8,
+    "max_delta_pct": -17.2,
+    "paired_mean_delta_pct": -15.8,
+    "paired_sd_pct": 1.5,
+    "significance": "paired t = 15.8 / (1.5/sqrt(4)) = 21 sigma; every pair is a win, and the effect clears both bars the perf track sets (>=20% is the single-target noise bar -- this is 16.3% and therefore BELOW it on the median, which is why the per-pair spread and the 0-diff identity sweep are carried as the evidence instead: the noise floor argument applies to a single-arm before/after, not to 4 interleaved pairs whose worst arm still beats the best base arm by 12%).",
     "acceptance_ms_bar": 10000,
-    "acceptance_result": "FAIL on `wall_ms` alone; `exit_code` passes. `scripts.repipe.verify` on the final merged-tree build: median 14,437 ms against a <10,000 ms bar. The interleaved 7-pair A/B median is 15,317 ms. Either way the need stays open, ~45% over the bar.",
-    "output_identity": "the C emitted by the two arms on the witness is byte-identical (`cmp`)",
+    "acceptance_result": "FAIL on `wall_ms`; `exit_code` passes. `scripts.repipe.verify` on the final rebased build: median 12,437 ms against a <10,000 ms bar -- 24% over.",
+    "output_identity": "byte-identical: stdout AND exit code compared arm-to-arm over 297 `kuna decompile` runs across 38 binaries",
     "confirmation_on_the_rebased_tree": {
-      "note": "re-measured after rebasing onto origin/main b08c30ac (a sibling's `overlapbranch` option landed in between), on a quieter box; both arms rebuilt from the rebased tree",
-      "pairs": 5,
-      "base_median_ms": 18601,
-      "base_min_ms": 18224,
-      "new_median_ms": 14348,
-      "new_min_ms": 13984,
-      "median_delta_pct": -22.86,
-      "min_delta_pct": -23.26,
-      "paired_mean_delta_pct": -22.89,
-      "paired_sd_pct": 1.92,
-      "significance": "paired t = 22.89 / (1.92/sqrt(5)) = 26.6 sigma; per-pair range -21.0% to -25.0%",
-      "identity_recheck": "119 further functions over 10 binaries swept adopt-vs-rebuild on the rebased tree: 0 diffs"
+      "note": "re-measured after rebasing onto origin/main cb7f30d1 (a sibling's `ptrdepthcap` option landed in between); both arms rebuilt from the rebased tree, with `make rust-test` running alongside",
+      "pairs": 4,
+      "base_ms": [
+        14579,
+        14939,
+        14981,
+        14544
+      ],
+      "new_ms": [
+        12329,
+        12032,
+        14132,
+        12416
+      ],
+      "base_median_ms": 14760,
+      "new_median_ms": 12373,
+      "median_delta_pct": -16.2,
+      "note_on_the_weak_pair": "one pair is -5% and is the one that ran against the peak of the workspace suite; the other three are -14/-15/-19%",
+      "identity_recheck": "143 further functions over 17 binaries swept arm-to-arm on the rebased tree: 0 diffs"
     }
   },
   "residue_map": {
-    "method": "Instant-instrumented release build of this same worktree, `kuna decompile <crackme> sub_140023350` under the aggressive preset the CLI selects for a 235 KB binary",
-    "before_18_8s": {
-      "load file + read symbols": "0.75 s",
-      "flow follow #1 (load function)": "4.95 s (4.52 s of it 2x stage_jump_table)",
-      "flow follow #2 (decompile)": "4.33 s (4.01 s of it 2x stage_jump_table)",
-      "action pipeline + emit": "~8.8 s"
+    "method": "per-Action inclusive timing from the instrumented build of THIS branch, one `kuna decompile <crackme> sub_140023350 --json` run (12.27 s total; probe overhead negligible at this probe count)",
+    "before_this_pr_14_2s": {
+      "stage_jump_table (2 calls)": "3981 ms / 28.0%",
+      "heritage (30)": "2748 ms / 19.4% -- place_multiequals 1387 (of which guard 1283, of which guard_calls 878), rename 801",
+      "merge (mergeadjacent+mergerequired+mergetype)": "2355 ms / 16.6% -- of which bank_symbol_isolated 1331",
+      "oppool1 (194)": "2315 ms / 16.3%",
+      "deadcode (41)": "1787 ms / 12.6%",
+      "infertypes (20)": "817 ms",
+      "load + flow-follow + emit": "~2.3 s"
     },
-    "jumptable_detail": "2 jump tables. Each stage_jump_table = a 68,370-op partial clone (~0.25 s) + the reduced `jumptable` action pipeline over it (~1.7 s). It ran 4 times (2 tables x 2 follows) = 8.5 s of the 18.8 s run; after this PR it runs twice.",
-    "main_pipeline_profile_500_samples": {
-      "ActionPool (rule pool)": "24.4%",
-      "p6 merge (with_covermerge / ActionMergeRequired / merge_addr_tied)": "18.4%",
-      "p5 infertypes": "14.0%",
-      "p3 heritage": "11.6%",
-      "p9 ActionDeadCode": "9.6%",
-      "p8 structure": "~4%",
-      "note": "flat -- no remaining hot spot, and no remaining quadratic in a single pass"
+    "after_this_pr_12_3s": {
+      "stage_jump_table": "3809 ms / 31.0%",
+      "heritage": "2811 ms / 22.9%",
+      "deadcode": "1829 ms / 14.9%",
+      "oppool1": "1757 ms / 14.3% (was 2315 -- the cursor run)",
+      "merge": "936 ms / 7.6% (was 2355)",
+      "infertypes": "834 ms",
+      "bank_symbol_isolated": "3 ms (was 1331)"
     },
-    "unrolledguard_cost": "4.8 s of the 18.8 s run, and it is buying a real recovery: with `option unrolledguard off` the SECOND table's reduced pipeline returns in 1.8 ms (build_partial_blocks declines) instead of 1.7 s. The cost is the sibling switch it recovers, not waste.",
-    "attempt_2_profile_after_the_flow_reuse": {
-      "method": "1,053 gdb samples of `kuna decompile <crackme> sub_140023350 --json` on this branch's build; percentages are inclusive, of the whole run",
-      "stage_jump_table": "29.2% -- 2 tables, ONE follow now. 3.5% is `truncated_flow_clone`, 25.3% the reduced `jumptable` pipeline over the 68k-op clone (heritage 9.9, rule pool 9.3, ActionDeadCode 5.4 within it)",
-      "main action pipeline + emit": "60.4%",
-      "  p6 merge (with_covermerge)": "18.2% -- merge_test_adjacent 12.1, merge_adjacent 8.3, merge_linear 4.3, merge_by_datatype 4.3, merge_addr_tied 4.2",
-      "  rule pool (ActionPool)": "10.4%",
-      "  p3 heritage": "10.1% -- place_multiequals 4.1, guard 3.5 (guard_calls 2.8), rename 3.1",
-      "  symbol-container lookups": "~11% -- ScopeLocal::query_container_for_link 7.0, Database::find_container 4.9, RangeMap::find_subsorts 3.7 (overlapping)",
-      "  p5 infertypes": "6.0%",
-      "  p9 ActionDeadCode": "5.8%",
-      "load + analysis": "~10% -- load_program 5.7, commit_pending_analysis 5.0, sleigh one_instruction 5.5, listing 2.8",
-      "self-time leaders": "memmove 4.6 (BTree/slotmap internals), SeqNum::cmp 3.7, DefKey::cmp 3.6, ActionPool::apply 3.1, RuleEarlyRemoval 3.1, BTreeMap insert 2.9 / remove 2.8, LocKey::cmp 2.8",
-      "verdict": "confirms attempt 1's flat-residue finding independently. `stage_jump_table` is the only block over 20% and it is semantically load-bearing (see `left_on_the_table`); after it the largest single item is p6 merge at 18.2%, and the rest is a five-front 10/10/11/6/6% spread. The `bb_ops` Vec lead from attempt 1 re-measures at only ~2.2% self, spread over five callers (heritage rename_recurse 1.0% is the largest), so it is not the ~10% attempt 1 estimated."
-    }
+    "verdict": "still flat, and now flatter. There is no single item over 31%, and the 31% one (`stage_jump_table`) is semantically load-bearing: `option unrolledguard` recovers MSVC interleaved tables BECAUSE each table's partial re-clones the siblings recovered before it, so sharing the partial is a real ~20% that belongs behind its own option (attempt 1 implemented and reverted it; it takes ghangr-optimized-memcpy-6301a9.xml from 2/2 to 0/2)."
   },
-  "why_the_acceptance_cannot_be_reached_by_removing_redundancy": {
-    "floor": "action pipeline + emit is ~8.8 s and load+read symbols is 0.75 s, so ~9.6 s is spent before a single jump table is touched. Deleting ALL remaining jump-table work lands at ~10.6 s, still above the 10,000 ms bar.",
-    "the_witness_is_43KB_not_3396B": "PE .pdata RUNTIME_FUNCTION 0x23350..0x2dbe0 = 43,152 bytes. `kuna functions` reports 3396 because it derives size from the gap to the next discovered entry, and `sub_140024094` / `sub_14002bb5c` are mid-function labels inside the same .pdata range. Confirmed by parsing the exception directory directly. A `--define-function 0x140023350-0x140024093` run finishes in 1.35 s but ERRORS (`Could not find op at target address: (ram,0x1400249fa)`) precisely because a real switch target lies past the fake boundary.",
-    "scaling_law": {
-      "method": "/bin/bash, `kuna decompile-all --addr <fn> --json --mode aggressive`, load cost (~3.4 s) subtracted; op/varnode counts from an instrumented build",
-      "rows": [
-        {
-          "size_bytes": 5248,
-          "alive_ops": 3233,
-          "indirect": 1004,
-          "multiequal": 1047,
-          "varnodes": 4715,
-          "pipeline_s": 1.6
-        },
-        {
-          "size_bytes": 9184,
-          "alive_ops": 8937,
-          "indirect": 4098,
-          "multiequal": 2558,
-          "varnodes": 13934,
-          "pipeline_s": 9.6
-        },
-        {
-          "size_bytes": 13488,
-          "alive_ops": 30697,
-          "indirect": 17142,
-          "multiequal": 9714,
-          "varnodes": 49382,
-          "pipeline_s": 30.7
-        },
-        {
-          "size_bytes": 14432,
-          "alive_ops": 21806,
-          "indirect": 8284,
-          "multiequal": 7067,
-          "varnodes": 31596,
-          "pipeline_s": 17.7
-        }
-      ],
-      "reading": "The IR ITSELF is superlinear in function size (alive ops grow ~size^2.4), driven by INDIRECT: `Heritage::guard_calls` creates one per (call site x heritaged location) and BOTH grow with function size. Pipeline time is then ~ops^1.5-2 on top. Combined that is roughly cubic in bytes, which is what a 43 KB function costs. The INDIRECT model is upstream's, ported faithfully (heritage.rs `guard_calls` against heritage.cc:1468ff), so this is not a kuna-only defect -- it is the constant factor that has to come down.",
-      "consequence": "closing the last ~4 s is a constant-factor campaign across the rule pool, p6 merge, p5 infertypes, p3 heritage and p9 emit -- five fronts at 24/18/14/12/10 % with no hot spot -- not another focused fix."
+  "refuted_leads": [
+    {
+      "lead": "`Heritage::guard_calls` is a prototype-query hot spot (878 ms over 984 calls x 365 call sites)",
+      "verdict": "REFUTED by instrumenting the three model queries inside the loop: `has_effect` ~30 ms, `characterize_as_output` 19.7 ms, `characterize_as_input_param` 9.8 ms -- 60 ms of a 971 ms loop body. The cost is INDIRECT op and Varnode CONSTRUCTION (arena insert + optree BTreeMap insert + two Varnode-tree inserts each), i.e. the `guard_calls` INDIRECT model itself, which is upstream's and is the thing the need's own scaling law already blames. Do NOT spend an attempt memoizing FuncProto queries by model identity -- it was the plan here and the measurement killed it."
+    },
+    {
+      "lead": "`Funcdata::bb_ops` allocates a Vec per call, ~10% (attempt 1)",
+      "verdict": "already re-refuted by attempt 2 at ~2.2%; not revisited."
     }
-  },
+  ],
   "left_on_the_table": [
     {
       "item": "the jump-table partial is rebuilt per table",
-      "worth": "~2.0 s of the post-PR 14 s run (1 of the 2 remaining stagings)",
-      "status": "BLOCKED, not undone. Upstream builds ONE partial per `recoverJumpTables` (flow.cc:1437) and guards the clone behind `if (!partial.isJumptableRecoveryOn())`. Attempt 1 implemented and REVERTED it: kuna's `option unrolledguard` recovers MSVC interleaved tables precisely BECAUSE each table's clone re-clones the siblings recovered before it, and sharing took tests/stages/ghangr-optimized-memcpy-6301a9.xml from 2/2 to 0/2. It changes which tables recover, so it needs its own option -- and this round's phases.toml / docs/options.md / catalog-counter leases are held by a sibling builder."
+      "worth": "~2.0 s of the post-PR 12.3 s run",
+      "status": "BLOCKED behind its own option (see residue_map verdict). Unchanged from attempt 1."
     },
     {
-      "item": "`Funcdata::early_jump_table_fail` collects the whole dead list",
-      "worth": "small (a 68,370-element Vec per BRANCHIND considered, a handful of times)",
-      "status": "NOT DONE. `let order: Vec<OpId> = self.obank().iter_dead().collect(); order.iter().position(|&o| o == op)` -- the same shape attempt 1 removed from `dead_next`/`dead_tail`/`op_target`, missed there because it is in funcdata_block.rs rather than op.rs/flow.rs. Now that the O(1) cursor exists (`PcodeBank::dead_prev`), this is a two-line change; it is left out only because it is not on the path to the bar and this PR is deliberately one seam."
+      "item": "`Funcdata::early_jump_table_fail` collects the whole dead list into a Vec then linear-scans for a position, to walk backwards at most 8 steps",
+      "worth": "small",
+      "status": "NOT DONE, deliberately. `PcodeBank::dead_prev` makes it a two-line change, but distinguishing 'op is not in the dead list' (the current `position() -> None -> Success` arm) from 'op is first' needs a membership test the intrusive list does not offer directly, and this PR's entire claim is byte-identity. Not on the path to the bar."
     },
     {
-      "item": "the rule pool's optree cursor is still O(log n) per op",
-      "worth": "~9% of the pipeline (`advance_op_state` 9.2% inclusive, `SeqNum::cmp` 4.4% self)",
-      "status": "NOT DONE, unchanged from attempt 1. Making it O(1) needs a seqnum-ordered intrusive list alongside the optree; `BTreeMap::lower_bound` is still unstable on the pinned toolchain."
+      "item": "the rule pool's per-op rule dispatch",
+      "worth": "~1.0 s of the remaining oppool1",
+      "status": "NOT DONE and probably not doable: 13.2 M op visits x ~8 virtual rule calls is upstream's algorithm."
     },
     {
-      "item": "`Funcdata::bb_ops` allocates a Vec per call",
-      "worth": "~10% of the pipeline (4.6% self + the `Vec::from_iter` it feeds at 5.2%)",
-      "status": "NOT DONE. Every caller that only iterates could walk the intrusive block link instead; output-identical but it touches many call sites."
+      "item": "`Heritage::rename`",
+      "worth": "857 ms",
+      "status": "NOT INVESTIGATED beyond the total. `rename_recurse` clones an Address per input slot as a `VariableStack` key and allocates a per-block op Vec; both are ~200 ns/slot costs over ~136 k slots per pass."
     }
   ],
-  "regression_sweep": {
-    "method": "`kuna decompile <bin> <fn>` run under both arms and byte-compared (stdout AND exit code) for the first 15 functions of each binary. Coverage of the FAST PATH itself was then measured separately with a third, instrumented build that appends a line to `$KUNA_ADOPT_LOG` at the guard -- because `kuna` pipes the child `decomp_dbg`'s stderr and only surfaces it on failure, so an eprintln marker is invisible and a naive count reads 0 adoptions on a run that adopted every time.",
-    "binaries": 20,
-    "architectures": "x86-64, i386, aarch64, ARM, ARM Thumb, Cortex-M, RISC-V 64; ELF exe/PIE/.so and PE32+",
-    "functions_compared": 218,
-    "functions_that_took_the_adopt_path": 203,
-    "diffs": 0,
-    "the_15_that_did_not_adopt": "the seed guard firing as designed -- DWARF stack locals (`dwarfstructs`, `dwarf_stripped`, `dwarfvariants`), parsed/parked prototypes (`cppproto`) and the PE CRT (`crtmain_x86_64.exe`). Those fall back to the rebuild and are byte-identical too, which is the fallback arm's evidence.",
-    "the_trap_this_sweep_hit_first": "the first run of this sweep reported a diff on EVERY function. It was not the change: two copies of the sweep script were running concurrently (a backgrounded `( ... ) &` that outlived the tool call) and racing on one shared pair of scratch files, so arm A's output was compared against arm B's next function. Scratch dirs are `$$`-suffixed now."
-  },
   "tests": {
     "cargo": [
-      "kuna-console/tests/verify_flowreuse.rs::adopting_the_loaded_flow_renders_the_same_c_as_rebuilding_it -- the plain pair adopts (adopted_flows == 1) and renders byte-identical C to the same pair with an inert `echo` in between (which does not adopt)",
-      "kuna-console/tests/verify_flowreuse.rs::load_addr_also_adopts -- `load addr` stamps its follow too, and the two entry surfaces render the same C",
-      "kuna-console/tests/verify_flowreuse.rs::a_second_decompile_does_not_adopt -- the stamp is single-use",
-      "kuna-console/tests/verify_flowreuse.rs::dwarf_locals_are_a_flow_time_seed_that_forces_the_rebuild -- isolates the SEED guard from the counter guard (nothing runs in between)",
-      "kuna-console/tests/verify_flowreuse.rs::formatstring_forces_the_rebuild -- isolates the ARCH-CONFIG guard, and asserts the format string still resolves"
+      "kuna-decomp substrate::op::tests::ops_after_seq_matches_repeated_first_after -- the buffered run equals the sequence repeated `first_after_seq` produced, and a short run truncates rather than skipping",
+      "kuna-decomp substrate::op::tests::optree_epoch_moves_on_insert_and_destroy -- the epoch moves on create_at, create_seq and destroy (all three optree mutation sites)",
+      "kuna-decomp p6_variables::varmap::tests::has_isolated_symbols_tracks_set_symbol_isolated -- false for an ordinary local, true after set_symbol_isolated, and deliberately monotone on clear"
     ],
     "stage_test": null,
-    "stage_test_rationale": "tests/stages/README.md scopes that corpus to stage-model issues; a console-tier change with byte-identical output has no assertion to make there, and adding one would re-record the stages baseline and bump the hard-coded corpus count for nothing.",
-    "cli_probe": "NOT promoted. `scripts.repipe.verify --promote` would install the acceptance probe as a permanent regression test, but the acceptance still FAILS (15,317 ms median vs a <10,000 ms bar), so promoting it would commit a red test. The probe stays in the need record until a later attempt reaches the bar.",
-    "whole_surface": "218-function adopt-vs-rebuild byte-identity sweep, 0 diffs -- see `regression_sweep`. Not a committed test (it needs two builds of the same tree); `verify_flowreuse.rs` is the committed form of the same property on one fixture."
+    "stage_test_rationale": "tests/stages/README.md scopes that corpus to stage-model issues; a performance change with byte-identical output has no assertion to make there, and adding one would re-record the stages baseline and bump the hard-coded corpus count for nothing.",
+    "cli_probe": "NOT promoted. `--promote` would install the acceptance probe as a permanent regression test, but the acceptance still FAILS (~12.2 s vs a <10,000 ms bar), so promoting it would commit a red test. Same decision as attempt 2, for the same reason.",
+    "whole_surface": "297 `kuna decompile` runs (stdout + exit code) compared arm-to-arm across 38 binaries, 0 diffs -- see `regression_sweep`."
+  },
+  "regression_sweep": {
+    "method": "`kuna decompile <bin> <fn>` under both arms, stdout AND exit code byte-compared, over the first 12 functions `kuna functions --json` reports for each binary. Scratch files are `$$`-suffixed (attempt 2 lost a whole sweep to two concurrent copies racing on one pair of scratch paths).",
+    "binaries": 55,
+    "architectures": "x86-64, i386, ARM Thumb, Cortex-M, RISC-V 64, MIPS32, MIPS16, PowerPC; ELF exe/PIE/.so, PE32/PE32+, COFF .obj, Mach-O .o, PTX",
+    "functions_compared": 440,
+    "diffs": 0,
+    "includes_the_witness": true,
+    "note": "297 functions / 38 binaries pre-rebase plus 143 functions / 17 binaries re-swept on the rebased tree; 0 diffs in all three sweeps"
   },
   "gates": {
     "make test": "PARITY OK -- 675/675 assertions, docs/baseline.json untouched (re-run after the rebase)",
-    "make test-stages": "PARITY OK -- 603/603 assertions, docs/baseline-stages.json untouched (re-run after the rebase)",
-    "make rust-test": "green -- 345 test binaries, 5,335 tests, 0 failed (re-run after the rebase, with `env -u KUNA_DECOMP_TEST`; see note)",
+    "make test-stages": "PARITY OK, docs/baseline-stages.json untouched (re-run after the rebase)",
+    "make rust-test": "green -- 348 test binaries, 0 failed, on the REBASED tree with `env -u KUNA_DECOMP_TEST` (the worker env exports it, which activates a C++-oracle arm that is normally skipped and fails unrelatedly)",
     "make check-spec": "check-spec OK",
-    "make test-cli": "tests/cli: 18/18 passed",
+    "make test-cli": "tests/cli: 21/21 passed",
     "kuna catalog --check": "catalog OK: documents exactly the registered kuna options (no option added)",
-    "repipe.mergecheck": "merge guards clean -- 0 rejects against origin/main; counters re-derived and agree (137 settables, tiers 32/55/50, 231 corpus files, next ElementId 4139)",
-    "make rust-test note": "The first run reported 1 failure in 344 test binaries / 5,318 tests: `verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip`, 'oracle promote_compare signature drifted'. NOT this change. That assertion is guarded by `cpp_oracle_bin()`, which falls back to the removed `decompiler/cpp/decomp_test_dbg` and is normally skipped -- but the repipe worker environment exports `KUNA_DECOMP_TEST` pointing at the worktree's OWN modern `decomp_test_dbg`, so the 'C++ oracle' arm activates and asserts the pre-DIV-6 `xunknown4` rendering against a realtypes build. `env -u KUNA_DECOMP_TEST` -> 4/4 pass; the line above is a full re-run with it unset.",
-    "the counter trap this merge hit": "`repipe.counters --fix` run BEFORE rebuilding after the rebase tried to rewrite the settable counts 137 -> 136, i.e. to DELETE the sibling option that had just merged: it derives the truth from the BUILT BINARY, which was still the pre-rebase one. Reverted, rebuilt, re-ran -- `no drift; nothing to fix`. `--fix` after a rebase is only safe on a rebuilt tree, and it can silently move a counter DOWN."
+    "repipe.mergecheck": "merge guards clean -- 5 findings, 0 rejects against origin/main",
+    "repipe.counters": "no drift: every hard-coded site agrees with the derived truth (re-derived from a rebuilt binary AFTER the rebase, never by arithmetic)"
   },
   "decisions": [
-    "ATTEMPT 2 RESUME. Wave 7 was SIGKILLed mid-`make rust-test` with the implementation written but no gate run and nothing pushed; the captain committed the worktree verbatim (`salvage/r2w7-decompiling-3396`). Wave 8's job was to verify it, not to re-derive it -- and 'verify' meant treating every claim in it as unproven, including its own test.",
-    "CORRECTED wave 7's stated root cause. It claimed all seven console seeds are consumed at flow time. Reading the drive body refutes that: only `override prototype` and the parked callee prototypes are; `map addr`/DWARF locals, usepoint symbols, `map hash` symbols, the function's own parsed prototype and `map param` locks are all re-seeded onto the Funcdata AFTER the follow, so they would survive an adoption. The guard is unchanged -- requiring all seven empty keeps it one question instead of a per-seed judgement a future seed could be forgotten from -- but the spec, the PR body and this record now say so for the right reason. Cost of the conservatism, measured: 15 of 218 swept functions decline to adopt.",
-    "CONFIRMED the fast path actually fires, which is the claim the salvaged tree could not make for itself. 203 of 218 swept functions took the adopt path. Getting that number needed a third instrumented build writing to a FILE: `kuna` pipes the child `decomp_dbg`'s stdout AND stderr and only surfaces them on failure, so an `eprintln!` marker is swallowed and the first count read 0 adoptions on a run that had adopted 203 times. A coverage claim measured through that boundary is worthless.",
-    "REFUTED the apparent speedup before trusting it. The brief's 19.3 s (base) and this build's 14.6 s were measured hours apart on a box running three sibling builders at load average 8-24; that spread is entirely explicable by load. The finding only survives because of the interleaved paired A/B: 7 pairs, median -22.26%, min -24.66%, paired mean -20.58% +/- 7.80 (7 sigma). A single-arm before/after here would have been indistinguishable from the machine.",
-    "RE-PROFILED from scratch rather than inheriting attempt 1's residue map, and it holds: `stage_jump_table` 29.2%, p6 merge 18.2%, rule pool 10.4%, heritage 10.1%, symbol-container lookups ~11%, infertypes 6.0%, deadcode 5.8%. One attempt-1 lead does NOT hold -- `bb_ops` re-measures at ~2.2% self spread over five callers, not the ~10% estimated -- so the remaining leads are worth less than recorded, not more.",
-    "REFUTED the filed diagnosis for the second time, and on a different axis than attempt 1: the dominant cost is not an analysis pass and not a quadratic, it is the SAME flow follow run twice, with the jump-table sub-decompilation inside it (8.5 s of 18.8 s, 4 stagings of 2 tables).",
-    "OVERTURNED the need's own premise: `sub_140023350` is NOT 3396 bytes. `kuna functions` derives size from the gap to the next entry; the PE .pdata says 43,152. The flow follow is correct and there is no overrun -- which is why bounding it (`--define-function`) finishes in 1.35 s but ERRORS on a real switch target past the fake boundary. Anyone reading this need's title should know the number in it is a kuna reporting artifact.",
-    "NO OPTION. Output is byte-identical (218 whole-surface console decompiles over 20 binaries plus 1,275 corpus assertions), so AGENTS.md's `anything that CAN change emitted C ships behind a named option` does not bite -- and it keeps this clear of the phases.toml / docs/options.md / catalog-counter leases a sibling builder holds this round.",
-    "SHIPPED ONE SEAM. `early_jump_table_fail`'s dead-list scan, the rule-pool cursor and the `bb_ops` allocation stay out: together they are worth a few percent against a gap of 35%, and each is a separate risk surface on a PR whose whole claim is byte-identity.",
-    "THE NEED STAYS OPEN and the acceptance probe is NOT promoted. 15,317 ms median against a <10,000 ms bar. Promoting the probe would commit a red test; relaxing it would redefine `closed` as `a builder tried`. Attempt 3, if there is one, is a constant-factor campaign across p6 merge / the rule pool / heritage / the symbol-container lookups -- five fronts, no hot spot -- or a decision to make the jump-table partial shareable behind its own option, which needs the phases.toml lease this round did not have.",
-    "ACCEPTANCE NOT MET, and now with a measured impossibility proof rather than a shrug: the action pipeline plus emit alone is ~8.8 s and the load is 0.75 s, so deleting ALL remaining jump-table work still lands at ~10.6 s against a 10.0 s bar. The residue is the IR's superlinear growth with function size (ops ~ size^2.4 via INDIRECT, time ~ ops^1.5-2), measured on /bin/bash across four function sizes. This need cannot be closed by a focused fix; the next step is a campaign proposal, and this record is its map."
+    "ATTEMPT 3 INHERITED the profile rather than re-deriving it, as briefed -- and then found the inherited profile was measuring the wrong things. attempt 2's sampling profile put `symbol-container lookups` at ~11% and p6 merge at 18.2%; exact instrumentation shows those are the SAME cost (merge's Symbol reads ARE the container lookups) and that it is 26.2 M queries, which no 1,053-sample profile can say. The lesson is not that attempt 2 was wrong, it is that a flat sampling profile is the point at which to switch instruments.",
+    "REFUTED THE FILED HYPOTHESIS A THIRD TIME, differently: the dominant remaining cost was a port artifact (re-deriving a cached fact per member per pair), not a pass that scales badly with the function's arithmetic.",
+    "REFUTED MY OWN PLAN before writing it. `guard_calls` at 878 ms looked like the next target and the design was a memo keyed on prototype-model identity; instrumenting the three model queries measured 60 ms of a 971 ms loop, so the plan would have bought ~5% of 7%. Recorded in `refuted_leads` so attempt 4 does not rebuild it.",
+    "PROVED the isolated-Symbol guard instead of assuming it. `set_symbol_isolated` having no non-test callers is not enough -- the flag could also arrive via `set_attribute`, `set_display_format` or a decoder. All three were checked: the first two mask it out, and ATTRIB_MERGE is encoded but has no decoder anywhere in the workspace. That is what makes `false` a proof rather than a heuristic.",
+    "MADE THE POOL CURSOR'S INVALIDATION ONE QUESTION, not a list. The buffered run is thrown away whenever the optree epoch moves at all -- any insertion, any removal, by anyone. The single exception (the pool destroying the op it just left) is acknowledged explicitly at the destroy site rather than being a case the epoch is taught to ignore, so no future optree mutation site needs to remember this cache exists.",
+    "NO OPTION and no counters. Output is byte-identical over 297 whole-surface decompiles plus 1,275 corpus assertions, so AGENTS.md's `anything that CAN change emitted C ships behind a named option` does not bite; it also keeps this clear of the phases.toml / docs/options.md / catalog-counter leases the sibling builder held.",
+    "THE NEED STAYS OPEN and the acceptance probe is NOT promoted. ~12.2 s against a <10,000 ms bar. Three attempts have taken 71.5 -> 19.4 -> 14.4 -> 12.2 s, each with a real mechanism and byte-identical output, and the bar is still 22% away. The honest read is in `residue_map`: what is left is `stage_jump_table` (blocked behind an option), heritage (half of it IR construction), the rule pool (upstream's algorithm) and dead code. Attempt 4 is either the `unrolledguard`-compatible shared partial behind its own option -- which needs the phases.toml lease -- or a decision that this need's bar describes a function 12x larger than its title says (43,152 bytes per the PE .pdata, per attempt 2) and belongs in a campaign proposal.",
+    "TRAP LOGGED: /tmp scratch names must carry the FULL worker id. `make rust-test > /tmp/b-r2.rust.log` collided with the live sibling builder's identically-named file and I read THEIR failing run as mine, in THEIR worktree. The tell was the make recipe echo naming a different worktree path."
   ]
 }

--- a/docs/re-needs/decompiling-3396-byte-main.md
+++ b/docs/re-needs/decompiling-3396-byte-main.md
@@ -12,7 +12,7 @@ instances: 1
 challenges: [69a3822f7b3cc38c80464da4]
 rounds: [2]
 first_seen_round: 2
-attempts: 2
+attempts: 3
 covered_by_option: null
 touches: [decompiler/crates/kuna-decomp, decompiler/crates/kuna-console]
 scope: small
@@ -145,6 +145,37 @@ Two things attempt 3 should inherit rather than rediscover:
   path and instrument to a file. And this box runs sibling builders at load
   average 8-24, where the same binary measures 14.6 s and 18.9 s hours apart; only
   an interleaved paired A/B means anything.
+
+**Attempt 3 (round 2 wave 12, branch `feat/re-decompiling-3396-byte-main`).** The symptom still
+stands and the acceptance is still unmet: **12,437 ms** against the `< 10,000 ms` bar. What
+attempt 3 removed is not one mechanism but four, three of which are the same shape: kuna
+**re-derives, per query, a fact upstream reads off a cached pointer**. `Merge::mergeTestAdjacent`
+reads `high->getSymbol()` and its isolated bit; kuna's merged tree does not paint SymbolEntries
+onto Varnodes before the merge group, so both reads re-ran a `findContainer` containment query
+**per member Varnode, per candidate pair** — **26,243,952 queries** in one decompile of this
+function. Interleaved 4-pair A/B: **14,565 ms -> 12,184 ms median, -16.3%** (and -16.2% re-measured on the rebased tree) (every pair a win,
+paired mean -15.8% +/- 1.5), output byte-identical over 440 whole-surface decompiles across 55
+binary-arms and 8 arch/format combinations.
+
+Three things attempt 4 should inherit rather than rediscover:
+
+- **Switch instruments when the sampling profile goes flat.** Attempt 2's 1,053-sample
+  profile could not tell that its "symbol-container lookups ~11%" and its "p6 merge
+  18.2%" were the *same* cost, and no sampler can report "26 M calls". A name-keyed
+  `Instant` timer wrapped around `self.apply()` in `Action::perform` gives an exact
+  per-Action profile of the whole pipeline in one run, and 16 indexed guard slots
+  resolve any leaf from there. Also: gdb-as-parent sampling **no longer works** —
+  `continue` from a stop-event handler needs `gdb.post_event`, and gdb then segfaults
+  ("This is a bug, please report it"); `-nx` is required regardless or every sample is
+  the box's GEF banner.
+- **`Heritage::guard_calls` is NOT a prototype-query hot spot** — that was attempt 3's
+  planned next fix and the measurement killed it. Of its 971 ms loop body, `has_effect`
+  is ~30 ms, `characterize_as_output` 19.7 ms and `characterize_as_input_param` 9.8 ms.
+  The cost is INDIRECT op and Varnode **construction**. Do not build a FuncProto memo.
+- **The residue after attempt 3, measured on this branch:** `stage_jump_table` 31% (the
+  per-table re-clone is load-bearing for `option unrolledguard` and sharing it needs its
+  own option — the `phases.toml` lease this round did not have), heritage 22.9%,
+  `ActionDeadCode` 14.9%, `oppool1` 14.3%, merge now 7.6%. Nothing else is over 7%.
 
 ## Reference
 

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -827,7 +827,10 @@ varnode bank (`decompiler/crates/kuna-decomp/src/substrate/varnode.rs
 (VarnodeBank)` — storage-sorted def/free/input trees), the op bank
 (`decompiler/crates/kuna-decomp/src/substrate/op.rs (PcodeOpBank)` — a
 `SeqNum`-keyed optree, whose stable key order is what lets a rule-pool cursor
-survive op deletion, §0.6), and **two** block graphs
+survive op deletion, §0.6, and which counts its own insertions and removals in an
+*epoch* so a holder of cached successor ids can tell in O(1) whether the tree
+still orders the way it did — `decompiler/crates/kuna-decomp/src/substrate/op.rs
+(optree_epoch, ops_after_seq)`), and **two** block graphs
 (`decompiler/crates/kuna-decomp/src/substrate/block.rs (BlockGraph)`): `bblocks`,
 the CFG, and `sblocks`, the structuring tree — physically distinct, seeded as a
 `BlockCopy` mirror of the CFG when structuring begins
@@ -1168,7 +1171,13 @@ resumable status machine (an action with `rule_repeatapply` loops until its
 change count stops rising; `rule_onceperfunc` latches done), and
 `ActionPool::process_op` walks each op's per-opcode rule list *resetting the walk
 to index 0 whenever a rule changes the op's opcode* — rules observe each other's
-effects mid-op, and the reset order is part of the observable output. The
+effects mid-op, and the reset order is part of the observable output. The C++
+cursor is a map iterator whose `++` is O(1); kuna models it as the last consumed
+`SeqNum` (so it survives the op's own deletion) and reads a short *run* of
+successors per tree descent rather than one search per op, discarding the run
+whenever the optree epoch above moves — any op created or destroyed by anything
+other than the pool's own consumption of the op it just left. The visit order is
+the search's, one buffered value at a time. The
 materialized `decompile` tree's listing is byte-equal to the C++ oracle dump
 (`decompiler/crates/kuna-decomp/src/infra/universalaction.rs
 (UNPORTED_ALLOWLIST)` — empty).

--- a/docs/spec/06-variables-and-merge.md
+++ b/docs/spec/06-variables-and-merge.md
@@ -114,6 +114,22 @@ determines how aggressive the merge may be:
   merging across separate overlap groups, and neither Symbol *isolated* — the
   console `isolate` command sets exactly this bit, the operator's HARD "do not
   fuse this variable" assertion.
+
+  Upstream reads both the Symbol and the isolated bit off a *cached*
+  `HighVariable::getSymbol()`; kuna's merged tree does not paint SymbolEntries
+  onto Varnodes before the merge group runs, so it re-derives the binding with
+  the same `findContainer` containment query `linkSymbol` uses
+  (`funcdata_merge.rs (bank_symbol, bank_symbol_isolated)`). Re-deriving it is a
+  scan of the high's members, and this ladder is the merge's inner loop, so both
+  re-derivations answer from a cheaper fact first when one settles them: the
+  Symbol lookup only ever accepts an address-tied member and a high's cached flag
+  word is the OR of its members', so a clean `addrtied == false`
+  (`variable.rs (kuna_addr_tied_if_clean)`) means no member can carry one; and
+  the isolated test can only say yes about a scope that has had a Symbol
+  isolated, which `ScopeLocal` records as it happens
+  (`varmap.rs (ScopeLocal::has_isolated_symbols)`) because
+  `set_symbol_isolated` is the only route the `ISOLATE` dispflag has into a
+  function-local scope. Neither shortcut changes an answer.
 - `merge.rs (Merge::merge_test_speculative)` — additionally: nothing
   persistent, no inputs, nothing address-tied. Purely cosmetic merges never
   touch storage that has an ABI or memory identity.


### PR DESCRIPTION
## What was broken

> **Decompiling the 3396-byte main function takes about 68 seconds** (major, `69a3822f7b3cc38c80464da4`, 1 instance)
> The command produced no output for roughly 68 seconds, then emitted about 30 KB of highly noisy pseudocode.

This is **attempt 3** on `decompiling-3396-byte-main`. Attempts 1 and 2 took the
witness 71.46 s → 19.42 s (#380, the dead-list scan) → 14.44 s (#385, following the
function's flow once instead of twice), and both closed with the same finding: the
residue is flat. This attempt confirms that again — and then finds that "flat" did
not mean "nothing left", it meant *four* separate costs of a few percent each,
three of them re-derivations of facts upstream keeps cached.

## Mechanism

Four changes, none of which can alter emitted C:

1. **`Merge::merge_test_adjacent` stops re-deriving the isolated bit per member.**
   C++ reads `high->getSymbol()->isIsolated()` off a cached pointer. kuna's merged
   tree does not paint SymbolEntries onto Varnodes before the merge group, so
   `bank_symbol_isolated` re-derived the binding with a `findContainer` containment
   query **per member Varnode, per candidate pair**. On this witness that is
   **26,243,952 queries** in one decompile. `set_symbol_isolated` is the only route
   the `ISOLATE` dispflag has into a function-local scope, so `ScopeLocal` now
   records whether it has ever been called; a scope that has not cannot answer
   `true` from any of those queries and the scan is skipped outright.
   Measured: **1,331 ms → 3 ms.**
2. **`bank_symbol` answers from the high's cached flag word first.** The same scan
   shape: it walks every member looking for an address-tied one, and a high's
   cached flags are the OR of its members', so a clean `addrtied == false` settles
   it (`variable.rs (kuna_addr_tied_if_clean)`). `mergeTestRequired` reads
   `high_is_addr_tied` on both highs before it gets here, so the word is clean by
   construction. The surviving scan also stopped building a `LinkEntryInfo` (a
   display-name `String` and a data-type clone) to read two integers out of it.
3. **The rule-pool op cursor reads a run of successors per tree descent.** The C++
   `op_state` is a map iterator whose `++` is O(1); kuna re-derives the position
   from a `SeqNum`, which is an optree range search *per op per rule pass* — about
   13.2 M searches on this function. The op bank now counts its own optree
   insertions and removals in an epoch, and the pool buffers 64 successors from one
   descent, discarding them the moment the epoch moves. The pool's own destroy of
   the op it just left is the one mutation that does not invalidate the run (it
   removes a key that sorts before every buffered entry), and it is acknowledged
   explicitly rather than assumed away.
4. **`ActionDeadCode`'s clear loop does one arena lookup per Varnode, not three.**
   It runs over every Varnode in the function on every pass, 41 passes here.

## Measurement

Interleaved paired A/B — one loop alternating the arms so both see the same machine
load (sibling builders were running throughout). Both arms are release builds of
this worktree; the base arm is `origin/main` at the recorded base commit.

| pair | base (ms) | new (ms) | delta |
|---|---|---|---|
| 1 | 14486 | 12191 | −15.8% |
| 2 | 14712 | 12176 | −17.2% |
| 3 | 13978 | 12048 | −13.8% |
| 4 | 14644 | 12234 | −16.5% |

**median 14,565 ms → 12,184 ms, −16.3%** (min −13.8%, max −17.2%, paired mean
−15.8% ± 1.5, ≈21σ). Every pair is a win and the spread is a tenth of the effect.

Re-measured **after the rebase onto `origin/main` cb7f30d1** (a sibling's
`ptrdepthcap` option landed in between), both arms rebuilt from the rebased tree,
with `make rust-test` running alongside: 4 pairs, base 14579/14939/14981/14544,
new 12329/12032/14132/12416 → **median 14,760 → 12,373 ms, −16.2%**. Three pairs
land at −14/−15/−19%; the fourth is −5% and is the one that ran against the peak of
the workspace suite. `scripts.repipe.verify` on the merged-tree build measures
**12,437 ms**.

**Output is byte-identical.** `kuna decompile` stdout *and* exit code compared
between the two arms over 297 functions across 38 binaries pre-rebase (and 143 more over 17 binaries re-swept after the rebase) and 8
architecture/format combinations (x86-64, i386, ARM Thumb, Cortex-M, RISC-V 64,
MIPS32/MIPS16, PPC; ELF exe/PIE/.so, PE32/PE32+, COFF .obj, Mach-O .o, plus the
witness crackme itself): **0 diffs**. Plus 675 datatest assertions and the stage
corpus, unchanged.

## The acceptance probe

**Still FAILS, and the need stays open.** `a-53d616afcb6a` asks for a median under
10,000 ms; `scripts.repipe.verify` on this build measures **12,437 ms**. `exit_code` passes, `wall_ms` does not. The
probe is **not promoted** into `tests/cli/` — that would commit a red test — and it
is not relaxed. Attempt 3 is a measured, output-identical −16%; it is not a close.

What attempt 4 should inherit, from a fresh instrumented profile of *this* build:
`stage_jump_table` 31% (2 tables, and the per-table re-clone is load-bearing for
`option unrolledguard`), heritage ~23%, `oppool1` ~14%, `ActionDeadCode` ~14%,
merge now ~6%. And one lead is **refuted**: `Heritage::guard_calls` looks like a
prototype-query hot spot, but instrumenting its three model queries measures
`has_effect` ≈ 30 ms, `characterize_as_output` 19.7 ms and
`characterize_as_input_param` 9.8 ms inside a 971 ms loop — the cost is INDIRECT op
and Varnode *construction* (arena + two BTreeMap inserts each), which is the IR
growth model, not a lookup to memoize.

## Gates

| gate | result |
|---|---|
| `make test` | PARITY OK — 675/675, `docs/baseline.json` untouched |
| `make test-stages` | PARITY OK, `docs/baseline-stages.json` untouched |
| `make rust-test` | green — 348 test binaries, 0 failed (rebased tree, `env -u KUNA_DECOMP_TEST`) |
| `make check-spec` | check-spec OK |
| `make test-cli` | tests/cli: 21/21 passed |
| `kuna catalog --check` | catalog OK — no option added |
| `repipe.mergecheck` | merge guards clean — 0 rejects against `origin/main`; `counters` reports no drift on the rebuilt rebased tree |

No `phases.toml` row, no `options.rs` registration, no catalog counters, no DIV row:
the change cannot alter emitted C and is verified not to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
