### PR TITLE
[AUTOMATED] perf(cli): cold-load-xref-lookup — one decode per reference query, with the gap-walk kept

### DIFF
--- a/decompiler/crates/kuna-analysis/src/listing/kuna_picbase.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/kuna_picbase.rs
@@ -222,9 +222,42 @@ fn mask(size: u32) -> u64 {
     }
 }
 
+/// The live-varnode map. A `HashMap` here made every written op pay a
+/// bucket-wide `retain`, which over a whole program was this pass's dominant
+/// cost; the map never holds more than one instruction's worth of varnodes, so a
+/// linear vector is both smaller and faster. Insertion order is not observed —
+/// the one iterating reader ([`holder_of`]) takes a minimum.
+#[derive(Default)]
+struct KeyMap(Vec<(Key, Val)>);
+
+impl KeyMap {
+    fn insert(&mut self, k: Key, v: Val) {
+        match self.0.iter_mut().find(|(known, _)| *known == k) {
+            Some(slot) => slot.1 = v,
+            None => self.0.push((k, v)),
+        }
+    }
+
+    fn get(&self, k: &Key) -> Option<&Val> {
+        self.0.iter().find(|(known, _)| known == k).map(|(_, v)| v)
+    }
+
+    fn retain(&mut self, mut keep: impl FnMut(&Key) -> bool) {
+        self.0.retain(|(k, _)| keep(k));
+    }
+
+    fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&Key, &Val)> {
+        self.0.iter().map(|(k, v)| (k, v))
+    }
+}
+
 #[derive(Default)]
 struct Machine {
-    vals: HashMap<Key, Val>,
+    vals: KeyMap,
     /// Constants stored at offsets from the seeded stack pointer.
     stack: HashMap<i64, (u64, bool)>,
 }
@@ -242,7 +275,7 @@ impl Machine {
     fn invalidate(&mut self, vn: &VarnodeData) {
         let Some((idx, off, size)) = key_of(vn) else { return };
         let (lo, hi) = (off, off.saturating_add(u64::from(size)));
-        self.vals.retain(|&(i, o, s), _| {
+        self.vals.retain(|&(i, o, s)| {
             i != idx || o.saturating_add(u64::from(s)) <= lo || o >= hi
         });
     }
@@ -494,7 +527,7 @@ fn holder_of(m: &Machine, ctx: &Ctx, want: u64) -> Option<VarnodeData> {
     let space = ctx.sp.space.as_ref()?;
     let reg_index = space.get_index();
     let mut best: Option<Key> = None;
-    for (&k, v) in &m.vals {
+    for (&k, v) in m.vals.iter() {
         if k.0 != reg_index {
             continue;
         }
@@ -638,23 +671,17 @@ pub(super) fn scope(
     ctx: &Ctx,
     thunks: &mut HashMap<u64, Option<VarnodeData>>,
     base: &PicBase,
-    body: &[(u64, Vec<FullOp>)],
+    body: &[BaseCandidate],
 ) -> Option<Scope> {
-    let Some((idx, lo, size)) = key_of(&base.reg) else { return None };
-    let hi = lo.saturating_add(u64::from(size));
-    let writes = |ops: &[FullOp]| {
-        ops.iter().any(|op| {
-            op.out.as_ref().and_then(key_of).is_some_and(|(i, o, s)| {
-                i == idx && o < hi && o.saturating_add(u64::from(s)) > lo
-            })
-        })
-    };
-    if !body.iter().any(|(_, ops)| writes(ops)) {
+    if key_of(&base.reg).is_none() {
+        return None;
+    }
+    if !body.iter().any(|c| c.writes_base) {
         return Some(Scope::Whole);
     }
 
-    let entry = body.first()?.0;
-    let last = body.last()?.0;
+    let entry = body.first()?.vma;
+    let last = body.last()?.vma;
     let outside = |vma: u64| vma > last;
     let (from, reg) = establish(
         translate,
@@ -671,9 +698,35 @@ pub(super) fn scope(
     }
     let until = body
         .iter()
-        .find(|(vma, ops)| *vma > from && writes(ops))
-        .map_or(u64::MAX, |(vma, _)| *vma);
+        .find(|c| c.vma > from && c.writes_base)
+        .map_or(u64::MAX, |c| c.vma);
     Some(Scope::Between { from, until })
+}
+
+/// One walked instruction's contribution to the deferred base-relative pass.
+///
+/// The pass used to buffer every instruction's whole p-code and re-derive both
+/// halves afterwards, which meant cloning every emitted op of every function on
+/// any image with a PIC base. Both halves are pure functions of the ops, so they
+/// are computed once, in the walk, and only their answers are carried.
+pub(super) struct BaseCandidate {
+    pub(super) vma: u64,
+    /// Does this instruction write the base register (the live window's cut)?
+    pub(super) writes_base: bool,
+    /// The references it forms through the base — filed only if the scope
+    /// admits it. Empty for the overwhelming majority of instructions.
+    pub(super) refs: Vec<(u64, XrefKind)>,
+}
+
+/// Does `ops` write the base register (the `scope` live-window cut)?
+pub(super) fn writes_base(ops: &[FullOp], base: &PicBase) -> bool {
+    let Some((idx, lo, size)) = key_of(&base.reg) else { return false };
+    let hi = lo.saturating_add(u64::from(size));
+    ops.iter().any(|op| {
+        op.out.as_ref().and_then(key_of).is_some_and(|(i, o, s)| {
+            i == idx && o < hi && o.saturating_add(u64::from(s)) > lo
+        })
+    })
 }
 
 // --- the harvest -------------------------------------------------------------

--- a/decompiler/crates/kuna-analysis/src/listing/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/mod.rs
@@ -85,6 +85,30 @@ impl Listing {
         Self::build_with_meta(file, _image, arch, translate, seeds, &[], &[])
     }
 
+    /// A Listing assembled from a partition someone else already decoded.
+    ///
+    /// The reference walk ([`xrefs::build`]) is a recursive descent over the same
+    /// loadimage and leaves behind the same two facts the AIF gap-walk consumes —
+    /// which bytes are instructions, and which addresses are functions — so it can
+    /// hand them here instead of paying for a second decode of the program. Only
+    /// the partition is populated: `mnemonic` is filled for the prologues the
+    /// fingerprint histogram reads and empty everywhere else, and the reference
+    /// model is empty (the gap-walk reads neither).
+    pub fn from_partition(
+        insns: BTreeMap<u64, Insn>,
+        funcs: BTreeMap<u64, DiscoveredFunction>,
+        exec_ranges: Vec<(u64, u64)>,
+    ) -> Listing {
+        Listing {
+            insns,
+            refs_to: BTreeMap::new(),
+            refs_from: BTreeMap::new(),
+            funcs,
+            covered: RangeList::default(),
+            exec_ranges,
+        }
+    }
+
     /// Like [`Listing::build`], but with seed metadata: `funcsym_seeds` is the
     /// subset of `seeds` that came from a real funcsym (sets `from_symbol`), and
     /// `seed_names` is an `(addr, name)` overlay for naming seed functions.

--- a/decompiler/crates/kuna-analysis/src/listing/xrefs.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/xrefs.rs
@@ -367,9 +367,9 @@ impl AssemblyEmit for AsmCapture {
 /// duplicate decode. x86-64 is untouched (its entry oracles already carry the
 /// prologue scan, and the drivers inject nothing there), so the seed set on that
 /// architecture is exactly the caller's inventory.
-pub fn discovery_seeds(file: &object::File, entries: &[u64]) -> Vec<u64> {
+pub fn discovery_seeds(file: &object::File, entries: &[u64], patterns: bool) -> Vec<u64> {
     let mut seeds: Vec<u64> = entries.to_vec();
-    if file.architecture() != object::Architecture::X86_64 {
+    if patterns && file.architecture() != object::Architecture::X86_64 {
         let execs = crate::entry::executable_sections(file);
         seeds.extend(
             crate::entry::full_pattern_starts(file)
@@ -398,6 +398,28 @@ pub fn build(
     arch: &Architecture,
     translate: &dyn Translate,
     seeds: &[u64],
+) -> XrefIndex {
+    build_with_focus(file, arch, translate, seeds, &[])
+}
+
+/// [`build`], plus the addresses the CALLER named.
+///
+/// A recursive descent answers for the code it can reach, and the one address a
+/// reference query is certainly interested in is the one it was asked about — an
+/// entry reached only through a function-pointer table has no direct CALL edge
+/// pointing at it, so no seed set built from prologues and symbols reaches it and
+/// `--from <that entry>` answers zero references about a function that plainly
+/// has some. Each `focus` address is walked as a function of its own, but only
+/// AFTER the seeded walk has drained: anything the natural descent claims is
+/// already in `decoded` and skipped, so a focus address can only ADD coverage,
+/// never re-attribute an instruction some other entry already owns. An address
+/// that does not decode is dropped rather than recorded as a function.
+pub fn build_with_focus(
+    file: &object::File,
+    arch: &Architecture,
+    translate: &dyn Translate,
+    seeds: &[u64],
+    focus: &[u64],
 ) -> XrefIndex {
     let Some(code_space) = arch.manage().get_default_code_space().map(Rc::clone) else {
         return empty();
@@ -465,11 +487,58 @@ pub fn build(
     let mut cap = FullCapture::default();
     let mut raw: Vec<RawOp> = Vec::new();
 
+    // (kuna, `aif`) The instruction partition the gap-walk consumes, recorded
+    // only when it will run. A `push` per decode is the whole cost of keeping
+    // AIF reachable without a second decode of the program.
+    let gapwalk = arch.analysis_aif;
+    let mut gapwalk_done = false;
+    let mut partition: Vec<(u64, u32)> = Vec::new();
+
     let mut func_queue: VecDeque<u64> = seed_set.iter().copied().collect();
     let mut walked: HashSet<u64> = HashSet::new();
 
+    // The caller-named addresses the seeded walk did not already cover, tried one
+    // at a time once the queue drains (see [`build_with_focus`]).
+    let mut pending_focus: Vec<u64> =
+        focus.iter().copied().filter(|f| !seed_set.contains(f)).collect();
+    pending_focus.sort_unstable();
+    pending_focus.dedup();
+    pending_focus.reverse();
+    let mut focused: Vec<u64> = Vec::new();
 
-    while let Some(entry) = func_queue.pop_front() {
+    loop {
+        // The seeded walk drains first; only then is the next caller-named
+        // address it never reached taken up as a function of its own.
+        let entry = match func_queue.pop_front() {
+            Some(entry) => entry,
+            None => match pending_focus.pop() {
+                Some(f) => {
+                    if st.decoded.contains(&f) || (sections_are_runtime && !in_range(&exec, f)) {
+                        continue;
+                    }
+                    st.funcs.insert(f);
+                    focused.push(f);
+                    f
+                }
+                // (kuna, `aif`) Nothing reachable is left: run the speculative
+                // gap-walk over the partition THIS walk left behind, and take up
+                // whatever it finds as more entries to walk. See `gap_entries`.
+                None if gapwalk && !gapwalk_done => {
+                    gapwalk_done = true;
+                    let found = gap_entries(
+                        arch,
+                        translate,
+                        &code_space,
+                        &partition,
+                        &st.funcs,
+                        &exec,
+                    );
+                    pending_focus.extend(found.into_iter().rev());
+                    continue;
+                }
+                None => break,
+            },
+        };
         if !walked.insert(entry) {
             continue;
         }
@@ -496,6 +565,9 @@ pub fn build(
                 continue; // undecodable (or zero-length): stop this path
             };
             st.decoded.insert(vma);
+            if gapwalk {
+                partition.push((vma, len));
+            }
 
             raw.clear();
             raw.extend(
@@ -581,6 +653,13 @@ pub fn build(
             let _ = ctx;
         }
     }
+    // A focus address that did not decode is not a function: recording it as one
+    // would answer `sub_<addr>` for a byte in the middle of a string.
+    for f in focused {
+        if !st.decoded.contains(&f) {
+            st.funcs.remove(&f);
+        }
+    }
 
     // The forwarding relation, over the entries the walk actually decoded. It
     // re-decodes at most `MAX_VENEER_INSNS` instructions per entry (a veneer is
@@ -602,6 +681,97 @@ pub fn build(
     }
 
     st.finish(veneers)
+}
+
+/// Ghidra's `MINIMUM_FUNCTION_COUNT`, mirrored here so the partition is not even
+/// assembled for a program the gap-walk would decline to fingerprint.
+const AIF_MIN_FUNCTIONS: usize = 20;
+
+/// The functions the speculative gap-walk (`aif`) finds in what THIS walk left
+/// undecoded.
+///
+/// A function reached only through a function-pointer table has no direct CALL
+/// edge, so a recursive descent structurally cannot reach it and every reference
+/// it makes is missing from the answer — on a stripped i386 PE, 61 of the 174
+/// callers of one function. That recall is what the analysis-tier Listing was
+/// buying a reference query, and it is the only thing it was buying one: the
+/// Listing's own walk duplicates this one over the same bytes. Assembling the
+/// partition from the decode already done keeps the recall and drops the
+/// duplicate decode.
+///
+/// The gap-walk fingerprints each candidate against the prologues of the already
+/// -discovered functions, so the two leading instructions of each are rendered
+/// here — `2 * functions` renders, against the whole program's worth the Listing
+/// path rendered.
+fn gap_entries(
+    arch: &Architecture,
+    translate: &dyn Translate,
+    code_space: &Rc<AddrSpace>,
+    partition: &[(u64, u32)],
+    funcs: &BTreeSet<u64>,
+    exec: &[(u64, u64)],
+) -> Vec<u64> {
+    if funcs.len() < AIF_MIN_FUNCTIONS || partition.is_empty() {
+        return Vec::new();
+    }
+    let mut insns: BTreeMap<u64, super::Insn> = BTreeMap::new();
+    for &(addr, len) in partition {
+        insns.insert(
+            addr,
+            super::Insn {
+                addr,
+                len,
+                fall_through: None,
+                flow: super::FlowType::default(),
+                flows: Vec::new(),
+                mnemonic: String::new(),
+                operands: String::new(),
+                pcode: None,
+            },
+        );
+    }
+    // The fingerprint reads the first two instructions of every discovered
+    // function; nothing else in the gap-walk reads a mnemonic.
+    for &entry in funcs {
+        let mut vma = entry;
+        for _ in 0..2 {
+            let Some(insn) = insns.get(&vma) else { break };
+            let next = vma.wrapping_add(u64::from(insn.len));
+            let text = assembly(translate, vma, code_space);
+            if let Some(slot) = insns.get_mut(&vma) {
+                slot.mnemonic =
+                    text.split_whitespace().next().unwrap_or_default().to_string();
+            }
+            vma = next;
+        }
+    }
+    let listing = super::Listing::from_partition(
+        insns,
+        funcs
+            .iter()
+            .map(|&entry| {
+                (
+                    entry,
+                    super::DiscoveredFunction {
+                        entry,
+                        name: None,
+                        from_symbol: false,
+                        has_no_return: false,
+                        call_fixup: None,
+                    },
+                )
+            })
+            .collect(),
+        exec.to_vec(),
+    );
+    crate::aif::run_aif(
+        &listing,
+        translate,
+        Rc::clone(code_space),
+        listing.exec_ranges(),
+        arch.analysis_aifstrict,
+        arch.analysis_aifcorroborate,
+    )
 }
 
 /// A forwarding veneer: the fixed pointer slot it jumps through, and the VMA one

--- a/decompiler/crates/kuna-analysis/src/listing/xrefs.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/xrefs.rs
@@ -61,7 +61,7 @@
 //! excluded from the answer: it is the other half of the callable, not a caller
 //! of it, which is what makes the two addresses answer identically.
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque, HashSet};
 use std::rc::Rc;
 
 use kuna_base::address::Address;
@@ -145,8 +145,8 @@ pub struct XrefIndex {
     /// Outgoing edges, keyed by the entry of the function the source lies in;
     /// sorted by target then source.
     by_source_function: BTreeMap<u64, Vec<Xref>>,
-    /// Every instruction VMA the walk decoded.
-    decoded: BTreeSet<u64>,
+    /// Every instruction VMA the walk decoded (membership only).
+    decoded: HashSet<u64>,
     /// Every function entry the walk seeded or discovered, in address order.
     funcs: BTreeSet<u64>,
     /// Forwarding veneers, keyed by function entry ([`veneer_at`]).
@@ -285,6 +285,7 @@ impl XrefIndex {
 /// classifier needs); the parts it drops are what the data-reference scan is
 /// made of — the output says a memory location was written, the later inputs
 /// carry the addresses.
+#[derive(Clone)]
 pub(super) struct FullOp {
     pub(super) opcode: OpCode,
     pub(super) out: Option<VarnodeData>,
@@ -292,9 +293,28 @@ pub(super) struct FullOp {
 }
 
 /// A capturing [`PcodeEmit`] that keeps every emitted op whole.
+///
+/// One capture is reused for the whole walk: [`FullCapture::begin`] rewinds the
+/// cursor instead of dropping the ops, so each slot's input vector is refilled in
+/// place. Allocating per op cost one heap allocation for every p-code op in the
+/// program (1.44 M on a 466 KB obfuscated i386 image).
 #[derive(Default)]
 struct FullCapture {
     ops: Vec<FullOp>,
+    /// How many of `ops` the current instruction has filled.
+    filled: usize,
+}
+
+impl FullCapture {
+    /// Start capturing a new instruction over the retained storage.
+    fn begin(&mut self) {
+        self.filled = 0;
+    }
+
+    /// The ops the current instruction emitted.
+    fn ops(&self) -> &[FullOp] {
+        &self.ops[..self.filled]
+    }
 }
 
 impl PcodeEmit for FullCapture {
@@ -305,7 +325,16 @@ impl PcodeEmit for FullCapture {
         outvar: Option<&VarnodeData>,
         vars: &[VarnodeData],
     ) {
-        self.ops.push(FullOp { opcode: opc, out: outvar.cloned(), ins: vars.to_vec() });
+        if self.filled == self.ops.len() {
+            self.ops.push(FullOp { opcode: opc, out: outvar.cloned(), ins: vars.to_vec() });
+        } else {
+            let slot = &mut self.ops[self.filled];
+            slot.opcode = opc;
+            slot.out = outvar.cloned();
+            slot.ins.clear();
+            slot.ins.extend_from_slice(vars);
+        }
+        self.filled += 1;
     }
 }
 
@@ -324,6 +353,33 @@ impl AssemblyEmit for AsmCapture {
             self.text.push_str(body);
         }
     }
+}
+
+/// The seed set a STANDALONE reference walk needs: the caller's committed
+/// function inventory, plus the `<patternpairs>` prologue starts on the
+/// architectures the drivers route through the Listing tier (DIV-20/DIV-68).
+///
+/// `kuna xrefs` does its own recursive descent ([`build`] follows every direct
+/// CALL out of its seeds), so the only thing the analysis-tier Listing walk
+/// contributed to a reference query was a richer seed set — and building that
+/// Listing means decoding the whole program a second time. Handing the same
+/// prologue starts straight to the reference walk keeps the seeds and drops the
+/// duplicate decode. x86-64 is untouched (its entry oracles already carry the
+/// prologue scan, and the drivers inject nothing there), so the seed set on that
+/// architecture is exactly the caller's inventory.
+pub fn discovery_seeds(file: &object::File, entries: &[u64]) -> Vec<u64> {
+    let mut seeds: Vec<u64> = entries.to_vec();
+    if file.architecture() != object::Architecture::X86_64 {
+        let execs = crate::entry::executable_sections(file);
+        seeds.extend(
+            crate::entry::full_pattern_starts(file)
+                .into_iter()
+                .filter(|&vma| crate::entry::in_executable_section(&execs, vma)),
+        );
+    }
+    seeds.sort_unstable();
+    seeds.dedup();
+    seeds
 }
 
 /// Walk every function reachable from `seeds` and index every reference edge.
@@ -401,15 +457,17 @@ pub fn build(
     let mut st = State {
         by_target: BTreeMap::new(),
         by_source: BTreeMap::new(),
-        decoded: BTreeSet::new(),
+        decoded: HashSet::new(),
         funcs: seed_set.clone(),
     };
 
+    // Reused across every decode in the walk (see [`FullCapture`]).
+    let mut cap = FullCapture::default();
+    let mut raw: Vec<RawOp> = Vec::new();
+
     let mut func_queue: VecDeque<u64> = seed_set.iter().copied().collect();
-    let mut walked: BTreeSet<u64> = BTreeSet::new();
-    // The assembly render of each buffered instruction, so the deferred
-    // base-relative pass files the same `instruction` text the inline pass does.
-    let mut texts: BTreeMap<u64, (u32, String)> = BTreeMap::new();
+    let mut walked: HashSet<u64> = HashSet::new();
+
 
     while let Some(entry) = func_queue.pop_front() {
         if !walked.insert(entry) {
@@ -419,7 +477,7 @@ pub fn build(
         // Only collected when a base exists: the admission rule needs the whole
         // body before any of it can be attributed (`kuna_picbase::scope`), and
         // buffering it costs nothing on the overwhelmingly common `None` path.
-        let mut body: Vec<(u64, Vec<FullOp>)> = Vec::new();
+        let mut body: Vec<kuna_picbase::BaseCandidate> = Vec::new();
         while let Some(vma) = insn_queue.pop_front() {
             if st.decoded.contains(&vma) {
                 continue; // already decoded (the VisitStat dedup)
@@ -434,24 +492,35 @@ pub fn build(
             if sections_are_runtime && !in_range(&exec, vma) {
                 continue; // out of bounds (the `flow.rs` gate)
             }
-            let Some(decoded) = decode(translate, vma, &code_space) else {
-                continue; // undecodable: stop this path
+            let Some(len) = decode(translate, vma, &code_space, &mut cap) else {
+                continue; // undecodable (or zero-length): stop this path
             };
-            if decoded.len == 0 {
-                continue; // a zero-length decode would not advance
-            }
             st.decoded.insert(vma);
 
-            let raw: Vec<RawOp> = decoded
-                .ops
-                .iter()
-                .map(|op| RawOp { opcode: op.opcode, in0: op.ins.first().cloned() })
-                .collect();
-            let c = classify(&raw, vma, decoded.len);
+            raw.clear();
+            raw.extend(
+                cap.ops()
+                    .iter()
+                    .map(|op| RawOp { opcode: op.opcode, in0: op.ins.first().cloned() }),
+            );
+            let c = classify(&raw, vma, len);
+            let drefs = if mapped.is_empty() {
+                Vec::new()
+            } else {
+                let fall_through = vma.wrapping_add(len as u64);
+                data_refs(cap.ops(), data_space.as_ref(), &mapped, fall_through)
+            };
+            // Every row this instruction produces carries the same render, and an
+            // instruction that produces none needs no render at all.
+            let text = if c.flows.is_empty() && drefs.is_empty() {
+                String::new()
+            } else {
+                assembly(translate, vma, &code_space)
+            };
 
             for &target in &c.flows {
                 let kind = if c.flow.is_call { XrefKind::Call } else { XrefKind::Jump };
-                st.file(vma, target, kind, &decoded.text);
+                st.file(vma, target, kind, &text);
                 if c.flow.is_call {
                     st.funcs.insert(target);
                     func_queue.push_back(target);
@@ -464,41 +533,52 @@ pub fn build(
                 insn_queue.push_back(fall);
             }
 
-            if !mapped.is_empty() {
-                let fall_through = vma.wrapping_add(decoded.len as u64);
-                for (to, kind) in
-                    data_refs(&decoded.ops, data_space.as_ref(), &mapped, fall_through)
-                {
-                    st.file(vma, to, kind, &decoded.text);
-                }
+            for (to, kind) in drefs {
+                st.file(vma, to, kind, &text);
             }
-            if picbase.is_some() {
-                body.push((vma, decoded.ops));
-                texts.insert(vma, (decoded.len, decoded.text));
+            // Both halves the deferred base-relative pass needs are pure
+            // functions of this instruction's ops, so they are computed here
+            // rather than by buffering (and cloning) the whole p-code.
+            if let Some((ctx, base)) = &picbase {
+                let fall_through = vma.wrapping_add(u64::from(len));
+                body.push(kuna_picbase::BaseCandidate {
+                    vma,
+                    writes_base: kuna_picbase::writes_base(cap.ops(), base),
+                    refs: kuna_picbase::refs_through_base(
+                        cap.ops(),
+                        base,
+                        ctx,
+                        &mapped,
+                        fall_through,
+                    ),
+                });
             }
         }
 
         // (kuna) `picbase`: the references this body forms THROUGH the base
         // register, filed only where the body cannot have changed it.
         if let Some((ctx, base)) = &picbase {
-            body.sort_by_key(|(vma, _)| *vma);
+            body.sort_by_key(|c| c.vma);
             if let Some(scope) =
                 kuna_picbase::scope(translate, &code_space, ctx, &mut pc_thunks, base, &body)
             {
-                for (vma, ops) in &body {
-                    if !scope.admits(*vma) {
+                for cand in &body {
+                    if cand.refs.is_empty() || !scope.admits(cand.vma) {
                         continue;
                     }
-                    let Some((len, text)) = texts.get(vma) else { continue };
-                    let fall_through = vma.wrapping_add(u64::from(*len));
-                    for (to, kind) in
-                        kuna_picbase::refs_through_base(ops, base, ctx, &mapped, fall_through)
-                    {
-                        st.file(*vma, to, kind, text);
+                    // Rendered here, not in the walk: an admitted instruction
+                    // that forms a reference is rare, and rendering every
+                    // buffered instruction up front was a second full SLEIGH
+                    // parse of the whole program on any image with a PIC base
+                    // (an i386 `__x86.get_pc_thunk` binary: 154,608 renders to
+                    // file 151 references).
+                    let text = assembly(translate, cand.vma, &code_space);
+                    for &(to, kind) in &cand.refs {
+                        st.file(cand.vma, to, kind, &text);
                     }
                 }
             }
-            texts.clear();
+            let _ = ctx;
         }
     }
 
@@ -564,24 +644,22 @@ fn veneer_at(
     mapped: &[(u64, u64)],
 ) -> Option<Veneer> {
     let mut vma = entry;
+    let mut cap = FullCapture::default();
     for _ in 0..MAX_VENEER_INSNS {
-        let decoded = decode(translate, vma, code_space)?;
-        if decoded.len == 0 {
-            return None;
-        }
-        let raw: Vec<RawOp> = decoded
-            .ops
+        let len = decode(translate, vma, code_space, &mut cap)?;
+        let raw: Vec<RawOp> = cap
+            .ops()
             .iter()
             .map(|op| RawOp { opcode: op.opcode, in0: op.ins.first().cloned() })
             .collect();
-        let c = classify(&raw, vma, decoded.len);
+        let c = classify(&raw, vma, len);
         if !c.flows.is_empty() || c.flow.is_call || c.flow.kind == FlowKind::Return {
             return None;
         }
-        if let Some(op) = decoded.ops.iter().find(|o| o.opcode == OpCode::CPUI_BRANCHIND) {
+        if let Some(op) = cap.ops().iter().find(|o| o.opcode == OpCode::CPUI_BRANCHIND) {
             let vn = op.ins.first()?;
             let in_data = matches!((&vn.space, data_space), (Some(s), Some(d)) if Rc::ptr_eq(s, d));
-            let end = vma.wrapping_add(u64::from(decoded.len));
+            let end = vma.wrapping_add(u64::from(len));
             return (in_data && in_range(mapped, vn.offset))
                 .then_some(Veneer { slot: vn.offset, end });
         }
@@ -594,7 +672,9 @@ fn veneer_at(
 struct State {
     by_target: BTreeMap<u64, Vec<Xref>>,
     by_source: BTreeMap<u64, Vec<Xref>>,
-    decoded: BTreeSet<u64>,
+    /// Membership only (the `VisitStat` dedup), so it is hashed rather than
+    /// ordered: it is probed once per successor edge over the whole program.
+    decoded: HashSet<u64>,
     funcs: BTreeSet<u64>,
 }
 
@@ -661,7 +741,7 @@ fn empty() -> XrefIndex {
         by_target: BTreeMap::new(),
         by_source: BTreeMap::new(),
         by_source_function: BTreeMap::new(),
-        decoded: BTreeSet::new(),
+        decoded: HashSet::new(),
         funcs: BTreeSet::new(),
         veneers: BTreeMap::new(),
         veneers_of_slot: BTreeMap::new(),
@@ -669,33 +749,43 @@ fn empty() -> XrefIndex {
     }
 }
 
-/// One decoded instruction: its byte length, its full p-code, and its rendering.
-struct Decoded {
-    len: u32,
-    ops: Vec<FullOp>,
-    text: String,
+/// Decode the instruction at `vma` into `cap`, keeping every input varnode, and
+/// return its byte length.
+///
+/// A translator panic on exotic bytes is contained to `None` — a query surface
+/// must never take the process down over one bad address.
+fn decode(
+    translate: &dyn Translate,
+    vma: u64,
+    code_space: &Rc<AddrSpace>,
+    cap: &mut FullCapture,
+) -> Option<u32> {
+    let addr = Address::new(Rc::clone(code_space), vma);
+    cap.begin();
+    let decoded = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        translate.one_instruction(cap, &addr)
+    }));
+    match decoded {
+        Ok(Ok(len)) if len > 0 => Some(len as u32),
+        _ => None,
+    }
 }
 
-/// Decode the instruction at `vma`, keeping every input varnode.
+/// Render the instruction at `vma`, best-effort (empty when the render errs).
 ///
-/// The assembly render is best-effort (the p-code is the load-bearing half), and
-/// a translator panic on exotic bytes is contained to `None` — a query surface
-/// must never take the process down over one bad address.
-fn decode(translate: &dyn Translate, vma: u64, code_space: &Rc<AddrSpace>) -> Option<Decoded> {
+/// This is a SECOND full SLEIGH parse of the address — `print_assembly` shares no
+/// resolved state with `one_instruction` — so the walk pays it only where a row
+/// will actually carry the text. On a 466 KB obfuscated i386 image (154,638
+/// instructions) rendering every decode cost 0.22 s of a 1.3 s walk, and the
+/// large majority of instructions file no reference at all.
+fn assembly(translate: &dyn Translate, vma: u64, code_space: &Rc<AddrSpace>) -> String {
+
     let addr = Address::new(Rc::clone(code_space), vma);
-    let mut cap = FullCapture::default();
-    let decoded = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        translate.one_instruction(&mut cap, &addr)
-    }));
-    let len = match decoded {
-        Ok(Ok(len)) if len > 0 => len as u32,
-        _ => return None,
-    };
     let mut asm = AsmCapture::default();
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let _ = translate.print_assembly(&mut asm, &addr);
     }));
-    Some(Decoded { len, ops: cap.ops, text: asm.text })
+    asm.text
 }
 
 /// The data references one instruction's p-code carries.
@@ -1000,7 +1090,7 @@ mod tests {
         let mut st = State {
             by_target: BTreeMap::new(),
             by_source: BTreeMap::new(),
-            decoded: BTreeSet::from([0x1030, 0x1102, 0x1200]),
+            decoded: HashSet::from([0x1030, 0x1102, 0x1200]),
             funcs: BTreeSet::from([0x1000, 0x1030, 0x1180]),
         };
         for e in edges {

--- a/decompiler/crates/kuna-cli/src/decompile.rs
+++ b/decompiler/crates/kuna-cli/src/decompile.rs
@@ -625,7 +625,7 @@ fn decompile(args: &DecompileArgs) -> Result<DecompileOutcome, String> {
     // selection that missed. That is exactly the reported gap — `kuna functions` prints
     // a discovery-generated name that `kuna decompile` then refuses — and nothing that
     // already resolved changes at all.
-    let full = decompile_all::driver_default_options(&binary, true, &args.options);
+    let full = decompile_all::driver_default_options(&binary, true, true, &args.options);
     let (base, discovery): (Vec<_>, Vec<_>) =
         full.into_iter().partition(|(name, _)| *name == "listing");
 
@@ -1809,7 +1809,7 @@ Execution error: No symbol named: v9
     #[test]
     fn the_retry_widens_to_the_in_process_drivers_bundle() {
         let arm = fixture("entrymain_arm");
-        let full = decompile_all::driver_default_options(&arm, true, &[]);
+        let full = decompile_all::driver_default_options(&arm, true, true, &[]);
         assert_eq!(full, WIDENED, "the non-x86-64 bundle");
         let (base, discovery): (Vec<_>, Vec<_>) =
             full.into_iter().partition(|(name, _)| *name == "listing");
@@ -1822,7 +1822,7 @@ Execution error: No symbol named: v9
     /// over-produce, which is why the bundle is non-x86-64 only.
     #[test]
     fn there_is_no_retry_to_make_on_x86_64() {
-        let full = decompile_all::driver_default_options(&fixture("fauxware"), true, &[]);
+        let full = decompile_all::driver_default_options(&fixture("fauxware"), true, true, &[]);
         assert_eq!(full, LISTING);
     }
 
@@ -1832,7 +1832,7 @@ Execution error: No symbol named: v9
     #[test]
     fn the_bundle_yields_to_a_named_option() {
         let options = vec![("aif".to_string(), "off".to_string())];
-        let full = decompile_all::driver_default_options(&fixture("entrymain_arm"), true, &options);
+        let full = decompile_all::driver_default_options(&fixture("entrymain_arm"), true, true, &options);
         assert_eq!(full, &[("listing", "on"), ("funcstart_patterns", "on")]);
     }
 

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -883,6 +883,10 @@ pub(crate) enum DriverDefaults {
     Inventory,
     /// `kuna decompile-all` / `kuna decompile-project` — enumeration plus bodies.
     Decompile,
+    /// `kuna xrefs` — a reference query that runs its OWN recursive descent, so
+    /// the Listing tier would only decode the program a second time to hand it
+    /// seeds it can be given directly (`listing::xrefs::discovery_seeds`).
+    Query,
 }
 
 impl DriverDefaults {
@@ -890,6 +894,11 @@ impl DriverDefaults {
     /// no-return facts change its output, not just its inventory)?
     fn decompiles(&self) -> bool {
         matches!(self, DriverDefaults::Decompile)
+    }
+
+    /// Does this surface take the DIV-15/DIV-20/DIV-68 driver-default bundle?
+    fn takes_driver_defaults(&self) -> bool {
+        !matches!(self, DriverDefaults::Query)
     }
 }
 
@@ -1024,10 +1033,12 @@ pub(crate) fn load_program(
     let mut prog = bootstrap_from_object(&binary, target, &spec_roots)
         .map_err(|e| format!("could not build an architecture for {binary}: {}", e.explain()))?;
 
-    for (name, value) in driver_default_options(&binary, defaults.decompiles(), &args.options) {
-        prog.arch_mut()
-            .set_kuna_option(name, value)
-            .map_err(|e| format!("option {name}: {}", e.explain()))?;
+    if defaults.takes_driver_defaults() {
+        for (name, value) in driver_default_options(&binary, defaults.decompiles(), &args.options) {
+            prog.arch_mut()
+                .set_kuna_option(name, value)
+                .map_err(|e| format!("option {name}: {}", e.explain()))?;
+        }
     }
 
     // (kuna `--assert`) A `readonly` range is inert unless read-only propagation

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -884,8 +884,11 @@ pub(crate) enum DriverDefaults {
     /// `kuna decompile-all` / `kuna decompile-project` — enumeration plus bodies.
     Decompile,
     /// `kuna xrefs` — a reference query that runs its OWN recursive descent, so
-    /// the Listing tier would only decode the program a second time to hand it
-    /// seeds it can be given directly (`listing::xrefs::discovery_seeds`).
+    /// the Listing tier would only decode the program a second time over the
+    /// same bytes. It takes the discovery bundle (`funcstart_patterns`, `aif`)
+    /// but not the Listing: the seeds go straight into the reference walk
+    /// (`listing::xrefs::discovery_seeds`) and the gap-walk runs over the
+    /// partition that walk leaves behind.
     Query,
 }
 
@@ -896,8 +899,12 @@ impl DriverDefaults {
         matches!(self, DriverDefaults::Decompile)
     }
 
-    /// Does this surface take the DIV-15/DIV-20/DIV-68 driver-default bundle?
-    fn takes_driver_defaults(&self) -> bool {
+    /// Does this surface want the program-wide Listing built for it (DIV-15)?
+    ///
+    /// `Query` does not: it walks the program itself, so the Listing would be a
+    /// second decode of the same bytes. The DIV-20/DIV-68 discovery flags it
+    /// still takes — the reference walk consumes both of them directly.
+    fn wants_listing(&self) -> bool {
         !matches!(self, DriverDefaults::Query)
     }
 }
@@ -982,6 +989,7 @@ impl DriverDefaults {
 pub(crate) fn driver_default_options(
     binary: &str,
     decompiles: bool,
+    wants_listing: bool,
     options: &[(String, String)],
 ) -> Vec<(&'static str, &'static str)> {
     let named = |name: &str| options.iter().any(|(option, _)| option == name);
@@ -995,7 +1003,7 @@ pub(crate) fn driver_default_options(
         .unwrap_or(false);
 
     let mut injected = Vec::new();
-    if (decompiles || non_x86_64) && !named("listing") {
+    if wants_listing && (decompiles || non_x86_64) && !named("listing") {
         injected.push(("listing", "on"));
     }
     if non_x86_64 && !named("funcstart_patterns") {
@@ -1033,12 +1041,15 @@ pub(crate) fn load_program(
     let mut prog = bootstrap_from_object(&binary, target, &spec_roots)
         .map_err(|e| format!("could not build an architecture for {binary}: {}", e.explain()))?;
 
-    if defaults.takes_driver_defaults() {
-        for (name, value) in driver_default_options(&binary, defaults.decompiles(), &args.options) {
-            prog.arch_mut()
-                .set_kuna_option(name, value)
-                .map_err(|e| format!("option {name}: {}", e.explain()))?;
-        }
+    for (name, value) in driver_default_options(
+        &binary,
+        defaults.decompiles(),
+        defaults.wants_listing(),
+        &args.options,
+    ) {
+        prog.arch_mut()
+            .set_kuna_option(name, value)
+            .map_err(|e| format!("option {name}: {}", e.explain()))?;
     }
 
     // (kuna `--assert`) A `readonly` range is inert unless read-only propagation

--- a/decompiler/crates/kuna-cli/src/xrefs.rs
+++ b/decompiler/crates/kuna-cli/src/xrefs.rs
@@ -94,10 +94,20 @@ pub fn run(argv: &[String]) -> i32 {
 
 /// Load, index, resolve, and render — the whole command in one pass.
 fn query(args: &XrefArgs) -> Result<String, String> {
-    let options = mode_options_for_binary(args.mode.as_deref(), &args.binary, args.options.clone())?;
-    // The inventory driver bundle: `xrefs` enumerates entries and walks them
-    // itself, so it wants the discovery defaults (DIV-20/DIV-68 on non-x86-64)
-    // without paying for the whole-binary Listing a decompiling surface needs.
+    // A reference query is not a decompile, so `--mode` is NOT resolved through
+    // `auto` here: `auto` picks `aggressive` under 500 KiB, and `aggressive` is a
+    // preset for the QUALITY of emitted C. Two of the passes it turns on cost a
+    // whole extra decode of the program apiece and answer nothing this command
+    // reads — the analysis-tier Listing walk (which `xrefs` re-walks itself) and
+    // `operand_refs` (whose scalar markup `xrefs` recomputes from the p-code it
+    // already has). On a 466 KB obfuscated i386 image they were 1.08 s and 0.58 s
+    // of a 3.2 s answer that is byte-identical without them. `--mode aggressive`
+    // still asks for the full bundle explicitly.
+    let mode = Some(args.mode.as_deref().unwrap_or("reliable"));
+    let options = mode_options_for_binary(mode, &args.binary, args.options.clone())?;
+    // The query driver bundle: `xrefs` enumerates entries and walks them itself,
+    // so it takes no Listing-tier injection at all — the discovery seeds the
+    // injection existed to produce go straight into the reference walk below.
     let load = Args {
         binary: args.binary.clone(),
         json: args.json,
@@ -113,14 +123,15 @@ fn query(args: &XrefArgs) -> Result<String, String> {
         target: args.target.clone(),
         sleighpath: args.sleighpath.clone(),
     };
-    let prog = load_program(&load, DriverDefaults::Inventory)?;
+    let prog = load_program(&load, DriverDefaults::Query)?;
 
     let bytes = std::fs::read(&args.binary).map_err(|e| format!("{}: {e}", args.binary))?;
     let file = object::File::parse(&*bytes)
         .map_err(|e| format!("could not parse {}: {e}", args.binary))?;
 
     let entries = prog.function_entries_canonical();
-    let seeds: Vec<u64> = entries.iter().map(|e| e.addr.get_offset()).collect();
+    let inventory: Vec<u64> = entries.iter().map(|e| e.addr.get_offset()).collect();
+    let seeds = kuna_analysis::listing::xrefs::discovery_seeds(&file, &inventory);
     let index = kuna_analysis::listing::xrefs::build(
         &file,
         prog.arch(),

--- a/decompiler/crates/kuna-cli/src/xrefs.rs
+++ b/decompiler/crates/kuna-cli/src/xrefs.rs
@@ -139,7 +139,7 @@ fn query(args: &XrefArgs) -> Result<String, String> {
         &seeds,
     );
 
-    let target = resolve_target(&prog, &args.spec)?;
+    let target = resolve_target(&prog, &index, &args.spec)?;
     let rows = match args.direction {
         // `--to` answers for the callable, not the literal address: an import
         // reached through a veneer and an IAT/GOT slot is one thing under two
@@ -178,12 +178,12 @@ fn query(args: &XrefArgs) -> Result<String, String> {
 /// A name that identifies several entries is an ERROR naming all of them, not a
 /// miss: falling through to the symbol table would answer for whichever one it
 /// happens to hold first, which is the guess the selector model exists to refuse.
-fn resolve_target(prog: &ConsoleProgram, spec: &str) -> Result<Target, String> {
+fn resolve_target(prog: &ConsoleProgram, index: &XrefIndex, spec: &str) -> Result<Target, String> {
     let spec = spec.trim();
     if let Some(body) = spec.strip_prefix("0x").or_else(|| spec.strip_prefix("0X")) {
         let addr = u64::from_str_radix(body, 16)
             .map_err(|_| format!("invalid address {spec:?}"))?;
-        return Ok(Target { addr, name: name_at(prog, addr) });
+        return Ok(Target { addr, name: name_at(prog, index, addr) });
     }
     match prog.resolve_entry(&EntrySelector::Name(spec.to_string())) {
         Ok(entry) => return Ok(Target { addr: entry.addr.get_offset(), name: Some(entry.name) }),
@@ -192,7 +192,7 @@ fn resolve_target(prog: &ConsoleProgram, spec: &str) -> Result<Target, String> {
     }
     if let Some(addr) = prog.lookup_symbol(spec) {
         let addr = addr.get_offset();
-        return Ok(Target { addr, name: name_at(prog, addr).or_else(|| Some(spec.to_string())) });
+        return Ok(Target { addr, name: name_at(prog, index, addr).or_else(|| Some(spec.to_string())) });
     }
     if let Some((name, addr, _)) = prog
         .global_data_symbols()
@@ -202,17 +202,30 @@ fn resolve_target(prog: &ConsoleProgram, spec: &str) -> Result<Target, String> {
         return Ok(Target { addr, name: Some(name) });
     }
     if let Ok(addr) = u64::from_str_radix(spec, 16) {
-        return Ok(Target { addr, name: name_at(prog, addr) });
+        return Ok(Target { addr, name: name_at(prog, index, addr) });
     }
     Err(format!("no symbol named {spec:?} (and it is not an address)"))
 }
 
 /// The program's best name for `vma`: the canonical function entry there, then a
 /// function symbol, then a named global data object. `None` when nothing names it.
-fn name_at(prog: &ConsoleProgram, vma: u64) -> Option<String> {
+fn name_at(prog: &ConsoleProgram, index: &XrefIndex, vma: u64) -> Option<String> {
     prog.find_entry_at(vma)
         .map(|e| e.name)
         .or_else(|| prog.function_named_at(vma))
+        // The walk discovers functions the engine's inventory does not carry (it
+        // follows the call graph out of its seeds), and a row that names one must
+        // still name it rather than answer `null`.
+        .or_else(|| {
+            index.is_function_entry(vma).then(|| {
+                match prog.arch().manage().get_default_code_space() {
+                    Some(space) => {
+                        prog.arch().name_function(&Address::new(Rc::clone(space), vma))
+                    }
+                    None => format!("sub_{vma:x}"),
+                }
+            })
+        })
         .or_else(|| {
             prog.global_data_symbols()
                 .into_iter()
@@ -228,13 +241,13 @@ fn owning_function(prog: &ConsoleProgram, index: &XrefIndex, vma: u64) -> Option
     let entry = index
         .function_containing(vma)
         .or_else(|| prog.find_entry_at(vma).map(|e| e.addr.get_offset()))?;
-    Some((entry, function_name(prog, entry)))
+    Some((entry, function_name(prog, index, entry)))
 }
 
 /// The display name for a function entry, falling back to the engine's own
 /// placeholder (`sub_<addr>`) so a row is never nameless.
-fn function_name(prog: &ConsoleProgram, entry: u64) -> String {
-    name_at(prog, entry).unwrap_or_else(|| {
+fn function_name(prog: &ConsoleProgram, index: &XrefIndex, entry: u64) -> String {
+    name_at(prog, index, entry).unwrap_or_else(|| {
         match prog.arch().manage().get_default_code_space() {
             Some(space) => prog.arch().name_function(&Address::new(Rc::clone(space), entry)),
             None => format!("sub_{entry:x}"),
@@ -321,7 +334,7 @@ fn result_json(
                             .into_iter()
                             .map(|a| {
                                 function_json(
-                                    &name_at(prog, a).unwrap_or_else(|| format!("0x{a:x}")),
+                                    &name_at(prog, index, a).unwrap_or_else(|| format!("0x{a:x}")),
                                     a,
                                 )
                             })
@@ -366,7 +379,7 @@ fn render_text(
         let _ = writeln!(
             out,
             "# same import at 0x{a:x} ({}) - a forwarding veneer and the pointer slot it jumps through",
-            name_at(prog, a).unwrap_or_else(|| "-".into())
+            name_at(prog, index, a).unwrap_or_else(|| "-".into())
         );
     }
     for r in rows {
@@ -387,7 +400,7 @@ fn render_text(
                     "0x{:x}\t{}\t{}\t@0x{:x}\t{}",
                     r.to,
                     r.kind.as_str(),
-                    name_at(prog, r.to).unwrap_or_else(|| "-".into()),
+                    name_at(prog, index, r.to).unwrap_or_else(|| "-".into()),
                     r.from,
                     r.instruction
                 );

--- a/decompiler/crates/kuna-cli/src/xrefs.rs
+++ b/decompiler/crates/kuna-cli/src/xrefs.rs
@@ -73,6 +73,18 @@ struct Target {
     name: Option<String>,
 }
 
+/// The operand resolved to an address, before the walk that names it.
+///
+/// The address is what the walk needs (it is pointed at it, `build_with_focus`);
+/// the naming half runs afterwards because it reads the walk's own discovered
+/// functions. `name` is a name the lookup itself established, `fallback` one to
+/// use only if nothing else names the address.
+struct TargetSpec {
+    addr: u64,
+    name: Option<String>,
+    fallback: Option<String>,
+}
+
 /// `kuna xrefs` entry point.
 pub fn run(argv: &[String]) -> i32 {
     let args = match parse_args(argv) {
@@ -131,15 +143,25 @@ fn query(args: &XrefArgs) -> Result<String, String> {
 
     let entries = prog.function_entries_canonical();
     let inventory: Vec<u64> = entries.iter().map(|e| e.addr.get_offset()).collect();
-    let seeds = kuna_analysis::listing::xrefs::discovery_seeds(&file, &inventory);
-    let index = kuna_analysis::listing::xrefs::build(
+    let seeds = kuna_analysis::listing::xrefs::discovery_seeds(
+        &file,
+        &inventory,
+        prog.arch().analysis_funcstart_patterns,
+    );
+    // The operand resolves to an address BEFORE the walk so the walk can be
+    // pointed at it: a function whose only inbound edge is an indirect call
+    // through a table is in no seed set, and a query about it must not answer
+    // "no references" about the very address the caller named.
+    let spec = target_address(&prog, &args.spec)?;
+    let index = kuna_analysis::listing::xrefs::build_with_focus(
         &file,
         prog.arch(),
         prog.arch().translate(),
         &seeds,
+        &[spec.addr],
     );
 
-    let target = resolve_target(&prog, &index, &args.spec)?;
+    let target = resolve_target(&prog, &index, spec);
     let rows = match args.direction {
         // `--to` answers for the callable, not the literal address: an import
         // reached through a veneer and an IAT/GOT slot is one thing under two
@@ -178,33 +200,50 @@ fn query(args: &XrefArgs) -> Result<String, String> {
 /// A name that identifies several entries is an ERROR naming all of them, not a
 /// miss: falling through to the symbol table would answer for whichever one it
 /// happens to hold first, which is the guess the selector model exists to refuse.
-fn resolve_target(prog: &ConsoleProgram, index: &XrefIndex, spec: &str) -> Result<Target, String> {
+fn target_address(prog: &ConsoleProgram, spec: &str) -> Result<TargetSpec, String> {
     let spec = spec.trim();
     if let Some(body) = spec.strip_prefix("0x").or_else(|| spec.strip_prefix("0X")) {
         let addr = u64::from_str_radix(body, 16)
             .map_err(|_| format!("invalid address {spec:?}"))?;
-        return Ok(Target { addr, name: name_at(prog, index, addr) });
+        return Ok(TargetSpec { addr, name: None, fallback: None });
     }
     match prog.resolve_entry(&EntrySelector::Name(spec.to_string())) {
-        Ok(entry) => return Ok(Target { addr: entry.addr.get_offset(), name: Some(entry.name) }),
+        Ok(entry) => {
+            return Ok(TargetSpec {
+                addr: entry.addr.get_offset(),
+                name: Some(entry.name),
+                fallback: None,
+            })
+        }
         Err(error @ EntryLookupError::Ambiguous { .. }) => return Err(error.to_string()),
         Err(_) => {}
     }
     if let Some(addr) = prog.lookup_symbol(spec) {
-        let addr = addr.get_offset();
-        return Ok(Target { addr, name: name_at(prog, index, addr).or_else(|| Some(spec.to_string())) });
+        return Ok(TargetSpec {
+            addr: addr.get_offset(),
+            name: None,
+            fallback: Some(spec.to_string()),
+        });
     }
     if let Some((name, addr, _)) = prog
         .global_data_symbols()
         .into_iter()
         .find(|(name, _, _)| name == spec)
     {
-        return Ok(Target { addr, name: Some(name) });
+        return Ok(TargetSpec { addr, name: Some(name), fallback: None });
     }
     if let Ok(addr) = u64::from_str_radix(spec, 16) {
-        return Ok(Target { addr, name: name_at(prog, index, addr) });
+        return Ok(TargetSpec { addr, name: None, fallback: None });
     }
     Err(format!("no symbol named {spec:?} (and it is not an address)"))
+}
+
+/// Attach the display name to an address the spec already resolved: whatever the
+/// lookup itself knew, else the program's best name for the address, else the
+/// spec's own fallback (a symbol names its address even when nothing else does).
+fn resolve_target(prog: &ConsoleProgram, index: &XrefIndex, spec: TargetSpec) -> Target {
+    let TargetSpec { addr, name, fallback } = spec;
+    Target { addr, name: name.or_else(|| name_at(prog, index, addr)).or(fallback) }
 }
 
 /// The program's best name for `vma`: the canonical function entry there, then a

--- a/decompiler/crates/kuna-cli/tests/xrefs_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/xrefs_cli.rs
@@ -32,6 +32,16 @@ fn fixture(name: &str) -> String {
         .to_string()
 }
 
+/// The stripped Cortex-M firmware whose `0x800039c` is reachable ONLY through a
+/// data path: no symbol, no `<patternpairs>` prologue pair, and no direct `bl`
+/// points at it, so no recursive descent seeded from the inventory reaches it.
+/// It is the witness for both halves of the query's discovery
+/// ([`a_function_no_descent_reaches_still_answers_for_itself`] and
+/// [`the_gap_walk_finds_call_sites_a_descent_cannot_reach`]).
+fn cortexm_gap() -> String {
+    fixture("cortexm_aifcorroborate_le32")
+}
+
 /// The stripped x86-64 PIE the acceptance probe names. `0x1030` is its
 /// `.plt.got` `__cxa_finalize` thunk; `0x4010`/`0x4014` are its two globals.
 fn aif_gap() -> String {
@@ -353,4 +363,55 @@ fn usage_errors_exit_two() {
         assert_eq!(code, 2, "{args:?} should be a usage error, got {code}: {stderr}");
         assert!(stderr.contains("usage: kuna xrefs"), "{args:?}: {stderr}");
     }
+}
+
+/// A reference query seeds its walk with the address it was ASKED about.
+///
+/// `0x800039c` has no inbound `bl`, no funcsym and no paired prologue, so the
+/// recursive descent structurally cannot reach it and the answer used to be
+/// `count: 0` about a function that plainly calls something. It is walked after
+/// the seeded descent drains, so it can only add coverage — and it is answered
+/// even with the speculative gap-walk off, because the caller naming an address
+/// is a stronger fact than a fingerprint match.
+#[test]
+fn a_function_no_descent_reaches_still_answers_for_itself() {
+    let Some(doc) = xrefs(&[&cortexm_gap(), "--from", "0x800039c", "--json"]) else {
+        return;
+    };
+    assert_eq!(json_int(&doc, "count"), Some(1), "the focus seed did not walk:\n{doc}");
+    assert_eq!(json_str(&doc, "name").as_deref(), Some("sub_800039c"), "{doc}");
+    assert!(doc.contains("\"to_address_hex\": \"0x8000160\""), "wrong callee:\n{doc}");
+    assert!(doc.contains("\"from_address_hex\": \"0x80003a0\""), "wrong call site:\n{doc}");
+
+    let off = xrefs(&[&cortexm_gap(), "--from", "0x800039c", "--json", "--option", "aif", "off"])
+        .expect("the gap-walk-off query");
+    assert_eq!(json_int(&off, "count"), Some(1), "the focus seed needs the gap-walk:\n{off}");
+}
+
+/// The speculative gap-walk runs over the partition the reference walk itself
+/// leaves behind, so the call sites inside a function only it discovers are in
+/// the answer — without the analysis-tier Listing decoding the program a second
+/// time to produce them.
+///
+/// `0x8000160` is called twice: once from `0x8000042`, which every descent
+/// reaches, and once from `0x80003a0`, which lives inside the data-reachable
+/// `0x800039c`. Turning the gap-walk off drops the second one, which is exactly
+/// the recall this query would lose by dropping the Listing without replacing it.
+#[test]
+fn the_gap_walk_finds_call_sites_a_descent_cannot_reach() {
+    let Some(doc) = xrefs(&[&cortexm_gap(), "--to", "0x8000160", "--json"]) else {
+        return;
+    };
+    assert_eq!(json_int(&doc, "count"), Some(2), "a caller is missing:\n{doc}");
+    for site in ["0x8000042", "0x80003a0"] {
+        assert!(doc.contains(&format!("\"from_address_hex\": \"{site}\"")), "no {site}:\n{doc}");
+    }
+
+    let off = xrefs(&[&cortexm_gap(), "--to", "0x8000160", "--json", "--option", "aif", "off"])
+        .expect("the gap-walk-off query");
+    assert_eq!(json_int(&off, "count"), Some(1), "the gap-walk was not the reason:\n{off}");
+    assert!(
+        !off.contains("\"from_address_hex\": \"0x80003a0\""),
+        "the gap-walk-off answer still has the gap call site:\n{off}"
+    );
 }

--- a/decompiler/crates/kuna-sleigh/src/sleigh.rs
+++ b/decompiler/crates/kuna-sleigh/src/sleigh.rs
@@ -964,6 +964,7 @@ struct PcodeData {
 /// one instruction.  The C++ raw-pointer pool becomes a `Vec<VarnodeData>`
 /// (pool) indexed by op input/output (ADR 0001); growth never invalidates
 /// indices.
+#[derive(Default)]
 struct PcodeCacher {
     /// The pool of VarnodeData objects (C++ `poolstart..endpool`).
     pool: Vec<VarnodeData>,
@@ -980,6 +981,7 @@ impl PcodeCacher {
     fn new() -> PcodeCacher {
         PcodeCacher { pool: Vec::new(), issued: Vec::new(), label_refs: Vec::new(), labels: Vec::new() }
     }
+
 
     /// C++ `allocateVarnodes(uint4 size)`: returns the pool index of the first
     /// of `size` freshly allocated VarnodeData (indices are stable).
@@ -1016,11 +1018,9 @@ impl PcodeCacher {
         self.labels[id as usize] = self.issued.len() as u64;
     }
 
-    /// C++ `clear`: reset the cache so all objects are unallocated.  The
-    /// engine allocates a fresh [`PcodeCacher`] per instruction (the C++
-    /// single instance is `clear`ed between instructions instead); kept for
-    /// API parity.
-    #[allow(dead_code)] // C++ PcodeCacher::clear (the port allocates fresh per insn)
+    /// C++ `clear`: reset the cache so all objects are unallocated, keeping the
+    /// allocations. The engine parks one cacher on the [`Sleigh`] and clears it
+    /// between instructions, exactly as the C++ single instance does.
     fn clear(&mut self) {
         self.pool.clear();
         self.issued.clear();
@@ -1049,17 +1049,20 @@ impl PcodeCacher {
     fn emit(&self, addr: &Address, emt: &mut dyn PcodeEmit, manager: &AddrSpaceManager) {
         for op in &self.issued {
             let outvar = op.outvar.map(|i| &self.pool[i]);
-            let invars: Vec<VarnodeData> = (0..op.isize)
-                .map(|k| {
-                    let base = op.invar.expect("issued op with inputs has invar");
-                    self.pool[base + k as usize].clone()
-                })
-                .collect();
+            // An op's inputs are a consecutive run in the pool
+            // (`allocate_varnodes` hands back the run's start), so the emit
+            // borrows the run the way the C++ passes a pointer into the same
+            // array. Rebuilding it cost one heap allocation per emitted p-code
+            // op on every decode in the program.
+            let invars: &[VarnodeData] = match op.invar {
+                Some(base) => &self.pool[base..base + op.isize as usize],
+                None => &[],
+            };
             // The spaceid pointer constant (input 0 of LOAD/STORE) is stored
             // as the space's manager index (LOSS-015); the emitter renders the
             // space name, so the value passed through is the raw stored index.
             let _ = manager;
-            emt.dump(addr, op.opc, outvar, &invars);
+            emt.dump(addr, op.opc, outvar, invars);
         }
     }
 }
@@ -1148,7 +1151,7 @@ impl<'a> SleighBuilder<'a> {
     }
 
     /// The constructor template referenced by a handle (C++ `getTempl`).
-    fn templ(&self, handle: usize) -> &ConstructTpl {
+    fn templ(&self, handle: usize) -> &'a ConstructTpl {
         &self.templates[handle]
     }
 
@@ -1258,7 +1261,10 @@ impl<'a> SleighBuilder<'a> {
             let construct = self.table.get_constructor(cur_ct)?.get_named_templ(secnum);
             match construct {
                 None => self.build_empty(cur_ct, secnum)?,
-                Some(handle) => self.build(Some(self.templ(handle).clone()).as_ref(), secnum)?,
+                Some(handle) => {
+                    let tpl = self.templ(handle);
+                    self.build(Some(tpl), secnum)?
+                }
             }
             self.pop_operand();
         }
@@ -1405,12 +1411,15 @@ impl PcodeBuilder for SleighBuilder<'_> {
             let construct = self.table.get_constructor(cur_ct)?.get_named_templ(secnum);
             match construct {
                 None => self.build_empty(cur_ct, secnum)?,
-                Some(handle) => self.build(Some(self.templ(handle).clone()).as_ref(), secnum)?,
+                Some(handle) => {
+                    let tpl = self.templ(handle);
+                    self.build(Some(tpl), secnum)?
+                }
             }
         } else {
             let handle = self.table.get_constructor(cur_ct)?.get_templ();
-            let tpl = handle.map(|h| self.templ(h).clone());
-            self.build(tpl.as_ref(), -1)?;
+            let tpl = handle.map(|h| self.templ(h));
+            self.build(tpl, -1)?;
         }
         self.pop_operand();
         Ok(())
@@ -1448,8 +1457,8 @@ impl PcodeBuilder for SleighBuilder<'_> {
             self.cur.point = Some(self.contexts[idx].ctx.base_state);
             let ct = self.walker().get_constructor_inner()?;
             let handle = self.table.get_constructor(ct)?.get_templ();
-            let tpl = handle.map(|h| self.templ(h).clone());
-            self.build(tpl.as_ref(), -1)?;
+            let tpl = handle.map(|h| self.templ(h));
+            self.build(tpl, -1)?;
             fall_offset += len;
             bytecount += len;
             if bytecount >= delay_byte_cnt {
@@ -1504,7 +1513,10 @@ impl PcodeBuilder for SleighBuilder<'_> {
         let construct = self.table.get_constructor(ct)?.get_named_templ(secnum);
         match construct {
             None => self.build_empty(ct, secnum)?,
-            Some(handle) => self.build(Some(self.templ(handle).clone()).as_ref(), secnum)?,
+            Some(handle) => {
+                let tpl = self.templ(handle);
+                self.build(Some(tpl), secnum)?
+            }
         }
         self.cur = saved_cur;
         self.cur_ctx = saved_ctx;
@@ -1561,6 +1573,12 @@ pub struct Sleigh {
     /// Reusable parser arenas. Checked-out contexts are removed from the pool,
     /// so nested `inst_next2` and delay-slot decodes receive distinct storage.
     parser_contexts: Rc<RefCell<Vec<ParserContext>>>,
+    /// The reusable p-code build arena. `one_instruction` filled four fresh
+    /// `Vec`s per decode and grew each of them as the instruction's ops issued;
+    /// parking the cacher here reuses that capacity across the whole program.
+    /// Taken (not borrowed) for the duration of a decode, so a nested decode
+    /// simply builds its own.
+    pcode_cacher: RefCell<PcodeCacher>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1623,6 +1641,7 @@ impl Sleigh {
             context_db: RefCell::new(context_db),
             cache: RefCell::new(ContextCache::new()),
             parser_contexts: Rc::new(RefCell::new(Vec::new())),
+            pcode_cacher: RefCell::new(PcodeCacher::new()),
         }
     }
 
@@ -2452,7 +2471,8 @@ impl Sleigh {
         let const_space = self.const_space();
         let uniq_space = self.unique_space();
         let umask = self.base.unique_allocatemask;
-        let mut cache = PcodeCacher::new();
+        let mut cache = std::mem::take(&mut *self.pcode_cacher.borrow_mut());
+        cache.clear();
         // walker over the main context, baseState
         let mut builder = SleighBuilder {
             labelbase: 0,
@@ -2473,9 +2493,9 @@ impl Sleigh {
         builder.cur.point = Some(contexts[0].ctx.base_state);
         let main_ct = builder.walker().get_constructor_inner()?;
         let handle = table.get_constructor(main_ct)?.get_templ();
-        let tpl = handle.map(|h| self.base.templates[h].clone());
+        let tpl = handle.map(|h| &self.base.templates[h]);
         let build_res = (|| -> KunaResult<()> {
-            builder.build(tpl.as_ref(), -1)?;
+            builder.build(tpl, -1)?;
             Ok(())
         })();
         match build_res {
@@ -2507,6 +2527,7 @@ impl Sleigh {
         }
         cache.resolve_relatives()?;
         cache.emit(baseaddr, emit, &self.base.manager);
+        *self.pcode_cacher.borrow_mut() = cache;
         Ok(fall_offset)
     }
 }

--- a/decompiler/crates/kuna-sleigh/src/sleigh.rs
+++ b/decompiler/crates/kuna-sleigh/src/sleigh.rs
@@ -1579,6 +1579,16 @@ pub struct Sleigh {
     /// Taken (not borrowed) for the duration of a decode, so a nested decode
     /// simply builds its own.
     pcode_cacher: RefCell<PcodeCacher>,
+    /// Whether a decode should stash each node's matched [`DisjointPattern`].
+    ///
+    /// Only [`Sleigh::instruction_mask`] ever reads them, and it re-decodes
+    /// under this flag, so an ordinary decode does not pay for them: the clone
+    /// is a deep copy of the leaf's pattern blocks at every constructor node and
+    /// was 55% of every heap allocation the program made while disassembling.
+    capture_patterns: std::cell::Cell<bool>,
+    /// The reusable delay-slot context vector (`one_instruction` needs one
+    /// entry per decode, and all but a delay-slot architecture need exactly one).
+    ctx_vec: RefCell<Vec<ResolvedCtx>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1642,6 +1652,8 @@ impl Sleigh {
             cache: RefCell::new(ContextCache::new()),
             parser_contexts: Rc::new(RefCell::new(Vec::new())),
             pcode_cacher: RefCell::new(PcodeCacher::new()),
+            capture_patterns: std::cell::Cell::new(false),
+            ctx_vec: RefCell::new(Vec::new()),
         }
     }
 
@@ -1853,14 +1865,21 @@ impl Sleigh {
         // selected the constructor — and stash it on this node for the FID
         // instruction-mask accessor.  The chosen constructor is unchanged.
         let subtable = subtable_ref(table, root)?;
+        let capture = self.capture_patterns.get();
         let (root_ct_id, root_pat) = {
             let reader = walker.as_reader();
-            let (pat, ct) = subtable.resolve_matched(&reader)?;
-            (*ct, pat.clone())
+            if capture {
+                let (pat, ct) = subtable.resolve_matched(&reader)?;
+                (*ct, Some(pat.clone()))
+            } else {
+                (subtable.resolve(&reader)?, None)
+            }
         };
         let root_ref = ConstructorRef { table_id: root, ct_id: root_ct_id };
         walker.set_constructor(root_ref);
-        walker.set_matched_pattern(root_pat);
+        if let Some(pat) = root_pat {
+            walker.set_matched_pattern(pat);
+        }
         apply_context(table, root_ref, &mut walker)?;
 
         while walker.is_state() {
@@ -1890,7 +1909,11 @@ impl Sleigh {
                     // the FID instruction-mask accessor.  Same constructor.
                     let (subct, subpat) = {
                         let reader = walker.as_reader();
-                        resolve_triple_matched(table, tsym, &reader)?
+                        if capture {
+                            resolve_triple_matched(table, tsym, &reader)?
+                        } else {
+                            (resolve_triple(table, tsym, &reader)?, None)
+                        }
                     };
                     if let Some(subct_id) = subct {
                         let subct_ref = ConstructorRef { table_id: tsym, ct_id: subct_id };
@@ -2141,6 +2164,19 @@ fn resolve_triple_matched(
     sym.resolve_matched(walker)
 }
 
+/// [`resolve_triple_matched`] without the pattern capture — the same decision
+/// walk and the same constructor, minus the deep clone of the matched leaf.
+fn resolve_triple(
+    table: &SymbolTable,
+    id: u32,
+    walker: &ParserWalker<'_>,
+) -> KunaResult<Option<u32>> {
+    let sym = table
+        .find_symbol_by_id(id)
+        .ok_or_else(|| KunaError::sleigh("triple symbol undefined"))?;
+    sym.resolve(walker)
+}
+
 /// C++ `Constructor::applyContext` via the symbol table + mutating walker.
 fn apply_context(
     table: &SymbolTable,
@@ -2262,7 +2298,12 @@ impl Sleigh {
     pub fn instruction_mask(&self, baseaddr: &Address) -> KunaResult<InsnMask> {
         // Pcode state so operand handles are resolved (classification reads
         // them); the fixed-mask tree walk works at either parse state.
-        let pos = self.obtain_context(baseaddr, ParseState::Pcode)?;
+        // The stashed patterns exist only for this accessor, so the decode that
+        // produces them is the one that asks for them.
+        self.capture_patterns.set(true);
+        let pos = self.obtain_context(baseaddr, ParseState::Pcode);
+        self.capture_patterns.set(false);
+        let pos = pos?;
         let len = pos.get_length();
         if len <= 0 || len > MAX_INSTRUCTION_LEN {
             return Err(KunaError::bad_data(format!(
@@ -2443,8 +2484,12 @@ impl Sleigh {
         self.apply_commits(&pos)?;
         let mut fall_offset = pos.get_length();
 
-        // Resolve all delay-slot contexts up front (the C++ caches them).
-        let mut contexts: Vec<ResolvedCtx> = Vec::new();
+        // Resolve all delay-slot contexts up front (the C++ caches them). The
+        // vector is parked on the engine between decodes: it holds one entry on
+        // every architecture without delay slots, i.e. one heap allocation per
+        // instruction of the program.
+        let mut contexts: Vec<ResolvedCtx> = std::mem::take(&mut *self.ctx_vec.borrow_mut());
+        contexts.clear();
         if pos.get_delay_slot() > 0 {
             let mut bytecount = 0i32;
             loop {
@@ -2528,6 +2573,8 @@ impl Sleigh {
         cache.resolve_relatives()?;
         cache.emit(baseaddr, emit, &self.base.manager);
         *self.pcode_cacher.borrow_mut() = cache;
+        contexts.clear();
+        *self.ctx_vec.borrow_mut() = contexts;
         Ok(fall_offset)
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -644,13 +644,31 @@ inventory missed is still covered.
 `auto` selects `aggressive` under 500 KiB, and `aggressive` is a preset for the
 quality of emitted *C*. Two of the passes it turns on cost a whole extra decode of
 the program apiece and answer nothing a reference query reads — the analysis-tier
-Listing walk (whose recursive descent `xrefs` repeats itself, so it contributed
-only seeds, which are now handed to the walk directly) and `operand_refs` (whose
-scalar markup `xrefs` recomputes from the p-code it already has). So the query
-surface defaults to the shipped defaults, and `kuna xrefs --mode aggressive` still
-asks for the full analysis bundle explicitly. On a 466 KB obfuscated i386 image
-the two skipped decodes were 1.08 s and 0.58 s of a 3.4 s answer that is
-byte-identical without them.
+Listing walk (whose recursive descent `xrefs` repeats itself over the same bytes)
+and `operand_refs` (whose scalar markup `xrefs` recomputes from the p-code it
+already has). So the query surface defaults to the shipped defaults, and
+`kuna xrefs --mode aggressive` still asks for the full analysis bundle explicitly.
+On a 466 KB obfuscated i386 image the two skipped decodes were 1.08 s and 0.58 s of
+a 3.4 s answer that is byte-identical without them.
+
+Dropping the Listing does **not** drop the discovery it fed. The query surface takes
+the same DIV-20/DIV-68 discovery flags every other surface does (`funcstart_patterns`,
+`aif`); it just consumes them itself, from its own decode:
+
+* the `<patternpairs>` prologue starts go straight into the walk's seed set;
+* the speculative gap-walk (`aif`) runs over the partition the walk leaves behind,
+  and the functions it accepts are walked like any other, so their references join
+  the answer. Without it, a function reached only through a function-pointer table
+  is in no seed set and `--to` loses every call site inside it — measured on a
+  stripped i386 PE as 61 of one function's 174 callers.
+
+The address you ask about is itself a seed. A recursive descent answers for the code
+it can reach, and an entry with no inbound CALL edge is not reachable from any seed
+set, so `kuna xrefs --from <that entry>` used to answer `count: 0` about a function
+that plainly has references. It is now walked last, after the seeded descent has
+drained, so it can only add coverage — an address the walk already decoded is
+attributed exactly as before, and an address that does not decode is not recorded as
+a function at all.
 
 A target nothing references is exit `0` with `count: 0` — an answer, not a
 failure. A name that resolves to nothing is exit `1` with the reason on stderr; a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -640,6 +640,18 @@ changes no emitted C. Function discovery is the `kuna functions` inventory, whic
 the walk then extends by following the call graph out of it, so a callee the
 inventory missed is still covered.
 
+`--mode` is **not** resolved through `auto` here, unlike the decompiling surfaces:
+`auto` selects `aggressive` under 500 KiB, and `aggressive` is a preset for the
+quality of emitted *C*. Two of the passes it turns on cost a whole extra decode of
+the program apiece and answer nothing a reference query reads — the analysis-tier
+Listing walk (whose recursive descent `xrefs` repeats itself, so it contributed
+only seeds, which are now handed to the walk directly) and `operand_refs` (whose
+scalar markup `xrefs` recomputes from the p-code it already has). So the query
+surface defaults to the shipped defaults, and `kuna xrefs --mode aggressive` still
+asks for the full analysis bundle explicitly. On a 466 KB obfuscated i386 image
+the two skipped decodes were 1.08 s and 0.58 s of a 3.4 s answer that is
+byte-identical without them.
+
 A target nothing references is exit `0` with `count: 0` — an answer, not a
 failure. A name that resolves to nothing is exit `1` with the reason on stderr; a
 malformed command line is exit `2` with the usage block.

--- a/docs/features/cold-load-xref-lookup/pr_body.md
+++ b/docs/features/cold-load-xref-lookup/pr_body.md
@@ -1,0 +1,81 @@
+## What was broken
+
+RE-need `cold-load-xref-lookup` (1 instance, round 2, challenge `5bd1d1bb33c5d4110a29b31e`):
+
+> **Cold-load xref lookup takes about four seconds on a 466 KB ELF** — the actual
+> `kuna xrefs ./target/Obfuscation1 --to 0x80ba3d2 --json` invocation took 4.1303 seconds.
+> Every independent query reloads analysis state.
+
+The tester's diagnosis was "no persistent session". Measured, that names the workflow cost
+but not the per-query one: **one cold query decoded the program three times.**
+
+| stage | cost | what it is |
+|---|---|---|
+| bootstrap (loader + `.sla` + load-time oracles) | 0.10 s | |
+| analysis-tier Listing walk | 1.08 s | decode pass #1, 154,608 instructions |
+| `operand_refs` | 0.58 s | decode pass #2, its own linear decode |
+| `xrefs::build` recursive descent | 1.26 s | decode pass #3, the same 154,608 instructions |
+
+Both extra passes arrived through `--mode auto`, which selects `aggressive` under 500 KiB —
+a preset for the quality of emitted *C*, on a command that emits none.
+
+## Mechanism
+
+Five changes. No new option (a reference query cannot change emitted C), no `phases.toml`
+row, no catalog counters.
+
+1. **`kuna xrefs` takes its own driver bundle** (`DriverDefaults::Query`) and resolves no
+   automatic mode. The Listing's only contribution to a *reference* answer was seeds, and
+   `xrefs::build` already runs its own two-worklist descent — so the `<patternpairs>`
+   prologue starts go straight into that walk (`listing::xrefs::discovery_seeds`, gated to
+   the same non-x86-64 architectures DIV-20/DIV-68 injects for, so x86-64's seed set is
+   unchanged). `kuna xrefs --mode aggressive` still asks for the full analysis tier.
+2. **The assembly render is lazy.** `print_assembly` is a second full SLEIGH parse of the
+   address, and the walk paid it for every instruction to fill rows only a few carry.
+3. **The PIC-base pass stops buffering p-code.** On any 32-bit PIC image the deferred
+   base-relative pass cloned every instruction's whole op list *and* rendered every
+   instruction — 154,608 renders to file 151 references. Both halves it needs
+   (`writes_base`, the base-relative refs) are pure functions of the ops, so they are
+   computed in the walk and only the answers carried; the render happens for the admitted
+   instructions that actually form a reference. Its live-varnode map is a small vector
+   rather than a `HashMap`, which was paying a bucket-wide `retain` per written op.
+4. **`PcodeCacher::emit` borrows its input run** out of the pool instead of rebuilding it —
+   one heap allocation per emitted p-code op, on **every decode in the program**, gone.
+   The C++ passes a pointer into the same array.
+5. **The p-code build arena and the walk's capture are pooled.** `one_instruction` allocated
+   four fresh `Vec`s per decode (the C++ clears one long-lived instance); the xref walk
+   allocated a vector per emitted op.
+
+Refuted en route, and recorded in `record.json`: the per-node `ConstructTpl` deep clone
+(fixed anyway, ~2%), the `WalkCursor` breadcrumb copy (`MAX_DEPTH` 32 → 12 is byte-identical
+and no faster), and the SLEIGH context-DB commits (9 ms of 3.4 s).
+
+## The acceptance probe now passes
+
+```
+$ python -m scripts.repipe.verify --need cold-load-xref-lookup --json
+```
+
+Promoted verbatim into `tests/cli/cold-load-xref-lookup.json`.
+
+Interleaved base/new, warmup + 7 reps, same shell, same binary:
+
+| | median | min |
+|---|---|---|
+| base | 3418 ms | 3367 ms |
+| this PR | 1039 ms | 727 ms |
+
+**−69.6 % median**, and the JSON answer is byte-identical.
+
+## Gates
+
+- `make test` — **PARITY OK**, 675/675
+- `make test-stages` — **PARITY OK**
+- `make rust-test` — green
+- `make check-spec` — green
+- `kuna catalog --check` — catalog OK
+
+Spec prose: `docs/spec/01-program-prep.md` (the query's own analysis bundle). CLI surface:
+`docs/cli.md` (`kuna xrefs` does not resolve `--mode auto`).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/cold-load-xref-lookup/pr_body.md
+++ b/docs/features/cold-load-xref-lookup/pr_body.md
@@ -1,81 +1,104 @@
 ## What was broken
 
-RE-need `cold-load-xref-lookup` (1 instance, round 2, challenge `5bd1d1bb33c5d4110a29b31e`):
+RE-need `cold-load-xref-lookup` (round 2, 1 instance, challenge `5bd1d1bb33c5d4110a29b31e`):
 
-> **Cold-load xref lookup takes about four seconds on a 466 KB ELF** — the actual
+> **Cold-load xref lookup takes about four seconds on a 466 KB ELF.** The actual
 > `kuna xrefs ./target/Obfuscation1 --to 0x80ba3d2 --json` invocation took 4.1303 seconds.
 > Every independent query reloads analysis state.
 
-The tester's diagnosis was "no persistent session". Measured, that names the workflow cost
-but not the per-query one: **one cold query decoded the program three times.**
+The filed diagnosis — no persistent session — names the *workflow* cost, not the per-query one.
+Measured, **one** cold query decoded the program **three times**, 154,608 instructions each: the
+analysis-tier Listing walk, `operand_refs`' linear decode, and the reference index's own recursive
+descent. A resident session would have amortised that; removing two of the three eliminates it.
 
-| stage | cost | what it is |
-|---|---|---|
-| bootstrap (loader + `.sla` + load-time oracles) | 0.10 s | |
-| analysis-tier Listing walk | 1.08 s | decode pass #1, 154,608 instructions |
-| `operand_refs` | 0.58 s | decode pass #2, its own linear decode |
-| `xrefs::build` recursive descent | 1.26 s | decode pass #3, the same 154,608 instructions |
+Both extra decodes arrived because `--mode auto` promotes a sub-500 KiB image to `aggressive` — a
+preset for the quality of emitted **C**, on a command that emits none.
 
-Both extra passes arrived through `--mode auto`, which selects `aggressive` under 500 KiB —
-a preset for the quality of emitted *C*, on a command that emits none.
+## Why attempt 1 did not merge, and what changed
+
+Attempt 1 (taken over here verbatim and rebased) reached −70% with byte-identical output but left
+one blocker: dropping the Listing dropped the **AIF gap-walk** with it, and that is the only thing
+the Listing contributed to a *reference* answer. A function reached only through a function-pointer
+table has no inbound CALL edge, so no recursive descent finds it — on a stripped i386 PE that cost
+`--to 0x43edfa` **61 of its 174 callers**, and `--from` on such a function answered `0`. Both are
+now closed **without** restoring the second decode.
 
 ## Mechanism
 
-Five changes. No new option (a reference query cannot change emitted C), no `phases.toml`
-row, no catalog counters.
+1. **The query seeds its walk with the address it was asked about.** Walked *last*, after the
+   seeded descent drains, so an address the natural walk already claimed is already in `decoded`
+   and attributed exactly as before — the focus pass can only add coverage, never re-attribute an
+   instruction another entry owns. An address that does not decode is dropped, not recorded as a
+   function.
+2. **The AIF gap-walk runs over the partition the reference walk itself leaves behind**
+   (`Listing::from_partition`). The two facts it needs — which bytes are instructions, which
+   addresses are functions — are exactly what the walk already computed; only the prologue mnemonics
+   its fingerprint histogram reads are rendered, 2 per discovered function, against the whole
+   program's worth the Listing path rendered. Its accepted entries are walked like any other seed.
+   So `DriverDefaults::Query` takes the DIV-20/DIV-68 discovery flags and declines only the Listing.
+3. **SLEIGH stops deep-cloning the matched `DisjointPattern` on every constructor node.** Only
+   `Sleigh::instruction_mask` (the default-off `fid` pass) ever reads them, and it re-decodes under
+   a flag it sets itself. That clone was **55% of every heap allocation the program made while
+   disassembling**. With the per-instruction delay-slot context vector parked on the engine:
+   **1,412,338 → 477,392 allocations, 228 MB → 72 MB.**
 
-1. **`kuna xrefs` takes its own driver bundle** (`DriverDefaults::Query`) and resolves no
-   automatic mode. The Listing's only contribution to a *reference* answer was seeds, and
-   `xrefs::build` already runs its own two-worklist descent — so the `<patternpairs>`
-   prologue starts go straight into that walk (`listing::xrefs::discovery_seeds`, gated to
-   the same non-x86-64 architectures DIV-20/DIV-68 injects for, so x86-64's seed set is
-   unchanged). `kuna xrefs --mode aggressive` still asks for the full analysis tier.
-2. **The assembly render is lazy.** `print_assembly` is a second full SLEIGH parse of the
-   address, and the walk paid it for every instruction to fill rows only a few carry.
-3. **The PIC-base pass stops buffering p-code.** On any 32-bit PIC image the deferred
-   base-relative pass cloned every instruction's whole op list *and* rendered every
-   instruction — 154,608 renders to file 151 references. Both halves it needs
-   (`writes_base`, the base-relative refs) are pure functions of the ops, so they are
-   computed in the walk and only the answers carried; the render happens for the admitted
-   instructions that actually form a reference. Its live-varnode map is a small vector
-   rather than a `HashMap`, which was paying a bucket-wide `retain` per written op.
-4. **`PcodeCacher::emit` borrows its input run** out of the pool instead of rebuilding it —
-   one heap allocation per emitted p-code op, on **every decode in the program**, gone.
-   The C++ passes a pointer into the same array.
-5. **The p-code build arena and the walk's capture are pooled.** `one_instruction` allocated
-   four fresh `Vec`s per decode (the C++ clears one long-lived instance); the xref walk
-   allocated a vector per emitted op.
+Plus attempt 1's own: lazy assembly rendering, the PIC-base pass carrying precomputed answers
+instead of a clone of every instruction's p-code, and `PcodeCacher::emit` borrowing its input run.
 
-Refuted en route, and recorded in `record.json`: the per-node `ConstructTpl` deep clone
-(fixed anyway, ~2%), the `WalkCursor` breadcrumb copy (`MAX_DEPTH` 32 → 12 is byte-identical
-and no faster), and the SLEIGH context-DB commits (9 ms of 3.4 s).
+No new option, no `phases.toml` row, no emitted-C change.
 
 ## The acceptance probe now passes
 
 ```
-$ python -m scripts.repipe.verify --need cold-load-xref-lookup --json
+python -m scripts.repipe.verify --need cold-load-xref-lookup --json   →  passed = true
 ```
 
-Promoted verbatim into `tests/cli/cold-load-xref-lookup.json`.
+Promoted to `tests/cli/cold-load-xref-lookup.json`, repointed from the dataset image to the largest
+in-repo fixture (CI has no dataset) with the bound recalibrated on it: `mcount_x86_64` measured
+**1169 ms min before the change, 687-989 ms after**, so `min` of 5 < 1100 fails on the old answer (1169 ms) and passes on the new (687-989 ms).
+`min` of 5 rather than `median` because this box is a 2-socket Xeon Silver 4316 whose turbo/base
+split makes any single sample bimodal by 1.48x (652–672 ms or 933–1036 ms for identical work);
+every number below is `taskset`-pinned and interleaved base/new.
 
-Interleaved base/new, warmup + 7 reps, same shell, same binary:
+| target | base | new | Δ |
+|---|---|---|---|
+| `Obfuscation1` (466 KB obfuscated i386 ELF, the witness) | 3573 ms | **715 ms** | **−80.0%** |
+| `KeyVal2.exe` (stripped i386 PE) | 2047 ms | **799 ms** | −61.0% |
+| `mcount_x86_64` (in-repo, 896 KB) | 1181 ms | **702 ms** | −40.6% |
+| `pe_imports.exe` (in-repo, 499 KB) | 282 ms | **161 ms** | −42.9% |
 
-| | median | min |
-|---|---|---|
-| base | 3418 ms | 3367 ms |
-| this PR | 1039 ms | 727 ms |
+Output on the witness is byte-identical; `KeyVal2.exe --to 0x43edfa` answers all **174** callers
+both ways.
 
-**−69.6 % median**, and the JSON answer is byte-identical.
+## Recall sweep
+
+15 sampled entries × 2 directions on 4 binaries, comparing **row sets** (not counts) against the
+full old discovery bundle. `Obfuscation1` 30/30 identical, `system.exe` 30/30 identical,
+`KeyVal2.exe` 1 query short by 4 of ~1400 rows (was 5 queries and 61 rows before the gap-walk was
+restored), `nikos_crack_me.exe` 1 query short by 134. Two residuals, both recorded in
+`record.json`:
+
+* the gap-walk over the reference walk's partition is not bit-identical to the gap-walk over a
+  Listing's — the seeds and therefore the gaps differ, so a few speculative accepts differ;
+* on an **x86-64 image under 500 KiB** the base answered with `aif` on, because it resolved
+  `--mode auto` to `aggressive` — the exact C-quality-preset leak this need is about. The new
+  default matches `kuna functions` and `kuna decompile-all` on that architecture (DIV-20: `aif` is
+  off on x86-64). `kuna xrefs --option aif on` answers **more** than the base did there (1066 vs
+  1044) in 600 ms against the base's ~1000.
 
 ## Gates
 
-- `make test` — **PARITY OK**, 675/675
-- `make test-stages` — **PARITY OK**
-- `make rust-test` — green
-- `make check-spec` — green
-- `kuna catalog --check` — catalog OK
+| gate | result |
+|---|---|
+| `make test` | **PARITY OK** 675/675 |
+| `make test-stages` | **PARITY OK** |
+| `make check-spec` | green |
+| `kuna catalog --check` | catalog OK |
+| `make rust-test` | 212 suites green except one **pre-existing** failure — `kuna-decomp::verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip`. Verified pre-existing by restoring `a13f570d`'s `kuna-sleigh/src/sleigh.rs` and re-running that single test alone: it fails identically. Post-rebase the full-workspace run was killed early three times on this box for reasons outside the tree (no failures, no build error, truncated mid-suite); the three crates this PR touches were then re-run in full and are green — `-p kuna-sleigh -p kuna-analysis -p kuna-cli`, 0 failed. |
 
-Spec prose: `docs/spec/01-program-prep.md` (the query's own analysis bundle). CLI surface:
-`docs/cli.md` (`kuna xrefs` does not resolve `--mode auto`).
+New cargo coverage: `xrefs_cli::a_function_no_descent_reaches_still_answers_for_itself` and
+`xrefs_cli::the_gap_walk_finds_call_sites_a_descent_cannot_reach`, both on the vendored
+`cortexm_aifcorroborate_le32` — `0x800039c` is reachable only through a data path, and `0x8000160`
+is called both from code every descent reaches and from inside that function.
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/cold-load-xref-lookup/record.json
+++ b/docs/features/cold-load-xref-lookup/record.json
@@ -1,0 +1,33 @@
+{
+  "slug": "cold-load-xref-lookup",
+  "need_id": "cold-load-xref-lookup",
+  "track": "perf",
+  "scope": "small",
+  "worker": "b-r2-cold-load-xref-l",
+  "round": 2,
+  "date": "2026-09-04",
+  "symptom": "kuna xrefs ./target/Obfuscation1 --to 0x80ba3d2 --json took 4.13 s on a 466 KB ELF; every independent query pays it again (1 instance, challenge 5bd1d1bb33c5d4110a29b31e).",
+  "hypothesis_filed": "Each CLI invocation performs a full cold load and analysis rather than reusing a project or resident analysis session.",
+  "hypothesis_verdict": "partly refuted",
+  "decisions": [
+    "The filed diagnosis (no persistent session) names the workflow cost but not the per-query cost. Measured, ONE cold query decoded the program THREE times: the analysis-tier Listing walk (1.08 s), the operand_refs linear decode (0.58 s), and the xrefs index's own recursive descent (1.26 s), over 154,608 instructions each. A resident session would have amortised that; removing two of the three decodes eliminates it outright, and leaves the cold answer fast enough that a session is not the lever.",
+    "The Listing walk contributed exactly one thing to a reference answer: seeds. `xrefs::build` already runs its own two-worklist descent and follows every direct CALL out of its seeds, so handing it the same <patternpairs> prologue starts (listing::xrefs::discovery_seeds, gated to the non-x86-64 architectures DIV-20/DIV-68 injects for) keeps the seed set and drops the duplicate decode.",
+    "operand_refs' scalar markup is recomputed by the query from the p-code it already holds, so it answers nothing xrefs reads. Both passes arrived through --mode auto -> aggressive (the binary is under 500 KiB); the query surface now resolves no automatic mode, and `kuna xrefs --mode aggressive` still asks for the full bundle.",
+    "REFUTED en route: the ConstructTpl deep clone per constructor node (fixed anyway, ~2%); the WalkCursor breadcrumb copy (MAX_DEPTH 32 -> 12 is byte-identical output and no speedup); SLEIGH context-DB commits (9 ms of 3.4 s).",
+    "The largest single find was not in the redundancy at all: on any image with a PIC base -- every 32-bit PIC ELF -- the deferred base-relative pass buffered a CLONE of every instruction's whole p-code and rendered every instruction's assembly, i.e. a second full SLEIGH parse of the program, to file 151 references. Both halves it needs are pure functions of the ops, so they are computed in the walk and only the answers carried."
+  ],
+  "mechanism": "Five changes, no new option and no emitted-C change: (1) kuna xrefs takes its own driver bundle (DriverDefaults::Query, no automatic mode) and seeds its walk with the prologue starts directly; (2) the xref walk renders assembly only for instructions that file a reference; (3) the picbase pass carries precomputed (writes_base, refs) instead of a clone of every instruction's p-code, and renders lazily; (4) PcodeCacher::emit borrows the input run out of its pool instead of rebuilding it (one heap allocation per emitted p-code op, program-wide); (5) the p-code build arena and the walk's capture are pooled/reused instead of freshly allocated per instruction.",
+  "measurement": {
+    "target": "kuna xrefs <Obfuscation1> --to 0x80ba3d2 --json",
+    "method": "interleaved base/new, warmup + 7 reps, same shell",
+    "base_median_ms": 3418,
+    "new_median_ms": 1039,
+    "base_min_ms": 3367,
+    "new_min_ms": 727,
+    "delta_median_pct": -69.6,
+    "output": "byte-identical JSON"
+  },
+  "acceptance": "scripts.repipe.verify --need cold-load-xref-lookup (wall_ms median < 1000)",
+  "tests": ["tests/cli/cold-load-xref-lookup.json"],
+  "gates": {}
+}

--- a/docs/features/cold-load-xref-lookup/record.json
+++ b/docs/features/cold-load-xref-lookup/record.json
@@ -5,42 +5,77 @@
   "scope": "small",
   "worker": "b-r2-cold-load-xref-l",
   "round": 2,
+  "attempt": 2,
   "date": "2026-09-04",
   "symptom": "kuna xrefs ./target/Obfuscation1 --to 0x80ba3d2 --json took 4.13 s on a 466 KB ELF; every independent query pays it again (1 instance, challenge 5bd1d1bb33c5d4110a29b31e).",
   "hypothesis_filed": "Each CLI invocation performs a full cold load and analysis rather than reusing a project or resident analysis session.",
-  "hypothesis_verdict": "partly refuted",
+  "hypothesis_verdict": "partly refuted (attempt 1, re-confirmed here)",
+  "builds_on": "attempt 1 (local branch wip/re-cold-load-xref-lookup-a1, commits bcbad0a9 + 873d9e8c), taken over verbatim and rebased; this attempt adds the two things it could not close.",
   "decisions": [
-    "The filed diagnosis (no persistent session) names the workflow cost but not the per-query cost. Measured, ONE cold query decoded the program THREE times: the analysis-tier Listing walk (1.08 s), the operand_refs linear decode (0.58 s), and the xrefs index's own recursive descent (1.26 s), over 154,608 instructions each. A resident session would have amortised that; removing two of the three decodes eliminates it outright, and leaves the cold answer fast enough that a session is not the lever.",
-    "The Listing walk contributed exactly one thing to a reference answer: seeds. `xrefs::build` already runs its own two-worklist descent and follows every direct CALL out of its seeds, so handing it the same <patternpairs> prologue starts (listing::xrefs::discovery_seeds, gated to the non-x86-64 architectures DIV-20/DIV-68 injects for) keeps the seed set and drops the duplicate decode.",
-    "operand_refs' scalar markup is recomputed by the query from the p-code it already holds, so it answers nothing xrefs reads. Both passes arrived through --mode auto -> aggressive (the binary is under 500 KiB); the query surface now resolves no automatic mode, and `kuna xrefs --mode aggressive` still asks for the full bundle.",
-    "REFUTED en route: the ConstructTpl deep clone per constructor node (fixed anyway, ~2%); the WalkCursor breadcrumb copy (MAX_DEPTH 32 -> 12 is byte-identical output and no speedup); SLEIGH context-DB commits (9 ms of 3.4 s).",
-    "The largest single find was not in the redundancy at all: on any image with a PIC base -- every 32-bit PIC ELF -- the deferred base-relative pass buffered a CLONE of every instruction's whole p-code and rendered every instruction's assembly, i.e. a second full SLEIGH parse of the program, to file 151 references. Both halves it needs are pure functions of the ops, so they are computed in the walk and only the answers carried."
+    "The filed diagnosis (no persistent session) names the WORKFLOW cost, not the per-query one. Measured, one cold query decoded the program THREE times over 154,608 instructions: the analysis-tier Listing walk, the operand_refs linear decode, and the xrefs index's own recursive descent. Removing two of the three eliminates the cost outright; a resident session would only have amortised it.",
+    "Attempt 1's blocker was that dropping the Listing dropped the AIF gap-walk with it, and AIF is the only thing the Listing contributed to a reference answer. That is not a trade to accept: on a stripped i386 PE `--to 0x43edfa` fell from 174 callers to 113, and `--from` on a function reachable only through a function-pointer table answered 0. Both are now closed WITHOUT restoring the second decode.",
+    "FIX 1 (--from): the query seeds its own walk with the address it was ASKED about. A recursive descent cannot reach an entry with no inbound CALL edge, so no seed set contains it; the named address is walked LAST, after the seeded descent and the prologue/gap seeds drain, so an address the natural walk already claimed is already in `decoded` and attributed exactly as before -- the focus pass can only add coverage. An address that does not decode is dropped rather than recorded as a function.",
+    "FIX 2 (--to): the AIF gap-walk is run over the instruction partition THIS walk leaves behind (`Listing::from_partition`), not over a Listing built by a second decode. The two facts it needs -- which bytes are instructions, which addresses are functions -- are exactly what the reference walk already computed; only the prologue mnemonics its fingerprint histogram reads are rendered, 2 per discovered function. Its accepted entries are walked like any other seed, so their references join the index. `DriverDefaults::Query` therefore takes the DIV-20/DIV-68 discovery flags (`funcstart_patterns`, `aif`) and declines only the Listing (DIV-15).",
+    "PERF (this attempt): 55% of every heap allocation the program made while disassembling was the FID matched-pattern deep clone -- `Sleigh::resolve` stashed a cloned DisjointPattern on every constructor node of every instruction, and only `instruction_mask` (the default-off `fid` pass) ever reads them. Capturing them now happens only under the flag `instruction_mask` itself sets. With the per-instruction delay-slot context vector parked on the engine as well: 1,412,338 -> 477,392 allocations and 228 MB -> 72 MB on the witness.",
+    "REFUTED en route (attempt 1): the ConstructTpl deep clone per constructor node (fixed anyway, ~2%); the WalkCursor breadcrumb copy (MAX_DEPTH 32 -> 12 is byte-identical and no faster); SLEIGH context-DB commits (9 ms of 3.4 s).",
+    "MEASUREMENT TRAP: this box is a 2-socket Xeon Silver 4316 (2.3 GHz base / ~3.4 GHz turbo) and an unpinned run is bimodal at exactly that 1.48x ratio -- 652-672 ms or 933-1036 ms for the same work. Every number here is `taskset`-pinned and interleaved base/new; the promoted probe uses `min` of 3 repeats for the same reason."
   ],
-  "mechanism": "Five changes, no new option and no emitted-C change: (1) kuna xrefs takes its own driver bundle (DriverDefaults::Query, no automatic mode) and seeds its walk with the prologue starts directly; (2) the xref walk renders assembly only for instructions that file a reference; (3) the picbase pass carries precomputed (writes_base, refs) instead of a clone of every instruction's p-code, and renders lazily; (4) PcodeCacher::emit borrows the input run out of its pool instead of rebuilding it (one heap allocation per emitted p-code op, program-wide); (5) the p-code build arena and the walk's capture are pooled/reused instead of freshly allocated per instruction.",
+  "mechanism": "Seven changes, no new option and no emitted-C change. From attempt 1: (1) `kuna xrefs` takes its own driver bundle and does not resolve `--mode auto` (which promotes a sub-500 KiB image to `aggressive`, a preset for the quality of emitted C, on a command that emits none); (2) the walk renders assembly only for instructions that file a reference; (3) the PIC-base pass carries precomputed (writes_base, refs) instead of a clone of every instruction's p-code, and renders lazily; (4) PcodeCacher::emit borrows the input run out of its pool. New here: (5) the walk takes `focus` addresses -- the query target -- walked after it drains; (6) the AIF gap-walk runs over the walk's own partition (`Listing::from_partition`), so the Query bundle keeps `funcstart_patterns`+`aif` and drops only the Listing; (7) SLEIGH stops deep-cloning the matched DisjointPattern per constructor node unless `instruction_mask` asked for it, and parks the delay-slot context vector on the engine.",
   "measurement": {
-    "target": "kuna xrefs <Obfuscation1> --to 0x80ba3d2 --json",
-    "method": "interleaved base/new, warmup + 7 reps, same shell",
-    "base_median_ms": 3418,
-    "new_median_ms": 1039,
-    "base_min_ms": 3367,
-    "new_min_ms": 727,
-    "delta_median_pct": -69.6,
-    "output": "byte-identical JSON"
+    "method": "interleaved base/new, same shell, taskset-pinned to one core, warmup + 5-7 reps",
+    "targets": [
+      {
+        "target": "Obfuscation1 (466 KB obfuscated i386 ELF) --to 0x80ba3d2",
+        "base_median_ms": 3573,
+        "new_median_ms": 715,
+        "delta_pct": -80.0,
+        "output": "byte-identical"
+      },
+      {
+        "target": "KeyVal2.exe (stripped i386 PE) --to 0x43edfa",
+        "base_median_ms": 2047,
+        "new_median_ms": 799,
+        "delta_pct": -61.0,
+        "output": "174 callers both ways"
+      },
+      {
+        "target": "mcount_x86_64 (in-repo, 896 KB) --to 0x44b470",
+        "base_median_ms": 1181,
+        "new_median_ms": 702,
+        "delta_pct": -40.6
+      },
+      {
+        "target": "pe_imports.exe (in-repo, 499 KB) --to 0x1400079b0",
+        "base_median_ms": 282,
+        "new_median_ms": 161,
+        "delta_pct": -42.9
+      }
+    ],
+    "allocations": {
+      "base": 1412338,
+      "new": 477392,
+      "base_bytes": 228553964,
+      "new_bytes": 71876148
+    }
   },
-  "acceptance": "scripts.repipe.verify --need cold-load-xref-lookup (wall_ms median < 1000)",
+  "acceptance": "scripts.repipe.verify --need cold-load-xref-lookup (wall_ms median < 1000) -- PASS",
   "tests": [
-    "tests/cli/cold-load-xref-lookup.json"
+    "tests/cli/cold-load-xref-lookup.json (repointed to the in-repo mcount_x86_64 fixture, min of 5 < 1100 ms; CI has no dataset)",
+    "decompiler/crates/kuna-cli/tests/xrefs_cli.rs::a_function_no_descent_reaches_still_answers_for_itself",
+    "decompiler/crates/kuna-cli/tests/xrefs_cli.rs::the_gap_walk_finds_call_sites_a_descent_cannot_reach"
   ],
+  "sweep": {
+    "method": "kuna xrefs --to/--from over 15 sampled entries x 2 directions on 4 binaries (i386 ELF, 3 x PE), comparing ROW SETS (not counts) against the full old discovery bundle (--option listing on --option funcstart_patterns on --option aif on)",
+    "result": "Obfuscation1 30/30 identical; system.exe 30/30 identical; KeyVal2.exe 1 query short by 4 of ~1400 rows (was 5 queries and 61 rows before the gap-walk was restored); nikos_crack_me.exe 1 query short by 134.",
+    "residual_1": "The gap-walk over the reference walk's partition is not bit-identical to the gap-walk over a Listing's: the Listing's own seeds and gaps differ, so a handful of speculative accepts differ. 4 rows in 1 of 30 queries on the i386 PE witness.",
+    "residual_2": "On an x86-64 image UNDER 500 KiB the base answered with `aif` on, because it resolved `--mode auto` to `aggressive` -- the very C-quality preset this need is about. The new default matches `kuna functions` and `kuna decompile-all` on that architecture (aif off on x86-64, DIV-20), which costs 77 of 1044 rows on nikos_crack_me.exe. `kuna xrefs --option aif on` answers 1066 there -- MORE than the base did -- in 600 ms against the base's ~1000."
+  },
   "gates": {
     "make test": "PARITY OK 675/675",
     "make test-stages": "PARITY OK",
-    "make rust-test": "green",
-    "make check-spec": "green"
+    "make check-spec": "green",
+    "kuna catalog --check": "catalog OK",
+    "make rust-test": "pre-rebase full run: 212 suites green except one PRE-EXISTING failure, kuna-decomp::verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip -- proven pre-existing by restoring a13f570d's kuna-sleigh/src/sleigh.rs and re-running that test alone. Post-rebase the full-workspace run was killed early three times for reasons outside the tree (no failures, no build error); the three touched crates were re-run in full and are green."
   },
-  "sweep": {
-    "method": "kuna xrefs --to/--from over 6 sampled function entries on 8 binaries (i386 PE/ELF, ARM Cortex-M), base vs new JSON compared",
-    "finding_1_fixed": "target.name/from_function name fell to null for every entry the ENGINE inventory does not carry (the walk discovers them, the engine no longer does). Fixed: name_at now falls back to the index's own discovered functions, restoring sub_<addr>. Re-swept CrackMe_3.exe + Obfuscation1: 24/24 identical.",
-    "finding_2_open": "`--from <addr>` on a function only AIF's gap walk discovered now answers 0 references (betaflight_STM32F405 0x806b798 4->0, 0x801500e 2->0; KeyVal2.exe 0x45c080 1->0, 0x4031a7 1->0). AIF is a Listing consumer and cannot run without the Listing, so those entries are no longer seeds and the walk never reaches them. `kuna xrefs --mode aggressive` restores the old answer. This is a real recall trade on stripped ARM/Cortex-M and is NOT closed."
-  },
-  "status": "not merged: finding_2 (AIF-discovered functions lose their --from answers) is an unresolved quality trade, and the builder ran out of budget before it could be closed or re-measured."
+  "status": "merged"
 }

--- a/docs/features/cold-load-xref-lookup/record.json
+++ b/docs/features/cold-load-xref-lookup/record.json
@@ -28,6 +28,19 @@
     "output": "byte-identical JSON"
   },
   "acceptance": "scripts.repipe.verify --need cold-load-xref-lookup (wall_ms median < 1000)",
-  "tests": ["tests/cli/cold-load-xref-lookup.json"],
-  "gates": {}
+  "tests": [
+    "tests/cli/cold-load-xref-lookup.json"
+  ],
+  "gates": {
+    "make test": "PARITY OK 675/675",
+    "make test-stages": "PARITY OK",
+    "make rust-test": "green",
+    "make check-spec": "green"
+  },
+  "sweep": {
+    "method": "kuna xrefs --to/--from over 6 sampled function entries on 8 binaries (i386 PE/ELF, ARM Cortex-M), base vs new JSON compared",
+    "finding_1_fixed": "target.name/from_function name fell to null for every entry the ENGINE inventory does not carry (the walk discovers them, the engine no longer does). Fixed: name_at now falls back to the index's own discovered functions, restoring sub_<addr>. Re-swept CrackMe_3.exe + Obfuscation1: 24/24 identical.",
+    "finding_2_open": "`--from <addr>` on a function only AIF's gap walk discovered now answers 0 references (betaflight_STM32F405 0x806b798 4->0, 0x801500e 2->0; KeyVal2.exe 0x45c080 1->0, 0x4031a7 1->0). AIF is a Listing consumer and cannot run without the Listing, so those entries are no longer seeds and the walk never reaches them. `kuna xrefs --mode aggressive` restores the old answer. This is a real recall trade on stripped ARM/Cortex-M and is NOT closed."
+  },
+  "status": "not merged: finding_2 (AIF-discovered functions lose their --from answers) is an unresolved quality trade, and the builder ran out of budget before it could be closed or re-measured."
 }

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -1808,16 +1808,34 @@ same-named functions together.
 (kuna) Because the query runs that descent **itself**, it takes its own analysis
 bundle rather than a decompiling surface's. `kuna functions` and `kuna decompile-all`
 inject the DIV-15/DIV-20/DIV-68 defaults (the Listing, the prologue-pattern scan,
-AIF); the query surface injects none of them, and instead seeds its walk with the
-same `<patternpairs>` prologue starts the injection existed to produce
-(`decompiler/crates/kuna-analysis/src/listing/xrefs.rs (discovery_seeds)`, gated to
-the non-x86-64 architectures the injection covered, so x86-64's seed set is exactly
-the caller's inventory). The Listing's only contribution to a *reference* answer was
-a richer seed set, and building it meant decoding the whole program a second time;
-on a 466 KB obfuscated i386 image that walk, plus `operand_refs`' third linear
-decode, was 1.66 s of a 3.4 s answer that is byte-identical without either. A caller
-who wants the full analysis tier over the query — the AIF gap entries, the FID
-renames — asks for it by name (`kuna xrefs --mode aggressive`).
+AIF); the query surface takes the two *discovery* flags and declines the Listing,
+because the Listing's walk is this walk — a second recursive descent over the same
+bytes, decoded a second time. On a 466 KB obfuscated i386 image that walk, plus
+`operand_refs`' third linear decode, was 1.66 s of a 3.4 s answer that is
+byte-identical without either.
+
+The two discovery facts the Listing fed are produced from the query's own decode
+instead. The `<patternpairs>` prologue starts are handed straight to the walk as
+seeds (`decompiler/crates/kuna-analysis/src/listing/xrefs.rs (discovery_seeds)`,
+gated by `funcstart_patterns` and to the non-x86-64 architectures the injection
+covered, so x86-64's seed set is exactly the caller's inventory). The speculative
+gap-walk (`aif`) is run over the instruction partition the query's own walk leaves
+behind (`gap_entries` → `Listing::from_partition`), and every function it accepts is
+walked like any other seed, so the references inside it join the index. That recall
+is not optional decoration: a function whose only inbound edge is an indirect call
+through a data table has no CALL edge for any descent to follow, and without the
+gap-walk a `--to` query loses every call site that lives inside one — measured on a
+stripped i386 PE as 61 of one function's 174 callers.
+
+(kuna) A reference query also seeds the walk with **the address it was asked
+about**. The same structural gap applies to the query target itself: `--from <entry>`
+about a function no descent reaches answered `count: 0` about a function that plainly
+has references. The named address is walked after the seeded descent and the
+prologue/gap seeds have drained, so an address the natural walk already claimed is
+already in `decoded` and attributed exactly as before — the focus pass can only add
+coverage, never re-attribute an instruction another entry owns. An address that does
+not decode is dropped rather than recorded as a function, so a byte in the middle of
+a string does not become `sub_<addr>`.
 
 (kuna) Both of those rules read a reference out of *one instruction's* p-code,
 which is the whole answer on x86-64 and no answer at all in 32-bit

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -1805,6 +1805,20 @@ computed, and which therefore lifts to a `LOAD` through a temporary); the class 
 never derived from a shared symbol name, which would fold genuinely distinct
 same-named functions together.
 
+(kuna) Because the query runs that descent **itself**, it takes its own analysis
+bundle rather than a decompiling surface's. `kuna functions` and `kuna decompile-all`
+inject the DIV-15/DIV-20/DIV-68 defaults (the Listing, the prologue-pattern scan,
+AIF); the query surface injects none of them, and instead seeds its walk with the
+same `<patternpairs>` prologue starts the injection existed to produce
+(`decompiler/crates/kuna-analysis/src/listing/xrefs.rs (discovery_seeds)`, gated to
+the non-x86-64 architectures the injection covered, so x86-64's seed set is exactly
+the caller's inventory). The Listing's only contribution to a *reference* answer was
+a richer seed set, and building it meant decoding the whole program a second time;
+on a 466 KB obfuscated i386 image that walk, plus `operand_refs`' third linear
+decode, was 1.66 s of a 3.4 s answer that is byte-identical without either. A caller
+who wants the full analysis tier over the query — the AIF gap entries, the FID
+renames — asks for it by name (`kuna xrefs --mode aggressive`).
+
 (kuna) Both of those rules read a reference out of *one instruction's* p-code,
 which is the whole answer on x86-64 and no answer at all in 32-bit
 position-independent code. There the address of a string, a global or a function

--- a/tests/cli/cold-load-xref-lookup.json
+++ b/tests/cli/cold-load-xref-lookup.json
@@ -1,0 +1,39 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "xrefs",
+    "{{BIN}}",
+    "--to",
+    "0x44b470",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 5,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/mcount_x86_64",
+    "binary_sha256": "913d35f45475cc129d2fd6a94e35e62bd1b6be720a7207b74852705850611ee7",
+    "binary_size": 896032,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/mcount_x86_64",
+    "selector": "0x44b470",
+    "selector_kind": "addr"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "wall_ms": {
+      "stat": "min",
+      "lt": 1100
+    }
+  },
+  "notes": "Acceptance of RE-need cold-load-xref-lookup, repointed from its dataset image (466 KB obfuscated i386 ELF, 3573 -> 715 ms median) to the largest in-repo fixture: CI has no dataset. Bound recalibrated on it, min of 5: 1169 ms before, 687-989 after. `min`, not `median`: a turbo/base clock split makes one sample bimodal by ~1.5x. Guards ONE decode, not three."
+}


### PR DESCRIPTION
## What was broken

RE-need `cold-load-xref-lookup` (round 2, 1 instance, challenge `5bd1d1bb33c5d4110a29b31e`):

> **Cold-load xref lookup takes about four seconds on a 466 KB ELF.** The actual
> `kuna xrefs ./target/Obfuscation1 --to 0x80ba3d2 --json` invocation took 4.1303 seconds.
> Every independent query reloads analysis state.

The filed diagnosis — no persistent session — names the *workflow* cost, not the per-query one.
Measured, **one** cold query decoded the program **three times**, 154,608 instructions each: the
analysis-tier Listing walk, `operand_refs`' linear decode, and the reference index's own recursive
descent. A resident session would have amortised that; removing two of the three eliminates it.

Both extra decodes arrived because `--mode auto` promotes a sub-500 KiB image to `aggressive` — a
preset for the quality of emitted **C**, on a command that emits none.

## Why attempt 1 did not merge, and what changed

Attempt 1 (taken over here verbatim and rebased) reached −70% with byte-identical output but left
one blocker: dropping the Listing dropped the **AIF gap-walk** with it, and that is the only thing
the Listing contributed to a *reference* answer. A function reached only through a function-pointer
table has no inbound CALL edge, so no recursive descent finds it — on a stripped i386 PE that cost
`--to 0x43edfa` **61 of its 174 callers**, and `--from` on such a function answered `0`. Both are
now closed **without** restoring the second decode.

## Mechanism

1. **The query seeds its walk with the address it was asked about.** Walked *last*, after the
   seeded descent drains, so an address the natural walk already claimed is already in `decoded`
   and attributed exactly as before — the focus pass can only add coverage, never re-attribute an
   instruction another entry owns. An address that does not decode is dropped, not recorded as a
   function.
2. **The AIF gap-walk runs over the partition the reference walk itself leaves behind**
   (`Listing::from_partition`). The two facts it needs — which bytes are instructions, which
   addresses are functions — are exactly what the walk already computed; only the prologue mnemonics
   its fingerprint histogram reads are rendered, 2 per discovered function, against the whole
   program's worth the Listing path rendered. Its accepted entries are walked like any other seed.
   So `DriverDefaults::Query` takes the DIV-20/DIV-68 discovery flags and declines only the Listing.
3. **SLEIGH stops deep-cloning the matched `DisjointPattern` on every constructor node.** Only
   `Sleigh::instruction_mask` (the default-off `fid` pass) ever reads them, and it re-decodes under
   a flag it sets itself. That clone was **55% of every heap allocation the program made while
   disassembling**. With the per-instruction delay-slot context vector parked on the engine:
   **1,412,338 → 477,392 allocations, 228 MB → 72 MB.**

Plus attempt 1's own: lazy assembly rendering, the PIC-base pass carrying precomputed answers
instead of a clone of every instruction's p-code, and `PcodeCacher::emit` borrowing its input run.

No new option, no `phases.toml` row, no emitted-C change.

## The acceptance probe now passes

```
python -m scripts.repipe.verify --need cold-load-xref-lookup --json   →  passed = true
```

Promoted to `tests/cli/cold-load-xref-lookup.json`, repointed from the dataset image to the largest
in-repo fixture (CI has no dataset) with the bound recalibrated on it: `mcount_x86_64` measured
**1169 ms min before the change, 687-989 ms after**, so `min` of 5 < 1100 fails on the old answer (1169 ms) and passes on the new (687-989 ms).
`min` of 5 rather than `median` because this box is a 2-socket Xeon Silver 4316 whose turbo/base
split makes any single sample bimodal by 1.48x (652–672 ms or 933–1036 ms for identical work);
every number below is `taskset`-pinned and interleaved base/new.

| target | base | new | Δ |
|---|---|---|---|
| `Obfuscation1` (466 KB obfuscated i386 ELF, the witness) | 3573 ms | **715 ms** | **−80.0%** |
| `KeyVal2.exe` (stripped i386 PE) | 2047 ms | **799 ms** | −61.0% |
| `mcount_x86_64` (in-repo, 896 KB) | 1181 ms | **702 ms** | −40.6% |
| `pe_imports.exe` (in-repo, 499 KB) | 282 ms | **161 ms** | −42.9% |

Output on the witness is byte-identical; `KeyVal2.exe --to 0x43edfa` answers all **174** callers
both ways.

## Recall sweep

15 sampled entries × 2 directions on 4 binaries, comparing **row sets** (not counts) against the
full old discovery bundle. `Obfuscation1` 30/30 identical, `system.exe` 30/30 identical,
`KeyVal2.exe` 1 query short by 4 of ~1400 rows (was 5 queries and 61 rows before the gap-walk was
restored), `nikos_crack_me.exe` 1 query short by 134. Two residuals, both recorded in
`record.json`:

* the gap-walk over the reference walk's partition is not bit-identical to the gap-walk over a
  Listing's — the seeds and therefore the gaps differ, so a few speculative accepts differ;
* on an **x86-64 image under 500 KiB** the base answered with `aif` on, because it resolved
  `--mode auto` to `aggressive` — the exact C-quality-preset leak this need is about. The new
  default matches `kuna functions` and `kuna decompile-all` on that architecture (DIV-20: `aif` is
  off on x86-64). `kuna xrefs --option aif on` answers **more** than the base did there (1066 vs
  1044) in 600 ms against the base's ~1000.

## Gates

| gate | result |
|---|---|
| `make test` | **PARITY OK** 675/675 |
| `make test-stages` | **PARITY OK** |
| `make check-spec` | green |
| `kuna catalog --check` | catalog OK |
| `make rust-test` | 212 suites green except one **pre-existing** failure — `kuna-decomp::verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip`. Verified pre-existing by restoring `a13f570d`'s `kuna-sleigh/src/sleigh.rs` and re-running that single test alone: it fails identically. Post-rebase the full-workspace run was killed early three times on this box for reasons outside the tree (no failures, no build error, truncated mid-suite); the three crates this PR touches were then re-run in full and are green — `-p kuna-sleigh -p kuna-analysis -p kuna-cli`, 0 failed. |

New cargo coverage: `xrefs_cli::a_function_no_descent_reaches_still_answers_for_itself` and
`xrefs_cli::the_gap_walk_finds_call_sites_a_descent_cannot_reach`, both on the vendored
`cortexm_aifcorroborate_le32` — `0x800039c` is reachable only through a data path, and `0x8000160`
is called both from code every descent reaches and from inside that function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Before / after — `None` in `?`

Real captured kuna output on the function this feature was built for, with `option None` flipped. Ported from **angr**.

| metric | `None off` *(default)* | `None on` |
|---|---|---|
| gotos | 0 | 0 |
| labels | 0 | 0 |
| loc | 1 | 1 |
| switches | 0 | 0 |

<details open><summary><b>kuna — before (<code>option None off</code>)</b></summary>

```c
// kuna decompilation unavailable (no name/address)
```

</details>

<details open><summary><b>kuna — after (<code>option None on</code>)</b></summary>

```c
// kuna decompilation unavailable (no name/address)
```

</details>

