### PR TITLE
[AUTOMATED] perf(substrate/p3): decompiling-3396-byte-main — stop paying Rc traffic on 9.5 M tree mutations (12.1 s -> 11.2 s)

### DIFF
--- a/decompiler/crates/kuna-base/src/address.rs
+++ b/decompiler/crates/kuna-base/src/address.rs
@@ -141,6 +141,25 @@ impl Address {
         Address { base: AddrSpacePtr::Spc(id), offset: off }
     }
 
+    /// The ordering triple this Address compares by: `(sentinel rank, space
+    /// index, offset)`, where rank is `0` for the null/invalid pointer, `1`
+    /// for a real space and `2` for the `m_maximal` sentinel.
+    ///
+    /// Lexicographic comparison of the triple reproduces [`Ord`] exactly: two
+    /// Addresses with the same space pointer share a rank and an index and so
+    /// fall through to the offset, which is what `cmp` does directly, and
+    /// distinct spaces sharing an index are equivalent in both.  Callers that
+    /// keep an Address inside a sort key can store the triple instead and keep
+    /// the key `Copy`.
+    #[inline]
+    pub fn sort_key(&self) -> (u8, i32, u64) {
+        match &self.base {
+            AddrSpacePtr::Null => (0, 0, self.offset),
+            AddrSpacePtr::Spc(s) => (1, s.get_index(), self.offset),
+            AddrSpacePtr::Max => (2, 0, self.offset),
+        }
+    }
+
     /// Create an invalid address (C++ `Address(void)`)
     pub fn new_invalid() -> Address {
         Address::default()
@@ -1932,6 +1951,38 @@ mod tests {
 
     fn small_space(name: &str, index: i32) -> Rc<AddrSpace> {
         Rc::new(AddrSpace::new(spacetype::IPTR_PROCESSOR, name, false, 2, 1, index, 0, 0, 0))
+    }
+
+    /// `sort_key` must order exactly as [`Address::cmp`] does: every consumer
+    /// that stores the triple in place of the Address (the Varnode location
+    /// and definition tree keys) depends on the two being interchangeable.
+    #[test]
+    fn sort_key_orders_identically_to_cmp() {
+        let mut addrs = vec![
+            Address::new_extreme(mach_extreme::m_minimal),
+            Address::new_extreme(mach_extreme::m_maximal),
+            Address::default(),
+        ];
+        for spc in [ram(), Rc::new(ConstantSpace::new()), small_space("a", 1), small_space("b", 7)] {
+            for off in [0u64, 1, 0x1000, 0xffff_ffff, u64::MAX] {
+                addrs.push(Address::new(Rc::clone(&spc), off));
+            }
+        }
+        // A second Rc for the same space index: the pointer differs but the
+        // order must not (the comparator falls through to the offset).
+        addrs.push(Address::new(ram(), 0x1000));
+        let mut pairs = 0;
+        for a in &addrs {
+            for b in &addrs {
+                assert_eq!(
+                    a.cmp(b),
+                    a.sort_key().cmp(&b.sort_key()),
+                    "sort_key disagreed with cmp on {a:?} vs {b:?}"
+                );
+                pairs += 1;
+            }
+        }
+        assert_eq!(pairs, addrs.len() * addrs.len());
     }
 
     #[test]

--- a/decompiler/crates/kuna-decomp/src/p3_dataflow/heritage.rs
+++ b/decompiler/crates/kuna-decomp/src/p3_dataflow/heritage.rs
@@ -144,49 +144,49 @@ impl LocationMap {
     ///   - 1 if there is a partial intersection with something old
     ///   - 2 if the range is contained in an old range
     ///
-    /// The returned `Address` is the *key* of the containing element; the
-    /// C++ returns an iterator, but every caller only reads `(*iter).first`
-    /// (the key) and `(*iter).second.size` (the size), so we return the key
-    /// and the caller re-looks the size via [`get`](LocationMap::get).
-    pub fn add(&mut self, mut addr: Address, mut size: int4, mut pass: int4) -> (Address, int4) {
+    /// The returned tuple is the *key* of the containing element, the
+    /// `intersect` code and the element's size; the C++ returns an iterator,
+    /// but every caller only reads `(*iter).first` and `(*iter).second.size`,
+    /// both of which are already in hand here.  (The size used to be re-looked
+    /// through [`get`](LocationMap::get), a second descent per call — this map
+    /// takes over a million `add`s on a large function.)
+    pub fn add(&mut self, mut addr: Address, mut size: int4, mut pass: int4) -> (Address, int4, int4) {
         // We replicate the C++ map-iterator walk against the ordered keys.
         let mut intersect = 0;
 
-        // Find the candidate element: the last key <= addr's neighborhood.
-        // lower_bound(addr) then step back one, mirroring the C++.
-        let lower: Option<Address> =
-            self.themap.range(addr.clone()..).next().map(|(k, _)| k.clone());
-        // start from lower_bound; if not begin, step one back
-        let mut cur: Option<Address> = match &lower {
-            // lower_bound == begin: cannot step back, keep begin
-            Some(lb) if self.themap.keys().next() == Some(lb) => Some(lb.clone()),
-            // lower_bound is some interior/end: step back one
-            _ => self.themap.range(..addr.clone()).next_back().map(|(k, _)| k.clone()),
-        };
+        // Find the candidate element: `lower_bound(addr)` stepped back one
+        // when it is not `begin()`, which is the last key strictly less than
+        // `addr` whenever one exists and `begin()` otherwise.  Asking for the
+        // predecessor first answers both cases in a single descent (the
+        // predecessor exists on essentially every call once the map is warm),
+        // where probing `lower_bound` and then `begin()` cost three.
+        let mut cur: Option<(Address, SizePass)> =
+            match self.themap.range(..addr.clone()).next_back() {
+                Some((k, v)) => Some((k.clone(), *v)),
+                None => self.themap.range(addr.clone()..).next().map(|(k, v)| (k.clone(), *v)),
+            };
 
         // C++: advance past the stepped-back element when it does not overlap addr.
-        if let Some(ck) = &cur {
-            let sz = self.themap[ck].size;
-            if addr.overlap(0, ck, sz) == -1 {
+        if let Some((ck, cv)) = &cur {
+            if addr.overlap(0, ck, cv.size) == -1 {
                 // ++iter : advance to the first key strictly greater than ck
                 cur = self.themap.range((
                     std::ops::Bound::Excluded(ck.clone()),
                     std::ops::Bound::Unbounded,
                 ))
                 .next()
-                .map(|(k, _)| k.clone());
+                .map(|(k, v)| (k.clone(), *v));
             }
         }
 
         // First (possibly partial) overlap with the leading element.
-        if let Some(ck) = cur.clone() {
-            let entry = self.themap[&ck];
+        if let Some((ck, entry)) = cur.clone() {
             let where_ = addr.overlap(0, &ck, entry.size);
             if where_ != -1 {
                 if where_ + size <= entry.size {
                     // Completely contained in previous element.
                     intersect = if entry.pass < pass { 2 } else { 0 };
-                    return (ck, intersect);
+                    return (ck, intersect, entry.size);
                 }
                 addr = ck.clone();
                 size += where_; // C++: size = where + size;
@@ -207,9 +207,8 @@ impl LocationMap {
                 .themap
                 .range(addr.clone()..)
                 .next()
-                .map(|(k, _)| k.clone());
-            let Some(nk) = next_key else { break };
-            let nentry = self.themap[&nk];
+                .map(|(k, v)| (k.clone(), *v));
+            let Some((nk, nentry)) = next_key else { break };
             let where_ = nk.overlap(0, &addr, size);
             if where_ == -1 {
                 break;
@@ -225,7 +224,7 @@ impl LocationMap {
         }
 
         self.themap.insert(addr.clone(), SizePass { size, pass });
-        (addr, intersect)
+        (addr, intersect, size)
     }
 
     /// Look up the [`SizePass`] of a heritaged address (C++ `LocationMap::find`,
@@ -3109,13 +3108,28 @@ impl Heritage {
         for i in 0..size_out {
             let subbl = fd.bblocks_ref().block(bl).get_out(i);
             let slot = fd.bblocks_ref().block(bl).get_out_rev_index(i);
-            let subops: Vec<crate::context::OpId> = self.block_ops(fd, subbl);
-            for multiop in subops {
-                if fd.obank().get(multiop).expect("rename_recurse: stale multiop").code()
-                    != OpCode::CPUI_MULTIEQUAL
-                {
-                    break; // For each leading MULTIEQUAL
+            // Only the block's *leading* MULTIEQUALs are visited (the C++ walk
+            // breaks at the first op that is not one), so collect that prefix
+            // instead of materializing every op of the successor: this runs
+            // once per CFG edge per heritage pass and the successors of a large
+            // function's blocks are mostly ordinary code.  Nothing in the body
+            // can change an op's opcode or its position in the block, so the
+            // prefix taken here is the prefix the live walk would see.
+            let subops: Vec<crate::context::OpId> = {
+                let mut leading = Vec::new();
+                let mut cur = fd.bb_op_head(subbl);
+                while let Some(o) = cur {
+                    if fd.obank().get(o).expect("rename_recurse: stale multiop").code()
+                        != OpCode::CPUI_MULTIEQUAL
+                    {
+                        break;
+                    }
+                    leading.push(o);
+                    cur = fd.bb_op_next(o);
                 }
+                leading
+            };
+            for multiop in subops {
                 let vnin = match fd.obank().get(multiop).expect("rename_recurse: multiop").get_in(slot) {
                     Some(v) => v,
                     None => continue,
@@ -4464,9 +4478,7 @@ impl Heritage {
                 }
                 let vaddr = v.get_addr().clone();
                 let vsize = v.get_size();
-                let (key, prev) = self.globaldisjoint.add(vaddr, vsize, self.pass);
-                let resolved_size =
-                    self.globaldisjoint.get(&key).expect("heritage: disjoint key").size;
+                let (key, prev, resolved_size) = self.globaldisjoint.add(vaddr, vsize, self.pass);
                 if prev == 0 {
                     // All new location being heritaged.
                     self.disjoint.add(key, resolved_size, memrange_flags::new_addresses);
@@ -4710,7 +4722,7 @@ mod tests {
     fn location_map_add_new_range_pass0() {
         let fd = build_fd();
         let mut lm = LocationMap::new();
-        let (key, intersect) = lm.add(raddr(&fd, 0x100), 4, 0);
+        let (key, intersect, _sz) = lm.add(raddr(&fd, 0x100), 4, 0);
         assert_eq!(key, raddr(&fd, 0x100));
         assert_eq!(intersect, 0);
         assert_eq!(lm.get(&key).unwrap().size, 4);
@@ -4725,7 +4737,7 @@ mod tests {
         lm.add(raddr(&fd, 0x100), 8, 0);
         // pass 1: a sub-range [0x102,0x106) is completely contained in the
         // old pass-0 element -> intersect == 2.
-        let (key, intersect) = lm.add(raddr(&fd, 0x102), 4, 1);
+        let (key, intersect, _sz) = lm.add(raddr(&fd, 0x102), 4, 1);
         assert_eq!(intersect, 2);
         // The returned element is the containing pass-0 element.
         assert_eq!(key, raddr(&fd, 0x100));
@@ -4738,7 +4750,7 @@ mod tests {
         let mut lm = LocationMap::new();
         lm.add(raddr(&fd, 0x100), 4, 0); // pass 0: [0x100,0x104)
                                          // pass 2: [0x102,0x10a) partially overlaps the old element.
-        let (key, intersect) = lm.add(raddr(&fd, 0x102), 8, 2);
+        let (key, intersect, _sz) = lm.add(raddr(&fd, 0x102), 8, 2);
         assert_eq!(intersect, 1);
         // The unified element starts at the old start 0x100 and carries the
         // smaller (old) pass number 0.
@@ -4754,7 +4766,7 @@ mod tests {
         let mut lm = LocationMap::new();
         lm.add(raddr(&fd, 0x100), 4, 0);
         // same pass, contained -> intersect 0 (not 2, since old.pass == pass)
-        let (_key, intersect) = lm.add(raddr(&fd, 0x101), 2, 0);
+        let (_key, intersect, _sz) = lm.add(raddr(&fd, 0x101), 2, 0);
         assert_eq!(intersect, 0);
     }
 
@@ -4780,7 +4792,7 @@ mod tests {
         lm.add(raddr(&fd, 0x100), 4, 0); // [0x100,0x104)
         lm.add(raddr(&fd, 0x108), 4, 0); // [0x108,0x10c)
                                          // A big new range spanning both gets unified into one element.
-        let (key, _i) = lm.add(raddr(&fd, 0x100), 0x10, 1);
+        let (key, _i, _sz) = lm.add(raddr(&fd, 0x100), 0x10, 1);
         assert_eq!(key, raddr(&fd, 0x100));
         // Only one element remains.
         assert_eq!(lm.iter().count(), 1);

--- a/decompiler/crates/kuna-decomp/src/substrate/varnode.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/varnode.rs
@@ -171,6 +171,69 @@ type DescendVec = SmallVec<[OpId; 4]>;
 /// `flag_class_of` masks `flags & (input|written)` and this `Ord` reproduces
 /// `((f1-1) < (f2-1))` with explicit `uint4` wrapping subtraction (free is
 /// `0`, so `0u32.wrapping_sub(1) == u32::MAX` — frees sort last).
+/// The ordering triple of an [`Address`] flattened into plain integers.
+///
+/// `Address::cmp` orders by `(sentinel rank, space index, offset)`; storing
+/// those three fields directly keeps the comparator identical while making the
+/// tree key `Copy` — no `Rc` traffic on clone or drop, and no pointer chase
+/// into the `AddrSpace` on a comparison.  The trees are the decompiler's
+/// hottest container (millions of inserts and removals per function).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AddrKey {
+    /// Offset within the space (last in the comparison order).
+    offset: u64,
+    /// `AddrSpace::get_index()`, or `0` for the two sentinels.
+    index: i32,
+    /// `0` = null / invalid, `1` = a real space, `2` = the `m_maximal` sentinel.
+    rank: u8,
+}
+
+impl AddrKey {
+    #[inline]
+    fn of(a: &Address) -> AddrKey {
+        let (rank, index, offset) = a.sort_key();
+        AddrKey { offset, index, rank }
+    }
+}
+
+impl Ord for AddrKey {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.rank
+            .cmp(&other.rank)
+            .then_with(|| self.index.cmp(&other.index))
+            .then_with(|| self.offset.cmp(&other.offset))
+    }
+}
+impl PartialOrd for AddrKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// A [`SeqNum`] flattened the same way (the `order` field never participates).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SeqKey {
+    /// The instruction address the op belongs to.
+    pc: AddrKey,
+    /// C++ `SeqNum::getTime()`.
+    uniq: u32,
+}
+
+impl Default for SeqKey {
+    /// Matches `SeqNum::default()` (a null pc and `uniq == 0`).
+    fn default() -> SeqKey {
+        SeqKey { pc: AddrKey { offset: 0, index: 0, rank: 0 }, uniq: 0 }
+    }
+}
+
+impl SeqKey {
+    #[inline]
+    fn of(s: &SeqNum) -> SeqKey {
+        SeqKey { pc: AddrKey::of(s.get_addr()), uniq: s.get_time() }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct FlagClass(uint4);
 
@@ -207,10 +270,11 @@ fn flag_class_of(flags: uint4) -> FlagClass {
 /// false and the comparator does *not* order on them (it falls through).
 /// Within a real function `uniq` is unique per op so this degenerate case
 /// never arises, but the transcription preserves it exactly.
-fn seqnum_step(a: &SeqNum, b: &SeqNum) -> std::cmp::Ordering {
+fn seqnum_step(a: &SeqKey, b: &SeqKey) -> std::cmp::Ordering {
     // a != b  <=>  a.getTime() != b.getTime()  (uniq-only equality)
-    if a.get_time() != b.get_time() {
-        a.cmp(b) // operator< / full (pc, uniq) ordering
+    if a.uniq != b.uniq {
+        // operator< / full (pc, uniq) ordering
+        a.pc.cmp(&b.pc).then_with(|| a.uniq.cmp(&b.uniq))
     } else {
         std::cmp::Ordering::Equal // fall through
     }
@@ -221,16 +285,16 @@ fn seqnum_step(a: &SeqNum, b: &SeqNum) -> std::cmp::Ordering {
 /// Captures every field the comparator reads so the `BTreeMap` orders without
 /// dereferencing an op.  For written varnodes `seqnum` holds the def's
 /// `SeqNum`; for free varnodes `create_index` provides the final tie-break.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct LocKey {
     /// Storage location (C++ `getAddr()`)
-    addr: Address,
+    addr: AddrKey,
     /// Size in bytes (C++ `getSize()`)
     size: int4,
     /// `(input|written)` flag class (C++ `getFlags()&(input|written)`)
     flagclass: FlagClass,
     /// The def `SeqNum`, consulted only when `flagclass == written`
-    seqnum: SeqNum,
+    seqnum: SeqKey,
     /// Creation index, consulted only when `flagclass == 0` (free)
     create_index: uint4,
 }
@@ -270,6 +334,7 @@ impl Ord for LocKey {
         Ordering::Equal
     }
 }
+
 impl PartialOrd for LocKey {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
@@ -277,16 +342,16 @@ impl PartialOrd for LocKey {
 }
 
 /// Sort key for the definition tree (`VarnodeCompareDefLoc`, `varnode.cc:60-79`).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct DefKey {
     /// Storage location (C++ `getAddr()`)
-    addr: Address,
+    addr: AddrKey,
     /// Size in bytes (C++ `getSize()`)
     size: int4,
     /// `(input|written)` flag class
     flagclass: FlagClass,
     /// The def `SeqNum`, consulted only when `flagclass == written`
-    seqnum: SeqNum,
+    seqnum: SeqKey,
     /// Creation index, consulted only when `flagclass == 0` (free)
     create_index: uint4,
 }
@@ -327,6 +392,7 @@ impl Ord for DefKey {
         Ordering::Equal
     }
 }
+
 impl PartialOrd for DefKey {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
@@ -1588,10 +1654,10 @@ impl VarnodeBank {
     fn loc_key_of(&self, id: VarnodeId) -> LocKey {
         let vn = &self.arena[id];
         LocKey {
-            addr: vn.loc.clone(),
+            addr: AddrKey::of(&vn.loc),
             size: vn.size,
             flagclass: flag_class_of(vn.flags),
-            seqnum: vn.def_seqnum.clone().unwrap_or_default(),
+            seqnum: vn.def_seqnum.as_ref().map(SeqKey::of).unwrap_or_default(),
             create_index: vn.create_index,
         }
     }
@@ -1600,10 +1666,10 @@ impl VarnodeBank {
     fn def_key_of(&self, id: VarnodeId) -> DefKey {
         let vn = &self.arena[id];
         DefKey {
-            addr: vn.loc.clone(),
+            addr: AddrKey::of(&vn.loc),
             size: vn.size,
             flagclass: flag_class_of(vn.flags),
-            seqnum: vn.def_seqnum.clone().unwrap_or_default(),
+            seqnum: vn.def_seqnum.as_ref().map(SeqKey::of).unwrap_or_default(),
             create_index: vn.create_index,
         }
     }
@@ -1653,20 +1719,29 @@ impl VarnodeBank {
     /// removed from the arena, and the existing id is returned.  Otherwise the
     /// varnode is freshly inserted, marked `insert`, and added to the def tree.
     fn xref(&mut self, vn: VarnodeId, replace_reads: &mut ReplaceReads) -> KunaResult<VarnodeId> {
+        use std::collections::btree_map::Entry;
         let lk = self.loc_key_of(vn);
-        if let Some(&othervn) = self.loc_tree.get(&lk) {
+        // One descent, not two: the lookup and the insertion are the same
+        // search.  The `insert` flag set below is outside the (input|written)
+        // mask, so it does not change the loc/def keys and the entry placed
+        // here is the one the flagged Varnode belongs at.
+        let existing = match self.loc_tree.entry(lk) {
+            Entry::Occupied(e) => Some(*e.get()),
+            Entry::Vacant(e) => {
+                e.insert(vn);
+                None
+            }
+        };
+        if let Some(othervn) = existing {
             // Set already contains this varnode.
             replace_reads(self, vn, othervn)?; // Patch ops using the old varnode
             self.arena.remove(vn); // delete vn
             return Ok(othervn);
         }
-        // Otherwise a new insertion.  The `insert` flag is outside the
-        // (input|written) mask, so it does not change the loc/def keys.
         self.arena[vn].set_flags(varnode_flags::insert);
-        self.loc_tree.insert(lk.clone(), vn);
         self.arena[vn].lociter = Some(lk);
         let dk = self.def_key_of(vn);
-        self.def_tree.insert(dk.clone(), vn); // new in def_tree
+        self.def_tree.insert(dk, vn); // new in def_tree
         self.arena[vn].defiter = Some(dk);
         Ok(vn)
     }
@@ -1813,20 +1888,20 @@ impl VarnodeBank {
     ) -> impl Iterator<Item = VarnodeId> + '_ {
         let space_index = start.get_space().map(|s| s.get_index());
         let begin = LocProbe::Lower(LocKey {
-            addr: start.clone(),
+            addr: AddrKey::of(&start),
             size: 0,
             flagclass: flag_class_of(varnode_flags::input),
-            seqnum: SeqNum::default(),
+            seqnum: SeqKey::of(&(SeqNum::default())),
             create_index: 0,
         });
         let finish = if end.get_offset() < start.get_offset() {
             LocProbe::End
         } else {
             LocProbe::Lower(LocKey {
-                addr: end.clone(),
+                addr: AddrKey::of(&end),
                 size: 0,
                 flagclass: flag_class_of(varnode_flags::input),
-                seqnum: SeqNum::default(),
+                seqnum: SeqKey::of(&(SeqNum::default())),
                 create_index: 0,
             })
         };
@@ -1919,29 +1994,29 @@ impl VarnodeBank {
         if fl == varnode_flags::input {
             // searchvn{size=s, loc=addr, flags=input} ; lower_bound
             return LocProbe::Lower(LocKey {
-                addr: addr.clone(),
+                addr: AddrKey::of(&addr),
                 size: s,
                 flagclass: flag_class_of(varnode_flags::input),
-                seqnum: SeqNum::default(),
+                seqnum: SeqKey::of(&(SeqNum::default())),
                 create_index: 0,
             });
         }
         if fl == varnode_flags::written {
             // searchvn{size=s, loc=addr, flags=written, def=&searchop(minimal seq)} ; lower_bound
             return LocProbe::Lower(LocKey {
-                addr: addr.clone(),
+                addr: AddrKey::of(&addr),
                 size: s,
                 flagclass: flag_class_of(varnode_flags::written),
-                seqnum: SeqNum::new_extreme(mach_extreme::m_minimal),
+                seqnum: SeqKey::of(&(SeqNum::new_extreme(mach_extreme::m_minimal))),
                 create_index: 0,
             });
         }
         // fl == 0 (free): searchvn{size=s, loc=addr, flags=written, def=&searchop(maximal seq)} ; upper_bound
         LocProbe::Upper(LocKey {
-            addr: addr.clone(),
+            addr: AddrKey::of(&addr),
             size: s,
             flagclass: flag_class_of(varnode_flags::written),
-            seqnum: SeqNum::new_extreme(mach_extreme::m_maximal),
+            seqnum: SeqKey::of(&(SeqNum::new_extreme(mach_extreme::m_maximal))),
             create_index: 0,
         })
     }
@@ -1951,29 +2026,29 @@ impl VarnodeBank {
         if fl == varnode_flags::written {
             // searchvn{loc=addr, size=s, flags=written, def=&searchop(maximal seq)} ; upper_bound
             return LocProbe::Upper(LocKey {
-                addr: addr.clone(),
+                addr: AddrKey::of(&addr),
                 size: s,
                 flagclass: flag_class_of(varnode_flags::written),
-                seqnum: SeqNum::new_extreme(mach_extreme::m_maximal),
+                seqnum: SeqKey::of(&(SeqNum::new_extreme(mach_extreme::m_maximal))),
                 create_index: 0,
             });
         }
         if fl == varnode_flags::input {
             // searchvn{loc=addr, size=s, flags=input} ; upper_bound
             return LocProbe::Upper(LocKey {
-                addr: addr.clone(),
+                addr: AddrKey::of(&addr),
                 size: s,
                 flagclass: flag_class_of(varnode_flags::input),
-                seqnum: SeqNum::default(),
+                seqnum: SeqKey::of(&(SeqNum::default())),
                 create_index: 0,
             });
         }
         // fl == 0 (free): searchvn{loc=addr, size=s+1, flags=input} ; lower_bound
         LocProbe::Lower(LocKey {
-            addr: addr.clone(),
+            addr: AddrKey::of(&addr),
             size: s + 1,
             flagclass: flag_class_of(varnode_flags::input),
-            seqnum: SeqNum::default(),
+            seqnum: SeqKey::of(&(SeqNum::default())),
             create_index: 0,
         })
     }
@@ -1985,10 +2060,10 @@ impl VarnodeBank {
         let u = uniq.unwrap_or(0);
         // searchvn{size=s, loc=addr, flags=written, def=&searchop(pc,u)} ; lower_bound
         LocProbe::Lower(LocKey {
-            addr: addr.clone(),
+            addr: AddrKey::of(&addr),
             size: s,
             flagclass: flag_class_of(varnode_flags::written),
-            seqnum: SeqNum::new(pc.clone(), u),
+            seqnum: SeqKey::of(&(SeqNum::new(pc.clone(), u))),
             create_index: 0,
         })
     }
@@ -1998,10 +2073,10 @@ impl VarnodeBank {
     fn end_loc_pc(&self, s: int4, addr: &Address, pc: &Address, uniq: uintm) -> LocProbe {
         // (the C++ does NOT remap ~0 here) ; upper_bound
         LocProbe::Upper(LocKey {
-            addr: addr.clone(),
+            addr: AddrKey::of(&addr),
             size: s,
             flagclass: flag_class_of(varnode_flags::written),
-            seqnum: SeqNum::new(pc.clone(), uniq),
+            seqnum: SeqKey::of(&(SeqNum::new(pc.clone(), uniq))),
             create_index: 0,
         })
     }
@@ -2020,10 +2095,10 @@ impl VarnodeBank {
     pub fn loc_space_ids(&self, space: &Rc<AddrSpace>) -> Vec<VarnodeId> {
         let begin = Address::new(Rc::clone(space), 0);
         let lo = LocProbe::Lower(LocKey {
-            addr: begin,
+            addr: AddrKey::of(&begin),
             size: 0,
             flagclass: flag_class_of(varnode_flags::input),
-            seqnum: SeqNum::default(),
+            seqnum: SeqKey::of(&(SeqNum::default())),
             create_index: 0,
         });
         let mut out = Vec::new();
@@ -2045,18 +2120,18 @@ impl VarnodeBank {
     ) -> impl Iterator<Item = VarnodeId> + '_ {
         // beginLoc: searchvn{size=s, loc=addr} ; lower_bound  (flag = input)
         let begin = LocProbe::Lower(LocKey {
-            addr: addr.clone(),
+            addr: AddrKey::of(&addr),
             size: s,
             flagclass: flag_class_of(varnode_flags::input),
-            seqnum: SeqNum::default(),
+            seqnum: SeqKey::of(&(SeqNum::default())),
             create_index: 0,
         });
         // endLoc: searchvn{size=s+1, loc=addr} ; lower_bound
         let end = LocProbe::Lower(LocKey {
-            addr: addr.clone(),
+            addr: AddrKey::of(&addr),
             size: s + 1,
             flagclass: flag_class_of(varnode_flags::input),
-            seqnum: SeqNum::default(),
+            seqnum: SeqKey::of(&(SeqNum::default())),
             create_index: 0,
         });
         self.iter_loc_probe(begin, end)
@@ -2111,19 +2186,19 @@ impl VarnodeBank {
         if fl == varnode_flags::written {
             // searchvn{loc=minimal, flags=written, def=&searchop(minimal seq)} ; lower_bound
             return DefProbe::Lower(DefKey {
-                addr: Address::new_extreme(mach_extreme::m_minimal),
+                addr: AddrKey::of(&(Address::new_extreme(mach_extreme::m_minimal))),
                 size: 0,
                 flagclass: flag_class_of(varnode_flags::written),
-                seqnum: SeqNum::new_extreme(mach_extreme::m_minimal),
+                seqnum: SeqKey::of(&(SeqNum::new_extreme(mach_extreme::m_minimal))),
                 create_index: 0,
             });
         }
         // fl == 0 (free): searchvn{loc=maximal, flags=written, def=&searchop(maximal seq)} ; upper_bound
         DefProbe::Upper(DefKey {
-            addr: Address::new_extreme(mach_extreme::m_maximal),
+            addr: AddrKey::of(&(Address::new_extreme(mach_extreme::m_maximal))),
             size: 0,
             flagclass: flag_class_of(varnode_flags::written),
-            seqnum: SeqNum::new_extreme(mach_extreme::m_maximal),
+            seqnum: SeqKey::of(&(SeqNum::new_extreme(mach_extreme::m_maximal))),
             create_index: 0,
         })
     }
@@ -2133,20 +2208,20 @@ impl VarnodeBank {
         if fl == varnode_flags::input {
             // searchvn{loc=minimal, flags=written, def=&searchop(minimal seq)} ; lower_bound
             return DefProbe::Lower(DefKey {
-                addr: Address::new_extreme(mach_extreme::m_minimal),
+                addr: AddrKey::of(&(Address::new_extreme(mach_extreme::m_minimal))),
                 size: 0,
                 flagclass: flag_class_of(varnode_flags::written),
-                seqnum: SeqNum::new_extreme(mach_extreme::m_minimal),
+                seqnum: SeqKey::of(&(SeqNum::new_extreme(mach_extreme::m_minimal))),
                 create_index: 0,
             });
         }
         if fl == varnode_flags::written {
             // searchvn{loc=maximal, flags=written, def=&searchop(maximal seq)} ; upper_bound
             return DefProbe::Upper(DefKey {
-                addr: Address::new_extreme(mach_extreme::m_maximal),
+                addr: AddrKey::of(&(Address::new_extreme(mach_extreme::m_maximal))),
                 size: 0,
                 flagclass: flag_class_of(varnode_flags::written),
-                seqnum: SeqNum::new_extreme(mach_extreme::m_maximal),
+                seqnum: SeqKey::of(&(SeqNum::new_extreme(mach_extreme::m_maximal))),
                 create_index: 0,
             });
         }
@@ -2172,19 +2247,19 @@ impl VarnodeBank {
         if fl == varnode_flags::input {
             // searchvn{loc=addr} ; lower_bound  (flags default = input)
             return Ok(DefProbe::Lower(DefKey {
-                addr: addr.clone(),
+                addr: AddrKey::of(&addr),
                 size: 0,
                 flagclass: flag_class_of(varnode_flags::input),
-                seqnum: SeqNum::default(),
+                seqnum: SeqKey::of(&(SeqNum::default())),
                 create_index: 0,
             }));
         }
         // fl == 0 (free): searchvn{loc=addr, flags=0(free)} ; upper_bound
         Ok(DefProbe::Upper(DefKey {
-            addr: addr.clone(),
+            addr: AddrKey::of(&addr),
             size: 0,
             flagclass: flag_class_of(0),
-            seqnum: SeqNum::default(),
+            seqnum: SeqKey::of(&(SeqNum::default())),
             create_index: 0,
         }))
     }
@@ -2197,19 +2272,19 @@ impl VarnodeBank {
         if fl == varnode_flags::input {
             // searchvn{loc=addr, size=1000000} ; lower_bound
             return Ok(DefProbe::Lower(DefKey {
-                addr: addr.clone(),
+                addr: AddrKey::of(&addr),
                 size: 1000000,
                 flagclass: flag_class_of(varnode_flags::input),
-                seqnum: SeqNum::default(),
+                seqnum: SeqKey::of(&(SeqNum::default())),
                 create_index: 0,
             }));
         }
         // fl == 0 (free): searchvn{loc=addr, size=1000000, flags=0(free)} ; lower_bound
         Ok(DefProbe::Lower(DefKey {
-            addr: addr.clone(),
+            addr: AddrKey::of(&addr),
             size: 1000000,
             flagclass: flag_class_of(0),
-            seqnum: SeqNum::default(),
+            seqnum: SeqKey::of(&(SeqNum::default())),
             create_index: 0,
         }))
     }
@@ -2448,10 +2523,22 @@ mod tests {
     }
 
     fn make_loc_key(addr: Address, size: int4, fl: uint4, seq: SeqNum, ci: uint4) -> LocKey {
-        LocKey { addr, size, flagclass: flag_class_of(fl), seqnum: seq, create_index: ci }
+        LocKey {
+            addr: AddrKey::of(&addr),
+            size,
+            flagclass: flag_class_of(fl),
+            seqnum: SeqKey::of(&seq),
+            create_index: ci,
+        }
     }
     fn make_def_key(addr: Address, size: int4, fl: uint4, seq: SeqNum, ci: uint4) -> DefKey {
-        DefKey { addr, size, flagclass: flag_class_of(fl), seqnum: seq, create_index: ci }
+        DefKey {
+            addr: AddrKey::of(&addr),
+            size,
+            flagclass: flag_class_of(fl),
+            seqnum: SeqKey::of(&seq),
+            create_index: ci,
+        }
     }
 
     /// GOLDEN (varnodesort): the `tests/golden/vectors/` corpus has no varnode

--- a/decompiler/crates/kuna-decomp/tests/verify_w5_s3_heritage.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w5_s3_heritage.rs
@@ -121,7 +121,7 @@ fn location_map_add_skips_nonoverlapping_leading_then_unions_later() {
     //   successor end... in C++: lower_bound finds 0x200 is < 0x202 so the
     //   first key >= 0x202 is end; --iter -> 0x200, which DOES overlap 0x202,
     //   so NO ++iter, first-block branch taken, contained -> intersect 2.
-    let (key, intersect) = lm.add(raddr(&fd, 0x202), 4, 7);
+    let (key, intersect, _sz) = lm.add(raddr(&fd, 0x202), 4, 7);
     assert_eq!(key, raddr(&fd, 0x200), "contained sub-range returns containing element");
     assert_eq!(intersect, 2, "fully contained in older range -> intersect 2");
     assert_eq!(lm.get(&key).unwrap().pass, 3, "older pass preserved");
@@ -144,7 +144,7 @@ fn location_map_add_between_elements_is_fresh_disjoint() {
     // 0x100; 0x100 does NOT overlap 0x200 -> ++iter -> 0x300; 0x300 does not
     // overlap 0x200 either (where == -1) -> while loop body never runs;
     // inserted fresh.  intersect must stay 0.
-    let (key, intersect) = lm.add(raddr(&fd, 0x200), 4, 9);
+    let (key, intersect, _sz) = lm.add(raddr(&fd, 0x200), 4, 9);
     assert_eq!(key, raddr(&fd, 0x200));
     assert_eq!(intersect, 0, "disjoint insert -> intersect 0");
     assert_eq!(lm.get(&key).unwrap().pass, 9, "fresh element keeps its own pass");
@@ -166,7 +166,7 @@ fn location_map_add_swallow_carries_global_min_pass() {
     // (first-block branch): addr<-0x100, size grows, pass 6<9 -> intersect 1,
     // pass<-6, erase.  Then the while loop swallows 0x108 (pass 2 -> pass<-2)
     // and 0x110 (pass 4, not < 2, no change).  Final element pass == 2.
-    let (key, intersect) = lm.add(raddr(&fd, 0x100), 0x18, 9);
+    let (key, intersect, _sz) = lm.add(raddr(&fd, 0x100), 0x18, 9);
     assert_eq!(key, raddr(&fd, 0x100));
     assert_eq!(intersect, 1, "partial overlap with old -> intersect 1");
     assert_eq!(lm.get(&key).unwrap().pass, 2, "global minimum pass carried");

--- a/docs/features/decompiling-3396-byte-main/pr_body.md
+++ b/docs/features/decompiling-3396-byte-main/pr_body.md
@@ -1,109 +1,138 @@
-## What was broken
+Attempt 4 on the RE-need `decompiling-3396-byte-main`. A round-2 tester recorded, as a
+`major` finding on `nikos_crack_me.exe`:
 
-> **Decompiling the 3396-byte main function takes about 68 seconds** (major, `69a3822f7b3cc38c80464da4`, 1 instance)
-> The command produced no output for roughly 68 seconds, then emitted about 30 KB of highly noisy pseudocode.
+> **Decompiling the 3396-byte main function takes about 68 seconds** — "The command
+> produced no output for roughly 68 seconds. This observation is specifically about
+> latency."
 
-This is **attempt 3** on `decompiling-3396-byte-main`. Attempts 1 and 2 took the
-witness 71.46 s → 19.42 s (#380, the dead-list scan) → 14.44 s (#385, following the
-function's flow once instead of twice), and both closed with the same finding: the
-residue is flat. This attempt confirms that again — and then finds that "flat" did
-not mean "nothing left", it meant *four* separate costs of a few percent each,
-three of them re-derivations of facts upstream keeps cached.
+Attempts 1–3 (#380, #385, #393) took that witness 71.5 s → 19.4 s → 14.4 s → 11.8 s and
+each closed saying the residue was flat. It is. This attempt asked what "flat" is *made
+of*, and the answer turned out not to be a pass at all.
 
-## Mechanism
+## What was measured
 
-Four changes, none of which can alter emitted C:
+A per-Action exclusive timer plus 32 indexed guard slots — and, decisively, a per-Action
+**counter** of varnode and op creations, because no timer can report a call count. One
+`kuna decompile <crackme> sub_140023350 --json` run performs:
 
-1. **`Merge::merge_test_adjacent` stops re-deriving the isolated bit per member.**
-   C++ reads `high->getSymbol()->isIsolated()` off a cached pointer. kuna's merged
-   tree does not paint SymbolEntries onto Varnodes before the merge group, so
-   `bank_symbol_isolated` re-derived the binding with a `findContainer` containment
-   query **per member Varnode, per candidate pair**. On this witness that is
-   **26,243,952 queries** in one decompile. `set_symbol_isolated` is the only route
-   the `ISOLATE` dispflag has into a function-local scope, so `ScopeLocal` now
-   records whether it has ever been called; a scope that has not cannot answer
-   `true` from any of those queries and the scan is skipped outright.
-   Measured: **1,331 ms → 3 ms.**
-2. **`bank_symbol` answers from the high's cached flag word first.** The same scan
-   shape: it walks every member looking for an address-tied one, and a high's
-   cached flags are the OR of its members', so a clean `addrtied == false` settles
-   it (`variable.rs (kuna_addr_tied_if_clean)`). `mergeTestRequired` reads
-   `high_is_addr_tied` on both highs before it gets here, so the word is clean by
-   construction. The surviving scan also stopped building a `LinkEntryInfo` (a
-   display-name `String` and a data-type clone) to read two integers out of it.
-3. **The rule-pool op cursor reads a run of successors per tree descent.** The C++
-   `op_state` is a map iterator whose `++` is O(1); kuna re-derives the position
-   from a `SeqNum`, which is an optree range search *per op per rule pass* — about
-   13.2 M searches on this function. The op bank now counts its own optree
-   insertions and removals in an epoch, and the pool buffers 64 successors from one
-   descent, discarding them the moment the epoch moves. The pool's own destroy of
-   the op it just left is the one mutation that does not invalidate the run (it
-   removes a key that sorts before every buffered entry), and it is acknowledged
-   explicitly rather than assumed away.
-4. **`ActionDeadCode`'s clear loop does one arena lookup per Varnode, not three.**
-   It runs over every Varnode in the function on every pass, 41 passes here.
+| | count |
+|---|---|
+| `VarnodeBank::create` / `create_def` | 1,677,343 |
+| `VarnodeBank::destroy` | 1,523,008 |
+| `VarnodeBank::xref` / `make_free` | 1,110,157 |
+| `PcodeOpBank::create` / `destroy` | 1,106,775 |
+
+≈ **9.5 M ordered-container mutations**, costing 3.6 s of an 11.8 s run. The function is
+not slow because a pass scales badly; it is IR-volume-bound, and every unit of that
+volume pays two `BTreeMap` insertions and later two removals. (`heritage` alone accounts
+for 676,043 of the creations; `deadcode` for 857,187 of the destructions.)
+
+## The mechanism
+
+Four changes, none of which can move emitted C.
+
+* **The tree keys stop carrying `Rc`s.** `LocKey`/`DefKey` held an `Address` and a
+  `SeqNum`, i.e. two reference-counted space handles per key, cloned on every insert and
+  dropped on every remove. They now hold the ordering triple those objects *compare* by —
+  sentinel rank, space index, offset — flattened into integers by the new
+  `Address::sort_key`. Both keys become `Copy`: no refcount traffic, integer comparisons,
+  smaller nodes. The order is unchanged by construction, and an exhaustive-product unit
+  test asserts `a.cmp(b) == a.sort_key().cmp(&b.sort_key())` over sentinels, four spaces
+  (including two distinct `Rc` handles sharing an index) and five offsets.
+* **`VarnodeBank::xref` takes one descent, not two.** Its "is an equivalent varnode
+  already here" lookup and the insertion that follows were separate searches for the same
+  key; they are now one `entry()`. Safe because the `insert` flag set afterwards is
+  outside the `(input|written)` mask the key is built from, so it cannot move the entry.
+* **`LocationMap::add` stops re-deriving.** It probed `lower_bound`, then walked to
+  `begin()` to decide whether it could step back, then indexed the map again for the
+  element's size — and its caller then re-looked that size up a fourth time. Asking for
+  the *predecessor* first answers both cases in one descent, and `add` now returns the
+  size it already has in hand. 469.6 ms over **1,427,964** calls, which was 71% of
+  heritage's per-space varnode scan.
+* **`rename_recurse` stops snapshotting whole blocks.** Filling a successor's in-edge phi
+  slots reads only the block's *leading* MULTIEQUALs, then breaks; it was materializing
+  every op of every successor once per CFG edge per heritage pass.
 
 ## Measurement
 
-Interleaved paired A/B — one loop alternating the arms so both see the same machine
-load (sibling builders were running throughout). Both arms are release builds of
-this worktree; the base arm is `origin/main` at the recorded base commit.
+Interleaved paired A/B — one loop alternating the base and new binaries so both see the
+same machine load (sibling builders live at load average 3–6 throughout):
 
-| pair | base (ms) | new (ms) | delta |
-|---|---|---|---|
-| 1 | 14486 | 12191 | −15.8% |
-| 2 | 14712 | 12176 | −17.2% |
-| 3 | 13978 | 12048 | −13.8% |
-| 4 | 14644 | 12234 | −16.5% |
+```
+pair1 base=13.58 new=11.14      base median  12,055 ms
+pair2 base=12.10 new=10.93      new  median  11,225 ms
+pair3 base=12.44 new=11.52      median delta    -6.9 %
+pair4 base=12.04 new=11.18      paired mean     -7.3 % ± 5.0
+pair5 base=11.97 new=11.83      8 / 8 pairs are wins  (4.2 σ)
+pair6 base=11.87 new=11.27
+pair7 base=11.79 new=10.77
+pair8 base=12.07 new=11.89
+```
 
-**median 14,565 ms → 12,184 ms, −16.3%** (min −13.8%, max −17.2%, paired mean
-−15.8% ± 1.5, ≈21σ). Every pair is a win and the spread is a tenth of the effect.
+This is **below** the perf track's 20% single-target noise bar and is reported as such.
+It is carried on the pairing and the identity sweep instead: the noise-floor argument is
+about a single-arm before/after, and here no pair regresses and the output does not move
+one byte.
 
-Re-measured **after the rebase onto `origin/main` cb7f30d1** (a sibling's
-`ptrdepthcap` option landed in between), both arms rebuilt from the rebased tree,
-with `make rust-test` running alongside: 4 pairs, base 14579/14939/14981/14544,
-new 12329/12032/14132/12416 → **median 14,760 → 12,373 ms, −16.2%**. Three pairs
-land at −14/−15/−19%; the fourth is −5% and is the one that ran against the peak of
-the workspace suite. `scripts.repipe.verify` on the merged-tree build measures
-**12,437 ms**.
+**Output identity:** whole-surface `decompile-all --json` diffed base vs new — stdout
+*and* exit code — over the whole `kuna-analysis` fixture corpus plus the round's probe
+binaries (ELF x86-64/i386/aarch64/arm/riscv64/mips/ppc64le/sparc64, PE x86-64/i386,
+Mach-O x86-64/arm64/fat, COFF and ELF relocatables, UPX-packed, DWARF- and PDB-bearing
+images; one of them an 18,032-function image). **0 differences.**
 
-**Output is byte-identical.** `kuna decompile` stdout *and* exit code compared
-between the two arms over 297 functions across 38 binaries pre-rebase (and 143 more over 17 binaries re-swept after the rebase) and 8
-architecture/format combinations (x86-64, i386, ARM Thumb, Cortex-M, RISC-V 64,
-MIPS32/MIPS16, PPC; ELF exe/PIE/.so, PE32/PE32+, COFF .obj, Mach-O .o, plus the
-witness crackme itself): **0 diffs**. Plus 675 datatest assertions and the stage
-corpus, unchanged.
+## The acceptance probe still fails, and the need stays open
 
-## The acceptance probe
+`a-53d616afcb6a` asks for a median under 10,000 ms. This lands at ~11.2 s, so the probe
+is **not** promoted into `tests/cli` — vendoring it would vendor a red test — and the
+need is not closed.
 
-**Still FAILS, and the need stays open.** `a-53d616afcb6a` asks for a median under
-10,000 ms; `scripts.repipe.verify` on this build measures **12,437 ms**. `exit_code` passes, `wall_ms` does not. The
-probe is **not promoted** into `tests/cli/` — that would commit a red test — and it
-is not relaxed. Attempt 3 is a measured, output-identical −16%; it is not a close.
+**What would close it is now identified and priced.** kuna runs the jump-table partial
+sub-decompilation **once per table**; C++ runs it once per function
+(`Funcdata::stageJumpTable` guards the clone and the reduced pipeline behind
+`if (!partial.isJumptableRecoveryOn())`). On this witness that is two partials —
+3,077 ms of action time plus 464 ms of cloning — so sharing removes ≈1.7 s, ~15%.
+Combined with this PR it lands the witness near 9.5 s, under the bar. It cannot ship
+here: `option unrolledguard` recovers MSVC interleaved tables *because* each table's
+partial re-clones the siblings recovered before it, and it fires on this very function
+(`[kuna unrolledguard] interleaved jump table at 0x140023d90: skipped 6 undecoded
+sibling-table case-target edge(s)`), so sharing changes this function's own output and
+needs a `phases.toml` row — a lease the live `direct-address-keyboard-handler` builder
+held all round. A fifth dispatch should be given that lease and told to implement exactly
+that; it is a scoped feature PR, not another profiling run.
 
-What attempt 4 should inherit, from a fresh instrumented profile of *this* build:
-`stage_jump_table` 31% (2 tables, and the per-table re-clone is load-bearing for
-`option unrolledguard`), heritage ~23%, `oppool1` ~14%, `ActionDeadCode` ~14%,
-merge now ~6%. And one lead is **refuted**: `Heritage::guard_calls` looks like a
-prototype-query hot spot, but instrumenting its three model queries measures
-`has_effect` ≈ 30 ms, `characterize_as_output` 19.7 ms and
-`characterize_as_input_param` 9.8 ms inside a 971 ms loop — the cost is INDIRECT op
-and Varnode *construction* (arena + two BTreeMap inserts each), which is the IR
-growth model, not a lookup to memoize.
+Three leads were **refuted by measurement** and are recorded so attempt 5 does not buy
+them: `new_varnode`'s fresh `Rc<Datatype>` per varnode is 111 ms over 1.3 M calls (and
+memoizing it would alias pointers that `Rc::ptr_eq` comparisons can see);
+`setVarnodeProperties`' two scope containment queries are 86.5 ms over 539 k calls; and
+`guard_calls`' loop body outside INDIRECT construction is 97 ms over 546 k iterations —
+all 913 ms of `guard_calls` is the 192,528 INDIRECT constructions, i.e. tree mutations
+again.
 
 ## Gates
 
-| gate | result |
+| Gate | Result |
 |---|---|
-| `make test` | PARITY OK — 675/675, `docs/baseline.json` untouched |
-| `make test-stages` | PARITY OK, `docs/baseline-stages.json` untouched |
-| `make rust-test` | green — 348 test binaries, 0 failed (rebased tree, `env -u KUNA_DECOMP_TEST`) |
-| `make check-spec` | check-spec OK |
-| `make test-cli` | tests/cli: 21/21 passed |
-| `kuna catalog --check` | catalog OK — no option added |
-| `repipe.mergecheck` | merge guards clean — 0 rejects against `origin/main`; `counters` reports no drift on the rebuilt rebased tree |
+| `make test` | PARITY OK (675/675) |
+| `make test-stages` | PARITY OK |
+| `make rust-test` | green (see note) |
+| `make check-spec` | OK |
+| `kuna catalog --check` | catalog OK |
+| `scripts.repipe.verify --need decompiling-3396-byte-main` | probe PASS, **acceptance FAIL** (~11.2 s vs <10,000 ms) |
 
-No `phases.toml` row, no `options.rs` registration, no catalog counters, no DIV row:
-the change cannot alter emitted C and is verified not to.
+> **Note on `make rust-test` in a repipe worktree.** The worker environment exports
+> `KUNA_DECOMP_TEST`, and `verify_w10_proto_unlock`'s `cpp_oracle_bin()` reads that
+> variable as the path to the *C++* oracle — so the test ends up comparing kuna against
+> itself and asserts on a C++ spelling (`xunknown4`) kuna does not use. It fails
+> identically on pristine `origin/main` sources in this worktree and passes with the
+> variable unset, which is also why CI is green on main. The suite is green here with
+> `env -u KUNA_DECOMP_TEST`.
+
+> **Note on `make rust-test` in a repipe worktree.** The worker environment exports
+> `KUNA_DECOMP_TEST`, and `verify_w10_proto_unlock`'s `cpp_oracle_bin()` reads that
+> variable as the path to the *C++* oracle — so the test ends up comparing kuna against
+> itself and asserts on a C++ spelling (`xunknown4`) kuna does not use. It fails
+> identically on pristine `origin/main` sources in this worktree and passes with the
+> variable unset, which is also why CI is green on main. The suite is green here with
+> `env -u KUNA_DECOMP_TEST`.
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/decompiling-3396-byte-main/record.json
+++ b/docs/features/decompiling-3396-byte-main/record.json
@@ -1,181 +1,165 @@
 {
-  "opportunity": "decompiling-3396-byte-main",
-  "need_id": "decompiling-3396-byte-main",
-  "route": "RE-friction loop (docs/re-pipeline.md), round 2, track perf -- ATTEMPT 3",
-  "challenge": "69a3822f7b3cc38c80464da4",
-  "binary": ".kuna-repipe/probebin/bcfacd743bc607be/nikos_crack_me.exe (PE x86-64, 235725 bytes)",
-  "selector": "sub_140023350",
-  "scope": "small",
-  "attempt": 3,
-  "prior_attempts": [
-    {
-      "pr": 380,
-      "summary": "dead-list position re-derived by scanning; 71.46 s -> 19.42 s (-72.8%), acceptance not met"
-    },
-    {
-      "pr": 385,
-      "summary": "`kuna decompile` followed the same flow twice; 19.70 s -> 15.32 s (-22.3%), acceptance not met"
-    }
+ "opportunity": "decompiling-3396-byte-main",
+ "need_id": "decompiling-3396-byte-main",
+ "route": "RE-friction loop (docs/re-pipeline.md), round 2, track perf -- ATTEMPT 4",
+ "challenge": "69a3822f7b3cc38c80464da4",
+ "binary": ".kuna-repipe/probebin/bcfacd743bc607be/nikos_crack_me.exe (PE x86-64, 235725 bytes)",
+ "selector": "sub_140023350",
+ "scope": "small",
+ "attempt": 4,
+ "prior_attempts": [
+  {
+   "pr": 380,
+   "summary": "dead-list position re-derived by scanning; 71.46 s -> 19.42 s (-72.8%), acceptance not met"
+  },
+  {
+   "pr": 385,
+   "summary": "`kuna decompile` followed the same flow twice; 19.70 s -> 15.32 s (-22.3%), acceptance not met"
+  },
+  {
+   "pr": 393,
+   "summary": "three per-query re-derivations of cached facts + one fused arena lookup; 14.57 s -> 12.18 s (-16.3%), acceptance not met"
+  }
+ ],
+ "phase": "substrate varnode bank (the two sorted trees), p3 heritage (LocationMap, rename)",
+ "modules": [
+  "decompiler/crates/kuna-base/src/address.rs (Address::sort_key)",
+  "decompiler/crates/kuna-decomp/src/substrate/varnode.rs (AddrKey, SeqKey, LocKey, DefKey, VarnodeBank::xref)",
+  "decompiler/crates/kuna-decomp/src/p3_dataflow/heritage.rs (LocationMap::add, Heritage::heritage, Heritage::rename_recurse)"
+ ],
+ "change_kind": "performance-fix (output byte-identical)",
+ "option": null,
+ "gated": false,
+ "gating_rationale": "None of the four changes can alter emitted C. The tree keys keep the C++ comparator's order exactly (proved by an exhaustive-product unit test on Address::sort_key vs Address::cmp, plus the pre-existing >100k-pair LocKey/DefKey comparator product test); the xref insertion is the same entry the two-descent form placed, because the `insert` flag is outside the (input|written) mask the key is built from; `LocationMap::add` returns a value it already had in hand and reaches the same candidate element in one descent instead of three; and rename_recurse collects the same leading MULTIEQUAL run it already walked. No phases.toml row, no options.rs registration, no catalog counters, no docs/options.md, no DIV row -- which also keeps this clear of the phases.toml / catalog / DIV / stages-corpus leases the live `direct-address-keyboard-handler` builder held this round.",
+ "hypothesis_filed": "The function's extensive opaque arithmetic and indirect calls cause one or more analysis passes to scale poorly.",
+ "hypothesis_verdict": "REFUTED for the fourth time, on a fourth axis. Attempt 1 refuted 'analysis pass' (it was the lifter's dead-list quadratic), attempt 2 'one hot spot' (the flow was followed twice), attempt 3 'flat means empty' (three costs were per-query re-derivations). Attempt 4 finds the residue is not a pass at all: with a per-Action timer plus 10 indexed guard slots, 3.6 s of an 11.8 s run -- ~30% -- is inside `VarnodeBank::create/destroy/xref/make_free` and `PcodeOpBank::create/destroy`, i.e. BTreeMap insert/remove on the two storage-sorted varnode trees. One decompile of this function performs 1,677,343 varnode creations, 1,523,008 destructions, 1,110,157 xref/make_free re-keyings and 1,106,775 op creations/destructions -- about 9.5 M tree operations. The function is not slow because a pass scales badly; it is slow because it is IR-volume-bound and every unit of that volume pays two ordered-container mutations.",
+ "root_cause": [
+  {
+   "item": "the loc/def tree keys carried an `Address` and a `SeqNum`, each holding an `Rc<AddrSpace>`",
+   "evidence": "G20/G21/G22 = 1378 + 887 + 972 ms over 4.3 M calls; the inner split put 695 ms of `create` in its two `BTreeMap::insert`s and 579 ms of `destroy` in its two removes, against 56 ms for building the keys -- the cost is the tree, and the key's size and comparator are what the tree pays per node"
+  },
+  {
+   "item": "`VarnodeBank::xref` did a `loc_tree.get` and then a `loc_tree.insert` of the same key",
+   "evidence": "G28 (key + get) 134 ms and G29 (the two inserts) 349 ms over 596,280 calls, and the `get` misses on essentially every call -- one whole descent per xref discarded"
+  },
+  {
+   "item": "`LocationMap::add` re-derived its candidate element in three descents and the caller then re-looked the element's size",
+   "evidence": "469.6 ms over 1,427,964 calls inside heritage's per-space varnode scan (G19), which is 71% of that 663 ms scan"
+  },
+  {
+   "item": "`rename_recurse` materialized every op of every successor block to read its leading MULTIEQUALs",
+   "evidence": "`Heritage::rename` 819-835 ms; the successor walk runs once per CFG edge per heritage pass and breaks at the first non-MULTIEQUAL"
+  }
+ ],
+ "fix": [
+  "`Address::sort_key` returns the ordering triple (sentinel rank, space index, offset) that `Address::cmp` compares by; `LocKey`/`DefKey` store that triple and a flattened SeqNum instead of the objects, which makes both keys `Copy` -- no Rc traffic on clone or drop, integer comparisons, smaller nodes.",
+  "`VarnodeBank::xref` uses the `BTreeMap` entry API: one descent for the lookup and the insertion.",
+  "`LocationMap::add` probes the predecessor first (answering both the `--lower_bound` and the `== begin()` cases in one descent) and returns the containing element's size, so `Heritage::heritage` no longer re-searches for it.",
+  "`Heritage::rename_recurse` collects the successor's leading MULTIEQUAL run off the intrusive block op list instead of snapshotting the whole block."
+ ],
+ "profiling_method": "Instant-instrumented release builds writing to a file, NOT sampling (perf is blocked on this box: /proc/sys/kernel/perf_event_paranoid = 4, and there is no valgrind). Two tools: (a) a name-keyed exclusive timer around `self.apply(data, ctx)` in `Action::perform`, which also separates the three decompiles this command runs (the main function and the two jump-table partials each end a root `perform`); (b) 32 indexed Guard slots for named inner functions, plus a per-Action counter of varnode/op creations and destructions -- that counter is what turned 'the residue is flat' into 'the residue is 9.5 M tree operations', because no timer alone can report a call count. Guard overhead is visible and must be subtracted: 5.4 M guard pairs moved an 11.8 s run to 13.3 s.",
+ "measurement": {
+  "method": "Interleaved paired A/B, one loop alternating the base and the new binary per iteration so both see the same machine load (sibling builders live, load average 3-6 across the run). Base is a release build of the recorded base commit 3d45b044 built before any edit.",
+  "command": "kuna decompile <crackme> sub_140023350 --json",
+  "pairs": 8,
+  "base_ms": [
+   13580,
+   12100,
+   12440,
+   12040,
+   11970,
+   11870,
+   11790,
+   12070
   ],
-  "phase": "p6 merge (funcdata_merge/varmap/variable), infra action pool, substrate op bank, p9 ActionDeadCode",
-  "modules": [
-    "decompiler/crates/kuna-decomp/src/p6_variables/funcdata_merge.rs (bank_symbol_isolated, kuna_mapped_symbol_entry)",
-    "decompiler/crates/kuna-decomp/src/p6_variables/varmap.rs (ScopeLocal::has_isolated_symbols)",
-    "decompiler/crates/kuna-decomp/src/p6_variables/variable.rs (HighVariable::kuna_addr_tied_if_clean)",
-    "decompiler/crates/kuna-decomp/src/substrate/op.rs (PcodeOpBank::optree_epoch, ops_after_seq)",
-    "decompiler/crates/kuna-decomp/src/infra/action.rs (ActionPool lookahead run)",
-    "decompiler/crates/kuna-decomp/src/p9_emit/coreaction_render.rs (deadcode_apply clear loop)"
+  "new_ms": [
+   11140,
+   10930,
+   11520,
+   11180,
+   11830,
+   11270,
+   10770,
+   11890
   ],
-  "change_kind": "performance-fix (output byte-identical)",
-  "option": null,
-  "gated": false,
-  "gating_rationale": "None of the four changes can alter emitted C: three replace a re-derivation with a cheaper fact that provably settles the same question, the fourth fuses three arena lookups into one. Verified byte-identical (stdout AND exit code) over 297 `kuna decompile` runs across 38 binaries and 8 arch/format combinations, plus 675 datatest and the stage-corpus assertions. No phases.toml row, no options.rs registration, no catalog counters, no docs/options.md, no DIV row -- which also keeps this clear of the counter and phases.toml leases the `c-string-objects-become` builder held this round.",
-  "hypothesis_filed": "The function's extensive opaque arithmetic and indirect calls cause one or more analysis passes to scale poorly.",
-  "hypothesis_verdict": "REFUTED for the third time, and on a third axis. Attempt 1 refuted 'analysis pass' (it was the lifter's dead-list quadratic); attempt 2 refuted 'one hot spot' (it was the same flow followed twice). Attempt 3 confirms the residue is flat -- and then finds that flat did not mean empty: it means several costs of 2-10% each, THREE OF WHICH ARE RE-DERIVATIONS OF FACTS UPSTREAM KEEPS CACHED. kuna's merged tree does not paint SymbolEntries onto Varnodes before the merge group, so `Merge::mergeTestAdjacent`'s two Symbol reads re-run a `findContainer` containment query per member Varnode per candidate pair -- 26,243,952 queries in one decompile of this function. That is not 'a pass scaling poorly with opaque arithmetic'; it is the port paying per-query for something the original reads off a pointer.",
-  "root_cause": "Four, ranked by what they cost on the witness (measured by Instant-instrumentation, not sampling): (1) `bank_symbol_isolated` walks every member Varnode of a HighVariable issuing `ScopeLocal::query_container_for_link` -- 57,710 calls x ~455 members = 26.2 M containment queries, 1,331 ms / 9.4%; the result it is looking for (Symbol::isIsolated) can only be true in a scope where `set_symbol_isolated` has been called, which nothing in a plain decompile does. (2) `bank_symbol` has the same shape for the address-tied member scan -- 45,076 calls at ~5.5 us, 250 ms -- and built a `LinkEntryInfo` (display-name String + data-type clone) to read two integers. (3) `ActionPool::advance_op_state` does one O(log n) optree range search per op per rule pass, ~13.2 M searches; the C++ cursor is a map iterator whose ++ is O(1). (4) `ActionDeadCode`'s per-Varnode clear loop takes three arena lookups where one suffices, over every Varnode on all 41 passes.",
-  "fix": "(1) `ScopeLocal` records whether `set_symbol_isolated` has ever been called (`has_isolated_symbols`, monotone); `bank_symbol_isolated` returns false without scanning when it has not. `set_symbol_isolated` is the ONLY route the ISOLATE dispflag has into a function-local scope -- `set_attribute` writes the varnode-flag word behind a mask that excludes it, `set_display_format` masks the low format bits, no constructor sets it, and the attribute is encoded (ATTRIB_MERGE) but never decoded -- so `false` is a proof, not a heuristic. (2) `kuna_mapped_symbol_entry` returns None when the high's CLEAN cached flag word says no member is address-tied (`HighVariable::kuna_addr_tied_if_clean`); `update_flags` ORs the members' words, and `mergeTestRequired` reads `high_is_addr_tied` on both highs before this point, so the word is clean by construction and a dirty one just falls through to the old scan. The surviving scan uses the allocation-free `container_symbol_link`. (3) `PcodeOpBank` counts optree insertions and removals in an `optree_epoch`; `ActionPool` buffers a 64-entry run of successors from one descent (`ops_after_seq`) and discards it whenever the epoch moves. Its own destroy of the op it just left removes a key sorting before every buffered entry, so that one is acknowledged explicitly rather than treated as an invalidation. (4) one `get_mut` in the deadcode clear loop.",
-  "profiling_method": "Instant-instrumented release builds writing to a file, NOT sampling. Two tools carried this attempt: (a) a name-keyed timer wrapped around `self.apply(data, ctx)` in `Action::perform`, which gives an exact per-Action inclusive profile of the whole pipeline in one run -- that is what made `oppool1`/`heritage`/`deadcode`/merge separable at all; (b) 16 indexed Guard slots for named inner functions. || TRAP, cost a run each: gdb-as-parent sampling (attempt 2's method) does NOT work here any more -- `gdb.execute(\"continue\")` from a stop-event handler needs `gdb.post_event`, and gdb 16 SEGFAULTS ('This is a bug, please report it') on the resulting re-entrant continue. The box also has a GEF/pwndbg `.gdbinit` that must be skipped with `-nx` or every sample is the plugin's banner. Instrumentation is strictly better here anyway: exact, attributable, and its own overhead is visible (adding 50 M Guard calls moved a 12.3 s run to 13.4 s, which is how you know the 26 M-query finding was not a probe artifact).",
-  "measurement": {
-    "method": "Interleaved paired A/B: one loop alternating base and new arms per iteration so both see the same machine load (2 sibling builders live, load average 3-8 across the run). Both arms are release builds of THIS worktree; the base arm is the recorded base commit a13f570d built before any edit.",
-    "command": "kuna decompile <crackme> sub_140023350 --json",
-    "pairs": 4,
-    "base_ms": [
-      14486,
-      14712,
-      13978,
-      14644
-    ],
-    "new_ms": [
-      12191,
-      12176,
-      12048,
-      12234
-    ],
-    "base_median_ms": 14565,
-    "new_median_ms": 12184,
-    "median_delta_pct": -16.3,
-    "min_delta_pct": -13.8,
-    "max_delta_pct": -17.2,
-    "paired_mean_delta_pct": -15.8,
-    "paired_sd_pct": 1.5,
-    "significance": "paired t = 15.8 / (1.5/sqrt(4)) = 21 sigma; every pair is a win, and the effect clears both bars the perf track sets (>=20% is the single-target noise bar -- this is 16.3% and therefore BELOW it on the median, which is why the per-pair spread and the 0-diff identity sweep are carried as the evidence instead: the noise floor argument applies to a single-arm before/after, not to 4 interleaved pairs whose worst arm still beats the best base arm by 12%).",
-    "acceptance_ms_bar": 10000,
-    "acceptance_result": "FAIL on `wall_ms`; `exit_code` passes. `scripts.repipe.verify` on the final rebased build: median 12,437 ms against a <10,000 ms bar -- 24% over.",
-    "output_identity": "byte-identical: stdout AND exit code compared arm-to-arm over 297 `kuna decompile` runs across 38 binaries",
-    "confirmation_on_the_rebased_tree": {
-      "note": "re-measured after rebasing onto origin/main cb7f30d1 (a sibling's `ptrdepthcap` option landed in between); both arms rebuilt from the rebased tree, with `make rust-test` running alongside",
-      "pairs": 4,
-      "base_ms": [
-        14579,
-        14939,
-        14981,
-        14544
-      ],
-      "new_ms": [
-        12329,
-        12032,
-        14132,
-        12416
-      ],
-      "base_median_ms": 14760,
-      "new_median_ms": 12373,
-      "median_delta_pct": -16.2,
-      "note_on_the_weak_pair": "one pair is -5% and is the one that ran against the peak of the workspace suite; the other three are -14/-15/-19%",
-      "identity_recheck": "143 further functions over 17 binaries swept arm-to-arm on the rebased tree: 0 diffs"
-    }
+  "base_median_ms": 12055,
+  "new_median_ms": 11225,
+  "median_delta_pct": -6.9,
+  "paired_mean_delta_pct": -7.3,
+  "paired_sd_pct": 5.0,
+  "significance": "every one of the 8 pairs is a win; paired t = 7.3 / (5.0/sqrt(8)) = 4.2 sigma. This is BELOW the perf track's 20% single-target noise bar and is carried on the pairing plus the zero-diff identity sweep instead: the noise-floor argument is about a single-arm before/after, and no pair here regresses.",
+  "acceptance_ms_bar": 10000,
+  "acceptance_result": "FAIL on `wall_ms`; `exit_code` passes. The need stays open.",
+  "output_identity": "byte-identical stdout AND exit code, base vs new, on whole-surface `decompile-all --json` over the fixture corpus and the round's probe binaries"
+ },
+ "residue_map": {
+  "method": "per-Action exclusive timing plus indexed guards, from instrumented release builds of this branch; one `kuna decompile <crackme> sub_140023350 --json` run each",
+  "before_this_pr_11_8s": {
+   "total action time (3 decompiles)": "9624 ms",
+   "heritage (30)": "2714 ms -- per-space varnode scan + globaldisjoint 556 (of which LocationMap::add+get 470), place_multiequals 1367 (guard 1223, of which guard_calls 842, of which INDIRECT construction 798), rename 819",
+   "deadcode (41)": "1773 ms -- sweep 686, clear_dead_varnodes 382, propagate 225, alive-op seed 198, clear_dead_ops 164, consume clear 132",
+   "oppool1 (194)": "1688 ms",
+   "infertypes (20)": "813 ms",
+   "mergerequired (1)": "601 ms",
+   "the 2 jump-table partial sub-decompiles": "3077 ms of that action time + 464 ms building the partials",
+   "outside any Action": "~2.2 s -- 0.7 s binary load and setup, flow follow, jump-table address recovery, C emit and JSON"
   },
-  "residue_map": {
-    "method": "per-Action inclusive timing from the instrumented build of THIS branch, one `kuna decompile <crackme> sub_140023350 --json` run (12.27 s total; probe overhead negligible at this probe count)",
-    "before_this_pr_14_2s": {
-      "stage_jump_table (2 calls)": "3981 ms / 28.0%",
-      "heritage (30)": "2748 ms / 19.4% -- place_multiequals 1387 (of which guard 1283, of which guard_calls 878), rename 801",
-      "merge (mergeadjacent+mergerequired+mergetype)": "2355 ms / 16.6% -- of which bank_symbol_isolated 1331",
-      "oppool1 (194)": "2315 ms / 16.3%",
-      "deadcode (41)": "1787 ms / 12.6%",
-      "infertypes (20)": "817 ms",
-      "load + flow-follow + emit": "~2.3 s"
-    },
-    "after_this_pr_12_3s": {
-      "stage_jump_table": "3809 ms / 31.0%",
-      "heritage": "2811 ms / 22.9%",
-      "deadcode": "1829 ms / 14.9%",
-      "oppool1": "1757 ms / 14.3% (was 2315 -- the cursor run)",
-      "merge": "936 ms / 7.6% (was 2355)",
-      "infertypes": "834 ms",
-      "bank_symbol_isolated": "3 ms (was 1331)"
-    },
-    "verdict": "still flat, and now flatter. There is no single item over 31%, and the 31% one (`stage_jump_table`) is semantically load-bearing: `option unrolledguard` recovers MSVC interleaved tables BECAUSE each table's partial re-clones the siblings recovered before it, so sharing the partial is a real ~20% that belongs behind its own option (attempt 1 implemented and reverted it; it takes ghangr-optimized-memcpy-6301a9.xml from 2/2 to 0/2)."
+  "cross_cutting": {
+   "VarnodeBank::create + create_def": "1378 ms / 1,677,343 calls",
+   "VarnodeBank::destroy": "887 ms / 1,523,008 calls",
+   "VarnodeBank::xref + make_free": "972 ms / 1,110,157 calls",
+   "PcodeOpBank create + destroy": "398 ms / 1,106,775 calls",
+   "note": "these overlap the per-Action rows above; heritage alone accounts for 676,043 varnode creations, 532,174 destructions and 340,921 op creations, and `deadcode` for 857,187 destructions"
   },
-  "refuted_leads": [
-    {
-      "lead": "`Heritage::guard_calls` is a prototype-query hot spot (878 ms over 984 calls x 365 call sites)",
-      "verdict": "REFUTED by instrumenting the three model queries inside the loop: `has_effect` ~30 ms, `characterize_as_output` 19.7 ms, `characterize_as_input_param` 9.8 ms -- 60 ms of a 971 ms loop body. The cost is INDIRECT op and Varnode CONSTRUCTION (arena insert + optree BTreeMap insert + two Varnode-tree inserts each), i.e. the `guard_calls` INDIRECT model itself, which is upstream's and is the thing the need's own scaling law already blames. Do NOT spend an attempt memoizing FuncProto queries by model identity -- it was the plan here and the measurement killed it."
-    },
-    {
-      "lead": "`Funcdata::bb_ops` allocates a Vec per call, ~10% (attempt 1)",
-      "verdict": "already re-refuted by attempt 2 at ~2.2%; not revisited."
-    }
-  ],
-  "left_on_the_table": [
-    {
-      "item": "the jump-table partial is rebuilt per table",
-      "worth": "~2.0 s of the post-PR 12.3 s run",
-      "status": "BLOCKED behind its own option (see residue_map verdict). Unchanged from attempt 1."
-    },
-    {
-      "item": "`Funcdata::early_jump_table_fail` collects the whole dead list into a Vec then linear-scans for a position, to walk backwards at most 8 steps",
-      "worth": "small",
-      "status": "NOT DONE, deliberately. `PcodeBank::dead_prev` makes it a two-line change, but distinguishing 'op is not in the dead list' (the current `position() -> None -> Success` arm) from 'op is first' needs a membership test the intrusive list does not offer directly, and this PR's entire claim is byte-identity. Not on the path to the bar."
-    },
-    {
-      "item": "the rule pool's per-op rule dispatch",
-      "worth": "~1.0 s of the remaining oppool1",
-      "status": "NOT DONE and probably not doable: 13.2 M op visits x ~8 virtual rule calls is upstream's algorithm."
-    },
-    {
-      "item": "`Heritage::rename`",
-      "worth": "857 ms",
-      "status": "NOT INVESTIGATED beyond the total. `rename_recurse` clones an Address per input slot as a `VariableStack` key and allocates a per-block op Vec; both are ~200 ns/slot costs over ~136 k slots per pass."
-    }
-  ],
-  "tests": {
-    "cargo": [
-      "kuna-decomp substrate::op::tests::ops_after_seq_matches_repeated_first_after -- the buffered run equals the sequence repeated `first_after_seq` produced, and a short run truncates rather than skipping",
-      "kuna-decomp substrate::op::tests::optree_epoch_moves_on_insert_and_destroy -- the epoch moves on create_at, create_seq and destroy (all three optree mutation sites)",
-      "kuna-decomp p6_variables::varmap::tests::has_isolated_symbols_tracks_set_symbol_isolated -- false for an ordinary local, true after set_symbol_isolated, and deliberately monotone on clear"
-    ],
-    "stage_test": null,
-    "stage_test_rationale": "tests/stages/README.md scopes that corpus to stage-model issues; a performance change with byte-identical output has no assertion to make there, and adding one would re-record the stages baseline and bump the hard-coded corpus count for nothing.",
-    "cli_probe": "NOT promoted. `--promote` would install the acceptance probe as a permanent regression test, but the acceptance still FAILS (~12.2 s vs a <10,000 ms bar), so promoting it would commit a red test. Same decision as attempt 2, for the same reason.",
-    "whole_surface": "297 `kuna decompile` runs (stdout + exit code) compared arm-to-arm across 38 binaries, 0 diffs -- see `regression_sweep`."
+  "verdict": "IR-volume-bound. There is no pass left to fix; the two levers that remain are (a) creating less IR, which changes emitted C, and (b) making each tree mutation cheaper, which this PR does by ~7% and which has diminishing returns from here."
+ },
+ "refuted_leads": [
+  {
+   "lead": "`Funcdata::new_varnode` allocates a fresh `Rc<Datatype>` per varnode where C++ shares a cached one from the TypeFactory -- 1.3 M allocations",
+   "verdict": "REFUTED as a lever: `type_base_unknown` measures 111 ms over 1,304,246 calls (~85 ns each). Memoizing it would buy under 1% and would make previously-distinct `Rc<Datatype>` pointers alias, which several `Rc::ptr_eq` type comparisons can see. Not worth it."
   },
-  "regression_sweep": {
-    "method": "`kuna decompile <bin> <fn>` under both arms, stdout AND exit code byte-compared, over the first 12 functions `kuna functions --json` reports for each binary. Scratch files are `$$`-suffixed (attempt 2 lost a whole sweep to two concurrent copies racing on one pair of scratch paths).",
-    "binaries": 55,
-    "architectures": "x86-64, i386, ARM Thumb, Cortex-M, RISC-V 64, MIPS32, MIPS16, PowerPC; ELF exe/PIE/.so, PE32/PE32+, COFF .obj, Mach-O .o, PTX",
-    "functions_compared": 440,
-    "diffs": 0,
-    "includes_the_witness": true,
-    "note": "297 functions / 38 binaries pre-rebase plus 143 functions / 17 binaries re-swept on the rebased tree; 0 diffs in all three sweeps"
+  {
+   "lead": "`setVarnodeProperties` issues two scope containment queries per varnode creation -- the same shape as attempt 3's 26 M `findContainer` queries",
+   "verdict": "REFUTED by measurement: 86.5 ms over 539,462 calls, and `assign_high` 10.8 ms. Both are cheap; do not memoize them."
   },
-  "gates": {
-    "make test": "PARITY OK -- 675/675 assertions, docs/baseline.json untouched (re-run after the rebase)",
-    "make test-stages": "PARITY OK, docs/baseline-stages.json untouched (re-run after the rebase)",
-    "make rust-test": "green -- 348 test binaries, 0 failed, on the REBASED tree with `env -u KUNA_DECOMP_TEST` (the worker env exports it, which activates a C++-oracle arm that is normally skipped and fails unrelatedly)",
-    "make check-spec": "check-spec OK",
-    "make test-cli": "tests/cli: 21/21 passed",
-    "kuna catalog --check": "catalog OK: documents exactly the registered kuna options (no option added)",
-    "repipe.mergecheck": "merge guards clean -- 5 findings, 0 rejects against origin/main",
-    "repipe.counters": "no drift: every hard-coded site agrees with the derived truth (re-derived from a rebuilt binary AFTER the rebase, never by arithmetic)"
+  {
+   "lead": "`Heritage::guard_calls` per-iteration overhead (prototype queries, trial lookups, address construction)",
+   "verdict": "REFUTED again and now quantified: the loop body outside INDIRECT construction is 97 ms over 546,144 iterations (0.18 us). All 913 ms of guard_calls is the 192,528 INDIRECT constructions, i.e. tree mutations. Attempt 3 reached the same conclusion by elimination; this is the direct measurement."
+  }
+ ],
+ "left_on_the_table": [
+  {
+   "item": "the jump-table partial is rebuilt per table",
+   "worth": "the two partial sub-decompiles are 3,077 ms of action time plus 464 ms of cloning in an 11.8 s run; C++ builds ONE partial per function (`Funcdata::stageJumpTable` guards the clone and the reduced pipeline behind `if (!partial.isJumptableRecoveryOn())`), so sharing removes one of the two -- about 1.7 s, ~15%",
+   "status": "BLOCKED behind its own option, and this is now the ONLY identified change that can reach the acceptance bar. `option unrolledguard` recovers MSVC interleaved tables BECAUSE each table's partial re-clones the siblings recovered before it, and it fires on this very witness (kuna prints `[kuna unrolledguard] interleaved jump table at 0x140023d90: skipped 6 undecoded sibling-table case-target edge(s)`), so sharing changes this function's own output and needs a `phases.toml` row. That row is a lease attempt 4 did not hold (the live `direct-address-keyboard-handler` builder held phases.toml, the catalog counter, the DIV counter and docs/options.md all round). Combined with this PR's -7%, a shared partial lands the witness at roughly 9.5 s -- under the 10 s bar."
   },
-  "decisions": [
-    "ATTEMPT 3 INHERITED the profile rather than re-deriving it, as briefed -- and then found the inherited profile was measuring the wrong things. attempt 2's sampling profile put `symbol-container lookups` at ~11% and p6 merge at 18.2%; exact instrumentation shows those are the SAME cost (merge's Symbol reads ARE the container lookups) and that it is 26.2 M queries, which no 1,053-sample profile can say. The lesson is not that attempt 2 was wrong, it is that a flat sampling profile is the point at which to switch instruments.",
-    "REFUTED THE FILED HYPOTHESIS A THIRD TIME, differently: the dominant remaining cost was a port artifact (re-deriving a cached fact per member per pair), not a pass that scales badly with the function's arithmetic.",
-    "REFUTED MY OWN PLAN before writing it. `guard_calls` at 878 ms looked like the next target and the design was a memo keyed on prototype-model identity; instrumenting the three model queries measured 60 ms of a 971 ms loop, so the plan would have bought ~5% of 7%. Recorded in `refuted_leads` so attempt 4 does not rebuild it.",
-    "PROVED the isolated-Symbol guard instead of assuming it. `set_symbol_isolated` having no non-test callers is not enough -- the flag could also arrive via `set_attribute`, `set_display_format` or a decoder. All three were checked: the first two mask it out, and ATTRIB_MERGE is encoded but has no decoder anywhere in the workspace. That is what makes `false` a proof rather than a heuristic.",
-    "MADE THE POOL CURSOR'S INVALIDATION ONE QUESTION, not a list. The buffered run is thrown away whenever the optree epoch moves at all -- any insertion, any removal, by anyone. The single exception (the pool destroying the op it just left) is acknowledged explicitly at the destroy site rather than being a case the epoch is taught to ignore, so no future optree mutation site needs to remember this cache exists.",
-    "NO OPTION and no counters. Output is byte-identical over 297 whole-surface decompiles plus 1,275 corpus assertions, so AGENTS.md's `anything that CAN change emitted C ships behind a named option` does not bite; it also keeps this clear of the phases.toml / docs/options.md / catalog-counter leases the sibling builder held.",
-    "THE NEED STAYS OPEN and the acceptance probe is NOT promoted. ~12.2 s against a <10,000 ms bar. Three attempts have taken 71.5 -> 19.4 -> 14.4 -> 12.2 s, each with a real mechanism and byte-identical output, and the bar is still 22% away. The honest read is in `residue_map`: what is left is `stage_jump_table` (blocked behind an option), heritage (half of it IR construction), the rule pool (upstream's algorithm) and dead code. Attempt 4 is either the `unrolledguard`-compatible shared partial behind its own option -- which needs the phases.toml lease -- or a decision that this need's bar describes a function 12x larger than its title says (43,152 bytes per the PE .pdata, per attempt 2) and belongs in a campaign proposal.",
-    "TRAP LOGGED: /tmp scratch names must carry the FULL worker id. `make rust-test > /tmp/b-r2.rust.log` collided with the live sibling builder's identically-named file and I read THEIR failing run as mine, in THEIR worktree. The tell was the make recipe echo naming a different worktree path."
-  ]
+  {
+   "item": "the optree (`BTreeMap<SeqNum, OpId>`) key is not compacted the way the varnode keys now are",
+   "worth": "~100-150 ms; 1.1 M op creations and destructions plus the rule pool's cursor searches",
+   "status": "NOT DONE. Same transformation, more call sites (`find_op`, the cursor's range probes, `ops_after_seq`); left out to keep this PR's blast radius to two files of engine code."
+  },
+  {
+   "item": "`ActionDeadCode`'s three full-varnode scans per pass (`iter_loc().collect()` twice, `loc_space_ids` once)",
+   "worth": "~100 ms",
+   "status": "NOT DONE. The scans are upstream's algorithm and the destroys inside them, not the walk, are the cost (686 ms sweep vs 78 ms collecting the space's ids)."
+  },
+  {
+   "item": "`Funcdata::early_jump_table_fail` collects the whole dead list and linear-scans for a position",
+   "worth": "small",
+   "status": "NOT DONE, inherited from attempt 3 unchanged."
+  }
+ ],
+ "tests": [
+  "decompiler/crates/kuna-base/src/address.rs -- `sort_key_orders_identically_to_cmp`: an exhaustive product over sentinels, four spaces (including two distinct Rc handles for the same space index) and five offsets, asserting `a.cmp(b) == a.sort_key().cmp(&b.sort_key())` for all 529 pairs. This is the correctness keystone of the key compaction.",
+  "the pre-existing LocKey/DefKey comparator product test (>100,000 pairs) and the LocationMap add/intersect tests in `heritage.rs` and `tests/verify_w5_s3_heritage.rs` cover the retyped keys and the rewritten `add` unchanged.",
+  "no tests/cli promotion: the acceptance probe still FAILS, so promoting it would vendor a red regression test."
+ ],
+ "regression_sweep": "whole-surface `decompile-all --json` diffed base vs new (stdout and exit code) across the kuna-analysis fixture corpus and the round's probe binaries -- ELF x86-64/i386/aarch64/arm/riscv64/mips/ppc64le/sparc64, PE x86-64/i386, Mach-O x86-64/arm64/fat, COFF and ELF relocatables, UPX-packed, DWARF and PDB-bearing images.",
+ "gates": {},
+ "decisions": [
+  "The need's hypothesis is refuted for the fourth time; the symptom stands. Recorded under `hypothesis_verdict`.",
+  "The measurement is -6.9% median / -7.3% paired mean, which is under the perf track's nominal 20% single-target bar. It is carried anyway because all 8 interleaved pairs are wins and the output is byte-identical -- the 20% bar exists to reject a single-arm before/after that could be noise, and this is neither single-arm nor a coin flip. The number is reported honestly rather than dressed up.",
+  "The acceptance probe is NOT relaxed and NOT promoted. Attempt 4 lands the witness at ~11.2 s against a <10,000 ms bar.",
+  "The path to the bar is now identified and priced: sharing the jump-table partial (C++ parity) is ~15% and is the only remaining change of that size. It needs a phases.toml option because it changes which tables recover on this very witness, and that lease was held all round. A fifth dispatch should be given the phases.toml/catalog/DIV/stages leases and told to implement exactly that -- it is a scoped feature PR, not another profiling run."
+ ]
 }

--- a/docs/re-needs/decompiling-3396-byte-main.md
+++ b/docs/re-needs/decompiling-3396-byte-main.md
@@ -12,7 +12,7 @@ instances: 1
 challenges: [69a3822f7b3cc38c80464da4]
 rounds: [2]
 first_seen_round: 2
-attempts: 3
+attempts: 4
 covered_by_option: null
 touches: [decompiler/crates/kuna-decomp, decompiler/crates/kuna-console]
 scope: small
@@ -176,6 +176,49 @@ Three things attempt 4 should inherit rather than rediscover:
   per-table re-clone is load-bearing for `option unrolledguard` and sharing it needs its
   own option — the `phases.toml` lease this round did not have), heritage 22.9%,
   `ActionDeadCode` 14.9%, `oppool1` 14.3%, merge now 7.6%. Nothing else is over 7%.
+
+**Attempt 4 (round 2 wave 14, branch `feat/re-decompiling-3396-byte-main`).** The symptom
+still stands and the acceptance is still unmet: **11,225 ms** median against the
+`< 10,000 ms` bar. Attempt 4's contribution is a *diagnosis*, and the fix is the smaller
+half of it. A per-Action exclusive timer, 32 indexed guard slots and — decisively — a
+per-Action **counter** of varnode/op creations say that one decompile of this function
+performs **1,677,343 varnode creations, 1,523,008 destructions, 1,110,157 xref/make_free
+re-keyings and 1,106,775 op creations/destructions**: about **9.5 M ordered-container
+mutations, 3.6 s of an 11.8 s run**. The residue is not a pass that scales badly. The
+function is IR-volume-bound and every unit of that volume pays two `BTreeMap` insertions
+and later two removals. Four byte-identical cuts follow from that (tree keys stop
+carrying `Rc`s and become `Copy`; `xref` takes one descent instead of two;
+`LocationMap::add` reaches its candidate in one descent and returns the size its caller
+was re-looking up — 469.6 ms over 1,427,964 calls; `rename_recurse` stops snapshotting
+whole successor blocks). Interleaved 8-pair A/B: **12,055 ms -> 11,225 ms median, -6.9%**
+(paired mean -7.3% +/- 5.0, every pair a win, 4.2 sigma), output byte-identical over
+whole-surface `decompile-all` across the fixture corpus and the round's probe binaries,
+0 diffs.
+
+Attempt 5 should inherit three things and re-derive none of them:
+
+- **The bar is reachable, once, by one identified change: share the jump-table
+  partial.** kuna runs the partial sub-decompilation once *per table*; C++ runs it once
+  per *function* (`stageJumpTable` guards the clone and the reduced pipeline behind
+  `if (!partial.isJumptableRecoveryOn())`). Here that is two partials — **3,077 ms of
+  action time plus 464 ms of cloning** — so sharing removes ~1.7 s, **~15%**, which with
+  attempt 4's -7% lands the witness near **9.5 s, under the bar**. It changes which
+  tables recover (`unrolledguard` fires on this very function) and therefore needs a
+  `phases.toml` option row. **Dispatch attempt 5 WITH the phases.toml / catalog / DIV /
+  stages-corpus leases** — those were held by a live sibling all of wave 14, which is the
+  only reason this is still open. This is a scoped feature PR, not another profiling run.
+- **Three leads are refuted by direct measurement.** `new_varnode`'s fresh
+  `Rc<Datatype>` per varnode: 111 ms over 1,304,246 calls (and memoizing it aliases
+  pointers that `Rc::ptr_eq` type comparisons can see). `setVarnodeProperties`' two scope
+  containment queries: 86.5 ms over 539,462 calls. `guard_calls` outside INDIRECT
+  construction: 97 ms over 546,144 iterations — all 913 ms of it is the 192,528 INDIRECT
+  constructions, i.e. tree mutations again.
+- **The measurement harness.** `perf` is blocked on this box
+  (`perf_event_paranoid = 4`) and there is no valgrind, so instrumentation is the only
+  option; the per-Action timer separates the three decompiles the command runs (main +
+  two jump-table partials) for free, and the creation counter is what makes "flat"
+  legible. Guard overhead is real and must be subtracted — 5.4 M guard pairs moved an
+  11.8 s run to 13.3 s.
 
 ## Reference
 

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -836,6 +836,25 @@ the CFG, and `sblocks`, the structuring tree — physically distinct, seeded as 
 `BlockCopy` mirror of the CFG when structuring begins
 (`decompiler/crates/kuna-decomp/src/substrate/funcdata.rs (seed_sblocks_copy)`).
 
+The varnode bank's two sorted trees are the container the decompiler touches most
+— a large function creates and destroys well over a million Varnodes, each one
+inserted into and removed from both — so their keys
+(`decompiler/crates/kuna-decomp/src/substrate/varnode.rs (LocKey, DefKey)`) do not
+store an `Address` or a `SeqNum` directly. They store the ordering triple those
+compare by, flattened into plain integers: the sentinel rank, the space index and
+the offset (`decompiler/crates/kuna-base/src/address.rs (Address::sort_key)`).
+Lexicographic comparison of the triple reproduces `Address::cmp` exactly — two
+Addresses sharing a space pointer share a rank and an index and fall through to
+the offset, which is what the pointer-equality fast path does — so the tree order
+is the C++ comparator's order, while the key itself becomes `Copy`: no reference
+counting on clone or drop, no pointer chase into an `AddrSpace` to compare, and a
+smaller node. Insertion also takes a single descent
+(`decompiler/crates/kuna-decomp/src/substrate/varnode.rs (VarnodeBank::xref)`):
+the "is an equivalent varnode already present" lookup and the insertion that
+follows it are the same search, because the `insert` flag set afterwards is
+outside the `(input|written)` mask the key is built from and so cannot move the
+entry.
+
 Every cross-arena mutation routes through `Funcdata` — Rust cannot hold two
 `&mut` arenas through a method on one of them, so the op-in-block primitives the
 C++ splits between `Funcdata` and `BlockBasic` are all `Funcdata` methods here

--- a/docs/spec/03-ssa-and-simplification.md
+++ b/docs/spec/03-ssa-and-simplification.md
@@ -53,6 +53,13 @@ driver (`heritage.rs (Heritage::heritage)`) files the range under
 `new_addresses`/`old_addresses` flags accordingly. That classification is
 load-bearing twice over: only ranges with new addresses get call/return guards
 (below), and an *old* overlap is the trigger for the dead-code-delay machinery.
+`add` also hands back the size of the element the range ended up inside, which is
+the other half of the C++ iterator its callers read, so classifying a range costs
+one lookup rather than an add followed by a second search for the same entry; and
+the walk that finds the candidate element asks for the *predecessor* of the range
+first, which answers both the "step back from `lower_bound`" and the "already at
+`begin()`" cases in one descent. Every varnode of every heritaged space is
+re-offered to this map on every pass, so it is the most-called map in the phase.
 
 **The simple case.** For each disjoint range, `heritage.rs (Heritage::collect)`
 partitions the range's varnodes into reads (free), writes (defined), and
@@ -76,7 +83,12 @@ formal **input varnode** of the function; this is how registers read before
 being written become parameters-in-waiting for phase 04. One carve-out: an
 INDIRECT and the op it wraps happen "at the same time", so an op whose renamed
 read would resolve to its *own* INDIRECT output takes the next value down the
-stack (or a fresh input) instead (`heritage.rs (op_from_const)`).
+stack (or a fresh input) instead (`heritage.rs (op_from_const)`). After a block's
+own ops are renamed the walk fills the in-edge slots of each successor's leading
+MULTIEQUALs; it reads only that leading run (phi ops are always at the head of a
+block and the walk stops at the first op that is not one), so it collects the run
+off the block's intrusive op list rather than materializing every op of every
+successor once per CFG edge per pass.
 
 **Materializing an input over existing pieces (kuna, DIV-50).** The input a
 stack-empty read materializes may land on storage that already holds input


### PR DESCRIPTION
Attempt 4 on the RE-need `decompiling-3396-byte-main`. A round-2 tester recorded, as a
`major` finding on `nikos_crack_me.exe`:

> **Decompiling the 3396-byte main function takes about 68 seconds** — "The command
> produced no output for roughly 68 seconds. This observation is specifically about
> latency."

Attempts 1–3 (#380, #385, #393) took that witness 71.5 s → 19.4 s → 14.4 s → 11.8 s and
each closed saying the residue was flat. It is. This attempt asked what "flat" is *made
of*, and the answer turned out not to be a pass at all.

## What was measured

A per-Action exclusive timer plus 32 indexed guard slots — and, decisively, a per-Action
**counter** of varnode and op creations, because no timer can report a call count. One
`kuna decompile <crackme> sub_140023350 --json` run performs:

| | count |
|---|---|
| `VarnodeBank::create` / `create_def` | 1,677,343 |
| `VarnodeBank::destroy` | 1,523,008 |
| `VarnodeBank::xref` / `make_free` | 1,110,157 |
| `PcodeOpBank::create` / `destroy` | 1,106,775 |

≈ **9.5 M ordered-container mutations**, costing 3.6 s of an 11.8 s run. The function is
not slow because a pass scales badly; it is IR-volume-bound, and every unit of that
volume pays two `BTreeMap` insertions and later two removals. (`heritage` alone accounts
for 676,043 of the creations; `deadcode` for 857,187 of the destructions.)

## The mechanism

Four changes, none of which can move emitted C.

* **The tree keys stop carrying `Rc`s.** `LocKey`/`DefKey` held an `Address` and a
  `SeqNum`, i.e. two reference-counted space handles per key, cloned on every insert and
  dropped on every remove. They now hold the ordering triple those objects *compare* by —
  sentinel rank, space index, offset — flattened into integers by the new
  `Address::sort_key`. Both keys become `Copy`: no refcount traffic, integer comparisons,
  smaller nodes. The order is unchanged by construction, and an exhaustive-product unit
  test asserts `a.cmp(b) == a.sort_key().cmp(&b.sort_key())` over sentinels, four spaces
  (including two distinct `Rc` handles sharing an index) and five offsets.
* **`VarnodeBank::xref` takes one descent, not two.** Its "is an equivalent varnode
  already here" lookup and the insertion that follows were separate searches for the same
  key; they are now one `entry()`. Safe because the `insert` flag set afterwards is
  outside the `(input|written)` mask the key is built from, so it cannot move the entry.
* **`LocationMap::add` stops re-deriving.** It probed `lower_bound`, then walked to
  `begin()` to decide whether it could step back, then indexed the map again for the
  element's size — and its caller then re-looked that size up a fourth time. Asking for
  the *predecessor* first answers both cases in one descent, and `add` now returns the
  size it already has in hand. 469.6 ms over **1,427,964** calls, which was 71% of
  heritage's per-space varnode scan.
* **`rename_recurse` stops snapshotting whole blocks.** Filling a successor's in-edge phi
  slots reads only the block's *leading* MULTIEQUALs, then breaks; it was materializing
  every op of every successor once per CFG edge per heritage pass.

## Measurement

Interleaved paired A/B — one loop alternating the base and new binaries so both see the
same machine load (sibling builders live at load average 3–6 throughout):

```
pair1 base=13.58 new=11.14      base median  12,055 ms
pair2 base=12.10 new=10.93      new  median  11,225 ms
pair3 base=12.44 new=11.52      median delta    -6.9 %
pair4 base=12.04 new=11.18      paired mean     -7.3 % ± 5.0
pair5 base=11.97 new=11.83      8 / 8 pairs are wins  (4.2 σ)
pair6 base=11.87 new=11.27
pair7 base=11.79 new=10.77
pair8 base=12.07 new=11.89
```

This is **below** the perf track's 20% single-target noise bar and is reported as such.
It is carried on the pairing and the identity sweep instead: the noise-floor argument is
about a single-arm before/after, and here no pair regresses and the output does not move
one byte.

**Output identity:** whole-surface `decompile-all --json` diffed base vs new — stdout
*and* exit code — over the whole `kuna-analysis` fixture corpus plus the round's probe
binaries (ELF x86-64/i386/aarch64/arm/riscv64/mips/ppc64le/sparc64, PE x86-64/i386,
Mach-O x86-64/arm64/fat, COFF and ELF relocatables, UPX-packed, DWARF- and PDB-bearing
images; one of them an 18,032-function image). **0 differences.**

## The acceptance probe still fails, and the need stays open

`a-53d616afcb6a` asks for a median under 10,000 ms. This lands at ~11.2 s, so the probe
is **not** promoted into `tests/cli` — vendoring it would vendor a red test — and the
need is not closed.

**What would close it is now identified and priced.** kuna runs the jump-table partial
sub-decompilation **once per table**; C++ runs it once per function
(`Funcdata::stageJumpTable` guards the clone and the reduced pipeline behind
`if (!partial.isJumptableRecoveryOn())`). On this witness that is two partials —
3,077 ms of action time plus 464 ms of cloning — so sharing removes ≈1.7 s, ~15%.
Combined with this PR it lands the witness near 9.5 s, under the bar. It cannot ship
here: `option unrolledguard` recovers MSVC interleaved tables *because* each table's
partial re-clones the siblings recovered before it, and it fires on this very function
(`[kuna unrolledguard] interleaved jump table at 0x140023d90: skipped 6 undecoded
sibling-table case-target edge(s)`), so sharing changes this function's own output and
needs a `phases.toml` row — a lease the live `direct-address-keyboard-handler` builder
held all round. A fifth dispatch should be given that lease and told to implement exactly
that; it is a scoped feature PR, not another profiling run.

Three leads were **refuted by measurement** and are recorded so attempt 5 does not buy
them: `new_varnode`'s fresh `Rc<Datatype>` per varnode is 111 ms over 1.3 M calls (and
memoizing it would alias pointers that `Rc::ptr_eq` comparisons can see);
`setVarnodeProperties`' two scope containment queries are 86.5 ms over 539 k calls; and
`guard_calls`' loop body outside INDIRECT construction is 97 ms over 546 k iterations —
all 913 ms of `guard_calls` is the 192,528 INDIRECT constructions, i.e. tree mutations
again.

## Gates

| Gate | Result |
|---|---|
| `make test` | PARITY OK (675/675) |
| `make test-stages` | PARITY OK |
| `make rust-test` | green (see note) |
| `make check-spec` | OK |
| `kuna catalog --check` | catalog OK |
| `scripts.repipe.verify --need decompiling-3396-byte-main` | probe PASS, **acceptance FAIL** (~11.2 s vs <10,000 ms) |

> **Note on `make rust-test` in a repipe worktree.** The worker environment exports
> `KUNA_DECOMP_TEST`, and `verify_w10_proto_unlock`'s `cpp_oracle_bin()` reads that
> variable as the path to the *C++* oracle — so the test ends up comparing kuna against
> itself and asserts on a C++ spelling (`xunknown4`) kuna does not use. It fails
> identically on pristine `origin/main` sources in this worktree and passes with the
> variable unset, which is also why CI is green on main. The suite is green here with
> `env -u KUNA_DECOMP_TEST`.

> **Note on `make rust-test` in a repipe worktree.** The worker environment exports
> `KUNA_DECOMP_TEST`, and `verify_w10_proto_unlock`'s `cpp_oracle_bin()` reads that
> variable as the path to the *C++* oracle — so the test ends up comparing kuna against
> itself and asserts on a C++ spelling (`xunknown4`) kuna does not use. It fails
> identically on pristine `origin/main` sources in this worktree and passes with the
> variable unset, which is also why CI is green on main. The suite is green here with
> `env -u KUNA_DECOMP_TEST`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
