### PR TITLE
[AUTOMATED] feat(cli): no-cli-structuring-override — --assert 'flow <addr> branch|call|callreturn|return'

### DIFF
--- a/decompiler/crates/kuna-cli/src/assertdecl.rs
+++ b/decompiler/crates/kuna-cli/src/assertdecl.rs
@@ -18,6 +18,7 @@
 //!   --assert 'type v2 char[16]'
 //!   --assert 'name v2 credbuf'
 //!   --assert 'readonly 0x404028+8'
+//!   --assert 'flow 0x1405 return'
 //!   --assert 'volatile 0x50000000+4'
 //!   --assert @notes/overrides.kuna
 //! ```
@@ -269,12 +270,29 @@ pub(crate) fn parse_one(spec: &str) -> Result<Directive, String> {
                 Body::Volatile { addr, size }
             }
         }
+        "flow" => {
+            let (addr, kind) = take_token(rest);
+            let (func, addr) = split_qualifier(addr);
+            let addr = parse_vma(&addr).ok_or_else(|| bad("flow needs a hex <addr>"))?;
+            let (kind, tail) = take_token(kind);
+            if !tail.is_empty() {
+                return Err(bad("flow takes exactly <addr> <flowkind>"));
+            }
+            // The vocabulary is closed and four words wide, so a misspelling is a
+            // usage error here rather than a rejected outcome three phases later.
+            if !matches!(kind, "branch" | "call" | "callreturn" | "return") {
+                return Err(bad(
+                    "flow needs <addr> then one of branch, call, callreturn, return",
+                ));
+            }
+            Body::Flow { func, addr, kind: kind.to_string() }
+        }
         "" => return Err("--assert: empty directive".into()),
         other => {
             return Err(format!(
                 "--assert {raw:?}: unknown directive {other:?} (want one of \
-                 function, typedef, prototype, data, param, return, comment, name, type, \
-                 readonly, volatile)"
+                 function, typedef, prototype, data, param, return, comment, flow, name, \
+                 type, readonly, volatile)"
             ))
         }
     };
@@ -308,6 +326,9 @@ pub(crate) fn console_form(d: &Directive) -> Option<ConsoleForm> {
         }
         Body::Comment { addr, text, .. } => {
             (Slot::Function, format!("comment instruction {addr:#x} {text}"))
+        }
+        Body::Flow { addr, kind, .. } => {
+            (Slot::Function, format!("override flow {addr:#x} {kind}"))
         }
         Body::Readonly { addr, size } => (Slot::Image, format!("readonly {addr:#x} {size}")),
         Body::Volatile { addr, size } => (Slot::Image, format!("volatile {addr:#x} {size}")),
@@ -423,6 +444,31 @@ mod tests {
         );
     }
 
+    /// `flow` takes an address and one of the console's four flow words, and
+    /// qualifies like every other function-scoped directive.
+    #[test]
+    fn flow_takes_an_address_and_one_of_four_words() {
+        for kind in ["branch", "call", "callreturn", "return"] {
+            assert_eq!(
+                one(&format!("flow 0x1405 {kind}")).body,
+                Body::Flow { func: None, addr: 0x1405, kind: kind.into() }
+            );
+        }
+        // Bare hex is the `--define-function` convention, here too.
+        assert_eq!(
+            one("flow 1405 return").body,
+            Body::Flow { func: None, addr: 0x1405, kind: "return".into() }
+        );
+        assert_eq!(
+            one("flow sub_13c9::0x1405 callreturn").body,
+            Body::Flow {
+                func: Some("sub_13c9".into()),
+                addr: 0x1405,
+                kind: "callreturn".into()
+            }
+        );
+    }
+
     /// A directive kuna cannot honor must say so rather than be dropped: an
     /// accepted-and-inert assertion is the failure mode this plane exists to end.
     #[test]
@@ -437,6 +483,10 @@ mod tests {
             "param x RDI int4",
             "prototype authenticate",
             "comment 0x400699",
+            "flow 0x1405",
+            "flow 0x1405 goto",
+            "flow notahex return",
+            "flow 0x1405 return extra",
         ] {
             let err = parse_one(spec).expect_err("refuses");
             assert!(err.starts_with("--assert"), "got {err:?} for {spec:?}");
@@ -473,6 +523,10 @@ mod tests {
         assert_eq!(
             lowered("comment 0x400699 open the file"),
             (Slot::Function, "comment instruction 0x400699 open the file".into())
+        );
+        assert_eq!(
+            lowered("flow 0x1405 return"),
+            (Slot::Function, "override flow 0x1405 return".into())
         );
         assert_eq!(lowered("type v2 char[16]"), (Slot::Symbol, "retype v2 char[16]".into()));
         assert_eq!(lowered("name v2 credbuf"), (Slot::Symbol, "rename v2 credbuf".into()));

--- a/decompiler/crates/kuna-console/src/assertions.rs
+++ b/decompiler/crates/kuna-console/src/assertions.rs
@@ -24,6 +24,7 @@
 //!   typedef <C declaration>                parse line           P5
 //!   data <addr> <C typedeclaration>        map address          P5 const-pointer
 //!   comment [<func>::]<addr> <text>        comment instruction  P9
+//!   flow [<func>::]<addr> <flowkind>       override flow        P2 flow-classification
 //!   function <start>[-<end>][=<name>]      function bounds      P1  (= --define-function)
 //!   readonly <addr>+<size>                 readonly             P1 code-data-partition
 //!   volatile <addr>+<size>                 volatile             P1 code-data-partition
@@ -50,8 +51,13 @@
 //! * **Program-scoped** (`function`, `typedef`, `prototype`, `data`) is applied
 //!   by [`apply_program_scoped`] right after the analysis commit, so a declared
 //!   fact outranks whatever discovery decided.
-//! * **Function-scoped** (`param`, `return`, `comment`) is turned into decompile
-//!   SEEDS by [`function_seed`] — the facts the drive consumes at flow time.
+//! * **Function-scoped** (`param`, `return`, `comment`, `flow`) is turned into
+//!   decompile SEEDS by [`function_seed`] — the facts the drive consumes at flow
+//!   time.  `flow` is the sharpest of them: it reclassifies the flow out of one
+//!   instruction (`branch`, `call`, `callreturn`, `return`), which is how a
+//!   caller corrects a function whose body the flow-follower walked out of — an
+//!   indirect `call *%rdx` that never returns, a tail call kuna read as a call,
+//!   a jump into a neighbour.
 //! * **Symbol-scoped** (`name`, `type`) can only be applied AFTER a decompile:
 //!   a local like `v2` does not exist until one has run (`rename v2 buf` before
 //!   the first decompile answers `No symbol named: v2`, which is precisely the
@@ -104,6 +110,9 @@ pub enum Body {
     Return { func: Option<String>, storage: String, decl: String },
     /// `comment [<func>::]<addr> <text>` — a comment at an instruction.
     Comment { func: Option<String>, addr: u64, text: String },
+    /// `flow [<func>::]<addr> branch|call|callreturn|return` — the flow out of
+    /// this instruction is not what kuna decided it was.
+    Flow { func: Option<String>, addr: u64, kind: String },
     /// `name [<func>::]<symbol> <newname>` — rename a local.
     Name { func: Option<String>, symbol: String, newname: String },
     /// `type [<func>::]<symbol> <C type>` — retype a local.
@@ -141,6 +150,7 @@ impl Body {
             Body::Param { .. } => ("param", "P4", "prototype-source"),
             Body::Return { .. } => ("return", "P4", "prototype-source"),
             Body::Comment { .. } => ("comment", "P9", "external-refinement"),
+            Body::Flow { .. } => ("flow", "P2", "flow-classification"),
             Body::Name { .. } => ("name", "P9", "naming-policy"),
             Body::Type { .. } => ("type", "P5", "type-propagation"),
             Body::Readonly { .. } => ("readonly", "P1", "code-data-partition"),
@@ -155,6 +165,7 @@ impl Body {
             Body::Param { func, .. }
             | Body::Return { func, .. }
             | Body::Comment { func, .. }
+            | Body::Flow { func, .. }
             | Body::Name { func, .. }
             | Body::Type { func, .. } => func.as_deref(),
             _ => None,
@@ -168,6 +179,7 @@ impl Body {
             Body::Param { .. }
                 | Body::Return { .. }
                 | Body::Comment { .. }
+                | Body::Flow { .. }
                 | Body::Name { .. }
                 | Body::Type { .. }
         )
@@ -458,8 +470,10 @@ fn apply_data(prog: &mut ConsoleProgram, vma: u64, decl: &str) -> Result<(), Str
 ///
 /// `param` and `return` are consumed at flow time (they are the prototype the
 /// function is decompiled against), so they cannot be applied afterwards;
-/// `comment` is program state and is written here too, since it is keyed by the
-/// owning function's entry.
+/// `flow` is consumed at flow time too, and even earlier — the follower reads it
+/// while it is still deciding which bytes belong to the function; `comment` is
+/// program state and is written here too, since it is keyed by the owning
+/// function's entry.
 #[derive(Default)]
 pub struct FunctionSeed {
     /// `map param` storage locks, in the drive's `mapped_params` shape.
@@ -467,6 +481,9 @@ pub struct FunctionSeed {
     /// The prototype this function is decompiled against (`prototype`, plus the
     /// output storage a `return` directive locks).
     pub pending_proto: Option<PrototypePieces>,
+    /// `override flow` facts, in the drive's `flow_overrides` shape: the flow
+    /// type forced at each named instruction.
+    pub flow_overrides: Vec<(Address, uint4)>,
 }
 
 /// Build the [`FunctionSeed`] for the function `name` entered at `entry`, and
@@ -551,6 +568,18 @@ fn seed_one(
             let arch = prog.arch_mut();
             let ctype = arch.print().instruction_comment_flags();
             arch.commentdb.add_comment(ctype, entry, &at, text);
+            Ok(())
+        }
+        Body::Flow { addr, kind, .. } => {
+            let type_ = kuna_decomp::overrides::Override::string_to_type(kind.as_bytes());
+            if type_ == kuna_decomp::overrides::flow_type::NONE {
+                return Err(format!(
+                    "Bad override type: {kind} (want branch, call, callreturn or return)"
+                ));
+            }
+            let at = code_addr(prog, *addr)
+                .ok_or_else(|| "the loaded program has no default code space".to_string())?;
+            seed.flow_overrides.push((at, type_));
             Ok(())
         }
         _ => Err("internal: not a function-scoped directive".into()),

--- a/decompiler/crates/kuna-console/src/project.rs
+++ b/decompiler/crates/kuna-console/src/project.rs
@@ -193,6 +193,12 @@ pub fn decompile_targets(
         // field is empty for a run that passed no directive, which is what makes
         // the plane free (`crate::assertions`).
         let seed = crate::assertions::function_seed(prog, &name, &entry, single_target);
+        // (kuna `--assert`) A caller-stated `flow` reclassification is appended
+        // AFTER the derived no-return prunes, so it wins the map insert at an
+        // address both name (`Override::insertFlowOverride` is a map store):
+        // what the caller declared outranks what analysis inferred.
+        let mut flow_ovr = flow_ovr;
+        flow_ovr.extend(seed.flow_overrides.iter().cloned());
         let step = crate::decompile_step::decompile_one(
             prog.arch_mut(),
             &name,

--- a/decompiler/crates/kuna-console/tests/verify_assertflow.rs
+++ b/decompiler/crates/kuna-console/tests/verify_assertflow.rs
@@ -1,0 +1,240 @@
+//! The `--assert flow` directive end-to-end — `docs/re-needs/no-cli-structuring-override.md`.
+//!
+//! `override flow <addr> branch|call|callreturn|return` is the one structuring
+//! override whose engine path is fully ported, and it was reachable only from
+//! `decomp_dbg`: the `kuna` binary's `--assert` plane carried eleven directives
+//! and `flow` was not among them, so an agent driving the CLI could not correct
+//! a misclassified call, branch or return at all.
+//!
+//! Every case here asserts the **emitted C changed**, against a measured
+//! baseline — the bar this family is held to, because `override prototype` has
+//! printed "Successfully added override" and changed nothing since it was
+//! ported.
+//!
+//! Fixture: `kuna-analysis/tests/fixtures/aif_gap_x86_64`. `sub_13c9` reaches an
+//! indirect `call *%rdx` at `0x1405` and then twenty-four more calls; declaring
+//! that instruction a `return` cuts the body to its first statement.
+//!
+//! ## `.sla` precondition
+//!
+//! Bootstrapping needs the built x86 `.sla` under `specs/` (gitignored; `make
+//! specs`). When it is absent the bootstrap fails; the test prints that and
+//! returns early (a specs-less CI is a visible skip, never a false green).
+
+use std::path::PathBuf;
+
+use kuna_console::assertions::{self, Body, Directive, Outcome};
+use kuna_console::engine::{bootstrap_from_object, ConsoleProgram, EntrySelector};
+use kuna_console::project::decompile_targets;
+
+/// The function whose flow the directives below reclassify.
+const SUB_13C9: u64 = 0x13c9;
+/// The indirect `call *%rdx` inside it.
+const INDIRECT_CALL: u64 = 0x1405;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+/// Bootstrap the fixture and run the analysis commit.  `None` ⇒ specs-less skip.
+fn load() -> Option<ConsoleProgram> {
+    let root = repo_root();
+    let spec_roots = vec![root.join("specs").to_str().unwrap().to_string()];
+    let bin = root.join("decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64");
+    let mut prog = match bootstrap_from_object(bin.to_str()?, "", &spec_roots) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "verify_assertflow: skipping (bootstrap failed, build `.sla` with \
+                 `make specs`): {}",
+                e.explain()
+            );
+            return None;
+        }
+    };
+    prog.commit_pending_analysis().expect("analysis commit");
+    Some(prog)
+}
+
+fn flow(spec: &str, func: Option<&str>, addr: u64, kind: &str) -> Directive {
+    Directive {
+        raw: spec.to_string(),
+        body: Body::Flow {
+            func: func.map(str::to_string),
+            addr,
+            kind: kind.to_string(),
+        },
+    }
+}
+
+/// Decompile the entries at `at` under `directives`, returning `(C of the first,
+/// its pipeline error, report)`.  Mirrors what the CLI's in-process `--json`
+/// surface does.
+fn run(at: &[u64], directives: Vec<Directive>) -> Option<(String, Option<String>, Vec<Outcome>)> {
+    let mut prog = load()?;
+    if !directives.is_empty() {
+        prog.set_assertions(directives);
+        assertions::apply_program_scoped(&mut prog);
+    }
+    let targets = at
+        .iter()
+        .map(|vma| {
+            prog.resolve_entry(&EntrySelector::Numeric(*vma))
+                .expect("the fixture has a function at this address")
+        })
+        .collect();
+    let funcs = decompile_targets(&mut prog, targets, false, false, false);
+    let code = funcs[0].code.clone().unwrap_or_default();
+    Some((code, funcs[0].error.clone(), prog.assertion_outcomes()))
+}
+
+/// The common case: a run that is expected to decompile cleanly.
+fn decompile_with(at: &[u64], directives: Vec<Directive>) -> Option<(String, Vec<Outcome>)> {
+    let (code, error, report) = run(at, directives)?;
+    assert_eq!(error, None, "the pipeline aborted:\n{code}");
+    Some((code, report))
+}
+
+/// Every outcome is `applied`; panics naming the offender otherwise.
+fn all_applied(report: &[Outcome]) {
+    for outcome in report {
+        assert_eq!(
+            outcome.status, "applied",
+            "{:?} was rejected: {:?}",
+            outcome.directive, outcome.detail
+        );
+    }
+}
+
+/// The un-asserted baseline every case below is measured against: flow follows
+/// the indirect call and the twenty-four that follow it, so the body carries
+/// `v25` and ends in a twenty-five-term sum.
+#[test]
+fn the_baseline_follows_the_indirect_call_into_twenty_five_temporaries() {
+    let Some((code, report)) = decompile_with(&[SUB_13C9], Vec::new()) else { return };
+    assert!(report.is_empty(), "no directives ⇒ no report rows");
+    assert!(code.contains("v25"), "baseline no longer reaches v25:\n{code}");
+    assert!(
+        !code.contains("return dat_4014;"),
+        "baseline already stops at the indirect call:\n{code}"
+    );
+}
+
+/// The need's own case: `flow <addr> return` collapses the body.
+#[test]
+fn declaring_the_indirect_call_a_return_cuts_the_body_to_one_statement() {
+    let Some((code, report)) =
+        decompile_with(&[SUB_13C9], vec![flow("flow 0x1405 return", None, INDIRECT_CALL, "return")])
+    else {
+        return;
+    };
+    all_applied(&report);
+    assert_eq!(report.len(), 1);
+    assert_eq!(report[0].kind, "flow");
+    assert_eq!((report[0].phase, report[0].subphase), ("P2", "flow-classification"));
+    assert!(code.contains("return dat_4014;"), "the override did not take:\n{code}");
+    assert!(!code.contains("v25"), "the body still runs past the override:\n{code}");
+}
+
+/// The other three spellings are the console's own vocabulary
+/// (`Override::string_to_type`), and each lands as a DIFFERENT flow type — the
+/// point being that the directive carries the type through, not merely that it
+/// is accepted.  Measured on this fixture: `branch` re-reads the indirect call
+/// as a computed jump and recovers its two-case table; `callreturn` prunes the
+/// fall-through, leaving the call and nothing after it.
+#[test]
+fn branch_and_callreturn_land_as_their_own_flow_types() {
+    let Some((branch, _)) =
+        decompile_with(&[SUB_13C9], vec![flow("flow 0x1405 branch", None, INDIRECT_CALL, "branch")])
+    else {
+        return;
+    };
+    assert!(branch.contains("switch"), "branch did not become a computed jump:\n{branch}");
+
+    let Some((callret, _)) = decompile_with(
+        &[SUB_13C9],
+        vec![flow("flow 0x1405 callreturn", None, INDIRECT_CALL, "callreturn")],
+    ) else {
+        return;
+    };
+    assert!(!callret.contains("v25"), "callreturn did not prune the fall-through:\n{callret}");
+    assert!(callret.contains("("), "callreturn dropped the call itself:\n{callret}");
+    assert_ne!(branch, callret, "two flow types produced the same C");
+}
+
+/// `call` at this site is the one the ENGINE refuses — an indirect call has no
+/// destination to make direct, so `Funcdata::overrideFlow` raises "Could not
+/// apply flowoverride".  That refusal is the evidence the directive reached the
+/// engine at all: the run reports a per-function error instead of quietly
+/// decompiling as if nothing had been asserted.
+#[test]
+fn a_flow_type_the_engine_cannot_apply_surfaces_as_a_pipeline_error() {
+    let Some((_code, error, report)) =
+        run(&[SUB_13C9], vec![flow("flow 0x1405 call", None, INDIRECT_CALL, "call")])
+    else {
+        return;
+    };
+    all_applied(&report);
+    assert!(
+        error.as_deref().unwrap_or_default().contains("flowoverride"),
+        "expected the engine's own refusal, got {error:?}"
+    );
+}
+
+/// A spelling outside the four-word vocabulary is REJECTED with a reason, not
+/// accepted and dropped.  (The CLI parser rejects it earlier still, at `--assert`
+/// parse time; this is the engine-side guard for every other caller.)
+#[test]
+fn an_unknown_flow_kind_is_rejected_with_a_reason() {
+    let Some((_code, report)) =
+        decompile_with(&[SUB_13C9], vec![flow("flow 0x1405 goto", None, INDIRECT_CALL, "goto")])
+    else {
+        return;
+    };
+    assert_eq!(report.len(), 1);
+    assert_eq!(report[0].status, "rejected");
+    assert!(
+        report[0].detail.as_deref().unwrap_or_default().contains("Bad override type"),
+        "detail: {:?}",
+        report[0].detail
+    );
+}
+
+/// An unqualified directive binds to "the function under decompile", which is
+/// only unambiguous when the run selected one.  On a multi-target run it is
+/// rejected rather than applied to whichever function happens to span the
+/// address — the plane's standing rule.
+#[test]
+fn an_unqualified_directive_is_rejected_on_a_multi_target_run() {
+    let Some((_code, report)) = decompile_with(
+        &[SUB_13C9, 0x1129],
+        vec![flow("flow 0x1405 return", None, INDIRECT_CALL, "return")],
+    ) else {
+        return;
+    };
+    assert_eq!(report.len(), 1);
+    assert_eq!(report[0].status, "rejected");
+    assert!(
+        report[0].detail.as_deref().unwrap_or_default().contains("<func>::<operand>"),
+        "detail: {:?}",
+        report[0].detail
+    );
+}
+
+/// ...and the qualified spelling is how a whole-binary run states the same fact.
+#[test]
+fn a_qualified_directive_binds_on_a_multi_target_run() {
+    let Some((code, report)) = decompile_with(
+        &[SUB_13C9, 0x1129],
+        vec![flow(
+            "flow sub_13c9::0x1405 return",
+            Some("sub_13c9"),
+            INDIRECT_CALL,
+            "return",
+        )],
+    ) else {
+        return;
+    };
+    all_applied(&report);
+    assert!(code.contains("return dat_4014;"), "the override did not take:\n{code}");
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -119,6 +119,7 @@ One directive per `--assert`, keyed by intent rather than by phase:
 | `typedef <C declaration>` | intern a `struct`/`union`/`enum`/`typedef` so `type` can name it |
 | `data <addr> <C typedeclaration>` | a named, typed global at an address |
 | `comment [<func>::]<addr> <text>` | a comment rendered into the C at that instruction |
+| `flow [<func>::]<addr> branch\|call\|callreturn\|return` | the flow out of this instruction is not what kuna decided |
 | `function <start>[-<end>][=<name>]` | the `--define-function` spelling, on this plane |
 | `readonly <addr>+<size>` | the bytes in this range never change at run time |
 | `volatile <addr>+<size>` | device memory: every access is a real access |
@@ -152,6 +153,28 @@ Asserting a `readonly` range turns read-only propagation on for the run, because
 painting a range read-only and then not folding it would be a directive that is
 accepted and does nothing. It is applied *before* your own `--option`s, so an
 explicit `--option readonly off` still wins.
+
+**`flow` is the structuring lever**, and the one directive that changes which
+bytes are even *in* the function. kuna decides at P2 whether an instruction
+branches, calls, calls-and-does-not-return, or returns; on an obfuscated or
+hand-written image it gets that wrong, and everything downstream inherits the
+mistake. Stating the right answer costs one line:
+
+```bash
+# `sub_13c9` reaches an indirect `call *%rdx` that never comes back, so flow
+# walks on into its twenty-four neighbours and the body is 25 dead temporaries.
+kuna decompile ./a.out --addr 0x13c9 --json --assert 'flow 0x1405 return'
+#   - v2 = (**(void **)(...))(dat_4014); v3 = sub_1129(v1); ... return v2 + v3 + ...;
+#   + return dat_4014;
+```
+
+The four words are the console's own (`Override::stringToType`): `branch` reads
+the instruction as a jump — which is what puts an indirect call back through
+switch-table recovery — `call` as a call, `callreturn` as a call whose
+fall-through is dead (the "does not return" case), and `return` as the end of the
+function. A type the engine cannot apply at that instruction (`call` on an
+indirect call has no destination to make direct) is not silently dropped: the
+run reports the engine's own refusal as a per-function error.
 
 **Every directive's fate is reported.** `--json` grows an `assertions` array — one
 row per directive, in the order you gave them, carrying the directive text, its
@@ -203,6 +226,7 @@ prototype sub_401200 int check_license(char *key,int len)
 name sub_401200::v3 keylen
 type sub_401200::v2 char[32]
 data 0x601048 char *expected_key
+flow sub_401200::0x40123f return   # the dispatch tail never comes back
 readonly 0x601050+16   # the key table, written only by the installer
 volatile 0x40021000+4  # RCC->CR
 EOF

--- a/docs/features/no-cli-structuring-override/pr_body.md
+++ b/docs/features/no-cli-structuring-override/pr_body.md
@@ -1,0 +1,115 @@
+## What was broken
+
+> `override flow <addr> branch|call|callreturn|return` is fully ported and works — it is the
+> one structuring override that is not a stub — and it is reachable only from the console. The
+> `kuna` binary's `--assert` plane carries eleven directives (`function`, `typedef`,
+> `prototype`, `data`, `param`, `return`, `comment`, `name`, `type`, `readonly`, `volatile`)
+> and `flow` is not among them, so an agent driving the CLI cannot correct a misclassified
+> call/branch/return at all.
+>
+> — `docs/re-needs/no-cli-structuring-override.md` (1 instance, severity major, track tooling)
+
+kuna decides at P2 whether an instruction branches, calls, calls-and-does-not-return, or
+returns. On an obfuscated or hand-written image it gets that wrong, and everything downstream
+inherits the mistake — the function absorbs its neighbours, the body fills with dead
+temporaries, the structurer gives up. The console has had the correction all along; the
+binary an agent actually drives did not.
+
+## Mechanism
+
+A twelfth directive: **`flow [<func>::]<addr> branch|call|callreturn|return`**, at P2
+flow-classification. No engine change — `kuna-decomp` is untouched by this PR.
+
+* `kuna-console/src/assertions.rs` gains `Body::Flow`, **function-scoped**: a flow fact is
+  consumed at flow time (the follower reads it while it is still deciding which bytes belong
+  to the function), so it has to be a decompile *seed*, not a post-hoc edit. `seed_one`
+  resolves the address in the default code space, maps the caller's word through
+  `Override::string_to_type`, and parks the pair in `FunctionSeed::flow_overrides`.
+* `kuna-console/src/project.rs` appends that vector to the flow overrides the decompile loop
+  already carries — the analysis's `call error(nonzero,…)` no-return prunes. Appended
+  **after** them on purpose: `insertFlowOverride` is a map store, so at an address both name
+  the caller's fact wins. What was declared outranks what was inferred, the same rule the rest
+  of the plane runs on.
+* `kuna-cli/src/assertdecl.rs` parses the directive and lowers it to the `Slot::Function`
+  console line `override flow <addr> <kind>`, which lands on the already-ported
+  `IfcFlowOverride`.
+
+**Both surfaces, because they are different code paths.** The hypothesis asked a builder to
+confirm the CLI re-seeds the override the way the console does. It does — but not by the
+console's route, and getting this wrong would have shipped a directive that works on
+`kuna decompile` and is inert on `kuna decompile --json`, which is the surface the acceptance
+probe uses. `--json` does not fork `decomp_dbg`; it loads in-process, where the console's
+`pending_flow_overrides` stash is never consulted. Hence the two seedings. Measured emitting
+byte-identical C on both, for all four spellings.
+
+## Measured, on the need's own in-repo fixture
+
+`aif_gap_x86_64` / `sub_13c9`: an indirect `call *%rdx` at `0x1405`, then twenty-four more
+calls. Baseline is 55 lines, `v1`…`v25`.
+
+| directive | emitted C |
+|---|---|
+| *(none)* | 55 lines, 25 `// eax` temporaries, a twenty-five-term sum |
+| `flow 0x1405 return` | `unsigned int sub_13c9(void) { return dat_4014; }` — 4 lines |
+| `flow 0x1405 branch` | re-read as a computed jump, **two-case table recovered**: `switch(dat_4014 & 1) { case 0: … case 1: … }` |
+| `flow 0x1405 callreturn` | fall-through pruned: the call alone, nothing after it |
+| `flow 0x1405 call` | the engine refuses — `Could not apply flowoverride` — reported as the function's error, exit 1 |
+
+Four words, four distinct outcomes: the type is carried through, not defaulted. `call` is the
+one the engine can refuse (an indirect call has no destination to make direct) and that
+refusal is *itself* the proof the directive reaches the engine — a directive that reached
+nothing would have decompiled the baseline and said nothing.
+
+Controls: no directive ⇒ byte-identical output and an empty `assertions[]`;
+`--assert 'flow 0x1405 goto'` exits 2 at parse time naming the four spellings; unqualified on
+`decompile-all` is rejected with `name it as <func>::<operand>`, and
+`flow sub_13c9::0x1405 return` binds and moves the C.
+
+## The acceptance probe that now passes
+
+`a-158ef4220dee` — the need's own, unchanged, all six clauses:
+
+```
+kuna decompile <fixture> --addr 0x13c9 --json --assert 'flow 0x1405 return' --assert-strict
+  exit 0 · stdout is JSON · assertions[0].kind == "flow" · assertions[0].status == "applied"
+  · code contains "return dat_4014;" · code does not contain "v25"
+```
+
+`verify --need no-cli-structuring-override`: **pass 1, fail 0, transition `closed`** (it failed
+on all six clauses at `9d5ab78a`). Promoted verbatim to
+`tests/cli/no-cli-structuring-override.json`; `make test-cli` is 25/25.
+
+## Also
+
+**`phases.toml` is byte-identical to `main`, and that is the one part of the brief this PR
+does not deliver.** The need's hypothesis left the `exposure` call to the builder. The call:
+P2 flow-classification's `command override flow; option noreturn` is now untrue, and should
+read `command override flow; kuna --assert 'flow <addr> branch|call|callreturn|return'; option
+noreturn`. That edit was made and measured — regenerates through `build.rs`, catalog stays
+green, no count moves — and then **reverted**, because `mergecheck` shape-C guards
+`phases.toml` as a keep-both table and rejects the disappearance of any line present on
+`origin/main`. It cannot tell an edited row from a sibling's `[[settable]]` row eaten by a
+merge, and that is the right default for that file. Defeating a merge guard for a prose line
+is not a trade worth making; the replacement text is recorded as residue, and the additive
+route (a new `[[surface]]` row, at the cost of renaming `surface_count_is_107`) is noted there
+too.
+
+Not closed, and deliberately: the three `engine_unavailable` structuring stubs this record was
+narrowed away from (`force goto`, `override jumptable`, `structure blocks`). Each is real
+engine work and the need's own decision log says to re-file them with a witnessed instance.
+
+## Gates
+
+| gate | result |
+|---|---|
+| `make test` | PARITY OK 675/675 |
+| `make test-stages` | PARITY OK |
+| `make rust-test` | green (7 new cases in `verify_assertflow.rs`, 1 new + 2 extended in `assertdecl`) |
+| `make check-spec` | OK |
+| `make test-cli` | 25/25 |
+| `kuna catalog --check` | catalog OK |
+
+No option row, no stages case, no catalog counters, no DIV row — a CLI surface cannot change
+emitted C on its own; this one changes it only when a caller states a fact.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/no-cli-structuring-override/record.json
+++ b/docs/features/no-cli-structuring-override/record.json
@@ -1,0 +1,71 @@
+{
+  "slug": "no-cli-structuring-override",
+  "need_id": "no-cli-structuring-override",
+  "track": "tooling",
+  "opportunity": "re-need:no-cli-structuring-override",
+  "probe_id": "p-a862d011f87f",
+  "acceptance_id": "a-158ef4220dee",
+  "instances": 1,
+  "scope": "small",
+  "proposal": false,
+  "covers_needs": [
+    "no-cli-structuring-override"
+  ],
+  "option": null,
+  "flag": null,
+  "element_id": null,
+  "phase": "P2",
+  "tier": "driver",
+  "change_kind": "capability-add",
+  "default_on": null,
+  "owning_file": "decompiler/crates/kuna-console/src/assertions.rs",
+  "spec_chapter": "docs/spec/00-overview.md",
+  "parity": "make test PARITY OK 675/675; make test-stages PARITY OK; make rust-test green; make check-spec OK; kuna catalog --check OK; make test-cli 25/25. phases.toml is byte-identical to origin/main (see the exposure decision). Structurally unaffected: both parity corpora are symbol-less bytechunks driven by XML with no CLI in the loop, and nothing here runs unless a --assert flow directive is passed -- FunctionSeed::flow_overrides is empty otherwise and the one unconditional line added to the decompile loop is a Vec::extend over that empty vec.",
+  "root_cause_class": "absent-capability",
+  "hypothesis_status": "UPHELD",
+  "filed_hypothesis": "ADVISORY. Exposure, not implementation: the engine path exists (IfcFlowOverride) and the CLI plane exists (--assert). What is missing is the arm in assertdecl.rs that spells `flow` and routes it.",
+  "decisions": [
+    "HYPOTHESIS UPHELD IN BOTH HALVES, confirmed by measurement before any code was written. Half one: `override flow 0x1405 return` in decomp_dbg on the fixture collapses sub_13c9 to `return dat_4014;` (55 emitted lines -> 4). Half two: `kuna decompile ... --assert 'flow 0x1405 return'` exits 2 with `unknown directive \"flow\"`, the parser rejecting it before the engine is reached. No engine work was needed and none was done -- kuna-decomp is untouched by this PR.",
+    "THE ROUTE THE HYPOTHESIS ASKED ABOUT IS NOT THE CONSOLE'S. It asked a builder to confirm the CLI's one-shot decompile re-seeds the override the way the console's `load function` -> `override flow` -> `decompile` sequence does. It does, but by a different path, and getting this wrong would have shipped a directive that works on one surface and is inert on the other -- which is the surface the acceptance probe uses. `kuna decompile --json` does NOT fork decomp_dbg; it is the IN-PROCESS load (decompile.rs::decompile_json -> decompile_all::load_program -> project::decompile_targets), so the console's `pending_flow_overrides` stash is never consulted there. The directive is therefore seeded twice over: as a Slot::Function console line (`override flow <addr> <kind>`) for the forked-script text surface, and into FunctionSeed::flow_overrides -> DecompileSeed::flow_overrides for the in-process one. Both surfaces measured emitting byte-identical C for all four spellings.",
+    "A CALLER-STATED FLOW FACT IS APPENDED AFTER THE DERIVED ONES, DELIBERATELY. project::decompile_targets already carries a flow_overrides vector: the analysis's `call error(nonzero,...)` no-return prunes. Override::insertFlowOverride is a map store, so at an address both name the LAST writer wins; the seeded directives are extended onto the end so what the caller declared outranks what analysis inferred. Same precedence rule the rest of the plane runs on (a declared prototype outranks discovery).",
+    "THE SUBPHASE `exposure` FIELD DOES NEED TO CHANGE -- AND IS NOT CHANGED HERE, which is the one part of the need's brief this PR does not deliver. The hypothesis left the call to the builder; the call is that P2 flow-classification's `command override flow; option noreturn` is now untrue (console-only) and should read `command override flow; kuna --assert 'flow <addr> branch|call|callreturn|return'; option noreturn`. The edit was made and measured: it regenerates cleanly through build.rs, `kuna catalog --check` stays green, and no count moves (it is an `exposure` string, not a [[surface]] or [[settable]] row). It was then REVERTED, because `scripts.repipe.mergecheck` shape-C treats phases.toml as a keep-both-guarded table and rejects any line present on origin/main that is gone -- it cannot tell an edited row from a sibling's row eaten by a merge, and that is the right default for a file whose duplicated [[settable]] row would survive every gate in the repo. Defeating a merge guard (or `--path`-excluding the file) for a prose line is not a trade worth making, and TOML has no way to modify the value while leaving the physical line. Left as residue with the exact replacement text. The alternative route, for whoever takes it, is a NEW [[surface]] row -- an addition, which shape-C permits -- at the cost of renaming the hard-coded `surface_count_is_107` test.",
+    "`call` IS THE ONE WORD OF THE FOUR THE ENGINE CAN REFUSE, and the record did not anticipate it. Forcing the indirect `call *%rdx` at 0x1405 to a direct `call` has no destination to make direct, so Funcdata::overrideFlow raises `Could not apply flowoverride`. That is NOT swallowed: the directive still reports `applied` (it did reach the engine), and the run reports the engine's own refusal as the function's error and exits non-zero. The refusal is itself the proof the type is carried through rather than defaulted -- a directive that reached nothing would have decompiled the baseline and said nothing.",
+    "THE FLOW WORD IS VALIDATED AT --assert PARSE TIME, unlike every type-bearing directive on the plane. The vocabulary is closed and four words wide, so `flow 0x1405 goto` is a usage error (exit 2, naming the four) rather than a rejected outcome three phases later. The engine-side guard is kept too -- assertions::seed_one re-checks through Override::string_to_type and rejects with a reason -- because kuna-console's assertions API has callers other than the CLI parser.",
+    "NO OPTION, NO STAGES TESTCASE, NO CATALOG COUNTERS, NO DIV ROW. The tooling track's rule: a CLI surface cannot change emitted C on its own, and this one changes it only when a caller states a fact. Same shape #389 and #391 shipped the other eleven directives under.",
+    "SHIPPED AS A DIRECTIVE, NOT A FLAG, so it is durable: `--assert @overrides.kuna` carries a flow fact across invocations exactly as it carries a rename, and the file is the artifact. An interface that survives only inside one process is barely an interface."
+  ],
+  "mechanism": "A twelfth directive on the `--assert` plane: `flow [<func>::]<addr> branch|call|callreturn|return`, at P2 flow-classification. kuna-console/src/assertions.rs gains Body::Flow, function-scoped (consumed at flow time, so it must be a decompile SEED rather than a post-hoc edit), and a FunctionSeed::flow_overrides vector that assertions::seed_one fills by resolving the address in the default code space and mapping the caller's word through Override::string_to_type. kuna-console/src/project.rs appends that vector to the derived flow overrides the decompile loop already passes to DecompileSeed, so the in-process surfaces (kuna decompile --json, decompile-all, decompile-project) reach FlowInfo::process's override consult. kuna-cli/src/assertdecl.rs parses the directive (bare or 0x hex address, optional <func>:: qualifier, the four-word vocabulary validated here) and lowers it to the Slot::Function console line `override flow <addr> <kind>` for the forked-script surface, which lands on the already-ported IfcFlowOverride. No engine change: kuna-decomp is untouched.",
+  "measurements": {
+    "method": "drove the built `kuna` binary and decompiler/target/release/decomp_dbg directly on the need's own in-repo fixture; every verdict is a diff of the printed C, never a return code. Both CLI surfaces measured separately: `kuna decompile` forks decomp_dbg through the generated script, `kuna decompile --json` loads in-process.",
+    "fixture": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64 (14408 bytes, in-repo): sub_13c9 reaches an indirect `call *%rdx` at 0x1405 and then twenty-four more calls",
+    "baseline": "55 emitted lines: 25 `// eax` temporaries v1..v25 and a twenty-five-term sum",
+    "flow_return": "4 lines -- `unsigned int sub_13c9(void) { return dat_4014; }` (identical on both surfaces)",
+    "flow_branch": "the indirect call is re-read as a computed jump and its two-case table recovered: `switch(dat_4014 & 1) { case 0: return (dat_4014 + 10) * 2; case 1: return (dat_4014 + 0x40) * 2 + 9; }`",
+    "flow_callreturn": "the fall-through is pruned: the indirect call alone, nothing after it",
+    "flow_call": "the engine refuses -- `Could not apply flowoverride` -- reported as the function's error, exit 1",
+    "control_no_directive": "byte-identical to the pre-change binary: FunctionSeed::flow_overrides is empty and the assertions[] array is empty",
+    "control_bad_word": "`--assert 'flow 0x1405 goto'` exits 2 at parse time naming the four spellings; `--assert 'flow zzz return'` exits 2 naming the hex requirement",
+    "control_multi_target": "unqualified on `decompile-all` is REJECTED with `name it as <func>::<operand>`; `flow sub_13c9::0x1405 return` binds and moves the C"
+  },
+  "stage": "shipped",
+  "speed": "zero on every existing invocation: no directive means no extra console line, no extra seed and an empty assertions[]. A flow directive adds one map insert per address before flow follows -- no pipeline pass, no extra decompile (it is function-scoped, so unlike the symbol-scoped `name`/`type` it never forces the second pass).",
+  "risks": [
+    "the flow type is a caller ASSERTION and kuna cannot check it: declaring a live call a `return` deletes real code from the emitted C. That is the point of the lever, and it is only reached by stating it; the run reports the directive in assertions[] so the fact is never invisible.",
+    "`call` at an instruction with no resolvable destination aborts the function's pipeline rather than degrading. Pre-existing engine behaviour (the console does the same), surfaced honestly as the function's error rather than hidden.",
+    "blast radius is nil: nothing runs unless a `flow` directive is passed, and the parity corpora are symbol-less bytechunks driven by XML with no CLI in the loop."
+  ],
+  "gates": {
+    "make test": "PARITY OK 675/675",
+    "make test-stages": "PARITY OK",
+    "make rust-test": "green",
+    "make check-spec": "OK",
+    "make test-cli": "25/25",
+    "kuna catalog --check": "catalog OK: documents exactly the registered kuna options",
+    "acceptance": "a-158ef4220dee PASS (verify --need no-cli-structuring-override: pass 1, transition closed); promoted verbatim to tests/cli/no-cli-structuring-override.json"
+  },
+  "residue": [
+    "phases.toml P2 flow-classification `exposure` still reads `command override flow; option noreturn`, which is now untrue: the directive shipped here is a second exposure. The replacement text, verified to regenerate and to move no count, is `command override flow; kuna --assert 'flow <addr> branch|call|callreturn|return'; option noreturn`. Blocked here only by mergecheck shape-C, which rejects the disappearance of any phases.toml line; it belongs in a captain-side commit or a [[surface]] row.",
+    "the three structuring overrides this need was NARROWED away from are still engine_unavailable stubs and are NOT closed here: Dispatch::ForceGoto and `force goto` (P8), Dispatch::MultistageJump and `override jumptable` (P2 switch-model), and `structure blocks`. Each needs real engine work, and the need's own decision log says to re-file them with a witnessed instance rather than carry them as unprovable clauses.",
+    "`flow` binds by function name, so on a run that decompiles many functions the address must be qualified `<func>::<addr>`. An address-only binding (`whichever function's flow visits this instruction`) would be the more natural spelling for an agent that does not yet know the function name, but it is ambiguous by construction on overlapping/merged flows and no measured case needed it."
+  ]
+}

--- a/docs/re-needs/no-cli-structuring-override.md
+++ b/docs/re-needs/no-cli-structuring-override.md
@@ -211,6 +211,39 @@ exist). `kind` is effectively `absence`, which is the case `REPIPE_REFUTE_MODE=a
   under `## Reference` and are NOT closed by this need; re-file them with a witnessed instance
   (round 2 produced none -- this record was seeded, never tester-filed) rather than carrying them
   as unprovable clauses here.
+- round 2 builder `b-r2-no-cli-structuri` (BUILT, acceptance PASSES): shipped as the twelfth
+  `--assert` directive, `flow [<func>::]<addr> branch|call|callreturn|return`, lowering to the
+  ported `IfcFlowOverride` on the script surface and seeded through
+  `FunctionSeed::flow_overrides` on the in-process one. Hypothesis UPHELD in both halves --
+  exposure, not implementation, and no engine work was needed. The two things the hypothesis
+  asked a builder to confirm, both confirmed by measurement rather than by reading:
+    * the CLI's one-shot decompile DOES re-seed the override the way the console's
+      `load function` -> `override flow` -> `decompile` sequence does, and by a different
+      route than the console's: `kuna decompile --json` is the IN-PROCESS load
+      (`decompile_json` -> `decompile_all::load_program`), not the forked script, so the
+      console's `pending_flow_overrides` stash is never consulted there. The directive is
+      seeded into the same `DecompileSeed::flow_overrides` slot the analysis's `call
+      error(nonzero,…)` no-return prunes already use, appended AFTER them so a caller-stated
+      fact wins the map insert at an address both name. Both surfaces then render the same C,
+      byte for byte, on this fixture.
+    * the subphase `exposure` field DOES need to stop saying console-only -- and this PR does
+      NOT change it, the one part of the brief it does not deliver. The replacement text was
+      written and measured (`command override flow; kuna --assert 'flow <addr>
+      branch|call|callreturn|return'; option noreturn`: regenerates through build.rs, catalog
+      stays green, no count moves), then reverted, because `mergecheck` shape-C guards
+      phases.toml as a keep-both table and rejects any line present on origin/main that is
+      gone -- it cannot tell an edited row from a sibling's row eaten by a merge. Defeating a
+      merge guard for a prose line is not a trade worth making, so the file ships
+      byte-identical to main and the text is recorded as residue. The lease this need reserved
+      for phases.toml was therefore not spent.
+  One thing the record did not anticipate: `call` is the one word of the four the ENGINE can
+  refuse. Forcing an indirect call to a direct `call` has no destination to make direct, so
+  `Funcdata::overrideFlow` raises `Could not apply flowoverride`; the run reports that as the
+  function's own error rather than decompiling as though nothing had been asserted, and that
+  refusal is itself the proof the directive reaches the engine. `branch` at the same address
+  is the interesting one for RE: it re-reads the indirect call as a computed jump and recovers
+  its two-case table.
+
 - round 2 wave 21 (captain): scope large -> small. Measured basis: the plane the need was waiting
   for shipped mid-round (#389 `--assert`, #391 the range directives), so the remaining work is one
   directive arm in `assertdecl.rs` routed to an already-ported engine command. `touches` KEEPS

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -725,6 +725,7 @@ to know that renaming is P9 to rename something — parsed by
 | `param [<func>::]<i> <storage> <C typedeclaration>` | `map param` | P4 prototype-source |
 | `return [<func>::]<storage> <C typedeclaration>` | `map return` | P4 prototype-source |
 | `comment [<func>::]<addr> <text>` | `comment instruction` | P9 external-refinement |
+| `flow [<func>::]<addr> branch\|call\|callreturn\|return` | `override flow` | P2 flow-classification |
 | `name [<func>::]<symbol> <newname>` | `rename` | P9 naming-policy |
 | `type [<func>::]<symbol> <C type>` | `retype` | P5 type-propagation |
 | `readonly <addr>+<size>` | `readonly` | P1 code-data-partition |
@@ -745,9 +746,9 @@ render the same C. **Program-scoped** directives (`function`, `typedef`, `protot
 (`ConsoleProgram::set_assertions` + `assertions::apply_program_scoped`, called
 from `decompiler/crates/kuna-cli/src/decompile_all.rs (load_program)`), for the
 same reason a declared boundary is: an assertion outranks discovery.
-**Function-scoped** directives (`param`, `return`, `comment`) become decompile
-SEEDS (`assertions::function_seed`), because a prototype fact is consumed at flow
-time and cannot be applied afterwards. **Symbol-scoped** directives (`name`,
+**Function-scoped** directives (`param`, `return`, `comment`, `flow`) become
+decompile SEEDS (`assertions::function_seed`), because a prototype fact is
+consumed at flow time and cannot be applied afterwards. **Symbol-scoped** directives (`name`,
 `type`) can only be applied to an already-decompiled function — the local they
 name does not exist until a decompile has produced it — so
 `decompiler/crates/kuna-console/src/project.rs (decompile_targets)` decompiles,
@@ -772,6 +773,27 @@ rejection is reported and the run continues, so a batch of forty renames against
 re-decompiled binary does not lose the other thirty-nine to one stale name.
 Durability is caller-carried, as it is for boundaries: `--assert @FILE` is the
 artifact.
+
+A `flow` directive is the sharpest of the four function-scoped ones, and the only
+one that changes which bytes are in the function at all. P2 classifies the flow
+out of each instruction — branch, call, call-that-does-not-return, return — and
+`FlowInfo::process` consults the per-function `Override` store
+(`has_flow_override`/`get_flow_override`, then `Funcdata::overrideFlow`) before it
+decides. The directive seeds that store: `assertions::seed_one` resolves the
+address in the default code space, maps the caller's word through
+`Override::string_to_type` (rejecting anything outside `branch`, `call`,
+`callreturn`, `return` with a reason rather than dropping it), and parks the pair
+in `FunctionSeed::flow_overrides`, which
+`decompiler/crates/kuna-console/src/project.rs (decompile_targets)` appends to the
+derived overrides it already carries — the analysis's `call error(nonzero,…)`
+no-return prunes — so a caller-stated fact wins the map insert at an address both
+name. The script surface reaches the same store through the ported console
+command (`kuna-console/src/ifacedecomp.rs (IfcFlowOverride)`), whose facts the
+console re-seeds on every IR rebuild; the two surfaces render the same C. Because
+the override is read at flow time, a type the engine cannot honour at that
+instruction — `call` at an indirect call, which has no destination to make direct —
+raises `Could not apply flowoverride` and the run reports that as the function's
+error, rather than decompiling as though nothing had been asserted.
 
 A `readonly` range is the one directive whose effect depends on a second switch:
 folding a read-only load into the value behind it is

--- a/tests/cli/no-cli-structuring-override.json
+++ b/tests/cli/no-cli-structuring-override.json
@@ -1,0 +1,61 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "--addr",
+    "0x13c9",
+    "--json",
+    "--assert",
+    "flow 0x1405 return",
+    "--assert-strict"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "binary_sha256": "1a592a85f424cc2db8953d5a38c86676bcee5e37b242b6fb6244a2c9fccfeeef",
+    "binary_size": 14408,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "selector": "0x13c9",
+    "selector_kind": "addr"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "assertions[0].kind",
+        "op": "eq",
+        "value": "flow"
+      },
+      {
+        "path": "assertions[0].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "contains",
+        "value": "return dat_4014;"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "not_contains",
+        "value": "v25"
+      }
+    ]
+  },
+  "notes": "Desired: `--assert 'flow <addr> branch|call|callreturn|return'` reaches the ported IfcFlowOverride path and is reported in the assertions fate array. The output clause is MEASURED: `override flow 0x1405 return` in decomp_dbg today collapses the 65-line sub_13c9 body (v1..v25, 682-byte extent) to `return dat_4014;`. In-repo fixture, promotes verbatim.",
+  "probe_id": "a-158ef4220dee"
+}


### PR DESCRIPTION
## What was broken

> `override flow <addr> branch|call|callreturn|return` is fully ported and works — it is the
> one structuring override that is not a stub — and it is reachable only from the console. The
> `kuna` binary's `--assert` plane carries eleven directives (`function`, `typedef`,
> `prototype`, `data`, `param`, `return`, `comment`, `name`, `type`, `readonly`, `volatile`)
> and `flow` is not among them, so an agent driving the CLI cannot correct a misclassified
> call/branch/return at all.
>
> — `docs/re-needs/no-cli-structuring-override.md` (1 instance, severity major, track tooling)

kuna decides at P2 whether an instruction branches, calls, calls-and-does-not-return, or
returns. On an obfuscated or hand-written image it gets that wrong, and everything downstream
inherits the mistake — the function absorbs its neighbours, the body fills with dead
temporaries, the structurer gives up. The console has had the correction all along; the
binary an agent actually drives did not.

## Mechanism

A twelfth directive: **`flow [<func>::]<addr> branch|call|callreturn|return`**, at P2
flow-classification. No engine change — `kuna-decomp` is untouched by this PR.

* `kuna-console/src/assertions.rs` gains `Body::Flow`, **function-scoped**: a flow fact is
  consumed at flow time (the follower reads it while it is still deciding which bytes belong
  to the function), so it has to be a decompile *seed*, not a post-hoc edit. `seed_one`
  resolves the address in the default code space, maps the caller's word through
  `Override::string_to_type`, and parks the pair in `FunctionSeed::flow_overrides`.
* `kuna-console/src/project.rs` appends that vector to the flow overrides the decompile loop
  already carries — the analysis's `call error(nonzero,…)` no-return prunes. Appended
  **after** them on purpose: `insertFlowOverride` is a map store, so at an address both name
  the caller's fact wins. What was declared outranks what was inferred, the same rule the rest
  of the plane runs on.
* `kuna-cli/src/assertdecl.rs` parses the directive and lowers it to the `Slot::Function`
  console line `override flow <addr> <kind>`, which lands on the already-ported
  `IfcFlowOverride`.

**Both surfaces, because they are different code paths.** The hypothesis asked a builder to
confirm the CLI re-seeds the override the way the console does. It does — but not by the
console's route, and getting this wrong would have shipped a directive that works on
`kuna decompile` and is inert on `kuna decompile --json`, which is the surface the acceptance
probe uses. `--json` does not fork `decomp_dbg`; it loads in-process, where the console's
`pending_flow_overrides` stash is never consulted. Hence the two seedings. Measured emitting
byte-identical C on both, for all four spellings.

## Measured, on the need's own in-repo fixture

`aif_gap_x86_64` / `sub_13c9`: an indirect `call *%rdx` at `0x1405`, then twenty-four more
calls. Baseline is 55 lines, `v1`…`v25`.

| directive | emitted C |
|---|---|
| *(none)* | 55 lines, 25 `// eax` temporaries, a twenty-five-term sum |
| `flow 0x1405 return` | `unsigned int sub_13c9(void) { return dat_4014; }` — 4 lines |
| `flow 0x1405 branch` | re-read as a computed jump, **two-case table recovered**: `switch(dat_4014 & 1) { case 0: … case 1: … }` |
| `flow 0x1405 callreturn` | fall-through pruned: the call alone, nothing after it |
| `flow 0x1405 call` | the engine refuses — `Could not apply flowoverride` — reported as the function's error, exit 1 |

Four words, four distinct outcomes: the type is carried through, not defaulted. `call` is the
one the engine can refuse (an indirect call has no destination to make direct) and that
refusal is *itself* the proof the directive reaches the engine — a directive that reached
nothing would have decompiled the baseline and said nothing.

Controls: no directive ⇒ byte-identical output and an empty `assertions[]`;
`--assert 'flow 0x1405 goto'` exits 2 at parse time naming the four spellings; unqualified on
`decompile-all` is rejected with `name it as <func>::<operand>`, and
`flow sub_13c9::0x1405 return` binds and moves the C.

## The acceptance probe that now passes

`a-158ef4220dee` — the need's own, unchanged, all six clauses:

```
kuna decompile <fixture> --addr 0x13c9 --json --assert 'flow 0x1405 return' --assert-strict
  exit 0 · stdout is JSON · assertions[0].kind == "flow" · assertions[0].status == "applied"
  · code contains "return dat_4014;" · code does not contain "v25"
```

`verify --need no-cli-structuring-override`: **pass 1, fail 0, transition `closed`** (it failed
on all six clauses at `9d5ab78a`). Promoted verbatim to
`tests/cli/no-cli-structuring-override.json`; `make test-cli` is 25/25.

## Also

**`phases.toml` is byte-identical to `main`, and that is the one part of the brief this PR
does not deliver.** The need's hypothesis left the `exposure` call to the builder. The call:
P2 flow-classification's `command override flow; option noreturn` is now untrue, and should
read `command override flow; kuna --assert 'flow <addr> branch|call|callreturn|return'; option
noreturn`. That edit was made and measured — regenerates through `build.rs`, catalog stays
green, no count moves — and then **reverted**, because `mergecheck` shape-C guards
`phases.toml` as a keep-both table and rejects the disappearance of any line present on
`origin/main`. It cannot tell an edited row from a sibling's `[[settable]]` row eaten by a
merge, and that is the right default for that file. Defeating a merge guard for a prose line
is not a trade worth making; the replacement text is recorded as residue, and the additive
route (a new `[[surface]]` row, at the cost of renaming `surface_count_is_107`) is noted there
too.

Not closed, and deliberately: the three `engine_unavailable` structuring stubs this record was
narrowed away from (`force goto`, `override jumptable`, `structure blocks`). Each is real
engine work and the need's own decision log says to re-file them with a witnessed instance.

## Gates

| gate | result |
|---|---|
| `make test` | PARITY OK 675/675 |
| `make test-stages` | PARITY OK |
| `make rust-test` | green (7 new cases in `verify_assertflow.rs`, 1 new + 2 extended in `assertdecl`) |
| `make check-spec` | OK |
| `make test-cli` | 25/25 |
| `kuna catalog --check` | catalog OK |

No option row, no stages case, no catalog counters, no DIV row — a CLI surface cannot change
emitted C on its own; this one changes it only when a caller states a fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
