### PR TITLE
[AUTOMATED] fix(ghidra): stop speculative x86 register probes from throwing in the host

### DIFF
--- a/decompiler/crates/kuna-base/src/space.rs
+++ b/decompiler/crates/kuna-base/src/space.rs
@@ -1666,7 +1666,11 @@ impl AddrSpace {
     /// behavior for an *unknown* register — and only the catch branch
     /// (absolute offset parsing) is live.  The C++ try/catch is a
     /// *speculative* question ("is this token a register name?"), so it goes
-    /// through [`RegisterLookup::probe_register`].
+    /// through [`RegisterLookup::probe_register`].  That probe collapses every
+    /// failure to `None`, where the exact lookup used to re-raise a
+    /// non-`LowlevelError`: no lookup in the tree returns one, and the only
+    /// caller is the console's address parser, where a swallowed one resurfaces
+    /// as a hex-parse rejection of the same token.
     pub fn read(&self, s: &str, size: &mut i32, manage: &AddrSpaceManager) -> KunaResult<u64> {
         // JoinSpace::read: parse a comma-separated sequence of register
         // names / shortcut-prefixed offsets into a join record.

--- a/decompiler/crates/kuna-base/src/space.rs
+++ b/decompiler/crates/kuna-base/src/space.rs
@@ -297,6 +297,20 @@ pub trait RegisterLookup {
     /// if the register does not exist.
     fn get_register(&self, nm: &str) -> KunaResult<VarnodeStorage>;
 
+    /// Speculative form of [`RegisterLookup::get_register`]: ask whether `nm`
+    /// resolves *here*, cheaply and without side effects.
+    ///
+    /// `None` means "not resolvable on this lookup", never "this language has
+    /// no such register".  A back end that answers register questions by
+    /// asking a host — the Ghidra front end, whose exact lookup is a
+    /// `getRegister` query the host answers by throwing on an undefined name —
+    /// overrides this to consult only what it already knows.  Code that is
+    /// merely testing "does this language happen to have X?" must use this
+    /// rather than the exact lookup.
+    fn probe_register(&self, nm: &str) -> Option<VarnodeStorage> {
+        self.get_register(nm).ok()
+    }
+
     /// C++ `Translate::getRegisterName`: get the name of the smallest
     /// containing register given a location and size, or an empty string.
     fn get_register_name(&self, base: &Rc<AddrSpace>, off: u64, size: i32) -> String;
@@ -1650,7 +1664,9 @@ impl AddrSpace {
     /// manager's installed [`RegisterLookup`].  With none installed,
     /// `getRegister` behaves as always-throwing — identical to the C++
     /// behavior for an *unknown* register — and only the catch branch
-    /// (absolute offset parsing) is live.
+    /// (absolute offset parsing) is live.  The C++ try/catch is a
+    /// *speculative* question ("is this token a register name?"), so it goes
+    /// through [`RegisterLookup::probe_register`].
     pub fn read(&self, s: &str, size: &mut i32, manage: &AddrSpaceManager) -> KunaResult<u64> {
         // JoinSpace::read: parse a comma-separated sequence of register
         // names / shortcut-prefixed offsets into a join record.
@@ -1668,18 +1684,9 @@ impl AddrSpace {
                 i += 1; // Skip the comma
                 // try { getRegister(token) } catch(LowlevelError): name
                 // doesn't exist (no installed lookup == always throwing)
-                let mut piece: Option<VarnodeStorage> = None;
-                if let Some(lookup) = manage.register_lookup() {
-                    let lookup = Rc::clone(lookup);
-                    match lookup.get_register(&String::from_utf8_lossy(&token)) {
-                        Ok(point) => piece = Some(point),
-                        Err(err) => {
-                            if !err.is_lowlevel() {
-                                return Err(err); // C++ only catches LowlevelError
-                            }
-                        }
-                    }
-                }
+                let piece: Option<VarnodeStorage> = manage
+                    .register_lookup()
+                    .and_then(|lookup| lookup.probe_register(&String::from_utf8_lossy(&token)));
                 let piece = match piece {
                     Some(piece) => piece,
                     None => {
@@ -1715,22 +1722,13 @@ impl AddrSpace {
         let bytes = s.as_bytes();
         let append = bytes.iter().position(|&c| c == b':' || c == b'+');
         // try { getRegister } catch(LowlevelError) { absolute offset }
-        let mut point: Option<VarnodeStorage> = None;
-        if let Some(lookup) = manage.register_lookup() {
-            let lookup = Rc::clone(lookup);
+        let point: Option<VarnodeStorage> = manage.register_lookup().and_then(|lookup| {
             let name = match append {
                 None => s,
                 Some(append) => &s[..append],
             };
-            match lookup.get_register(name) {
-                Ok(p) => point = Some(p),
-                Err(err) => {
-                    if !err.is_lowlevel() {
-                        return Err(err); // C++ only catches LowlevelError
-                    }
-                }
-            }
-        }
+            lookup.probe_register(name)
+        });
         let mut offset: u64;
         match point {
             Some(point) => {

--- a/decompiler/crates/kuna-decomp/src/infra/architecture.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/architecture.rs
@@ -3742,15 +3742,22 @@ impl Architecture {
     /// Guarded to x86-32 because the body names `ST0..ST7`/`EAX`/`EDX`/`ESP`: on
     /// a language without them the SLEIGH snippet compile would fail at
     /// bootstrap, and `_ftol` exists on no other target.
+    ///
+    /// Skipped entirely in ghidra mode, exactly as `register_cortexmpriv_fixup`
+    /// is: with no local `.sla`, step 3 never compiles the payload, so the
+    /// registration could not pay off there anyway.
     fn decode_kuna_call_fixups(&mut self) -> KunaResult<()> {
         use kuna_base::marshal::{IdRegistry, XmlDecode};
 
+        if self.translate.as_sleigh().is_none() {
+            return Ok(());
+        }
         let code_addr_size = self
             .manage()
             .get_default_code_space()
             .map(|s| s.get_addr_size() as int4)
             .unwrap_or(0);
-        let resolve = |nm: &[u8]| self.translate.get_register_varnode(nm).is_ok();
+        let resolve = |nm: &[u8]| self.translate.probe_register_varnode(nm).is_some();
         if !crate::kuna_msvcftol::language_is_x86_32(resolve, code_addr_size) {
             return Ok(());
         }
@@ -4978,7 +4985,7 @@ impl Architecture {
         // `(uint8)v18 * -2 + 1`. Applied only where the spec is silent, and a
         // structural no-op on any language with no `DF` register.
         crate::kuna_dfunaffected::assert_direction_flag_unaffected(&mut model, |nm| {
-            self.translate.get_register_varnode(nm)
+            self.translate.probe_register_varnode(nm)
         })?;
         Ok(model)
     }

--- a/decompiler/crates/kuna-decomp/src/infra/architecture.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/architecture.rs
@@ -4986,7 +4986,7 @@ impl Architecture {
         // structural no-op on any language with no `DF` register.
         crate::kuna_dfunaffected::assert_direction_flag_unaffected(&mut model, |nm| {
             self.translate.probe_register_varnode(nm)
-        })?;
+        });
         Ok(model)
     }
 

--- a/decompiler/crates/kuna-decomp/src/infra/engine_translate.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/engine_translate.rs
@@ -69,6 +69,19 @@ pub trait EngineTranslate: Translate {
     /// `Translate::getRegister(name)`).
     fn get_register_varnode(&self, nm: &[u8]) -> KunaResult<VarnodeData>;
 
+    /// Speculative form of [`EngineTranslate::get_register_varnode`]: ask
+    /// whether `nm` resolves *here*, cheaply and without side effects.
+    ///
+    /// `None` means "not resolvable on this translator", never "this language
+    /// has no such register".  In ghidra mode the exact lookup is a
+    /// `getRegister` query and the host answers an undefined name by throwing,
+    /// so a pass merely testing "does this language happen to have X?" must
+    /// use this instead — the ghidra translator answers it from its cache and
+    /// issues no query.
+    fn probe_register_varnode(&self, nm: &[u8]) -> Option<VarnodeData> {
+        self.get_register_varnode(nm).ok()
+    }
+
     /// Run a closure with mutable access to the engine's [`ContextDatabase`]
     /// (C++ `glb->context`).  The object-safe form of
     /// [`Sleigh::with_context_db_mut`]: it takes `&mut dyn FnMut` (rather than

--- a/decompiler/crates/kuna-decomp/src/p2_lift/kuna_linuxsyscall.rs
+++ b/decompiler/crates/kuna-decomp/src/p2_lift/kuna_linuxsyscall.rs
@@ -496,6 +496,12 @@ pub struct SyscallAbi {
 /// space must be 4 bytes wide.  x86-64 resolves `EAX`..`EBP` as sub-registers,
 /// so the address-size test is what excludes it — there `int 0x80` is a
 /// compatibility path, not the syscall ABI this models.
+///
+/// The lookup is the speculative probe, so in ghidra mode it sees only names
+/// the register cache already holds; these seven are there because every
+/// `<prototype>` in `x86gcc.cspec`/`x86win.cspec` is decoded during
+/// registerProgram, before the first function is lifted (pinned by
+/// `kuna-ghidra/tests/register_probe_e2e.rs`).
 pub fn resolve_abi(data: &Funcdata) -> Option<SyscallAbi> {
     let manage = data.get_arch().manage();
     if manage.get_default_code_space()?.get_addr_size() != 4 {

--- a/decompiler/crates/kuna-decomp/src/p2_lift/kuna_linuxsyscall.rs
+++ b/decompiler/crates/kuna-decomp/src/p2_lift/kuna_linuxsyscall.rs
@@ -503,7 +503,7 @@ pub fn resolve_abi(data: &Funcdata) -> Option<SyscallAbi> {
     }
     let lookup = manage.register_lookup()?;
     let reg = |nm: &str| -> Option<Address> {
-        let st = lookup.get_register(nm).ok()?;
+        let st = lookup.probe_register(nm)?;
         if st.size != 4 {
             return None;
         }

--- a/decompiler/crates/kuna-decomp/src/p4_calls/kuna_dfunaffected.rs
+++ b/decompiler/crates/kuna-decomp/src/p4_calls/kuna_dfunaffected.rs
@@ -54,14 +54,15 @@ const DIRECTION_FLAG: &[u8] = b"DF";
 /// Add the direction flag to `model`'s unaffected list when the language defines
 /// one and the compiler spec did not mention it.
 ///
-/// `lookup` resolves a SLEIGH register name to its storage; it fails on a
-/// language that has no such register, which is how every non-x86 target falls
-/// out.
+/// `lookup` is a *speculative* register probe, not the exact lookup: it yields
+/// `None` on a language that has no such register, which is how every non-x86
+/// target falls out. The exact lookup must not be used here — in ghidra mode it
+/// is a host query that throws on an undefined name (GH-388).
 pub fn assert_direction_flag_unaffected<F>(model: &mut ProtoModel, lookup: F) -> KunaResult<()>
 where
-    F: FnOnce(&[u8]) -> KunaResult<kuna_num::pcoderaw::VarnodeData>,
+    F: FnOnce(&[u8]) -> Option<kuna_num::pcoderaw::VarnodeData>,
 {
-    let Ok(df) = lookup(DIRECTION_FLAG) else {
+    let Some(df) = lookup(DIRECTION_FLAG) else {
         return Ok(()); // not an x86 language
     };
     let Some(space) = df.space.clone() else { return Ok(()) };

--- a/decompiler/crates/kuna-decomp/src/p4_calls/kuna_dfunaffected.rs
+++ b/decompiler/crates/kuna-decomp/src/p4_calls/kuna_dfunaffected.rs
@@ -44,8 +44,6 @@
 //! alone, and a language with no `DF` register at all (every non-x86 target) is a
 //! structural no-op.
 
-use kuna_base::error::KunaResult;
-
 use crate::fspec::{effect_type, EffectRecord, ProtoModel};
 
 /// The SLEIGH register name for the x86 direction flag.
@@ -58,19 +56,18 @@ const DIRECTION_FLAG: &[u8] = b"DF";
 /// `None` on a language that has no such register, which is how every non-x86
 /// target falls out. The exact lookup must not be used here — in ghidra mode it
 /// is a host query that throws on an undefined name (GH-388).
-pub fn assert_direction_flag_unaffected<F>(model: &mut ProtoModel, lookup: F) -> KunaResult<()>
+pub fn assert_direction_flag_unaffected<F>(model: &mut ProtoModel, lookup: F)
 where
     F: FnOnce(&[u8]) -> Option<kuna_num::pcoderaw::VarnodeData>,
 {
     let Some(df) = lookup(DIRECTION_FLAG) else {
-        return Ok(()); // not an x86 language
+        return; // not an x86 language
     };
-    let Some(space) = df.space.clone() else { return Ok(()) };
+    let Some(space) = df.space.clone() else { return };
     let addr = kuna_base::address::Address::new(space, df.offset);
     // The spec already said something about this register: respect it.
     if model.has_effect(&addr, df.size as kuna_base::types::int4) != effect_type::UNKNOWN_EFFECT {
-        return Ok(());
+        return;
     }
     model.push_effect(EffectRecord::from_varnode(df, effect_type::UNAFFECTED));
-    Ok(())
 }

--- a/decompiler/crates/kuna-ghidra/src/translate.rs
+++ b/decompiler/crates/kuna-ghidra/src/translate.rs
@@ -294,6 +294,13 @@ impl<R: Read, W: Write> RegisterLookup for GhidraRegisterLookup<R, W> {
         Ok(vndata)
     }
 
+    /// Cache-only [`RegisterLookup::probe_register`]: a speculative name test
+    /// must not become a `getRegister` query, because the Java host answers an
+    /// undefined name by throwing `No Register Defined` (GH-388).
+    fn probe_register(&self, nm: &str) -> Option<VarnodeStorage> {
+        self.nm2addr.borrow().get(nm).cloned()
+    }
+
     /// C++ `GhidraTranslate::getRegisterName` (ghidra_translate.cc:72-87).
     #[allow(clippy::mutable_key_type)] // see cache_register
     fn get_register_name(&self, base: &Rc<AddrSpace>, off: u64, size: i32) -> String {
@@ -427,6 +434,11 @@ impl<R: Read, W: Write> RegisterLookup for GhidraTranslate<R, W> {
     fn get_register(&self, nm: &str) -> KunaResult<VarnodeStorage> {
         self.ensure_lookup_wired();
         self.reglookup.get_register(nm)
+    }
+
+    /// Cache-only [`RegisterLookup::probe_register`] — delegated.
+    fn probe_register(&self, nm: &str) -> Option<VarnodeStorage> {
+        self.reglookup.probe_register(nm)
     }
 
     /// C++ `GhidraTranslate::getRegisterName` — delegated.
@@ -594,6 +606,12 @@ impl<R: Read, W: Write> EngineTranslate for GhidraTranslate<R, W> {
         let name = String::from_utf8_lossy(nm);
         let vndata = RegisterLookup::get_register(self, &name)?;
         Ok(varnode_data_from_storage(&vndata))
+    }
+    /// Speculative [`EngineTranslate::probe_register_varnode`], answered from
+    /// the register cache alone — see [`RegisterLookup::probe_register`].
+    fn probe_register_varnode(&self, nm: &[u8]) -> Option<VarnodeData> {
+        let name = String::from_utf8_lossy(nm);
+        RegisterLookup::probe_register(self, &name).map(|v| varnode_data_from_storage(&v))
     }
     /// Run a closure with mutable access to the context database (C++
     /// `glb->context`).  STEP-2 STUB: the [`ContextInternal`] field (see the

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim/mod.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim/mod.rs
@@ -414,6 +414,20 @@ pub fn resp_empty() -> Vec<u8> {
     r
 }
 
+/// An exception frame instead of a query response: {10}"type"{14..15}"msg"{11}
+/// — what `DecompileProcess.readResponse` writes when the callback THREW
+/// (DecompileProcess.java:384-392), before logging `Unexpected Exception: …`.
+/// `getRegister` on a name the language does not define is the throwing case
+/// (`DecompileCallback.getRegister` → `No Register Defined: <name>`).
+pub fn resp_exception(extype: &str, msg: &str) -> Vec<u8> {
+    let mut r = Vec::new();
+    burst(&mut r, 10);
+    wire_string(&mut r, extype.as_bytes());
+    wire_string(&mut r, msg.as_bytes());
+    burst(&mut r, 11);
+    r
+}
+
 /// A byte-burst query response: {8}{12} raw {13}{9} (getBytes / getStringData;
 /// the payload is already nibble-doubled / header-prefixed by the caller).
 pub fn resp_bytes(raw: &[u8]) -> Vec<u8> {

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim/oracle.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim/oracle.rs
@@ -72,7 +72,9 @@ use kuna_ghidra::ids::{
 use kuna_ghidra::protocol::{nibble_expand, string_data_size_header};
 use kuna_sleigh::globalcontext::ELEM_TRACKED_POINTSET;
 
-use super::{resp_bytes, resp_empty, resp_string, AnswerSource, QUERY_COMMAND_IDS};
+use super::{
+    resp_bytes, resp_empty, resp_exception, resp_string, AnswerSource, QUERY_COMMAND_IDS,
+};
 
 /// `<inst>` — the getPcode response root (ELEM_INST, kuna-decomp
 /// pcodeinject.rs; the numeric id is the wire contract).
@@ -112,6 +114,12 @@ pub struct QueryLog {
     pub pcode_addrs: Vec<u64>,
     /// Distinct addresses the sim decoded successfully.
     pub decoded_insts: BTreeSet<u64>,
+    /// Every getRegister name asked for, in wire order (repeats included).
+    pub register_probes: Vec<String>,
+    /// The subset of [`QueryLog::register_probes`] the language does not
+    /// define — each one is a thrown `No Register Defined` in real Ghidra and
+    /// an `Unexpected Exception` ERROR record in its log.
+    pub register_probe_failures: Vec<String>,
 }
 
 /// The real-ELF mock-Java answer source (see the module docs).
@@ -847,6 +855,7 @@ impl AnswerSource for SimOracle {
                     .expect("oracle engine is a Sleigh");
                 RegisterLookup::get_register(sleigh, &name)
             };
+            self.log.register_probes.push(name.clone());
             match lookup {
                 Ok(v) => {
                     let spc = v.space.expect("register storage has a space");
@@ -859,7 +868,16 @@ impl AnswerSource for SimOracle {
                     }
                     resp_string(&doc)
                 }
-                Err(_) => resp_empty(),
+                // Java THROWS on an undefined name rather than answering an
+                // empty response (DecompileCallback.java:756-762), and the
+                // sim answering leniently is what hid GH-388.
+                Err(_) => {
+                    self.log.register_probe_failures.push(name.clone());
+                    resp_exception(
+                        "java.lang.RuntimeException",
+                        &format!("No Register Defined: {name}"),
+                    )
+                }
             }
         } else if el == ELEM_COMMAND_GETREGISTERNAME.get_id() {
             let (addr, size) =

--- a/decompiler/crates/kuna-ghidra/tests/ghidra_sim/oracle.rs
+++ b/decompiler/crates/kuna-ghidra/tests/ghidra_sim/oracle.rs
@@ -72,9 +72,7 @@ use kuna_ghidra::ids::{
 use kuna_ghidra::protocol::{nibble_expand, string_data_size_header};
 use kuna_sleigh::globalcontext::ELEM_TRACKED_POINTSET;
 
-use super::{
-    resp_bytes, resp_empty, resp_exception, resp_string, AnswerSource, QUERY_COMMAND_IDS,
-};
+use super::{resp_bytes, resp_empty, resp_exception, resp_string, AnswerSource, QUERY_COMMAND_IDS};
 
 /// `<inst>` — the getPcode response root (ELEM_INST, kuna-decomp
 /// pcodeinject.rs; the numeric id is the wire contract).

--- a/decompiler/crates/kuna-ghidra/tests/register_probe_e2e.rs
+++ b/decompiler/crates/kuna-ghidra/tests/register_probe_e2e.rs
@@ -1,0 +1,168 @@
+//! GH-388: ghidra mode must not ask the Java host for registers the language
+//! does not define.
+//!
+//! A by-name register lookup in ghidra mode is a `getRegister` query, and the
+//! host answers an undefined name by THROWING (`DecompileCallback.java:756-762`
+//! → `No Register Defined: <name>`), which `DecompileProcess.readResponse`
+//! turns into an exception frame plus an `Unexpected Exception: …` ERROR
+//! record in Ghidra's log.  So a pass merely testing "does this language happen
+//! to have X?" has to go through the probe seam, which answers from the
+//! register cache and issues no query.
+//!
+//! The sim oracle answers an undefined name the same way Java does (an
+//! exception frame) and records every probed / failed name, so the ARM drive
+//! below sees exactly what the GUI user's log would.
+
+mod ghidra_sim;
+
+use std::cell::RefCell;
+use std::path::Path;
+use std::rc::Rc;
+
+use kuna_base::marshal::PackedEncode;
+use kuna_ghidra::process::GhidraProcess;
+
+use ghidra_sim::oracle::{generate_tspec, repo_root, SimOracle};
+use ghidra_sim::{
+    cmd_decompile_at, cmd_deregister_program, cmd_flush_native, cmd_register_program,
+    cmd_set_action, trace_session, MockReader, MockState, MockWriter, SessionTrace,
+};
+
+struct Run {
+    oracle: SimOracle,
+    trace: SessionTrace,
+}
+
+/// Drive the DecompInterface lifecycle — registerProgram, setAction,
+/// decompileAt, flushNative, decompileAt, deregisterProgram — against the
+/// in-process [`GhidraProcess`] with the host end answered by the sim oracle.
+///
+/// `None` when the `.sla` specs are not built (the visible skip the CI canary
+/// greps for).
+fn run(binary: &Path, lang_dir: &str, pspec_name: &str, cspec_name: &str, target: &str) -> Option<Run> {
+    let oracle = SimOracle::bootstrap(binary)?;
+    let addr = oracle
+        .prog
+        .find_entry_by_name(target)
+        .unwrap_or_else(|| panic!("{binary:?}: no function named {target}"))
+        .addr;
+
+    let tspec = generate_tspec(&oracle.manager, oracle.big_endian, oracle.unique_base);
+    let dir = repo_root().join(lang_dir);
+    let pspec = std::fs::read(dir.join(pspec_name)).expect("vendored pspec");
+    let cspec = std::fs::read(dir.join(cspec_name)).expect("vendored cspec");
+
+    let mut packed_addr = Vec::new();
+    {
+        let mut e = PackedEncode::new(&mut packed_addr);
+        addr.encode(&mut e).expect("entry addr encodes");
+    }
+
+    let mut commands = Vec::new();
+    cmd_register_program(
+        &mut commands,
+        &pspec,
+        &cspec,
+        &tspec,
+        ghidra_sim::DEFAULT_CORETYPES_XML,
+    );
+    cmd_set_action(&mut commands, "0", "decompile", "c");
+    cmd_decompile_at(&mut commands, "0", &packed_addr);
+    cmd_flush_native(&mut commands, "0");
+    cmd_decompile_at(&mut commands, "0", &packed_addr);
+    cmd_deregister_program(&mut commands, "0");
+    let n = 6;
+
+    let shared = Rc::new(RefCell::new(MockState::new(commands, oracle)));
+    let reader = MockReader {
+        shared: Rc::clone(&shared),
+    };
+    let writer = MockWriter {
+        shared: Rc::clone(&shared),
+    };
+    let mut process = GhidraProcess::new(reader, writer);
+    for i in 0..n {
+        let status = process
+            .read_command()
+            .unwrap_or_else(|e| panic!("command #{i} failed: {e:?}"));
+        assert_eq!(status, if i == n - 1 { 1 } else { 0 }, "command #{i} status");
+    }
+    let _ = process.into_inner();
+    let state = match Rc::try_unwrap(shared) {
+        Ok(cell) => cell.into_inner(),
+        Err(_) => panic!("mock state still shared"),
+    };
+    Some(Run {
+        trace: trace_session(&state.from_process),
+        oracle: state.source,
+    })
+}
+
+/// GH-388: an ARM:LE:32 program must not make the host throw.  Before the fix
+/// this reports `["ST0", "DF", "DF", "DF"]` — one `ST0` from the msvcftol
+/// language test and one `DF` per `<prototype>` in `ARM.cspec`.
+#[test]
+fn arm32_asks_the_host_for_no_undefined_register() {
+    let binary = repo_root().join("decompiler/crates/kuna-analysis/tests/fixtures/fmt_arm");
+    let Some(r) = run(
+        &binary,
+        "specs/Ghidra/Processors/ARM/data/languages",
+        "ARMt.pspec",
+        "ARM.cspec",
+        "main",
+    ) else {
+        return;
+    };
+
+    let failures = &r.oracle.log.register_probe_failures;
+    eprintln!(
+        "ARM getRegister probes: {} total, {} undefined: {failures:?}",
+        r.oracle.log.register_probes.len(),
+        failures.len()
+    );
+    assert!(
+        failures.is_empty(),
+        "GH-388: ghidra mode on ARM:LE:32 asked the host for {} register(s) the language \
+         does not define ({failures:?}); each one throws `No Register Defined` in \
+         DecompileCallback and logs `Unexpected Exception` in Ghidra",
+        failures.len()
+    );
+
+    // The session is otherwise unchanged: every command answered and the
+    // registerProgram warnings frame stayed empty.
+    assert_eq!(r.trace.responses.len(), 6, "one response span per command");
+    assert!(
+        r.trace.responses[0].warnings.trim().is_empty(),
+        "registerProgram warnings: {}",
+        r.trace.responses[0].warnings
+    );
+}
+
+/// The other direction: x86-64 still resolves `DF` (the pspec `<tracked_set>`
+/// caches it during registerProgram), so the direction-flag assertion the probe
+/// feeds keeps applying where it matters.
+#[test]
+fn x86_64_still_resolves_the_direction_flag() {
+    let binary = repo_root().join("tests/bug-repro/faillog");
+    let Some(r) = run(
+        &binary,
+        "specs/Ghidra/Processors/x86/data/languages",
+        "x86-64.pspec",
+        "x86-64-gcc.cspec",
+        "sub_2620",
+    ) else {
+        return;
+    };
+
+    let probes = &r.oracle.log.register_probes;
+    eprintln!("x86-64 getRegister probes: {}", probes.len());
+    assert!(
+        r.oracle.log.register_probe_failures.is_empty(),
+        "x86-64 asked for undefined registers: {:?}",
+        r.oracle.log.register_probe_failures
+    );
+    assert!(
+        probes.iter().any(|n| n == "DF"),
+        "x86-64 never resolved DF, so the direction-flag assertion cannot apply: {probes:?}"
+    );
+}

--- a/decompiler/crates/kuna-ghidra/tests/register_probe_e2e.rs
+++ b/decompiler/crates/kuna-ghidra/tests/register_probe_e2e.rs
@@ -12,6 +12,11 @@
 //! The sim oracle answers an undefined name the same way Java does (an
 //! exception frame) and records every probed / failed name, so the ARM drive
 //! below sees exactly what the GUI user's log would.
+//!
+//! The other two drives pin what the seam must keep working: an x86-64 one that
+//! the direction-flag assertion still lands (its output is free of the string-op
+//! stride the assertion exists to fold away), and an x86-32 one that the
+//! syscall pass's ABI registers are already in the cache the probe reads.
 
 mod ghidra_sim;
 
@@ -20,43 +25,47 @@ use std::path::Path;
 use std::rc::Rc;
 
 use kuna_base::marshal::PackedEncode;
+use kuna_decomp::kuna_linuxsyscall::{ARG_REGISTERS, NUM_REGISTER};
 use kuna_ghidra::process::GhidraProcess;
 
 use ghidra_sim::oracle::{generate_tspec, repo_root, SimOracle};
 use ghidra_sim::{
     cmd_decompile_at, cmd_deregister_program, cmd_flush_native, cmd_register_program,
-    cmd_set_action, trace_session, MockReader, MockState, MockWriter, SessionTrace,
+    cmd_set_action, parse_decompile_doc, trace_session, MockReader, MockState, MockWriter,
+    ParsedDoc, SessionTrace,
 };
 
 struct Run {
     oracle: SimOracle,
     trace: SessionTrace,
+    /// The C flattened from each NON-EMPTY `decompileAt` response, in wire
+    /// order (empty when the drive registered the program only, and short when
+    /// a decompile came back empty — GH-407 on ARM/MIPS).
+    docs: Vec<ParsedDoc>,
 }
 
-/// Drive the DecompInterface lifecycle — registerProgram, setAction,
-/// decompileAt, flushNative, decompileAt, deregisterProgram — against the
-/// in-process [`GhidraProcess`] with the host end answered by the sim oracle.
+/// Drive the DecompInterface lifecycle against the in-process [`GhidraProcess`]
+/// with the host end answered by the sim oracle.
+///
+/// With a `target` the sequence is the full registerProgram → setAction →
+/// decompileAt → flushNative → decompileAt → deregisterProgram; without one it
+/// is registerProgram → deregisterProgram, so every logged query is one
+/// registerProgram itself issued.
 ///
 /// `None` when the `.sla` specs are not built (the visible skip the CI canary
 /// greps for).
-fn run(binary: &Path, lang_dir: &str, pspec_name: &str, cspec_name: &str, target: &str) -> Option<Run> {
+fn run(
+    binary: &Path,
+    lang_dir: &str,
+    pspec_name: &str,
+    cspec_name: &str,
+    target: Option<&str>,
+) -> Option<Run> {
     let oracle = SimOracle::bootstrap(binary)?;
-    let addr = oracle
-        .prog
-        .find_entry_by_name(target)
-        .unwrap_or_else(|| panic!("{binary:?}: no function named {target}"))
-        .addr;
-
     let tspec = generate_tspec(&oracle.manager, oracle.big_endian, oracle.unique_base);
     let dir = repo_root().join(lang_dir);
     let pspec = std::fs::read(dir.join(pspec_name)).expect("vendored pspec");
     let cspec = std::fs::read(dir.join(cspec_name)).expect("vendored cspec");
-
-    let mut packed_addr = Vec::new();
-    {
-        let mut e = PackedEncode::new(&mut packed_addr);
-        addr.encode(&mut e).expect("entry addr encodes");
-    }
 
     let mut commands = Vec::new();
     cmd_register_program(
@@ -66,12 +75,24 @@ fn run(binary: &Path, lang_dir: &str, pspec_name: &str, cspec_name: &str, target
         &tspec,
         ghidra_sim::DEFAULT_CORETYPES_XML,
     );
-    cmd_set_action(&mut commands, "0", "decompile", "c");
-    cmd_decompile_at(&mut commands, "0", &packed_addr);
-    cmd_flush_native(&mut commands, "0");
-    cmd_decompile_at(&mut commands, "0", &packed_addr);
+    if let Some(target) = target {
+        let addr = oracle
+            .prog
+            .find_entry_by_name(target)
+            .unwrap_or_else(|| panic!("{binary:?}: no function named {target}"))
+            .addr;
+        let mut packed_addr = Vec::new();
+        {
+            let mut e = PackedEncode::new(&mut packed_addr);
+            addr.encode(&mut e).expect("entry addr encodes");
+        }
+        cmd_set_action(&mut commands, "0", "decompile", "c");
+        cmd_decompile_at(&mut commands, "0", &packed_addr);
+        cmd_flush_native(&mut commands, "0");
+        cmd_decompile_at(&mut commands, "0", &packed_addr);
+    }
     cmd_deregister_program(&mut commands, "0");
-    let n = 6;
+    let n = if target.is_some() { 6 } else { 2 };
 
     let shared = Rc::new(RefCell::new(MockState::new(commands, oracle)));
     let reader = MockReader {
@@ -85,16 +106,35 @@ fn run(binary: &Path, lang_dir: &str, pspec_name: &str, cspec_name: &str, target
         let status = process
             .read_command()
             .unwrap_or_else(|e| panic!("command #{i} failed: {e:?}"));
-        assert_eq!(status, if i == n - 1 { 1 } else { 0 }, "command #{i} status");
+        assert_eq!(
+            status,
+            if i == n - 1 { 1 } else { 0 },
+            "command #{i} status"
+        );
     }
     let _ = process.into_inner();
     let state = match Rc::try_unwrap(shared) {
         Ok(cell) => cell.into_inner(),
         Err(_) => panic!("mock state still shared"),
     };
+    let oracle = state.source;
+    let trace = trace_session(&state.from_process);
+    // With a target the decompileAt spans are responses 2 and 4.
+    let mut docs = Vec::new();
+    if target.is_some() {
+        for i in [2usize, 4] {
+            match trace.responses[i].payload.as_deref() {
+                Some(payload) if !payload.is_empty() => {
+                    docs.push(parse_decompile_doc(payload, &oracle.manager))
+                }
+                _ => {}
+            }
+        }
+    }
     Some(Run {
-        trace: trace_session(&state.from_process),
-        oracle: state.source,
+        trace,
+        oracle,
+        docs,
     })
 }
 
@@ -109,7 +149,7 @@ fn arm32_asks_the_host_for_no_undefined_register() {
         "specs/Ghidra/Processors/ARM/data/languages",
         "ARMt.pspec",
         "ARM.cspec",
-        "main",
+        Some("main"),
     ) else {
         return;
     };
@@ -138,31 +178,81 @@ fn arm32_asks_the_host_for_no_undefined_register() {
     );
 }
 
-/// The other direction: x86-64 still resolves `DF` (the pspec `<tracked_set>`
-/// caches it during registerProgram), so the direction-flag assertion the probe
-/// feeds keeps applying where it matters.
+/// The other direction, asserted on the OUTPUT rather than on the query log:
+/// `grep`'s `sub_17400` clears a `struct stat` with `rep stosq`, so if the
+/// direction-flag assertion stops landing the string-op stride survives as
+/// `&v7[(unsigned long)v9 * -2 + 1]` with `v9` a live `df` variable, instead of
+/// the `&v8[1]` kuna emits.  That assertion is the reason `probe_register_varnode`
+/// has to answer `DF` at all in ghidra mode.
 #[test]
-fn x86_64_still_resolves_the_direction_flag() {
-    let binary = repo_root().join("tests/bug-repro/faillog");
+fn x86_64_folds_the_direction_flag_stride() {
+    let binary = repo_root().join("tests/bug-repro/grep");
     let Some(r) = run(
         &binary,
         "specs/Ghidra/Processors/x86/data/languages",
         "x86-64.pspec",
         "x86-64-gcc.cspec",
-        "sub_2620",
+        Some("sub_17400"),
     ) else {
         return;
     };
 
-    let probes = &r.oracle.log.register_probes;
-    eprintln!("x86-64 getRegister probes: {}", probes.len());
     assert!(
         r.oracle.log.register_probe_failures.is_empty(),
         "x86-64 asked for undefined registers: {:?}",
         r.oracle.log.register_probe_failures
     );
-    assert!(
-        probes.iter().any(|n| n == "DF"),
-        "x86-64 never resolved DF, so the direction-flag assertion cannot apply: {probes:?}"
+    assert_eq!(
+        r.docs.len(),
+        2,
+        "both decompileAt spans must carry a document"
     );
+    for (i, doc) in r.docs.iter().enumerate() {
+        assert!(
+            !doc.c_text.trim().is_empty(),
+            "decompileAt #{i} produced no C"
+        );
+        assert!(
+            !doc.c_text.contains("* -2 + 1"),
+            "decompileAt #{i}: the direction flag survived into the output as the \
+             string-op stride `1 - 2*DF`; the DF-unaffected assertion did not land:\n{}",
+            doc.c_text
+        );
+    }
+}
+
+/// The i386 syscall pass reads `EAX`/`EBX`/`ECX`/`EDX`/`ESI`/`EDI`/`EBP` through
+/// the same probe, and in ghidra mode a probe sees only what the register cache
+/// already holds.  What fills it is the compiler spec: every `<prototype>` in
+/// `x86gcc.cspec` is decoded during registerProgram, before any function is
+/// lifted.  This drive registers the program and nothing else, so every name in
+/// the log below was resolved by that decode — move it after the first lift and
+/// the syscall pass silently stops recognizing `int 0x80`.
+#[test]
+fn x86_32_caches_the_syscall_abi_registers_at_register_program() {
+    let binary = repo_root().join("decompiler/crates/kuna-analysis/tests/fixtures/picbase_i386");
+    let Some(r) = run(
+        &binary,
+        "specs/Ghidra/Processors/x86/data/languages",
+        "x86.pspec",
+        "x86gcc.cspec",
+        None,
+    ) else {
+        return;
+    };
+
+    assert!(
+        r.oracle.log.register_probe_failures.is_empty(),
+        "x86-32 asked for undefined registers: {:?}",
+        r.oracle.log.register_probe_failures
+    );
+    let probed = &r.oracle.log.register_probes;
+    for nm in std::iter::once(NUM_REGISTER).chain(ARG_REGISTERS) {
+        assert!(
+            probed.iter().any(|n| n == nm),
+            "registerProgram never resolved {nm}, so the i386 syscall ABI probe would \
+             miss it in ghidra mode: {probed:?}"
+        );
+    }
+    assert_eq!(r.trace.responses.len(), 2, "one response span per command");
 }

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -306,6 +306,24 @@ Four front-ends drive one engine assembly:
   ghidra mode too (`decompiler/crates/kuna-decomp/src/infra/architecture.rs
   (decode_ghidra_tracked_sets)`), resolving register names through the
   query-backed translator, so `ActionConstbase` plants the direction seed.
+  Because that lookup is a host query, an undefined name is not a local miss:
+  Ghidra's callback throws `No Register Defined`, which the host logs as an
+  `Unexpected Exception` with a stack trace before the exception frame ever
+  reaches kuna — recoverable on the wire, but visible to the user and
+  unsuppressible from this side. So a *speculative* by-name lookup — a pass
+  asking "does this language happen to have register X?" rather than resolving
+  a name the host itself supplied — must go through the probe seam
+  (`decompiler/crates/kuna-base/src/space.rs (RegisterLookup)`'s
+  `probe_register` and `decompiler/crates/kuna-decomp/src/infra/engine_translate.rs
+  (EngineTranslate)`'s `probe_register_varnode`) instead of the exact lookup.
+  Both default to the exact lookup's `Ok`-to-`Some`, so the standalone Sleigh
+  path is unchanged; the ghidra translator overrides them to answer from the
+  `nm2addr` cache alone and issue no query. A `None` therefore means "not
+  resolvable here", never "this language has no such register" — which is why
+  only speculative tests may consult it. The x86 direction-flag assertion
+  (chapter 04) is the case this shapes: its `DF` probe still resolves in ghidra
+  mode because the pspec `<tracked_set>` sweep above runs first and caches `DF`,
+  and every stock x86 pspec carries that set.
   External references resolve through the upstream two-step
   (`ScopeGhidra::resolveExternalRefFunction`): the `<externrefsymbol>` answer
   keeps its resolve address, getExternalRef fires at the POINTER address, the

--- a/docs/spec/02-lift-and-flow.md
+++ b/docs/spec/02-lift-and-flow.md
@@ -228,6 +228,12 @@ recovered switch table.
   code space) because the body would not compile elsewhere and the helper exists
   nowhere else; it is unconditional rather than option-gated because the
   architecture bootstraps at `load file`, before the console's `option` lines.
+  Registration is skipped outright in ghidra mode, exactly as the Cortex-M
+  callother fixup below is and for the same reason: with no local `.sla` there
+  is nothing to compile the body against, so the payload could never install.
+  Skipping it also keeps the x86-32 language test — which asks whether this
+  language has `ST0` — off the wire, since every 32-bit language reaches it (the
+  test's cheap half is the code-space width, which ARM32/MIPS32/PPC32 all pass).
   The user-visible gate is on the *install* instead (`option msvcftol`, default
   on), where the analysis-tier call-fixup installer drops this one payload's
   targets from its match map.

--- a/docs/spec/02-lift-and-flow.md
+++ b/docs/spec/02-lift-and-flow.md
@@ -1021,7 +1021,11 @@ register must resolve at its full 32-bit width and the default code space must
 be 4 bytes wide. x86-64 resolves `EAX`..`EBP` as sub-registers, so the
 address-size test is what excludes it — there `int 0x80` is a compatibility
 path, not the syscall ABI this models — and every non-x86 language is excluded
-because the register names do not resolve.
+because the register names do not resolve. That resolution is the speculative
+probe of §0, not the exact lookup, so in ghidra mode the gate sees only names
+the register cache already holds; the seven it needs are there because the
+compiler spec's `<prototype>` elements — which name all of them — are decoded
+during `registerProgram`, before the first function is lifted.
 
 **Why it ships off.** Naming the call asserts that the operating system behind
 vector `0x80` is Linux. That is true of essentially every 32-bit x86 ELF, but

--- a/docs/spec/04-calls-and-prototypes.md
+++ b/docs/spec/04-calls-and-prototypes.md
@@ -738,7 +738,12 @@ the same spec already records it, so kuna states the same guarantee for the mode
 that are silent, at model-decode time. A spec that mentions `DF` either way has
 made a deliberate statement and is left alone, and a language with no such
 register is a structural no-op — the assertion is keyed on the SLEIGH register
-name and a lookup miss is the exit.
+name and a lookup miss is the exit. That miss is a *speculative* question, so
+the assertion takes a probe (`Option<VarnodeData>`) rather than the exact
+by-name lookup: on a front-end that resolves register names by asking a host,
+asking for a name the language does not define is an error the host reports
+(§0's probe seam), and every non-x86 language would take that path on every
+decoded prototype.
 
 ### The spacebase placeholder
 


### PR DESCRIPTION
Fixes #388.

## The problem

With kuna as Ghidra's decompiler core, opening a non-x86 program makes Ghidra log an
`Unexpected Exception` with a stack trace for every x86 register kuna speculatively asks
about — four per `DecompInterface.openProgram` on ARM:LE:32, in red in the Front End status
bar. Nothing is broken, which is what makes it bad: the user sees a stack trace and assumes
the decompiler is.

This PR's test names the four against a tree without its `src/` changes, no Ghidra needed:

```
$ cd decompiler && cargo test -p kuna-ghidra --release --test register_probe_e2e arm32
ARM getRegister probes: 69 total, 4 undefined: ["ST0", "DF", "DF", "DF"]
GH-388: ghidra mode on ARM:LE:32 asked the host for 4 register(s) the language does not
define (["ST0", "DF", "DF", "DF"]); each one throws `No Register Defined` in
DecompileCallback and logs `Unexpected Exception` in Ghidra
```

In a live 12.1.2 install each is a `RuntimeException: No Register Defined: <name>` thrown from
`DecompileCallback.getRegister` under `registerProgram`: one `ST0` from an x86-32 language
test every 32-bit language reaches, plus one `DF` per `<prototype>` in the compiler spec.

## The fix

- Two passes asked "does this language happen to have register X?" through the exact by-name
  lookup, which in ghidra mode is a `getRegister` query the host answers by throwing. Adds a
  probe seam for that question — `RegisterLookup::probe_register` and
  `EngineTranslate::probe_register_varnode` — defaulting to the exact lookup's `Ok`-to-`Some`,
  and overridden in the Ghidra translator to answer from its register cache with no query.
- Catching the error would not help: Java writes the ERROR line before the exception frame
  reaches kuna, which already consumes it correctly. The only fix is not to ask.
- The `__ftol` call-fixup registration returns early in ghidra mode, as
  `register_cortexmpriv_fixup` already does — with no local `.sla` the payload can never
  compile, so the x86-32 language test it guards was pure cost.
- No option, because nothing here can change emitted C: `kuna decompile-all
  tests/bug-repro/grep` is byte-identical across the change, 18,253 lines; so is `fmt_arm`.

## The tests

The ARM drive in `register_probe_e2e.rs` is the repro above. An x86-64 drive over `grep`'s
`sub_17400` pins the direction-flag assertion the probe feeds by its output: without it the
`rep stosq` loop comes back as `&v7[(unsigned long)v9 * -2 + 1]` instead of `&v8[1]`. An
x86-32 drive pins that the i386 syscall ABI registers reach the register cache during
`registerProgram`, the only reason a probe can see them. The sim host had to start answering
an unresolvable `getRegister` with an exception frame as Java does — answering it emptily is
why the harness was blind to this class.

Known remaining limitation of ghidra mode on ARM/MIPS, separate from this: #407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzfafnkDMQiYoifXP5HSC8