### PR TITLE
[AUTOMATED] fix(p2): funcboundflow's truncation must start a basic block

### DIFF
--- a/decompiler/crates/kuna-base/src/xml.rs
+++ b/decompiler/crates/kuna-base/src/xml.rs
@@ -1797,7 +1797,11 @@ mod tests {
         // install cannot re-read is declined, so the compiler's if/else-if chain
         // over the real parameter survives (option off = `switch(0)`, every case
         // unreachable and the parameter absent from the prototype)
-        assert_eq!(count, 238, "corpus file count drifted");
+        // and gh403-funcboundflow-cfg / the funcboundflow truncation of a
+        // CONDITIONAL branch's fall-through starts its own basic block, so the
+        // branch no longer self-edges (invalid `} while ;`, or a collapsed single
+        // out-edge the two-way block readers index off the end of)
+        assert_eq!(count, 239, "corpus file count drifted");
     }
 
     /// ~20 representative SLEIGH spec files across varied processors

--- a/decompiler/crates/kuna-decomp/src/p2_lift/flow.rs
+++ b/decompiler/crates/kuna-decomp/src/p2_lift/flow.rs
@@ -1470,7 +1470,13 @@ truncating the fall-through here"
                 // one (the cross-function merge bug).  Mirrors the noreturn-call
                 // halt in `check_for_flow_modification`; the halt is appended
                 // after the current instruction's ops by `artificial_halt`.
-                let _halt = self.artificial_halt(curaddr, pcodeop_flags::noreturn)?;
+                // It starts a basic block because `collect_edges` emits a
+                // fall-through edge for a CBRANCH regardless, and without a
+                // boundary that edge is a self-loop on the branch's own block.  It
+                // is NOT marked an instruction start: `fallthru_op` can only reach
+                // it as a same-instruction op, the next address being undecoded.
+                let halt = self.artificial_halt(curaddr, pcodeop_flags::noreturn)?;
+                self.op_mark_start_basic(halt);
                 self.data.warning(
                     "funcboundflow: fall-through reached the next function entry; truncating flow here",
                     curaddr,

--- a/decompiler/crates/kuna-decomp/src/p3_dataflow/condconst.rs
+++ b/decompiler/crates/kuna-decomp/src/p3_dataflow/condconst.rs
@@ -718,6 +718,11 @@ pub(crate) fn condconst_apply(data: &mut Funcdata) -> int4 {
         if data.obank().get(c_branch).expect("condconst: stale cbranch").code() != OpCode::CPUI_CBRANCH {
             continue;
         }
+        // A CBRANCH block with fewer than two out-edges is a malformed CFG; skip
+        // it rather than index off the end of the edge list (upstream assumes two).
+        if data.bblocks_ref().block(bl).size_out() < 2 {
+            continue;
+        }
         let bool_vn = data.obank().get(c_branch).expect("condconst: stale cbranch").get_in(1).unwrap();
         // Make sure the boolean constant holds down each branch.
         let out0 = data.bblocks_ref().block(bl).get_out(0);

--- a/docs/baseline-stages.json
+++ b/docs/baseline-stages.json
@@ -1,7 +1,7 @@
 {
   "data_footer": [
-    628,
-    628
+    632,
+    632
   ],
   "passing": [
     "data:ARRAYSUBFIELD #1: an 8-byte read at offset 0 of char[16] is a sized sub-field, not element 0",
@@ -121,6 +121,10 @@
     "data:GH275 #3: spillargtrial reload binds the second call's argument to the register, not a spurious stack local",
     "data:GH2786 #1: nested float negation parenthesized (default-flip fix)",
     "data:GH2786 #2: the mis-parsing predecrement token is gone",
+    "data:GH403 #1: the truncated conditional branch never renders the condition-less `} while ;`",
+    "data:GH403 #2: the self-looping truncation still decompiles (both passes carry the loop)",
+    "data:GH403 #3: the default pass truncates, so neighbor's body appears only in the funcboundflow-off pass",
+    "data:GH403 #4: the conditional's surviving arm is unchanged by the truncation (both passes)",
     "data:GH4788 #1: disp17 Bcond decodes as bnc to 0x1963d8 (not ld.hu)",
     "data:GH4788 #2: the bytes are no longer mis-decoded as ld.hu",
     "data:GH558 #1: compareform canonical restores upstream x < 9 (old behavior, opt-in)",

--- a/docs/spec/02-lift-and-flow.md
+++ b/docs/spec/02-lift-and-flow.md
@@ -360,7 +360,17 @@ run off the end of the current function. The truncation lives at the fall-throug
 push of `flow.rs (FlowInfo::process_instruction)`: instead of pushing the target,
 a no-return artificial RETURN is planted (mirroring the `check_for_flow_modification`
 no-return-call halt) and a `funcboundflow` warning makes the truncation
-attributable. This overlaps `noreturn_extern`/`noreturn_externmatch` (which stop
+attributable. The halt also *starts a basic block*: `flow.rs (FlowInfo::collect_edges)`
+emits a fall-through edge for every CBRANCH whatever else the walk decided, so when
+the truncated instruction is a conditional branch the edge otherwise resolves back
+to the branch's own block. That self-edge is what the structurer renders as the
+condition-less, syntactically invalid `} while ;`, and where the branch's taken edge
+lands on that same block the two collapse into a single out-edge that the two-way
+block readers index off the end of. Giving the halt its own block puts a real
+no-return RETURN on the far end of the fall-through instead. The halt is deliberately
+*not* marked as an instruction start: `flow.rs (FlowInfo::fallthru_op)` can only
+resolve the fall-through to it as a same-instruction op, the truncated address never
+having been decoded. This overlaps `noreturn_extern`/`noreturn_externmatch` (which stop
 the same leak by callee *name*) but is name-independent — it bounds at the function
 *boundary* whatever the callee. On real binaries ~36% of application functions in a
 measured static-pie build end in such a call and were corrupted this way; IDA and

--- a/docs/spec/03-ssa-and-simplification.md
+++ b/docs/spec/03-ssa-and-simplification.md
@@ -626,6 +626,13 @@ but only when excising that edge leaves no alternate data-flow path rejoining
 the original value (`condconst.rs (handle_phi_nodes)`; multiple disconnected
 edges that flow together downstream get one shared placement).
 
+A block whose last op is a CBRANCH is read as a two-way branch, so
+`condconst.rs (condconst_apply)` skips one carrying fewer than two out-edges rather
+than indexing off the end of its edge list. The `funcboundflow` truncation used to
+produce one; the guard keeps a malformed graph from killing the process before the
+pass that malformed it can be identified, but it does not by itself make the emitted
+C right.
+
 (kuna) **condexeplace** — GH-9203: that materialized COPY could land inside a
 *loop* predecessor block, re-executing a supposedly loop-invariant `= 0` every
 iteration and malforming the do/while. Under the gate,

--- a/tests/stages/gh403-funcboundflow-cfg.xml
+++ b/tests/stages/gh403-funcboundflow-cfg.xml
@@ -1,0 +1,60 @@
+<decompilertest>
+<!--
+    funcboundflow's truncation must start a new basic block.  When the fall-through
+    that reaches the next function's entry belongs to a CONDITIONAL branch, the
+    artificial no-return RETURN planted in its place used to land inside the branch's
+    own basic block, so `collectEdges` resolved the CBRANCH's fall-through to that
+    same block: a spurious self-edge.  The structurer rendered it as the invalid C
+    `} while ;`, and where the branch's taken edge also pointed at that block the two
+    edges collapsed into one and `FlowBlock::getOut(1)` indexed off the end of the
+    edge list.  Stage model: S2 flow classification (`process_instruction`
+    fall-through).  Correctness fix, no option, because the old output was not valid
+    C.  kuna GH-403.
+
+    Layout (linked flat, one .text run):
+      branchcut @ 0x100040 : mov/add/test then `je cold`; fall-through is 0x100049
+      neighbor  @ 0x100049 : return a0 - 5;   (the entry that fall-through reaches)
+      cold      @ 0x10004d : return 99;       (branchcut's own conditional target)
+      loopcut   @ 0x100053 : `jl` back to 0x100055, its own block's first instruction;
+                             fall-through is 0x10005d
+      neighbor2 @ 0x10005d : return a0 - 7;   (the entry that fall-through reaches)
+
+    Pass 1 (default) decompiles both; pass 2 (funcboundflow off) is the reference
+    rendering where the walk runs on into the neighbour.
+
+    Assert #1 is the invalid-C shape: it must never be emitted.
+    Assert #2 pins loopcut's loop to BOTH passes; before the fix the default pass
+    emitted no body at all, `condconst_apply` having read `getOut(1)` on the
+    collapsed single out-edge.
+    Assert #3 pins the truncation itself: neighbor's body appears exactly once across
+    the two passes, i.e. only with funcboundflow off.
+    Assert #4 pins the branch's other arm, which the truncation must leave alone.
+-->
+<binaryimage arch="x86:LE:64:default:gcc">
+<bytechunk space="ram" offset="0x100040" readonly="true">89f883c00f85c074048d47fbc3b863000000c331c083c00f83f8647cf88d47f9c3</bytechunk>
+<symbol space="ram" offset="0x100040" name="branchcut"/>
+<symbol space="ram" offset="0x100049" name="neighbor"/>
+<symbol space="ram" offset="0x100053" name="loopcut"/>
+<symbol space="ram" offset="0x10005d" name="neighbor2"/>
+</binaryimage>
+<script>
+  <com>lo fu branchcut</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>lo fu loopcut</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>option funcboundflow off</com>
+  <com>lo fu branchcut</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>lo fu loopcut</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="GH403 #1: the truncated conditional branch never renders the condition-less `} while ;`" min="0" max="0">while ;</stringmatch>
+<stringmatch name="GH403 #2: the self-looping truncation still decompiles (both passes carry the loop)" min="2" max="2">while \(v1 &lt; 100\)</stringmatch>
+<stringmatch name="GH403 #3: the default pass truncates, so neighbor's body appears only in the funcboundflow-off pass" min="1" max="1">return a0 \+ -5;</stringmatch>
+<stringmatch name="GH403 #4: the conditional's surviving arm is unchanged by the truncation (both passes)" min="2" max="2">return 99;</stringmatch>
+</decompilertest>


### PR DESCRIPTION
## The problem

`funcboundflow` stops a function's flow where the fall-through runs into the
next function's entry. When that fall-through belongs to a *conditional* branch
the truncation lands inside the branch's own block, and the emitted C is not
valid C. Both shapes decompile fine with `--option funcboundflow off`.

```
$ cat repro.s
.text
.globl branchcut ; .type branchcut,@function
branchcut:                    # last insn is a conditional branch,
  mov  %edi,%eax              # whose fall-through is neighbor's entry
  add  $15,%eax
  test %eax,%eax
  je   cold
.globl neighbor ; .type neighbor,@function
neighbor:
  lea  -5(%rdi),%eax
  ret
cold:
  mov  $99,%eax
  ret
.globl loopcut ; .type loopcut,@function
loopcut:
  xor  %eax,%eax
1:add  $15,%eax
  cmp  $100,%eax
  jl   1b                     # fall-through is neighbor2's entry
.globl neighbor2 ; .type neighbor2,@function
neighbor2:
  lea  -7(%rdi),%eax
  ret

$ as -o repro.o repro.s && ld -Ttext=0x100040 -e branchcut -o repro.elf repro.o

$ kuna decompile repro.elf branchcut
unsigned long branchcut(int a0)
{
  do {
  } while ; // warn: funcboundflow: fall-through reached the next function entry; truncating flow here
  return 99;
}

$ kuna decompile repro.elf loopcut
void loopcut(void)
{
  /* WARNING: decompilation failed: decompile pipeline reached an un-ported seam (LOSS-131): index out of bounds: the len is 1 but the index is 1 */
}
error: decompilation failed for loopcut in repro.elf: decompile pipeline reached an un-ported seam (LOSS-131): index out of bounds: the len is 1 but the index is 1
note: decomp_dbg stderr:
thread 'main' panicked at crates/kuna-decomp/src/substrate/block.rs:640:23:
index out of bounds: the len is 1 but the index is 1
```

## The fix

- The artificial no-return RETURN that replaces the truncated fall-through now
  starts a basic block. `collectEdges` emits a fall-through edge for every
  CBRANCH whatever else the walk decided, so without a boundary that edge
  pointed back at the branch's own block: the self-edge the structurer renders
  as `} while ;`. This one change fixes both shapes.
- The halt is deliberately not marked an instruction start, because `fallthruOp`
  can only resolve the fall-through to it as a same-instruction op: the
  truncated address is never decoded.
- `ActionConditionalConst` checks for two out-edges before reading them. In
  `loopcut` the self-edge and the branch's taken edge landed on the same block,
  so the CBRANCH block had one out-edge and `getOut(1)` ran off the end. The
  check turns that into a skipped pass instead of a dead process; it does not
  make the C right on its own, since with the block boundary still missing
  `loopcut` comes out as `do { v1 += 0xf; (v1 < 100); } while( true );`.

Truncation at a non-branch instruction, which already put the halt in its own
block, is unchanged. On a PE crackme `kuna decompile-all` goes from 7
`} while ;` occurrences across 32 truncations to 0 with the truncation count
identical, and binaries with no truncation are byte-for-byte identical.

## The tests

`tests/stages/gh403-funcboundflow-cfg.xml` carries both shapes as a flat
bytechunk with function symbols. Without the fix the `} while ;` assertion and
the "loopcut still decompiles" assertion fail; the two that pin the truncation
itself pass either way. Datatests stay 675/675 and the workspace suite is green.

Fixes the invalid-C half of #403; the `.pdata` function-boundary half is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzfafnkDMQiYoifXP5HSC8