### PR TITLE
[AUTOMATED] perf(infra): decompiling-3396-byte-main — refute the regression by code A/B, and keep the profiler that showed it

### DIFF
--- a/decompiler/crates/kuna-decomp/src/infra/action.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/action.rs
@@ -495,7 +495,14 @@ pub trait Action {
                 || st == statusflags::status_repeat
                 || st == statusflags::status_mid
             {
-                let res = self.apply(data, ctx); // Start or continue action
+                let res = if crate::actionprof::enabled() {
+                    crate::actionprof::enter(self.get_name());
+                    let res = self.apply(data, ctx); // Start or continue action
+                    crate::actionprof::leave();
+                    res
+                } else {
+                    self.apply(data, ctx) // Start or continue action
+                };
                 if res < 0 {
                     // negative indicates partial completion
                     self.base_mut().status = statusflags::status_mid;
@@ -1643,6 +1650,7 @@ impl ActionDatabase {
     /// (see [`get_current`](ActionDatabase::get_current)).
     pub fn set_current(&mut self, actname: &str) -> KunaResult<()> {
         self.currentactname = actname.to_string();
+        crate::actionprof::set_root(actname);
         self.derive_action(UNIVERSAL_NAME, actname)?;
         Ok(())
     }

--- a/decompiler/crates/kuna-decomp/src/infra/actionprof.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/actionprof.rs
@@ -1,0 +1,145 @@
+//! (kuna) `KUNA_ACTION_PROF` — an exclusive-time profile of the Action tree.
+//!
+//! # Why this exists
+//!
+//! `perf` is unavailable on the machines this engine is tuned on
+//! (`perf_event_paranoid = 4`), and a sampling profiler stops being useful the
+//! moment a profile goes flat: it cannot tell that two 15% frames are the same
+//! cost reached down two paths, and it cannot count calls at all. Every
+//! performance investigation on a large function has therefore rebuilt the same
+//! throwaway timer around [`Action::perform`](crate::action::Action::perform)'s
+//! `apply` call. This is that timer, kept.
+//!
+//! Set `KUNA_ACTION_PROF` to a path and the engine writes an exclusive-time
+//! table there, sorted by cost:
+//!
+//! ```text
+//! total_exclusive_ms 7436.1
+//!     1627.8 ms   21.89%         25 calls  decompile/heritage
+//!     1282.9 ms   17.25%        131 calls  decompile/oppool1
+//!      184.0 ms    2.47%          9 calls  jumptable/heritage
+//! ```
+//!
+//! Time is **exclusive**: an [`ActionGroup`](crate::action::ActionGroup) is
+//! charged only what it spends outside its children, so the rows sum to the
+//! wall time of the schedule and a container never hides a leaf. Each row is
+//! keyed by the *root* action the work ran under, which separates a function's
+//! own `decompile` pass from the reduced `jumptable` pipeline that jump-table
+//! recovery runs on a partial clone.
+//!
+//! The file is rewritten every time the schedule unwinds, so it holds the
+//! running total for the whole process — one `decompile-all` leaves one table
+//! covering every function.
+//!
+//! # Cost when off
+//!
+//! One `OnceLock` load per `apply` call. `apply` is coarse — a pool applies
+//! every rule to every op in a single call — so a large function makes only a
+//! few hundred of them.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::sync::OnceLock;
+use std::time::Instant;
+
+thread_local! {
+    /// The open `apply` frames: (row key, entry time, time charged to children).
+    static STACK: RefCell<Vec<(String, Instant, u128)>> = const { RefCell::new(Vec::new()) };
+    /// Exclusive nanoseconds and call count per row key.
+    static TOTALS: RefCell<HashMap<String, (u128, u64)>> = RefCell::new(HashMap::new());
+    /// The root schedule rows are attributed to, set by
+    /// [`ActionDatabase::set_current`](crate::action::ActionDatabase::set_current).
+    static ROOT: RefCell<String> = const { RefCell::new(String::new()) };
+}
+
+/// The env var that names the output path.
+pub const ENV_VAR: &str = "KUNA_ACTION_PROF";
+
+/// Is profiling on? Read once per process.
+pub fn enabled() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os(ENV_VAR).is_some())
+}
+
+/// Name the root schedule that follows, so its rows can be told apart from
+/// another root's.
+///
+/// The derived root Action keeps the universal tree's own name, so the only
+/// place that knows a schedule is `decompile` rather than the reduced
+/// `jumptable` pipeline is the database that selected it.
+pub fn set_root(name: &str) {
+    if !enabled() {
+        return;
+    }
+    ROOT.with(|r| {
+        let mut cur = r.borrow_mut();
+        cur.clear();
+        cur.push_str(name);
+    });
+}
+
+/// Open a frame for the action named `name`.
+///
+/// Rows are keyed `<root>/<name>` — the schedule [`set_root`] last named, and
+/// the action inside it.
+pub fn enter(name: &str) {
+    let key = ROOT.with(|r| {
+        let root = r.borrow();
+        if root.is_empty() { name.to_string() } else { format!("{root}/{name}") }
+    });
+    STACK.with(|s| s.borrow_mut().push((key, Instant::now(), 0)));
+}
+
+/// Close the innermost frame, charging its exclusive time.
+///
+/// Writes the table out whenever the schedule unwinds to empty.
+pub fn leave() {
+    let closed = STACK.with(|s| {
+        let mut st = s.borrow_mut();
+        let (key, at, children) = st.pop()?;
+        let elapsed = at.elapsed().as_nanos();
+        if let Some(parent) = st.last_mut() {
+            parent.2 += elapsed;
+        }
+        Some((key, elapsed.saturating_sub(children), st.is_empty()))
+    });
+    let Some((key, exclusive, unwound)) = closed else { return };
+    TOTALS.with(|t| {
+        let mut m = t.borrow_mut();
+        let row = m.entry(key).or_insert((0, 0));
+        row.0 += exclusive;
+        row.1 += 1;
+    });
+    if unwound {
+        dump();
+    }
+}
+
+/// Render the running totals to the path in [`ENV_VAR`].
+///
+/// A write failure is ignored: a profile that cannot be written must not change
+/// what the engine does.
+pub fn dump() {
+    let Some(path) = std::env::var_os(ENV_VAR) else { return };
+    let _ = std::fs::write(path, render());
+}
+
+/// The table, as text.
+pub fn render() -> String {
+    let mut rows: Vec<(String, u128, u64)> =
+        TOTALS.with(|t| t.borrow().iter().map(|(k, v)| (k.clone(), v.0, v.1)).collect());
+    rows.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    let total: u128 = rows.iter().map(|r| r.1).sum();
+    let mut out = format!("total_exclusive_ms {:.1}\n", total as f64 / 1e6);
+    for (key, ns, calls) in rows {
+        let pct = if total == 0 { 0.0 } else { ns as f64 / total as f64 * 100.0 };
+        out.push_str(&format!(
+            "{:>10.1} ms  {pct:>6.2}%  {calls:>9} calls  {key}\n",
+            ns as f64 / 1e6
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/decompiler/crates/kuna-decomp/src/infra/actionprof/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/actionprof/tests.rs
@@ -1,0 +1,99 @@
+//! Tests for the `KUNA_ACTION_PROF` exclusive-time table.
+
+use super::*;
+
+fn reset() {
+    STACK.with(|s| s.borrow_mut().clear());
+    TOTALS.with(|t| t.borrow_mut().clear());
+    ROOT.with(|r| r.borrow_mut().clear());
+}
+
+/// `set_root` is a no-op unless the env var is set, so the tests write the
+/// thread-local directly.
+fn root(name: &str) {
+    ROOT.with(|r| {
+        let mut cur = r.borrow_mut();
+        cur.clear();
+        cur.push_str(name);
+    });
+}
+
+/// A parent is charged only what it spends outside its child, and both rows
+/// carry the root action's name.
+#[test]
+fn parent_time_is_exclusive_of_its_children() {
+    reset();
+    root("decompile");
+    enter("universal");
+    enter("heritage");
+    std::thread::sleep(std::time::Duration::from_millis(20));
+    leave();
+    leave();
+
+    let (parent, child) = TOTALS.with(|t| {
+        let m = t.borrow();
+        (m["decompile/universal"], m["decompile/heritage"])
+    });
+    assert!(child.0 >= 20_000_000, "child kept its own time: {}", child.0);
+    assert!(parent.0 < 20_000_000, "parent was charged the child's time: {}", parent.0);
+    assert_eq!((parent.1, child.1), (1, 1));
+    reset();
+}
+
+/// Two roots do not share a row, which is what separates a function's own
+/// `decompile` pass from the reduced `jumptable` pipeline.
+#[test]
+fn rows_are_keyed_by_root_action() {
+    reset();
+    for name in ["decompile", "jumptable"] {
+        root(name);
+        enter("universal");
+        enter("heritage");
+        leave();
+        leave();
+    }
+    let keys = TOTALS.with(|t| {
+        let mut k: Vec<String> = t.borrow().keys().cloned().collect();
+        k.sort();
+        k
+    });
+    assert_eq!(
+        keys,
+        [
+            "decompile/heritage",
+            "decompile/universal",
+            "jumptable/heritage",
+            "jumptable/universal"
+        ]
+    );
+    reset();
+}
+
+/// `render` sums to the recorded total and puts the most expensive row first.
+#[test]
+fn render_sorts_by_cost_and_totals() {
+    reset();
+    root("decompile");
+    enter("universal");
+    enter("cheap");
+    leave();
+    enter("dear");
+    std::thread::sleep(std::time::Duration::from_millis(15));
+    leave();
+    leave();
+
+    let text = render();
+    let body: Vec<&str> = text.lines().skip(1).collect();
+    assert!(body[0].ends_with("decompile/dear"), "dearest row first: {text}");
+    assert!(text.starts_with("total_exclusive_ms "), "{text}");
+    reset();
+}
+
+/// An unbalanced `leave` is a no-op rather than a panic: the instrument must
+/// never be able to take the engine down.
+#[test]
+fn leave_without_enter_is_inert() {
+    reset();
+    leave();
+    assert!(TOTALS.with(|t| t.borrow().is_empty()));
+}

--- a/decompiler/crates/kuna-decomp/src/infra/mod.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/mod.rs
@@ -17,3 +17,4 @@ pub mod signature;
 pub mod analyzesigs;
 pub mod paramid;
 pub mod universalaction;
+pub mod actionprof;

--- a/docs/features/decompiling-3396-byte-main/pr_body.md
+++ b/docs/features/decompiling-3396-byte-main/pr_body.md
@@ -1,122 +1,66 @@
-## What was broken
+## What was measured
 
-RE-friction need `decompiling-3396-byte-main` (round 2, 1 instance, challenge `69a3822f7b3cc38c80464da4`):
-
-> **Decompiling the 3396-byte main function takes about 68 seconds** (major)
-> The command produced no output for roughly 68 seconds, then emitted about 30 KB of highly noisy
-> pseudocode. [...] this observation is specifically about latency.
-
-Four merged attempts took that witness 71.5 → 19.4 (#380) → 14.4 (#385) → 11.8 (#393) → 10.8 s (#396)
-and the acceptance bar — a median under **10,000 ms** — stayed unmet. Five captains declined to re-cut it.
-
-## The mechanism
-
-Recovering a `BRANCHIND` means cloning the function's raw p-code into a partial `Funcdata`, building
-its blocks and running the reduced `"jumptable"` action set over it, so the switch's index calculation
-simplifies into something the emulator can walk. C++ `FlowInfo::recoverJumpTables` (`flow.cc:1429`)
-builds **one** `partial` per call, and `Funcdata::stageJumpTable` (`funcdata_block.cc:512`) guards the
-clone plus the reduced pipeline behind `if (!partial.isJumptableRecoveryOn())` — so upstream pays for
-that sub-decompilation once per function however many `BRANCHIND`s it holds.
-
-kuna paid it **once per table**. On the witness that is two partials: 3,077 ms of action time plus
-464 ms of cloning inside an 11 s decompile.
-
-This PR hoists the partial into `recover_jump_tables` as an `Option<Funcdata>` threaded through
-`recover_jump_table_flow` into `stage_jump_table`, and builds it only when the slot is empty.
-Recovery still runs per table against that shared partial and mutates it, exactly as upstream's does.
-
-**The correctness half turned out to be the bigger one.** Because kuna's later clone re-cloned the
-jumpvec *after* an earlier sibling had recovered, that clone's `collect_edges` called `target()` on a
-case body decoded only into the parent flow, threw `"Could not find op at target address"`, and
-truncated a perfectly recoverable dispatch to a computed `(code *)()` call. `option unrolledguard`
-(DIV-13) exists **only** to tolerate that self-inflicted condition. Restoring the upstream shape
-removes the cause rather than the symptom.
-
-Shipped behind a settable row — `jtsharepartial`, `on|off`, **default on** — because it changes which
-tables recover, and because `unrolledguard`'s per-table re-clone is precisely what it removes, so that
-option needs `jtsharepartial off` to keep working. The in-code claim that kuna *cannot* share the
-partial because sharing "loses 16 of the 17 switches" was tested rather than believed, and is
-**refuted**: with sharing on and `unrolledguard` off, the memcpy witness recovers all 16 and emits 0
-computed calls. The comment and the spec prose are corrected here.
-
-## The acceptance probe now passes
-
-`a-53d616afcb6a` (`kuna decompile nikos_crack_me.exe sub_140023350`, median `wall_ms < 10000`):
+RE-friction need `decompiling-3396-byte-main` was re-filed as `regressed` on the theory that
+#406 cost this witness ~680 ms. It did not. Two builds, `fba4ebd8` and `96224463`, each with
+its **own** `kuna` *and* `decomp_dbg` (the CLI forks the engine, so pinning only `kuna` times
+the other arm), 8 interleaved pairs of the acceptance command:
 
 ```
-acceptance: PASS   exit_code 0, wall_ms median 9,112 ms  (bar: < 10,000 ms)
-transition: closed
+pre  #406   median 9,619 ms   min 9,146   max 10,903
+post #406   median 9,742 ms   min 9,111   max 11,740
+            paired mean +3.00% ± 6.77 → 0.4σ, median-of-medians +1.28%
 ```
 
-Interleaved paired A/B with the option itself as the lever (same binary in both arms, so the
-`kuna decompile` → `decomp_dbg` fork cannot silently time a different engine), 8 pairs after a warmup
-of each arm:
+and both builds emit the same 120,063 bytes (`sha256 8ee55baf…`), so #406 never fires here.
+The named follow-up — `simdshufflelane` registered unconditionally in the `analysis` rule
+group, i.e. schedule cost that grows with every default-ON pass — was ablated by deleting its
+`rrow!` line and rebuilding: **+0.23% ± 5.33**. One more rule on `CPUI_SUBPIECE`, one of the
+hottest dispatch lists there is, is not measurable on this function.
 
-| arm | median | min |
-|---|---|---|
-| `--option jtsharepartial off` | 10,869 ms | 10,490 ms |
-| default (`on`) | **9,138 ms** | 8,843 ms |
+Six 7-8 sample medians taken this session on one build ranged **9,002–9,742 ms** against the
+10,000 ms bar, and the acceptance suite passed at 9,199 and 9,444 ms with one failure between
+them. The margin is ~7% and the box's spread is ±10%: the need is measurement-limited. The bar
+is not moved.
 
-**−15.92% median**, paired mean −15.96% ± 2.03, **8/8 pairs a win** (~7.8σ), stdout byte-identical on
-the witness. Five attempts: 71.5 → 19.4 → 14.4 → 11.8 → 10.8 → **9.1 s**. The bar was never moved.
+## What ships
 
-## Blast radius — every differing function classified
+Not a fix — the instrument that produced those numbers, which five prior attempts each
+rebuilt as a throwaway patch and threw away:
 
-Whole-surface `decompile-all --json` A/B (option off vs default) over **100 binaries / 21,458
-functions**: the 6 round-2 probe binaries, 9 system ELFs, the 83 `kuna-analysis` fixtures
-(ELF/PE/Mach-O/COFF; x86-64/i386/ARM/Cortex-M/PPC) and `betaflight_STM32F405.elf`.
+```
+$ KUNA_ACTION_PROF=/tmp/prof kuna decompile nikos_crack_me.exe sub_140023350
+$ head -6 /tmp/prof
+total_exclusive_ms 8853.6
+    1205.8 ms   13.62%         68 calls  decompile/oppool1
+    1180.3 ms   13.33%         20 calls  decompile/heritage
+    1083.5 ms   12.24%         27 calls  decompile/deadcode
+    1065.3 ms   12.03%         20 calls  decompile/infertypes
+     601.4 ms    6.79%          5 calls  jumptable/heritage
+```
 
-**62 functions differ. 61 gains, 0 losses, 1 unclassifiable by name.** Aggregate over the differing
-set: **68 truncated `(code *)()` dispatches removed, +237 `switch` statements, +14,770 `case` arms** —
-with `unrolledguard` **off** throughout. Largest movers:
+- Time is **exclusive**: a group is charged only what it runs outside its children, so rows sum
+  to the schedule's wall time and a container cannot hide a leaf. A sampler cannot do this, and
+  `perf` is unavailable on the machines this engine is tuned on.
+- Rows are keyed by **root variant**, which separates the reduced `jumptable` pipeline running
+  on a partial clone from the function's own `decompile` pass. The label comes from
+  `ActionDatabase::set_current`, not from the root Action — `clone_filtered` keeps the universal
+  tree's name, so every row otherwise reads `universal/…`.
+- **Call counts**, because "68 calls of `oppool1`" is the fact a flat profile turns on and no
+  sampler reports.
+- Inert unless `KUNA_ACTION_PROF` is set: one cached read per `apply`, and `apply` is coarse.
+  Measured off-cost on the same witness, 8 interleaved pairs: **+0.89% ± 3.84** (i.e. nothing),
+  stdout byte-identical.
 
-| binary | function | truncated | switch | case |
-|---|---|---|---|---|
-| `mcount_x86_64` | `__memcpy_ssse3_back` | 7 → 2 | 1 → 36 | 144 → 4,384 |
-| `mcount_x86_64` | `__vfprintf_internal` | 0 → 0 | 6 → 16 | 158 → 606 |
-| `mcount_x86_64` | `_nl_load_domain` | 13 → 0 | 1 → 14 | 5 → 70 |
-| `KeyVal2.exe` | `sub_442390` | 0 → 0 | 1 → 15 | 4 → 55 |
-| `system.exe` | `sub_14001d220` | 3 → 0 | 1 → 4 | 68 → 98 |
-
-The classifier keys functions by NAME, so `mcount_x86_64` was re-run keyed by **address**: 19 differing
-rather than 18 (two distinct `printf_positional` bodies collapse under one name), also all gains.
-
-## Gates
-
-| gate | result |
-|---|---|
-| `make test` | **PARITY OK 675/675** — `docs/baseline.json` unmoved (this is the default-ON evidence) |
-| `make test-stages` | **PARITY OK 610/610** (609 → 610), baseline re-recorded |
-| `make rust-test` | **green** (rc=0) |
-| `make check-spec` | OK |
-| `kuna catalog --check` | catalog OK (140 → 141 settables) |
-| `make test-cli` | 24/24 |
-| acceptance `a-53d616afcb6a` | **PASS**, 9,112 ms |
-
-`make rust-test`'s first run reported two failures, both artifacts, both handled: a hard-coded
-live-value count 45 → 46 (fixed here, alongside every other counter re-derived from a fresh capture),
-and `w10_proto_unlock_const_return_collapses_no_tied_roundtrip`, which is a `KUNA_DECOMP_TEST`
-environment artifact — that variable is exported in the builder environment and makes the test use the
-Rust binary as its "C++ oracle", so the oracle renders `unsigned int` where the test pins `xunknown4`.
-Green with the variable unset; nothing in this change can reach type spelling.
+No option row: this cannot change emitted C. It follows the existing env-gated debug-hook
+convention (`KUNA_DEFAULT_ON`, `KUNA_SYMBOLNAMEBOUND`).
 
 ## Tests
 
-- `tests/stages/ghangr-optimized-memcpy-6301a9.xml` grows a **third pass**: pass 1 both gates off = the
-  bug (7 `code **`, 1 `switch`), pass 2 `unrolledguard on` = its fix (+16), pass 3 `unrolledguard` OFF
-  + `jtsharepartial` ON = the shipped default's fix (+16). Asserts `code **` == 7 across the whole
-  stream and `switch(` == 33, plus a three-pass sentinel so the counts cannot be one dropped pass.
-- `tests/cli/decompiling-3396-byte-main.json` — the promoted regression probe. The dataset acceptance
-  is unvendorable *and* wall-clock, so the in-repo twin pins the mechanism on the existing
-  `mcount_x86_64` fixture: `__gettextparse` holds two tables in one batch and goes 1 switch + 1
-  truncated computed call → 2 switches + 0, with 28 more case arms.
-
-## Recorded as a convergence, not a DIV
-
-`docs/history.md`'s own rule: *"a port defect whose fix moves kuna back onto upstream's default earns
-no DIV row, but a corpus-wide output shift still needs a record for anyone bisecting."* After this
-change kuna's default **matches** C++ `stageJumpTable`, so there is no divergence left to register.
-The row is in the Convergences table. This is the one place the PR departs from the dispatch brief,
-and it departs toward the document's stated rule.
+Four unit tests in `infra/actionprof/tests.rs`: a parent is not charged its child's time, two
+roots do not share a row, `render` sorts by cost and totals, and an unbalanced `leave` is inert
+rather than a panic. `make test` PARITY OK 675/675 · `make test-stages` PARITY OK 628/628 ·
+`make rust-test` green (352 targets) · `make check-spec` OK · `kuna catalog --check` OK ·
+`make test-cli` 29/29 · acceptance `a-53d616afcb6a` PASS at a 7-rep median of **9,227 ms**
+(8,863–9,484).
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/decompiling-3396-byte-main/record.json
+++ b/docs/features/decompiling-3396-byte-main/record.json
@@ -1,73 +1,76 @@
 {
-  "opportunity": "decompiling-3396-byte-main",
-  "need_id": "decompiling-3396-byte-main",
-  "route": "RE-friction loop (docs/re-pipeline.md), round 2, track perf -- ATTEMPT 5 (IMPLEMENTATION, captain-briefed)",
-  "challenge": "69a3822f7b3cc38c80464da4",
-  "binary": ".kuna-repipe/probebin/bcfacd743bc607be/nikos_crack_me.exe (PE x86-64, 235725 bytes)",
-  "selector": "sub_140023350",
-  "scope": "small",
-  "attempt": 5,
-  "prior_attempts": [
-    {
-      "pr": 380,
-      "summary": "dead-list position re-derived by scanning; 71.46 s -> 19.42 s (-72.8%), acceptance not met"
-    },
-    {
-      "pr": 385,
-      "summary": "`kuna decompile` followed the same flow twice; 19.70 s -> 15.32 s (-22.3%), acceptance not met"
-    },
-    {
-      "pr": 393,
-      "summary": "three per-query re-derivations of cached facts + one fused arena lookup; 14.57 s -> 12.18 s (-16.3%), acceptance not met"
-    },
-    {
-      "pr": 396,
-      "summary": "Rc traffic on 9.5 M ordered-container mutations; 12.06 s -> 11.23 s (-6.9%), acceptance not met"
-    }
-  ],
-  "phase": "P2 lift/flow -- jump-table recovery (FlowInfo::recoverJumpTables / Funcdata::stageJumpTable)",
-  "modules": [
-    "decompiler/crates/kuna-decomp/src/substrate/funcdata_block.rs (Funcdata::stage_jump_table, Funcdata::recover_jump_table_flow)",
-    "decompiler/crates/kuna-decomp/src/p2_lift/flow.rs (FlowInfo::recover_jump_tables)",
-    "decompiler/crates/kuna-decomp/src/infra/architecture.rs (jumptable_share_partial + set_kuna_option + build_arch_handle)",
-    "decompiler/crates/kuna-decomp/src/substrate/context.rs (ArchSeam::jumptable_share_partial)",
-    "decompiler/crates/kuna-decomp/phases.toml + src/p0_knowledge/options.rs (settable row + registration)"
-  ],
-  "change_kind": "performance-fix that is also a recovery gain (upstream-shape convergence)",
-  "option": "jtsharepartial (on|off, default on)",
-  "gated": true,
-  "gating_rationale": "Sharing the partial changes WHICH jump tables recover -- it is the shape `option unrolledguard` was written against, and turning it off is the only way to get unrolledguard's per-table re-clone back. So it ships as a settable row even though every measured difference is a gain. Default ON has the required evidence: 0/675 datatest assertions moved, docs/baseline.json unmoved.",
-  "hypothesis_filed": "The function's extensive opaque arithmetic and indirect calls cause one or more analysis passes to scale poorly.",
-  "hypothesis_verdict": "Refuted for the fifth time, and this attempt did not re-derive it. The captain's brief named the mechanism: kuna ran the jump-table partial sub-decompilation once per TABLE where C++ runs it once per FUNCTION. Confirmed here at 2 tables on the witness.",
-  "root_cause": "`Funcdata::stage_jump_table` built a fresh `@@jumprecovery` partial (clone the raw p-code + jump-tables, build blocks, run the reduced \"jumptable\" action set) for EVERY table. C++ `FlowInfo::recoverJumpTables` (flow.cc:1429) constructs one `partial` per call and `Funcdata::stageJumpTable` (funcdata_block.cc:512) guards the clone plus the pipeline behind `if (!partial.isJumptableRecoveryOn())`. The correctness half is larger than the speed half: because kuna's later clone re-cloned the jumpvec AFTER an earlier sibling recovered, that clone's collect_edges called target() on a case body decoded only into the parent flow, threw \"Could not find op at target address\", and truncated a recoverable dispatch to a computed (code *)() call. `option unrolledguard` exists solely to tolerate that self-inflicted condition.",
-  "fix": "Hoist the partial into `FlowInfo::recover_jump_tables` as an `Option<Funcdata>` threaded through `recover_jump_table_flow` into `stage_jump_table`; build + run the reduced pipeline only when the slot is empty. Recovery itself still runs per table against the shared partial and mutates it, exactly as upstream does. `option jtsharepartial off` restores the per-table clone byte for byte.",
-  "profiling_method": "None needed and none run -- the profile was inherited from attempts 1-4 (this file and the need record). Measurement is an interleaved paired A/B using the OPTION as the lever, so both arms are the same binary and the `kuna decompile` -> `decomp_dbg` fork cannot silently time a different engine (the trap that voided wave 14's pre/post delta).",
-  "measurement": "Witness `kuna decompile nikos_crack_me.exe sub_140023350` (the acceptance command, no --json), 8 interleaved pairs after a warmup of each arm: OFF median 10,869 ms (min 10,490), ON median 9,138 ms (min 8,843). Median delta -15.92%; paired mean -15.96% +/- 2.03; 8/8 pairs a win (~7.8 sigma). Both arms byte-identical stdout on this witness.",
-  "residue_map": "Not re-measured; the post-#393/#396 profile stands (heritage ~23%, oppool1 ~14%, ActionDeadCode ~15%, merge ~8%) minus roughly one of the two `stage_jump_table` blocks. There is no single remaining lever of this size; the function is IR-volume-bound (#396).",
-  "refuted_leads": [
-    "The prior in-code claim that sharing 'loses 16 of the 17 switches' the unrolledguard testcase asserts is WRONG as stated. Measured: with sharing on and unrolledguard OFF the memcpy witness recovers 16 switches and 0 computed calls -- sharing FIXES that testcase's bug rather than regressing it. What sharing removes is unrolledguard's MECHANISM (the per-table re-clone), which is why the option is still reachable.",
-    "The captain's suggested gate 'share by default, keep per-table cloning for the unrolledguard-on path' was checked and rejected: `unrolledguard` is in AGGRESSIVE_OVERRIDES and `auto` picks aggressive under 500 KiB, so that gate would be inert on this very witness. The two options are documented as paired instead (turn unrolledguard on together with jtsharepartial off)."
-  ],
-  "left_on_the_table": "`unrolledguard` is now redundant on every shape measured here and is a candidate for removal or for dropping out of AGGRESSIVE_OVERRIDES; that is a separate default change with its own evidence burden and was not taken in this PR.",
-  "tests": [
-    "tests/stages/ghangr-optimized-memcpy-6301a9.xml grows a THIRD pass (609 -> 610 assertions): pass 1 both gates off = the bug (7 `code **`, 1 switch), pass 2 unrolledguard on = its fix (+16), pass 3 unrolledguard OFF + jtsharepartial ON = the shipped default's fix (+16). Asserts `code **` == 7 across the whole stream (so pass 3 adds none) and `switch(` == 33, plus a 3-pass sentinel (`memcpy_opt(` == 3) so the counts cannot be one dropped pass.",
-    "tests/cli/decompiling-3396-byte-main.json: the promoted regression probe. The dataset acceptance is unvendorable AND wall-clock, so the in-repo twin pins the mechanism on the existing `mcount_x86_64` fixture -- `__gettextparse` holds two tables in one batch and goes 1 switch + 1 truncated computed call -> 2 switches + 0, with 28 more case arms."
-  ],
-  "regression_sweep": "Whole-surface `decompile-all --json` A/B (option off vs default) over 100 binaries / 21,458 functions: the 6 round-2 probe binaries, 9 system ELFs (ls, grep, tar, bash, gzip, sed, awk, objdump, python3.12), the 83 kuna-analysis fixtures (ELF/PE/Mach-O/COFF; x86-64/i386/ARM/Cortex-M/PPC) and betaflight_STM32F405.elf. 62 functions differ. Every one was classified by truncated-dispatch / switch / case counts: 61 GAINS, 0 losses, 1 unclassifiable by name (two `printf_positional` bodies share a name). Aggregate: 68 truncated `(code *)()` dispatches removed, +237 switches, +14,770 case arms. `mcount_x86_64` was re-run keyed by ADDRESS to defeat the name collision: 19 differing, all gains. The two arms' warning streams also differ in the expected direction -- the witness's `[kuna unrolledguard] ... skipped 6 undecoded sibling-table case-target edge(s)` line disappears under the default, because the condition no longer arises.",
-  "gates": {
-    "make test": "PARITY OK 675/675, docs/baseline.json unmoved",
-    "make test-stages": "PARITY OK 610/610 (609 -> 610), docs/baseline-stages.json re-recorded",
-    "make rust-test": "green (rc=0). NOTE: the first run reported 2 failures, both artifacts: one hard-coded live-value count 45 -> 46 (fixed), and `w10_proto_unlock_const_return_collapses_no_tied_roundtrip`, which is a KUNA_DECOMP_TEST env artifact -- that var is exported in the builder environment and makes the test use the Rust binary as its 'C++ oracle', so the oracle renders `unsigned int` where the test pins `xunknown4`. Green with the var unset.",
-    "make check-spec": "OK",
-    "kuna catalog --check": "catalog OK (140 -> 141 settables; all hard-coded counters re-derived from a fresh capture, phase_catalog.json recaptured)",
-    "make test-cli": "24/24",
-    "acceptance a-53d616afcb6a": "PASS -- 9,112 ms median against the < 10,000 ms bar, exit 0"
+ "opportunity": "decompiling-3396-byte-main",
+ "need_id": "decompiling-3396-byte-main",
+ "route": "RE-friction loop (docs/re-pipeline.md), round 2, track perf -- ATTEMPT 6 (captain-briefed: run the code A/B first, do not fix)",
+ "challenge": "69a3822f7b3cc38c80464da4",
+ "binary": ".kuna-repipe/probebin/bcfacd743bc607be/nikos_crack_me.exe (PE x86-64, 235725 bytes)",
+ "selector": "sub_140023350",
+ "scope": "small",
+ "attempt": 6,
+ "prior_attempts": [
+  {
+   "pr": 380,
+   "summary": "dead-list position re-derived by scanning; 71.46 s -> 19.42 s (-72.8%), acceptance not met"
   },
-  "decisions": [
-    "THE NEED CLOSES. The acceptance probe passes for the first time in five attempts: 9,112 ms against < 10,000 ms (71.5 -> 19.4 -> 14.4 -> 11.8 -> 10.8 -> 9.1 s). The bar was never moved.",
-    "Recorded as a CONVERGENCE in docs/history.md, not a DIV row. docs/history.md's own rule is explicit: 'a port defect whose fix moves kuna back onto upstream's default earns no DIV row, but a corpus-wide output shift still needs a record'. After this change kuna's DEFAULT matches C++ stageJumpTable, so there is no divergence left to register. The captain's brief said 'DIV row'; this is the one place this PR departs from it, and it departs toward the document's stated rule.",
-    "The measured -15.92% is under the perf track's nominal 20% single-target bar and is carried anyway: 8/8 interleaved pairs are wins at +/- 2.03, the arms are the same binary with the option as the lever, and the acceptance probe -- the actual definition of done -- passes. The number is reported as measured.",
-    "The change ships DEFAULT-ON. Evidence per the standing requirement: 0/675 datatest assertions move. The output that does move (62 of 21,458 functions) was individually classified and is 61 gains / 0 losses.",
-    "The in-code comment claiming kuna 'cannot share' the partial because unrolledguard 'loses 16 of the 17 switches' was tested rather than believed, and is refuted: sharing recovers all 16 with unrolledguard off. The comment and the spec prose are corrected in this PR."
-  ]
+  {
+   "pr": 385,
+   "summary": "`kuna decompile` followed the same flow twice; 19.70 s -> 15.32 s (-22.3%), acceptance not met"
+  },
+  {
+   "pr": 393,
+   "summary": "three per-query re-derivations of cached facts + one fused arena lookup; 14.57 s -> 12.18 s (-16.3%), acceptance not met"
+  },
+  {
+   "pr": 396,
+   "summary": "Rc traffic on 9.5 M ordered-container mutations; 12.06 s -> 11.23 s (-6.9%), acceptance not met"
+  },
+  {
+   "pr": 397,
+   "summary": "share the jump-table partial across a batch's tables (option jtsharepartial, default on); 10.87 s -> 9.14 s (-15.9%), ACCEPTANCE MET at 9.2 s"
+  }
+ ],
+ "phase": "infra (Action scheduler instrumentation); no phase behaviour changed",
+ "modules": [
+  "decompiler/crates/kuna-decomp/src/infra/actionprof.rs (new -- the exclusive-time table)",
+  "decompiler/crates/kuna-decomp/src/infra/action.rs (Action::perform wraps apply; ActionDatabase::set_current names the root)",
+  "decompiler/crates/kuna-decomp/src/infra/mod.rs"
+ ],
+ "change_kind": "measurement + a refutation; no engine behaviour change and no option",
+ "option": null,
+ "gated": false,
+ "gating_rationale": "Nothing here can change emitted C: the profiler only times `apply` and writes a file, and it is inert unless KUNA_ACTION_PROF is set. No phases.toml row, no catalog count, no DIV.",
+ "hypothesis_filed": "wave 39 captain: #406 (simdlane + retsplitglobal) regressed this witness by ~680 ms on top of a 341 ms drift; the shape to look at first is cumulative default-ON schedule cost.",
+ "hypothesis_verdict": "REFUTED by the code A/B the brief asked for. fba4ebd8 vs 96224463, 8 interleaved pairs, engines pinned with KUNA_DECOMP_DBG: +3.00% +/- 6.77 (0.4 sigma), median-of-medians +1.28%, and stdout byte-identical between the two builds (sha256 8ee55baf..., 120,063 bytes) -- #406 does not fire on this function. The schedule-cost half was ablated separately by deleting the `simdshufflelane` rrow! line and rebuilding: +0.23% +/- 5.33, median-of-medians -0.72%.",
+ "root_cause": "There is no regression to have a cause. The acceptance margin is ~7% (9.0-9.5 s against a 10,000 ms bar) and this box's run-to-run spread on the same binary is +/-10%: six 7-8 sample medians taken in one session on ONE build ranged 9,002-9,742 ms, and the acceptance suite itself passed at 9,199 ms and 9,444 ms and failed once between them. The need is measurement-limited, which is exactly the flat branch the wave-39 brief wrote down.",
+ "fix": "None attempted, per the brief. What shipped instead is the instrument: `KUNA_ACTION_PROF=<path>` writes an exclusive-time, call-counted table of the Action tree, keyed by root variant (`decompile` vs the reduced `jumptable` pipeline) so a sub-decompilation is separated for free. Attempts 1-5 each built this timer as a throwaway patch; keeping it is the difference between a future attempt starting with a profile and starting with a build.",
+ "profiling_method": "Instrumentation, not sampling (`perf_event_paranoid = 4` on this box, no valgrind, and gdb-as-parent stopped working at attempt 4). Timing is an interleaved paired A/B with the two arms' `kuna` AND `decomp_dbg` both pinned per arm -- `kuna decompile` forks the engine, so copying only `kuna` aside silently times the other arm (the trap that voided wave 14's delta).",
+ "measurement": "Witness `kuna decompile nikos_crack_me.exe sub_140023350`. (1) pre/post #406: 9,619 vs 9,742 ms median, +3.00% +/- 6.77 paired, 8 pairs. (2) simdshufflelane ablated vs HEAD: 9,358 vs 9,290 ms median, +0.23% +/- 5.33, 8 pairs. (3) profiler-off cost, HEAD vs HEAD+profiler: 9,115 vs 9,002 ms median, +0.89% +/- 3.84, 8 pairs. Every arm of all three A/Bs produced the same 120,063-byte stdout.",
+ "residue_map": "Measured fresh with the new profiler (10.2 s run, 8,854 ms inside the Action tree): decompile/oppool1 1,206 ms 13.6% (68 calls), decompile/heritage 1,180 ms 13.3% (20), decompile/deadcode 1,084 ms 12.2% (27), decompile/infertypes 1,065 ms 12.0% (20), decompile/mergerequired 618 ms 7.0% (1), decompile/directwrite 401 ms, decompile/restructure_varnode 355 ms, decompile/blockstructure 320 ms, decompile/nonzeromask 289 ms, decompile/mergetype 269 ms; the shared jump-table partial totals 1,387 ms 15.7% (heritage 601, deadcode 388, oppool1 337). ~1.7 s of the run is outside the tree, of which 0.95 s is load + function discovery (timed with `kuna functions --json`). Four ~12% blocks and no lever: the function is IR-volume-bound, as #396 concluded.",
+ "refuted_leads": [
+  "#406 as the cause of the wave-39 flip: byte-identical output and 0.4 sigma across a code A/B.",
+  "Cumulative default-ON schedule cost, i.e. one more rule row on a hot opcode: +0.23% +/- 5.33 for `simdshufflelane`, which is registered for CPUI_SUBPIECE and so sits on one of the hottest dispatch lists there is. If a rule row there is unmeasurable, the schedule-growth theory needs a different mechanism than 'one more row'.",
+  "A load-tier win: `kuna functions` (load + markup + discovery, no decompile) is 0.95 s of a 9.2 s run."
+ ],
+ "left_on_the_table": "A seventh attempt needs a mechanism in hand before it is dispatched. The perf bar is 3 sigma and >=20% (~1.9 s here) and the residue is four ~12% blocks, so the only remaining shape is IR volume itself: 48,169 raw ops and ~37,710 INDIRECTs across 365 call sites, i.e. heritage's call guarding, which #393 and #396 both probed and both concluded was construction cost rather than a memoizable query.",
+ "tests": [
+  "decompiler/crates/kuna-decomp/src/infra/actionprof/tests.rs -- 4 unit tests: exclusive accounting (a parent is not charged its child's time), root keying (`decompile/` vs `jumptable/`), render ordering + total, and an unbalanced `leave` being inert.",
+  "tests/cli/decompiling-3396-byte-main.json -- the already-promoted in-repo timing twin, unchanged."
+ ],
+ "regression_sweep": "Not applicable in the usual sense (no behaviour change), and checked rather than assumed: all three A/Bs above compare stdout hashes across arms, 48 decompiles of the witness in total, one hash.",
+ "gates": {
+  "make test": "PARITY OK, 675/675 assertions",
+  "make test-stages": "PARITY OK, 628/628 assertions",
+  "make rust-test": "green (352 test targets ok), run with `env -u KUNA_DECOMP_TEST` -- see decisions",
+  "make check-spec": "OK",
+  "kuna catalog --check": "OK: documents exactly the registered kuna options",
+  "make test-cli": "29/29",
+  "acceptance a-53d616afcb6a": "PASS, 7-rep median 9,199 ms against the < 10,000 ms bar"
+ },
+ "decisions": [
+  "The brief's flat branch was taken literally: the A/B came back flat, so no fix was attempted and the bar was NOT relaxed. Re-cutting `< 10000` would redefine `closed` as 'a builder tried'; five captains have declined to move it and the sixth attempt did not need it moved.",
+  "The profiler ships without an option row. `docs/agents.md` gates anything that CAN change emitted C; this times `apply` and writes a file, and its off-path is one cached read. It follows the existing env-gated debug-hook convention (`KUNA_DEFAULT_ON`, `KUNA_SYMBOLNAMEBOUND`) rather than the settable-option convention.",
+  "Rows are keyed by root variant, not by the root Action's own name: `clone_filtered` keeps the universal tree's name, so every row came back as `universal/...` until the label was taken from `ActionDatabase::set_current` instead.",
+  "The stale `/tmp/<worker>.rust.rc` from a previous attempt on this same worker id read 0 minutes into this session's suite. Any rc-file wait on a reused worker id must delete the file first or check its mtime.",
+  "`make rust-test` is RED in a repipe worktree for a reason that is not the tree: the harness exports KUNA_DECOMP_TEST, and `cpp_oracle_bin()` in the verify_w10_* tests uses it as the C++ oracle. With the C++ tree gone that fallback path does not exist, so those oracle assertions are normally skipped; pointed at kuna's own decomp_test_dbg they assert upstream spellings kuna deliberately changed (`xunknown4` vs DIV-6 `unsigned int`) and fail. Confirmed by bisection: the same test fails on unmodified HEAD and passes under `env -u KUNA_DECOMP_TEST`. Run the suite with that env var unset."
+ ]
 }

--- a/docs/re-needs/decompiling-3396-byte-main.md
+++ b/docs/re-needs/decompiling-3396-byte-main.md
@@ -12,7 +12,7 @@ instances: 1
 challenges: [69a3822f7b3cc38c80464da4]
 rounds: [2]
 first_seen_round: 2
-attempts: 5
+attempts: 6
 covered_by_option: null
 touches: [decompiler/crates/kuna-decomp, decompiler/crates/kuna-console, decompiler/crates/kuna-decomp/phases.toml, decompiler/crates/kuna-decomp/src/p0_knowledge/options.rs, docs/options.md, docs/history.md, tests/stages]
 scope: small
@@ -256,6 +256,51 @@ Two findings worth keeping beyond this need:
   ON. The two options are documented as *paired* instead: turn `unrolledguard` on together with
   `jtsharepartial off`.
 
+**Attempt 6 (round 2 wave 40, branch `feat/re-decompiling-3396-byte-main`). The wave-39
+regression is REFUTED by the code A/B it asked for, and the acceptance passes again.** The
+brief's first job was: build `fba4ebd8` and `96224463` in two worktrees and interleave at
+reps >= 7 on the same box. Done, 8 interleaved pairs, each arm pinned with `KUNA_DECOMP_DBG`
+so the `kuna decompile` -> `decomp_dbg` fork cannot time the other arm's engine:
+
+    pre  #406 (fba4ebd8)  median 9,619 ms   min 9,146   max 10,903
+    post #406 (96224463)  median 9,742 ms   min 9,111   max 11,740
+    paired mean +3.00% +/- 6.77 (0.4 sigma), median-of-medians +1.28%
+
+That is half a sigma on a bar this loop holds to 3. **stdout is byte-identical across the two
+builds** (sha256 `8ee55baf...`, 120,063 bytes), so #406 does not fire on this function at all;
+what was measured at wave 39 was the box, not the merge. The second half of the brief --
+"cumulative default-ON schedule cost", `simdshufflelane` registered unconditionally in the
+`analysis` rule group -- was ablated the same way, by deleting the `rrow!` line and rebuilding:
+**+0.23% +/- 5.33** (median-of-medians -0.72%). One more rule on the hottest opcode's dispatch
+list is not measurable here.
+
+The finding is the one wave 39 named as the flat branch: **this bar is inside the box's noise
+floor and the need is measurement-limited.** Six separate 7-8 sample medians taken this session
+on the same build ranged 9,002-9,742 ms against a 10,000 ms bar; the acceptance suite itself
+passed at 9,199 ms, 9,444 ms and 9,227 ms and failed once between them. The margin is ~7% and the
+run-to-run spread is +/-10%. **The bar was not moved** -- five attempts took this witness 71.5 -> 19.4 ->
+14.4 -> 11.8 -> 10.8 -> 9.2 s and the sixth did not need to.
+
+What attempt 6 leaves behind instead of a fix is the instrument every prior attempt built and
+threw away: `KUNA_ACTION_PROF=<path>` writes an exclusive-time, call-counted table of the Action
+tree, keyed by root variant so the reduced `jumptable` pipeline is separated from the function's
+own `decompile` pass for free. Off by default, +0.89% +/- 3.84 (i.e. nothing) with the variable
+unset. The current profile of this witness, for whoever is dispatched next:
+
+    decompile/oppool1     1,206 ms  13.6%   68 calls
+    decompile/heritage    1,180 ms  13.3%   20 calls
+    decompile/deadcode    1,084 ms  12.2%   27 calls
+    decompile/infertypes  1,065 ms  12.0%   20 calls
+    decompile/mergerequired 618 ms   7.0%    1 call
+    jumptable/*           1,387 ms  15.7%          (the shared partial, post-#397)
+    (8,854 ms of action time in a 10.2 s profiled run; ~1.7 s of the run is outside
+     the tree -- 0.95 s of it is load + function discovery, measured with `kuna functions`)
+
+**A seventh attempt should be dispatched only with a mechanism in hand.** The residue is flat in
+four ~12% blocks, this loop's perf bar is 3 sigma and >=20%, and the box's noise floor on this
+witness is larger than the margin -- so any future win here has to be structural (IR volume), and
+any future `regressed` flip on this need has to be settled by a code A/B before it is believed.
+
 ## Reference
 
 _none recorded_
@@ -429,3 +474,11 @@ _none recorded_
   (`infra/universalaction.rs:425`); the question is what it costs on a 3396-byte function where it
   never fires. See [[kuna-lifter-quadratic]] for the profiling lever (`kuna decompile` forks
   `decomp_dbg` and eats its stderr -- profile `--json`).
+- round 2 wave 40 BUILDER (b-r2-decompiling-3396), **attempt 6: the wave-39 `regressed` flip is a
+  measurement artifact and the code A/B says so.** Interleaved 8-pair A/B of `fba4ebd8` vs
+  `96224463`, engines pinned with `KUNA_DECOMP_DBG`, gave +3.00% +/- 6.77 (0.4 sigma) with
+  byte-identical stdout across the two builds -- #406 does not fire on this function. The named
+  follow-up (`simdshufflelane` in the `analysis` rule group) was ablated by deleting its `rrow!`
+  line: +0.23% +/- 5.33. Per the brief's flat branch, no fix was attempted and the bar was not
+  relaxed. Shipped instead: `KUNA_ACTION_PROF`, the per-Action exclusive-time profiler attempts
+  1-5 each rebuilt and discarded, plus this witness's current profile in the prose above.

--- a/docs/re-needs/decompiling-3396-byte-main.md
+++ b/docs/re-needs/decompiling-3396-byte-main.md
@@ -17,7 +17,7 @@ covered_by_option: null
 touches: [decompiler/crates/kuna-decomp, decompiler/crates/kuna-console, decompiler/crates/kuna-decomp/phases.toml, decompiler/crates/kuna-decomp/src/p0_knowledge/options.rs, docs/options.md, docs/history.md, tests/stages]
 scope: small
 regression_of: null
-pr: "396"
+pr: "411"
 closed_in_round: 2
 closing_pr: "397"
 reject_reason: null

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -1230,6 +1230,21 @@ Flow-follow itself runs *before* the tree (the upstream `followFlow` →
 (reset_defaults_internal)`), applied at
 `decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs (follow_flow_on_fd)`.
 
+**Where a run's time went** (kuna). The schedule can be asked to account for
+itself: with `KUNA_ACTION_PROF` set to a path, every `apply` call is timed and
+the engine writes an exclusive-time table there
+(`decompiler/crates/kuna-decomp/src/infra/actionprof.rs`), rewritten each time
+the schedule unwinds so the file holds the running total for the whole process.
+Time is exclusive — a group is charged only what it spends outside its children,
+so the rows sum to the schedule's wall time and a container cannot hide a leaf —
+and each row is keyed by the root variant it ran under, which is what separates a
+function's own `decompile` pass from the reduced `jumptable` pipeline running on
+a partial clone beside it. The root label is set where the variant is selected
+(`decompiler/crates/kuna-decomp/src/infra/action.rs
+(ActionDatabase::set_current)`). This is a measuring instrument, not a decision
+point: it changes nothing the engine emits, and with the variable unset it costs
+one cached read per `apply`.
+
 ## 0.7 Feedback edges
 
 The pipeline is a fixpoint machine wearing a pipeline's clothes. Beyond the


### PR DESCRIPTION
## What was measured

RE-friction need `decompiling-3396-byte-main` was re-filed as `regressed` on the theory that
#406 cost this witness ~680 ms. It did not. Two builds, `fba4ebd8` and `96224463`, each with
its **own** `kuna` *and* `decomp_dbg` (the CLI forks the engine, so pinning only `kuna` times
the other arm), 8 interleaved pairs of the acceptance command:

```
pre  #406   median 9,619 ms   min 9,146   max 10,903
post #406   median 9,742 ms   min 9,111   max 11,740
            paired mean +3.00% ± 6.77 → 0.4σ, median-of-medians +1.28%
```

and both builds emit the same 120,063 bytes (`sha256 8ee55baf…`), so #406 never fires here.
The named follow-up — `simdshufflelane` registered unconditionally in the `analysis` rule
group, i.e. schedule cost that grows with every default-ON pass — was ablated by deleting its
`rrow!` line and rebuilding: **+0.23% ± 5.33**. One more rule on `CPUI_SUBPIECE`, one of the
hottest dispatch lists there is, is not measurable on this function.

Six 7-8 sample medians taken this session on one build ranged **9,002–9,742 ms** against the
10,000 ms bar, and the acceptance suite passed at 9,199 and 9,444 ms with one failure between
them. The margin is ~7% and the box's spread is ±10%: the need is measurement-limited. The bar
is not moved.

## What ships

Not a fix — the instrument that produced those numbers, which five prior attempts each
rebuilt as a throwaway patch and threw away:

```
$ KUNA_ACTION_PROF=/tmp/prof kuna decompile nikos_crack_me.exe sub_140023350
$ head -6 /tmp/prof
total_exclusive_ms 8853.6
    1205.8 ms   13.62%         68 calls  decompile/oppool1
    1180.3 ms   13.33%         20 calls  decompile/heritage
    1083.5 ms   12.24%         27 calls  decompile/deadcode
    1065.3 ms   12.03%         20 calls  decompile/infertypes
     601.4 ms    6.79%          5 calls  jumptable/heritage
```

- Time is **exclusive**: a group is charged only what it runs outside its children, so rows sum
  to the schedule's wall time and a container cannot hide a leaf. A sampler cannot do this, and
  `perf` is unavailable on the machines this engine is tuned on.
- Rows are keyed by **root variant**, which separates the reduced `jumptable` pipeline running
  on a partial clone from the function's own `decompile` pass. The label comes from
  `ActionDatabase::set_current`, not from the root Action — `clone_filtered` keeps the universal
  tree's name, so every row otherwise reads `universal/…`.
- **Call counts**, because "68 calls of `oppool1`" is the fact a flat profile turns on and no
  sampler reports.
- Inert unless `KUNA_ACTION_PROF` is set: one cached read per `apply`, and `apply` is coarse.
  Measured off-cost on the same witness, 8 interleaved pairs: **+0.89% ± 3.84** (i.e. nothing),
  stdout byte-identical.

No option row: this cannot change emitted C. It follows the existing env-gated debug-hook
convention (`KUNA_DEFAULT_ON`, `KUNA_SYMBOLNAMEBOUND`).

## Tests

Four unit tests in `infra/actionprof/tests.rs`: a parent is not charged its child's time, two
roots do not share a row, `render` sorts by cost and totals, and an unbalanced `leave` is inert
rather than a panic. `make test` PARITY OK 675/675 · `make test-stages` PARITY OK 628/628 ·
`make rust-test` green (352 targets) · `make check-spec` OK · `kuna catalog --check` OK ·
`make test-cli` 29/29 · acceptance `a-53d616afcb6a` PASS at a 7-rep median of **9,227 ms**
(8,863–9,484).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
