### PR TITLE
[AUTOMATED] fix(brief): take one reference reading before giving up kuna-blocked

### DIFF
--- a/tools/repipe/tester_prompt.md
+++ b/tools/repipe/tester_prompt.md
@@ -33,6 +33,22 @@ Round {{ROUND}} · challenge `{{HEXID}}` · time budget **{{TIME_BUDGET}} minute
 2. **You may give up.** If kuna is too bad to make progress, set `outcome: "gave_up"` with
    `gave_up_reason: "kuna-blocked"` and file the observations that blocked you. That is a
    *success* for this pipeline, not a failure. Do not grind for an hour to save face.
+
+   **But before you do, take ONE reading from `bin/ida-decompile` on the exact thing that
+   blocked you**, and put it in that observation's `reference_better`. This is the single
+   most valuable measurement you can make, and it is the one we keep failing to collect:
+   round 3 had two testers give up `kuna-blocked` inside three minutes each, both without a
+   single reference call, so we learned that kuna failed and nothing about whether the task
+   was possible.
+   - If the reference **succeeds** where kuna failed, that is the strongest evidence this
+     pipeline can produce: the job is doable and kuna specifically cannot do it. Record what
+     it returned.
+   - If the reference **fails too**, say so. That is just as useful — it reclassifies the
+     need from "kuna is behind" to "nobody does this", which changes what gets built and
+     usually lowers its priority.
+
+   One call, on the blocking question only. This is not permission to work the challenge with
+   the reference; you are still giving up.
 3. **Do not read anything outside `{{ARENA}}`** except the kuna repo's own docs. The
    challenge's metadata, its published solutions and its answer are deliberately not in your
    sandbox. Do not go looking.


### PR DESCRIPTION
`gave_up: kuna-blocked` is the loop's headline metric and round 3 produced it for
the first time -- two of five finished testers, in three minutes each. Both gave up
without a single `bin/ida-decompile` call, so what we learned is "kuna failed" and
nothing at all about whether the task was even possible.

That gap is not the testers being lazy. The brief says IDA is a last resort and
gives no instruction about the moment a tester actually decides to stop, which is
precisely the moment one reference call is worth most. Round 3 is also the FIRST
round where the reference arm works at all -- it was broken by two separate bugs
for rounds 1 and 2 (#371, #373) -- so no brief had a reason to ask before now.

So: one call, on the blocking question only, recorded in `reference_better`.
Both outcomes are useful and the brief says so explicitly:

- reference SUCCEEDS where kuna failed -> the strongest evidence this pipeline can
  produce, because it separates "kuna is behind" from "the task is hard".
- reference FAILS too -> reclassifies the need from a kuna gap to "nobody does
  this", which changes what gets built and usually lowers its priority.

Scoped deliberately: one call, not permission to work the challenge with the
reference. The tester is still giving up.

tools/repipe/smoke.sh 111/111.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcFmfZndNjgfqLQVBZCdkY