### PR TITLE
[AUTOMATED] fix(cli): --assert's error named the wrong problem, and five agents believed it

### DIFF
--- a/decompiler/crates/kuna-cli/src/assertdecl.rs
+++ b/decompiler/crates/kuna-cli/src/assertdecl.rs
@@ -180,7 +180,33 @@ fn take_token(s: &str) -> (&str, &str) {
 pub(crate) fn parse_one(spec: &str) -> Result<Directive, String> {
     let raw = spec.trim().to_string();
     let (keyword, rest) = take_token(&raw);
-    let bad = |what: &str| format!("--assert {raw:?}: {what}");
+    // The WHOLE directive is one argument. Five of eight round-3 testers wrote
+    //   --assert prototype main int main(void)
+    // instead of
+    //   --assert "prototype main int main(void)"
+    // so the shell handed us just "prototype", `rest` came back empty, and the message
+    // ("prototype needs <func> then a C declaration") named the CONTENT we wanted while
+    // saying nothing about the shape. All five read it as a type rejection and filed
+    // "kuna rejects the standard C type int" -- a defect that does not exist; the quoted
+    // form accepts `int`, `unsigned int` and `char **` fine. A diagnostic that produces
+    // the same false diagnosis in five independent agents is worse than the bug they
+    // thought they had found, so when the spec is a bare keyword, say what is actually
+    // wrong and show the fix.
+    let bad = |what: &str| {
+        if rest.is_empty() && !raw.is_empty() {
+            format!(
+                "--assert {raw:?}: {what}\n\
+                 hint: the whole assertion is ONE argument -- quote it. You probably wrote\n\
+                 \x20      --assert {kw} <rest of the declaration>\n\
+                 \x20  and the shell split it. Write:\n\
+                 \x20      --assert \"{kw} <rest of the declaration>\"\n\
+                 \x20  e.g. --assert \"prototype main int main(int argc, char **argv)\"",
+                kw = keyword
+            )
+        } else {
+            format!("--assert {raw:?}: {what}")
+        }
+    };
     let body = match keyword {
         "function" => {
             let decls = crate::funcdecl::parse_flag(rest)

--- a/tests/cli/assert-unquoted-says-so.json
+++ b/tests/cli/assert-unquoted-says-so.json
@@ -1,0 +1,34 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "main",
+    "--assert",
+    "prototype"
+  ],
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/midstring_x86_64",
+    "binary_sha256": "1a4cc3ca2bc124f6228923046c0859465234c2269dae6d4bfe5c1554feb2c682",
+    "binary_size": 16072,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/midstring_x86_64",
+    "selector": "main",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "ne": 0
+    },
+    "stderr_matches": [
+      "ONE argument",
+      "quote it",
+      "--assert \"prototype main int main"
+    ]
+  },
+  "notes": "Five of eight round-3 testers wrote --assert unquoted, so the shell split it and the old message named the CONTENT it wanted while saying nothing about the shape. All five concluded kuna rejects the C type `int` -- it does not. Asserting the hint text, because the diagnostic IS the fix here."
+}


### PR DESCRIPTION
FIVE of round 3's eight testers independently filed "prototype assertions reject
standard C types" -- `int`, `unsigned int`, on x86 and on ARM. That is the
strongest convergence this loop has produced. It is also wrong, and the wrongness
is kuna's fault.

The whole directive is ONE argument. All five wrote

    --assert prototype main int main(void)

so the shell split it, `parse_one` received just "prototype", `rest` came back
empty, and the message read

    error: --assert "prototype": prototype needs <func> then a C declaration

which names the CONTENT it wants and says nothing about the shape. Every one of
the five read "needs a C declaration" as "your C declaration was rejected" and
filed a type-system bug. Quoted, the same assertions are accepted:
`int`, `int4`, `unsigned int`, `char **` all parse.

A diagnostic that induces the same false diagnosis in five independent agents is a
worse defect than the one they thought they had found -- and one this pipeline
structurally cannot fix on its own, because the gate will correctly refute all five
probes as not-reproducible and the real cause escapes unfiled. Hence a direct fix.

When the spec is a bare keyword (`rest` empty), the error now also says the
assertion must be one argument, shows the split the user probably made, and gives a
working example. A genuine CONTENT error -- `--assert "prototype main"`, or
`--assert "data notahexaddr int x"` -- is unchanged and gets no shape hint, because
the hint would be a lie there.

tests/cli/assert-unquoted-says-so.json pins the hint text: the diagnostic IS the
fix here, so asserting it is asserting the behaviour.

Gates: make test PARITY OK · make test-stages PARITY OK · make check-spec OK ·
kuna catalog --check OK · counters --check no drift · cargo test -p kuna-cli green ·
make test-cli 30/30.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcFmfZndNjgfqLQVBZCdkY