### PR TITLE
[AUTOMATED] test(p1,p2): pin the truncated latch through a real .pdata table

### DIFF
--- a/decompiler/crates/kuna-console/tests/verify_pdatachained.rs
+++ b/decompiler/crates/kuna-console/tests/verify_pdatachained.rs
@@ -162,7 +162,35 @@ fn loop_shape_decompiles_at_the_default() {
         !out.contains("decompilation failed") && !out.contains("LOSS-131"),
         "the loop shape must decompile at the default, got:\n{out}"
     );
-    assert!(out.contains("while"), "expected the recovered loop, got:\n{out}");
+    // `while ;` is the malformed rendering the pre-#410 self-edge produced, and a
+    // bare `contains("while")` would accept it.
+    assert!(!out.contains("while ;"), "expected valid C, got:\n{out}");
+    assert!(
+        out.contains("while (v2 < 100)"),
+        "expected the recovered latch condition, got:\n{out}"
+    );
+    // 0x16 is the chained chunk's arithmetic; the truncated shape never reaches it.
+    assert!(out.contains("0x16"), "expected the chunk's arithmetic in the body, got:\n{out}");
+}
+
+/// The same fixture with the gate off, which is the only in-tree case that reaches
+/// `funcboundflow`'s truncation through a real `.pdata` table rather than a
+/// bytechunk. The truncation must still leave a well-formed CFG: the halt starts
+/// its own block, so the latch keeps its condition instead of collapsing onto the
+/// branch's own block.
+#[test]
+fn gate_off_truncation_still_renders_valid_c() {
+    let Some(prog) = boot("pe_chainedunwind_loop_x86_64.exe", Some(false)) else { return };
+    let out = decompile_func(prog, "sub_140001000");
+    assert!(
+        !out.contains("decompilation failed") && !out.contains("LOSS-131"),
+        "a truncated loop must not kill the decompile, got:\n{out}"
+    );
+    assert!(!out.contains("while ;"), "expected valid C, got:\n{out}");
+    assert!(
+        out.contains("while (v1 < 100)"),
+        "the latch must keep its condition, got:\n{out}"
+    );
 }
 
 /// A chunk reached by an ordinary fall-through rather than a branch: the


### PR DESCRIPTION
### The problem

`verify_pdatachained`'s loop case asserted only that the emitted C contained the
substring `while`. The malformed rendering the fix was meant to rule out contains
it too, so the assertion could not fail for the reason it existed:

```console
$ kuna decompile pe_chainedunwind_loop_x86_64.exe --addr 0x140001000 --option pdatachained off
void sub_140001000(void)
{
  int v1; // eax

  v1 = 0;
  do {
    v1 += 0xf;
    (v1 < 100); // warn: funcboundflow: fall-through reached the next function entry; truncating flow here
  } while( true );
}
```

That output — a latch that lost its condition to a dangling expression statement —
passes `contains("while")`. Nothing in the tree caught it, because the only case
reaching this truncation through a real `.pdata` table was not asserted on at all;
the funcboundflow coverage is a synthetic bytechunk.

### The fix

- The default loop case now pins the recovered latch condition and the chained
  chunk's arithmetic, not just the keyword.
- A new gate-off case asserts the truncation still leaves a well-formed CFG, which
  is what exercises the `.pdata` route end to end.

### The tests

Test-only. Reverting the block-boundary marking in `flow.rs` turns
`gate_off_truncation_still_renders_valid_c` red with the output above; the other
five cases stay green, which is why the tightening was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzfafnkDMQiYoifXP5HSC8