### PR TITLE
[AUTOMATED] docs: correct #415's diagnosis — the five testers were right, I was not

### DIFF
--- a/docs/re-pipeline.md
+++ b/docs/re-pipeline.md
@@ -583,6 +583,39 @@ So judge the gate on whether it refutes anything at all — `not-reproducible` a
 to flip the precedence for these pairs was written and **rejected** in review for this reason;
 before re-litigating it, check whether the two arms are independent or complementary.
 
+## "It did not error" is not "it worked", and kuna will not tell you
+
+Round 3 filed five independent observations saying prototype assertions reject standard C
+types. Reviewing them, I ran the assertion by hand, saw no error, and concluded the testers had
+made a quoting mistake. That was wrong, and the way it was wrong is the lesson.
+
+```
+kuna decompile <bin> main --assert "prototype main int main(void)"
+unsigned long main(void) { ... }          # exit 0, no error, no warning
+
+kuna decompile <bin> main --assert "prototype main int main(void)" --json
+  assertions[0].status = "rejected"       # the override was silently discarded
+```
+
+`int` is rejected; `int4` is applied. The testers were right on all five, the gate admitted all
+five, and the refutation was mine. The trap: **the text surface exits 0 and prints a function
+whether or not the assertion took**, so "no error" reads as success to anyone who does not think
+to ask a second question. A sixth tester filed exactly this as its own observation — *text output
+silently ignores a prototype override that JSON output applies*.
+
+Two standing rules follow.
+
+**For a reviewer refuting an observation.** Never refute on the absence of an error. Check the
+state the observation is *about*: for an assertion that is `assertions[].status` in `--json`, not
+the exit code and not the presence of output. If the surface has no way to report whether the
+thing took, that absence is itself the defect — file it rather than concluding the tester was
+confused.
+
+**For the gate.** This is why the two-arm gate runs the probe rather than reading the report. A
+human or an LLM reviewing five reports by eye reached the wrong verdict on all five; the gate
+replaying the probes reached the right one on all twenty-three. When the machine and the
+reviewer disagree, re-run the probe before believing the reviewer.
+
 ## Machinery reference
 
 | Piece | What |

--- a/tests/cli/assert-unquoted-says-so.json
+++ b/tests/cli/assert-unquoted-says-so.json
@@ -30,5 +30,5 @@
       "--assert \"prototype main int main"
     ]
   },
-  "notes": "Five of eight round-3 testers wrote --assert unquoted, so the shell split it and the old message named the CONTENT it wanted while saying nothing about the shape. All five concluded kuna rejects the C type `int` -- it does not. Asserting the hint text, because the diagnostic IS the fix here."
+  "notes": "An unquoted --assert lets the shell split the directive, and the old error named the CONTENT it wanted while saying nothing about the shape. The hint is asserted because the diagnostic IS the behaviour here. Filed originally with the claim that five round-3 testers hit this: they did NOT. Their probes were correctly quoted and they had found a real, separate defect. See docs/re-pipeline.md."
 }


### PR DESCRIPTION
#415 landed a real improvement (an unquoted `--assert` now says the whole directive
is one argument) but justified it with a claim that is false, and that claim is now
in the permanent history and in a tests/cli probe's notes. Correcting both.

WHAT #415 SAID: five of round 3's eight testers wrote `--assert` unquoted, the shell
split it, and they misread the resulting message as a type rejection.

WHAT IS ACTUALLY TRUE: their probes pass the directive as a SINGLE argv element --
`'prototype main int main(int argc,char **argv);'`. The shape was always correct.
And the defect they reported is real:

    --assert "prototype main int main(void)"   -> assertions[0].status = rejected
    --assert "prototype main int4 main(void)"  -> assertions[0].status = applied

kuna's prototype parser wants its internal type names and rejects standard C, in a
surface whose whole purpose is accepting a C declaration. The gate admitted all five,
and all 23 of round 3 -- 0 not-reproducible, 0 already-supported. The gate was right
and my by-hand refutation was wrong.

HOW THE REFUTATION WENT WRONG, which is the part worth keeping: I ran the assertion,
saw exit 0 and a printed function, and read that as "accepted". The text surface
prints a function whether or not the override took; only `--json` carries
`assertions[].status`. So "it did not error" is not "it worked" -- and a sixth tester
had already filed exactly that as its own observation.

docs/re-pipeline.md gains a section with the two rules that follow: never refute on
the absence of an error, check the state the observation is about; and when a
reviewer and the replayed probe disagree, believe the probe. Five reports reviewed by
eye produced five wrong verdicts; the gate replaying them produced twenty-three right
ones.

The #415 code change stands on its own merits and is unchanged.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcFmfZndNjgfqLQVBZCdkY