### PR TITLE
[AUTOMATED] fix(tester): a provider content refusal is not a kuna failure

### DIFF
--- a/docs/re-pipeline.md
+++ b/docs/re-pipeline.md
@@ -616,6 +616,37 @@ human or an LLM reviewing five reports by eye reached the wrong verdict on all f
 replaying the probes reached the right one on all twenty-three. When the machine and the
 reviewer disagree, re-run the probe before believing the reviewer.
 
+## The tester model can refuse the task, and that is not a kuna result
+
+Round 3 lost a tester 78 seconds in, `codex exited rc=1`, no report, nine tool calls of
+evidence gone. The cause is only in the event stream:
+
+```json
+{"type":"turn.failed","error":{"message":"This content was flagged for possible
+ cybersecurity risk. ... To get authorized for security work, join the Trusted Access
+ for Cyber program"}}
+```
+
+The provider declined the work. It happened on **6 of 36 tester runs**, and on **all three
+attempts** at challenge `63d5a26a` — which makes that challenge systematically unmeasurable
+with this tester model rather than hard. Three other runs hit it mid-session and still filed
+reports, so it is not always fatal.
+
+This matters because it silently corrupts the two numbers the loop exists to produce. A
+refusal exits `1`, exactly like a crash, so it lands as a generic `failed` — and a challenge
+nobody was allowed to attempt is indistinguishable from one kuna could not support. Both the
+solve rate and `gave_up: kuna-blocked` drift by however often it happens.
+
+`tester.sh` now reads the event stream and records `--phase refused` with a
+`provider-refusal:` note, so `scripts.repipe.status` and the round's grading can tell it apart
+from a kuna failure and from a harness fault.
+
+**Recorded, not worked around.** Do not reword prompts to get past the classifier — the
+refusal is the provider's call, and the sanctioned route is the authorization programme the
+message names. If the refusal rate rises far enough to starve a round, the options are to
+raise it with the provider or to run the tester on a model licensed for this work; neither is
+something the loop should route around on its own.
+
 ## Machinery reference
 
 | Piece | What |

--- a/tools/repipe/tester.sh
+++ b/tools/repipe/tester.sh
@@ -225,8 +225,29 @@ if [ "$RC" -eq 124 ]; then
   log "timed out after ${TIMEOUT}s (partial report still harvested if present)"
   "$KUNA_PY" -m scripts.pipeline.state update --worker "$TESTER_ID" --status done --phase timeout --note "timeout ${TIMEOUT}s"
 elif [ "$RC" -ne 0 ]; then
-  log "codex exited rc=$RC"
-  "$KUNA_PY" -m scripts.pipeline.state update --worker "$TESTER_ID" --status failed --note "codex rc=$RC"
+  # A provider-side content refusal is NOT a kuna failure and not a harness bug, and counting
+  # it as one corrupts the two numbers this loop exists to produce: the solve rate and
+  # `gave_up: kuna-blocked`. It is only visible in the event stream -- the exit code is a bare
+  # 1, identical to a crash. Round 3 hit it on 6 of 36 tester runs, and on ALL THREE attempts
+  # at challenge 63d5a26a, which makes that challenge systematically unmeasurable with this
+  # tester model rather than hard.
+  #
+  # Recorded, not worked around. The refusal is the provider's call to make; the sanctioned
+  # route is the authorization programme named in the message itself. Do NOT reword prompts to
+  # get past the classifier.
+  REFUSAL=""
+  if [ -f "$EVENTS" ] && grep -q 'flagged for possible cybersecurity risk' "$EVENTS" 2>/dev/null; then
+    REFUSAL=1
+  fi
+  if [ -n "$REFUSAL" ]; then
+    log "PROVIDER REFUSAL (not a kuna failure): the tester model declined this challenge on"
+    log "  content policy. Evidence from this run is partial by construction. See $EVENTS."
+    "$KUNA_PY" -m scripts.pipeline.state update --worker "$TESTER_ID" --status failed \
+      --phase refused --note "provider-refusal: tester model declined on content policy (codex rc=$RC)"
+  else
+    log "codex exited rc=$RC"
+    "$KUNA_PY" -m scripts.pipeline.state update --worker "$TESTER_ID" --status failed --note "codex rc=$RC"
+  fi
 else
   log "done in ${ELAPSED}s (thread $THREAD_ID)"
   "$KUNA_PY" -m scripts.pipeline.state update --worker "$TESTER_ID" --status done --phase done


### PR DESCRIPTION
A round-3 tester died 78 seconds in, `codex exited rc=1`, no report, nine tool calls
of evidence lost. The cause is only in the event stream:

  {"type":"turn.failed","error":{"message":"This content was flagged for possible
   cybersecurity risk. ... join the Trusted Access for Cyber program"}}

The tester MODEL declined the work. Measured across the runs on disk: **6 of 36**
tester runs hit it, and **all three** attempts at challenge 63d5a26a did -- so that
challenge is systematically unmeasurable with this tester model rather than hard.
Three other runs hit it mid-session and still filed reports, so it is not always
fatal.

It matters because it silently corrupts the two numbers this loop exists to produce.
A refusal exits 1, indistinguishable from a crash, so it was landing as a generic
`failed` -- and a challenge nobody was permitted to attempt looks exactly like one
kuna could not support. Both the solve rate and `gave_up: kuna-blocked` drift by
however often it happens, and round 3's rate is 17%.

tester.sh now reads the event stream on a non-zero exit and records `--phase refused`
with a `provider-refusal:` note, so status and grading can separate it from a kuna
failure and from a harness fault. The generic rc path is unchanged.

RECORDED, NOT WORKED AROUND. The comment and the runbook both say so explicitly: do
not reword prompts to get past the classifier. The refusal is the provider's call and
the sanctioned route is the authorization programme its own message names. If the rate
ever rises far enough to starve a round, the answers are to take it up with the
provider or to run the tester on a model licensed for this work -- not for the loop to
route around it.

tools/repipe/smoke.sh 127/127.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcFmfZndNjgfqLQVBZCdkY