### PR TITLE
[AUTOMATED] feat(needs): a CLI to record a refutation verdict, which T_REFUTE never had

### DIFF
--- a/scripts/repipe/needs.py
+++ b/scripts/repipe/needs.py
@@ -836,6 +836,16 @@ def main(argv=None):
     p_acc.add_argument("--pr", default=None)
     p_acc.add_argument("--json", action="store_true")
 
+    p_ref = sub.add_parser("refute",
+                           help="record a refutation verdict on a need's hypothesis")
+    p_ref.add_argument("need_id")
+    p_ref.add_argument("--verdict", required=True,
+                       choices=["upheld", "overturned", "inconclusive"])
+    p_ref.add_argument("--note", required=True,
+                       help="what the refuter did and what it found; recorded verbatim")
+    p_ref.add_argument("--round", type=int, default=None)
+    p_ref.add_argument("--json", action="store_true")
+
     p_rej = sub.add_parser("reject", help="move a need to docs/re-needs/rejected/")
     p_rej.add_argument("need_id")
     p_rej.add_argument("--reason", required=True)
@@ -871,6 +881,39 @@ def main(argv=None):
             print(json.dumps(doc, indent=2))
         else:
             sys.stdout.write(render(need))
+        return 0
+
+    if args.cmd == "refute":
+        # T_REFUTE told the captain to "record upheld/overturned either way" and gave it no
+        # way to do so: every writer of hypothesis_status was a DEFAULT (cluster.py at filing,
+        # needs.py in the schema), so the only route was hand-editing YAML front matter. Round
+        # 3 recorded a verdict on 5 of 16 needs and left 11 at `inconclusive`, which reads as
+        # "the refuter could not decide" when it means "the verdict had nowhere to go". The
+        # whole two-arm design rests on refutation -- decbench overturned 3 of 8 filed
+        # diagnoses -- so an instruction without a mechanism is the expensive kind of gap.
+        need = load(args.need_id)
+        if need is None:
+            print("no such need: %s" % args.need_id, file=sys.stderr)
+            return 1
+        before = need.fields.get("hypothesis_status") or "inconclusive"
+        need.fields["hypothesis_status"] = args.verdict
+        rnd = args.round if args.round is not None else (need.fields.get("rounds") or [None])[-1]
+        line = "- round %s REFUTER: hypothesis **%s**%s. %s" % (
+            rnd if rnd is not None else "?", args.verdict,
+            "" if before == args.verdict else " (was %s)" % before, args.note.strip())
+        log = (need.sections or {}).get("Decision log", "")
+        need.sections["Decision log"] = (log.rstrip() + "\n" + line + "\n") if log.strip() else (line + "\n")
+        problems = validate(need)
+        if problems:
+            print("refusing to write an invalid record: %s" % "; ".join(problems), file=sys.stderr)
+            return 1
+        write(need)
+        out = {"need_id": need.need_id, "hypothesis_status": args.verdict, "was": before}
+        if args.json:
+            print(json.dumps(out, indent=2))
+        else:
+            print("%s: hypothesis %s%s" % (need.need_id, args.verdict,
+                                           "" if before == args.verdict else " (was %s)" % before))
         return 0
 
     if args.cmd == "reindex":

--- a/tools/repipe/captain_prompt.md
+++ b/tools/repipe/captain_prompt.md
@@ -33,7 +33,7 @@ You may only move a machine along a legal edge; `captain.py` refuses anything el
 | `T_DRAIN` | while testers are live, do nothing but observe. As each finishes, grade it and run the tripwire | `T_GATE` |
 | `T_GATE` | `python3 -m scripts.repipe.verify --gate --round N`. **This is the load-bearing step.** | `T_DEDUP` |
 | `T_DEDUP` | `python3 -m scripts.repipe.cluster --round N` | `T_REFUTE` |
-| `T_REFUTE` | for each NEW cluster whose probe kind is not `absence`, spend one refuter on the *hypothesis*; record `upheld`/`overturned` either way | `T_TRIAGE` |
+| `T_REFUTE` | for each NEW cluster whose probe kind is not `absence`, spend one refuter on the *hypothesis*, then **record the verdict with `python3 -m scripts.repipe.needs refute <need_id> --verdict upheld\|overturned\|inconclusive --note '<what the refuter did and found>'`** — every non-absence need, either way. Leaving it at the filed default is not a verdict | `T_TRIAGE` |
 | `T_TRIAGE` | confirm each need's `track` and `touches` (they were inferred); set `scope` | `T_READY` |
 | `T_READY` | the backlog is published | `T_IDLE` |
 
@@ -64,8 +64,19 @@ cheap.
 **2. Refuting a hypothesis (`T_REFUTE`).** A need's `## Hypothesis` is the tester's guess.
 Spend one agent asking: *is this cause actually right, and would a fix built on it produce
 WRONG output?* In the sibling campaign, refuters overturned the filed diagnosis on **3 of 8**
-cases while the *symptom* stood in all 8. Record the verdict either way — an upheld
-hypothesis that was actually checked is worth more than one nobody looked at. Skip this
+cases while the *symptom* stood in all 8. Record the verdict either way, with
+
+```
+python3 -m scripts.repipe.needs refute <need_id> --verdict upheld|overturned|inconclusive \
+    --note "what the refuter did and what it found"
+```
+
+An upheld hypothesis that was actually checked is worth more than one nobody looked at, and
+`inconclusive` is a legitimate verdict — but only when a refuter ran and could not decide.
+**Leaving a need at the filed default is not a verdict**, and it is indistinguishable in the
+record from one. Round 3 recorded a verdict on 5 of 16 needs and left 11 at the default,
+which read as "the refuter could not decide" when it meant the verdict had nowhere to go:
+this command did not exist, so the only route was hand-editing YAML. Skip this
 entirely for `kind: absence` needs ("there is no `xrefs` subcommand" has no interesting root
 cause) — `REPIPE_REFUTE_MODE=absence-skip` is on by default for exactly that reason.
 


### PR DESCRIPTION
Round 3 filed 16 needs and recorded a hypothesis verdict on 5. The other 11 read
`inconclusive`, which looks like "a refuter ran and could not decide" and is
indistinguishable in the record from it. It is not what happened.

`hypothesis_status` had exactly two writers in the whole tree, and both are DEFAULTS:
cluster.py sets `inconclusive` at filing, needs.py repeats it in the schema. Nothing
ever changed it. The captain prompt says T_REFUTE must "record upheld/overturned
either way", and there was no command that could -- the only route was hand-editing
YAML front matter in a markdown file. So the instruction had no mechanism, and 69% of
round 3's needs went to builders with an un-refuted hypothesis.

That is the expensive kind of gap, because refutation is what the two-arm design rests
on: the sibling decbench campaign overturned the filed diagnosis on 3 of 8 cases while
the symptom stood in all 8. Round 3's own numbers say the same thing -- of the five
verdicts that WERE recorded, two were overturned. Extrapolated over eleven unexamined
hypotheses, that is roughly four builders working from a wrong cause.

    python3 -m scripts.repipe.needs refute <need_id> \
        --verdict upheld|overturned|inconclusive --note "what the refuter did and found"

Writes `hypothesis_status` and appends a dated line to the Decision log, so the verdict
and its reasoning live with the need rather than in a captain tick's transcript. Refuses
to write a record that fails `validate()`.

The captain prompt now names the command in both places it describes T_REFUTE, and says
plainly that `inconclusive` is legitimate ONLY when a refuter ran and could not decide --
leaving a need at the filed default is not a verdict.

Verified against a real record: front matter flips, the decision-log line lands with the
round number and the previous value, and the record still validates. tools/repipe/smoke.sh
127/127.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcFmfZndNjgfqLQVBZCdkY