### PR TITLE
[AUTOMATED] feat(console): --assert accepts the standard C scalar types

### DIFF
--- a/decompiler/crates/kuna-cli/src/assertdecl.rs
+++ b/decompiler/crates/kuna-cli/src/assertdecl.rs
@@ -180,18 +180,17 @@ fn take_token(s: &str) -> (&str, &str) {
 pub(crate) fn parse_one(spec: &str) -> Result<Directive, String> {
     let raw = spec.trim().to_string();
     let (keyword, rest) = take_token(&raw);
-    // The WHOLE directive is one argument. Five of eight round-3 testers wrote
+    // The WHOLE directive is one argument. Unquoted,
     //   --assert prototype main int main(void)
-    // instead of
-    //   --assert "prototype main int main(void)"
-    // so the shell handed us just "prototype", `rest` came back empty, and the message
+    // hands us just "prototype", `rest` comes back empty, and the old message
     // ("prototype needs <func> then a C declaration") named the CONTENT we wanted while
-    // saying nothing about the shape. All five read it as a type rejection and filed
-    // "kuna rejects the standard C type int" -- a defect that does not exist; the quoted
-    // form accepts `int`, `unsigned int` and `char **` fine. A diagnostic that produces
-    // the same false diagnosis in five independent agents is worse than the bug they
-    // thought they had found, so when the spec is a bare keyword, say what is actually
-    // wrong and show the fix.
+    // saying nothing about the shape -- so when the spec is a bare keyword, say what is
+    // actually wrong and show the fix.
+    // This comment used to blame five round-3 testers for writing it unquoted and to
+    // claim the type rejection they filed did not exist. Both halves were wrong (#418):
+    // their directives were correctly quoted, and `int` really was rejected, because the
+    // C-declaration grammar knew only Ghidra's `int4` vocabulary. That is the defect
+    // `grammar.rs (CParse::scalar_specifier)` closes; this hint is the unrelated half.
     let bad = |what: &str| {
         if rest.is_empty() && !raw.is_empty() {
             format!(

--- a/decompiler/crates/kuna-console/src/grammar.rs
+++ b/decompiler/crates/kuna-console/src/grammar.rs
@@ -1119,6 +1119,70 @@ pub enum DocType {
 // actions)
 // =============================================================================
 
+// =============================================================================
+// (kuna) Standard C scalar type specifiers
+// =============================================================================
+
+/// (kuna) One standard C scalar type-specifier keyword.
+///
+/// Upstream's grammar has no scalar keywords at all: a base type is whatever
+/// `TypeFactory::findByName` answers, so only Ghidra's own `int4` / `uint8` /
+/// `float8` vocabulary parses.  kuna's printer, however, spells core types the
+/// way the target's compiler would (`p9_emit/kuna_ctypes.rs`), so the C it
+/// emits could not be fed back to it.  These keywords are the inverse of that
+/// speller and read the same `<data_organization>` widths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScalarKw {
+    Void,
+    Char,
+    Short,
+    Int,
+    Long,
+    Float,
+    Double,
+    Signed,
+    Unsigned,
+    Bool,
+    WcharT,
+}
+
+impl ScalarKw {
+    /// The keyword's own spelling, for the single-keyword `findByName` probe.
+    fn name(self) -> &'static str {
+        match self {
+            ScalarKw::Void => "void",
+            ScalarKw::Char => "char",
+            ScalarKw::Short => "short",
+            ScalarKw::Int => "int",
+            ScalarKw::Long => "long",
+            ScalarKw::Float => "float",
+            ScalarKw::Double => "double",
+            ScalarKw::Signed => "signed",
+            ScalarKw::Unsigned => "unsigned",
+            ScalarKw::Bool => "_Bool",
+            ScalarKw::WcharT => "wchar_t",
+        }
+    }
+}
+
+/// Classify an identifier as a scalar type-specifier keyword.
+fn scalar_keyword(nm: &str) -> Option<ScalarKw> {
+    Some(match nm {
+        "void" => ScalarKw::Void,
+        "char" => ScalarKw::Char,
+        "short" => ScalarKw::Short,
+        "int" => ScalarKw::Int,
+        "long" => ScalarKw::Long,
+        "float" => ScalarKw::Float,
+        "double" => ScalarKw::Double,
+        "signed" => ScalarKw::Signed,
+        "unsigned" => ScalarKw::Unsigned,
+        "_Bool" => ScalarKw::Bool,
+        "wchar_t" => ScalarKw::WcharT,
+        _ => return None,
+    })
+}
+
 /// Token-class returned by [`CParse::lookup_identifier`], standing in for the
 /// bison terminal an identifier reduces to (`grammar.cc:1236-1272`).
 #[derive(Debug, Clone)]
@@ -1130,6 +1194,8 @@ enum IdentClass {
     Union,
     Enum,
     TypeName(Rc<Datatype>),
+    /// (kuna) A standard C scalar keyword; a run of them names one base type.
+    ScalarSpecifier(ScalarKw),
     Identifier,
 }
 
@@ -1148,6 +1214,8 @@ enum PToken {
     TypeQualifier(String),
     FunctionSpecifier(String),
     TypeName(Rc<Datatype>),
+    /// (kuna) A standard C scalar keyword ([`ScalarKw`]).
+    ScalarSpecifier(ScalarKw),
     Struct,
     Union,
     Enum,
@@ -1281,6 +1349,14 @@ impl<'a> CParse<'a> {
                 _ => {}
             }
         }
+        // (kuna) A standard C scalar keyword outranks `findByName` so that a run
+        // of them (`unsigned int`, `long long`) can be gathered as one base
+        // type.  A run of length one still falls back to `findByName` first
+        // ([`CParse::scalar_specifier`]), so `void` / `char` resolve to exactly
+        // the interned core type they resolve to today.
+        if let Some(kw) = scalar_keyword(nm) {
+            return IdentClass::ScalarSpecifier(kw);
+        }
         if let Ok(Some(tp)) = self.factory.find_by_name(nm) {
             return IdentClass::TypeName(tp);
         }
@@ -1315,6 +1391,7 @@ impl<'a> CParse<'a> {
                     IdentClass::Union => Ok(PToken::Union),
                     IdentClass::Enum => Ok(PToken::Enum),
                     IdentClass::TypeName(tp) => Ok(PToken::TypeName(tp)),
+                    IdentClass::ScalarSpecifier(kw) => Ok(PToken::ScalarSpecifier(kw)),
                     IdentClass::Identifier => Ok(PToken::Identifier(s)),
                 }
             }
@@ -1523,6 +1600,7 @@ impl<'a> CParse<'a> {
                 | PToken::TypeQualifier(_)
                 | PToken::FunctionSpecifier(_)
                 | PToken::TypeName(_)
+                | PToken::ScalarSpecifier(_)
                 | PToken::Struct
                 | PToken::Union
                 | PToken::Enum
@@ -1552,7 +1630,11 @@ impl<'a> CParse<'a> {
                 }
                 Ok(true)
             }
-            PToken::TypeName(_) | PToken::Struct | PToken::Union | PToken::Enum => {
+            PToken::TypeName(_)
+            | PToken::ScalarSpecifier(_)
+            | PToken::Struct
+            | PToken::Union
+            | PToken::Enum => {
                 let tp = self.type_specifier()?;
                 self.add_type_specifier(spec, tp);
                 Ok(true)
@@ -1583,9 +1665,158 @@ impl<'a> CParse<'a> {
                     unreachable!()
                 }
             }
+            PToken::ScalarSpecifier(_) => self.scalar_specifier(),
             PToken::Struct | PToken::Union => self.struct_or_union_specifier(),
             PToken::Enum => self.enum_specifier(),
             _ => self.syntax_error(),
+        }
+    }
+
+    /// (kuna) `type_specifier: scalar_keyword+` — the standard C scalar
+    /// specifiers, which name a base type as a *run* of keywords rather than as
+    /// one identifier (`unsigned int`, `long long`, `signed char`).
+    ///
+    /// A run of exactly one keyword is looked up by name first, so `void`,
+    /// `char` and any host-supplied type spelled with a keyword resolve to the
+    /// same interned type they always have; only combinations, and the keywords
+    /// the type factory does not name, take the width-driven path.
+    fn scalar_specifier(&mut self) -> KunaResult<Rc<Datatype>> {
+        let mut kws: Vec<ScalarKw> = Vec::new();
+        while let PToken::ScalarSpecifier(kw) = self.peek()? {
+            kws.push(*kw);
+            self.next()?;
+        }
+        if kws.len() == 1 {
+            if let Ok(Some(tp)) = self.factory.find_by_name(kws[0].name()) {
+                return Ok(tp);
+            }
+        }
+        match self.resolve_scalar(&kws)? {
+            Some(tp) => Ok(tp),
+            None => {
+                let spelling: Vec<&str> = kws.iter().map(|k| k.name()).collect();
+                self.set_error(&format!(
+                    "Invalid combination of C type specifiers: {}",
+                    spelling.join(" ")
+                ));
+                Err(KunaError::parse(self.lasterror.clone()))
+            }
+        }
+    }
+
+    /// (kuna) Turn a validated run of scalar keywords into a core data-type,
+    /// or `None` if the combination is not a C type.
+    ///
+    /// The widths come from the compiler spec's `<data_organization>` (the same
+    /// source `p9_emit/kuna_ctypes.rs` spells them back out from), never from a
+    /// hard-coded table, so `long` is 8 bytes on LP64 and 4 on LLP64.
+    fn resolve_scalar(&self, kws: &[ScalarKw]) -> KunaResult<Option<Rc<Datatype>>> {
+        use type_metatype::{TYPE_BOOL, TYPE_FLOAT, TYPE_INT, TYPE_UINT};
+        let n = |k: ScalarKw| kws.iter().filter(|x| **x == k).count();
+        let (void, ch, sh, int_, lng) = (
+            n(ScalarKw::Void),
+            n(ScalarKw::Char),
+            n(ScalarKw::Short),
+            n(ScalarKw::Int),
+            n(ScalarKw::Long),
+        );
+        let (flt, dbl, sgn, uns, bl, wc) = (
+            n(ScalarKw::Float),
+            n(ScalarKw::Double),
+            n(ScalarKw::Signed),
+            n(ScalarKw::Unsigned),
+            n(ScalarKw::Bool),
+            n(ScalarKw::WcharT),
+        );
+        // No keyword may repeat except `long`, which may appear twice.
+        if void > 1 || ch > 1 || sh > 1 || int_ > 1 || flt > 1 || dbl > 1 || bl > 1 || wc > 1 {
+            return Ok(None);
+        }
+        if lng > 2 || sgn + uns > 1 || (sh > 0 && lng > 0) {
+            return Ok(None);
+        }
+        let sign_only = sgn + uns;
+        // The specifiers that must stand alone.
+        for solo in [void, bl, wc] {
+            if solo > 0 && kws.len() != 1 {
+                return Ok(None);
+            }
+        }
+        if void > 0 {
+            return self.factory.get_type_void().map(Some);
+        }
+        if bl > 0 {
+            return self.factory.get_base(1, TYPE_BOOL).map(Some);
+        }
+        if wc > 0 {
+            return self.sized_scalar(self.factory.get_size_of_wchar(), None);
+        }
+        if flt > 0 {
+            // `float` takes no other specifier; `long float` is not C.
+            if kws.len() != 1 {
+                return Ok(None);
+            }
+            return self.sized_scalar(self.factory.get_size_of_float(), Some(TYPE_FLOAT));
+        }
+        if dbl > 0 {
+            // `double` or `long double`, nothing else.
+            if kws.len() != 1 + lng || lng > 1 {
+                return Ok(None);
+            }
+            let size = if lng == 1 {
+                self.factory.get_size_of_long_double()
+            } else {
+                self.factory.get_size_of_double()
+            };
+            return self.sized_scalar(size, Some(TYPE_FLOAT));
+        }
+        if ch > 0 {
+            // `char`, `signed char`, `unsigned char` — no length modifier.
+            if kws.len() != 1 + sign_only {
+                return Ok(None);
+            }
+            let size = self.factory.get_size_of_char();
+            if sign_only == 0 {
+                // Plain `char` is kuna's text type, not an integer of that width.
+                return self.sized_scalar(size, None);
+            }
+            return self.sized_scalar(size, Some(if uns > 0 { TYPE_UINT } else { TYPE_INT }));
+        }
+        // What is left is an integer: [signed|unsigned] [short|long|long long] [int].
+        if kws.len() != sign_only + sh + lng + int_ {
+            return Ok(None);
+        }
+        let size = if sh > 0 {
+            self.factory.get_size_of_short()
+        } else if lng == 2 {
+            self.factory.get_size_of_long_long()
+        } else if lng == 1 {
+            self.factory.get_size_of_long()
+        } else {
+            self.factory.get_size_of_int()
+        };
+        self.sized_scalar(size, Some(if uns > 0 { TYPE_UINT } else { TYPE_INT }))
+    }
+
+    /// (kuna) The core type of `size` bytes with the given meta-type, or the
+    /// character type of that width when `meta` is `None`.
+    ///
+    /// A zero or negative width means the compiler spec never declared one, so
+    /// the keyword names nothing on this target; that is a parse error rather
+    /// than a silently zero-sized type.
+    fn sized_scalar(
+        &self,
+        size: int4,
+        meta: Option<type_metatype>,
+    ) -> KunaResult<Option<Rc<Datatype>>> {
+        if size <= 0 {
+            return Ok(None);
+        }
+        match meta {
+            // `get_base_no_char` keeps a 1-byte integer off the `char` type, so
+            // `signed char` is `int1` and not the text type.
+            Some(m) => self.factory.get_base_no_char(size, m).map(Some),
+            None => self.factory.get_type_char(size).map(Some),
         }
     }
 
@@ -1632,7 +1863,12 @@ impl<'a> CParse<'a> {
         // Continue while the lookahead begins a specifier_qualifier_list.
         while matches!(
             self.peek()?,
-            PToken::TypeQualifier(_) | PToken::TypeName(_) | PToken::Struct | PToken::Union | PToken::Enum
+            PToken::TypeQualifier(_)
+                | PToken::TypeName(_)
+                | PToken::ScalarSpecifier(_)
+                | PToken::Struct
+                | PToken::Union
+                | PToken::Enum
         ) {
             let mut more = self.struct_declaration()?;
             v.append(&mut more);
@@ -1655,7 +1891,11 @@ impl<'a> CParse<'a> {
         let mut any = false;
         loop {
             match self.peek()? {
-                PToken::TypeName(_) | PToken::Struct | PToken::Union | PToken::Enum => {
+                PToken::TypeName(_)
+                | PToken::ScalarSpecifier(_)
+                | PToken::Struct
+                | PToken::Union
+                | PToken::Enum => {
                     let tp = self.type_specifier()?;
                     self.add_type_specifier(&mut spec, tp);
                     any = true;

--- a/decompiler/crates/kuna-console/src/grammar/tests.rs
+++ b/decompiler/crates/kuna-console/src/grammar/tests.rs
@@ -779,3 +779,152 @@ fn w9_con_grammar_v7_pointer_array_modifier_order() {
     assert_eq!(elem.get_ptr_to().unwrap().get_name(), "int4");
     assert_eq!(ty.get_size(), 2 * org().addr_size, "two pointer-sized elements");
 }
+
+// ===========================================================================
+// (kuna) Standard C scalar type specifiers
+// ===========================================================================
+
+/// The [`factory`] core types plus a declared data organization, so the scalar
+/// keywords have widths to resolve against.  `lp64` is the x86-64 SysV model
+/// (`long` 8); `llp64` is the Windows one (`long` 4), which is what makes the
+/// keyword resolution ABI-driven rather than a fixed table.
+fn factory_sized(long_size: i32) -> TypeFactoryImpl {
+    let f = factory();
+    f.set_core_type("wchar2", 2, meta::TYPE_INT, true).unwrap();
+    f.set_core_type("wchar4", 4, meta::TYPE_INT, true).unwrap();
+    f.set_core_type("float10", 10, meta::TYPE_FLOAT, false).unwrap();
+    f.cache_core_types().unwrap();
+    f.set_size_of_char(1);
+    f.set_size_of_short(2);
+    f.set_size_of_int(4);
+    f.set_size_of_long(long_size);
+    f.set_size_of_long_long(8);
+    f.set_size_of_wchar(2);
+    f.set_size_of_float(4);
+    f.set_size_of_double(8);
+    f.set_size_of_long_double(10);
+    f
+}
+
+#[test]
+fn scalar_keywords_resolve_to_core_types() {
+    let f = factory_sized(8);
+    for (decl, want) in [
+        ("int x", "int4"),
+        ("signed x", "int4"),
+        ("signed int x", "int4"),
+        ("unsigned x", "uint4"),
+        ("unsigned int x", "uint4"),
+        ("short x", "int2"),
+        ("short int x", "int2"),
+        ("unsigned short x", "uint2"),
+        ("short unsigned int x", "uint2"),
+        ("long x", "int8"),
+        ("unsigned long x", "uint8"),
+        ("long long x", "int8"),
+        ("unsigned long long x", "uint8"),
+        ("signed char x", "int1"),
+        ("unsigned char x", "uint1"),
+        ("float x", "float4"),
+        ("double x", "float8"),
+        ("long double x", "float10"),
+        ("wchar_t x", "wchar2"),
+        ("_Bool x", "bool"),
+    ] {
+        let (ty, name) = parse_type(decl, &f, org()).unwrap_or_else(|e| {
+            panic!("{decl:?} must parse: {}", e.explain());
+        });
+        assert_eq!(ty.get_name(), want, "{decl:?}");
+        assert_eq!(name, "x");
+    }
+}
+
+#[test]
+fn scalar_long_follows_the_targets_declared_width() {
+    // The whole point of reading `<data_organization>`: `long` is 8 bytes on
+    // LP64 and 4 on LLP64, and `long long` is 8 on both.
+    let lp64 = factory_sized(8);
+    assert_eq!(parse_type("long x", &lp64, org()).unwrap().0.get_name(), "int8");
+    let llp64 = factory_sized(4);
+    assert_eq!(parse_type("long x", &llp64, org()).unwrap().0.get_name(), "int4");
+    assert_eq!(parse_type("long long x", &llp64, org()).unwrap().0.get_name(), "int8");
+}
+
+#[test]
+fn plain_char_stays_the_text_type_and_signed_char_does_not() {
+    // `char` is kuna's ASCII core type; `signed char` is an ordinary 1-byte
+    // integer, which is what `getBaseNoChar` distinguishes.
+    let f = factory_sized(8);
+    let (plain, _) = parse_type("char c", &f, org()).unwrap();
+    assert_eq!(plain.get_name(), "char");
+    let (signed, _) = parse_type("signed char c", &f, org()).unwrap();
+    assert_eq!(signed.get_name(), "int1");
+    assert_ne!(plain.get_name(), signed.get_name());
+}
+
+#[test]
+fn scalar_keywords_work_in_a_prototype() {
+    // The `--assert prototype` shape: standard C in both return and parameter
+    // position, which is the form every emitted declaration is written in.
+    let f = factory_sized(8);
+    let p = parse_protopieces(
+        "extern void *VirtualAlloc(void *p,unsigned int n,unsigned long long a,long double b);",
+        &f,
+        org(),
+    )
+    .expect("standard C prototype parses");
+    assert_eq!(p.name, "VirtualAlloc");
+    assert_eq!(p.outtype.as_ref().unwrap().get_metatype(), meta::TYPE_PTR);
+    let names: Vec<&str> = p.intypes.iter().map(|t| t.get_name()).collect();
+    assert_eq!(names, vec!["", "uint4", "uint8", "float10"], "pointer, then the scalars");
+}
+
+#[test]
+fn ghidra_type_names_still_win_for_a_single_keyword() {
+    // The 261 `parse line` corpus payloads feed `int4`/`char`/`void` through
+    // `findByName`; a one-keyword run must still resolve to exactly that type.
+    let f = factory_sized(8);
+    assert_eq!(parse_type("int4 x", &f, org()).unwrap().0.get_name(), "int4");
+    assert_eq!(parse_type("void", &f, org()).unwrap().0.get_metatype(), meta::TYPE_VOID);
+    assert_eq!(parse_type("char *p", &f, org()).unwrap().0.get_ptr_to().unwrap().get_name(), "char");
+}
+
+#[test]
+fn reject_impossible_scalar_combinations() {
+    let f = factory_sized(8);
+    for decl in [
+        "short long x",
+        "long long long x",
+        "float int x",
+        "unsigned void x",
+        "unsigned float x",
+        "signed unsigned x",
+        "long char x",
+        "int int x",
+        "unsigned wchar_t x",
+    ] {
+        let err = parse_type(decl, &f, org())
+            .map(|(t, _)| t.get_name().to_string())
+            .expect_err(&format!("{decl:?} is not a C type"));
+        assert!(
+            err.explain().contains("Invalid combination of C type specifiers"),
+            "{decl:?} got: {}",
+            err.explain()
+        );
+    }
+}
+
+#[test]
+fn a_scalar_keyword_with_no_declared_width_is_a_parse_error() {
+    // A compiler spec that declares no `<long_double_size>` names no wider
+    // floating type; resolving to a zero-sized type instead would be silent.
+    let f = factory();
+    f.set_size_of_int(4);
+    let err = parse_type("unsigned short x", &f, org()).expect_err("no short width declared");
+    assert!(
+        err.explain().contains("Invalid combination of C type specifiers"),
+        "got: {}",
+        err.explain()
+    );
+    assert_eq!(parse_type("unsigned int x", &f, org()).unwrap().0.get_name(), "uint4");
+}

--- a/decompiler/crates/kuna-console/tests/verify_assertplane.rs
+++ b/decompiler/crates/kuna-console/tests/verify_assertplane.rs
@@ -360,3 +360,74 @@ fn output_only_prototype_pieces_do_not_abort_the_drive() {
     );
     assert!(step.result.is_ok(), "an output-only prototype aborted the drive");
 }
+
+/// The declarations kuna PRINTS are declarations kuna ACCEPTS
+/// (`docs/re-needs/prototype-assertions-reject-ordinary.md`).  Until the
+/// C-declaration grammar learned the standard scalar keywords, a base type was
+/// whatever `findByName` answered, so `int` / `unsigned int` / `long long` --
+/// exactly what the printer emits -- were rejected as syntax errors while
+/// `int4` / `uint4` / `int8` worked.  Five testers filed it in one round, and
+/// `docs/cli.md`'s own worked example was among the rejected forms.
+#[test]
+fn standard_c_scalar_types_reach_the_emitted_c() {
+    let Some((code, report)) = decompile_with(vec![
+        directive(
+            "prototype authenticate unsigned int authenticate(char *user,char *pass)",
+            Body::Prototype {
+                func: TARGET.into(),
+                decl: "unsigned int authenticate(char *user,char *pass)".into(),
+            },
+        ),
+        directive(
+            "prototype read long long read(int fd,void *buf,unsigned long n)",
+            Body::Prototype {
+                func: "read".into(),
+                decl: "long long read(int fd,void *buf,unsigned long n)".into(),
+            },
+        ),
+        directive(
+            "type v2 unsigned char[8]",
+            Body::Type { func: None, symbol: "v2".into(), decl: "unsigned char[8]".into() },
+        ),
+    ]) else {
+        return;
+    };
+    all_applied(&report);
+    // This surface renders core types with their interned names (the C speller
+    // is a `--mode` preset the CLI applies, not this bare drive), so the
+    // declared `unsigned int` reads back as `uint4` and `unsigned char` as
+    // `uint1` -- either spelling names the type that was asserted.  The
+    // baseline return type is an 8-byte integer, so a 4-byte unsigned one is
+    // the discriminator.
+    assert!(
+        code.contains("uint4 authenticate(char *user,char *pass)")
+            || code.contains("unsigned int authenticate(char *user,char *pass)"),
+        "the C return type did not reach the C:\n{code}"
+    );
+    assert!(
+        code.contains("uint1 v2 [8];") || code.contains("unsigned char v2 [8];"),
+        "a multi-word scalar did not survive as a `type` base:\n{code}"
+    );
+}
+
+/// A combination that is not a C type is named, not answered with a bare
+/// "Syntax error" pointing at the second keyword.
+#[test]
+fn an_impossible_scalar_combination_is_rejected_by_name() {
+    let Some((_code, report)) = decompile_with(vec![directive(
+        "prototype authenticate short long authenticate(void)",
+        Body::Prototype {
+            func: TARGET.into(),
+            decl: "short long authenticate(void)".into(),
+        },
+    )]) else {
+        return;
+    };
+    assert_eq!(report.len(), 1);
+    assert_eq!(report[0].status, "rejected", "{report:?}");
+    let detail = report[0].detail.clone().unwrap_or_default();
+    assert!(
+        detail.contains("Invalid combination of C type specifiers: short long"),
+        "the rejection did not name the combination: {detail}"
+    );
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -130,6 +130,23 @@ decimal unless it carries a `0x`, and `<addr> <size>` is accepted wherever
 `<addr>+<size>` is. A C type may be anything the console's `parse line` accepts,
 including a `typedef` you asserted earlier in the same run.
 
+**Write the type in C.** The standard scalar keywords — `void`, `char`, `short`,
+`int`, `long`, `float`, `double`, `signed`, `unsigned`, `_Bool`, `wchar_t` — are
+accepted in any legal combination, in return position, in parameter position and
+as a `type`/`param`/`return`/`data` operand, so a declaration kuna emitted can be
+pasted straight back at it:
+
+```bash
+kuna decompile ./a.out sub_140004dcc --json \
+  --assert 'prototype VirtualAlloc void *VirtualAlloc(void *p,unsigned int n,unsigned int a,unsigned int b)'
+```
+
+Widths come from the target's own compiler spec, so `long` is eight bytes on LP64
+and four on LLP64. Ghidra's sized spellings (`int4`, `uint8`, `float8`,
+`undefined`) still work and take precedence for a name the type factory already
+knows. A combination that is not a C type (`short long`, `float int`) is rejected
+by name.
+
 **The two range directives are for memory kuna cannot classify by itself**, which
 on a hostile or embedded image is most of it. `--option readonly on|off` is a
 program-wide switch, not a range, and the loader's own read-only markup stops at

--- a/docs/features/prototype-assertions-reject-ordinary/pr_body.md
+++ b/docs/features/prototype-assertions-reject-ordinary/pr_body.md
@@ -1,0 +1,55 @@
+## The problem
+
+`--assert prototype` rejects the standard C scalar types. `int`, `unsigned int`,
+`long long` and `double` are all a syntax error, in return position and in
+parameter position alike, while Ghidra's internal `int4` / `uint4` / `float8`
+spellings work. Five testers filed it independently in one round.
+
+```console
+$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/fauxware authenticate \
+    --assert 'prototype authenticate unsigned int authenticate(char *user,char *pass)'
+warning: --assert "prototype authenticate unsigned int authenticate(char *user,char *pass)" rejected: Syntax error at line 0 in stream
+extern unsigned int 
+                ^--
+```
+
+The declaration kuna itself prints cannot be pasted back at it — the same
+function's header is `unsigned long authenticate(char *a0,char *a1)`. The
+worked example in `docs/cli.md` was one of the rejected forms.
+
+## The fix
+
+- The console's C-declaration grammar learns the standard scalar specifiers —
+  `void`, `char`, `short`, `int`, `long`, `float`, `double`, `signed`,
+  `unsigned`, `_Bool`, `wchar_t` — in any legal combination, everywhere a type
+  may appear.
+- Widths come from the compiler spec's `<data_organization>`, the same fields
+  the printer's C speller reads, so `long` is 8 bytes on LP64 and 4 on LLP64 and
+  the two halves cannot disagree. `signed char` is a 1-byte integer; plain
+  `char` stays the text type.
+- Additive by construction: a run of exactly one keyword is resolved by
+  `findByName` first, so `void`, `char` and any host-supplied type spelled with a
+  keyword resolve to exactly the type they did before. Only combinations — which
+  were 100% syntax errors — take the new path. None of the 261 `parse line`
+  payloads in the two parity corpora uses any of the eleven keywords.
+- An impossible combination (`short long`, `float int`, three `long`s) is
+  rejected as `Invalid combination of C type specifiers: short long` rather than
+  a bare "Syntax error" at the second word, and a keyword whose width the
+  compiler spec never declared is rejected rather than resolving to a zero-sized
+  type.
+
+## The tests
+
+Seven unit tests in `kuna-console/src/grammar/tests.rs` (the 20-spelling
+resolution table, `long` under LP64 vs LLP64, `char` vs `signed char`, nine
+impossible combinations, and the `findByName`-still-wins guarantee), two
+end-to-end tests in `verify_assertplane.rs` driving the real `--assert` path,
+and the promoted probe `tests/cli/prototype-assertions-reject-ordinary.json`.
+All three of that probe's directives are rejected before this change and applied
+after.
+
+Gates: `make test` PARITY OK 675/675 · `make test-stages` PARITY OK ·
+`make rust-test` green · `make check-spec` OK · `kuna catalog --check` OK ·
+`make test-cli` 32/32.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/prototype-assertions-reject-ordinary/record.json
+++ b/docs/features/prototype-assertions-reject-ordinary/record.json
@@ -1,0 +1,52 @@
+{
+  "slug": "prototype-assertions-reject-ordinary",
+  "need_id": "prototype-assertions-reject-ordinary",
+  "track": "tooling",
+  "opportunity": "re-need:prototype-assertions-reject-ordinary",
+  "probe_id": "p-b95fa6549eeb",
+  "acceptance_id": "a-e9643c3e9aaa",
+  "instances": 5,
+  "challenges": 5,
+  "scope": "increment",
+  "proposal": false,
+  "covers_needs": [
+    "prototype-assertions-reject-ordinary"
+  ],
+  "option": null,
+  "flag": null,
+  "element_id": null,
+  "phase": null,
+  "tier": "driver",
+  "change_kind": "capability-add",
+  "default_on": null,
+  "owning_file": "decompiler/crates/kuna-console/src/grammar.rs",
+  "owning_function": "CParse::scalar_specifier / CParse::resolve_scalar",
+  "upstream_anchor": "grammar.y:93-97 (type_specifier), grammar.cc:1236-1272 (CParse::lookupIdentifier)",
+  "spec_chapter": "docs/spec/00-overview.md",
+  "hypothesis_status": "UPHELD",
+  "filed_hypothesis": "The assertion parser may lack the C aliases used by the emitter / target-native scalar type aliases / unsigned type specifiers.",
+  "parity": "make test PARITY OK 675/675; make test-stages PARITY OK; make rust-test green; make check-spec OK; kuna catalog --check OK; make test-cli 32/32",
+  "decisions": [
+    "HYPOTHESIS UPHELD AND LOCATED. The C-declaration grammar (kuna-console/src/grammar.rs, the port of upstream grammar.y) has no scalar keywords at all: CParse::lookupIdentifier classifies an identifier as a base type solely by TypeFactory::findByName, so the only spellings that parse are Ghidra's own core-type names -- int4, uint8, float8, char, void, bool. `int`, `unsigned`, `signed`, `short`, `long`, `float`, `double`, `wchar_t` and `_Bool` are not core-type names on any target, so all of them lexed as plain identifiers and hit the bison default 'Syntax error'. This is upstream behaviour, not a kuna regression.",
+    "WHAT MAKES IT A DEFECT IN KUNA SPECIFICALLY IS THE OTHER HALF. kuna's printer does NOT print Ghidra's vocabulary: p9_emit/kuna_ctypes.rs spells every core type the way the target's own compiler would (`unsigned int`, `long long`, `signed char`, `wchar_t`), reading the widths out of the compiler spec's <data_organization>. So the decompiler emitted one language and accepted another, and the round-trip an agent naturally reaches for -- paste back the declaration kuna just printed -- could not work. kuna_ctypes.rs's own header names the grammar as the reason it did not rename the core types; this is the missing inverse it implies.",
+    "MEASURED ON THE UNPATCHED TREE (cf5234ac, release binary): `unsigned int authenticate(char *user,char *pass)`, `long long read(int fd,void *buf,unsigned long n)` and `type v2 unsigned char[8]` are all three rejected with 'Syntax error', in return position, parameter position and as a `type` operand alike. docs/cli.md's own worked example for --assert (line 100, `prototype authenticate int authenticate(char *user,char *pass)`) was among the rejected forms -- the manual documented a command that did not run.",
+    "PR #415's claim that the quoted form already accepts `int` / `unsigned int` is wrong, exactly as the captain's refutation says. #415 fixed a real and different defect (the error message named the wrong problem when the shell split the directive); its inline comment in assertdecl.rs asserted the type vocabulary was fine. That comment is corrected in this PR.",
+    "DESIGN -- STRICTLY ADDITIVE, AND PROVABLY SO. A run of exactly one scalar keyword is still resolved by findByName FIRST, so `void`, `char`, and any host- or DWARF-supplied type that happens to be spelled with a keyword resolve to exactly the interned Rc<Datatype> they resolved to before. Only multi-keyword combinations -- which were 100% syntax errors before -- and the keywords the type factory does not name take the new width-driven path. Independently: zero of the 261 `parse line` payloads across tests/datatests and tests/stages contains any of the eleven keywords, so neither parity corpus can be moved by this change.",
+    "DESIGN -- WIDTHS FROM THE COMPILER SPEC, NEVER A 2/4/8 TABLE. resolve_scalar reads get_size_of_{char,short,int,long,long_long,wchar,float,double,long_double} off the type factory, the same <data_organization> fields kuna_ctypes.rs's speller reads, so `long` is int8 on LP64 and int4 on LLP64 and the two halves cannot disagree. `signed char` goes through get_base_no_char so it is int1 and not kuna's ASCII `char` type; plain `char` stays the text type.",
+    "DESIGN -- REJECT LOUDLY. An impossible combination (`short long`, `float int`, three `long`s, `unsigned void`) is rejected with 'Invalid combination of C type specifiers: <the words>' rather than a bare 'Syntax error' pointing at the second keyword, because the whole reason five testers filed this need is that the old diagnostic did not say what was wrong. A keyword whose width the compiler spec never declared (a cspec with no <short_size>) names nothing on that target and is rejected too, rather than resolving to a zero-sized type.",
+    "ACCEPTANCE RETARGETED, NOT RELAXED. The filed acceptance pointed at a dataset PE (bin/crackme.exe, binary_source: dataset), which `verify --promote` refuses because CI has no dataset. It is retargeted onto the in-repo fixture kuna-analysis/tests/fixtures/fauxware -- the same fixture the sibling no-cli-rename-or-prototype-override probe uses -- and STRENGTHENED while moving: three directives instead of one, all three asserted `applied`, plus two positive clauses on the emitted C (`unsigned int authenticate(char *user,char *pass)` and `unsigned char v2 [8];`) and stderr_absent on both 'Syntax error' and 'Bad C syntax'. Measured rejected 3/3 on the unpatched cf5234ac binary and applied 3/3 after, so it is a genuine discriminator. The original dataset acceptance was also measured PASS on the fixed tree before the retarget.",
+    "NO OPTION, NO STAGE TESTCASE. Track tooling: this is the console's declaration parser accepting more input, and it cannot change emitted C for any run that does not pass a --assert/parse-line directive using the new spellings. phases.toml, options.rs, docs/options.md, docs/history.md and every catalog counter are untouched, and kuna catalog --check stays green.",
+    "A SECOND LOOKAHEAD SITE, found only by the workspace suite. struct_declaration_list's continuation predicate tested TypeQualifier|TypeName|Struct|Union|Enum, so once `void` became a scalar keyword the SECOND member of `struct methods { void (*peek)(int4 a); void (*get)(int4 b); };` ended the member loop and the struct failed to parse. Neither parity gate caught it: tests/datatests/indproto.xml carries that payload but is NOT in docs/baseline.json's 83-file corpus, so only kuna-harness/tests/verify_w10_indproto_e2e runs it. Fixed, and then swept: all 229 distinct `parse line`/`parse file` payloads in tests/datatests + tests/stages (multi-line ones included) were run through the old and the new decomp_dbg and compared -- 0 differences, 71 pre-existing context errors identical on both sides.",
+    "verify_w10_proto_unlock's `xunknown4` failure in the first suite run is the known KUNA_DECOMP_TEST artifact, not this change: the repipe harness points that var at the worktree's own Rust decomp_test_dbg while the test treats it as the removed C++ oracle and asserts C++-era spellings. Run the suite as `env -u KUNA_DECOMP_TEST make rust-test`; CI never sets it."
+  ],
+  "residue": [
+    "`long double` resolves to the target's <long_double_size> VALUE width, which on x86 is 10 -- so `long double` round-trips float10 exactly but a genuine float16 also prints as `long double` and parses back as float10. That asymmetry is inherited from the printer's own approximation (kuna_ctypes.rs float_spelling), not introduced here.",
+    "The printer's `undefined<N>` spellings (residual TYPE_UNKNOWN) are still not parseable: the core types are named xunknown<N>, so findByName misses. Out of scope for this need, which is about the standard C scalars; worth a follow-up if a tester hits it.",
+    "SIDE FINDING carried over from the captain's refutation and NOT addressed here: an ACCEPTED `float8`/`double` prototype on i386 can exit 1 on an un-ported seam (LOSS-131, heritage typeop_skeleton CPUI_FLOAT_FLOAT2FLOAT), and with --json panics at p3_dataflow/heritage.rs:4610 instead of reporting it. That is a P3 defect, unrelated to the grammar."
+  ],
+  "tests": [
+    "decompiler/crates/kuna-console/src/grammar/tests.rs: 7 new unit tests -- the 20-spelling resolution table, the LP64-vs-LLP64 `long` width, plain-char-vs-signed-char, a standard-C prototype through parse_protopieces, the findByName-still-wins guarantee, 9 impossible combinations, and the undeclared-width rejection.",
+    "decompiler/crates/kuna-console/tests/verify_assertplane.rs: 2 new end-to-end tests through the real --assert application path on fauxware -- standard C reaching the emitted C, and an impossible combination rejected BY NAME.",
+    "tests/cli/prototype-assertions-reject-ordinary.json: the promoted acceptance probe (make test-cli, 32/32)."
+  ]
+}

--- a/docs/re-needs/prototype-assertions-reject-ordinary.md
+++ b/docs/re-needs/prototype-assertions-reject-ordinary.md
@@ -1,0 +1,227 @@
+---
+need_id: prototype-assertions-reject-ordinary
+title: Prototype assertions reject ordinary unsigned int declarations
+track: tooling
+status: open
+severity: major
+probe_id: p-b95fa6549eeb
+acceptance_id: a-e9643c3e9aaa
+hypothesis_status: upheld
+credibility: 1.0
+instances: 5
+challenges: [5ab77f5733c5d40ad448c380, 5ab77f5833c5d40ad448c399, 640a526833c5d447bc761899, 68d9ee36224c0ec5dcedc3fc, 6a0b84982b3df128c1df5c0d]
+rounds: [3]
+first_seen_round: 3
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-console/src/grammar, decompiler/crates/kuna-console/src/ifacedecomp.rs]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Use standard C parameter types in prototype assertions.
+
+> **Prototype assertion rejects standard C int on ARM** (minor, `5ab77f5733c5d40ad448c380`)
+> Exited 0 with 'rejected: Bad C syntax'. With and without a semicolon failed; replacing int with int4 succeeded.
+
+> **Prototype assertion rejects C int but accepts int4** (minor, `5ab77f5833c5d40ad448c399`)
+> Rejected int with Bad C syntax, with or without a semicolon. Replacing int with int4 succeeded.
+
+> **Standard C scalar types are rejected in prototype assertions** (major, `640a526833c5d447bc761899`)
+> Rejected the assertion with Bad C syntax while exiting 0. A trailing semicolon did not help. int declarations also failed; float8 and int4 were accepted.
+
+> **Prototype assertions reject ordinary unsigned int declarations** (minor, `68d9ee36224c0ec5dcedc3fc`)
+> Rejected unsigned int with Syntax error. Internal uint4 and uint8 spellings worked.
+
+> **Prototype assertions reject the standard C type int** (major, `6a0b84982b3df128c1df5c0d`)
+> An int-returning prototype is rejected with Bad C syntax, with or without a semicolon. Replacing int with int4 succeeds and emits int.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_140004dcc",
+    "--assert",
+    "prototype VirtualAlloc void *VirtualAlloc(void *p,unsigned int n,unsigned int a,unsigned int b)",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "assertions[0].status",
+        "op": "eq",
+        "value": "rejected"
+      }
+    ],
+    "stderr_matches": [
+      "Syntax error"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/crackme.exe",
+    "binary_sha256": "30849bed966c92e64009a23df62210e615a2b3e3342a79372866af53cdffa540",
+    "binary_size": 74752,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-e9643c3e9aaa",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "authenticate",
+    "--json",
+    "--assert",
+    "prototype authenticate unsigned int authenticate(char *user,char *pass)",
+    "--assert",
+    "prototype read long long read(int fd,void *buf,unsigned long n)",
+    "--assert",
+    "type v2 unsigned char[8]"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "binary_sha256": "c2d90645a45e99221593547e55c601a901b80f807ae96f94c60a7661df0b3e0b",
+    "binary_size": 8776,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "selector": "authenticate",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "assertions",
+        "op": "len_eq",
+        "value": 3
+      },
+      {
+        "path": "assertions[0].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "assertions[1].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "assertions[2].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "contains",
+        "value": "unsigned int authenticate(char *user,char *pass)"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "contains",
+        "value": "unsigned char v2 [8];"
+      }
+    ],
+    "stderr_absent": [
+      "Syntax error",
+      "Bad C syntax"
+    ]
+  },
+  "notes": "Desired: the standard C scalar keywords the printer EMITS are the ones --assert accepts -- in return position (`unsigned int`, `long long`), in parameter position (`int`, `unsigned long`), and as an --assert type base (`unsigned char[8]`). Retargeted onto the in-repo fauxware fixture so it runs with no dataset; all three measured rejected on cf5234ac."
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- The assertion parser may lack the C aliases used by the emitter.
+- The assertion parser may lack target-native scalar type aliases.
+- The declaration parser may not recognize unsigned type specifiers.
+- The parser may lack the standard int alias in this language configuration.
+
+## Refutation
+
+**UPHELD by direct measurement** (captain, round 3, cf5234ac, freshly built binary).
+
+The hypothesis is that the `--assert prototype` C-declaration grammar accepts only sized
+Ghidra type names plus `void`/`char`, not the standard scalar keywords. One quoted argv
+element each, on `collide` (i386), function `sub_8049f20`:
+
+| assertion | result |
+|---|---|
+| `int sub_8049f20(void)` | rejected, "Bad C syntax" |
+| `unsigned int sub_8049f20(void)` | rejected |
+| `double sub_8049f20(void)` | rejected |
+| `int4 sub_8049f20(int x)` | rejected (parameter position too) |
+| `int4 sub_8049f20(int4 x)` | applied |
+| `void sub_8049f20(void)` | applied |
+
+So the defect is a missing keyword set in the grammar, present in return AND parameter
+position; it is not shell splitting. PR #415 asserts the opposite ("Quoted, the same
+assertions are accepted: int, int4, unsigned int, char ** all parse") and is wrong on that
+claim -- #415 fixed a real but different defect, the error message. A builder must not read
+#415 and close this need.
+
+SIDE FINDING, not this need's business but recorded so it is not lost: an ACCEPTED assertion
+`float8 sub_8049f20(void)` on the same i386 function exits 1 on an un-ported seam
+(LOSS-131, `heritage typeop_skeleton: unexpected opcode CPUI_FLOAT_FLOAT2FLOAT`), and with
+`--json` the same run panics at `p3_dataflow/heritage.rs:4610` instead of reporting it.
+Related to [accepted-sqrt-prototype-still].
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `5ab77f5733c5d40ad448c380` (round 3, tester t-r3-5ab77f57)
+- `5ab77f5833c5d40ad448c399` (round 3, tester t-r3-5ab77f58)
+- `640a526833c5d447bc761899` (round 3, tester t-r3-640a5268)
+- `68d9ee36224c0ec5dcedc3fc` (round 3, tester t-r3-68d9ee36)
+- `6a0b84982b3df128c1df5c0d` (round 3, tester t-r3-6a0b8498)
+
+## Decision log
+
+- filed by cluster.py from 5 observation(s)
+captain T_DEDUP r3: MERGED 3 deterministic clusters (prototype-assertion-rejects-standard obs0/obs4, standard-c-scalar-types obs9/obs20, this one obs15) -- one gap, split only because kind differed (bad-ux vs wrong-output) and group() will not merge across kinds.
+captain T_DEDUP r3: witness overridden to the obs15 instance. The other four acceptances assert only `stderr_absent: rejected`, which a crash or a silently-dropped spec also satisfies; this one asserts assertions[0].status == "applied" in --json. Severity raised minor -> major (max across the merged group).
+captain T_DEDUP r3: measured on cf5234ac (post-#415), one quoted argv element each -- REJECTED: `int`, `unsigned int`, `double`, and `int` in a parameter. ACCEPTED: `void`, `char *`, `char **`, `int4`, `float8`, `int4 a,char **b`. The grammar lacks the standard scalar keywords; it is not a quoting problem.
+captain T_REFUTE r3: hypothesis upheld -- see ## Refutation (measured on cf5234ac with the release binary).
+captain T_TRIAGE r3: track tooling CONFIRMED; touches CORRECTED kuna-cli -> kuna-console/src/grammar, which is where parse_C runs and where run_parse_c raises the 'Bad C syntax' the probe matches (ifacedecomp.rs:705). Upheld at T_REFUTE: int / unsigned int / double are rejected in BOTH return and parameter position while int4 / void / char * are accepted -- the grammar lacks the standard scalar keywords. Highest corroboration in the round: 5 instances across 5 challenges, credibility 1.0. NOTE FOR THE BUILDER: PR #415 asserts this is already handled and is wrong on that claim; re-measure before believing it.
+captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.
+builder b-r3-prototype-assert r3: acceptance RETARGETED (a-35ab0d1e49fc -> a-e9643c3e9aaa) from the dataset PE onto the in-repo fixture `decompiler/crates/kuna-analysis/tests/fixtures/fauxware`, because `verify --promote` refuses a dataset target (CI has no dataset) and the need's regression guard is worth more than the original binary. Strengthened while moving: three directives instead of one (`unsigned int` in return position, `long long`/`int`/`unsigned long` in a callee prototype, `unsigned char[8]` as a `type` base), all three asserted `applied`, plus two positive clauses on the emitted C and `stderr_absent` on both "Syntax error" and "Bad C syntax". Measured rejected 3/3 on the unpatched cf5234ac binary; the ORIGINAL dataset acceptance was also measured PASS on the fixed tree before the retarget.

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -781,6 +781,39 @@ script surface (`decompiler/crates/kuna-cli/src/decompile.rs (build_script)`)
 emits the same facts at the same three slots, with the same conditional second
 `decompile`.
 
+(kuna) **The C the assertion plane accepts is the C it prints.** Six directives
+carry a C declaration, and every one of them goes through the console's
+C-declaration grammar (`decompiler/crates/kuna-console/src/grammar.rs (CParse)`),
+a port of upstream's `grammar.y`. Upstream has no scalar keywords at all: a base
+type is whatever `TypeFactory::findByName` answers, so only Ghidra's own `int4` /
+`uint8` / `float8` core-type names parse. kuna's printer, though, spells those
+types the way the target's own compiler would (§9,
+`decompiler/crates/kuna-decomp/src/p9_emit/kuna_ctypes.rs`), which left the two
+halves speaking different languages: a declaration kuna had just emitted could
+not be pasted back at it, and the manual's own example
+(`prototype authenticate int authenticate(char *user,char *pass)`) was rejected
+as a syntax error.
+
+The grammar therefore also accepts the standard C scalar specifiers
+(`decompiler/crates/kuna-console/src/grammar.rs (CParse::scalar_specifier)`):
+`void`, `char`, `short`, `int`, `long`, `float`, `double`, `signed`, `unsigned`,
+`_Bool` and `wchar_t`, in any legal combination and in every position a type may
+appear — a return type, a parameter, a `type` / `param` / `return` / `data`
+operand, a struct field. A run of these keywords names ONE base type, and its
+width is read from the compiler spec's `<data_organization>` rather than from a
+fixed table, so `long` is eight bytes on LP64 and four on LLP64 — the same
+source, read the same way, that §9's speller prints them back out from. A
+combination that is not a C type (`short long`, `float int`, three `long`s) is
+rejected by name rather than as a bare syntax error, and a keyword whose width
+the compiler spec never declared names nothing on that target and is rejected
+too, rather than resolving to a zero-sized type.
+
+The Ghidra vocabulary is untouched and still wins: a run of exactly one keyword
+is resolved by `findByName` first, so `void`, `char` and any host-supplied type
+that happens to be spelled with a keyword resolve to exactly the interned type
+they always did. Only combinations, and the keywords the type factory does not
+name, take the width-driven path.
+
 A directive that names no function binds to the function being decompiled, which
 is unambiguous only when the run selected exactly one; on a whole-binary run it
 would silently mean *every* function that happens to have a `v2`, so it is

--- a/tests/cli/prototype-assertions-reject-ordinary.json
+++ b/tests/cli/prototype-assertions-reject-ordinary.json
@@ -1,0 +1,77 @@
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-e9643c3e9aaa",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "authenticate",
+    "--json",
+    "--assert",
+    "prototype authenticate unsigned int authenticate(char *user,char *pass)",
+    "--assert",
+    "prototype read long long read(int fd,void *buf,unsigned long n)",
+    "--assert",
+    "type v2 unsigned char[8]"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "binary_sha256": "c2d90645a45e99221593547e55c601a901b80f807ae96f94c60a7661df0b3e0b",
+    "binary_size": 8776,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "selector": "authenticate",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "assertions",
+        "op": "len_eq",
+        "value": 3
+      },
+      {
+        "path": "assertions[0].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "assertions[1].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "assertions[2].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "contains",
+        "value": "unsigned int authenticate(char *user,char *pass)"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "contains",
+        "value": "unsigned char v2 [8];"
+      }
+    ],
+    "stderr_absent": [
+      "Syntax error",
+      "Bad C syntax"
+    ]
+  },
+  "notes": "Desired: the standard C scalar keywords the printer EMITS are the ones --assert accepts -- in return position (`unsigned int`, `long long`), in parameter position (`int`, `unsigned long`), and as an --assert type base (`unsigned char[8]`). Retargeted onto the in-repo fauxware fixture so it runs with no dataset; all three measured rejected on cf5234ac."
+}


### PR DESCRIPTION
## The problem

`--assert prototype` rejects the standard C scalar types. `int`, `unsigned int`,
`long long` and `double` are all a syntax error, in return position and in
parameter position alike, while Ghidra's internal `int4` / `uint4` / `float8`
spellings work. Five testers filed it independently in one round.

```console
$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/fauxware authenticate \
    --assert 'prototype authenticate unsigned int authenticate(char *user,char *pass)'
warning: --assert "prototype authenticate unsigned int authenticate(char *user,char *pass)" rejected: Syntax error at line 0 in stream
extern unsigned int 
                ^--
```

The declaration kuna itself prints cannot be pasted back at it — the same
function's header is `unsigned long authenticate(char *a0,char *a1)`. The
worked example in `docs/cli.md` was one of the rejected forms.

## The fix

- The console's C-declaration grammar learns the standard scalar specifiers —
  `void`, `char`, `short`, `int`, `long`, `float`, `double`, `signed`,
  `unsigned`, `_Bool`, `wchar_t` — in any legal combination, everywhere a type
  may appear.
- Widths come from the compiler spec's `<data_organization>`, the same fields
  the printer's C speller reads, so `long` is 8 bytes on LP64 and 4 on LLP64 and
  the two halves cannot disagree. `signed char` is a 1-byte integer; plain
  `char` stays the text type.
- Additive by construction: a run of exactly one keyword is resolved by
  `findByName` first, so `void`, `char` and any host-supplied type spelled with a
  keyword resolve to exactly the type they did before. Only combinations — which
  were 100% syntax errors — take the new path. None of the 261 `parse line`
  payloads in the two parity corpora uses any of the eleven keywords.
- An impossible combination (`short long`, `float int`, three `long`s) is
  rejected as `Invalid combination of C type specifiers: short long` rather than
  a bare "Syntax error" at the second word, and a keyword whose width the
  compiler spec never declared is rejected rather than resolving to a zero-sized
  type.

## The tests

Seven unit tests in `kuna-console/src/grammar/tests.rs` (the 20-spelling
resolution table, `long` under LP64 vs LLP64, `char` vs `signed char`, nine
impossible combinations, and the `findByName`-still-wins guarantee), two
end-to-end tests in `verify_assertplane.rs` driving the real `--assert` path,
and the promoted probe `tests/cli/prototype-assertions-reject-ordinary.json`.
All three of that probe's directives are rejected before this change and applied
after.

Gates: `make test` PARITY OK 675/675 · `make test-stages` PARITY OK ·
`make rust-test` green · `make check-spec` OK · `kuna catalog --check` OK ·
`make test-cli` 32/32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
