### PR TITLE
[AUTOMATED] docs(re-needs): 10 needs were closed without an acceptance flip — say so

### DIFF
--- a/docs/re-needs/call-args-discarded.md
+++ b/docs/re-needs/call-args-discarded.md
@@ -24,6 +24,12 @@ Filed by round-1 testers on the crackmes corpus. See `.kuna-repipe/rounds/1/gate
 
 CLOSED in round 1. Shipped: `varargstackargs` and `calleearity` (both default OFF): two ways a recovered argument was dropped
 
+**Closed WITHOUT an acceptance flip.** Filed by hand, so this record carries no `probe_id`/`acceptance_id` and the gate never closed it -- a human did. The design says only the acceptance probe may close a need; this one did not go through that. The durable evidence that the capability works is:
+- `tests/stages/kuna-calleearity.xml`
+- `tests/stages/kuna-varargstackargs.xml`
+
+Recorded rather than back-filled: a probe retro-fitted now would assert TODAY's behaviour, not the behaviour at closing time, and would look like gate evidence while being nothing of the kind.
+
 ## Decision log
 
 - round 1: gated `admitted`, built, merged in PR #367; probe re-run on the merged build confirms the bad behaviour no longer reproduces.

--- a/docs/re-needs/int80-opaque-syscall.md
+++ b/docs/re-needs/int80-opaque-syscall.md
@@ -24,6 +24,11 @@ Filed by round-1 testers on the crackmes corpus. See `.kuna-repipe/rounds/1/gate
 
 CLOSED in round 1. Shipped: `linuxsyscall` (default OFF -- pass `--option linuxsyscall on`): names the syscall EAX selects and takes the ABI registers as arguments
 
+**Closed WITHOUT an acceptance flip.** Filed by hand, so this record carries no `probe_id`/`acceptance_id` and the gate never closed it -- a human did. The design says only the acceptance probe may close a need; this one did not go through that. The durable evidence that the capability works is:
+- `tests/stages/kuna-linuxsyscall.xml`
+
+Recorded rather than back-filled: a probe retro-fitted now would assert TODAY's behaviour, not the behaviour at closing time, and would look like gate evidence while being nothing of the kind.
+
 ## Decision log
 
 - round 1: gated `admitted`, built, merged in PR #367; probe re-run on the merged build confirms the bad behaviour no longer reproduces.

--- a/docs/re-needs/main-void-prototype.md
+++ b/docs/re-needs/main-void-prototype.md
@@ -24,6 +24,11 @@ Filed by round-1 testers on the crackmes corpus. See `.kuna-repipe/rounds/1/gate
 
 CLOSED in round 1. Shipped: `entrymainproto` (default ON): the in-image CRT call site types argc/argv/envp
 
+**Closed WITHOUT an acceptance flip.** Filed by hand, so this record carries no `probe_id`/`acceptance_id` and the gate never closed it -- a human did. The design says only the acceptance probe may close a need; this one did not go through that. The durable evidence that the capability works is:
+- `tests/stages/kuna-entrymainproto.xml`
+
+Recorded rather than back-filled: a probe retro-fitted now would assert TODAY's behaviour, not the behaviour at closing time, and would look like gate evidence while being nothing of the kind.
+
 ## Decision log
 
 - round 1: gated `admitted`, built, merged in PR #367; probe re-run on the merged build confirms the bad behaviour no longer reproduces.

--- a/docs/re-needs/no-cli-data-code-override.md
+++ b/docs/re-needs/no-cli-data-code-override.md
@@ -134,6 +134,11 @@ Refutation below.
 }
 ```
 
+**Closed WITHOUT an acceptance flip.** Filed by hand, so this record carries no `probe_id`/`acceptance_id` and the gate never closed it -- a human did. The design says only the acceptance probe may close a need; this one did not go through that. The durable evidence that the capability works is:
+- `closed by #391 (--assert data / volatile)`
+
+Recorded rather than back-filled: a probe retro-fitted now would assert TODAY's behaviour, not the behaviour at closing time, and would look like gate evidence while being nothing of the kind.
+
 ## Hypothesis
 
 ADVISORY. The cheap half is exposure, not implementation: most of these commands already work and only lack a path from the `kuna` binary. The expensive half is the stubs. A builder should measure which is which before choosing a design, and should NOT assume a `kuna console` passthrough is the right shape -- a scriptable console is a different product from a set of flags an agent can compose.

--- a/docs/re-needs/no-cli-rename-or-prototype-override.md
+++ b/docs/re-needs/no-cli-rename-or-prototype-override.md
@@ -115,6 +115,11 @@ run reports each one's fate as machine-readable JSON. FAILS at e3db5512: every
 }
 ```
 
+**Closed WITHOUT an acceptance flip.** Filed by hand, so this record carries no `probe_id`/`acceptance_id` and the gate never closed it -- a human did. The design says only the acceptance probe may close a need; this one did not go through that. The durable evidence that the capability works is:
+- `closed by #389 (--assert name / prototype)`
+
+Recorded rather than back-filled: a probe retro-fitted now would assert TODAY's behaviour, not the behaviour at closing time, and would look like gate evidence while being nothing of the kind.
+
 ## Hypothesis
 
 ADVISORY. The cheap half is exposure, not implementation: most of these commands already work and only lack a path from the `kuna` binary. The expensive half is the stubs. A builder should measure which is which before choosing a design, and should NOT assume a `kuna console` passthrough is the right shape -- a scriptable console is a different product from a set of flags an agent can compose.

--- a/docs/re-needs/no-disassembly-command.md
+++ b/docs/re-needs/no-disassembly-command.md
@@ -24,6 +24,11 @@ Filed by round-1 testers on the crackmes corpus. See `.kuna-repipe/rounds/1/gate
 
 CLOSED in round 1. Shipped: `kuna disassemble <bin> <name|0xaddr|0xstart-0xend> [--addr] [--count N] [--bytes N] [--json]` -- --json carries the raw bytes so a decompilation can be checked against them
 
+**Closed WITHOUT an acceptance flip.** Filed by hand, so this record carries no `probe_id`/`acceptance_id` and the gate never closed it -- a human did. The design says only the acceptance probe may close a need; this one did not go through that. The durable evidence that the capability works is:
+- `tests/cli/disassemble-named-function.json`
+
+Recorded rather than back-filled: a probe retro-fitted now would assert TODAY's behaviour, not the behaviour at closing time, and would look like gate evidence while being nothing of the kind.
+
 ## Decision log
 
 - round 1: gated `admitted`, built, merged in PR #367; probe re-run on the merged build confirms the bad behaviour no longer reproduces.

--- a/docs/re-needs/no-strings-inventory.md
+++ b/docs/re-needs/no-strings-inventory.md
@@ -24,6 +24,12 @@ Filed by round-1 testers on the crackmes corpus. See `.kuna-repipe/rounds/1/gate
 
 CLOSED in round 1. Shipped: `kuna strings <bin> [--json] [--min-length N] [--filter RE] [--encoding ascii|utf16|all] [--section S]` -- each row carries the VMA, the section, and the OWNING FUNCTION, which strings(1) cannot give
 
+**Closed WITHOUT an acceptance flip.** Filed by hand, so this record carries no `probe_id`/`acceptance_id` and the gate never closed it -- a human did. The design says only the acceptance probe may close a need; this one did not go through that. The durable evidence that the capability works is:
+- `tests/cli/strings-inventory-with-xrefs.json`
+- `tests/cli/strings-filter-narrows.json`
+
+Recorded rather than back-filled: a probe retro-fitted now would assert TODAY's behaviour, not the behaviour at closing time, and would look like gate evidence while being nothing of the kind.
+
 ## Decision log
 
 - round 1: gated `admitted`, built, merged in PR #367; probe re-run on the merged build confirms the bad behaviour no longer reproduces.

--- a/docs/re-needs/phantom-unmapped-entry.md
+++ b/docs/re-needs/phantom-unmapped-entry.md
@@ -24,6 +24,12 @@ Filed by round-1 testers on the crackmes corpus. See `.kuna-repipe/rounds/1/gate
 
 CLOSED in round 1. Shipped: `unmappedentry` (default ON): the function worklist now applies the same in_exec gate the instruction worklist always did
 
+**Closed WITHOUT an acceptance flip.** Filed by hand, so this record carries no `probe_id`/`acceptance_id` and the gate never closed it -- a human did. The design says only the acceptance probe may close a need; this one did not go through that. The durable evidence that the capability works is:
+- `tests/cli/unmappedentry-no-phantom-entry.json`
+- `tests/stages/kuna-unmappedentry.xml`
+
+Recorded rather than back-filled: a probe retro-fitted now would assert TODAY's behaviour, not the behaviour at closing time, and would look like gate evidence while being nothing of the kind.
+
 ## Decision log
 
 - round 1: gated `admitted`, built, merged in PR #367; probe re-run on the merged build confirms the bad behaviour no longer reproduces.

--- a/docs/re-needs/switch-on-constant-selector.md
+++ b/docs/re-needs/switch-on-constant-selector.md
@@ -24,6 +24,11 @@ Filed by round-1 testers on the crackmes corpus. See `.kuna-repipe/rounds/1/gate
 
 CLOSED in round 1. Shipped: `switchselector` (default OFF -- pass `--option switchselector on`): declines a lowered-switch install whose selector cannot be re-read, leaving the compiler if/else-if chain over the real parameter
 
+**Closed WITHOUT an acceptance flip.** Filed by hand, so this record carries no `probe_id`/`acceptance_id` and the gate never closed it -- a human did. The design says only the acceptance probe may close a need; this one did not go through that. The durable evidence that the capability works is:
+- `tests/stages/kuna-switchselector.xml`
+
+Recorded rather than back-filled: a probe retro-fitted now would assert TODAY's behaviour, not the behaviour at closing time, and would look like gate evidence while being nothing of the kind.
+
 ## Decision log
 
 - round 1: gated `admitted`, built, merged in PR #367; probe re-run on the merged build confirms the bad behaviour no longer reproduces.

--- a/docs/re-needs/whole-binary-json-untriageable.md
+++ b/docs/re-needs/whole-binary-json-untriageable.md
@@ -24,6 +24,11 @@ Filed by round-1 testers on the crackmes corpus. See `.kuna-repipe/rounds/1/gate
 
 CLOSED in round 1. Shipped: `kuna functions --summary --filter RE --reachable-from F --min-size N --sort size --limit N` -- on a 211 KB PE the summary is 2.8 KB against 174 KB unfiltered
 
+**Closed WITHOUT an acceptance flip.** Filed by hand, so this record carries no `probe_id`/`acceptance_id` and the gate never closed it -- a human did. The design says only the acceptance probe may close a need; this one did not go through that. The durable evidence that the capability works is:
+- `tests/cli/functions-summary-is-triageable.json`
+
+Recorded rather than back-filled: a probe retro-fitted now would assert TODAY's behaviour, not the behaviour at closing time, and would look like gate evidence while being nothing of the kind.
+
 ## Decision log
 
 - round 1: gated `admitted`, built, merged in PR #367; probe re-run on the merged build confirms the bad behaviour no longer reproduces.


### PR DESCRIPTION
Auditing which need fields are actually written, 10 of 51 records carry no
`probe_id` and 8 no `acceptance_id`. All ten are records I filed BY HAND -- the
eight round-1 needs written from ADMITTED.md and two round-2 seeds. Every need the
loop itself filed through cluster.py has both.

All ten are `closed`. None was closed by the gate, because none has an acceptance
probe to flip. A human decided they were done. The design's central rule is that
only the acceptance probe may close a need -- the captain enforced exactly this on
`decompiling-3396-byte-main`, refusing six times to relax a 10 s bar rather than
redefine `closed` as "a builder tried" -- and these ten quietly sit outside it.

The capabilities are real and I verified them by hand at the time; the point is that
the RECORD does not carry that evidence, so the closure is unauditable and the needs
are invisible to regression detection. Each now says so under `## Acceptance`, and
names the durable artefact that does cover it:

  no-strings-inventory            tests/cli/strings-inventory-with-xrefs.json, ...
  no-disassembly-command          tests/cli/disassemble-named-function.json
  whole-binary-json-untriageable  tests/cli/functions-summary-is-triageable.json
  phantom-unmapped-entry          tests/cli/unmappedentry-no-phantom-entry.json + stage
  main-void-prototype             tests/stages/kuna-entrymainproto.xml
  switch-on-constant-selector     tests/stages/kuna-switchselector.xml
  int80-opaque-syscall            tests/stages/kuna-linuxsyscall.xml
  call-args-discarded             tests/stages/kuna-calleearity.xml, -varargstackargs.xml
  no-cli-data-code-override       #391
  no-cli-rename-or-prototype-...  #389

DELIBERATELY NOT BACK-FILLED. A probe written now would assert today's behaviour, not
the behaviour at closing time, and would sit in the record looking like gate evidence
while being nothing of the kind. An honest gap beats a manufactured flip.

The note lives under `## Acceptance` rather than a new `## Evidence` heading because
SECTIONS is a fixed list and the round-trip drops anything outside it -- caught by the
smoke's own front-matter round-trip, 10 failures, one per record I had just edited.

tools/repipe/smoke.sh 127/127.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcFmfZndNjgfqLQVBZCdkY