### PR TITLE
[AUTOMATED] docs(re-needs): restore 14 round-3 records I deleted

### DIFF
--- a/docs/re-needs/accepted-sqrt-prototype-still.md
+++ b/docs/re-needs/accepted-sqrt-prototype-still.md
@@ -1,0 +1,135 @@
+---
+need_id: accepted-sqrt-prototype-still
+title: Accepted sqrt prototype still leaves floating arguments absent
+track: quality
+status: open
+severity: major
+probe_id: p-fd6d3fefafe2
+acceptance_id: a-bb9896e9cfbb
+hypothesis_status: overturned
+credibility: 0.7
+instances: 1
+challenges: [640a526833c5d447bc761899]
+rounds: [3]
+first_seen_round: 3
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-decomp/src/p4_calls]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Force the known XMM0 double argument using an explicit prototype.
+
+> **Accepted sqrt prototype still leaves floating arguments absent** (major, `640a526833c5d447bc761899`)
+> Default output drops sqrt arguments and reads unassigned result locals. calloverlap full recovers results, but accepted thunk-address, import-address, and parameter assertions still leave sqrt() argumentless.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_140001890",
+    "--option",
+    "calloverlap",
+    "full",
+    "--assert",
+    "prototype 0x140003ddf float8 sqrt(float8 x)"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stderr_absent": [
+      "rejected"
+    ],
+    "stdout_matches": [
+      "sqrt\\(\\s*\\)"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/KeyCheker.exe",
+    "binary_sha256": "351e54ecaa80f0395111a90e332313c15bd1e19d1e12da87606a045efb5afecf",
+    "binary_size": 25600,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_140001890",
+    "--option",
+    "calloverlap",
+    "full",
+    "--assert",
+    "prototype 0x140003ddf float8 sqrt(float8 x)"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stderr_absent": [
+      "rejected"
+    ],
+    "stdout_matches": [
+      "sqrt\\("
+    ],
+    "stdout_absent": [
+      "sqrt\\(\\s*\\)"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/KeyCheker.exe",
+    "binary_sha256": "351e54ecaa80f0395111a90e332313c15bd1e19d1e12da87606a045efb5afecf",
+    "binary_size": 25600,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- Whole-width XMM writes may defeat the locked scalar argument.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `640a526833c5d447bc761899` (round 3, tester t-r3-640a5268)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+captain T_TRIAGE r3: track quality CONFIRMED and touches narrowed to p4_calls: the prototype is accepted (the assert does not error), so the loss is in call input-trial/float-parameter recovery, not in the grammar -- unlike prototype-assertions-reject-ordinary, which is the grammar and is on the tooling track.
+captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.
+- round 3 REFUTER: hypothesis **overturned** (was inconclusive). OVERTURNED by measurement on the 20:01 release binary (arena/3/640a526833c5d447bc761899/target/KeyCheker.exe). The filed cause is 'whole-width XMM writes may defeat the locked scalar argument'. Nothing about XMM width is ever reached: the prototype assertion is a SILENT NO-OP at this call site. Three runs, same 4 call sites each time, output identical in all three: (a) the filed 'float8 sqrt(float8 x)' -> 'v26 = (double)sqrt();'; (b) 'float8 sqrt(float8 x, float8 y)' -> still zero arguments, and a locked 2-input prototype cannot print zero args; (c) 'int8 zzzmarker(int8 x)' -> the name is still sqrt and the cast is still (double). kuna functions puts a real 33-byte function 'sqrt' at exactly 0x140003ddf, so the address is right and the assert exits 0 with an empty stderr -- accepted and then discarded. The (double) cast and the sqrt name come from kuna's own recovery for that address, which is what makes the assertion look applied. A builder who follows the hypothesis into p4_calls float-parameter recovery would be fixing a mechanism that never runs; the T_TRIAGE narrowing to p4_calls rested on 'the assert does not error' and is wrong for the same reason. The gap is upstream in the path that turns a --assert prototype into a locked FuncProto on the callee (kuna decides nothing from it here); the argumentless call is the downstream symptom. Not measured: which of parse / attach-to-address / lock-the-input drops it. Note the relation to in-flight PR #421 (prototype-assertions-reject-ordinary): that one is the GRAMMAR rejecting ordinary C signatures; this one is a signature the grammar accepts being thrown away, so #421 merging will not close it.

--- a/docs/re-needs/arm-literal-pool-string.md
+++ b/docs/re-needs/arm-literal-pool-string.md
@@ -1,0 +1,129 @@
+---
+need_id: arm-literal-pool-string
+title: ARM literal-pool string use has no owning function
+track: tooling
+status: open
+severity: major
+probe_id: p-d995eb7a24ba
+acceptance_id: a-763430881ec8
+hypothesis_status: inconclusive
+credibility: 0.7
+instances: 1
+challenges: [5ab77f5733c5d40ad448c380]
+rounds: [3]
+first_seen_round: 3
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-analysis/src/listing/xrefs.rs, decompiler/crates/kuna-analysis/src/analyzers/strings]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Find the function using the kernel-version error string.
+
+> **ARM literal-pool string use has no owning function** (major, `5ab77f5733c5d40ad448c380`)
+> Reports xrefs_count 0 and functions []. Kuna disassembly shows __libc_start_main loading r0 from 0x86e4 at 0x862c before calling __libc_fatal. Kuna read confirms that pool word points to the string at 0x661bc.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "strings",
+    "{{BIN}}",
+    "--filter",
+    "FATAL: kernel too old",
+    "--json"
+  ],
+  "expect": {
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "strings[0].functions",
+        "op": "len_eq",
+        "value": 0
+      },
+      {
+        "path": "strings[0].xrefs_count",
+        "op": "eq",
+        "value": 0
+      }
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/1337_ARM.zip.__x/1337ARM.bin",
+    "binary_sha256": "c8dcf51596afaee2c31b3f87fb9df9e84257c1b3881e90e24a1015fd88e2dd80",
+    "binary_size": 571848,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "strings",
+    "{{BIN}}",
+    "--filter",
+    "FATAL: kernel too old",
+    "--json"
+  ],
+  "expect": {
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "strings[0].functions",
+        "op": "len_gt",
+        "value": 0
+      }
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/1337_ARM.zip.__x/1337ARM.bin",
+    "binary_sha256": "c8dcf51596afaee2c31b3f87fb9df9e84257c1b3881e90e24a1015fd88e2dd80",
+    "binary_size": 571848,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+_none offered_
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `5ab77f5733c5d40ad448c380` (round 3, tester t-r3-5ab77f57)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+captain T_DEDUP r3: cleared regression_of: no-strings-inventory (the tester's own field), which was applying REGRESSION_FLOOR and putting this 1-instance need at score 1110 -- ahead of a 5-tester need at 179. Two reasons. (a) Wrong target: no-strings-inventory is "kuna cannot list or search strings", which plainly still works; the need this resembles is strings-json-fails-report ("strings JSON fails to report the owning function for a directly referenced string"). (b) Not a regression: I re-ran both acceptance probes on cf5234ac -- strings-json-fails-report PASSES (kuna strings --json still attributes the owning function, functions[0] = sub_8048ace), and no-strings-inventory has no runnable acceptance at all (passed: null). The ARM literal-pool case is a NEW narrower gap in xref-to-function attribution when the reference goes through a literal pool, not a shipped capability that broke. Ranked on merit it scores 13.86.
+captain T_TRIAGE r3: track CORRECTED quality -> tooling, touches CORRECTED kuna-decomp -> kuna-analysis. cluster.py inferred quality from kind=wrong-output, but the probe drives `kuna strings --json` and emits no C at all. Measured on cf5234ac: the string at 0x661bc reports xrefs_count 0 / functions [], so the gap is that the reference scan does not follow an ARM literal-pool load (LDR Rn,[PC,#imm]). No emitted C changes, so no option and no stages case; exact precedent is the closed xrefs-unify-pe-import (tooling, listing/xrefs.rs).
+captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.

--- a/docs/re-needs/block-processing-panics-out.md
+++ b/docs/re-needs/block-processing-panics-out.md
@@ -1,0 +1,123 @@
+---
+need_id: block-processing-panics-out
+title: Block processing panics with an out-of-bounds index
+track: quality
+status: open
+severity: major
+probe_id: p-84fba836c289
+acceptance_id: a-5d5e1d9200d1
+hypothesis_status: upheld
+credibility: 0.7
+instances: 1
+challenges: [629a286b33c5d45b75903c7a]
+rounds: [3]
+first_seen_round: 3
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-decomp/src/substrate/block.rs]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Inspect the function at 0x41cd08 without an internal block-processing failure.
+
+> **Block processing panics with an out-of-bounds index** (major, `629a286b33c5d45b75903c7a`)
+> Exited 1 with a block.rs panic: index out of bounds. Reliable mode reproduced it; decompile-all recorded a per-function error.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x41cd08",
+    "--addr"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 1
+    },
+    "stderr_matches": [
+      "index out of bounds"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/thief_crackme.exe",
+    "binary_sha256": "d176b3254177ecf03709513a72a52941a6031002f64e9f3681568f03dd96f0fc",
+    "binary_size": 184320,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x41cd08",
+    "--addr"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_absent": [
+      "decompilation failed"
+    ],
+    "stderr_absent": [
+      "panicked",
+      "un-ported seam"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/thief_crackme.exe",
+    "binary_sha256": "d176b3254177ecf03709513a72a52941a6031002f64e9f3681568f03dd96f0fc",
+    "binary_size": 184320,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- An unchecked block invariant fails on the protected instruction stream; exact cause unverified.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `629a286b33c5d45b75903c7a` (round 3, tester t-r3-629a286b)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+captain T_DEDUP r3: SPLIT from ssa-renaming-panics-protected, which the deterministic pass merged on kind+shape. Distinct panic site -- substrate/block.rs:648 `index out of bounds: the len is 1 but the index is 1` at sub_41cd08. Same binary, different phase.
+captain T_TRIAGE r3: track CORRECTED tooling -> quality, touches CORRECTED kuna-cli -> kuna-decomp. cluster.py sends every non-`functions` crash to tooling, but the panic site is measured: substrate/block.rs:648 'index out of bounds: the len is 1 but the index is 1' (LOSS-131 seam) on thief_crackme.exe 0x41cd08. BUILDER: this is a STRICT BUG FIX -- do NOT add a phases.toml option row; a panic that yields a WARNING stub instead of C is not a judgement call. The quality track is assigned for the counter lease and the whole-corpus sweep discipline, because an unguarded index fix in ported substrate code can silently move output far from this witness.
+captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.
+- round 3 REFUTER: hypothesis **upheld** (was inconclusive). Captain refuted BY MEASUREMENT in-tick (main-tree kuna, 20:01 build). The filed guess -- 'an unchecked block invariant fails' -- is UPHELD, and the invariant is now named: RUST_BACKTRACE puts the panic at substrate/block.rs:648 inside FlowBlock::get_in, called from funcdata_block.rs:1334 'let inbl = self.bblocks_ref().block(parent).get_in(i)' in descend2_undef, reached via block_remove_internal(unreachable=true) <- remove_unreachable_blocks. i is the MULTIEQUAL's slot for the dead varnode (get_slot, line 1327), so 'len is 1 but the index is 1' means the phi still has 2 inputs while its parent block has 1 in-edge: MULTIEQUAL arity and parent in-degree are already desynced BEFORE descend2_undef runs. Note the unreachable arm SKIPS the whole push_multiequals + per-out-edge op_remove_input resync that the !unreachable arm does (funcdata_block.rs:1397-1419), which is where the ordering has to be looked at. TWO CORRECTIONS FOR THE BUILDER. (1) Nothing measured here is specific to the 'protected instruction stream' -- the path is generic unreachable-block removal; the packer only supplies the dead-block shape. Do not scope the fix to obfuscated input. (2) THE ACCEPTANCE PROBE CANNOT TELL A FIX FROM A COVER-UP: it only asks for exit 0 with 'panicked' absent from stderr, so a bounds guard (or a clamp/skip at block.rs:648) closes this need while emitting a phi with a dropped or mis-wired input -- silently WRONG C instead of a crash. The fix must restore the arity invariant, and the builder should diff the emitted C for sub_41cd08 against the surrounding call graph rather than trusting the absence probe.

--- a/docs/re-needs/corrupt-elf-section-table.md
+++ b/docs/re-needs/corrupt-elf-section-table.md
@@ -1,0 +1,121 @@
+---
+need_id: corrupt-elf-section-table
+title: Corrupt ELF section table blocks analysis despite readable program headers
+track: tooling
+status: open
+severity: blocker
+probe_id: p-b0eecb741356
+acceptance_id: a-e4f84764b32f
+hypothesis_status: overturned
+credibility: 0.85
+instances: 1
+challenges: [5ab77f6633c5d40ad448cc64]
+rounds: [3]
+first_seen_round: 3
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-analysis/src/loader]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Load through program headers, optionally overriding corrupt section metadata, and enumerate executable functions.
+
+> **Corrupt ELF section table blocks analysis despite readable program headers** (blocker, `5ab77f6633c5d40ad448cc64`)
+> functions, decompile-all, strings, and disassemble exited 1 with Invalid ELF section header offset/size/alignment. readelf recovered entry 0x80492d0 and both LOAD segments. Clearing section metadata in a copy allowed parsing but still yielded zero functions and zero code bytes.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 1
+    },
+    "stderr_matches": [
+      "Invalid ELF section header offset/size/alignment"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/0x1d01ebcc.tar.gz.__x/0x1d01ebcc.tar.__x/0x1d01ebcc",
+    "binary_sha256": "821fab4ad881c3ad26f79cbd3c700b0dcc1faf6643449f896cc8f4b40890bd0e",
+    "binary_size": 161156,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "count",
+        "op": "gt",
+        "value": 0
+      }
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/0x1d01ebcc.tar.gz.__x/0x1d01ebcc.tar.__x/0x1d01ebcc",
+    "binary_sha256": "821fab4ad881c3ad26f79cbd3c700b0dcc1faf6643449f896cc8f4b40890bd0e",
+    "binary_size": 161156,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- The loader requires valid section metadata before exploiting program-header mappings; removing the table also leaves code classification empty.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+- `readelf -h -l target/0x1d01ebcc.tar.gz.__x/0x1d01ebcc.tar.__x/0x1d01ebcc` — Warns about section headers but emits the entry point, LOAD segments, interpreter, and DYNAMIC segment; exits 0.
+
+## Instances
+
+- `5ab77f6633c5d40ad448cc64` (round 3, tester t-r3-5ab77f66)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+captain T_TRIAGE r3: track tooling CONFIRMED (kind=missing-capability), touches CORRECTED kuna-cli -> kuna-analysis/src/loader: `kuna functions --json` returning nothing is a loader-tier fallback (use the program headers when the section table is unusable), not a CLI defect. Deliberately NOT filed on the `loader` track -- builder_prompt.md has sections for tooling/quality/perf only, so a `loader` need would reach its builder with no protocol at all.
+captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.
+- round 3 REFUTER: hypothesis **overturned** (was inconclusive). Captain refuted BY MEASUREMENT in-tick on the main tree build (kuna 20:01, cf5234ac-era). The filed cause -- 'the loader requires valid section metadata before exploiting program-header mappings' -- is WRONG in its load-bearing half. Measured: (1) the stock probe fails as filed (exit 1, 'Invalid ELF section header offset/size/alignment'); the header is deliberately corrupt -- e_shoff=57005 (0xDEAD), e_shnum=57007, e_shstrndx=47806 -- while the 9 program headers are intact (entry 0x80492d0, LOAD 0x08048000+0x26c6c R E). (2) With e_shoff/e_shnum/e_shstrndx zeroed in a copy, 'kuna functions --json' exits 0 with count=0 -- the tester's second observation reproduces exactly. (3) But 'kuna decompile <copy> --addr 0x80492d0' DECOMPILES CLEANLY (emits sub_80492d0 calling sub_8048c60), so memory mapping already comes from PT_LOAD and needs no sections at all. The real shape is TWO independent gaps: (a) the loader hard-errors on an unusable section table instead of falling back to the program headers, and (b) function DISCOVERY returns nothing without sections even though EntryDiscoveryPass (passes.rs:90, always-on, sources ELF e_entry) should have the entry seed -- i.e. discovery, not mapping, is what yields zero. CONSEQUENCE FOR THE BUILDER: a fix that only tolerates the corrupt table will exit 0 with count=0 and the acceptance probe (count gt 0) STILL FAILS; it must also seed discovery from e_entry and the executable PT_LOAD ranges. Symptom and severity stand; credibility unchanged.

--- a/docs/re-needs/default-decompilation-fails-despite.md
+++ b/docs/re-needs/default-decompilation-fails-despite.md
@@ -1,0 +1,154 @@
+---
+need_id: default-decompilation-fails-despite
+title: Default decompilation fails despite an explicit function extent
+track: quality
+status: open
+severity: major
+probe_id: p-dfb1e0ead0ec
+acceptance_id: a-61b6770a99df
+hypothesis_status: overturned
+credibility: 0.7
+instances: 1
+challenges: [5ab77f5833c5d40ad448c399]
+rounds: [3]
+first_seen_round: 3
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-analysis/src/analyzers/entry/patterns, decompiler/crates/kuna-decomp/src/p0_knowledge/options.rs]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Recover the complete keyfile reader.
+
+> **Default decompilation fails despite an explicit function extent** (major, `5ab77f5833c5d40ad448c399`)
+> Exited 1 with Could not find op at target address. The target is a NOP before the read loop. Explicit boundaries did not repair it; reliable mode worked.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x80484f2",
+    "--addr",
+    "--define-function",
+    "0x80484f2-0x80485ba=read_key"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 1
+    },
+    "stderr_matches": [
+      "Could not find op at target address"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/collide.tgz.__x/collide.tar.__x/collide/collide",
+    "binary_sha256": "2141200d97193c42c25144374eeeced095d570e6f5e88b30ff9e6d4fa4594c97",
+    "binary_size": 9400,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x80484f2",
+    "--addr",
+    "--define-function",
+    "0x80484f2-0x80485ba=read_key"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stderr_absent": [
+      "Could not find op at target address"
+    ],
+    "stdout_matches": [
+      "read\\("
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/collide.tgz.__x/collide.tar.__x/collide/collide",
+    "binary_sha256": "2141200d97193c42c25144374eeeced095d570e6f5e88b30ff9e6d4fa4594c97",
+    "binary_size": 9400,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- An aggressive-mode flow transformation may mishandle the branch targeting a NOP.
+
+## Refutation
+
+**OVERTURNED -- and the trigger is named** (captain, round 3, cf5234ac).
+
+Filed hypothesis: "an aggressive-mode flow transformation may mishandle the branch targeting a
+NOP". It is aggressive-mode-only, but it is not a flow transformation: it is the analysis-tier
+function-discovery option **`funcstart_patterns`**, which aggressive turns on.
+
+Bisected over aggressive's 31 overrides on `collide`, `read_key`
+(`--define-function 0x80484f2-0x80485ba`):
+
+```
+--mode aggressive                                  -> exit 1, Could not find op at (ram,0x08048541)
+--mode aggressive, all 31 overrides off            -> full C
+--mode aggressive, only funcstart_patterns on      -> exit 1, same address
+--mode reliable / --mode fast                      -> full C, "// warn: Function flows out of bounds"
+```
+
+The mechanism is visible in the inventory: under aggressive `kuna functions` reports
+`sub_8048542`, a byte-pattern "function" planted INSIDE read_key's body, one byte past the
+`NOP` at 0x8048541 that `JNZ 0x8048541` (at 0x804853d) targets. The enclosing body is cut at
+that phantom entry, the NOP's op stops existing, and the branch-target lookup aborts the
+function.
+
+The existing containment guard does not reach it: `--option fdeinterior on` changes nothing
+because this i386 image has NO `.eh_frame` section at all, so the FDE-body test has no
+authority to apply. `overlapbranch on` does not help either. The fix belongs in discovery --
+reject a pattern-discovered entry that falls inside a body the walk already decoded, the
+eh_frame-less analogue of `fdeinterior` -- not at the branch-target lookup, and not in the
+structuring passes the hypothesis pointed at. Same option is the prime suspect for
+[false-function-entry-inside].
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `5ab77f5833c5d40ad448c399` (round 3, tester t-r3-5ab77f58)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+captain T_DEDUP r3: kept separate from explicit-function-boundary-aborts despite the identical error text. Its failing address 0x08048541 lies INSIDE the declared extent 0x80484f2-0x80485ba, so it is not the flow-past-the-end case. Re-verified failing on cf5234ac.
+captain T_REFUTE r3: hypothesis overturned -- see ## Refutation (measured on cf5234ac with the release binary).
+captain T_TRIAGE r3: touches CORRECTED per the T_REFUTE measurement: the trigger is the discovery tier, not structuring. `--mode aggressive --option funcstart_patterns off` gives full C, and funcstart_patterns alone reproduces the abort by inventing sub_8048542 one byte inside read_key. Track stays quality because narrowing a default-ON discovery pattern moves emitted C and function inventories corpus-wide -- that is a DIV-shaped default change (cf. ppc64-localentry-splits-function), not CLI plumbing. See also false-function-entry-inside, the same suspected mechanism on a PE.
+captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.

--- a/docs/re-needs/explicit-function-boundary-aborts.md
+++ b/docs/re-needs/explicit-function-boundary-aborts.md
@@ -1,0 +1,172 @@
+---
+need_id: explicit-function-boundary-aborts
+title: Explicit function boundary aborts on a branch to its exclusive end
+track: quality
+status: open
+severity: blocker
+probe_id: p-75d948cd4495
+acceptance_id: a-2eea743fefa7
+hypothesis_status: upheld
+credibility: 1.0
+instances: 2
+challenges: [69d6affb110488a3205426e2, 6a0b84982b3df128c1df5c0d]
+rounds: [3]
+first_seen_round: 3
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-decomp/src/p2_lift]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Analyze the 205-byte entry prefix with the documented warning for cut control-flow edges.
+
+> **Explicit function boundary aborts on a branch to its exclusive end** (blocker, `69d6affb110488a3205426e2`)
+> Decompilation exits 1 with code:null and Could not find op at target address. The missing target is the declared exclusive end, 0x1400010cd. Kuna disassembly confirms a conditional branch there from 0x140001054.
+
+> **Clipping cold error paths aborts instead of emitting a boundary warning** (minor, `6a0b84982b3df128c1df5c0d`)
+> The supplied end cuts cold error paths after the normal return. Kuna exits 1 with Could not find op at target address instead of producing warning-bearing C.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 120,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x140001000",
+    "--addr",
+    "--define-function",
+    "0x140001000-0x1400010cd=entry_prefix",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 1
+    },
+    "json": [
+      {
+        "path": "functions[0].error",
+        "op": "matches",
+        "value": "Could not find op at target address"
+      }
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/crackme_shroud.exe",
+    "binary_sha256": "72336301c26c106024d5ade1470fd10580bf444b53107b14908dfb12e50f0fe6",
+    "binary_size": 7131136,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 120,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x140001000",
+    "--addr",
+    "--define-function",
+    "0x140001000-0x1400010cd=entry_prefix",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "json": [
+      {
+        "path": "functions[0].code",
+        "op": "matches",
+        "value": "\\S"
+      },
+      {
+        "path": "functions[0].error",
+        "op": "eq",
+        "value": null
+      }
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/crackme_shroud.exe",
+    "binary_sha256": "72336301c26c106024d5ade1470fd10580bf444b53107b14908dfb12e50f0fe6",
+    "binary_size": 7131136,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- A clipped conditional target is still resolved as an internal operation.
+- A later pass may reference an operation removed by the explicit boundary.
+
+## Refutation
+
+**UPHELD, and narrowed by measurement** (captain, round 3, cf5234ac).
+
+Filed hypotheses were "a clipped conditional target is still resolved as an internal
+operation" (upheld) and "a later pass may reference an operation removed by the explicit
+boundary" (overturned: the op is never created, not created-then-removed -- the target is
+outside the declared extent, so it is never decoded, and the branch-target lookup aborts the
+whole function).
+
+Measured on `crackme_shroud.exe`, entry 0x140001000:
+
+| `--define-function` end | result |
+|---|---|
+| `0x1400010cd` (the filed one) | exit 1, "Could not find op at target address: (ram,0x0001400010cd)" |
+| `0x1400010c0` (target 13 bytes past END) | same error, same address |
+| `0x140001060` (target far past END) | same error, same address |
+| `0x1400010ce` (that target now inside) | same error at the NEXT unresolved target, 0x1406a7f3d |
+
+So this is not about a target landing exactly ON the exclusive end: ANY branch target with no
+decoded op aborts, and the failures chain. It is also mode-independent -- `--mode reliable`
+and `--mode fast` both fail identically -- which separates it cleanly from
+[default-decompilation-fails-despite], where reliable and fast both SUCCEED.
+
+WHAT A BUILDER MUST NOT DO. The obvious fix -- "if the branch target has no op, drop the edge
+and warn" -- is right here and WRONG for the sibling need, whose missing target
+(0x8048541) is a real NOP inside its declared extent that a false discovered entry removed. A
+blanket clip at the lookup site would silently truncate a function that decompiles correctly
+today under `--mode reliable`. The clip must be conditioned on the target being outside the
+declared extent. Note that reliable mode already prints the wanted shape of answer on the
+sibling case -- `// warn: Function flows out of bounds` -- so the warning vocabulary exists.
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `69d6affb110488a3205426e2` (round 3, tester t-r3-69d6affb)
+- `6a0b84982b3df128c1df5c0d` (round 3, tester t-r3-6a0b8498)
+
+## Decision log
+
+- filed by cluster.py from 2 observation(s)
+captain T_DEDUP r3: MERGED with obs22 (clipping-cold-error-paths, frz_crackme_rage_v7.exe sha256). Same mechanism on two challenges and two testers: under --define-function START-END, control reaching or passing END makes kuna hard-error `Could not find op at target address` and exit 1 instead of clipping with a warning. Verified still failing on cf5234ac (0x1400010cd == the exclusive end; 0x1400060c5 is 5 bytes past it).
+captain T_DEDUP r3: deliberately NOT merged with default-decompilation-fails-despite. That one prints the same message but for 0x08048541, an address INSIDE its declared extent -- same symptom, different trigger.
+captain T_REFUTE r3: hypothesis upheld -- see ## Refutation (measured on cf5234ac with the release binary).
+captain T_TRIAGE r3: track quality and scope small CONFIRMED; touches narrowed to p2_lift (flow/function-boundary). Upheld and narrowed at T_REFUTE: any branch target with no decoded op aborts, measured at four different --define-function ends and identical under --mode reliable and --mode fast. BUILDER: the obvious repair -- drop the unresolvable edge and warn -- is correct HERE and WRONG for default-decompilation-fails-despite, whose missing target is a real in-extent NOP deleted by a phantom entry; do not write one fix for both.
+captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.

--- a/docs/re-needs/false-function-entry-inside.md
+++ b/docs/re-needs/false-function-entry-inside.md
@@ -1,0 +1,115 @@
+---
+need_id: false-function-entry-inside
+title: False function entry inside an instruction splits the checker inventory
+track: quality
+status: open
+severity: major
+probe_id: p-a508b5cf3d7c
+acceptance_id: a-889458c51ba2
+hypothesis_status: inconclusive
+credibility: 0.7
+instances: 1
+challenges: [6a0b84982b3df128c1df5c0d]
+rounds: [3]
+first_seen_round: 3
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-analysis/src/analyzers/entry/patterns]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Trustworthy function boundaries and complete checker disassembly.
+
+> **False function entry inside an instruction splits the checker inventory** (major, `6a0b84982b3df128c1df5c0d`)
+> Discovered 0x14000310c inside the ten-byte MOV beginning at 0x14000310b. Default checker disassembly consequently stops at 0x140003115 with truncated=false. Decompiling the false entry interprets immediate bytes as instructions. Another internal entry truncates the SHA-256 helper into a tail call.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "\"address\":\\s*5368721676\\b"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/frz_crackme_rage_v7.exe",
+    "binary_sha256": "971dbc9fc68f8c2a3f516f49cc7c13534e6c57143d0160c648e0c1490662fbf2",
+    "binary_size": 279552,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_absent": [
+      "\"address\":\\s*5368721676\\b"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/frz_crackme_rage_v7.exe",
+    "binary_sha256": "971dbc9fc68f8c2a3f516f49cc7c13534e6c57143d0160c648e0c1490662fbf2",
+    "binary_size": 279552,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- Discovery may accept entries without reconciling established instruction ownership.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `6a0b84982b3df128c1df5c0d` (round 3, tester t-r3-6a0b8498)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+captain T_TRIAGE r3: touches CORRECTED kuna-decomp -> the discovery tier. The probe is `kuna functions --json` and the complaint is a fabricated entry inside an instruction, which is what the byte-pattern entry matcher does; T_REFUTE named funcstart_patterns as the prime suspect after measuring exactly that failure on a second binary. Track stays quality for the same reason as default-decompilation-fails-despite (a default-ON discovery pattern moves inventories corpus-wide). NOT merged with that need: different format (PE vs i386 ELF) and the shared cause is suspected, not measured -- but a builder taking one MUST read the other, since both would edit analyzers/entry/patterns and neither holds a lease on it.
+captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.

--- a/docs/re-needs/function-disassembly-decodes-arm.md
+++ b/docs/re-needs/function-disassembly-decodes-arm.md
@@ -1,0 +1,113 @@
+---
+need_id: function-disassembly-decodes-arm
+title: Function disassembly decodes ARM literal-pool data as an instruction
+track: tooling
+status: open
+severity: minor
+probe_id: p-e6b8fbb0a325
+acceptance_id: a-19c4b0c635a6
+hypothesis_status: inconclusive
+credibility: 0.7
+instances: 1
+challenges: [5ab77f5733c5d40ad448c380]
+rounds: [3]
+first_seen_round: 3
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-cli/src/disassemble.rs, decompiler/crates/kuna-analysis/src/listing]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Distinguish main's trailing success constant from executable instructions.
+
+> **Function disassembly decodes ARM literal-pool data as an instruction** (minor, `5ab77f5733c5d40ad448c380`)
+> Lists the pool word 39050000 at 0x8458 as andeq after the return. The load at 0x8440 reads this word; asserting readonly 0x8458+4 makes decompilation return 0x539.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "disassemble",
+    "{{BIN}}",
+    "main",
+    "--json"
+  ],
+  "expect": {
+    "stdout_is_json": true,
+    "stdout_matches": [
+      "\"bytes\": \"39050000\",\\s*\"mnemonic\": \"andeq\""
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/1337_ARM.zip.__x/1337ARM.bin",
+    "binary_sha256": "c8dcf51596afaee2c31b3f87fb9df9e84257c1b3881e90e24a1015fd88e2dd80",
+    "binary_size": 571848,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "disassemble",
+    "{{BIN}}",
+    "main",
+    "--json"
+  ],
+  "expect": {
+    "stdout_is_json": true,
+    "stdout_absent": [
+      "\"bytes\": \"39050000\",\\s*\"mnemonic\": \"andeq\""
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/1337_ARM.zip.__x/1337ARM.bin",
+    "binary_sha256": "c8dcf51596afaee2c31b3f87fb9df9e84257c1b3881e90e24a1015fd88e2dd80",
+    "binary_size": 571848,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+_none offered_
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `5ab77f5733c5d40ad448c380` (round 3, tester t-r3-5ab77f57)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+captain T_TRIAGE r3: track CORRECTED quality -> tooling, touches CORRECTED kuna-decomp -> the disassembly path. Inferred quality from kind=wrong-output, but the probe is `kuna disassemble main --json` and no C is produced; the gap is that the listing walks an ARM literal pool as code. Same data-vs-code question as arm-literal-pool-string on the same binary -- a builder taking either should read both, though the fixes are in different files.
+captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.

--- a/docs/re-needs/get-pc-helper-loses.md
+++ b/docs/re-needs/get-pc-helper-loses.md
@@ -1,0 +1,171 @@
+---
+need_id: get-pc-helper-loses
+title: Get-PC helper loses a live stat-buffer argument
+track: quality
+status: open
+severity: major
+probe_id: p-8980f5aa3c7b
+acceptance_id: a-1d7268631488
+hypothesis_status: upheld
+credibility: 1.0
+instances: 2
+challenges: [5ab77f5833c5d40ad448c399, 68d9ee36224c0ec5dcedc3fc]
+rounds: [3]
+first_seen_round: 3
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-decomp/src/p4_calls]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Preserve the incoming buffer argument across a helper that only writes EBX.
+
+> **Get-PC helper loses a live stat-buffer argument** (major, `5ab77f5833c5d40ad448c399`)
+> The __lxstat call uses an undefined EDX local. Disassembly shows EDX loaded from the buffer parameter before the helper and preserved through it. Explicit prototype and both argument-recovery options did not repair the output.
+
+> **Loader return is incorrectly sourced from the security-cookie check** (major, `68d9ee36224c0ec5dcedc3fc`)
+> Default output loses the return. Asserting a pointer return instead returns an invented security_cookie_check result. Disassembly shows RAX receives RBX before the helper, whose returning path preserves RAX. Also encountered already-filed runtime-decrypted-code-opaque; not refiled.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x8049f20",
+    "--addr",
+    "--assert",
+    "prototype sub_8049f20 int4 sub_8049f20(char *path,void *buf);",
+    "--option",
+    "calleearity",
+    "on",
+    "--option",
+    "varargstackargs",
+    "on"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "__lxstat\\(3,path,v[0-9]+\\)"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/collide.tgz.__x/collide.tar.__x/collide/collide",
+    "binary_sha256": "2141200d97193c42c25144374eeeced095d570e6f5e88b30ff9e6d4fa4594c97",
+    "binary_size": 9400,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x8049f20",
+    "--addr",
+    "--assert",
+    "prototype sub_8049f20 int4 sub_8049f20(char *path,void *buf);",
+    "--option",
+    "calleearity",
+    "on",
+    "--option",
+    "varargstackargs",
+    "on"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_absent": [
+      "__lxstat\\(3,path,v[0-9]+\\)"
+    ],
+    "stdout_matches": [
+      "__lxstat\\(3,path,[^;]*buf"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/collide.tgz.__x/collide.tar.__x/collide/collide",
+    "binary_sha256": "2141200d97193c42c25144374eeeced095d570e6f5e88b30ff9e6d4fa4594c97",
+    "binary_size": 9400,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- Ordinary ABI call-clobber assumptions obscure the helper's actual register effects.
+- An ordinary caller-clobbering ABI model is applied to a register-preserving helper.
+
+## Refutation
+
+**UPHELD on the i386 arm by direct measurement**; the Win64 arm is argued, not measured
+(captain, round 3, cf5234ac).
+
+`collide`, `sub_8049f20`, with the filed prototype assertion:
+
+```
+0x8049f29  MOV EDX,[EBP + 0xc]     ; the `buf` parameter
+0x8049f2c  CALL 0x8049f55          ; the get-PC thunk: MOV EBX,[ESP]; RET  -- writes EBX only
+0x8049f3e  MOV [ESP + 0x8],EDX     ; third argument of __lxstat
+0x8049f42  MOV EDX,[EBP + 0x8]     ; the `path` parameter
+```
+
+kuna emits `__lxstat(3,path,v1)` with `unsigned int v1; // edx`. The controlled comparison is
+inside the one function: `path` is loaded from the frame AFTER the call and is recovered;
+`buf` is loaded from the frame BEFORE it and is lost. The only difference between the two is
+that EDX crosses the CALL, and EDX is in the i386 cdecl killedbycall set -- while the callee
+provably writes EBX and nothing else. So an ABI clobber model applied to a register-preserving
+helper is the mechanism, as filed.
+
+Two things a builder must carry. (1) No option covers this: nothing in the 149-row catalog
+narrows a call's killed set from the callee's actual writes, and there is no get-PC-thunk
+recognizer (the image is stripped, so `__x86.get_pc_thunk.bx` is not a name here). (2) The
+general form -- "trust the decoded callee's register writes over the cspec" -- is only sound
+for a fully decoded, non-recursive, call-free callee; anything looser produces wrong output on
+an unresolved or indirect callee.
+
+ACCEPTANCE STRENGTHENED: the filed acceptance only required `__lxstat(3,path,v<N>)` to
+disappear, which a fabricated or constant third argument also satisfies. It now requires `buf`
+to appear as that argument (tolerant of a cast).
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `5ab77f5833c5d40ad448c399` (round 3, tester t-r3-5ab77f58)
+- `68d9ee36224c0ec5dcedc3fc` (round 3, tester t-r3-68d9ee36)
+
+## Decision log
+
+- filed by cluster.py from 2 observation(s)
+captain T_DEDUP r3: SPLIT out of a 5-observation cluster. Kept with obs14 (Win64 security-cookie helper) because both hypotheses are the same mechanism -- a caller-clobbering ABI model applied to a helper that demonstrably preserves the register (EDX across the i386 get-PC thunk; RAX across the cookie check). Two testers, two challenges, two architectures.
+captain T_REFUTE r3: hypothesis upheld -- see ## Refutation (measured on cf5234ac with the release binary).
+captain T_TRIAGE r3: track quality CONFIRMED and touches narrowed to p4_calls; scope small. Upheld by measurement at T_REFUTE. This one DOES need an option: 'trust the decoded callee's register writes over the cspec killedbycall set' is a judgement call and is only sound for a fully decoded, non-recursive, call-free callee, so it ships gated per docs/agents.md.
+captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -1,21 +1,21 @@
 {
   "schema": "re-needs-index/1",
   "generated_by": "scripts.repipe.needs",
-  "count": 35,
+  "count": 51,
   "rejected_count": 0,
   "by_status": {
-    "closed": 32,
-    "open": 3
+    "closed": 35,
+    "open": 16
   },
   "by_track": {
     "perf": 2,
-    "quality": 21,
-    "tooling": 12
+    "quality": 30,
+    "tooling": 19
   },
   "by_severity": {
-    "blocker": 2,
-    "major": 29,
-    "minor": 4
+    "blocker": 5,
+    "major": 40,
+    "minor": 6
   },
   "by_reject_reason": {},
   "needs": [
@@ -86,6 +86,142 @@
       "path": "docs/re-needs/strings-json-fails-report.md"
     },
     {
+      "need_id": "prototype-assertions-reject-ordinary",
+      "title": "Prototype assertions reject ordinary unsigned int declarations",
+      "track": "tooling",
+      "status": "closed",
+      "severity": "major",
+      "probe_id": "p-b95fa6549eeb",
+      "acceptance_id": "a-e9643c3e9aaa",
+      "hypothesis_status": "upheld",
+      "credibility": 1.0,
+      "instances": 5,
+      "challenges": [
+        "5ab77f5733c5d40ad448c380",
+        "5ab77f5833c5d40ad448c399",
+        "640a526833c5d447bc761899",
+        "68d9ee36224c0ec5dcedc3fc",
+        "6a0b84982b3df128c1df5c0d"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-console/src/grammar",
+        "decompiler/crates/kuna-console/src/ifacedecomp.rs"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": 421,
+      "closed_in_round": 3,
+      "closing_pr": 421,
+      "reject_reason": null,
+      "score": 179.175947,
+      "path": "docs/re-needs/prototype-assertions-reject-ordinary.md"
+    },
+    {
+      "need_id": "explicit-function-boundary-aborts",
+      "title": "Explicit function boundary aborts on a branch to its exclusive end",
+      "track": "quality",
+      "status": "open",
+      "severity": "blocker",
+      "probe_id": "p-75d948cd4495",
+      "acceptance_id": "a-2eea743fefa7",
+      "hypothesis_status": "upheld",
+      "credibility": 1.0,
+      "instances": 2,
+      "challenges": [
+        "69d6affb110488a3205426e2",
+        "6a0b84982b3df128c1df5c0d"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-decomp/src/p2_lift"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 65.916737,
+      "path": "docs/re-needs/explicit-function-boundary-aborts.md"
+    },
+    {
+      "need_id": "get-pc-helper-loses",
+      "title": "Get-PC helper loses a live stat-buffer argument",
+      "track": "quality",
+      "status": "open",
+      "severity": "major",
+      "probe_id": "p-8980f5aa3c7b",
+      "acceptance_id": "a-1d7268631488",
+      "hypothesis_status": "upheld",
+      "credibility": 1.0,
+      "instances": 2,
+      "challenges": [
+        "5ab77f5833c5d40ad448c399",
+        "68d9ee36224c0ec5dcedc3fc"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-decomp/src/p4_calls"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 43.944492,
+      "path": "docs/re-needs/get-pc-helper-loses.md"
+    },
+    {
+      "need_id": "win32-process-enumeration-loses",
+      "title": "Win32 process enumeration loses required call arguments",
+      "track": "quality",
+      "status": "open",
+      "severity": "major",
+      "probe_id": "p-92a90707ef5a",
+      "acceptance_id": "a-e1701a898c8f",
+      "hypothesis_status": "overturned",
+      "credibility": 1.0,
+      "instances": 2,
+      "challenges": [
+        "640a526833c5d447bc761899",
+        "68d9ee36224c0ec5dcedc3fc"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-decomp/src/p4_calls"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 43.944492,
+      "path": "docs/re-needs/win32-process-enumeration-loses.md"
+    },
+    {
       "need_id": "analysis-generated-function-name",
       "title": "Analysis-generated function name cannot be used by decompile",
       "track": "tooling",
@@ -116,6 +252,71 @@
       "reject_reason": null,
       "score": 21.972246,
       "path": "docs/re-needs/analysis-generated-function-name.md"
+    },
+    {
+      "need_id": "checker-exceeds-instruction-ceiling",
+      "title": "Checker exceeds instruction ceiling with no discoverable override",
+      "track": "tooling",
+      "status": "closed",
+      "severity": "blocker",
+      "probe_id": "p-59baa2cff0a9",
+      "acceptance_id": "a-d0071cb49b29",
+      "hypothesis_status": "inconclusive",
+      "credibility": 0.7,
+      "instances": 1,
+      "challenges": [
+        "69d6affb110488a3205426e2"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-cli/src",
+        "decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": 422,
+      "closed_in_round": 3,
+      "closing_pr": 422,
+      "reject_reason": null,
+      "score": 20.794415,
+      "path": "docs/re-needs/checker-exceeds-instruction-ceiling.md"
+    },
+    {
+      "need_id": "corrupt-elf-section-table",
+      "title": "Corrupt ELF section table blocks analysis despite readable program headers",
+      "track": "tooling",
+      "status": "open",
+      "severity": "blocker",
+      "probe_id": "p-b0eecb741356",
+      "acceptance_id": "a-e4f84764b32f",
+      "hypothesis_status": "overturned",
+      "credibility": 0.85,
+      "instances": 1,
+      "challenges": [
+        "5ab77f6633c5d40ad448cc64"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-analysis/src/loader"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 20.794415,
+      "path": "docs/re-needs/corrupt-elf-section-table.md"
     },
     {
       "need_id": "no-cli-function-boundary-override",
@@ -179,6 +380,168 @@
       "reject_reason": null,
       "score": 20.794415,
       "path": "docs/re-needs/overlapping-anti-disassembly-sequence.md"
+    },
+    {
+      "need_id": "accepted-sqrt-prototype-still",
+      "title": "Accepted sqrt prototype still leaves floating arguments absent",
+      "track": "quality",
+      "status": "open",
+      "severity": "major",
+      "probe_id": "p-fd6d3fefafe2",
+      "acceptance_id": "a-bb9896e9cfbb",
+      "hypothesis_status": "overturned",
+      "credibility": 0.7,
+      "instances": 1,
+      "challenges": [
+        "640a526833c5d447bc761899"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-decomp/src/p4_calls"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 13.862944,
+      "path": "docs/re-needs/accepted-sqrt-prototype-still.md"
+    },
+    {
+      "need_id": "arm-literal-pool-string",
+      "title": "ARM literal-pool string use has no owning function",
+      "track": "tooling",
+      "status": "open",
+      "severity": "major",
+      "probe_id": "p-d995eb7a24ba",
+      "acceptance_id": "a-763430881ec8",
+      "hypothesis_status": "inconclusive",
+      "credibility": 0.7,
+      "instances": 1,
+      "challenges": [
+        "5ab77f5733c5d40ad448c380"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-analysis/src/listing/xrefs.rs",
+        "decompiler/crates/kuna-analysis/src/analyzers/strings"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 13.862944,
+      "path": "docs/re-needs/arm-literal-pool-string.md"
+    },
+    {
+      "need_id": "block-processing-panics-out",
+      "title": "Block processing panics with an out-of-bounds index",
+      "track": "quality",
+      "status": "open",
+      "severity": "major",
+      "probe_id": "p-84fba836c289",
+      "acceptance_id": "a-5d5e1d9200d1",
+      "hypothesis_status": "upheld",
+      "credibility": 0.7,
+      "instances": 1,
+      "challenges": [
+        "629a286b33c5d45b75903c7a"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-decomp/src/substrate/block.rs"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 13.862944,
+      "path": "docs/re-needs/block-processing-panics-out.md"
+    },
+    {
+      "need_id": "default-decompilation-fails-despite",
+      "title": "Default decompilation fails despite an explicit function extent",
+      "track": "quality",
+      "status": "open",
+      "severity": "major",
+      "probe_id": "p-dfb1e0ead0ec",
+      "acceptance_id": "a-61b6770a99df",
+      "hypothesis_status": "overturned",
+      "credibility": 0.7,
+      "instances": 1,
+      "challenges": [
+        "5ab77f5833c5d40ad448c399"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-analysis/src/analyzers/entry/patterns",
+        "decompiler/crates/kuna-decomp/src/p0_knowledge/options.rs"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 13.862944,
+      "path": "docs/re-needs/default-decompilation-fails-despite.md"
+    },
+    {
+      "need_id": "false-function-entry-inside",
+      "title": "False function entry inside an instruction splits the checker inventory",
+      "track": "quality",
+      "status": "open",
+      "severity": "major",
+      "probe_id": "p-a508b5cf3d7c",
+      "acceptance_id": "a-889458c51ba2",
+      "hypothesis_status": "inconclusive",
+      "credibility": 0.7,
+      "instances": 1,
+      "challenges": [
+        "6a0b84982b3df128c1df5c0d"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-analysis/src/analyzers/entry/patterns"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 13.862944,
+      "path": "docs/re-needs/false-function-entry-inside.md"
     },
     {
       "need_id": "no-cli-structuring-override",
@@ -246,6 +609,70 @@
       "path": "docs/re-needs/pe-function-inventory-labels.md"
     },
     {
+      "need_id": "ssa-renaming-panics-protected",
+      "title": "SSA renaming panics on a protected function",
+      "track": "quality",
+      "status": "open",
+      "severity": "major",
+      "probe_id": "p-f29a4d139e4a",
+      "acceptance_id": "a-903a7ff59249",
+      "hypothesis_status": "overturned",
+      "credibility": 0.7,
+      "instances": 1,
+      "challenges": [
+        "629a286b33c5d45b75903c7a"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-decomp/src/p3_dataflow/heritage.rs"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 13.862944,
+      "path": "docs/re-needs/ssa-renaming-panics-protected.md"
+    },
+    {
+      "need_id": "string-copy-destination-incorrectly",
+      "title": "String copy destination incorrectly becomes a null pointer",
+      "track": "quality",
+      "status": "open",
+      "severity": "major",
+      "probe_id": "p-18068442ae53",
+      "acceptance_id": "a-f88ffa89ede1",
+      "hypothesis_status": "inconclusive",
+      "credibility": 0.7,
+      "instances": 1,
+      "challenges": [
+        "640a526833c5d447bc761899"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-decomp"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 13.862944,
+      "path": "docs/re-needs/string-copy-destination-incorrectly.md"
+    },
+    {
       "need_id": "strings-inventory-omits-statically",
       "title": "Strings inventory omits statically constructed strings needed by the checker",
       "track": "quality",
@@ -276,6 +703,39 @@
       "reject_reason": null,
       "score": 13.862944,
       "path": "docs/re-needs/strings-inventory-omits-statically.md"
+    },
+    {
+      "need_id": "text-output-silently-ignores",
+      "title": "Text output silently ignores a prototype override that JSON output applies",
+      "track": "tooling",
+      "status": "open",
+      "severity": "major",
+      "probe_id": "p-8cb750f382af",
+      "acceptance_id": "a-5627f7bb77cf",
+      "hypothesis_status": "upheld",
+      "credibility": 0.7,
+      "instances": 1,
+      "challenges": [
+        "6a0b84982b3df128c1df5c0d"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-cli/src/assertdecl.rs",
+        "decompiler/crates/kuna-cli/src/decompile.rs"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 13.862944,
+      "path": "docs/re-needs/text-output-silently-ignores.md"
     },
     {
       "need_id": "wide-api-string-args",
@@ -474,7 +934,7 @@
       "need_id": "large-function-malformed-output",
       "title": "a large checker decompiles into malformed and prohibitively noisy C",
       "track": "quality",
-      "status": "open",
+      "status": "closed",
       "severity": "major",
       "probe_id": "p-8355fed97a86",
       "acceptance_id": "a-2a1f5bccb422",
@@ -497,8 +957,8 @@
       "scope": "large",
       "regression_of": null,
       "pr": 417,
-      "closed_in_round": null,
-      "closing_pr": null,
+      "closed_in_round": 3,
+      "closing_pr": 417,
       "reject_reason": null,
       "score": 9.241962,
       "path": "docs/re-needs/large-function-malformed-output.md"
@@ -757,6 +1217,39 @@
       "path": "docs/re-needs/disassembling-non-executable-rdata.md"
     },
     {
+      "need_id": "function-disassembly-decodes-arm",
+      "title": "Function disassembly decodes ARM literal-pool data as an instruction",
+      "track": "tooling",
+      "status": "open",
+      "severity": "minor",
+      "probe_id": "p-e6b8fbb0a325",
+      "acceptance_id": "a-19c4b0c635a6",
+      "hypothesis_status": "inconclusive",
+      "credibility": 0.7,
+      "instances": 1,
+      "challenges": [
+        "5ab77f5733c5d40ad448c380"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-cli/src/disassemble.rs",
+        "decompiler/crates/kuna-analysis/src/listing"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 6.931472,
+      "path": "docs/re-needs/function-disassembly-decodes-arm.md"
+    },
+    {
       "need_id": "getprocaddress-result-discarded",
       "title": "a GetProcAddress result is discarded and the pointer left uninitialised",
       "track": "quality",
@@ -788,6 +1281,39 @@
       "reject_reason": null,
       "score": 6.931472,
       "path": "docs/re-needs/getprocaddress-result-discarded.md"
+    },
+    {
+      "need_id": "name-based-xrefs-rejects",
+      "title": "Name-based xrefs rejects memcmp although its candidates are aliases",
+      "track": "tooling",
+      "status": "open",
+      "severity": "minor",
+      "probe_id": "p-264f6f6dbdd7",
+      "acceptance_id": "a-6576d0dff8a6",
+      "hypothesis_status": "inconclusive",
+      "credibility": 0.7,
+      "instances": 1,
+      "challenges": [
+        "68d9ee36224c0ec5dcedc3fc"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 0,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-cli/src/xrefs.rs",
+        "decompiler/crates/kuna-analysis/src/listing/xrefs.rs"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": null,
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 6.931472,
+      "path": "docs/re-needs/name-based-xrefs-rejects.md"
     },
     {
       "need_id": "runtime-decrypted-code-opaque",

--- a/docs/re-needs/name-based-xrefs-rejects.md
+++ b/docs/re-needs/name-based-xrefs-rejects.md
@@ -1,0 +1,125 @@
+---
+need_id: name-based-xrefs-rejects
+title: Name-based xrefs rejects memcmp although its candidates are aliases
+track: tooling
+status: open
+severity: minor
+probe_id: p-264f6f6dbdd7
+acceptance_id: a-6576d0dff8a6
+hypothesis_status: inconclusive
+credibility: 0.7
+instances: 1
+challenges: [68d9ee36224c0ec5dcedc3fc]
+rounds: [3]
+first_seen_round: 3
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-cli/src/xrefs.rs, decompiler/crates/kuna-analysis/src/listing/xrefs.rs]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Find references to memcmp by name.
+
+> **Name-based xrefs rejects memcmp although its candidates are aliases** (minor, `68d9ee36224c0ec5dcedc3fc`)
+> Reported ambiguity between 0x140007a1b and 0x140009280. Querying the latter address identifies the former as an alias and returns references to both.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "xrefs",
+    "{{BIN}}",
+    "--to",
+    "memcmp",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 1
+    },
+    "stderr_matches": [
+      "ambiguous",
+      "memcmp"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/crackme.exe",
+    "binary_sha256": "30849bed966c92e64009a23df62210e615a2b3e3342a79372866af53cdffa540",
+    "binary_size": 74752,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "xrefs",
+    "{{BIN}}",
+    "--to",
+    "memcmp",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "count",
+        "op": "gt",
+        "value": 0
+      }
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/crackme.exe",
+    "binary_sha256": "30849bed966c92e64009a23df62210e615a2b3e3342a79372866af53cdffa540",
+    "binary_size": 74752,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- Ambiguity checking precedes import-thunk alias resolution.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `68d9ee36224c0ec5dcedc3fc` (round 3, tester t-r3-68d9ee36)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+captain T_TRIAGE r3: track tooling CONFIRMED (kind=bad-ux, name resolution in `kuna xrefs --to`), touches widened to the analysis-tier xref index the CLI resolves against. No emitted C, so no option.
+captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.

--- a/docs/re-needs/ssa-renaming-panics-protected.md
+++ b/docs/re-needs/ssa-renaming-panics-protected.md
@@ -1,0 +1,126 @@
+---
+need_id: ssa-renaming-panics-protected
+title: SSA renaming panics on a protected function
+track: quality
+status: open
+severity: major
+probe_id: p-f29a4d139e4a
+acceptance_id: a-903a7ff59249
+hypothesis_status: overturned
+credibility: 0.7
+instances: 1
+challenges: [629a286b33c5d45b75903c7a]
+rounds: [3]
+first_seen_round: 3
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-decomp/src/p3_dataflow/heritage.rs]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Inspect the function at 0x40ed14 without an internal dataflow failure.
+
+> **SSA renaming panics on a protected function** (major, `629a286b33c5d45b75903c7a`)
+> Emitted a failed-function placeholder and exited 1 with an empty-stack panic. Reliable mode reproduced it; decompile-all recorded a per-function error.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x40ed14",
+    "--addr"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 1
+    },
+    "stderr_matches": [
+      "rename_recurse: set_input_varnode \\(empty stack\\)"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/thief_crackme.exe",
+    "binary_sha256": "d176b3254177ecf03709513a72a52941a6031002f64e9f3681568f03dd96f0fc",
+    "binary_size": 184320,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x40ed14",
+    "--addr"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_absent": [
+      "decompilation failed"
+    ],
+    "stderr_absent": [
+      "panicked",
+      "un-ported seam"
+    ],
+    "stdout_matches": [
+      ";"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/thief_crackme.exe",
+    "binary_sha256": "d176b3254177ecf03709513a72a52941a6031002f64e9f3681568f03dd96f0fc",
+    "binary_size": 184320,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- The protected instruction stream exposes an unchecked SSA invariant; exact cause unverified.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `629a286b33c5d45b75903c7a` (round 3, tester t-r3-629a286b)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+captain T_DEDUP r3: SPLIT from obs8. Distinct panic site -- p3_dataflow/heritage.rs:3048 `rename_recurse: set_input_varnode (empty stack)` at sub_40ed14. Filed separately as block-processing-panics-out; fixing one will not fix the other.
+captain T_TRIAGE r3: track CORRECTED tooling -> quality, touches CORRECTED kuna-cli -> kuna-decomp. Panic site measured on cf5234ac: p3_dataflow/heritage.rs:3048 'rename_recurse: set_input_varnode (empty stack)' on thief_crackme.exe 0x40ed14. BUILDER: STRICT BUG FIX -- do NOT add a phases.toml option row. Quality track is for the counter lease and the mandatory whole-corpus sweep: heritage rename is on every function's path, so a fix that is right here can be silently wrong everywhere else.
+captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.
+- round 3 REFUTER: hypothesis **overturned** (was inconclusive). measured on 904d8f88 (origin/main 14895370 + the refute CLI; no engine delta) with the release binary. THE FILED CAUSE IS WRONG ON BOTH HALVES. (a) Nothing is unchecked: an empty variable stack is the NORMAL path taken for every function input (heritage.rs:3040), and what fails is the input CREATION that follows it, so the panic text names the trigger and not the failure. kuna_inputtile::new_tiled_input returns None after discarding the real error at kuna_inputtile.rs:44 (Err(_)) -- that error is KunaError::lowlevel('Overlapping input varnodes') raised at funcdata_varnode.rs:1056, i.e. the full-size input request collides with a non-identical input varnode that already exists. (b) There is NO upstream path to port: Ghidra's Funcdata::setInputVarnode (vendored funcdata_varnode.cc) throws the same LowlevelError from the same single step-back, so kuna's port is faithful and the only divergence is that kuna raises it as a panic instead of a per-function error. A builder chasing 'a missing SSA guard' or 'an un-ported seam' will find neither. WHAT THE FIX ACTUALLY IS, AND THE WRONG-OUTPUT TRAP IN IT. kuna already reconciles ONE overlap shape -- DIV-50/#238's kuna_inputtile, for guardInput's leftover WRITE-MASKED pieces -- and this binary hits a shape that module deliberately declines (a live or straddling input). Its own header states why the write-mask restriction is what makes a mid-rename rewrite safe: a write-masked varnode is never on a VariableStack, a live input can be, so relaxing that check to 'combine whatever overlaps' destroys a varnode a live stack still holds and produces silently wrong output rather than a fixed function. That is the obvious fix and it is the wrong one. SCOPE, MEASURED. 6 of 443 functions in thief_crackme.exe, 4 of 415 in the tester's unpacked image, and 0 of 2135 functions across three ordinary binaries (Cube.exe, illusion.exe, /usr/bin/xxd) -- not a common-path defect. 'Protected' is correlation, not cause: all six failures are self-decrypting PUSHFD/POPFD/XCHG stubs, but structurally identical neighbours (sub_42bc8e and sub_42bd44, the same 91-byte stub shape) decompile cleanly, and all four --mode presets panic identically, so no configuration dodges it. NOT MEASURED: which storage overlaps which input. The flags-vs-eflags idiom in these stubs is the suspicion, unconfirmed -- one eprintln at kuna_inputtile.rs:44 would settle it, and making that error text reach the message is worth doing anyway. ACCEPTANCE STRENGTHENED: exit 0 + absent 'decompilation failed' + absent panicked/un-ported seam was absence-shaped and closable by emitting an empty body, so stdout_matches ';' was added; re-verified after the edit -- the acceptance RUNS and FAILS on 904d8f88, which is the state an open need must be in.

--- a/docs/re-needs/string-copy-destination-incorrectly.md
+++ b/docs/re-needs/string-copy-destination-incorrectly.md
@@ -1,0 +1,119 @@
+---
+need_id: string-copy-destination-incorrectly
+title: String copy destination incorrectly becomes a null pointer
+track: quality
+status: open
+severity: major
+probe_id: p-18068442ae53
+acceptance_id: a-f88ffa89ede1
+hypothesis_status: inconclusive
+credibility: 0.7
+instances: 1
+challenges: [640a526833c5d447bc761899]
+rounds: [3]
+first_seen_round: 3
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-decomp]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Determine where the short-string copy writes.
+
+> **String copy destination incorrectly becomes a null pointer** (major, `640a526833c5d447bc761899`)
+> Emitted memmove(0,...,0x10). Disassembly at 0x14000229e shows RCX still holds the incoming destination pointer. Earlier instructions store zero through RCX, not into RCX. Reliable mode and argument-recovery options retain the error.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_140002240"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "memmove\\(\\s*(?:0|NULL)\\s*,"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/KeyCheker.exe",
+    "binary_sha256": "351e54ecaa80f0395111a90e332313c15bd1e19d1e12da87606a045efb5afecf",
+    "binary_size": 25600,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_140002240"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "memmove\\("
+    ],
+    "stdout_absent": [
+      "memmove\\(\\s*(?:0|NULL)\\s*,"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/KeyCheker.exe",
+    "binary_sha256": "351e54ecaa80f0395111a90e332313c15bd1e19d1e12da87606a045efb5afecf",
+    "binary_size": 25600,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- A stored memory value may have been substituted for its destination address.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `640a526833c5d447bc761899` (round 3, tester t-r3-640a5268)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+captain T_DEDUP r3: SPLIT out of the same 5-observation cluster. Not an argument-count or ABI gap: RCX still holds the destination at the call and a value stored THROUGH RCX is emitted in its place, which is a dataflow substitution.
+captain T_TRIAGE r3: track quality and touches kuna-decomp CONFIRMED: the probe is a plain `kuna decompile` of one function and the complaint is the emitted C. Touches left at the crate because the phase is not yet identified -- a null destination in a copy is plausibly p3 dataflow or p5/p6 type-and-variable work, and guessing narrower would mislead the builder. Hypothesis is inconclusive and unrefuted (single instance, credibility 0.7): reproduce before designing.
+captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.

--- a/docs/re-needs/text-output-silently-ignores.md
+++ b/docs/re-needs/text-output-silently-ignores.md
@@ -1,0 +1,132 @@
+---
+need_id: text-output-silently-ignores
+title: Text output silently ignores a prototype override that JSON output applies
+track: tooling
+status: open
+severity: major
+probe_id: p-8cb750f382af
+acceptance_id: a-5627f7bb77cf
+hypothesis_status: upheld
+credibility: 0.7
+instances: 1
+challenges: [6a0b84982b3df128c1df5c0d]
+rounds: [3]
+first_seen_round: 3
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-cli/src/assertdecl.rs, decompiler/crates/kuna-cli/src/decompile.rs]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Assign the hash helper a pointer return and named pointer parameters.
+
+> **Text output silently ignores a prototype override that JSON output applies** (major, `6a0b84982b3df128c1df5c0d`)
+> When the declaration uses a new function name, text output retains the original void return and integer parameters, exiting 0 even with --assert-strict. Adding --json applies the requested types and reports the assertion applied.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_1400055e0",
+    "--assert",
+    "prototype sub_1400055e0 void * sha256(void *out, void *input)",
+    "--assert-strict"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "^void\\s+[^\\s(]+\\("
+    ],
+    "stderr_absent": [
+      "rejected"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/frz_crackme_rage_v7.exe",
+    "binary_sha256": "971dbc9fc68f8c2a3f516f49cc7c13534e6c57143d0160c648e0c1490662fbf2",
+    "binary_size": 279552,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_1400055e0",
+    "--assert",
+    "prototype sub_1400055e0 void * sha256(void *out, void *input)",
+    "--assert-strict"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_absent": [
+      "^void\\s+[^\\s(]+\\("
+    ],
+    "stdout_matches": [
+      "void\\s*\\*"
+    ],
+    "stderr_absent": [
+      "rejected"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/frz_crackme_rage_v7.exe",
+    "binary_sha256": "971dbc9fc68f8c2a3f516f49cc7c13534e6c57143d0160c648e0c1490662fbf2",
+    "binary_size": 279552,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- Text and JSON paths may bind the declaration to different function names.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `6a0b84982b3df128c1df5c0d` (round 3, tester t-r3-6a0b8498)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+captain T_TRIAGE r3: track tooling CONFIRMED and touches narrowed. The defect is a divergence between two CLI output paths -- the same --assert/--assert-strict is applied under --json and dropped in text -- so the engine is producing the right thing and the printer path is losing it. No option, no stages case; a cargo test in kuna-cli plus the promoted probe.
+captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.
+- round 3 REFUTER: hypothesis **upheld** (was inconclusive). Refuted by measurement (captain, B_DRAIN observe tick, release kuna @20:01 on cf5234ac+, probebin/971dbc9fc68f8c2a/frz_crackme_rage_v7.exe). SYMPTOM STANDS AND THE HYPOTHESIS IS RIGHT, BUT THE SEAM IS NAMED WRONG -- it is not two paths disagreeing about a name, it is ONE path throwing the name away. Measured 4 ways: (a) text + decl name 'sha256' -> 'void sub_1400055e0(unsigned int *a0,unsigned long long *a1)', override dropped, exit 0, nothing on stderr even with --assert-strict; (b) --json, same directive -> 'void * sub_1400055e0(void *out,void *input)', applied; (c) TEXT WITH THE SAME NAME IN THE DECL ('prototype sub_1400055e0 void * sub_1400055e0(void *out, void *input)') APPLIES CORRECTLY -- so the discriminator is the decl name, not the output format; (d) --json with <func> naming another or a bogus function ('prototype main ...', 'prototype no_such_fn ...') does NOT touch the selected function, so JSON honours <func>. MECHANISM: assertdecl.rs:343 lowers Body::Prototype { func: _, decl } -- the <func> target is DISCARDED -- to 'parse line extern <decl>;', which binds the prototype to a symbol named by the DECLARATION. Same name => it lands on the selected function; a renaming decl => it lands on a fresh unrelated symbol and the selected function is untouched. The JSON surface is a SECOND IMPLEMENTATION, not a second dialect as decompile.rs:14 claims: --json routes through run_json -> in-process decompile_all (decompile.rs:1152/1241), while text drives decomp_dbg as a subprocess over the console script. FIX DIRECTION: make the text lowering honour <func> (bind the parsed prototype to the target function, renaming it when the decl name differs). Making JSON match text would be the wrong direction. SECOND DEFECT FOUND, DO NOT TREAT --assert-strict AS A GUARD HERE: the outcome is recovered from the console transcript (assertion_outcomes), so a directive that changed nothing still reports status 'applied' -- including 'prototype no_such_fn ...' under --json. The acceptance probe's stderr_absent 'rejected' clause therefore proves nothing on its own; the load-bearing clauses are stdout_absent/stdout_matches.
+captain B_DRAIN r3: touches CORRECTED after the refutation -- the seam is assertdecl.rs:343 (the prototype lowering that discards <func>), not output.rs, which the refuter measured is not involved. assertdecl.rs is also being edited RIGHT NOW by b-r3-prototype-assert (feat/re-prototype-assertions-reject-ordinary, --assert scalar types); this need must not be dispatched until that lands, and select.py's file-lease disjointness now sees the overlap.

--- a/docs/re-needs/win32-process-enumeration-loses.md
+++ b/docs/re-needs/win32-process-enumeration-loses.md
@@ -1,0 +1,178 @@
+---
+need_id: win32-process-enumeration-loses
+title: Win32 process enumeration loses required call arguments
+track: quality
+status: open
+severity: major
+probe_id: p-92a90707ef5a
+acceptance_id: a-e1701a898c8f
+hypothesis_status: overturned
+credibility: 1.0
+instances: 2
+challenges: [640a526833c5d447bc761899, 68d9ee36224c0ec5dcedc3fc]
+rounds: [3]
+first_seen_round: 3
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-decomp/src/p4_calls]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Follow the snapshot handle and entry buffer through the anti-debug loop.
+
+> **Win32 process enumeration loses required call arguments** (major, `640a526833c5d447bc761899`)
+> Emitted CreateToolhelp32Snapshot(2), CloseHandle(), and Process32NextW(). Both argument-recovery options retained the omissions. Kuna disassembly shows the missing arguments explicitly prepared in RCX/RDX. Main additionally invents an argument to GetCurrentProcess.
+
+> **VirtualAlloc loses its fourth register argument** (major, `68d9ee36224c0ec5dcedc3fc`)
+> Emitted VirtualAlloc(0,0x36,0x3000), omitting 0x40 passed in R9D. Enabling calleearity and varargstackargs did not restore it. A prototype assertion did.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_1400015c0",
+    "--option",
+    "calleearity",
+    "on",
+    "--option",
+    "varargstackargs",
+    "on"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "Process32NextW\\(\\s*\\)",
+      "CloseHandle\\(\\s*\\)"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/KeyCheker.exe",
+    "binary_sha256": "351e54ecaa80f0395111a90e332313c15bd1e19d1e12da87606a045efb5afecf",
+    "binary_size": 25600,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_1400015c0",
+    "--option",
+    "calleearity",
+    "on",
+    "--option",
+    "varargstackargs",
+    "on"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "Process32NextW\\([^),]+,[^)]+\\)",
+      "CloseHandle\\([^)]+\\)"
+    ],
+    "stdout_absent": [
+      "Process32NextW\\(\\s*\\)",
+      "CloseHandle\\(\\s*\\)"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/KeyCheker.exe",
+    "binary_sha256": "351e54ecaa80f0395111a90e332313c15bd1e19d1e12da87606a045efb5afecf",
+    "binary_size": 25600,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- Missing imported Win32 prototypes leave recovery dependent on local argument scoring.
+- Missing WinAPI prototype knowledge combined with register argument recovery.
+
+## Refutation
+
+**OVERTURNED** -- symptom stands, filed mechanism does not (captain, round 3, cf5234ac).
+
+Filed hypothesis: "missing imported Win32 prototypes leave recovery dependent on local
+argument scoring". Measured on `KeyCheker.exe`, `sub_1400015c0`, one run, no assertions:
+
+```
+v1 = Process32FirstW(CreateToolhelp32Snapshot(2),v3);   <- 2 args recovered
+    CloseHandle();                                      <- 0 args
+v1 = Process32NextW();                                  <- 0 args
+```
+
+Three imported kernel32 calls, one run, no prototype knowledge for any of them, and one of
+them recovers both arguments. Import prototypes are therefore NOT the gate. The disassembly
+says what is: the argument register is defined in a PREDECESSOR block.
+
+```
+0x140001600  CALL [0x140005018]   ; Process32FirstW -- RCX set 6 bytes earlier, same block  -> recovered
+0x14000161e  MOV  RCX,RDI         ; hoisted above the JNZ
+0x140001624  JNZ  0x140001656
+0x14000162b  CALL [0x140005010]   ; Process32NextW  -- RCX from the predecessor block       -> dropped
+0x14000165a  CALL [0x140005020]   ; CloseHandle     -- RCX from the same predecessor block   -> dropped
+```
+
+Note the second arg of Process32NextW (`LEA RDX,[RSP+0x20]` at 0x140001626) is set in the
+call's OWN block and is dropped too, so once the first slot's trial dies the whole list dies.
+
+The values are present in the dataflow the whole time: with
+`--assert 'prototype CloseHandle int4 CloseHandle(void *h);'` and the matching
+Process32NextW assertion, the same run emits `CloseHandle(h)` and `Process32NextW(h,v3)`
+with h the CreateToolhelp32Snapshot result. So this is input-trial scoring at a call whose
+argument register is defined in a dominating predecessor, in kuna-decomp p4_calls -- not
+missing knowledge, and NOT a Win32 prototype database. A builder who ships kernel32
+prototypes would make this need's acceptance pass while leaving the general defect (which is
+not Windows-specific) untouched.
+
+ACCEPTANCE STRENGTHENED for exactly that reason: it previously asserted only the ABSENCE of
+`Process32NextW()`/`CloseHandle()`, which a prototype table -- or a fabricated argument --
+satisfies. It now also requires two non-empty arguments at Process32NextW and one at
+CloseHandle.
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `640a526833c5d447bc761899` (round 3, tester t-r3-640a5268)
+- `68d9ee36224c0ec5dcedc3fc` (round 3, tester t-r3-68d9ee36)
+
+## Decision log
+
+- filed by cluster.py from 2 observation(s)
+captain T_DEDUP r3: SPLIT out of the same 5-observation cluster (obs10 + obs13). Both name missing imported Win32 prototypes, and obs13 records that an explicit prototype assertion DID restore the argument -- so the gap is import prototype knowledge, not the argument-recovery machinery. Related but NOT identical to the closed need argument-recovery-knobs-still; check that need's acceptance at the next acceptance-suite run.
+captain T_REFUTE r3: hypothesis overturned -- see ## Refutation (measured on cf5234ac with the release binary).
+captain T_TRIAGE r3: touches CORRECTED per the T_REFUTE overturn: this is p4_calls input-trial scoring, NOT missing Win32 knowledge. Refuted inside one run -- Process32FirstW recovers both arguments with no prototype while CloseHandle and Process32NextW recover none, and the difference is that Process32FirstW's RCX arrives from a MOV in a PREDECESSOR block. BUILDER: a kernel32 prototype table would satisfy the old acceptance while leaving the defect intact, which is why the acceptance was strengthened (a-e1701a898c8f) to require two non-empty arguments at Process32NextW and one at CloseHandle.
+captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.


### PR DESCRIPTION
I destroyed these and am putting them back. Round 3's gate admitted 23 observations
which clustered into 16 needs; only 2 reached main. The other 14 are here.

WHAT I DID. Preparing an unrelated change I ran `git add docs/re-needs/` while the
loop had 17 round-3 records written but not yet committed. That staged them onto my
branch, making them tracked THERE and not on main. Switching back to main then
deleted them from the working tree -- correct git behaviour, and silent. The deletion
happened on a later, unrelated command, which is why nothing looked wrong at the time.
I noticed only when the round-3 need count read 2 instead of 16.

Recovered whole from the orphaned commit 8b3e8dc3; all 51 records pass
`needs.validate()` and the index reindexes to 51 (35 closed, 16 open).

WHY IT MATTERED. `_recently_shipped` and the backlog are both built from these
records, so round 4's tester brief would have omitted a round of findings and its
builders would have had 14 fewer needs to work -- including two crashes
(`ssa-renaming-panics-protected`, `block-processing-panics-out`), the corrupt-ELF
loader gap, and the `--define-function` boundary defect.

WHAT NOT TO REPEAT. `docs/re-needs/` and `docs/re-pipeline.md` are shared journals
that the loop and an operator both append to; this is the third collision there this
session and the first destructive one. Never `git add <dir>` in them -- name files.
And after any branch switch in a repo where another agent is working, verify its
UNTRACKED files are still present: committing someone's untracked work is invisible
at the time and removes it later.

This commit stages the 14 restored records and the reindexed index.json, and
deliberately leaves the three records the loop is editing right now
(checker-exceeds-instruction-ceiling, large-function-malformed-output,
prototype-assertions-reject-ordinary) uncommitted, for it to land itself.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcFmfZndNjgfqLQVBZCdkY