### PR TITLE
[AUTOMATED] docs(re-needs): persist the three round-3 closes

### DIFF
--- a/docs/re-needs/checker-exceeds-instruction-ceiling.md
+++ b/docs/re-needs/checker-exceeds-instruction-ceiling.md
@@ -2,7 +2,7 @@
 need_id: checker-exceeds-instruction-ceiling
 title: Checker exceeds instruction ceiling with no discoverable override
 track: tooling
-status: open
+status: closed
 severity: blocker
 probe_id: p-59baa2cff0a9
 acceptance_id: a-d0071cb49b29
@@ -17,9 +17,9 @@ covered_by_option: null
 touches: [decompiler/crates/kuna-cli/src, decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs]
 scope: small
 regression_of: null
-pr: null
-closed_in_round: null
-closing_pr: null
+pr: 422
+closed_in_round: 3
+closing_pr: 422
 reject_reason: null
 ---
 
@@ -128,3 +128,5 @@ _none recorded_
 - filed by cluster.py from 1 observation(s)
 captain T_TRIAGE r3: track tooling CONFIRMED, touches CORRECTED to name the ceiling's real home. Verified on cf5234ac: none of the 149 catalog options is the instruction ceiling (no match for instr/max/ceil/budget), so `--option` genuinely cannot reach it; the value is Architecture::max_instructions, set at infra/decompile_drive.rs:580 from the console-only `maxinstruction`. The need is reachability, so this is CLI plumbing of an existing knob -- no new option, no stages case.
 captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.
+- closed: acceptance a-d0071cb49b29 now PASSES at 80e965ca649d
+captain B_DONE r3 (re-applied): closed by #422 (80e965ca); the first application of this bookkeeping was lost when the main tree was checked out to branch docs/restore-round3-records and back, so it was redone from rounds/3/acceptance-suite.json (sha 80e965ca, the current HEAD).

--- a/docs/re-needs/large-function-malformed-output.md
+++ b/docs/re-needs/large-function-malformed-output.md
@@ -2,7 +2,7 @@
 need_id: large-function-malformed-output
 title: a large checker decompiles into malformed and prohibitively noisy C
 track: quality
-status: open
+status: closed
 severity: major
 probe_id: p-8355fed97a86
 acceptance_id: a-2a1f5bccb422
@@ -18,8 +18,8 @@ touches: [decompiler/crates/kuna-decomp/src/p2_lift]
 scope: large
 regression_of: null
 pr: 417
-closed_in_round: null
-closing_pr: null
+closed_in_round: 3
+closing_pr: 417
 reject_reason: null
 ---
 
@@ -225,3 +225,5 @@ _none recorded_
   carries BOTH clauses verbatim against a vendored 1,536-byte synthesized PE32+
   (`decompiler/crates/kuna-analysis/tests/fixtures/fastfail_x86_64.exe`) that reproduces the same
   shape in both directions. Increments B1/B2/C remain open in `proposal.md`.
+- closed: acceptance a-2a1f5bccb422 now PASSES at 80e965ca649d
+captain B_DONE r3 (re-applied): closed by #417 (bae88a02); the first application of this bookkeeping was lost when the main tree was checked out to branch docs/restore-round3-records and back, so it was redone from rounds/3/acceptance-suite.json (sha 80e965ca, the current HEAD).

--- a/docs/re-needs/prototype-assertions-reject-ordinary.md
+++ b/docs/re-needs/prototype-assertions-reject-ordinary.md
@@ -2,7 +2,7 @@
 need_id: prototype-assertions-reject-ordinary
 title: Prototype assertions reject ordinary unsigned int declarations
 track: tooling
-status: open
+status: closed
 severity: major
 probe_id: p-b95fa6549eeb
 acceptance_id: a-e9643c3e9aaa
@@ -17,9 +17,9 @@ covered_by_option: null
 touches: [decompiler/crates/kuna-console/src/grammar, decompiler/crates/kuna-console/src/ifacedecomp.rs]
 scope: small
 regression_of: null
-pr: null
-closed_in_round: null
-closing_pr: null
+pr: 421
+closed_in_round: 3
+closing_pr: 421
 reject_reason: null
 ---
 
@@ -225,3 +225,5 @@ captain T_REFUTE r3: hypothesis upheld -- see ## Refutation (measured on cf5234a
 captain T_TRIAGE r3: track tooling CONFIRMED; touches CORRECTED kuna-cli -> kuna-console/src/grammar, which is where parse_C runs and where run_parse_c raises the 'Bad C syntax' the probe matches (ifacedecomp.rs:705). Upheld at T_REFUTE: int / unsigned int / double are rejected in BOTH return and parameter position while int4 / void / char * are accepted -- the grammar lacks the standard scalar keywords. Highest corroboration in the round: 5 instances across 5 challenges, credibility 1.0. NOTE FOR THE BUILDER: PR #415 asserts this is already handled and is wrong on that claim; re-measure before believing it.
 captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.
 builder b-r3-prototype-assert r3: acceptance RETARGETED (a-35ab0d1e49fc -> a-e9643c3e9aaa) from the dataset PE onto the in-repo fixture `decompiler/crates/kuna-analysis/tests/fixtures/fauxware`, because `verify --promote` refuses a dataset target (CI has no dataset) and the need's regression guard is worth more than the original binary. Strengthened while moving: three directives instead of one (`unsigned int` in return position, `long long`/`int`/`unsigned long` in a callee prototype, `unsigned char[8]` as a `type` base), all three asserted `applied`, plus two positive clauses on the emitted C and `stderr_absent` on both "Syntax error" and "Bad C syntax". Measured rejected 3/3 on the unpatched cf5234ac binary; the ORIGINAL dataset acceptance was also measured PASS on the fixed tree before the retarget.
+- closed: acceptance a-e9643c3e9aaa now PASSES at 80e965ca649d
+captain B_DONE r3 (re-applied): closed by #421 (dff8be44); the first application of this bookkeeping was lost when the main tree was checked out to branch docs/restore-round3-records and back, so it was redone from rounds/3/acceptance-suite.json (sha 80e965ca, the current HEAD).


### PR DESCRIPTION
## The problem

Three needs shipped in round 3 and their acceptance probes now pass, but the record on disk still says they are open:

```
$ grep -H '^status:' docs/re-needs/{checker-exceeds-instruction-ceiling,large-function-malformed-output,prototype-assertions-reject-ordinary}.md
docs/re-needs/checker-exceeds-instruction-ceiling.md:status: open
docs/re-needs/large-function-malformed-output.md:status: open
docs/re-needs/prototype-assertions-reject-ordinary.md:status: open
```

while the round's own acceptance run disagrees:

```
$ python3 -c "import json;d=json.load(open('.kuna-repipe/rounds/3/acceptance-suite.json'));print(d['sha'],d['counts'],d['closed'])"
80e965ca649d... {'total': 37, 'pass': 27, 'fail': 2, 'closed': 3, 'regressed': 0, 'indeterminate': 8}
['checker-exceeds-instruction-ceiling', 'large-function-malformed-output', 'prototype-assertions-reject-ordinary']
```

An open need is dispatchable, so the backlog offers three already-closed gaps as work.

## The fix

- Set `status: closed`, `closed_in_round: 3` and `closing_pr` (#417, #421, #422) on the three records, and append the acceptance line naming the sha the probe passed at.
- Every field is copied from `rounds/3/acceptance-suite.json`; nothing is re-derived, and no probe is re-run or relaxed.
- The same edit was applied once before directly in the main working tree and never committed, so it was lost when that tree moved between branches. Committing it is what makes it stick.

## The tests

Records only -- no code, no gate input. `docs/re-needs/` feeds no gate; the acceptance probes themselves are unchanged.