### PR TITLE
[AUTOMATED] fix(cli): function-disassembly-decodes-arm — list a literal-pool word as the constant it holds

### DIFF
--- a/decompiler/crates/kuna-cli/src/disassemble.rs
+++ b/decompiler/crates/kuna-cli/src/disassemble.rs
@@ -66,12 +66,13 @@
 //! about the decode changes: the same walk, the same bytes, a different view of
 //! them.
 
-use kuna_console::engine::ConsoleProgram;
+use kuna_console::engine::{ConsoleProgram, FixedRefs};
 use kuna_sleigh::loadimage::section_flags;
 
 use crate::decompile::looks_like_addr;
 use crate::decompile_all::{load_program, mode_options_for_binary, Args, DriverDefaults};
 use crate::jsonfmt::{dumps_indent2, Json};
+use crate::litpool;
 
 /// How much to list from an address that lies inside no known function extent:
 /// an unmapped-by-the-inventory blob, a decrypted payload dumped to a file, a
@@ -302,10 +303,13 @@ pub(crate) fn render(args: &DisArgs) -> Result<Listing, String> {
             region.start, args.binary
         ));
     }
-    let (view, notes) = choose_view(&prog, &region, args.view.unwrap_or(ViewRequest::Auto));
+    let (view, mut notes) = choose_view(&prog, &region, args.view.unwrap_or(ViewRequest::Auto));
     let text = match view {
         View::Code => {
-            let (rows, truncated) = walk(&prog, &region, args.count);
+            let (rows, truncated, folded) = walk(&prog, &region, args.count);
+            if folded > 0 {
+                notes.push(pool_note(folded));
+            }
             if args.json {
                 format!("{}\n", dumps_indent2(&result_json(args, &region, &rows, truncated, &notes)))
             } else {
@@ -394,9 +398,38 @@ fn decide_view(want: ViewRequest, from_entry: bool, section: Option<u32>) -> Vie
 /// An address the translator rejects is listed as a single `.byte` row rather
 /// than ending the listing, because the common reason for one is a listing that
 /// ran into inline data and there is usually code again after it.
-fn walk(prog: &ConsoleProgram, region: &Region, count: Option<usize>) -> (Vec<Row>, bool) {
+///
+/// A word the listing's OWN instructions read at a fixed address is then folded
+/// back into a data row rather than left decoded as the instruction its bytes
+/// happen to spell — the literal pool an ARM/MIPS/PPC function carries inside
+/// its own extent. What is folded, and what refuses a fold, is
+/// [`crate::litpool`]; the fold never moves a row, so the listing's addresses
+/// are the same either way.
+///
+/// Returns the rows, whether the walk was truncated, and how many words were
+/// folded — which the caller says out loud, because "this is not an
+/// instruction" is exactly the fact an agent reading a listing needs and cannot
+/// infer from the row.
+fn walk(
+    prog: &ConsoleProgram,
+    region: &Region,
+    count: Option<usize>,
+) -> (Vec<Row>, bool, usize) {
+    let (rows, truncated, refs) = decode_rows(prog, region, count);
+    let (rows, folded) = fold_pool_words(prog, region, rows, &refs);
+    (rows, truncated, folded)
+}
+
+/// The straight-line decode itself: rows in address order, whether the walk was
+/// truncated, and the fixed-address evidence the rows carry.
+fn decode_rows(
+    prog: &ConsoleProgram,
+    region: &Region,
+    count: Option<usize>,
+) -> (Vec<Row>, bool, FixedRefs) {
     let cap = if region.derived { Some(DERIVED_INSTRUCTION_CAP) } else { None };
     let mut rows: Vec<Row> = Vec::new();
+    let mut evidence = FixedRefs::default();
     let mut truncated = false;
     let mut addr = region.start;
     let (mut mnem, mut body, mut raw) = (String::new(), String::new(), Vec::new());
@@ -417,6 +450,7 @@ fn walk(prog: &ConsoleProgram, region: &Region, count: Option<usize>) -> (Vec<Ro
         // never claim a length it cannot show the bytes for.
         match decoded {
             Some(len) if prog.read_bytes_into(addr, len as usize, &mut raw) => {
+                prog.add_fixed_refs_at(addr, &mut evidence);
                 rows.push(Row {
                     addr,
                     size: len as u64,
@@ -441,7 +475,76 @@ fn walk(prog: &ConsoleProgram, region: &Region, count: Option<usize>) -> (Vec<Ro
             }
         }
     }
-    (rows, truncated)
+    (rows, truncated, evidence)
+}
+
+/// Replace each proved literal-pool word with one data row.
+///
+/// The rows a word covers are folded into a single `.word 0x...` row over the
+/// same bytes, so the listing's addresses are untouched — [`crate::litpool`]
+/// only proves a word whose width tiles whole decoded rows, which is what makes
+/// that true.
+fn fold_pool_words(
+    prog: &ConsoleProgram,
+    region: &Region,
+    rows: Vec<Row>,
+    evidence: &FixedRefs,
+) -> (Vec<Row>, usize) {
+    let Some(&Row { addr: first, .. }) = rows.first() else {
+        return (rows, 0);
+    };
+    let last = rows.last().map_or(first, |r| r.addr + r.size);
+    // A word only qualifies where the program says data can live and does not
+    // say code does: a mapped non-writable section (a GOT slot is read by
+    // address too, and a writable `.text` is a packer), and no function symbol
+    // installed at that very address. The extent clip already keeps a *named*
+    // target's listing off the next function, but an explicit multi-function
+    // range walks straight through entries and must not eat one.
+    let sections = prog.sections();
+    let is_pool_slot = |vma: u64| {
+        sections
+            .iter()
+            .find(|(start, size, _)| vma >= *start && vma - start < *size)
+            .is_some_and(|(_, _, flags)| flags & section_flags::READONLY != 0)
+            && prog.function_named_at(vma).is_none()
+    };
+    let boundaries: Vec<litpool::Boundary> = rows.iter().map(|r| (r.addr, r.size)).collect();
+    let pool = litpool::pool_words(
+        &boundaries,
+        &evidence.reads,
+        &evidence.flow_targets,
+        (region.start.max(first), last),
+        &is_pool_slot,
+    );
+    if pool.is_empty() {
+        return (rows, 0);
+    }
+    let big_endian = prog.arch().translate().is_big_endian();
+    let mut out: Vec<Row> = Vec::with_capacity(rows.len());
+    let mut folded = 0;
+    let mut it = rows.into_iter();
+    while let Some(row) = it.next() {
+        let Some(&width) = pool.get(&row.addr) else {
+            out.push(row);
+            continue;
+        };
+        let (addr, mut bytes) = (row.addr, row.bytes);
+        while (bytes.len() as u64) < width {
+            match it.next() {
+                Some(next) => bytes.extend_from_slice(&next.bytes),
+                None => break,
+            }
+        }
+        out.push(Row {
+            addr,
+            size: bytes.len() as u64,
+            mnemonic: litpool::word_mnemonic(width).to_string(),
+            operands: litpool::word_operand(&bytes, big_endian),
+            bytes,
+        });
+        folded += 1;
+    }
+    (out, folded)
 }
 
 /// Read the region's bytes forward from `region.start` into hexdump rows, until
@@ -806,7 +909,7 @@ pub(crate) fn function_listing(prog: &ConsoleProgram, start: u64, end: u64) -> O
     }
     let region =
         Region { start, end: Some(end), name: None, derived: false, from_entry: true };
-    let (rows, _) = walk(prog, &region, None);
+    let (rows, _, _) = walk(prog, &region, None);
     if rows.is_empty() {
         return None;
     }
@@ -815,6 +918,25 @@ pub(crate) fn function_listing(prog: &ConsoleProgram, start: u64, end: u64) -> O
         let _ = writeln!(out, "{:08x}  {}", r.addr, r.text());
     }
     Some(out.trim_end().to_string())
+}
+
+/// Why a row in this listing is a data word and not the instruction its bytes
+/// spell — the one fact an agent reading a `.word` row cannot infer, and the
+/// move that decodes it anyway.
+fn pool_note(folded: usize) -> String {
+    let tail = "-- disassemble such an address on its own to decode it anyway";
+    if folded == 1 {
+        format!(
+            "one word in this range is read as a constant by the range's own instructions \
+             (a literal pool), so it is listed as data rather than decoded {tail}"
+        )
+    } else {
+        format!(
+            "{folded} words in this range are read as constants by the range's own \
+             instructions (a literal pool), so they are listed as data rather than decoded \
+             {tail}"
+        )
+    }
 }
 
 /// What to call the start address in a header: its name and address when the

--- a/decompiler/crates/kuna-cli/src/litpool.rs
+++ b/decompiler/crates/kuna-cli/src/litpool.rs
@@ -1,0 +1,234 @@
+//! Which words inside a code listing are a **literal pool**, not instructions.
+//!
+//! On a fixed-width RISC target a constant that will not fit an immediate is
+//! parked in `.text` next to the code that uses it and loaded PC-relatively.
+//! `main` in the `1337ARM` crackme ends
+//!
+//! ```text
+//!   0x8440  10309fe5  ldr r3,[0x8458]
+//!   ...
+//!   0x8454  10a89de8  ldmia sp,{r4,r11,sp,pc}
+//!   0x8458  39050000  andeq r0,r0,r9, lsr r5
+//! ```
+//!
+//! — and that last row is a lie. `0x8458` is the constant `0x539` (1337), the
+//! answer the program compares against; nothing executes it, and an RE agent
+//! reading the listing for the success value is handed a bitwise-and instead.
+//! Every disassembler an agent would otherwise fall back to renders it as a
+//! data word.
+//!
+//! ## The evidence is inside the listing
+//!
+//! A pool word is not guessed at here, it is **proved by the range's own
+//! instructions**: some instruction in the listed range spells the address out
+//! and reads it ([`ConsoleProgram::fixed_refs_at`](kuna_console::engine::ConsoleProgram::fixed_refs_at)),
+//! and no instruction in the range names it as a branch target. That makes the
+//! rule self-limiting in a way a caller can predict and steer: listing
+//! `0x8458-0x845c` on its own contains no such load, so the word decodes as it
+//! always did, and a caller who wants the raw decode of a pool word has that as
+//! the escape hatch.
+//!
+//! ## What it refuses
+//!
+//! Each refusal is a way this could otherwise fabricate data where there is
+//! code:
+//!
+//! * a target in a **writable** section — a GOT slot is read by address too, and
+//!   a writable `.text` is a packer, whose "pool word" is very likely code — or
+//!   one with a function symbol installed on it, which is code by declaration;
+//! * an **unaligned** target, or a width that is not 1/2/4/8 — a real pool word
+//!   is a naturally-aligned scalar. The width is the width of the ACCESS, which
+//!   a `LOAD`'s address varnode does not carry (it is pointer-sized whatever it
+//!   reads), so `ldrh r0,[0x1003c]` folds nothing: two bytes do not tile the
+//!   four-byte row the slot decoded as;
+//! * a target that any instruction in the range **branches to**, which is a
+//!   label whatever else reads it;
+//! * a target that does not fall on a decoded instruction boundary, or whose
+//!   width does not tile a whole number of decoded rows. Folding only on an
+//!   exact tiling is what keeps the rest of the listing byte-for-byte where it
+//!   was: no address after a folded word can shift, so a false positive costs
+//!   one mis-rendered row and never a re-aligned listing.
+//! * the range's own **first** address, which is what the caller asked to see
+//!   instructions at.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+/// A decoded row's extent, in listing order: `(address, size)`.
+pub(crate) type Boundary = (u64, u64);
+
+/// The widths a literal pool word is spelled in.
+fn width_is_scalar(width: u32) -> bool {
+    matches!(width, 1 | 2 | 4 | 8)
+}
+
+/// The pool words a listing's own evidence proves, as `address -> width`.
+///
+/// `rows` are the decoded extents in address order, `reads` every
+/// `(address, width)` the range's instructions read at a fixed address,
+/// `flow_targets` every address they branch or call to, `span` the listed
+/// `[lo, hi)`, and `is_pool_slot` whether the program allows a pool word to live
+/// at an address at all.
+pub(crate) fn pool_words(
+    rows: &[Boundary],
+    reads: &[(u64, u32)],
+    flow_targets: &[u64],
+    span: (u64, u64),
+    is_pool_slot: &dyn Fn(u64) -> bool,
+) -> BTreeMap<u64, u64> {
+    let labels: BTreeSet<u64> = flow_targets.iter().copied().collect();
+    let starts: BTreeMap<u64, usize> =
+        rows.iter().enumerate().map(|(i, (addr, _))| (*addr, i)).collect();
+    let mut out = BTreeMap::new();
+    for &(addr, width) in reads {
+        if !width_is_scalar(width) {
+            continue;
+        }
+        let width = u64::from(width);
+        if addr % width != 0 {
+            continue;
+        }
+        if addr <= span.0 || addr.saturating_add(width) > span.1 {
+            continue;
+        }
+        if labels.contains(&addr) || !is_pool_slot(addr) {
+            continue;
+        }
+        if !tiles_whole_rows(rows, &starts, &labels, addr, width) {
+            continue;
+        }
+        out.insert(addr, width);
+    }
+    out
+}
+
+/// Do the decoded rows starting at `addr` cover exactly `width` bytes, with no
+/// branch target among the rows after the first?
+fn tiles_whole_rows(
+    rows: &[Boundary],
+    starts: &BTreeMap<u64, usize>,
+    labels: &BTreeSet<u64>,
+    addr: u64,
+    width: u64,
+) -> bool {
+    let Some(&first) = starts.get(&addr) else {
+        return false;
+    };
+    let mut covered = 0u64;
+    for (i, &(at, size)) in rows.iter().enumerate().skip(first) {
+        if i > first && labels.contains(&at) {
+            return false;
+        }
+        covered += size;
+        if covered >= width {
+            break;
+        }
+    }
+    covered == width
+}
+
+/// The GAS directive a `width`-byte data word is spelled with.
+pub(crate) fn word_mnemonic(width: u64) -> &'static str {
+    match width {
+        1 => ".byte",
+        2 => ".short",
+        8 => ".quad",
+        _ => ".word",
+    }
+}
+
+/// The value `bytes` holds, zero-padded to its own width — the spelling a pool
+/// word is read for (`0x00000539`, not `0x539`).
+pub(crate) fn word_operand(bytes: &[u8], big_endian: bool) -> String {
+    let mut value: u64 = 0;
+    if big_endian {
+        for &b in bytes {
+            value = (value << 8) | u64::from(b);
+        }
+    } else {
+        for &b in bytes.iter().rev() {
+            value = (value << 8) | u64::from(b);
+        }
+    }
+    format!("0x{:0width$x}", value, width = bytes.len() * 2)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALWAYS: &dyn Fn(u64) -> bool = &|_| true;
+    const NEVER: &dyn Fn(u64) -> bool = &|_| false;
+
+    /// Four 4-byte rows at 0x100..0x110.
+    fn rows() -> Vec<Boundary> {
+        vec![(0x100, 4), (0x104, 4), (0x108, 4), (0x10c, 4)]
+    }
+
+    /// The shape the need is about: an instruction in the range reads a word
+    /// that lies later in the same range, so that word is data.
+    #[test]
+    fn a_word_the_range_reads_at_a_fixed_address_is_a_pool_word() {
+        let got = pool_words(&rows(), &[(0x108, 4)], &[], (0x100, 0x110), ALWAYS);
+        assert_eq!(got, BTreeMap::from([(0x108, 4)]));
+    }
+
+    /// A branch target is a label whatever else reads it.
+    #[test]
+    fn a_branch_target_is_never_folded() {
+        let got = pool_words(&rows(), &[(0x108, 4)], &[0x108], (0x100, 0x110), ALWAYS);
+        assert!(got.is_empty());
+    }
+
+    /// A writable slot holds whatever the loader last wrote, and an address a
+    /// function symbol sits on is code by declaration; neither can hold a pool.
+    #[test]
+    fn a_slot_the_program_refuses_is_never_folded() {
+        let got = pool_words(&rows(), &[(0x108, 4)], &[], (0x100, 0x110), NEVER);
+        assert!(got.is_empty());
+    }
+
+    /// Outside the listed span there is no evidence and no row to fold.
+    #[test]
+    fn a_target_outside_the_span_is_never_folded() {
+        let outside = pool_words(&rows(), &[(0x200, 4)], &[], (0x100, 0x110), ALWAYS);
+        assert!(outside.is_empty());
+        let first = pool_words(&rows(), &[(0x100, 4)], &[], (0x100, 0x110), ALWAYS);
+        assert!(first.is_empty(), "the address the caller asked to disassemble stays code");
+        let past_end = pool_words(&rows(), &[(0x10c, 8)], &[], (0x100, 0x110), ALWAYS);
+        assert!(past_end.is_empty());
+    }
+
+    /// A real pool word is a naturally-aligned scalar.
+    #[test]
+    fn an_unaligned_or_odd_width_target_is_never_folded() {
+        assert!(pool_words(&rows(), &[(0x106, 4)], &[], (0x100, 0x110), ALWAYS).is_empty());
+        assert!(pool_words(&rows(), &[(0x108, 3)], &[], (0x100, 0x110), ALWAYS).is_empty());
+    }
+
+    /// Folding only on an exact tiling is what stops the listing re-aligning:
+    /// a 4-byte read landing mid-instruction, or covering part of the next one,
+    /// is declined.
+    #[test]
+    fn a_read_that_does_not_tile_whole_rows_is_declined() {
+        let mixed = vec![(0x100, 4), (0x104, 2), (0x106, 4), (0x10a, 2), (0x10c, 4)];
+        assert!(
+            pool_words(&mixed, &[(0x104, 4)], &[], (0x100, 0x110), ALWAYS).is_empty(),
+            "0x104 is 2 bytes and 0x106 is 4, so nothing tiles 4 bytes"
+        );
+        // Two Thumb-sized rows DO tile a 4-byte word.
+        let thumb = vec![(0x100, 2), (0x102, 2), (0x104, 2), (0x106, 2)];
+        assert_eq!(
+            pool_words(&thumb, &[(0x104, 4)], &[], (0x100, 0x108), ALWAYS),
+            BTreeMap::from([(0x104, 4)])
+        );
+    }
+
+    #[test]
+    fn a_word_reads_in_the_programs_own_byte_order_padded_to_its_width() {
+        assert_eq!(word_operand(&[0x39, 0x05, 0x00, 0x00], false), "0x00000539");
+        assert_eq!(word_operand(&[0x00, 0x00, 0x05, 0x39], true), "0x00000539");
+        assert_eq!(word_mnemonic(4), ".word");
+        assert_eq!(word_mnemonic(2), ".short");
+        assert_eq!(word_mnemonic(8), ".quad");
+    }
+}

--- a/decompiler/crates/kuna-cli/src/main.rs
+++ b/decompiler/crates/kuna-cli/src/main.rs
@@ -28,6 +28,7 @@ mod fid;
 mod assertdecl;
 mod funcdecl;
 mod jsonfmt;
+mod litpool;
 mod output;
 mod paths;
 mod specs;

--- a/decompiler/crates/kuna-cli/tests/disassemble_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/disassemble_cli.rs
@@ -52,6 +52,9 @@ mod decompile_all;
 #[allow(dead_code)]
 #[path = "../src/disassemble.rs"]
 mod disassemble;
+#[allow(dead_code)]
+#[path = "../src/litpool.rs"]
+mod litpool;
 
 use jsonfmt::Json;
 
@@ -195,6 +198,110 @@ fn the_acceptance_probe() {
     assert_eq!(columns(rows[2]), ("0x400721", "4883ec40", "SUB RSP,0x40".to_string()));
     // ...and the call objdump renders as `call 400510 <puts@plt>`.
     assert!(text.contains("CALL 0x400510"), "the call to puts@plt is missing:\n{text}");
+}
+
+/// The third acceptance probe: a word the listed code READS is the constant it
+/// holds, not the instruction its bytes happen to spell.
+///
+/// `sub_8000140` in `cortexm_poolentry_le32` is the shape in the wild
+/// (`1337ARM`'s `main` ends the same way): four Thumb instructions, then the
+/// literal `0x20001000` the `ldr` two rows above loaded. Decoded, those four
+/// bytes read `asrs r0,r0,#0x20` / `movs r0,#0x0` — two instructions nothing
+/// executes, in place of the constant the program is about.
+#[test]
+fn a_literal_pool_word_lists_as_the_constant_it_holds() {
+    let bin = fixture("cortexm_poolentry_le32");
+    let Some((text, notes)) = rendered(&[&bin, "0x8000140", "--addr"]) else {
+        return;
+    };
+    let rows = rows(&text);
+    assert_eq!(
+        columns(rows[1]),
+        ("0x8000142", "0148", "ldr r0,[0x8000148]".to_string()),
+        "the load that proves 0x8000148 is data:\n{text}"
+    );
+    assert_eq!(
+        columns(rows[4]),
+        ("0x8000148", "00100020", ".word 0x20001000".to_string()),
+        "the pool word, and the two Thumb rows it was decoded as folded into one:\n{text}"
+    );
+    assert_eq!(rows.len(), 5, "the extent is unchanged, one row shorter:\n{text}");
+    assert!(!text.contains("asrs"), "the misdecode is gone:\n{text}");
+    assert!(
+        notes.iter().any(|n| n.contains("literal pool")),
+        "a `.word` row must say why it is not an instruction: {notes:?}"
+    );
+
+    // The evidence has to be IN the listing, which is also the escape hatch: ask
+    // for the word on its own and there is no load to prove anything, so it
+    // decodes exactly as it always did.
+    let Some(alone) = listing(&[&bin, "0x8000148-0x800014c"]) else {
+        return;
+    };
+    assert!(alone.contains("asrs r0,r0,#0x20"), "the raw decode is still reachable:\n{alone}");
+}
+
+/// The same row through `--json`, which is the surface an agent reads: the fold
+/// is one row of `size` 4 carrying the pool word's own bytes.
+#[test]
+fn a_pool_word_is_one_json_row_carrying_its_bytes() {
+    let bin = fixture("cortexm_poolentry_le32");
+    let Some(doc) = listing(&[&bin, "0x8000148", "--addr", "--bytes", "20", "--json"]) else {
+        return;
+    };
+    // Listed from the pool word itself there is no load in range, so nothing
+    // folds -- the same self-limiting rule the human surface has.
+    let raw = instructions(&doc);
+    assert_eq!(as_str(field(&raw[0], "mnemonic")), "asrs");
+
+    let Some(doc) = listing(&[&bin, "0x8000140", "--addr", "--json"]) else {
+        return;
+    };
+    let insns = instructions(&doc);
+    let word = insns.iter().find(|i| as_str(field(i, "address_hex")) == "0x8000148").unwrap();
+    assert_eq!(as_str(field(word, "mnemonic")), ".word");
+    assert_eq!(as_str(field(word, "operands")), "0x20001000");
+    assert_eq!(as_str(field(word, "text")), ".word 0x20001000");
+    assert_eq!(as_str(field(word, "bytes")), "00100020");
+    assert_eq!(as_u64(field(word, "size")), 4);
+    // Folding two rows into one must not move the extent the header reports.
+    assert_eq!(as_u64(field(&parse_doc(&doc), "end")), 0x800014c);
+    assert_eq!(as_u64(field(&parse_doc(&doc), "bytes")), 12);
+}
+
+/// The refusals, on the A32 fixture built for the reference walk's own pool
+/// following: a pointer-sized read folds, and a HALFWORD read of the same kind
+/// of slot does not — the width has to come from the access, and two bytes do
+/// not tile a four-byte row.
+#[test]
+fn a_narrow_read_does_not_fold_the_word_around_it() {
+    let bin = fixture("poolref_arm_le32");
+    let Some(wide) = listing(&[&bin, "0x10040", "--addr"]) else {
+        return;
+    };
+    let wide = rows(&wide);
+    assert_eq!(columns(wide[0]), ("0x10040", "00009fe5", "ldr r0,[0x10048]".to_string()));
+    assert_eq!(columns(wide[2]), ("0x10048", "2a000000", ".word 0x0000002a".to_string()));
+
+    let Some(narrow) = listing(&[&bin, "0x10034", "--addr"]) else {
+        return;
+    };
+    let narrow = rows(&narrow);
+    assert_eq!(columns(narrow[0]), ("0x10034", "b000dfe1", "ldrh r0,[0x1003c]".to_string()));
+    let (addr, _, insn) = columns(narrow[2]);
+    assert_eq!(addr, "0x1003c");
+    assert!(!insn.starts_with('.'), "a halfword read must not fold a word: {insn}");
+}
+
+/// x86-64 parks its constants in immediates, so nothing folds there and the
+/// listing an agent already knew is byte-identical.
+#[test]
+fn a_listing_with_no_literal_pool_is_untouched() {
+    let Some((text, notes)) = rendered(&[&fauxware(), "main"]) else {
+        return;
+    };
+    assert!(!text.contains(".word"), "nothing to fold in an x86-64 body:\n{text}");
+    assert!(notes.is_empty(), "and nothing to say about it: {notes:?}");
 }
 
 /// The second acceptance probe: `--json` is valid JSON carrying `address_hex`

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -72,6 +72,131 @@ struct ProgramSymbol {
     provenance: EntryProvenance,
 }
 
+/// (kuna) One emitted p-code op, whole: the opcode, the output varnode and
+/// every input. [`OneShotPcodeEmit`] keeps only `in0`; the parts it drops are
+/// what a data-reference scan is made of.
+struct WholeOp {
+    opcode: OpCode,
+    out: Option<VarnodeData>,
+    ins: Vec<VarnodeData>,
+}
+
+/// (kuna) Every FIXED address a RANGE of instructions names, in the two flavours
+/// a listing needs to tell code from data — plus the decode buffer the walk
+/// filling it reuses.
+///
+/// One value is filled by many [`ConsoleProgram::add_fixed_refs_at`] calls, and
+/// the op capture is rewound rather than dropped between them: allocating per op
+/// costs one heap allocation for every p-code op walked, which on a whole-image
+/// listing is millions of them.
+#[derive(Default)]
+pub struct FixedRefs {
+    /// `(address, width)` for each read of an address an instruction spelled
+    /// out. The width is what was READ, not the size of the address varnode.
+    pub reads: Vec<(u64, u32)>,
+    /// Every address a `BRANCH`/`CBRANCH`/`CALL` named outright.
+    pub flow_targets: Vec<u64>,
+    /// The current instruction's ops, over storage retained across instructions.
+    ops: Vec<WholeOp>,
+    /// How many of `ops` the current instruction has filled.
+    filled: usize,
+}
+
+impl kuna_sleigh::translate::PcodeEmit for FixedRefs {
+    fn dump(
+        &mut self,
+        _addr: &Address,
+        opc: OpCode,
+        outvar: Option<&VarnodeData>,
+        vars: &[VarnodeData],
+    ) {
+        if self.filled == self.ops.len() {
+            self.ops.push(WholeOp { opcode: opc, out: outvar.cloned(), ins: vars.to_vec() });
+        } else {
+            let slot = &mut self.ops[self.filled];
+            slot.opcode = opc;
+            slot.out = outvar.cloned();
+            slot.ins.clear();
+            slot.ins.extend_from_slice(vars);
+        }
+        self.filled += 1;
+    }
+}
+
+impl FixedRefs {
+    /// Project the ops the last decode emitted onto the two reference lists.
+    ///
+    /// A read is harvested in the two shapes SLEIGH spells one in: a `LOAD`
+    /// whose address input is a constant (`ldr r3,[0x8458]`) and a direct memory
+    /// varnode in the default data space (`mov eax,[0x404018]`). The width is
+    /// the width of the ACCESS — a `LOAD`'s address varnode is pointer-sized
+    /// whatever the access is, so `ldrh r0,[0x1003c]` must not read as a
+    /// pointer-sized one. The `in0` slot of `LOAD`/`STORE`/`CALLOTHER` and of
+    /// every flow op is skipped: it carries a space id or a destination, not an
+    /// address that is read.
+    ///
+    /// `fall_through` (`vma + len`) is not recorded as a flow target, for the
+    /// same reason [`super::super`]'s reference walk declines it as a value:
+    /// every conditionally-executed ARM instruction lowers to a `CBRANCH` over
+    /// its own body, so its successor is named by a flow op whatever it is.
+    /// Counted, that would mark the word after every predicated instruction as a
+    /// branch label — and a literal pool is a run of them.
+    fn harvest(&mut self, data_space: Option<&Rc<AddrSpace>>, fall_through: u64) {
+        let Self { reads, flow_targets, ops, filled } = self;
+        let is_constant = |vn: &VarnodeData| {
+            vn.space
+                .as_ref()
+                .is_some_and(|s| s.get_type() == kuna_base::space::spacetype::IPTR_CONSTANT)
+        };
+        // Space identity is pointer identity throughout the engine, so match on
+        // the `Rc`, never on the space's name or index.
+        let in_data_space = |vn: &VarnodeData| {
+            matches!((&vn.space, data_space), (Some(s), Some(d)) if Rc::ptr_eq(s, d))
+        };
+        for op in &ops[..*filled] {
+            let flow = matches!(
+                op.opcode,
+                OpCode::CPUI_BRANCH | OpCode::CPUI_CBRANCH | OpCode::CPUI_CALL
+            );
+            if flow {
+                if let Some(vn) = op.ins.first() {
+                    if !is_constant(vn) && vn.offset != fall_through {
+                        flow_targets.push(vn.offset);
+                    }
+                }
+            }
+            for (i, vn) in op.ins.iter().enumerate() {
+                let target_slot = i == 0
+                    && (flow
+                        || matches!(
+                            op.opcode,
+                            OpCode::CPUI_LOAD | OpCode::CPUI_STORE | OpCode::CPUI_CALLOTHER
+                        ));
+                if target_slot {
+                    continue;
+                }
+                let names_an_address = in_data_space(vn)
+                    || (i == 1 && op.opcode == OpCode::CPUI_LOAD && is_constant(vn));
+                if !names_an_address {
+                    continue;
+                }
+                // The width of the ACCESS, which for a `LOAD` is its output and
+                // NOT its address varnode -- SLEIGH gives `ldrh r0,[0x1003c]` a
+                // pointer-sized `ram` address and a 2-byte output, and reading
+                // the address would call a halfword read a word.
+                let width = match op.opcode {
+                    OpCode::CPUI_LOAD if i == 1 => op.out.as_ref().map(|o| o.size),
+                    OpCode::CPUI_STORE => None,
+                    _ => Some(vn.size),
+                };
+                if let Some(width) = width {
+                    reads.push((vn.offset, width));
+                }
+            }
+        }
+    }
+}
+
 /// (kuna) A one-shot [`PcodeEmit`](kuna_sleigh::translate::PcodeEmit) sink:
 /// `Translate::one_instruction` dumps exactly one instruction's p-code, each
 /// op captured here as opcode + first input (the single-instruction pcode
@@ -917,6 +1042,38 @@ impl ConsoleProgram {
             OpCode::CPUI_BRANCHIND => Some(None),
             _ => None,
         }
+    }
+
+    /// (kuna) Add the fixed addresses the instruction at `vma` names — the
+    /// constant locations it reads and the constant addresses it branches or
+    /// calls to — to `into`.
+    ///
+    /// The projection a listing needs to tell a literal-pool word from an
+    /// instruction. A pool word is proved by the code around it (some
+    /// instruction spells its address out and reads it) and disproved the same
+    /// way (a branch names it as a label), so a caller walking a range
+    /// accumulates both facts into one [`FixedRefs`] as it goes. What is
+    /// harvested from the p-code is [`FixedRefs::harvest`].
+    ///
+    /// Adds nothing (never an error, never a panic) for an address that does not
+    /// decode or a program with no code space — this is advisory evidence, and a
+    /// caller that gets none simply learns nothing.
+    pub fn add_fixed_refs_at(&self, vma: u64, into: &mut FixedRefs) {
+        let Some(code_space) = self.arch().manage().get_default_code_space().cloned() else {
+            return;
+        };
+        let addr = Address::new(code_space, vma);
+        into.filled = 0;
+        // Advisory probe: contain a decode `Err` AND any translator panic on
+        // exotic bytes to "no evidence", exactly as `lone_jump_target` does.
+        let decoded = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.arch().translate().one_instruction(into, &addr)
+        }));
+        let Ok(Ok(len)) = decoded else {
+            return;
+        };
+        let data_space = self.arch().manage().get_default_data_space().cloned();
+        into.harvest(data_space.as_ref(), vma.wrapping_add(len as u64));
     }
 
     /// This allocating convenience API is retained for occasional reads.
@@ -2951,7 +3108,98 @@ pub const UNBOUNDED_SIZE: int4 = 0;
 
 #[cfg(test)]
 mod tests {
-    use super::{entry_name_rank, is_vtable_slot_name};
+    use std::rc::Rc;
+
+    use kuna_base::space::{spacetype, AddrSpace};
+    use kuna_num::opcodes::OpCode;
+    use kuna_num::pcoderaw::VarnodeData;
+
+    use super::{entry_name_rank, is_vtable_slot_name, FixedRefs, WholeOp};
+
+    /// A throwaway `(ram, constant)` space pair; `ram` stands in for the default
+    /// data space, exactly as `listing::xrefs`'s own tests build it.
+    fn spaces() -> (Rc<AddrSpace>, Rc<AddrSpace>) {
+        (
+            Rc::new(AddrSpace::new_for_decode(spacetype::IPTR_PROCESSOR)),
+            Rc::new(AddrSpace::new_for_decode(spacetype::IPTR_CONSTANT)),
+        )
+    }
+
+    fn vn(space: &Rc<AddrSpace>, offset: u64, size: u32) -> VarnodeData {
+        VarnodeData { space: Some(Rc::clone(space)), offset, size }
+    }
+
+    /// Harvest `ops` as one instruction of length 4 at `vma`.
+    fn harvest(ram: &Rc<AddrSpace>, vma: u64, ops: Vec<WholeOp>) -> FixedRefs {
+        let mut refs = FixedRefs { ops, filled: 0, ..FixedRefs::default() };
+        refs.filled = refs.ops.len();
+        refs.harvest(Some(ram), vma + 4);
+        refs
+    }
+
+    fn op(opcode: OpCode, out: Option<VarnodeData>, ins: Vec<VarnodeData>) -> WholeOp {
+        WholeOp { opcode, out, ins }
+    }
+
+    /// The literal-pool read, in the two shapes SLEIGH spells one in: a `LOAD`
+    /// off a constant address, and a direct memory varnode.
+    #[test]
+    fn a_fixed_address_read_is_reported_with_the_width_of_the_access() {
+        let (ram, cst) = spaces();
+        let load = op(
+            OpCode::CPUI_LOAD,
+            Some(vn(&cst, 0x100, 4)),
+            vec![vn(&cst, 0x1b, 8), vn(&cst, 0x8458, 4)],
+        );
+        assert_eq!(harvest(&ram, 0x8440, vec![load]).reads, vec![(0x8458, 4)]);
+
+        let direct = op(OpCode::CPUI_COPY, None, vec![vn(&ram, 0x404018, 4)]);
+        assert_eq!(harvest(&ram, 0x1000, vec![direct]).reads, vec![(0x404018, 4)]);
+
+        // A `LOAD`'s address varnode is pointer-sized whatever the access is, so
+        // the width has to come from the output: `ldrh r0,[0x1003c]` lifts to a
+        // 4-byte `ram` address and a 2-byte load, and calling that a word would
+        // fold four bytes for a halfword read.
+        let narrow = op(
+            OpCode::CPUI_LOAD,
+            Some(vn(&cst, 0x100, 2)),
+            vec![vn(&cst, 0x1b, 8), vn(&ram, 0x1003c, 4)],
+        );
+        assert_eq!(harvest(&ram, 0x10034, vec![narrow]).reads, vec![(0x1003c, 2)]);
+    }
+
+    /// The `in0` of a `LOAD`/`STORE`/`CALLOTHER` is a space id, and of a flow op
+    /// a destination; neither is an address that was read.
+    #[test]
+    fn a_target_slot_is_never_a_read() {
+        let (ram, cst) = spaces();
+        let store = op(
+            OpCode::CPUI_STORE,
+            None,
+            vec![vn(&cst, 0x1b, 8), vn(&ram, 0x404018, 4), vn(&cst, 7, 4)],
+        );
+        assert!(harvest(&ram, 0x1000, vec![store]).reads.is_empty());
+        let call = op(OpCode::CPUI_CALL, None, vec![vn(&ram, 0x2000, 4)]);
+        let got = harvest(&ram, 0x1000, vec![call]);
+        assert!(got.reads.is_empty());
+        assert_eq!(got.flow_targets, vec![0x2000]);
+    }
+
+    /// Every conditionally-executed ARM instruction lowers to a `CBRANCH` over
+    /// its own body, so its successor is named by a flow op whatever it is.
+    /// Counted, that marks the word after each predicated instruction as a
+    /// branch label — and a literal pool is a run of them, so `andeq` at
+    /// 0x1000c would veto the pool word at 0x10010.
+    #[test]
+    fn an_instructions_own_fall_through_is_not_a_branch_target() {
+        let (ram, _cst) = spaces();
+        let skip = op(OpCode::CPUI_CBRANCH, None, vec![vn(&ram, 0x10010, 4)]);
+        assert!(harvest(&ram, 0x1000c, vec![skip]).flow_targets.is_empty());
+        // A real branch to anywhere else is kept.
+        let real = op(OpCode::CPUI_CBRANCH, None, vec![vn(&ram, 0x83d0, 4)]);
+        assert_eq!(harvest(&ram, 0x1000c, vec![real]).flow_targets, vec![0x83d0]);
+    }
+
 
     /// Which of an entry's names `function_entries_canonical` reports.
     fn wins<'a>(a: &'a str, b: &'a str) -> &'a str {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -860,6 +860,43 @@ Bytes the translator will not decode are listed in place as `.byte 0x<nn>` rows,
 one byte each, and the walk continues — a listing that ran into inline data says
 so where it happened instead of stopping silently.
 
+### Literal pools are listed as data
+
+A constant that will not fit an ARM/MIPS/PowerPC immediate is parked in `.text`
+beside the code that uses it and loaded PC-relatively, so a function's own extent
+contains words that are not instructions. Decoded, they are a lie: `main` in the
+`1337ARM` crackme ended
+
+```
+0x8454        10a89de8              ldmia sp,{r4,r11,sp,pc}
+0x8458        39050000              andeq r0,r0,r9, lsr r5
+```
+
+where `0x8458` is the success constant `0x539` the `ldr` at `0x8440` loads, and
+`andeq` is four bytes nothing executes. Such a word now lists as the constant it
+holds, with the reason on **stderr** (and in `notes`):
+
+```
+0x8458        39050000              .word 0x00000539
+```
+
+The evidence is inside the listing and nowhere else: some instruction **in the
+listed range** spells the address out and reads it, and none branches to it. A
+word is left decoded if it is in a writable section, if a function symbol sits on
+it, if it is unaligned or not 1/2/4/8 bytes wide, or if its width does not tile a
+whole number of decoded rows — so no address in the listing ever moves, folded or
+not. The width is the width of the **access**, not of the address: `ldrh
+r0,[0x1003c]` reads two bytes out of a four-byte slot, and folds nothing. Listing the word on its own contains no such load, which is the escape hatch
+when the raw decode is what you want:
+
+```
+$ kuna disassemble ./1337ARM.bin 0x8458-0x845c
+0x8458        39050000              andeq r0,r0,r9, lsr r5
+```
+
+The `mnemonic` is `.byte`/`.short`/`.word`/`.quad` by width and `operands` is the
+value zero-padded to it; the row's `bytes` are the image's, as for any other row.
+
 ### The byte view
 
 An instruction listing is the wrong answer for a data address, and for a while it

--- a/docs/features/function-disassembly-decodes-arm/pr_body.md
+++ b/docs/features/function-disassembly-decodes-arm/pr_body.md
@@ -1,0 +1,62 @@
+## The problem
+
+An ARM function's extent contains its own literal pool, so a straight-line
+disassembly of `main` walks off the end of the code and decodes the constant as
+an instruction. On the `1337ARM` crackme (crackmes.one
+`5ab77f5733c5d40ad448c380`), the word an agent is looking for — the success value
+`0x539`, i.e. 1337 — is the last row of `kuna disassemble main`, spelled as a
+bitwise-and:
+
+```
+$ kuna disassemble ./1337ARM.bin main | tail -3
+0x8450        10d04be2              sub sp,r11,#0x10
+0x8454        10a89de8              ldmia sp,{r4,r11,sp,pc}
+0x8458        39050000              andeq r0,r0,r9, lsr r5
+```
+
+Nothing executes `0x8458`; the `ldr r3,[0x8458]` five rows above reads it. The
+same shape is in the repo already, in `cortexm_poolentry_le32`, where a pool word
+lists as `asrs r0,r0,#0x20` / `movs r0,#0x0`:
+
+```
+$ kuna disassemble decompiler/crates/kuna-analysis/tests/fixtures/cortexm_poolentry_le32 0x8000140 --addr
+0x8000142     0148                  ldr r0,[0x8000148]
+...
+0x8000148     0010                  asrs r0,r0,#0x20
+0x800014a     0020                  movs r0,#0x0
+```
+
+## The fix
+
+- A word the **listed range's own instructions** read at a fixed address, and
+  none of them branch to, lists as the constant it holds: `.word 0x00000539`.
+  The evidence comes from the p-code of each row as it is decoded
+  (`ConsoleProgram::add_fixed_refs_at`) — the constant addresses it reads, in the
+  two shapes SLEIGH spells one in, and the ones its flow ops name.
+- Keeping the evidence inside the range is what makes the rule predictable and
+  gives it an escape hatch: `kuna disassemble ./1337ARM.bin 0x8458-0x845c`
+  contains no such load, so it decodes exactly as before.
+- Four refusals bound it: a writable section, an address a function symbol sits
+  on, an unaligned or non-scalar width, and a width that does not tile whole
+  decoded rows. The last is why no address in the listing can move — a fold only
+  merges whole rows over the same bytes, so a wrong fold costs one row, never a
+  re-aligned listing. A `notes` line (and stderr) says a fold happened.
+- No option, no emitted C: this is the listing surface, and `kuna disassemble`
+  cannot change a decompile.
+
+## The tests
+
+`tests/cli/function-disassembly-decodes-arm.json` (the promoted acceptance,
+re-pointed at the in-repo `cortexm_poolentry_le32` — CI has no dataset) plus
+three `disassemble_cli.rs` cases: the fold and its escape hatch, the JSON row,
+and an x86-64 body that is byte-identical, plus the halfword-read refusal on
+`poolref_arm_le32`. `litpool.rs` unit-tests each refusal and `engine.rs` the
+p-code projection. Sweeping every fixture in `kuna-analysis/tests/fixtures`
+old-vs-new, the only listings that change are ARM/Thumb and every changed row is
+a pool word. On a 32,768-instruction range of the witness, 315 rows change, and
+an independent A32 literal-load decoder (no kuna in the reference path) backs
+all 315 and disagrees with none of their values. Cost: one extra decode per row —
++0.5 ms on a default 115-instruction listing (below the noise floor), +0.09 s
+on that 32k range (1.408 s → 1.501 s, min of 9, load-dominated).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/function-disassembly-decodes-arm/record.json
+++ b/docs/features/function-disassembly-decodes-arm/record.json
@@ -1,0 +1,131 @@
+{
+  "opportunity": "repipe:5ab77f5733c5d40ad448c380::function-disassembly-decodes-arm",
+  "need_id": "function-disassembly-decodes-arm",
+  "track": "tooling",
+  "round": 4,
+  "test_name": "repipe round 4, challenge 5ab77f5733c5d40ad448c380",
+  "binary": "kuna-re-dataset/challenges/5ab77f5733c5d40ad448c380/bin/1337_ARM.zip.__x/1337ARM.bin",
+  "selector": "main",
+  "func_addr": "0x8290",
+  "option": null,
+  "flag": null,
+  "element_id": null,
+  "change_kind": "correctness-fix",
+  "source_decompiler": "kuna",
+  "inspiration": "repipe round 4 need function-disassembly-decodes-arm; the listing-surface sibling of kuna_poolref (#431), and the shape every disassembler an agent falls back to already has -- IDA's `DCD`, Ghidra's defined data at a pc-relative literal target",
+  "default_on": true,
+  "div": null,
+  "scope": "small",
+  "worker": "b-r4-function-disasse",
+  "branch": "feat/re-function-disassembly-decodes-arm",
+  "hypothesis_status": "no hypothesis was offered; the captain's T_TRIAGE reading (the listing walks an ARM literal pool as code) is upheld exactly. What the symptom line proposes as the fix -- asserting readonly over 0x8458+4 -- is a DECOMPILE knob and does not touch the listing at all; the listing needed its own evidence.",
+  "files": [
+    "decompiler/crates/kuna-cli/src/litpool.rs",
+    "decompiler/crates/kuna-cli/src/disassemble.rs",
+    "decompiler/crates/kuna-cli/src/main.rs",
+    "decompiler/crates/kuna-cli/tests/disassemble_cli.rs",
+    "decompiler/crates/kuna-console/src/engine.rs",
+    "tests/cli/function-disassembly-decodes-arm.json",
+    "docs/cli.md",
+    "docs/spec/01-program-prep.md"
+  ],
+  "parity": "OK",
+  "gates": {
+    "make test": "PARITY OK 675/675",
+    "make test-stages": "PARITY OK 635/635",
+    "make check-spec": "OK",
+    "kuna catalog --check": "catalog OK",
+    "make test-cli": "38/38",
+    "make rust-test": "5669 passed, 1 failed -- verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip, PRE-EXISTING and not reachable by this change. It asserts on the output of an EXTERNAL decomp_test_dbg process (KUNA_DECOMP_TEST), and reproduces identically when pointed at the main tree's own binary built before this session. The diff touches no file under kuna-decomp/kuna-base/kuna-sleigh/kuna-analysis/specs. It passed on the first run of this branch only because the worktree had no release decomp_test_dbg yet, which makes the oracle block vacuous -- which is also why CI cannot see it: .github/workflows/tests.yml never sets KUNA_DECOMP_TEST."
+  },
+  "probe_flip": {
+    "probe_still_passes": false,
+    "acceptance_passes": true,
+    "acceptance_row_before": "0x8458  39050000  andeq r0,r0,r9, lsr r5",
+    "acceptance_row_after": "0x8458  39050000  .word 0x00000539"
+  },
+  "promoted_probe": {
+    "path": "tests/cli/function-disassembly-decodes-arm.json",
+    "retargeted": true,
+    "target": "decompiler/crates/kuna-analysis/tests/fixtures/cortexm_poolentry_le32",
+    "why": "the acceptance's own target is `binary_source: dataset` and CI has no dataset; the vendored 601-byte Cortex-M fixture already carries the same defect (0x8000148 is the literal 0x20001000 the ldr at 0x8000142 loads, decoded as `asrs r0,r0,#0x20` / `movs r0,#0x0`), and it exercises the Thumb two-row merge the A32 witness does not"
+  },
+  "no_option_because": "Track `tooling`. `kuna disassemble` is a query -- it loads, decodes and prints, commits nothing into the engine and decompiles nothing -- so no emitted C can change and there is no judgement call for the pipeline to carry. The escape hatch a flag would provide already exists and is better: the rule only fires on evidence inside the listed range, so `kuna disassemble BIN 0x8458-0x845c` decodes the word raw, and the note says so.",
+  "sweep": {
+    "method": "every non-source file in decompiler/crates/kuna-analysis/tests/fixtures (all architectures), `kuna disassemble <entry>` for up to 40 entries each, old binary vs new, full text diff; plus a 32,768-instruction explicit range over the witness",
+    "fixtures_swept": 60,
+    "fixtures_with_any_diff": 5,
+    "architectures_with_any_diff": [
+      "ARM A32",
+      "ARM Thumb/Cortex-M"
+    ],
+    "x86_64_i386_pe_macho_mips_ppc_diffs": 0,
+    "rows_changed_witness_32k_range": 315,
+    "rows_changed_that_were_not_a_pool_word": 1,
+    "the_one": "cortexm_poolentry_le32 0x8000170 -- the fixture's own deliberate SPLIT case, where G's literal reference resolves onto an UNDISCOVERED function's first word. Nothing calls that function and the load really does read those bytes, so the fold is not provably wrong; it is the documented residual false positive and it costs one row.",
+    "oracle": {
+      "what": "an independent A32 LDR-literal decoder (pure Python over the ELF program headers -- no kuna code in the reference path) over the same 0x8290-0x28290 range, computing each pc-relative literal target",
+      "kuna_folded": 315,
+      "folded_not_backed_by_the_oracle": 0,
+      "folded_value_disagreeing_with_the_image_word": 0,
+      "oracle_targets_kuna_left_decoded": 551,
+      "of_which_the_target_was_not_a_decoded_row_boundary": 421,
+      "of_which_the_referencing_ldr_was_never_decoded_by_the_walk": 130,
+      "note": "recall is bounded by the straight-line walk: where it emits 1-byte `.byte` rows it goes out of phase and neither the load nor the pool word lands on a row boundary, and the tiling refusal then declines. No fabricated fold in either direction."
+    }
+  },
+  "speed": {
+    "method": "interleaved before/after, 9 repeats, MIN of N (the box ran the workspace suite throughout, so medians swing +-20% on the same binary and are not used)",
+    "default_listing_115_insns_min_s": {
+      "before": 1.315,
+      "after": 1.312
+    },
+    "explicit_32768_insn_range_min_s": {
+      "before": 1.408,
+      "after": 1.501
+    },
+    "walk_only_32768_insns_s": {
+      "before": 0.1,
+      "after": 0.19
+    },
+    "per_instruction_us": 2.8,
+    "note": "the cost is one extra `one_instruction` decode per row for the p-code. Load dominates every real invocation (1.31 s of both numbers above) and the derived listing is capped at 1024 rows, so the visible cost on a default `kuna disassemble main` is ~0.5 ms and below the noise floor. The op capture is rewound rather than reallocated per instruction (the FullCapture precedent in listing/xrefs.rs); that alone took the 32k walk from 0.25 s to 0.19 s."
+  },
+  "decisions": [
+    {
+      "id": "the-refutation-found-two-real-defects",
+      "claim": "Checking the mechanism against WRONGNESS rather than against no-op found two bugs the witness alone never showed.",
+      "evidence": "(1) An instruction's own fall-through was being counted as a branch target. Every predicated ARM instruction lowers to a CBRANCH over its body, and a literal pool is a run of words that decode as predicated instructions -- so every pool word but the first was vetoed by its predecessor. The witness's `main` has a single pool word and passed throughout; the count on a 32k range went 91 -> 315 once the fall-through was excluded. (2) The read width was taken from the address varnode when SLEIGH lifts a literal load with a `ram` address (`ldrh r0,[0x1003c]` is LOAD out:2 ins=[const, ram:4]), so a halfword read claimed a four-byte word. Both are pinned by unit tests in engine.rs and, for the narrow read, end to end on poolref_arm_le32."
+    },
+    {
+      "id": "the-evidence-must-be-inside-the-listed-range",
+      "claim": "A word is folded only when an instruction IN THE LISTING reads it; no global data/code partition is consulted.",
+      "evidence": "The alternative -- building the whole-image XrefIndex `kuna xrefs` uses -- costs a second full-program recursive descent and makes the answer depend on discovery quality. Keeping the evidence local makes the rule predictable, self-limiting and steerable: `kuna disassemble BIN 0x8458-0x845c` contains no load of 0x8458, so it decodes raw, which is the escape hatch a flag would otherwise have to provide. It also means the rule cannot fire on a range the caller did not ask about."
+    },
+    {
+      "id": "fold-only-on-an-exact-row-tiling",
+      "claim": "A pool word is folded only when its width tiles a whole number of already-decoded rows starting exactly at its address.",
+      "evidence": "This is what makes a false positive cheap. The fold rewrites rows over the same bytes and never re-decodes, so no address after a folded word can shift -- a wrong fold costs one mis-rendered row with its bytes printed beside it, never a re-aligned listing. It is also what makes Thumb work: 0x8000148 in cortexm_poolentry_le32 decodes as two 2-byte rows and both are merged into one 4-byte `.word`, pinned by `a_literal_pool_word_lists_as_the_constant_it_holds`."
+    },
+    {
+      "id": "the-width-must-come-from-the-access",
+      "claim": "The folded width is the LOAD's OUTPUT size, not the size of its address varnode.",
+      "evidence": "A LOAD's address varnode is pointer-sized whatever the access is, so `ldrh r0,[0x1003c]` would otherwise fold four bytes for a two-byte read. Same trap #431 hit one surface over (`kuna-xref-load-width`); `read_width` there and the `op.out` read here are the same rule."
+    },
+    {
+      "id": "a-branch-target-is-never-data",
+      "claim": "An address any instruction in the range branches or calls to is left decoded however else it is read.",
+      "evidence": "Harvested from the same p-code pass at zero extra cost. Without it a jump table's own entries, or a loop head a nearby instruction happens to read, could fold. Pinned by `a_branch_target_is_never_folded`."
+    },
+    {
+      "id": "the-residual-false-positive-is-a-literal-landing-on-code",
+      "claim": "The rule cannot distinguish a pool word from a real instruction that some other instruction reads as a constant, and the repo already contains one.",
+      "evidence": "cortexm_poolentry_le32's SPLIT case: `G`'s `ldr r0,[pc,#4]` resolves onto function `F`'s first word. All the local guards pass (readonly, aligned, tiles a row, after a `pop {r7,pc}`, no symbol, not a branch target) and the two `movs` fold into `.word 0x21082007`. Nothing in the fixture calls F and the load genuinely reads those bytes, so the row is not provably wrong -- but the shape is real (the fixture's own header traces it to betaflight `SCSI_RequestSense`+4). Ruling it out needs a global reachability partition, which is the whole-image walk this deliberately does not do. Documented in litpool.rs, in docs/cli.md and in docs/spec/01-program-prep.md rather than hidden."
+    },
+    {
+      "id": "no-decompile-behaviour-changed",
+      "claim": "The change is confined to the disassembly listing; the decompiler never sees it.",
+      "evidence": "`fold_pool_words` runs inside `disassemble::walk`, which only `kuna disassemble`, `kuna read` and `decompile-graph`'s per-function `assembly` field call. No p-code, prototype, type or emitted C reads it, and all four parity gates are byte-identical."
+    }
+  ]
+}

--- a/docs/re-needs/function-disassembly-decodes-arm.md
+++ b/docs/re-needs/function-disassembly-decodes-arm.md
@@ -2,23 +2,23 @@
 need_id: function-disassembly-decodes-arm
 title: Function disassembly decodes ARM literal-pool data as an instruction
 track: tooling
-status: open
+status: closed
 severity: minor
 probe_id: p-e6b8fbb0a325
 acceptance_id: a-19c4b0c635a6
-hypothesis_status: inconclusive
+hypothesis_status: upheld
 credibility: 0.7
 instances: 1
 challenges: [5ab77f5733c5d40ad448c380]
 rounds: [3]
 first_seen_round: 3
-attempts: 0
+attempts: 1
 covered_by_option: null
-touches: [decompiler/crates/kuna-cli/src/disassemble.rs, decompiler/crates/kuna-analysis/src/listing]
+touches: [decompiler/crates/kuna-cli/src/litpool.rs, decompiler/crates/kuna-cli/src/disassemble.rs, decompiler/crates/kuna-console/src/engine.rs]
 scope: small
 regression_of: null
 pr: null
-closed_in_round: null
+closed_in_round: 4
 closing_pr: null
 reject_reason: null
 ---
@@ -96,7 +96,11 @@ _none offered_
 
 ## Refutation
 
-_not yet refuted_
+The symptom stands exactly as filed. The *fix* the symptom line proposes does
+not: asserting `readonly 0x8458+4` is a decompile-plane knob and never reaches
+the listing, which does its own straight-line walk of the extent. The listing
+needed evidence of its own -- and it already has it, in the `ldr r3,[0x8458]`
+five rows above.
 
 ## Reference
 
@@ -107,6 +111,14 @@ _none recorded_
 - `5ab77f5733c5d40ad448c380` (round 3, tester t-r3-5ab77f57)
 
 ## Decision log
+
+builder b-r4-function-disasse r4: CLOSED. `kuna disassemble` now folds a word its
+own listed instructions read at a fixed address, and none of them branch to, into
+a `.word 0x...` data row (`decompiler/crates/kuna-cli/src/litpool.rs`, fed by
+`ConsoleProgram::add_fixed_refs_at`). Evidence stays inside the listed range, so
+listing the word alone still decodes it raw. Acceptance PASSES; promoted to
+`tests/cli/function-disassembly-decodes-arm.json`, re-pointed at the in-repo
+`cortexm_poolentry_le32` (CI has no dataset).
 
 - filed by cluster.py from 1 observation(s)
 captain T_TRIAGE r3: track CORRECTED quality -> tooling, touches CORRECTED kuna-decomp -> the disassembly path. Inferred quality from kind=wrong-output, but the probe is `kuna disassemble main --json` and no C is produced; the gap is that the listing walks an ARM literal pool as code. Same data-vs-code question as arm-literal-pool-string on the same binary -- a builder taking either should read both, though the fixes are in different files.

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -2140,6 +2140,40 @@ the filing crackme — of which an independent capstone-plus-symtab oracle
 corroborates 2,234 and 761 as real PC-relative pool loads, with every one of the
 remainder confirmed by hand as a load the oracle's own sweep missed.
 
+(kuna) The same pool word is a second defect one surface over, in the **listing**
+rather than the reference walk. A function's extent contains its pool, so a
+straight-line disassembly of `main` walks off the end of the code and decodes the
+constant: `1337ARM`'s `main` ended `ldmia sp,{r4,r11,sp,pc}` and then
+`0x8458 39050000 andeq r0,r0,r9, lsr r5` — four bytes nothing executes, listed as
+an instruction, in place of the success constant `0x539` the program is about.
+**Pool-word folding** (`decompiler/crates/kuna-cli/src/litpool.rs`, fed by
+`ConsoleProgram::add_fixed_refs_at`) lists such a word as the constant it holds
+(`.word 0x00000539`) instead. The evidence is the listing's own and nothing
+wider: as each row is decoded, the fixed addresses it names are harvested from
+its p-code — the constant locations it READS, in the two shapes SLEIGH spells one
+in (a `LOAD` off a constant address, and a direct memory varnode), and the
+constant addresses its flow ops name. A word read by some instruction in the
+range, and branched to by none of them, is data.
+
+That the evidence has to be *in the range* is what makes the rule predictable and
+steerable rather than a global guess: listing the pool word on its own contains
+no such load, so it decodes exactly as before, and that is the escape hatch. Four
+further refusals bound it — a writable section (a GOT slot is read by address
+too, and a writable `.text` is a packer), an address a function symbol sits on
+(code by declaration), an unaligned or non-scalar width, and a width that does
+not tile a whole number of decoded rows. As in the reference walk, the width has
+to come from the ACCESS rather than from the address varnode, which a `LOAD`
+makes pointer-sized whatever it reads; and an instruction's own fall-through is
+not counted as a branch target, because every predicated ARM instruction lowers
+to a `CBRANCH` over its body and a literal pool is a run of words that decode as
+predicated instructions — counting it would veto every pool word but the first. The last one is what keeps the listing
+stable: a fold only ever merges whole rows over the same bytes, so no address
+after it can shift and a wrong fold costs one mis-rendered row rather than a
+re-aligned listing. The residual false positive is a literal that lands on real
+code — `cortexm_poolentry_le32` carries one deliberately, where a pool reference
+resolves onto an undiscovered function's first word — and it costs exactly that
+one row, with the bytes beside it and the raw decode one command away.
+
 ## 1.7 The no-return family
 
 Whether a call falls through decides the CFG of every caller, so no-return facts

--- a/tests/cli/function-disassembly-decodes-arm.json
+++ b/tests/cli/function-disassembly-decodes-arm.json
@@ -1,0 +1,86 @@
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-0082c83fdc4c",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "disassemble",
+    "{{BIN}}",
+    "0x8000140",
+    "--addr",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/cortexm_poolentry_le32",
+    "binary_sha256": "8194242c64bafb297cf705e456bd808e08b7544bc843d8118d5051617608471f",
+    "binary_size": 601,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/cortexm_poolentry_le32",
+    "selector": "0x8000140",
+    "selector_kind": "addr"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "stdout_absent": [
+      "\"mnemonic\": \"asrs\""
+    ],
+    "json": [
+      {
+        "path": "count",
+        "op": "eq",
+        "value": 5
+      },
+      {
+        "path": "end_hex",
+        "op": "eq",
+        "value": "0x800014c"
+      },
+      {
+        "path": "instructions[1].text",
+        "op": "eq",
+        "value": "ldr r0,[0x8000148]"
+      },
+      {
+        "path": "instructions[4].address_hex",
+        "op": "eq",
+        "value": "0x8000148"
+      },
+      {
+        "path": "instructions[4].mnemonic",
+        "op": "eq",
+        "value": ".word"
+      },
+      {
+        "path": "instructions[4].operands",
+        "op": "eq",
+        "value": "0x20001000"
+      },
+      {
+        "path": "instructions[4].bytes",
+        "op": "eq",
+        "value": "00100020"
+      },
+      {
+        "path": "instructions[4].size",
+        "op": "eq",
+        "value": 4
+      },
+      {
+        "path": "notes[0]",
+        "op": "contains",
+        "value": "literal pool"
+      }
+    ]
+  },
+  "notes": "Promoted acceptance of function-disassembly-decodes-arm, re-pointed from the dataset witness (main's last word 0x8458 listed as `andeq r0,r0,r9, lsr r5` instead of the 0x539 the ldr at 0x8440 loads) at the vendored cortexm_poolentry_le32 fixture -- CI has no dataset. 0x8000148 is the literal the ldr at 0x8000142 loads; count and end_hex pin that folding two Thumb rows did not move the extent."
+}


### PR DESCRIPTION
## The problem

An ARM function's extent contains its own literal pool, so a straight-line
disassembly of `main` walks off the end of the code and decodes the constant as
an instruction. On the `1337ARM` crackme (crackmes.one
`5ab77f5733c5d40ad448c380`), the word an agent is looking for — the success value
`0x539`, i.e. 1337 — is the last row of `kuna disassemble main`, spelled as a
bitwise-and:

```
$ kuna disassemble ./1337ARM.bin main | tail -3
0x8450        10d04be2              sub sp,r11,#0x10
0x8454        10a89de8              ldmia sp,{r4,r11,sp,pc}
0x8458        39050000              andeq r0,r0,r9, lsr r5
```

Nothing executes `0x8458`; the `ldr r3,[0x8458]` five rows above reads it. The
same shape is in the repo already, in `cortexm_poolentry_le32`, where a pool word
lists as `asrs r0,r0,#0x20` / `movs r0,#0x0`:

```
$ kuna disassemble decompiler/crates/kuna-analysis/tests/fixtures/cortexm_poolentry_le32 0x8000140 --addr
0x8000142     0148                  ldr r0,[0x8000148]
...
0x8000148     0010                  asrs r0,r0,#0x20
0x800014a     0020                  movs r0,#0x0
```

## The fix

- A word the **listed range's own instructions** read at a fixed address, and
  none of them branch to, lists as the constant it holds: `.word 0x00000539`.
  The evidence comes from the p-code of each row as it is decoded
  (`ConsoleProgram::add_fixed_refs_at`) — the constant addresses it reads, in the
  two shapes SLEIGH spells one in, and the ones its flow ops name.
- Keeping the evidence inside the range is what makes the rule predictable and
  gives it an escape hatch: `kuna disassemble ./1337ARM.bin 0x8458-0x845c`
  contains no such load, so it decodes exactly as before.
- Four refusals bound it: a writable section, an address a function symbol sits
  on, an unaligned or non-scalar width, and a width that does not tile whole
  decoded rows. The last is why no address in the listing can move — a fold only
  merges whole rows over the same bytes, so a wrong fold costs one row, never a
  re-aligned listing. A `notes` line (and stderr) says a fold happened.
- No option, no emitted C: this is the listing surface, and `kuna disassemble`
  cannot change a decompile.

## The tests

`tests/cli/function-disassembly-decodes-arm.json` (the promoted acceptance,
re-pointed at the in-repo `cortexm_poolentry_le32` — CI has no dataset) plus
three `disassemble_cli.rs` cases: the fold and its escape hatch, the JSON row,
and an x86-64 body that is byte-identical, plus the halfword-read refusal on
`poolref_arm_le32`. `litpool.rs` unit-tests each refusal and `engine.rs` the
p-code projection. Sweeping every fixture in `kuna-analysis/tests/fixtures`
old-vs-new, the only listings that change are ARM/Thumb and every changed row is
a pool word. On a 32,768-instruction range of the witness, 315 rows change, and
an independent A32 literal-load decoder (no kuna in the reference path) backs
all 315 and disagrees with none of their values. Cost: one extra decode per row —
+0.5 ms on a default 115-instruction listing (below the noise floor), +0.09 s
on that 32k range (1.408 s → 1.501 s, min of 9, load-dominated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
