### PR TITLE
[AUTOMATED] fix(worker): a builder budget cap is not a build failure either

### DIFF
--- a/tools/pipeline/worker.sh
+++ b/tools/pipeline/worker.sh
@@ -216,16 +216,32 @@ if [ $RC -ne 0 ]; then
   QUOTA="$("$KUNA_PY" - "$RESULT_JSON" <<'QEOF' 2>/dev/null
 import json, re, sys
 try:
-    r = str(json.load(open(sys.argv[1])).get("result") or "")
+    d = json.load(open(sys.argv[1]))
 except Exception:
-    r = ""
-pat = r"(session|usage|rate)\s+limit|limit\s+(reached|exceeded)"
-print(r.strip() if re.search(pat, r, re.I) else "")
+    d = {}
+# Two DIFFERENT stops, and only one of them says anything in `result`.
+#
+#   account/session limit  ->  subtype "success", is_error true, and the reason ONLY in
+#                              `result` ("You've hit your session limit ...").
+#   --max-budget-usd cap   ->  subtype "error_max_budget_usd" and `result` is NULL.
+#
+# Reading `result` alone therefore classified a budget cap as a generic `claude rc=N`,
+# and round 4's captain had to diagnose "the budget-cap salvage case" by opening the
+# result JSON itself. Check `subtype` first: where it is informative it is exact, and
+# it is the only signal the budget case has.
+sub = str(d.get("subtype") or "")
+if sub.startswith("error_max_budget"):
+    print("builder budget cap ($%s over %s turns)"
+          % (d.get("total_cost_usd") or "?", d.get("num_turns") or "?"))
+else:
+    r = str(d.get("result") or "")
+    pat = r"(session|usage|rate)\s+limit|limit\s+(reached|exceeded)"
+    print(r.strip() if re.search(pat, r, re.I) else "")
 QEOF
 )"
   if [ -n "$QUOTA" ]; then
-    log "ACCOUNT LIMIT, not a build failure: $QUOTA"
-    NOTE="quota: $QUOTA (claude rc=$RC)"
+    log "STOPPED BY A CAP, not a build failure: $QUOTA"
+    NOTE="capped: $QUOTA (claude rc=$RC)"
   else
     NOTE="claude rc=$RC"
   fi


### PR DESCRIPTION
Found in production: round 4's `get-pc-helper-loses` builder stopped at 200 turns and
$25.07 -- `REPIPE_BUILDER_USD` exhausted -- and worker.sh recorded the generic
`claude rc=1`. The round-4 captain had to open the result JSON itself to work out it
was "the budget-cap salvage case", which is exactly the diagnosis the note should
have handed it.

The classifier added for account limits reads only `result`, and the two stops do not
look alike:

  account/session limit  subtype "success", is_error true, reason ONLY in `result`
                         ("You've hit your session limit ...")
  --max-budget-usd cap   subtype "error_max_budget_usd", and `result` is NULL

So the budget case had nothing for a `result`-only matcher to see. `subtype` is now
checked FIRST -- where it is informative it is exact, and it is the only signal the
budget case carries -- and the note becomes
`capped: builder budget cap ($25.07 over 200 turns) (claude rc=1)`.

The log line and note say "STOPPED BY A CAP" rather than "ACCOUNT LIMIT", since it now
covers both.

Verified against the three shapes, using round 4's REAL result JSON for the first:
budget cap -> priced message; session limit -> unchanged, still matches; a genuine
refusal ("I could not fix this; the tests fail") -> neither, falls through to the
generic note as it must.

Worth noting the pattern: this is the third metric this loop reported as something it
was not -- provider refusals counted as kuna failures (#419), un-refuted hypotheses
indistinguishable from undecided ones (#420), and now a budget cap indistinguishable
from a broken build. Each was invisible until a number was checked for another reason.

tools/repipe/smoke.sh 127/127.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcFmfZndNjgfqLQVBZCdkY