### PR TITLE
[AUTOMATED] fix(status): a dead worker printed 'running' — say DEAD

### DIFF
--- a/scripts/pipeline/status.py
+++ b/scripts/pipeline/status.py
@@ -111,6 +111,27 @@ def collect():
     for w in workers:
         w["elapsed_s"] = int(now - w.get("started_at", now))
         w["stale_s"] = int(now - w.get("updated_at", now))
+        # `stale_s` is time since the last `state update`, i.e. since the last PHASE CHANGE --
+        # not since the last sign of life. A worker that dies mid-phase therefore reads
+        # `running` with a growing counter, and reap() only corrects it after
+        # `stale_seconds` (1800) AND only when something calls it. Round 4's captain hit
+        # exactly this and had to fall back to `ps`: "checked with ps, not with status.py,
+        # whose stale_s only ticks on a phase change and still lists b-r4-function-disasse as
+        # running". One label was covering two very different states. A `kill(pid, 0)` is
+        # cheap and answers the question directly.
+        pid = w.get("pid")
+        if not isinstance(pid, int) or pid <= 0:
+            w["alive"] = None            # nothing recorded a pid; unknowable, not "dead"
+        else:
+            try:
+                os.kill(pid, 0)
+                w["alive"] = True
+            except ProcessLookupError:
+                w["alive"] = False
+            except PermissionError:
+                w["alive"] = True        # exists, owned by another uid
+            except OSError:
+                w["alive"] = None
     workers.sort(key=lambda w: w.get("started_at", 0))
     active = [w for w in workers if w.get("status") == "running"]
     return {

--- a/scripts/repipe/status.py
+++ b/scripts/repipe/status.py
@@ -124,9 +124,15 @@ def render(s):
                                                      "STALE", "SLUG / PR"))
         for w in shown:
             stale = int(w.get("stale_s") or 0)
+            # A row saying `running` whose pid is gone is the single most misleading thing
+            # this table can print, and it is what sent round 4's captain to `ps`. Say it.
+            alive = w.get("alive")
+            status_txt = str(w.get("status"))
+            if status_txt == "running" and alive is False:
+                status_txt = "DEAD"
             L.append("  %-18s %-9s %-8s %-8s %-7s %s"
                      % (str(w.get("worker"))[:18], str(w.get("phase"))[:9],
-                        str(w.get("status"))[:8], pstatus._fmt_elapsed(w.get("elapsed_s") or 0),
+                        status_txt[:8], pstatus._fmt_elapsed(w.get("elapsed_s") or 0),
                         ("%ds" % stale) if stale < 120 else ("%ds!" % stale),
                         w.get("pr_url") or w.get("slug") or "-"))
         if hidden:


### PR DESCRIPTION
Found by round 4's captain, which wrote in its own notes that it had checked the
builders with `ps`, "not with status.py, whose stale_s only ticks on a phase change
and still lists b-r4-function-disasse as running". It was right, and it had to work
around the tool this loop gives it for exactly this question.

`stale_s` is `now - updated_at`, and `updated_at` moves on a `state update`, i.e. on a
PHASE CHANGE -- not on any sign of life. Neither status module calls `os.kill`, so
nothing ever asks whether the pid exists. `reap()` does ask, but only past
`stale_seconds` (1800) and only when something calls it. So a worker that dies mid-phase
reads `running` with a growing counter for up to half an hour, and the operator cannot
tell it from one working hard on a long phase. One label, two very different states.

`collect()` now records `alive` from a `kill(pid, 0)`: True, False, or None when no pid
was recorded or the check itself failed -- unknowable is not the same as dead, and
PermissionError means the process exists under another uid. The repipe table prints
`DEAD` in the status column when a row claims `running` and the pid is gone.

Verified by planting a `running` worker with pid 999999 in the inventory: the row prints
DEAD, and the inventory was restored afterwards. `scripts.pipeline.status --json` still
works, so the angr lane is unaffected. tools/repipe/smoke.sh 127/127.

Fourth instance of one pattern this session, and the last three were found the same way
-- a number checked for an unrelated reason. Provider refusals counted as kuna failures
(#419); un-refuted hypotheses indistinguishable from undecided ones (#420); a builder
budget cap indistinguishable from a broken build (#436); now a dead worker
indistinguishable from a busy one. Each time, a status collapsed two causes into one
label, and nothing failed loudly.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcFmfZndNjgfqLQVBZCdkY