### PR TITLE
[AUTOMATED] fix(captain): --status never carried the notes, so ticks could not read each other

### DIFF
--- a/docs/re-needs/function-disassembly-decodes-arm.md
+++ b/docs/re-needs/function-disassembly-decodes-arm.md
@@ -17,9 +17,9 @@ covered_by_option: null
 touches: [decompiler/crates/kuna-cli/src/litpool.rs, decompiler/crates/kuna-cli/src/disassemble.rs, decompiler/crates/kuna-console/src/engine.rs]
 scope: small
 regression_of: null
-pr: null
+pr: 435
 closed_in_round: 4
-closing_pr: null
+closing_pr: 435
 reject_reason: null
 ---
 

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -4,8 +4,8 @@
   "count": 51,
   "rejected_count": 0,
   "by_status": {
-    "closed": 39,
-    "open": 12
+    "closed": 40,
+    "open": 11
   },
   "by_track": {
     "perf": 2,
@@ -708,7 +708,7 @@
       "need_id": "text-output-silently-ignores",
       "title": "Text output silently ignores a prototype override that JSON output applies",
       "track": "tooling",
-      "status": "open",
+      "status": "closed",
       "severity": "major",
       "probe_id": "p-8cb750f382af",
       "acceptance_id": "a-5a9ec955c9a0",
@@ -731,8 +731,8 @@
       "scope": "small",
       "regression_of": null,
       "pr": null,
-      "closed_in_round": null,
-      "closing_pr": null,
+      "closed_in_round": 4,
+      "closing_pr": "433",
       "reject_reason": null,
       "score": 13.862944,
       "path": "docs/re-needs/text-output-silently-ignores.md"

--- a/docs/re-needs/text-output-silently-ignores.md
+++ b/docs/re-needs/text-output-silently-ignores.md
@@ -2,7 +2,7 @@
 need_id: text-output-silently-ignores
 title: Text output silently ignores a prototype override that JSON output applies
 track: tooling
-status: open
+status: closed
 severity: major
 probe_id: p-8cb750f382af
 acceptance_id: a-5a9ec955c9a0
@@ -18,8 +18,8 @@ touches: [decompiler/crates/kuna-cli/src/assertdecl.rs, decompiler/crates/kuna-c
 scope: small
 regression_of: null
 pr: null
-closed_in_round: null
-closing_pr: null
+closed_in_round: 4
+closing_pr: "433"
 reject_reason: null
 ---
 
@@ -141,3 +141,4 @@ captain T_TRIAGE r3: track tooling CONFIRMED and touches narrowed. The defect is
 captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.
 - round 3 REFUTER: hypothesis **upheld** (was inconclusive). Refuted by measurement (captain, B_DRAIN observe tick, release kuna @20:01 on cf5234ac+, probebin/971dbc9fc68f8c2a/frz_crackme_rage_v7.exe). SYMPTOM STANDS AND THE HYPOTHESIS IS RIGHT, BUT THE SEAM IS NAMED WRONG -- it is not two paths disagreeing about a name, it is ONE path throwing the name away. Measured 4 ways: (a) text + decl name 'sha256' -> 'void sub_1400055e0(unsigned int *a0,unsigned long long *a1)', override dropped, exit 0, nothing on stderr even with --assert-strict; (b) --json, same directive -> 'void * sub_1400055e0(void *out,void *input)', applied; (c) TEXT WITH THE SAME NAME IN THE DECL ('prototype sub_1400055e0 void * sub_1400055e0(void *out, void *input)') APPLIES CORRECTLY -- so the discriminator is the decl name, not the output format; (d) --json with <func> naming another or a bogus function ('prototype main ...', 'prototype no_such_fn ...') does NOT touch the selected function, so JSON honours <func>. MECHANISM: assertdecl.rs:343 lowers Body::Prototype { func: _, decl } -- the <func> target is DISCARDED -- to 'parse line extern <decl>;', which binds the prototype to a symbol named by the DECLARATION. Same name => it lands on the selected function; a renaming decl => it lands on a fresh unrelated symbol and the selected function is untouched. The JSON surface is a SECOND IMPLEMENTATION, not a second dialect as decompile.rs:14 claims: --json routes through run_json -> in-process decompile_all (decompile.rs:1152/1241), while text drives decomp_dbg as a subprocess over the console script. FIX DIRECTION: make the text lowering honour <func> (bind the parsed prototype to the target function, renaming it when the decl name differs). Making JSON match text would be the wrong direction. SECOND DEFECT FOUND, DO NOT TREAT --assert-strict AS A GUARD HERE: the outcome is recovered from the console transcript (assertion_outcomes), so a directive that changed nothing still reports status 'applied' -- including 'prototype no_such_fn ...' under --json. The acceptance probe's stderr_absent 'rejected' clause therefore proves nothing on its own; the load-bearing clauses are stdout_absent/stdout_matches.
 captain B_DRAIN r3: touches CORRECTED after the refutation -- the seam is assertdecl.rs:343 (the prototype lowering that discards <func>), not output.rs, which the refuter measured is not involved. assertdecl.rs is also being edited RIGHT NOW by b-r3-prototype-assert (feat/re-prototype-assertions-reject-ordinary, --assert scalar types); this need must not be dispatched until that lands, and select.py's file-lease disjointness now sees the overlap.
+- closed: acceptance a-5a9ec955c9a0 now PASSES at f34cb8798b05

--- a/scripts/repipe/captain.py
+++ b/scripts/repipe/captain.py
@@ -369,6 +369,8 @@ def main(argv=None):
     ap.add_argument("--round", type=int, default=None)
     ap.add_argument("--transition", nargs=2, metavar=("MACHINE", "TO"))
     ap.add_argument("--note", default=None)
+    ap.add_argument("--notes", type=int, default=6,
+                    help="how many of the round's most recent notes --status carries (0 = none)")
     ap.add_argument("--json", action="store_true")
     args = ap.parse_args(argv)
 
@@ -402,10 +404,36 @@ def main(argv=None):
 
     if args.status or not args.tick:
         doc = load_round(args.round if args.round is not None else current_round())
+        # The prompt says "record every non-obvious decision in the round doc's `notes`; the
+        # next tick is a different session with none of your context" -- and then nothing put
+        # those notes in front of the next tick. Neither this payload nor
+        # `scripts.repipe.status --json` carried them, so a note was only ever read by a tick
+        # that happened to open rounds/N/round.json by hand. Some did; most did not, and an
+        # operator note sat unread through ~110 ticks of round 4. Notes ARE the continuity
+        # mechanism of this design, so `--status`, the first thing the prompt tells a tick to
+        # read, has to carry them.
+        #
+        # Most recent last, because that is reading order, and tail-truncated per note: a
+        # tick's own write-up runs to paragraphs, and a payload nobody finishes reading is the
+        # same failure again in a different costume. `--notes N` widens it when a tick needs
+        # the older history.
+        notes = []
+        # `[-0:]` is the WHOLE list, not an empty one, so --notes 0 has to be handled before
+        # the slice or it does the opposite of what it says.
+        recent = (doc.get("notes") or [])[-args.notes:] if args.notes > 0 else []
+        for entry in recent:
+            if isinstance(entry, dict):
+                text, by, ts = entry.get("note") or "", entry.get("by"), entry.get("ts")
+            else:
+                text, by, ts = str(entry), None, None
+            text = " ".join(str(text).split())
+            notes.append({"by": by, "ts": ts,
+                          "note": text if len(text) <= 700 else text[:700] + " ...[truncated]"})
         out = {"round": doc["round"], "states": {k: doc[k] for k in MACHINES},
                "free_gb": free_gb(), "split": config.agent_split(),
                "stop": stop_requested(), "pause": paused(), "abort": abort_requested(),
-               "live": {"tester": live_agents("tester"), "builder": live_agents("builder")}}
+               "live": {"tester": live_agents("tester"), "builder": live_agents("builder")},
+               "notes_total": len(doc.get("notes") or []), "notes": notes}
         print(json.dumps(out, indent=2))
         return 0
 

--- a/tools/repipe/captain_prompt.md
+++ b/tools/repipe/captain_prompt.md
@@ -121,7 +121,9 @@ acceptance flips back to FAIL becomes `regressed` and outranks everything.
   after a rollback — move the supervisor to `HALTED` with a reason and stop. Halting loudly
   beats limping.
 - Record every non-obvious decision in the round doc's `notes`. The next tick is a different
-  session with none of your context.
+  session with none of your context — **and `--status` hands you the last few notes, so this
+  is how you talk to it.** Read them before you decide anything; an operator can leave one
+  there too. Widen the window with `--notes N` when you need older history.
 
 ## Finish
 


### PR DESCRIPTION
The captain prompt says: "Record every non-obvious decision in the round doc's
`notes`. The next tick is a different session with none of your context." Notes are
therefore the entire cross-tick continuity mechanism of this design.

Nothing put them in front of the next tick. Neither `captain --status` nor
`scripts.repipe.status --json` carried `notes`, so a note was read only by a tick that
happened to open `.kuna-repipe/rounds/N/round.json` by hand. Some did -- round 3's
carryover note reached round 4 that way and prevented three builders being dispatched
onto already-merged work. Most did not: an operator note asking round 4 to decide about
its idle test track sat unread through roughly 110 ticks while the captain wrote 15
notes of its own into the same file.

`--status` -- the first thing the prompt tells a tick to read -- now carries the most
recent notes, oldest first, each collapsed to one line and tail-truncated at 700 chars,
with `notes_total` alongside so a tick knows how much it is not seeing. `--notes N`
widens the window; `--notes 0` suppresses it. Truncation is deliberate: a tick's own
write-up runs to paragraphs, and a payload nobody finishes reading would be this same
failure in a different costume.

The prompt now says plainly that `--status` hands you the last few notes and that this
is how ticks talk to each other, including to an operator.

Caught while testing: `--notes 0` returned all 23 notes, because `[-0:]` is the whole
list rather than an empty one. Handled before the slice.

Fifth instance of one pattern this session, and the costliest, because it degrades the
captain's judgment rather than a metric: a decision recorded but never delivered is
indistinguishable from one never made.

tools/repipe/smoke.sh 127/127.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcFmfZndNjgfqLQVBZCdkY