### PR TITLE
[AUTOMATED] fix(cli): xrefs --to <import name> answers instead of refusing it as ambiguous

### DIFF
--- a/decompiler/crates/kuna-cli/src/xrefs.rs
+++ b/decompiler/crates/kuna-cli/src/xrefs.rs
@@ -85,6 +85,69 @@ struct TargetSpec {
     fallback: Option<String>,
 }
 
+/// What the operand resolved to before the walk ran.
+///
+/// A name several entries carry is deliberately NOT decided here. Which
+/// addresses are one callable is a property of the decoded forwarding jumps, and
+/// those are only known once the walk has run — so the candidates ride into the
+/// walk as its focus and the ambiguity is settled against the alias class
+/// afterwards ([`Resolution::settle`]).
+enum Resolution {
+    Settled(TargetSpec),
+    Contested {
+        name: String,
+        candidates: Vec<u64>,
+        error: String,
+    },
+}
+
+impl Resolution {
+    /// The addresses the walk must decode: the settled one, or every candidate a
+    /// contested name carries — an alias class cannot be read off a veneer the
+    /// walk never decoded.
+    fn focus(&self) -> Vec<u64> {
+        match self {
+            Resolution::Settled(spec) => vec![spec.addr],
+            Resolution::Contested { candidates, .. } => candidates.clone(),
+        }
+    }
+
+    /// Decide a contested name against the walk's alias classes.
+    ///
+    /// Candidates that all sit in one class are one callable under several
+    /// addresses — the import shape `--to` already answers identically at either
+    /// end — so the name is not ambiguous in any sense the caller can act on, and
+    /// the query proceeds at the class's code half. Candidates that do not all
+    /// share a class are genuinely distinct functions and keep the error.
+    fn settle(self, index: &XrefIndex) -> Result<TargetSpec, String> {
+        match self {
+            Resolution::Settled(spec) => Ok(spec),
+            Resolution::Contested { name, candidates, error } => {
+                let class =
+                    candidates.first().map_or_else(Default::default, |&c| index.alias_class(c));
+                if !candidates.iter().all(|c| class.contains(c)) {
+                    return Err(error);
+                }
+                Ok(TargetSpec {
+                    addr: canonical_member(index, &candidates),
+                    name: Some(name),
+                    fallback: None,
+                })
+            }
+        }
+    }
+}
+
+/// The address a folded alias class answers at: the forwarding veneer, which is
+/// the code an agent goes on to disassemble, rather than the pointer slot it
+/// jumps through. Lowest address otherwise, so several veneers through one slot
+/// still pick deterministically.
+fn canonical_member(index: &XrefIndex, candidates: &[u64]) -> u64 {
+    let mut sorted = candidates.to_vec();
+    sorted.sort_unstable();
+    sorted.iter().copied().find(|c| index.veneer_slot(*c).is_some()).unwrap_or(sorted[0])
+}
+
 /// `kuna xrefs` entry point.
 pub fn run(argv: &[String]) -> i32 {
     let args = match parse_args(argv) {
@@ -152,17 +215,19 @@ fn query(args: &XrefArgs) -> Result<String, String> {
     // The operand resolves to an address BEFORE the walk so the walk can be
     // pointed at it: a function whose only inbound edge is an indirect call
     // through a table is in no seed set, and a query about it must not answer
-    // "no references" about the very address the caller named.
-    let spec = target_address(&prog, &args.spec)?;
+    // "no references" about the very address the caller named. A name several
+    // entries carry points the walk at all of them and is settled afterwards,
+    // because whether they are one callable is the walk's own finding.
+    let resolution = target_address(&prog, &args.spec)?;
     let index = kuna_analysis::listing::xrefs::build_with_focus(
         &file,
         prog.arch(),
         prog.arch().translate(),
         &seeds,
-        &[spec.addr],
+        &resolution.focus(),
     );
 
-    let target = resolve_target(&prog, &index, spec);
+    let target = resolve_target(&prog, &index, resolution.settle(&index)?);
     let rows = match args.direction {
         // `--to` answers for the callable, not the literal address: an import
         // reached through a veneer and an IAT/GOT slot is one thing under two
@@ -198,43 +263,53 @@ fn query(args: &XrefArgs) -> Result<String, String> {
 /// that as `0xabc` would answer a question nobody asked — and only falls back to
 /// a bare-hex reading when no symbol carries the name.
 ///
-/// A name that identifies several entries is an ERROR naming all of them, not a
-/// miss: falling through to the symbol table would answer for whichever one it
-/// happens to hold first, which is the guess the selector model exists to refuse.
-fn target_address(prog: &ConsoleProgram, spec: &str) -> Result<TargetSpec, String> {
+/// A name that identifies several entries never falls through to the symbol
+/// table: that would answer for whichever one it happens to hold first, which is
+/// the guess the selector model exists to refuse. It is carried out as
+/// [`Resolution::Contested`] instead, because an import is routinely two entries
+/// under one name and refusing it would be a refusal to answer a question that
+/// has exactly one answer.
+fn target_address(prog: &ConsoleProgram, spec: &str) -> Result<Resolution, String> {
     let spec = spec.trim();
     if let Some(body) = spec.strip_prefix("0x").or_else(|| spec.strip_prefix("0X")) {
         let addr = u64::from_str_radix(body, 16)
             .map_err(|_| format!("invalid address {spec:?}"))?;
-        return Ok(TargetSpec { addr, name: None, fallback: None });
+        return Ok(Resolution::Settled(TargetSpec { addr, name: None, fallback: None }));
     }
     match prog.resolve_entry(&EntrySelector::Name(spec.to_string())) {
         Ok(entry) => {
-            return Ok(TargetSpec {
+            return Ok(Resolution::Settled(TargetSpec {
                 addr: entry.addr.get_offset(),
                 name: Some(entry.name),
                 fallback: None,
-            })
+            }))
         }
-        Err(error @ EntryLookupError::Ambiguous { .. }) => return Err(error.to_string()),
-        Err(_) => {}
+        Err(error) => {
+            if let EntryLookupError::Ambiguous { candidates, .. } = &error {
+                return Ok(Resolution::Contested {
+                    name: spec.to_string(),
+                    candidates: candidates.iter().map(|c| c.addr.get_offset()).collect(),
+                    error: error.to_string(),
+                });
+            }
+        }
     }
     if let Some(addr) = prog.lookup_symbol(spec) {
-        return Ok(TargetSpec {
+        return Ok(Resolution::Settled(TargetSpec {
             addr: addr.get_offset(),
             name: None,
             fallback: Some(spec.to_string()),
-        });
+        }));
     }
     if let Some((name, addr, _)) = prog
         .global_data_symbols()
         .into_iter()
         .find(|(name, _, _)| name == spec)
     {
-        return Ok(TargetSpec { addr, name: Some(name), fallback: None });
+        return Ok(Resolution::Settled(TargetSpec { addr, name: Some(name), fallback: None }));
     }
     if let Ok(addr) = u64::from_str_radix(spec, 16) {
-        return Ok(TargetSpec { addr, name: None, fallback: None });
+        return Ok(Resolution::Settled(TargetSpec { addr, name: None, fallback: None }));
     }
     Err(format!("no symbol named {spec:?} (and it is not an address)"))
 }

--- a/decompiler/crates/kuna-cli/tests/xrefs_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/xrefs_cli.rs
@@ -315,6 +315,57 @@ fn a_slot_reached_only_through_its_veneer_still_finds_its_callers() {
     assert!(doc.contains("\"name\": \"main\""), "call site unattributed:\n{doc}");
 }
 
+/// The `name-based-xrefs-rejects` need: asking for the import by NAME must answer
+/// the same as asking for either of its addresses.
+///
+/// Both addresses carry the name, so the selector model called `VirtualProtect`
+/// ambiguous and exited 1 — refusing a question that has exactly one answer,
+/// while `--to 0x1400079b0` and `--to 0x14000d234` both answered it. The two
+/// candidates are one alias class, so the name settles on the class's code half,
+/// the veneer, and the slot is disclosed as its alias.
+#[test]
+fn an_import_named_by_its_veneer_and_its_slot_resolves_by_name() {
+    let Some(by_name) = xrefs(&[&pe_imports(), "--to", "VirtualProtect", "--json"]) else {
+        return;
+    };
+    let by_veneer = xrefs(&[&pe_imports(), "--to", "0x1400079b0", "--json"]).expect("the veneer");
+
+    assert_eq!(json_str(&by_name, "address_hex").as_deref(), Some("0x1400079b0"), "{by_name}");
+    assert!(by_name.contains("\"0x14000d234\""), "the slot is not disclosed:\n{by_name}");
+    // Not merely the same count: the same rows, byte for byte.
+    let answer = |doc: &str| doc[doc.find("\"xrefs\"").expect("an xrefs array")..].to_string();
+    assert_eq!(answer(&by_name), answer(&by_veneer), "the name and its veneer disagree");
+}
+
+/// The mirror: `puts` is reached through its veneer rather than its slot, so the
+/// fold must not depend on which half the call sites happen to reference.
+#[test]
+fn a_name_folds_whichever_half_of_the_import_is_called() {
+    let Some(doc) = xrefs(&[&pe_imports(), "--to", "puts", "--json"]) else {
+        return;
+    };
+    assert_eq!(json_str(&doc, "address_hex").as_deref(), Some("0x140007240"), "{doc}");
+    assert_eq!(json_int(&doc, "count"), Some(1), "{doc}");
+    assert!(doc.contains("\"from_address_hex\": \"0x1400015a5\""), "not main's call:\n{doc}");
+}
+
+/// The fold is the alias class and nothing looser. Two static `duplicate_local`
+/// definitions in one relocatable object share a name and no forwarding jump, so
+/// the query still refuses them and still names both — picking one would be the
+/// guess the selector model exists to refuse.
+#[test]
+fn two_genuinely_distinct_functions_of_one_name_are_still_refused() {
+    let object = fixture("entry_selectors_x86_64.o");
+    let (_, stderr, code) = run_kuna(&["xrefs", &object, "--to", "duplicate_local"]);
+    if is_specs_skip(&stderr) {
+        return;
+    }
+    assert_eq!(code, 1, "{stderr}");
+    assert!(stderr.contains("ambiguous"), "{stderr}");
+    assert!(stderr.contains(".text.selector_a+0x0"), "{stderr}");
+    assert!(stderr.contains(".text.selector_b+0x0"), "{stderr}");
+}
+
 /// The alias class is built from the decoded forwarding jump, never from a shared
 /// name: an ordinary function keeps an empty `aliases` list and its own answer.
 #[test]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -683,9 +683,11 @@ is always resolved as a symbol first, so a function really called `abc` is not
 silently read as `0xabc`. Function names, the `s_<addr>` string symbols the
 `strings` pass installs, and named data globals all resolve — which is what makes
 the string-to-its-users hop work: `kuna xrefs ./a.out --to s_400915`. A function
-name that identifies several entries — two same-named locals in a relocatable
-object — is reported as ambiguous with every candidate, never answered for
-whichever one the symbol table holds first.
+name that identifies several *distinct* entries — two same-named locals in a
+relocatable object — is reported as ambiguous with every candidate, never answered
+for whichever one the symbol table holds first. A name that identifies several
+addresses of the **same** callable is not ambiguous in any sense the caller can
+act on and is answered; see below.
 
 | `kind` | What it is |
 |---|---|
@@ -714,6 +716,15 @@ it. `target.aliases` lists the other members (empty for everything that is not a
 import, which is nearly everything), and every row still carries the real
 `to_address` it landed on, so an agent can see whether a call site went through
 the veneer or straight through the slot.
+
+Because the name is on both addresses, `--to VirtualProtect` is a selector that
+matches two entries. It is still answered: the candidates are settled against the
+alias class the walk found, and candidates that are all one class are one callable,
+so the query proceeds at the class's code half — the veneer, which is the address
+an agent goes on to `kuna decompile`. Candidates that are *not* one class are
+genuinely different functions and keep the ambiguity error with every candidate
+listed. So the fold never rests on the name: it rests on the decoded forwarding
+jump, and the name only has to point the walk at the addresses to check.
 
 ```
 # 2 references to VirtualProtect @ 0x1400079b0

--- a/docs/features/name-based-xrefs-rejects/pr_body.md
+++ b/docs/features/name-based-xrefs-rejects/pr_body.md
@@ -1,0 +1,57 @@
+## The problem
+
+`kuna xrefs --to <name>` refuses to answer for an import, because an import's
+name is on two addresses and the selector model calls that ambiguous — while
+either of the two addresses answers the question fine.
+
+```console
+$ kuna xrefs decompiler/crates/kuna-analysis/tests/fixtures/pe_imports.exe --to VirtualProtect --json
+error: selector "VirtualProtect" is ambiguous; candidates:
+  VirtualProtect at synthetic 0x1400079b0
+  VirtualProtect at synthetic 0x14000d234
+use a section-qualified selector to choose one candidate
+$ echo $?
+1
+
+$ kuna xrefs decompiler/crates/kuna-analysis/tests/fixtures/pe_imports.exe --to 0x1400079b0
+# 2 references to VirtualProtect @ 0x1400079b0
+# same import at 0x14000d234 (VirtualProtect) - a forwarding veneer and the pointer slot it jumps through
+0x140001a9e	read	__write_memory.part.0+0x18e	CALL qword ptr [0x14000d234]
+0x140001cce	read	_pei386_runtime_relocator+0x19e	MOV R12,qword ptr [0x14000d234]
+```
+
+The two candidates are one callable: a `.text` `FF 25` veneer and the `.rdata`
+IAT slot it jumps through. `--to` has answered over that alias class since
+`xrefs-unify-pe-import`, so both addresses already return the same rows — the
+name was the only spelling that could not reach them.
+
+## The fix
+
+- A contested name is no longer decided at lookup time. Which addresses are one
+  callable is a property of the decoded forwarding jumps, and those only exist
+  once the walk has run, so the candidates are carried into the walk as its focus
+  set and the ambiguity is settled afterwards against the alias class.
+- Candidates that all lie in one class are one callable; the query proceeds at
+  the class's code half — the veneer, which is the address the answer is next
+  disassembled at — with the lowest address breaking a tie between several
+  veneers through one slot.
+- Candidates that do not all share a class are distinct functions and keep the
+  refusal, with every candidate still named. The fold rests on the decoded jump,
+  never on the shared name, so two static `duplicate_local`s are never merged.
+- No option: a read-only query surface commits nothing into the engine and
+  cannot change emitted C.
+
+## The tests
+
+Three cases in `kuna-cli/tests/xrefs_cli.rs`: the import resolved by name answers
+byte-for-byte what its veneer address answers; `puts`, reached through the veneer
+rather than the slot, folds the same way; and `duplicate_local` in a relocatable
+object is still refused with both candidates. The first two fail without the fix
+(exit 1, "is ambiguous"). The acceptance probe is promoted to
+`tests/cli/name-based-xrefs-rejects.json`.
+
+A sweep over every duplicate-name entry in every binary fixture — 148 names in 14
+images — folded 129 and refused 18, with every fold answering identically to each
+of its own candidate addresses and every refusal naming all of them.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/name-based-xrefs-rejects/record.json
+++ b/docs/features/name-based-xrefs-rejects/record.json
@@ -1,0 +1,65 @@
+{
+  "slug": "name-based-xrefs-rejects",
+  "need_id": "name-based-xrefs-rejects",
+  "track": "tooling",
+  "scope": "small",
+  "round": 4,
+  "branch": "feat/re-name-based-xrefs-rejects",
+  "summary": "`kuna xrefs --to <name>` answers for an import instead of refusing it. A name that matches several entries is no longer decided at lookup time: the candidates are carried into the reference walk as its focus set and settled against the alias class the walk found, so candidates that are one callable under several addresses (a forwarding veneer and the IAT/GOT slot it jumps through) resolve to the class's code half, and candidates that are genuinely distinct functions keep the ambiguity refusal with every candidate named.",
+  "decisions": [
+    {
+      "what": "hypothesis UPHELD, and the ordering it names is the whole fix",
+      "detail": "The filed hypothesis -- 'ambiguity checking precedes import-thunk alias resolution' -- is exactly right, and it is not merely an ordering accident: the alias relation is derived from decoded `jmp [slot]` instructions, which do not exist until `build_with_focus` has run, and the walk is built AFTER target resolution because it needs the target address to focus on. So the check could not have consulted the alias class where it stood. The fix is to stop deciding at lookup time and carry the candidates forward, not to move a check earlier."
+    },
+    {
+      "what": "the fold is settled against the DECODED forwarding jump, never against the shared name",
+      "detail": "`XrefIndex::alias_class` is the connected component of the veneer/slot forwarding relation and is explicitly documented as never derived from a shared symbol name. `Resolution::settle` folds only when EVERY candidate lies in one class, so the fold inherits that guarantee: two static `duplicate_local`s in a relocatable object, twelve duplicated glibc statics in `mcount_x86_64`, and a C++ overload set all still refuse. The name's only job is to point the walk at the addresses to check."
+    },
+    {
+      "what": "the folded name answers at the VENEER, not the slot",
+      "detail": "Both members answer identically for `--to`, so the choice is about what the caller does next: the veneer is the code an agent goes on to `kuna decompile` or disassemble, the slot is a pointer word. It also makes `--from <name>` meaningful (the veneer's forwarding jump) instead of empty (a data address references nothing). Ties -- several veneers through one slot -- break on the lowest address, so the pick is deterministic. `target.aliases` and the text surface's `# same import at ...` line already disclose the other member, so nothing is hidden by the choice."
+    },
+    {
+      "what": "no option, no stages XML, no catalog counter, no DIV row",
+      "detail": "The diff is one file of `kuna-cli` plus its tests and docs. `kuna xrefs` is a read-only query: it commits nothing into the engine, runs no pass that would not otherwise run, and emits no C. The three parity gates are byte-identical, which is the evidence."
+    }
+  ],
+  "inertness": {
+    "method": "the only source file changed is decompiler/crates/kuna-cli/src/xrefs.rs; no engine, analysis or console source is touched, so emitted C cannot move",
+    "note": "make test 675/675 PARITY OK and make test-stages 635/635 PARITY OK confirm it"
+  },
+  "sweep": {
+    "question": "does the fold ever merge two entries that are NOT one callable -- and does it ever refuse one that is?",
+    "method": "every duplicate-name entry in every binary fixture under kuna-analysis/tests/fixtures and tests/hang-repro (names `kuna functions --json` reports at two or more distinct addresses), queried by NAME, then cross-checked against each candidate ADDRESS. A fold is legitimate only if the name's `xrefs` array is byte-identical to every one of its candidates' -- i.e. the fold answered a question all its candidates already agreed on. A refusal must still name every candidate.",
+    "result": "148 duplicate names across 14 images: 129 folded, 18 refused, 0 mismatches. Every fold matched every one of its own candidates byte for byte; every refusal listed all its candidates. The folds are entirely PE imports (pe_imports 46, pe_imports_stripped 46, pe_dwarf 33, crtmain 3, pe_noreturn_import 1). The refusals are entirely genuine collisions: 12 duplicated glibc statics in the statically-linked mcount_x86_64 (free_mem has EIGHT distinct definitions), the two entry_selectors_x86_64.o duplicate_locals, a C++ overload set (cppproto maxof), and Mach-O printf on 5 images. The one error is pre-existing and unrelated: macho_fat is a fat Mach-O that `kuna xrefs` cannot parse at any selector, address included."
+  },
+  "gates": {
+    "make test": "PARITY OK, 675/675 assertions",
+    "make test-stages": "PARITY OK, 635/635 assertions",
+    "make rust-test": "green on the rebased tree \u2014 5,684 passed / 0 failed / 38 ignored, exit 0, run with KUNA_DECOMP_TEST unset. With the repipe loop's KUNA_DECOMP_TEST exported, `verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip` reports an 'oracle drifted' failure -- the known harness artifact, since that variable points the oracle at a Rust decomp_test_dbg. The diff touches no kuna-decomp source.",
+    "make check-spec": "OK (lenient mode)",
+    "make test-cli": "40/40",
+    "kuna catalog --check": "catalog OK",
+    "cargo test -p kuna-cli --test xrefs_cli": "19/19",
+    "cargo test -p kuna-cli": "489/489 (whole crate, after the final refactor)"
+  },
+  "acceptance": {
+    "acceptance_id": "a-6576d0dff8a6",
+    "result": "PASS",
+    "transition": "closed",
+    "promoted_to": "tests/cli/name-based-xrefs-rejects.json",
+    "promotion_note": "verify --promote refused (target.binary_source is 'dataset'; CI has no dataset, and --force does not override that arm). Re-pointed by hand at pe_imports.exe, the vendored MinGW twin the sibling xrefs-unify-pe-import probe already uses -- same shape, an import named by both a .text FF25 veneer (0x1400079b0) and an .rdata IAT slot (0x14000d234). Strengthened past the recorded count>0: target.address_hex must be the veneer and the rows must be the two real uses, so a fold that picked the slot, lost the alias disclosure, or answered with the wrong rows still fails.",
+    "reproduction_confirmed_on_main": "on 49678d6a, `kuna xrefs pe_imports.exe --to VirtualProtect --json` exits 1 with `selector \"VirtualProtect\" is ambiguous`; the dataset crackme reproduces identically on memcmp (0x140007a1b / 0x140009280)"
+  },
+  "not_closed": [
+    "A Mach-O `__stubs` entry and its `__got`/lazy-pointer slot are NOT recognized as one alias class, so `printf` on the five Mach-O fixtures still refuses. This is pre-existing and lives in `veneer_at`, not in name resolution: `--to 0x100003000` on macho_imports already answers `count: 0` with `aliases: []` today, exactly as it did before. Extending veneer recognition to the Mach-O stub shape would close it for both spellings at once.",
+    "The other name-taking surfaces are untouched. `kuna decompile <bin> VirtualProtect` and `kuna decompile-all --functions VirtualProtect` still refuse an import by name, and their refusal is arguably right -- they decompile a body, and an IAT slot has none -- but nothing yet tells a caller which of the two candidates has one.",
+    "The fold is silent on the human surface beyond the existing `# same import at ...` line: a caller who typed a name and expected a refusal is not told that a fold happened, only which addresses were involved."
+  ],
+  "rebase": {
+    "base": "49678d6af166dbb708fa448436ae2962569959bc",
+    "onto": "798f01e56c7fa454856ff9acba482ba6179c8fb8",
+    "note": "origin/main moved by one repipe-docs commit (#439); counters re-derived from a fresh capture on the rebased tree with no drift, mergecheck clean (0 rejects), and every gate re-run after the rebase"
+  },
+  "pr": "https://github.com/Noelo-Lab/kuna/pull/441"
+}

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -1250,39 +1250,6 @@
       "path": "docs/re-needs/getprocaddress-result-discarded.md"
     },
     {
-      "need_id": "name-based-xrefs-rejects",
-      "title": "Name-based xrefs rejects memcmp although its candidates are aliases",
-      "track": "tooling",
-      "status": "open",
-      "severity": "minor",
-      "probe_id": "p-264f6f6dbdd7",
-      "acceptance_id": "a-6576d0dff8a6",
-      "hypothesis_status": "inconclusive",
-      "credibility": 0.7,
-      "instances": 1,
-      "challenges": [
-        "68d9ee36224c0ec5dcedc3fc"
-      ],
-      "rounds": [
-        3
-      ],
-      "first_seen_round": 3,
-      "attempts": 0,
-      "covered_by_option": null,
-      "touches": [
-        "decompiler/crates/kuna-cli/src/xrefs.rs",
-        "decompiler/crates/kuna-analysis/src/listing/xrefs.rs"
-      ],
-      "scope": "small",
-      "regression_of": null,
-      "pr": null,
-      "closed_in_round": null,
-      "closing_pr": null,
-      "reject_reason": null,
-      "score": 6.931472,
-      "path": "docs/re-needs/name-based-xrefs-rejects.md"
-    },
-    {
       "need_id": "runtime-decrypted-code-opaque",
       "title": "code decrypted at runtime stays an opaque indirect call",
       "track": "quality",
@@ -1376,12 +1343,45 @@
       ],
       "scope": "small",
       "regression_of": null,
-      "pr": null,
+      "pr": 435,
       "closed_in_round": 4,
-      "closing_pr": null,
+      "closing_pr": 435,
       "reject_reason": null,
       "score": 4.620981,
       "path": "docs/re-needs/function-disassembly-decodes-arm.md"
+    },
+    {
+      "need_id": "name-based-xrefs-rejects",
+      "title": "Name-based xrefs rejects memcmp although its candidates are aliases",
+      "track": "tooling",
+      "status": "open",
+      "severity": "minor",
+      "probe_id": "p-264f6f6dbdd7",
+      "acceptance_id": "a-6576d0dff8a6",
+      "hypothesis_status": "upheld",
+      "credibility": 0.7,
+      "instances": 1,
+      "challenges": [
+        "68d9ee36224c0ec5dcedc3fc"
+      ],
+      "rounds": [
+        3
+      ],
+      "first_seen_round": 3,
+      "attempts": 1,
+      "covered_by_option": null,
+      "touches": [
+        "decompiler/crates/kuna-cli/src/xrefs.rs",
+        "decompiler/crates/kuna-analysis/src/listing/xrefs.rs"
+      ],
+      "scope": "small",
+      "regression_of": null,
+      "pr": "441",
+      "closed_in_round": null,
+      "closing_pr": null,
+      "reject_reason": null,
+      "score": 4.620981,
+      "path": "docs/re-needs/name-based-xrefs-rejects.md"
     },
     {
       "need_id": "stack-string-invalid-cast",

--- a/docs/re-needs/name-based-xrefs-rejects.md
+++ b/docs/re-needs/name-based-xrefs-rejects.md
@@ -6,18 +6,18 @@ status: open
 severity: minor
 probe_id: p-264f6f6dbdd7
 acceptance_id: a-6576d0dff8a6
-hypothesis_status: inconclusive
+hypothesis_status: upheld
 credibility: 0.7
 instances: 1
 challenges: [68d9ee36224c0ec5dcedc3fc]
 rounds: [3]
 first_seen_round: 3
-attempts: 0
+attempts: 1
 covered_by_option: null
 touches: [decompiler/crates/kuna-cli/src/xrefs.rs, decompiler/crates/kuna-analysis/src/listing/xrefs.rs]
 scope: small
 regression_of: null
-pr: null
+pr: "441"
 closed_in_round: null
 closing_pr: null
 reject_reason: null
@@ -123,3 +123,4 @@ _none recorded_
 - filed by cluster.py from 1 observation(s)
 captain T_TRIAGE r3: track tooling CONFIRMED (kind=bad-ux, name resolution in `kuna xrefs --to`), touches widened to the analysis-tier xref index the CLI resolves against. No emitted C, so no option.
 captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.
+- round 4 BUILDER (b-r4-name-based-xrefs): hypothesis **UPHELD**. The ambiguity really is decided before the alias class exists -- and it could not have been otherwise where the check stood: `alias_class` is the connected component of the DECODED `jmp [slot]` forwarding relation, and the walk that decodes it (`build_with_focus`) runs after target resolution because it needs the target address to focus on. Fixed by not deciding at lookup time: a contested name carries its candidates into the walk as its focus set and is settled against the alias class afterwards (`Resolution::settle`, kuna-cli/src/xrefs.rs). Candidates that are all one class resolve to the class's code half (the veneer); candidates that are not keep the refusal with every candidate named. Acceptance a-6576d0dff8a6 PASSES. Sweep over all 148 duplicate-name entries in 14 binary fixtures: 129 folded, 18 refused, 0 mismatches -- every fold answers byte-identically to each of its own candidate addresses.

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -2030,6 +2030,23 @@ computed, and which therefore lifts to a `LOAD` through a temporary); the class 
 never derived from a shared symbol name, which would fold genuinely distinct
 same-named functions together.
 
+(kuna) The same two addresses make the import's **name** a selector that matches
+two entries, and the selector model's answer to that is a refusal naming every
+candidate — which would refuse a question that has exactly one answer, since either
+address alone answers it. So a contested name is not decided at lookup time at all:
+whether its candidates are one callable is a property of the decoded forwarding
+jumps, which only exist once the walk has run. The candidates are carried into the
+walk as its focus set, so every one of them is decoded, and the ambiguity is settled
+afterwards against the alias class
+(`decompiler/crates/kuna-cli/src/xrefs.rs (Resolution::settle)`). Candidates that all
+lie in one class are one callable and the query proceeds at the class's code half —
+the forwarding veneer rather than the pointer slot, because that is the address the
+answer will next be disassembled at, with the lowest address breaking a tie between
+several veneers through one slot. Candidates that do not all share a class are
+distinct functions and keep the refusal, with every candidate still named. The fold
+therefore still rests on the decoded jump and never on the shared name; the name only
+selects which addresses to check.
+
 (kuna) Because the query runs that descent **itself**, it takes its own analysis
 bundle rather than a decompiling surface's. `kuna functions` and `kuna decompile-all`
 inject the DIV-15/DIV-20/DIV-68 defaults (the Listing, the prologue-pattern scan,

--- a/tests/cli/name-based-xrefs-rejects.json
+++ b/tests/cli/name-based-xrefs-rejects.json
@@ -1,0 +1,68 @@
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-a44980246d40",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "xrefs",
+    "{{BIN}}",
+    "--to",
+    "VirtualProtect",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 300,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/pe_imports.exe",
+    "binary_sha256": "963e04af7e654da9344fbcfb89e37a49838d38624949895352ca1a77149f74c5",
+    "binary_size": 498895,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/pe_imports.exe",
+    "selector": "VirtualProtect",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "target.name",
+        "op": "eq",
+        "value": "VirtualProtect"
+      },
+      {
+        "path": "target.address_hex",
+        "op": "eq",
+        "value": "0x1400079b0"
+      },
+      {
+        "path": "target.aliases[0].address_hex",
+        "op": "eq",
+        "value": "0x14000d234"
+      },
+      {
+        "path": "count",
+        "op": "eq",
+        "value": 2
+      },
+      {
+        "path": "xrefs[0].from_address_hex",
+        "op": "eq",
+        "value": "0x140001a9e"
+      },
+      {
+        "path": "xrefs[1].from_address_hex",
+        "op": "eq",
+        "value": "0x140001cce"
+      }
+    ]
+  },
+  "notes": "Promoted acceptance of docs/re-needs/name-based-xrefs-rejects.md, re-pointed from the dataset crackme to its vendored MinGW twin (CI has no dataset): same shape, an import named by both a .text FF25 veneer and an .rdata IAT slot, where --to <name> exited 1 'is ambiguous' while either address answered fine. Stronger than the recorded count>0: the answer must be the veneer's."
+}


### PR DESCRIPTION
## The problem

`kuna xrefs --to <name>` refuses to answer for an import, because an import's
name is on two addresses and the selector model calls that ambiguous — while
either of the two addresses answers the question fine.

```console
$ kuna xrefs decompiler/crates/kuna-analysis/tests/fixtures/pe_imports.exe --to VirtualProtect --json
error: selector "VirtualProtect" is ambiguous; candidates:
  VirtualProtect at synthetic 0x1400079b0
  VirtualProtect at synthetic 0x14000d234
use a section-qualified selector to choose one candidate
$ echo $?
1

$ kuna xrefs decompiler/crates/kuna-analysis/tests/fixtures/pe_imports.exe --to 0x1400079b0
# 2 references to VirtualProtect @ 0x1400079b0
# same import at 0x14000d234 (VirtualProtect) - a forwarding veneer and the pointer slot it jumps through
0x140001a9e	read	__write_memory.part.0+0x18e	CALL qword ptr [0x14000d234]
0x140001cce	read	_pei386_runtime_relocator+0x19e	MOV R12,qword ptr [0x14000d234]
```

The two candidates are one callable: a `.text` `FF 25` veneer and the `.rdata`
IAT slot it jumps through. `--to` has answered over that alias class since
`xrefs-unify-pe-import`, so both addresses already return the same rows — the
name was the only spelling that could not reach them.

## The fix

- A contested name is no longer decided at lookup time. Which addresses are one
  callable is a property of the decoded forwarding jumps, and those only exist
  once the walk has run, so the candidates are carried into the walk as its focus
  set and the ambiguity is settled afterwards against the alias class.
- Candidates that all lie in one class are one callable; the query proceeds at
  the class's code half — the veneer, which is the address the answer is next
  disassembled at — with the lowest address breaking a tie between several
  veneers through one slot.
- Candidates that do not all share a class are distinct functions and keep the
  refusal, with every candidate still named. The fold rests on the decoded jump,
  never on the shared name, so two static `duplicate_local`s are never merged.
- No option: a read-only query surface commits nothing into the engine and
  cannot change emitted C.

## The tests

Three cases in `kuna-cli/tests/xrefs_cli.rs`: the import resolved by name answers
byte-for-byte what its veneer address answers; `puts`, reached through the veneer
rather than the slot, folds the same way; and `duplicate_local` in a relocatable
object is still refused with both candidates. The first two fail without the fix
(exit 1, "is ambiguous"). The acceptance probe is promoted to
`tests/cli/name-based-xrefs-rejects.json`.

A sweep over every duplicate-name entry in every binary fixture — 148 names in 14
images — folded 129 and refused 18, with every fold answering identically to each
of its own candidate addresses and every refusal naming all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
