### PR TITLE
[AUTOMATED] fix(repipe): one unparseable probe string killed the whole round's gate

### DIFF
--- a/scripts/repipe/verify.py
+++ b/scripts/repipe/verify.py
@@ -250,7 +250,7 @@ def gate_reps(p):
     byte-identical output. acceptance_suite() does NOT apply a floor by default: at
     INTEGRATE it re-runs the whole suite, and kuna's worst measured case is 445 s.
     """
-    kind = (p or {}).get("kind")
+    kind = p.get("kind") if isinstance(p, dict) else None
     return config.TIMING_REPS if kind in ("timing", "memory") else config.REPLAY_REPS
 
 
@@ -267,6 +267,8 @@ def run_probe(p, is_acceptance=False, ctx=None, work=None, challenges=(), reps=N
     "we could not tell" as a result rather than lose the observation.
     """
     arm = "acceptance" if is_acceptance else "probe"
+    if isinstance(p, str):
+        return _stub(None, "%s did not parse as JSON, so it is not a probe" % arm, arm)
     if not isinstance(p, dict):
         return _stub(None, "observation carries no %s" % arm, arm)
     if not p.get("cmd"):

--- a/tools/repipe/smoke.sh
+++ b/tools/repipe/smoke.sh
@@ -181,6 +181,18 @@ mk_obs '{"exit_code":{"eq":99}}' '{"exit_code":{"eq":0}}'
 V="$(gate_verdict)"
 [ "$V" = "not-reproducible" ] && ok "probe does not reproduce -> not-reproducible" \
                              || bad "expected not-reproducible, got $V"
+# an arm that arrived as a JSON string codex could not serialise cleanly is UNRUNNABLE, not a
+# traceback: one such observation used to take down the gate for the whole round with it
+"$PY" - > "$GATE_OBS" <<'PY'
+import json
+arm = '{"schema":"re-probe/1","kind":"cli","cmd":["{{KUNA}}","--version"],"expect":{"stdout_matches":["\\s+"]}}'
+json.dump({"kind": "bad-ux", "title": "gate self-test", "what_i_wanted": "x",
+           "what_kuna_did": "y", "severity": "minor",
+           "probe": arm, "acceptance": arm}, open("/dev/stdout", "w"))
+PY
+V="$(gate_verdict)"
+[ "$V" = "unrunnable" ] && ok "an arm that will not parse -> unrunnable, not a traceback" \
+                       || bad "expected unrunnable, got $V"
 
 for f in probe-zero-functions accept-zero-functions accept-functions-size; do
   [ -f "$FIX/$f.json" ] || bad "missing fixture $f.json"


### PR DESCRIPTION
## The problem

A tester's probe can arrive as a JSON string (structured-output mode cannot express the
probe schema, so `coerce_probes` parses it back). When that string does not parse, the
whole gate run dies on the first such observation — every other observation in the round
loses its verdict, not just the malformed one.

```console
$ python3 - > /tmp/obs.json <<'PY'
import json
arm = '{"schema":"re-probe/1","kind":"cli","cmd":["{{KUNA}}","--version"],"expect":{"stdout_matches":["\\s+"]}}'
json.dump({"kind": "bad-ux", "title": "t", "what_i_wanted": "x", "what_kuna_did": "y",
           "severity": "minor", "probe": arm, "acceptance": arm}, open("/dev/stdout", "w"))
PY
$ python3 -m scripts.repipe.verify --observation /tmp/obs.json --json
  File "scripts/repipe/verify.py", line 253, in gate_reps
    kind = (p or {}).get("kind")
AttributeError: 'str' object has no attribute 'get'
```

`\s` is not a valid JSON escape, so the arm stays a string — which `coerce_probes` already
documents as the honest outcome ("left as-is, which makes the observation `unrunnable`").
That path was unreachable: `gate()` computes `gate_reps(p)` before `run_probe(p)`, and
`run_probe` is where the `isinstance(p, dict)` guard lives.

## The fix

- `gate_reps` reads `kind` only from a dict, like every other consumer of a probe
  (`run_probe`, `vendorable`) already does. The arm then reaches `run_probe` and comes back
  `unrunnable`, one observation lost instead of the round.
- A string arm gets its own reason — "probe did not parse as JSON, so it is not a probe" —
  rather than the misleading "observation carries no probe". A tester that filed a bad
  probe and one that filed none are different facts.

## The tests

One smoke case in `tools/repipe/smoke.sh`: an observation whose arms are unparseable
strings must grade `unrunnable`. It raises the `AttributeError` on the unpatched tree.