### PR TITLE
[AUTOMATED] fix(brief): a probe is one argv and there is no shell — 6 of 26 were lost to this

### DIFF
--- a/scripts/repipe/verify.py
+++ b/scripts/repipe/verify.py
@@ -250,7 +250,7 @@ def gate_reps(p):
     byte-identical output. acceptance_suite() does NOT apply a floor by default: at
     INTEGRATE it re-runs the whole suite, and kuna's worst measured case is 445 s.
     """
-    kind = (p or {}).get("kind")
+    kind = p.get("kind") if isinstance(p, dict) else None
     return config.TIMING_REPS if kind in ("timing", "memory") else config.REPLAY_REPS
 
 
@@ -267,6 +267,8 @@ def run_probe(p, is_acceptance=False, ctx=None, work=None, challenges=(), reps=N
     "we could not tell" as a result rather than lose the observation.
     """
     arm = "acceptance" if is_acceptance else "probe"
+    if isinstance(p, str):
+        return _stub(None, "%s did not parse as JSON, so it is not a probe" % arm, arm)
     if not isinstance(p, dict):
         return _stub(None, "observation carries no %s" % arm, arm)
     if not p.get("cmd"):

--- a/tools/repipe/smoke.sh
+++ b/tools/repipe/smoke.sh
@@ -181,6 +181,18 @@ mk_obs '{"exit_code":{"eq":99}}' '{"exit_code":{"eq":0}}'
 V="$(gate_verdict)"
 [ "$V" = "not-reproducible" ] && ok "probe does not reproduce -> not-reproducible" \
                              || bad "expected not-reproducible, got $V"
+# an arm that arrived as a JSON string codex could not serialise cleanly is UNRUNNABLE, not a
+# traceback: one such observation used to take down the gate for the whole round with it
+"$PY" - > "$GATE_OBS" <<'PY'
+import json
+arm = '{"schema":"re-probe/1","kind":"cli","cmd":["{{KUNA}}","--version"],"expect":{"stdout_matches":["\\s+"]}}'
+json.dump({"kind": "bad-ux", "title": "gate self-test", "what_i_wanted": "x",
+           "what_kuna_did": "y", "severity": "minor",
+           "probe": arm, "acceptance": arm}, open("/dev/stdout", "w"))
+PY
+V="$(gate_verdict)"
+[ "$V" = "unrunnable" ] && ok "an arm that will not parse -> unrunnable, not a traceback" \
+                       || bad "expected unrunnable, got $V"
 
 for f in probe-zero-functions accept-zero-functions accept-functions-size; do
   [ -f "$FIX/$f.json" ] || bad "missing fixture $f.json"

--- a/tools/repipe/tester_prompt.md
+++ b/tools/repipe/tester_prompt.md
@@ -98,6 +98,26 @@ actually observed evidence for.
 If you genuinely need a positive assertion, keep it to the weakest one that would still be
 false today — `stdout_matches: ["write|mprotect|syscall"]` beats naming one of them.
 
+**`cmd` is ONE argv, and there is no shell.** This is the single most common way a good
+observation is thrown away: round 4 lost 6 of 26 to it. `cmd` is exec'd directly against an
+allowlist, so `sh`, `bash` and `timeout` are all refused — a probe that can run code passed as
+an argument makes the allowlist meaningless, and the refusal is deliberate.
+
+You do not need a shell, because the `expect` clauses do what you were reaching for a pipe to
+do:
+
+| you would have written | write instead |
+|---|---|
+| `sh -c 'kuna decompile B f \| grep -c switch'` | `"cmd": ["{{KUNA}}","decompile","{{BIN}}","f"]` + `"stdout_matches": ["switch"]` |
+| `sh -c '... \| grep -v swi(0x80)'` | `"stdout_absent": ["swi\\(0x80\\)"]` |
+| `sh -c '... \| jq .count'` | `"json": [{"path":"count","op":"eq","value":0}]` |
+| `timeout 60 kuna ...` | `"timeout_s": 60` — the field already exists |
+| `sh -c 'kuna a && kuna b'` | two observations, or one probe on the command that actually shows the defect |
+
+If you genuinely cannot express the assertion without a shell, say so in `what_kuna_did` and
+file the observation anyway with the best single-command probe you can — a weaker probe that
+RUNS beats a perfect one the gate has to discard.
+
 A worked example of the shape:
 
 ```json


### PR DESCRIPTION
Round 4's gate: 20 admitted, 6 UNRUNNABLE. That is 23% of the round's evidence
discarded, and the discarded set includes "Misspelled option is silently accepted",
one of the two most interesting findings of the round.

The cause is not a bug. Four of the six wrote their probe as `sh -c '<pipeline>'` and
the allowlist refused it:

  ProbeError: probe may not execute 'sh': it runs code passed as an argument,
  which would make the allowlist meaningless

Two more used `timeout`, refused for the same reason. The guard is correct and stays --
probes are LLM-authored and replayed in the main tree outside the sandbox, which is
exactly why argv[0] is allowlisted by resolved realpath.

The brief was the gap. It showed a worked example whose `cmd` happens to need no shell
and never said a shell is impossible, so a tester reaching for `| grep` to check output
had no way to know the probe would be thrown away rather than run. Same shape as the
`--assert` quoting trap: the tool is right, the instruction is incomplete, and evidence
is lost silently.

Adds the rule with a translation table, because "no shell" alone would leave testers
stuck: `| grep X` is `stdout_matches`, `| grep -v X` is `stdout_absent`, `| jq .count`
is a `json` path clause, and `timeout 60` is the `timeout_s` field that already exists.
Also says plainly that a weaker probe which RUNS beats a perfect one the gate discards --
the failure here was testers writing better assertions than the format accepts.

tools/repipe/smoke.sh 138/138.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcFmfZndNjgfqLQVBZCdkY