### PR TITLE
[AUTOMATED] fix(cli): mach-o-summary-reports — report the Mach-O LC_MAIN entry as a VMA, not a file offset

### DIFF
--- a/decompiler/crates/kuna-analysis/src/analyzers/entry/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/entry/mod.rs
@@ -97,6 +97,34 @@ pub mod patterns;
 mod pe_entry;
 
 // ===========================================================================
+// The image entry point, as a virtual address
+// ===========================================================================
+
+/// The image's declared entry point as a **virtual address**, or `None` when the
+/// format declares none.
+///
+/// `object`'s `File::entry()` returns the raw load-command/header field, which is
+/// already a VMA for ELF (`e_entry`), for PE (`AddressOfEntryPoint`, rebased by
+/// `object`) and for a Mach-O `LC_UNIXTHREAD` (the thread state's PC) — but is a
+/// `__TEXT`-relative **file offset** for `LC_MAIN`, the modern Mach-O entry. The
+/// VMA there is `__TEXT.vmaddr + entryoff` ([`macho_entry::macho_main_entry_vma`],
+/// which answers only for `LC_MAIN` and so leaves `LC_UNIXTHREAD` and dylibs to
+/// the raw field rather than double-counting the segment base).
+///
+/// Anything that REPORTS the entry, or roots a reachability walk at it, wants this
+/// rather than `entry()`: on an `LC_MAIN` image the raw field is an offset into the
+/// file that names no function (`0x1ce0` where `main` is at `0x100001ce0`).
+///
+/// A `0` entry is reported as `None` — a relocatable declares no entry, and `0` is
+/// a real address there.
+pub fn image_entry_vma(file: &object::File, bytes: &[u8]) -> Option<u64> {
+    macho_entry::macho_main_entry_vma(bytes).or(match file.entry() {
+        0 => None,
+        vma => Some(vma),
+    })
+}
+
+// ===========================================================================
 // The pass
 // ===========================================================================
 
@@ -2280,6 +2308,48 @@ mod tests {
     fn fixture(name: &str) -> Vec<u8> {
         let path = format!("{}/tests/fixtures/{}", env!("CARGO_MANIFEST_DIR"), name);
         std::fs::read(&path).unwrap_or_else(|_| panic!("read fixture {path}"))
+    }
+
+    /// A Mach-O `LC_MAIN` states its entry as a `__TEXT`-relative FILE OFFSET, so
+    /// `object`'s `entry()` answers `0x5b0` where the function is at
+    /// `0x1000005b0`. `image_entry_vma` rebases it; the stripped twin proves the
+    /// answer comes from the load command and not from a symbol.
+    #[test]
+    fn image_entry_vma_rebases_a_macho_lc_main() {
+        for name in ["macho_imports", "macho_stripped_main"] {
+            let bytes = fixture(name);
+            let file = object::File::parse(bytes.as_slice()).expect("parse");
+            assert_eq!(file.entry(), 0x5b0, "{name}: object reports the raw entryoff");
+            assert_eq!(image_entry_vma(&file, &bytes), Some(0x1000005b0), "{name}");
+        }
+        let bytes = fixture("macho_imports_arm64");
+        let file = object::File::parse(bytes.as_slice()).expect("parse arm64");
+        assert_eq!(image_entry_vma(&file, &bytes), Some(0x10000056c));
+    }
+
+    /// Every other format already states a VMA, so the rebase must not fire:
+    /// an ELF `e_entry` (including the ARM Thumb-odd spelling) and a PE
+    /// `AddressOfEntryPoint` are passed through byte-for-byte.
+    #[test]
+    fn image_entry_vma_passes_through_a_vma_entry() {
+        for name in ["cet_pie_x86_64", "entrymain_arm", "fauxware"] {
+            let bytes = fixture(name);
+            let file = object::File::parse(bytes.as_slice()).expect("parse");
+            assert_eq!(image_entry_vma(&file, &bytes), Some(file.entry()), "{name}");
+        }
+    }
+
+    /// A relocatable declares no entry, and `0` is a real address there — so it
+    /// is reported as absent rather than as `0x0`. A Mach-O `.o` is the case that
+    /// would break if the rebase were applied unconditionally by format.
+    #[test]
+    fn image_entry_vma_reports_no_entry_as_none() {
+        for name in ["macho_min.o", "macho_dwarf.o"] {
+            let bytes = fixture(name);
+            let file = object::File::parse(bytes.as_slice()).expect("parse");
+            assert_eq!(file.entry(), 0, "{name}");
+            assert_eq!(image_entry_vma(&file, &bytes), None, "{name}");
+        }
     }
 
     /// `bytes` with the ELF section table pointed at garbage -- the shape the

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -591,14 +591,13 @@ fn summarize(
 ///
 /// This is the FORMAT's entry (a PE `AddressOfEntryPoint` is the CRT startup,
 /// not `main`) — the one address every image agrees on, and the honest root for
-/// "what does this program actually reach".
+/// "what does this program actually reach". Taken through
+/// [`kuna_analysis::analyzers::entry::image_entry_vma`], because a Mach-O
+/// `LC_MAIN` states its entry as a `__TEXT`-relative file offset, not a VMA.
 fn image_entry(prog: &ConsoleProgram, binary: &str) -> Option<(u64, String)> {
     let bytes = std::fs::read(binary).ok()?;
     let file = object::File::parse(&*bytes).ok()?;
-    let vma = file.entry();
-    if vma == 0 {
-        return None;
-    }
+    let vma = kuna_analysis::analyzers::entry::image_entry_vma(&file, &bytes)?;
     // Reported THROUGH the inventory, so an ARM `e_entry` carrying the Thumb mode
     // bit is answered at the even entry the rest of the document uses.
     match prog.find_entry_at(vma) {

--- a/decompiler/crates/kuna-cli/src/decompile_graph.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_graph.rs
@@ -184,12 +184,11 @@ fn export(args: &Args, label: &str) -> Result<String, String> {
     let known: BTreeSet<u64> = entries.iter().map(|e| e.addr.get_offset()).collect();
 
     // Through the inventory, because an ARM ELF stores the Thumb mode bit in
-    // `e_entry` (`0x100d7` for a `_start` reported at `0x100d6`), and a format
-    // that declares no entry reports `0` -- a real address in a relocatable.
-    let image_entry: Option<u64> = match file.entry() {
-        0 => None,
-        vma => Some(prog.find_entry_at(vma).map_or(vma, |e| e.addr.get_offset())),
-    };
+    // `e_entry` (`0x100d7` for a `_start` reported at `0x100d6`); and through
+    // `image_entry_vma`, because a Mach-O `LC_MAIN` states its entry as a
+    // `__TEXT`-relative file offset, which roots the walk at no function at all.
+    let image_entry: Option<u64> = kuna_analysis::analyzers::entry::image_entry_vma(&file, &bytes)
+        .map(|vma| prog.find_entry_at(vma).map_or(vma, |e| e.addr.get_offset()));
 
     let functions = Json::Array(
         entries

--- a/decompiler/crates/kuna-cli/tests/decompile_graph_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_graph_cli.rs
@@ -290,3 +290,17 @@ fn a_rust_binary_is_still_exported_as_c() {
         assert!(!body.starts_with("#[allow("), "Rust in codeC: {body}");
     }
 }
+
+/// The graph's `isEntryPoint` roots the document, and it was rooted at the raw
+/// Mach-O `LC_MAIN` entryoff -- an address no row carries, so NO row was flagged
+/// on any `LC_MAIN` image.
+#[test]
+fn a_macho_entry_point_row_is_flagged() {
+    let Some(document) = graph(&[&fixture("macho_stripped_main")]) else { return };
+    let flagged: Vec<String> = rows(&document, "functions")
+        .into_iter()
+        .filter(|row| field(row, "isEntryPoint").as_deref() == Some("true"))
+        .filter_map(|row| field(&row, "name"))
+        .collect();
+    assert_eq!(flagged, vec!["main".to_string()], "exactly the LC_MAIN entry: {document}");
+}

--- a/decompiler/crates/kuna-cli/tests/decompile_project_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_project_cli.rs
@@ -129,6 +129,20 @@ fn project_folder_written_for_fauxware() {
     assert!(readme_text.contains("## Sections"), "README missing sections table:\n{readme_text}");
 }
 
+/// The README's entry-point row was `object`'s raw `entry()`, which on a Mach-O
+/// `LC_MAIN` image is a `__TEXT`-relative file offset -- so the export claimed an
+/// entry at `0x5b0` for a program whose `main` is at `0x1000005b0`.
+#[test]
+fn macho_readme_entry_point_is_a_vma() {
+    let Some(dir) = project("macho_stripped_main", "macho_entry") else { return };
+    let (_c, _h, _asm, readme) = artifacts(&dir, "macho_stripped_main");
+    let readme_text = std::fs::read_to_string(&readme).unwrap();
+    assert!(
+        readme_text.contains("| Entry point | `0x1000005b0` |"),
+        "README entry point must be the VMA:\n{readme_text}"
+    );
+}
+
 #[test]
 fn asm_labels_match_c_function_names() {
     let Some(dir) = project("fauxware", "labels") else { return };

--- a/decompiler/crates/kuna-cli/tests/triage_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/triage_cli.rs
@@ -344,6 +344,30 @@ fn an_arm_thumb_entry_resolves_to_its_even_address() {
     assert!(!listing_rows(&odd).is_empty(), "{odd}");
 }
 
+/// A Mach-O `LC_MAIN` states its entry as a `__TEXT`-relative FILE OFFSET where
+/// every other format states a VMA, so the summary reported `0x5b0` -- an address
+/// that names no function, which then made `reachable_from_entry` null and left
+/// the one orientation field an agent starts from useless.
+#[test]
+fn a_macho_lc_main_entry_is_reported_as_a_vma() {
+    let macho = repo_root()
+        .join("decompiler/crates/kuna-analysis/tests/fixtures/macho_stripped_main")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let (out, err, code) = run_kuna(&["functions", &macho, "--summary", "--json"]);
+    if no_specs(&err, code) {
+        eprintln!("skipping: no .sla under {} ({err})", specs());
+        return;
+    }
+    assert_eq!(code, 0, "{err}");
+    assert!(out.contains("\"address_hex\": \"0x1000005b0\""), "__TEXT.vmaddr + entryoff: {out}");
+    assert!(!out.contains("\"address_hex\": \"0x5b0\""), "the raw entryoff must be gone: {out}");
+    assert!(out.contains("\"name\": \"main\""), "the entry names a function: {out}");
+    let reachable = json_field(&out, "reachable_from_entry");
+    assert!(reachable.is_some_and(|n| n > 0), "the entry must reach something: {out}");
+}
+
 /// The zero-discovery verdict belongs to DISCOVERY. A narrowed run on an image
 /// that yielded nothing must still fail loudly — the packer diagnosis is the one
 /// thing the caller can act on, and a filter must not be able to swallow it.

--- a/decompiler/crates/kuna-console/src/project.rs
+++ b/decompiler/crates/kuna-console/src/project.rs
@@ -876,10 +876,15 @@ pub fn build_readme(
 
     // Entry point + named sections come from an `object` re-parse (the engine's
     // section iterator has no name field).
-    let parsed = std::fs::read(binary_path).ok();
-    let parsed = parsed.as_deref().and_then(|b| object::File::parse(b).ok());
+    let raw = std::fs::read(binary_path).unwrap_or_default();
+    let parsed = object::File::parse(&*raw).ok();
     match &parsed {
-        Some(f) => out.push_str(&format!("| Entry point | `0x{:x}` |\n", f.entry())),
+        // `image_entry_vma`, not `entry()`: a Mach-O `LC_MAIN` states a
+        // `__TEXT`-relative file offset where every other format states a VMA.
+        Some(f) => out.push_str(&format!(
+            "| Entry point | `0x{:x}` |\n",
+            kuna_analysis::analyzers::entry::image_entry_vma(f, &raw).unwrap_or(0)
+        )),
         None => out.push_str("| Entry point | unavailable |\n"),
     }
     out.push_str(&format!("| Functions | {} total, {ok} decompiled, {failed} failed |\n", results.len()));

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -497,7 +497,9 @@ without emitting a function list at all, let alone pseudocode.
 
 - `entry` is the **image's declared entry point** (a PE `AddressOfEntryPoint` is
   the CRT startup, not `main`), named with kuna's best name for it, or `null`
-  when the format declares none.
+  when the format declares none. Always a virtual address: a Mach-O `LC_MAIN`
+  states its entry as a `__TEXT`-relative file offset, and it is rebased here
+  (`0x1000005b0`, not `0x5b0`).
 - `reachable_from_entry` counts *discovered* functions the entry point reaches,
   and is `null` when there is no entry point or nothing was decoded at it (a
   packed image); `no_callers` counts *selected* functions that no CALL site
@@ -1259,7 +1261,7 @@ emitted. Two runs of one command are byte-identical.
 | `error` | Why this function has no `codeC`, when the decompile was attempted and failed. `null` with a `null` `codeC` means no body was attempted: a bodyless `kind`, or a `--functions`/`--addr` narrowing that did not select it. |
 | `hasIndirectCalls` | The body contains a computed call (`CALLIND`), which files no edge because it has no static target. An indirect *branch* is not one — see `forwardsTo`. The call site is attributed to the row that contains it, the same rule that decides which function `kuna xrefs --from` lists an instruction under. |
 | `forwardsTo` | Where a forwarding entry sends control: the destination of a direct lone jump, or the fixed pointer slot an indirect one reads. The slot half needs the jump to name it as a decode-time constant, which an x86 `jmp [rip+disp]` stub does and an AArch64 `adrp`/`ldr`/`br x16` stub does not — a Mach-O `__stubs` entry is therefore `kind` `thunk` with a `null` `forwardsTo`, and the import slot it reaches is a row of its own found by name. `null` for anything that does not forward. |
-| `isEntryPoint` | This row is the image's declared entry point, resolved through the inventory so an ARM `e_entry` carrying the Thumb mode bit still lands on it. A format that declares no entry point marks no row. |
+| `isEntryPoint` | This row is the image's declared entry point, resolved through the inventory so an ARM `e_entry` carrying the Thumb mode bit still lands on it, and rebased so a Mach-O `LC_MAIN` — which states a `__TEXT`-relative file offset rather than a VMA — marks the row it names. A format that declares no entry point marks no row. |
 | `edges[].kind` | The `kuna xrefs` kind, so the two surfaces cannot disagree: `call` a direct call; `jump` a tail call or a branch into a neighbouring entry; `data` an address handed to something else to call — the edge that gives `main` a caller, since `_start` passes it to `__libc_start_main` as a pointer rather than calling it. A caller that both calls and mentions one callee gets one edge carrying the strongest of the two. |
 | `edges[].calleeOrder` | Contiguous and zero-based per caller, in first-reference order, deduplicated on the callee. |
 

--- a/docs/features/mach-o-summary-reports/pr_body.md
+++ b/docs/features/mach-o-summary-reports/pr_body.md
@@ -1,0 +1,59 @@
+## The problem
+
+`kuna functions --summary` reports the image entry point, and on any modern
+Mach-O it reported a file offset where every other format reports a virtual
+address. The offset matches no function, so the name degrades to a hex string
+and the reachability count collapses to `null` — the two fields the summary
+exists to answer.
+
+```
+$ kuna functions decompiler/crates/kuna-analysis/tests/fixtures/macho_stripped_main --summary --json
+  "summary": {
+    "entry": {
+      "name": "0x5b0",
+      "address": 1456,
+      "address_hex": "0x5b0"
+    },
+    "reachable_from_entry": null,
+```
+
+`main` is at `0x1000005b0`: `LC_MAIN.entryoff` is `0x5b0` and `__TEXT.vmaddr` is
+`0x100000000`. The inventory in the same document already has it right — the
+`largest` list names `main` at `0x1000005b0`.
+
+## The fix
+
+- `object`'s `File::entry()` returns the raw header field, which is already a VMA
+  for ELF `e_entry`, PE `AddressOfEntryPoint` and Mach-O `LC_UNIXTHREAD` (the
+  saved thread state's PC), but is a `__TEXT`-relative file offset for `LC_MAIN`.
+  New `kuna_analysis::analyzers::entry::image_entry_vma` states that once.
+- It rebases **only** `LC_MAIN`, through the existing `macho_main_entry_vma`,
+  which answers for nothing else. Adding `__TEXT.vmaddr` by format instead would
+  double-count an `LC_UNIXTHREAD` entry, which already carries it.
+- Three surfaces read the raw field and now read the helper: `functions
+  --summary`'s `entry`/`reachable_from_entry`, `decompile-graph`'s
+  `isEntryPoint` (which flagged no row at all on an `LC_MAIN` image), and the
+  `decompile-project` README's entry row.
+- A `0` entry is still reported as absent, not as `0x0` — a relocatable declares
+  no entry and `0` is a real address there.
+
+After:
+
+```
+    "entry": { "name": "main", "address": 4294968752, "address_hex": "0x1000005b0" },
+    "reachable_from_entry": 2,
+```
+
+## The tests
+
+Three unit tests on `image_entry_vma` (Mach-O rebase, ELF/PE/ARM-Thumb
+pass-through, `.o` → `None`) and one end-to-end test per consumer; each of the
+three end-to-end tests fails on the unpatched tree. `tests/cli/mach-o-summary-reports.json`
+promotes the acceptance, re-pointed onto the in-repo `macho_stripped_main`
+fixture because CI has no dataset.
+
+`make test` 675/675 PARITY OK · `make test-stages` 635/635 PARITY OK ·
+`make check-spec` OK · `kuna catalog --check` OK · `make test-cli` 42/42.
+No existing expectation moved.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/mach-o-summary-reports/record.json
+++ b/docs/features/mach-o-summary-reports/record.json
@@ -1,0 +1,45 @@
+{
+  "need_id": "mach-o-summary-reports",
+  "track": "tooling",
+  "scope": "small",
+  "worker": "b-r4-mach-o-summary-r",
+  "branch": "feat/re-mach-o-summary-reports",
+  "symptom": "kuna functions --summary --json reported summary.entry.address = 7392 (0x1ce0) on a Mach-O whose main is at 0x100001ce0, and summary.reachable_from_entry = null. 1 instance, round 4.",
+  "diagnosis": "object::File::entry() returns the raw LC_MAIN entryoff -- a __TEXT-relative FILE OFFSET -- for a modern Mach-O, where it returns a virtual address for ELF e_entry, PE AddressOfEntryPoint and Mach-O LC_UNIXTHREAD. Three surfaces reported that field directly.",
+  "hypothesis_status": "upheld",
+  "decisions": [
+    "The filed hypothesis (LC_MAIN.entryoff not translated to a VMA) is exactly right; the refuter's byte-patch controls already proved it and its fix site.",
+    "The rebase is stated once, as kuna_analysis::analyzers::entry::image_entry_vma, rather than inlined at each consumer. It rebases ONLY LC_MAIN (via the existing macho_main_entry_vma, which answers for nothing else) and falls through to the raw field otherwise -- adding __TEXT.vmaddr unconditionally for Mach-O would double-count an LC_UNIXTHREAD entry, whose thread-state PC is already a VMA.",
+    "A THIRD consumer beyond the two the need names: kuna-console/src/project.rs printed file.entry() as the decompile-project README's `Entry point` row, with the identical defect. Fixed in the same change, same helper, one call site.",
+    "A 0 entry stays None rather than 0x0: a relocatable declares no entry and 0 is a real address there. Verified on macho_min.o / macho_dwarf.o, which would break if the rebase were applied by format instead of by load command.",
+    "No option row: a tooling-track change that cannot move emitted C. No phases.toml, options.rs, catalog counter or DIV row touched.",
+    "The acceptance probe's dataset target is not vendorable, so the promoted tests/cli probe is re-pointed onto the in-repo macho_stripped_main fixture, which reproduces the identical defect (entryoff 0x5b0 vs VMA 0x1000005b0).",
+    "The need doc docs/re-needs/mach-o-summary-reports.md is deliberately NOT in this commit: it is untracked on origin/main, need-doc bookkeeping (status/closing_pr) belongs to the captain, and it is the one file in this change likely to collide with a concurrent reindex."
+  ],
+  "changed": [
+    "decompiler/crates/kuna-analysis/src/analyzers/entry/mod.rs",
+    "decompiler/crates/kuna-cli/src/decompile_all.rs",
+    "decompiler/crates/kuna-cli/src/decompile_graph.rs",
+    "decompiler/crates/kuna-console/src/project.rs",
+    "decompiler/crates/kuna-cli/tests/triage_cli.rs",
+    "decompiler/crates/kuna-cli/tests/decompile_graph_cli.rs",
+    "decompiler/crates/kuna-cli/tests/decompile_project_cli.rs",
+    "tests/cli/mach-o-summary-reports.json",
+    "docs/cli.md",
+    "docs/spec/01-program-prep.md"
+  ],
+  "acceptance": "PASS -- summary.entry.address == 4294974688 (0x100001ce0) on the filed instance",
+  "tests": {
+    "kuna-analysis": "3 unit tests on image_entry_vma (rebase / pass-through / no-entry)",
+    "kuna-cli": "3 end-to-end tests, one per consumer; each fails on the unpatched tree",
+    "tests/cli": "mach-o-summary-reports.json, 42/42"
+  },
+  "gates": {
+    "make test": "PARITY OK, 675/675",
+    "make test-stages": "PARITY OK, 635/635",
+    "make check-spec": "OK",
+    "kuna catalog --check": "OK",
+    "make test-cli": "42/42",
+    "make rust-test": "GREEN (rc=0, 0 failures) with `env -u KUNA_DECOMP_TEST`, which is what CI runs. With the repipe launcher's KUNA_DECOMP_TEST exported, verify_w10_proto_unlock goes red with `oracle promote_compare signature drifted` -- the known worktree artifact: the var points the C++ oracle at kuna's own decomp_test_dbg, so kuna's modern `unsigned int` spelling reads as drift. Falsified by rerunning that one target with the var unset (4/4)."
+  }
+}

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -1593,6 +1593,24 @@ reason to withhold the entry declaration. Structurally inert on every ELF, PE an
 COFF target, which is also why neither parity corpus can observe it in either
 direction: both are symbol-less ELF bytechunks.
 
+The same `entryoff`-is-not-a-VMA fact is what every *reporting* surface has to
+know, so it is stated once as
+`decompiler/crates/kuna-analysis/src/analyzers/entry/mod.rs (image_entry_vma)`
+rather than re-derived. `object`'s `File::entry()` hands back the raw header/
+load-command field, which is already a virtual address for an ELF `e_entry`, for a
+PE `AddressOfEntryPoint` and for a Mach-O `LC_UNIXTHREAD` (the saved thread state's
+PC), and is a `__TEXT`-relative file offset for `LC_MAIN`. Reporting that field
+directly answers `0x1ce0` for a program whose `main` is at `0x100001ce0` — an
+address that matches no function, so the name resolves to a bare hex string and any
+reachability walk rooted there returns nothing. The helper rebases only the
+`LC_MAIN` case (via `macho_main_entry_vma`, which answers for nothing else) and
+falls through to the raw field otherwise, so an `LC_UNIXTHREAD` image does not have
+`__TEXT.vmaddr` added to an address that already carries it. A `0` entry is
+reported as absent rather than as `0x0`, because a relocatable declares no entry
+and `0` is a real address there. The consumers are `kuna functions --summary`'s
+`entry`/`reachable_from_entry`, `kuna decompile-graph`'s `isEntryPoint`, and the
+`kuna decompile-project` README's entry row.
+
 **Address tables** (`addrtable`,
 `decompiler/crates/kuna-analysis/src/analyzers/addrtable/mod.rs (AddrTablePass)`)
 scan `.rodata`/`.data` for runs of pointer-width values all landing in executable

--- a/tests/cli/mach-o-summary-reports.json
+++ b/tests/cli/mach-o-summary-reports.json
@@ -1,0 +1,59 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--summary",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/macho_stripped_main",
+    "binary_sha256": "9102bb6a99b0f2c833a354e22d8936a28f56e02a454c483b3870ac6234170a34",
+    "binary_size": 16688,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/macho_stripped_main",
+    "selector": null,
+    "selector_kind": "none"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "stdout_absent": [
+      "\"address_hex\": \"0x5b0\""
+    ],
+    "json": [
+      {
+        "path": "summary.entry.address",
+        "op": "eq",
+        "value": 4294968752
+      },
+      {
+        "path": "summary.entry.address_hex",
+        "op": "eq",
+        "value": "0x1000005b0"
+      },
+      {
+        "path": "summary.entry.name",
+        "op": "eq",
+        "value": "main"
+      },
+      {
+        "path": "summary.reachable_from_entry",
+        "op": "gt",
+        "value": 0
+      }
+    ]
+  },
+  "notes": "Promoted acceptance of mach-o-summary-reports, re-pointed onto the in-repo macho_stripped_main fixture (CI has no dataset). Same defect: the filed instance wanted 0x100001ce0 where the raw LC_MAIN entryoff was 0x1ce0; here the entry is 0x1000005b0 where the entryoff is 0x5b0. reachable_from_entry was collateral -- a walk rooted at an address naming no function returned null."
+}


### PR DESCRIPTION
## The problem

`kuna functions --summary` reports the image entry point, and on any modern
Mach-O it reported a file offset where every other format reports a virtual
address. The offset matches no function, so the name degrades to a hex string
and the reachability count collapses to `null` — the two fields the summary
exists to answer.

```
$ kuna functions decompiler/crates/kuna-analysis/tests/fixtures/macho_stripped_main --summary --json
  "summary": {
    "entry": {
      "name": "0x5b0",
      "address": 1456,
      "address_hex": "0x5b0"
    },
    "reachable_from_entry": null,
```

`main` is at `0x1000005b0`: `LC_MAIN.entryoff` is `0x5b0` and `__TEXT.vmaddr` is
`0x100000000`. The inventory in the same document already has it right — the
`largest` list names `main` at `0x1000005b0`.

## The fix

- `object`'s `File::entry()` returns the raw header field, which is already a VMA
  for ELF `e_entry`, PE `AddressOfEntryPoint` and Mach-O `LC_UNIXTHREAD` (the
  saved thread state's PC), but is a `__TEXT`-relative file offset for `LC_MAIN`.
  New `kuna_analysis::analyzers::entry::image_entry_vma` states that once.
- It rebases **only** `LC_MAIN`, through the existing `macho_main_entry_vma`,
  which answers for nothing else. Adding `__TEXT.vmaddr` by format instead would
  double-count an `LC_UNIXTHREAD` entry, which already carries it.
- Three surfaces read the raw field and now read the helper: `functions
  --summary`'s `entry`/`reachable_from_entry`, `decompile-graph`'s
  `isEntryPoint` (which flagged no row at all on an `LC_MAIN` image), and the
  `decompile-project` README's entry row.
- A `0` entry is still reported as absent, not as `0x0` — a relocatable declares
  no entry and `0` is a real address there.

After:

```
    "entry": { "name": "main", "address": 4294968752, "address_hex": "0x1000005b0" },
    "reachable_from_entry": 2,
```

## The tests

Three unit tests on `image_entry_vma` (Mach-O rebase, ELF/PE/ARM-Thumb
pass-through, `.o` → `None`) and one end-to-end test per consumer; each of the
three end-to-end tests fails on the unpatched tree. `tests/cli/mach-o-summary-reports.json`
promotes the acceptance, re-pointed onto the in-repo `macho_stripped_main`
fixture because CI has no dataset.

`make test` 675/675 PARITY OK · `make test-stages` 635/635 PARITY OK ·
`make check-spec` OK · `kuna catalog --check` OK · `make test-cli` 42/42.
No existing expectation moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
