### PR TITLE
[AUTOMATED] fix(cli): unknown-option-name-silently — reject an unrecognized --option NAME

### DIFF
--- a/decompiler/crates/kuna-cli/src/decompile.rs
+++ b/decompiler/crates/kuna-cli/src/decompile.rs
@@ -1028,6 +1028,10 @@ pub fn main(argv: &[String]) -> i32 {
                     eprintln!("error: --option requires NAME VALUE");
                     return 2;
                 }
+                if let Err(msg) = crate::optname::check(&argv[i + 1]) {
+                    eprintln!("error: {msg}");
+                    return 2;
+                }
                 options.push((argv[i + 1].clone(), argv[i + 2].clone()));
                 forwarded.extend(argv[i..i + 3].iter().cloned());
                 i += 2;

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -1217,7 +1217,7 @@ pub(crate) fn resolve_targets(
 /// gates are exported as env vars BEFORE the bootstrap; the matching `option`
 /// line is still applied afterward (for the catalog record), exactly as
 /// `kuna decompile` does.
-fn is_loadtime_gate(name: &str) -> bool {
+pub(crate) fn is_loadtime_gate(name: &str) -> bool {
     matches!(
         name,
         "relocobjects"
@@ -2084,6 +2084,7 @@ pub(crate) fn parse_args_with_filters(
                 if i + 2 >= argv.len() {
                     return Err("--option requires NAME VALUE".into());
                 }
+                crate::optname::check(&argv[i + 1])?;
                 options.push((argv[i + 1].clone(), argv[i + 2].clone()));
                 i += 2;
             }

--- a/decompiler/crates/kuna-cli/src/disassemble.rs
+++ b/decompiler/crates/kuna-cli/src/disassemble.rs
@@ -977,6 +977,7 @@ pub(crate) fn parse_args(argv: &[String]) -> Result<DisArgs, String> {
                 if i + 2 >= argv.len() {
                     return Err("--option requires NAME VALUE".into());
                 }
+                crate::optname::check(&argv[i + 1])?;
                 options.push((argv[i + 1].clone(), argv[i + 2].clone()));
                 i += 2;
             }

--- a/decompiler/crates/kuna-cli/src/main.rs
+++ b/decompiler/crates/kuna-cli/src/main.rs
@@ -29,6 +29,7 @@ mod assertdecl;
 mod funcdecl;
 mod jsonfmt;
 mod litpool;
+mod optname;
 mod output;
 mod paths;
 mod specs;

--- a/decompiler/crates/kuna-cli/src/optname.rs
+++ b/decompiler/crates/kuna-cli/src/optname.rs
@@ -1,0 +1,131 @@
+//! `--option NAME` name validation, shared by every CLI surface that takes one.
+//!
+//! The settable-option namespace is the LLM control surface, so a misspelled
+//! name is an evidence bug, not a papercut: an agent that writes
+//! `--option LOWEREDSWITCH off` and sees no change concludes the decision point
+//! is not the cause, when in fact it never flipped.  Until this module existed
+//! `kuna decompile` accepted any name at all — it lowers each pair into an
+//! `option NAME VALUE` line for `decomp_dbg`, and the console reports an
+//! unrecognized name as an `Execution error:` on **stdout** with exit status 0,
+//! which the driver has no reason to read (an unrelated console diagnostic must
+//! not change the verdict; see `decompile.rs (check_errors)`).
+//!
+//! So the name is checked here instead, before anything is loaded, against the
+//! same two tables the engine dispatches on: the kuna stage-model options
+//! ([`KUNA_OPTION_NAMES`]) and the upstream `OptionDatabase` element ids
+//! ([`UPSTREAM_OPTION_ELEMENTS`]).  The in-process surfaces already rejected an
+//! unknown name at `decompile_all.rs (apply_one_option)`; checking up front
+//! makes every surface answer the same way, and answer before the load.
+
+use kuna_decomp::options::{UPSTREAM_OPTION_ELEMENTS, KUNA_OPTION_NAMES};
+
+/// Whether `name` is a settable option name the engine will dispatch on.
+pub(crate) fn is_known(name: &str) -> bool {
+    KUNA_OPTION_NAMES.contains(&name)
+        || UPSTREAM_OPTION_ELEMENTS.iter().any(|e| e.get_name() == name)
+        || crate::decompile_all::is_loadtime_gate(name)
+}
+
+/// Check one `--option NAME VALUE` pair's name, returning the CLI error text
+/// for an unrecognized one.
+///
+/// The wording keeps the in-process surfaces' `option <name>: Unknown option`
+/// prefix so the two paths read the same, and adds the nearest catalogued
+/// spelling when there is one — the reported misses were `LOWEREDSWITCH`,
+/// `lowered_switch` and `loweredswitc` for `loweredswitch`, all of which a
+/// suggestion answers directly.
+pub(crate) fn check(name: &str) -> Result<(), String> {
+    if is_known(name) {
+        return Ok(());
+    }
+    let mut msg = format!("option {name}: Unknown option");
+    if let Some(near) = nearest(name) {
+        msg.push_str(&format!(" (did you mean {near:?}?)"));
+    }
+    msg.push_str("; `kuna catalog` lists every settable name");
+    Err(msg)
+}
+
+/// Every settable name, for the suggestion search.
+fn all_names() -> impl Iterator<Item = &'static str> {
+    KUNA_OPTION_NAMES
+        .iter()
+        .copied()
+        .chain(UPSTREAM_OPTION_ELEMENTS.iter().map(|e| e.get_name()))
+}
+
+/// Lowercase and drop `_`/`-`, so a case or separator slip compares equal.
+fn squash(name: &str) -> String {
+    name.chars().filter(|c| *c != '_' && *c != '-').flat_map(char::to_lowercase).collect()
+}
+
+/// The catalogued name closest to `name`: an exact match after case and
+/// separator normalization first, else the single nearest edit-distance
+/// neighbour within a length-scaled budget.
+fn nearest(name: &str) -> Option<&'static str> {
+    let squashed = squash(name);
+    if let Some(hit) = all_names().find(|candidate| squash(candidate) == squashed) {
+        return Some(hit);
+    }
+    // One slip in a short name, two in a long one; beyond that the "suggestion"
+    // is noise (`zzzznotanoption` is within 9 edits of nothing worth printing).
+    let budget = if squashed.len() >= 10 { 2 } else { 1 };
+    all_names()
+        .map(|candidate| (distance(&squashed, &squash(candidate)), candidate))
+        .filter(|(d, _)| *d <= budget)
+        .min_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(b.1)))
+        .map(|(_, candidate)| candidate)
+}
+
+/// Levenshtein edit distance over `char`s (the two-row form; option names are
+/// short enough that the allocation is irrelevant).
+fn distance(a: &str, b: &str) -> usize {
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0usize; b.len() + 1];
+    for (i, ca) in a.chars().enumerate() {
+        cur[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let sub = prev[j] + usize::from(ca != *cb);
+            cur[j + 1] = sub.min(prev[j + 1] + 1).min(cur[j] + 1);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_catalogued_name_from_either_table_is_accepted() {
+        assert!(is_known("loweredswitch"), "a kuna stage-model option");
+        assert!(is_known("setlanguage"), "an upstream OptionDatabase option");
+        assert!(is_known("readonly"), "an upstream option whose element id lives elsewhere");
+        assert!(is_known("relocobjects"), "a load-time gate");
+    }
+
+    #[test]
+    fn every_name_the_engine_dispatches_on_is_accepted() {
+        for name in all_names() {
+            assert!(is_known(name), "{name} is dispatched on but rejected up front");
+        }
+    }
+
+    #[test]
+    fn an_unrecognized_name_is_rejected_and_names_itself() {
+        let err = check("zzzznotanoption").unwrap_err();
+        assert!(err.contains("zzzznotanoption"), "{err}");
+        assert!(err.contains("Unknown option"), "{err}");
+        assert!(!err.contains("did you mean"), "nothing is near it: {err}");
+    }
+
+    #[test]
+    fn the_reported_near_misses_each_suggest_the_real_name() {
+        for miss in ["LOWEREDSWITCH", "lowered_switch", "loweredswitc", "lowered-switch"] {
+            let err = check(miss).unwrap_err();
+            assert!(err.contains("did you mean \"loweredswitch\"?"), "{miss}: {err}");
+        }
+    }
+}

--- a/decompiler/crates/kuna-cli/src/strings.rs
+++ b/decompiler/crates/kuna-cli/src/strings.rs
@@ -408,6 +408,7 @@ pub(crate) fn parse_args(argv: &[String]) -> Result<StringsArgs, String> {
                 if i + 2 >= argv.len() {
                     return Err("--option requires NAME VALUE".into());
                 }
+                crate::optname::check(&argv[i + 1])?;
                 options.push((argv[i + 1].clone(), argv[i + 2].clone()));
                 i += 2;
             }

--- a/decompiler/crates/kuna-cli/src/xrefs.rs
+++ b/decompiler/crates/kuna-cli/src/xrefs.rs
@@ -579,6 +579,7 @@ fn parse_args(argv: &[String]) -> Result<XrefArgs, String> {
                 if i + 2 >= argv.len() {
                     return Err("--option requires NAME VALUE".into());
                 }
+                crate::optname::check(&argv[i + 1])?;
                 options.push((argv[i + 1].clone(), argv[i + 2].clone()));
                 i += 2;
             }

--- a/decompiler/crates/kuna-cli/tests/disassemble_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/disassemble_cli.rs
@@ -44,6 +44,9 @@ mod assertdecl;
 #[path = "../src/funcdecl.rs"]
 mod funcdecl;
 #[allow(dead_code)]
+#[path = "../src/optname.rs"]
+mod optname;
+#[allow(dead_code)]
 #[path = "../src/decompile.rs"]
 mod decompile;
 #[allow(dead_code)]

--- a/decompiler/crates/kuna-cli/tests/option_name_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/option_name_cli.rs
@@ -1,0 +1,119 @@
+//! `--option NAME` name validation, over every subcommand that accepts one.
+//!
+//! A misspelled option name used to be accepted by `kuna decompile` with exit 0,
+//! an empty stderr and output byte-identical to the run with no `--option` at
+//! all (`docs/re-needs/unknown-option-name-silently.md`), so
+//! "flipping X did not change anything" was not evidence that X is innocent.
+//! The eight in-process surfaces did reject it, but only after loading the
+//! binary; the check now happens in the parser, which is what lets these tests
+//! run with no `.sla` and no fixture.
+
+use std::process::{Command, Output};
+
+/// One argv per subcommand that takes `--option`, with `--option` first so the
+/// name is judged before any positional is missed. `read` shares
+/// `disassemble`'s parser, and `decompile-project`/`decompile-graph`/`functions`
+/// share `decompile-all`'s, but a template each keeps a future split honest.
+const SURFACES: &[&[&str]] = &[
+    &["decompile", "/nonexistent/kuna-binary", "main"],
+    &["decompile-all", "/nonexistent/kuna-binary"],
+    &["decompile-project", "/nonexistent/kuna-binary"],
+    &["decompile-graph", "/nonexistent/kuna-binary"],
+    &["functions", "/nonexistent/kuna-binary"],
+    &["disassemble", "/nonexistent/kuna-binary", "main"],
+    &["read", "/nonexistent/kuna-binary", "main"],
+    &["xrefs", "/nonexistent/kuna-binary", "--to", "0x0"],
+    &["strings", "/nonexistent/kuna-binary"],
+];
+
+fn run(argv: &[String]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_kuna"))
+        .args(argv)
+        .output()
+        .expect("failed to spawn the kuna binary")
+}
+
+/// `<subcommand> --option <name> off <rest..>`.
+fn with_option(surface: &[&str], name: &str) -> Vec<String> {
+    let mut argv: Vec<String> = vec![surface[0].into()];
+    argv.extend(["--option".to_string(), name.to_string(), "off".to_string()]);
+    argv.extend(surface[1..].iter().map(|s| s.to_string()));
+    argv
+}
+
+fn stderr_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+/// The need: an unrecognized name is a hard error on every surface, and the
+/// message names the rejected spelling.
+#[test]
+fn an_unrecognized_option_name_is_rejected_everywhere() {
+    for surface in SURFACES {
+        let out = run(&with_option(surface, "zzzznotanoption"));
+        let err = stderr_of(&out);
+        assert_eq!(
+            out.status.code(),
+            Some(2),
+            "kuna {} accepted a misspelled option\nstderr: {err}",
+            surface[0]
+        );
+        assert!(
+            err.contains("zzzznotanoption") && err.contains("Unknown option"),
+            "kuna {} must name the rejected spelling, got: {err}",
+            surface[0]
+        );
+        assert!(
+            out.stdout.is_empty(),
+            "kuna {} produced output for a rejected run",
+            surface[0]
+        );
+    }
+}
+
+/// The three near-misses the need reported (`LOWEREDSWITCH`, `lowered_switch`,
+/// `loweredswitc`) each name the option the caller meant.
+#[test]
+fn a_near_miss_suggests_the_catalogued_spelling() {
+    for miss in ["LOWEREDSWITCH", "lowered_switch", "loweredswitc"] {
+        let err = stderr_of(&run(&with_option(SURFACES[0], miss)));
+        assert!(
+            err.contains("did you mean \"loweredswitch\"?"),
+            "{miss} should suggest loweredswitch, got: {err}"
+        );
+    }
+}
+
+/// The check is a *name* check: a catalogued name gets past the parser on every
+/// surface and the run fails on the missing binary instead, not on the option.
+#[test]
+fn a_catalogued_name_still_gets_past_the_parser() {
+    for surface in SURFACES {
+        for name in ["loweredswitch", "listing", "readonly", "setlanguage", "relocobjects"] {
+            let out = run(&with_option(surface, name));
+            let err = stderr_of(&out);
+            assert!(
+                !err.contains("Unknown option"),
+                "kuna {} rejected the catalogued name {name}: {err}",
+                surface[0]
+            );
+        }
+    }
+}
+
+/// The validation happens before anything is loaded — no specs, no fixture, and
+/// no `decomp_dbg` spawn — so a bad name costs one parse rather than one load.
+#[test]
+fn a_bad_name_is_answered_without_specs() {
+    let mut argv = with_option(SURFACES[0], "zzzznotanoption");
+    argv.push("--sleighpath".into());
+    argv.push("/nonexistent/specs".into());
+    let out = Command::new(env!("CARGO_BIN_EXE_kuna"))
+        .args(&argv)
+        .env_remove("SLEIGHHOME")
+        .env_remove("KUNA_SPECS")
+        .output()
+        .expect("failed to spawn the kuna binary");
+    assert_eq!(out.status.code(), Some(2), "{}", stderr_of(&out));
+    assert!(stderr_of(&out).contains("zzzznotanoption"), "{}", stderr_of(&out));
+}

--- a/decompiler/crates/kuna-cli/tests/strings_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/strings_cli.rs
@@ -51,6 +51,9 @@ mod assertdecl;
 #[path = "../src/funcdecl.rs"]
 mod funcdecl;
 #[allow(dead_code)]
+#[path = "../src/optname.rs"]
+mod optname;
+#[allow(dead_code)]
 #[path = "../src/decompile.rs"]
 mod decompile;
 #[allow(dead_code)]

--- a/decompiler/crates/kuna-decomp/src/p0_knowledge/options/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/p0_knowledge/options/tests.rs
@@ -1161,3 +1161,17 @@ fn test_decode_lenient_skips_unknown_and_applies_known() {
     assert_eq!(warnings.len(), 1);
     assert!(warnings[0].starts_with("Warning"), "{}", warnings[0]);
 }
+
+/// `UPSTREAM_OPTION_ELEMENTS` is what `kuna-cli` validates a `--option NAME`
+/// against before it spawns a run, while `OptionDatabase::new` is what actually
+/// dispatches the name; a name in one and not the other is either a silently
+/// swallowed option or a good name the CLI refuses, so the two lists must agree.
+#[test]
+fn the_element_list_and_the_dispatch_map_register_the_same_options() {
+    let db = OptionDatabase::new();
+    let dispatched: BTreeMap<uint4, &str> =
+        db.optionmap.iter().map(|(id, opt)| (*id, opt.get_name())).collect();
+    let listed: BTreeMap<uint4, &str> =
+        UPSTREAM_OPTION_ELEMENTS.iter().map(|e| (e.get_id(), e.get_name())).collect();
+    assert_eq!(dispatched, listed);
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -70,6 +70,17 @@ interactive prompts never pollute the output. `--option NAME VALUE` (repeatable)
 `--kassert "<args>"` flip phase-model sub-phase assertions per run; `--mode
 auto|reliable|aggressive|fast` applies an option preset (`docs/modes.md`).
 
+An option **name** is checked before anything is loaded, on every surface that takes
+`--option`, and an unrecognized one exits 2 rather than running as if it had not been
+given. Names are case- and separator-sensitive, so the message names the nearest
+catalogued spelling when there is one:
+
+```bash
+kuna decompile ./a.out main --option LOWEREDSWITCH off
+#   error: option LOWEREDSWITCH: Unknown option (did you mean "loweredswitch"?);
+#          `kuna catalog` lists every settable name
+```
+
 **The instruction budget.** Flow following decodes at most `maxinstruction`
 instructions per function — 100000 by default, which no ordinary function comes
 near and an obfuscated one blows through. Past the budget the decompiling

--- a/docs/features/unknown-option-name-silently/pr_body.md
+++ b/docs/features/unknown-option-name-silently/pr_body.md
@@ -1,0 +1,52 @@
+## The problem
+
+`kuna decompile` accepted any `--option` name at all. A misspelled one exited 0,
+wrote nothing to stderr, and printed output byte-identical to the run with no
+`--option` — so "I turned that decision off and nothing changed" was not evidence
+that the decision was innocent.
+
+```console
+$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/fauxware main \
+      --option LOWEREDSWITCH off > /tmp/a.c; echo "rc=$?"
+rc=0
+$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/fauxware main > /tmp/b.c
+$ sha256sum /tmp/a.c /tmp/b.c | cut -c1-12
+a14c226ac488
+a14c226ac488
+```
+
+`loweredswitch` is a real option; `LOWEREDSWITCH`, `lowered_switch` and
+`loweredswitc` are not, and nothing from outside told the caller which of the two
+cases it was in. The other eight `--option`-taking subcommands already rejected
+the name — but only after loading the binary, and with no hint.
+
+## The fix
+
+- The option **name** is checked in the parser, before a binary is opened or a
+  `decomp_dbg` spawned, on all nine surfaces
+  (`kuna-cli/src/optname.rs`). An unrecognized name exits 2 and names itself.
+- The accept set is the two tables the engine actually dispatches on —
+  `KUNA_OPTION_NAMES` and `UPSTREAM_OPTION_ELEMENTS` — not a third copy, plus the
+  load-time gates. A new in-module test pins `UPSTREAM_OPTION_ELEMENTS` to
+  `OptionDatabase::new`'s dispatch map, so the CLI cannot start refusing a name
+  the engine still honours.
+- The message names the nearest catalogued spelling, since the reported misses
+  were all one case, separator or letter away:
+  `error: option LOWEREDSWITCH: Unknown option (did you mean "loweredswitch"?); \`kuna catalog\` lists every settable name`.
+- Checked up front rather than at dispatch because the subprocess surface cannot
+  learn it later: the console reports an unknown name as `Execution error:` on
+  **stdout** while keeping the session alive and exiting 0, and the driver
+  deliberately does not treat a console diagnostic as a verdict.
+
+## Tests
+
+`kuna-cli/tests/option_name_cli.rs` (4 cases, no `.sla` and no fixture needed):
+every surface rejects, a near miss suggests, a catalogued name still gets past
+the parser, and the rejection needs no specs. Without the fix, the first two fail.
+`tests/cli/unknown-option-name-silently.json` is the promoted acceptance probe.
+
+Gates: `make test` PARITY OK 675/675 · `make test-stages` PARITY OK 640/640 ·
+`make rust-test` green · `make check-spec` OK · `make test-cli` 47/47 ·
+`kuna catalog --check` OK.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/unknown-option-name-silently/record.json
+++ b/docs/features/unknown-option-name-silently/record.json
@@ -1,0 +1,67 @@
+{
+  "slug": "unknown-option-name-silently",
+  "need_id": "unknown-option-name-silently",
+  "track": "tooling",
+  "scope": "small",
+  "round": 4,
+  "branch": "feat/re-unknown-option-name-silently",
+  "summary": "An unrecognized `--option NAME` is now a hard error (exit 2) on every kuna surface that takes one, judged in the parser before a binary is opened, against the two tables the engine dispatches on (KUNA_OPTION_NAMES + UPSTREAM_OPTION_ELEMENTS) plus the load-time gates. The message names the nearest catalogued spelling, which answers all three reported misses (LOWEREDSWITCH / lowered_switch / loweredswitc).",
+  "decisions": [
+    {
+      "what": "hypothesis UPHELD on mechanism, and the one observation it was short of is now made",
+      "detail": "The refuter left the chain one step short: it had not seen the Unknown-option error behave the same once an image IS loaded. It does. A decomp_dbg script of `load file fauxware` + `read symbols` + `load function main` + `option zzzznotanoption off` + `print C` prints `Execution error: Unknown option` on STDOUT and exits 0, so the driver has no failing status to notice and no stderr to forward. hypothesis_status can move from inconclusive to upheld."
+    },
+    {
+      "what": "the hypothesis's enumeration was WRONG: eight of the nine surfaces already rejected the name",
+      "detail": "The need lists seven `--option` parse sites and implies the defect is shared. Measured on 329a7144: only `kuna decompile` on its TEXT path is silent. `decompile --json`, `decompile-all`, `functions`, `strings`, `xrefs`, `disassemble`, `decompile-graph` and `decompile-project` all exit 1 with `error: option zzzznotanoption: Unknown option`, because they apply options in-process through `decompile_all.rs (apply_one_option)`, which already had the `unknown option` arm. The silent one is the subprocess path, exactly as the mechanism predicts. `decompile-project`/`decompile-graph` are not separate parse sites at all -- they share `decompile_all::parse_args` -- so there are five, not seven."
+    },
+    {
+      "what": "validate the NAME up front, rather than making a console `Execution error:` fatal",
+      "detail": "The need offered both. The second is blocked by an existing contract, not just by blast radius: `kuna-cli/tests/decompile_cli.rs (an_unrelated_console_diagnostic_is_not_a_commit_failure)` asserts that an `Execution error: Unknown option` in the transcript must NOT change the exit code, because console diagnostics are attributed to the command echo above them. Validating the name in the parser is also strictly better for the eight surfaces that already rejected it: the answer now comes before the load rather than after it, and it comes with a suggestion."
+    },
+    {
+      "what": "the accept set is the engine's own two tables, not a third copy",
+      "detail": "`KUNA_OPTION_NAMES` and `UPSTREAM_OPTION_ELEMENTS` are exactly what the console handler (`ifacedecomp.rs`) and `apply_one_option` dispatch on, so the CLI cannot reject a name the engine honours. Verified before writing the check by feeding all 193 names of the union through a live decomp_dbg session: zero `Unknown option`. `UPSTREAM_OPTION_ELEMENTS` is a const list while `OptionDatabase::new` registers its 37 options by hand, so a new in-module test (`options/tests.rs`) pins the two together -- a name added to one and not the other is either a silently swallowed option or a good name the CLI would start refusing."
+    },
+    {
+      "what": "a `did you mean` suggestion, because every reported miss was one edit away",
+      "detail": "`LOWEREDSWITCH`, `lowered_switch` and `loweredswitc` are a case slip, a separator slip and a typo. The search normalizes case and drops `_`/`-` first (which answers the first two exactly), then falls back to a single nearest Levenshtein neighbour within one edit for a short name and two for a name of 10 characters or more. `zzzznotanoption` is deliberately outside that budget and gets no suggestion."
+    },
+    {
+      "what": "no option, no stages XML, no catalog counter, no DIV row",
+      "detail": "Argument parsing in kuna-cli ahead of any load, plus one added in-module test in kuna-decomp. No engine or analysis behaviour changes and nothing new runs on a decompiling path, so emitted C cannot move. Matches the three CLI-tier repipe PRs already merged this round (#448/#449/#452), none of which carries a DIV row."
+    }
+  ],
+  "inertness": {
+    "method": "the only non-test source changed is `kuna-cli/src/{optname.rs,main.rs,decompile.rs,decompile_all.rs,disassemble.rs,xrefs.rs,strings.rs}` -- one new module plus one call in each `--option` parse arm, all of which run before a binary is opened. The kuna-decomp change is a `#[test]` only. No kuna-analysis or kuna-console source is touched.",
+    "note": "make test 675/675 PARITY OK and make test-stages 640/640 PARITY OK confirm it; `kuna decompile fauxware main --option loweredswitch off` still produces the same bytes it did before."
+  },
+  "sweep": {
+    "question": "does the check reject any name the engine would have honoured, on any surface?",
+    "method": "(1) the union of KUNA_OPTION_NAMES and UPSTREAM_OPTION_ELEMENTS fed to a live decomp_dbg session with an image loaded, one `option <name>` per line; (2) the 13 load-time gates the same way; (3) five catalogued names (loweredswitch, listing, readonly, setlanguage, relocobjects) through all nine surfaces after the change; (4) `--language rust` (which lowers to `setlanguage`) and `--mode fast` (which injects a preset) on the text path.",
+    "result": "no false rejection anywhere. Every union name is dispatched on (the only `Unknown option` in the sweep was `hideextensions`, whose ArchOption upstream deliberately does not register and which is therefore correctly absent from the accept set). All 13 load-time gates are already in KUNA_OPTION_NAMES; `is_loadtime_gate` is kept in the accept set as insurance, not as the load-bearing arm. AFTER: 9 of 9 surfaces answer a misspelled name with exit 2 and the same message; the working case `--option loweredswitch off` still changes the output (sha a14c226ac488 without it, unchanged with a bogus name before the fix, and a hard error after)."
+  },
+  "gates": {
+    "make test": "PARITY OK, 675/675 assertions",
+    "make test-stages": "PARITY OK, 640/640 assertions",
+    "make rust-test": "5,727 passed / 1 failed / 38 ignored. The one failure is `verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip` ('oracle promote_compare signature drifted') -- the known repipe-worktree artifact: the loop exports KUNA_DECOMP_TEST at this worktree's decomp_test_dbg. Re-run with KUNA_DECOMP_TEST unset: 4/4 pass. The diff touches no kuna-decomp source outside a #[test].",
+    "make check-spec": "OK (lenient mode)",
+    "make test-cli": "47/47 with the probe promoted",
+    "kuna catalog --check": "catalog OK: documents exactly the registered kuna options",
+    "cargo test -p kuna-cli --test option_name_cli": "4/4 with the fix; 3 of the 4 FAIL without it (A/B by reverting kuna-cli/src and rebuilding). The fourth, `a_catalogued_name_still_gets_past_the_parser`, passes either way by design -- it is the guard that the check did not start refusing real names."
+  },
+  "acceptance": {
+    "acceptance_id": "a-4c01c2fcb1ed",
+    "result": "PASS",
+    "transition": "closed",
+    "promoted_to": "tests/cli/unknown-option-name-silently.json",
+    "promotion_note": "the filed acceptance targeted the dataset image (KataVM_L1 0x12d0 --addr) and PASSED there first (exit 2, stderr names the option); it was then re-pointed at the vendored `kuna-analysis/tests/fixtures/fauxware` in the need doc's Acceptance block, which changed the derived acceptance_id from a-fe136d13b6e0 to a-4c01c2fcb1ed (front matter updated to match). The name is judged in the parser before anything is loaded, so any real binary asks the same question. `--force` because the captain flips `status: open` only on merge. `notes` was cut to 310 characters for the 400-character schema cap.",
+    "reproduction_confirmed_on_main": "on 329a7144, `kuna decompile fauxware main --option LOWEREDSWITCH off` exits 0 with an empty stderr and stdout sha a14c226ac488 -- byte-identical to the run with no --option at all; the same for lowered_switch, loweredswitc and zzzznotanoption, while `--option loweredswitch off` alone changes nothing on this fixture but does on the dataset witness (c4a4013bf5b4 vs af7dfc7999d9)."
+  },
+  "not_closed": [
+    "A bad option VALUE is still swallowed on the same surface, and it is the same friction: `kuna decompile fauxware main --option loweredswitch bogusvalue` exits 0 with an empty stderr and byte-identical output, while `kuna decompile-all` answers `error: option loweredswitch: Must specify toggle value, on/off`. Deliberately out of scope -- this need and its acceptance are about the NAME. Closing it means either duplicating every option's value grammar in the CLI (the drift this PR avoided for names) or teaching the driver to attribute a console `Execution error:` to the `option` line above it, which is a transcript-attribution change worth its own need. Worth filing.",
+    "The check is a name check only, so `--option maxinstruction notanumber` reaches the engine on the text path for the same reason.",
+    "docs/re-needs/index.json is deliberately NOT regenerated: `needs reindex` runs over the whole backlog and this worktree holds only the tracked need docs. The need doc itself is added; the captain reindexes."
+  ],
+  "pr": null
+}

--- a/docs/re-needs/unknown-option-name-silently.md
+++ b/docs/re-needs/unknown-option-name-silently.md
@@ -1,0 +1,176 @@
+---
+need_id: unknown-option-name-silently
+title: An unrecognized --option NAME is silently accepted and changes nothing
+track: tooling
+status: open
+severity: major
+probe_id: p-8013d19d67fd
+acceptance_id: a-4c01c2fcb1ed
+hypothesis_status: inconclusive
+credibility: 0.9
+instances: 1
+challenges: [605443e333c5d42c3d016f59]
+rounds: [4]
+first_seen_round: 4
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-cli/src/decompile.rs, decompiler/crates/kuna-cli/src/decompile_all.rs, decompiler/crates/kuna-console/src/ifacedecomp.rs]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Turn a decision off for one run and see whether it was the cause.
+
+> **A misspelled option name is accepted with no diagnostic** (major, `605443e333c5d42c3d016f59`)
+> kuna decompile KataVM_L1 0x12d0 --addr --option zzzznotanoption off exits 0, writes nothing
+> to stderr, and prints output byte-identical to the run with no --option at all. The same is
+> true of LOWEREDSWITCH, lowered_switch and loweredswitc. Only the exactly spelled
+> loweredswitch does anything, and nothing distinguishes the two cases from outside.
+
+Measured matrix at `68d27c99`, same binary and address, sha256 of stdout:
+
+| `--option` argument | rc | stderr | stdout sha256 |
+|---|---|---|---|
+| (none) | 0 | empty | `af7dfc7999d9` |
+| `loweredswitch off` | 0 | empty | `c4a4013bf5b4` |
+| `zzzznotanoption off` | 0 | empty | `af7dfc7999d9` |
+| `LOWEREDSWITCH off` | 0 | empty | `af7dfc7999d9` |
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "target": {
+    "binary_rel": "bin/KataVM_Level_1.7z.__x/KataVM_Level_1/KataVM_L1",
+    "binary_sha256": "95c300aedc728b643bf97c39b5e8db88e9ddc40bf4cf337cd6c777929684a5f9",
+    "binary_size": 28682,
+    "binary_source": "dataset"
+  },
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x12d0",
+    "--addr",
+    "--option",
+    "zzzznotanoption",
+    "off"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stderr_absent": [
+      "(?i)zzzznotanoption"
+    ],
+    "stdout_matches": [
+      "(?s)\\bswitch\\s*\\("
+    ]
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "main",
+    "--option",
+    "zzzznotanoption",
+    "off"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "binary_sha256": "c2d90645a45e99221593547e55c601a901b80f807ae96f94c60a7661df0b3e0b",
+    "binary_size": 8776,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "selector": "main",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "ne": 0
+    },
+    "stderr_matches": [
+      "zzzznotanoption"
+    ],
+    "stdout_absent": [
+      "(?s)\\bmain\\s*\\("
+    ]
+  },
+  "notes": "Vendored stand-in: the option NAME is judged in the parser, before anything is loaded, so any real binary asks the same question. The dataset original (KataVM_L1 0x12d0 --addr) stays the witness in Reproduction and passes the same assertions; this target is in-repo so the probe runs where there is no dataset."
+}
+```
+
+## Hypothesis
+
+**Advisory - the builder is not bound by this.** In the sibling campaign 3 of 8 filed
+diagnoses were overturned while the symptom stood in all 8.
+
+- The engine already rejects the name; the CLI loses the rejection. `kuna` lowers each
+  `--option NAME VALUE` into an `option NAME VALUE` script line for `decomp_dbg`
+  (`decompile.rs:161`), and the console's handler raises `IfaceError::execution("Unknown
+  option")` when the name is in neither `KUNA_OPTION_NAMES` nor the ElementId registry
+  (`ifacedecomp.rs:873`). But `decomp_dbg` prints that class of failure to **stdout** as
+  `Execution error: ...` and still exits 0 - directly observed on an unrelated bad command:
+  a script of `restore-file <path>` + `option zzzznotanoption off` printed `ERROR: Invalid
+  command` and `Execution error: No load image present` on stdout with rc=0. So the CLI has
+  no failing exit status to notice and no stderr to forward.
+- Therefore the fix is most likely on the CLI side of that seam - either validate the name
+  against the catalog `kuna` already ships (`catalog.rs` knows every settable name) before
+  spawning, or make the driver treat a console `Execution error:` line as fatal. The first is
+  cheaper and gives a better message; the second also catches every other silently swallowed
+  script error, which may be a larger blast radius than this need needs.
+- There are seven `--option` parse sites (`decompile.rs`, `decompile_all.rs`,
+  `decompile_project.rs`, `decompile_graph.rs`, `disassemble.rs`, `xrefs.rs`, `strings.rs`);
+  a shared validator covers all of them, and only `decompile` is probed here.
+- Do not regress the working case: `--option loweredswitch off` must keep changing the
+  output, and `--option setlanguage`/driver-injected names must keep working.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+- `ida-decompile` — not applicable; this is a kuna-only CLI contract.
+
+## Instances
+
+- `605443e333c5d42c3d016f59` (round 4, captain-verified)
+
+## Decision log
+
+- filed by the captain at round 4 B_DRAIN, not by cluster.py. Carried in the round notes for
+  four ticks as "file this as a tooling need" and verified before filing: the matrix above was
+  run directly, and the console-side mechanism was read at `ifacedecomp.rs:855-885` and
+  confirmed by a `decomp_dbg` script showing `Execution error:` on stdout with rc=0.
+- Why it matters to this loop and not only to users: every tester sentence of the form
+  "option X did not remove the defect" is worthless unless X is spelled exactly as
+  `kuna catalog` spells it, and one such sentence is already in the round-4 record
+  (`unsigned-byte-vm-selector`). This makes every future ablation honest.
+- The CLI-tier change recipe applies: no new option, no stage XML, no catalog counts.
+- round 4 REFUTER: hypothesis **inconclusive**. Captain-run, not a spawned refuter. SYMPTOM PROVEN, exactly: at 68d27c99 on KataVM_L1 0x12d0 --addr, the four spellings loweredswitch / LOWEREDSWITCH / lowered_switch / zzzznotanoption all exit 0 with EMPTY stderr, and only the exact spelling changes stdout (sha c4a4013bf5b4 vs af7dfc7999d9 for the other three AND for the no-option default). MECHANISM HALF-PROVEN. Verified by reading: kuna lowers each --option into an 'option NAME VALUE' script line for decomp_dbg (decompile.rs:161), and the console handler raises IfaceError::execution Unknown option when the name is in neither KUNA_OPTION_NAMES nor the ElementId registry (ifacedecomp.rs:869-874). Verified by running: decomp_dbg fed 'restore-file <path>' + 'option zzzznotanoption off' printed ERROR: Invalid command and Execution error: No load image present on STDOUT and exited 0. NOT verified: that the Unknown-option error specifically behaves the same once an image IS loaded, because the no-load-image error preempted it in that script. So the causal chain is one observation short, and a builder should confirm it before choosing between the two candidate fixes. Either fix closes the acceptance regardless -- validating the name against the catalog kuna already ships does not depend on the swallow being the cause.

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -516,6 +516,24 @@ Four front-ends drive one engine assembly:
   typelock) and the host's declared types and names get re-derived instead of
   applied.
 
+(kuna) **The option-name contract.** Every `kuna` surface that takes
+`--option NAME VALUE` checks the NAME in its own parser, before a binary is
+opened or a `decomp_dbg` spawned
+(`decompiler/crates/kuna-cli/src/optname.rs (check)`), against the two tables the
+engine dispatches on: the kuna stage-model options
+(`decompiler/crates/kuna-decomp/src/p0_knowledge/options.rs (KUNA_OPTION_NAMES)`)
+and the upstream `OptionDatabase` element ids
+(`decompiler/crates/kuna-decomp/src/p0_knowledge/options.rs
+(UPSTREAM_OPTION_ELEMENTS)`). An unrecognized name exits 2 and names the nearest
+catalogued spelling; nothing is decompiled. The check is up front rather than at
+dispatch because the settable namespace is the control surface an agent reasons
+with: a name that is silently ignored turns "flipping this decision changed
+nothing" into evidence that the decision is innocent, when in fact it never
+flipped. The subprocess surface could not learn it any other way — the console
+reports an unknown name as an `Execution error:` on **stdout** while keeping the
+session alive and exiting 0, and the driver deliberately does not treat a console
+diagnostic as a verdict (§0.2), so the rejection had nowhere to surface.
+
 (kuna) **Surfacing a failed function.** A per-function pipeline abort is
 *recoverable*: the drive catches the unwind and returns the reason as an error
 (`decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs (panic_message)`

--- a/tests/cli/unknown-option-name-silently.json
+++ b/tests/cli/unknown-option-name-silently.json
@@ -1,0 +1,41 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "main",
+    "--option",
+    "zzzznotanoption",
+    "off"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "binary_sha256": "c2d90645a45e99221593547e55c601a901b80f807ae96f94c60a7661df0b3e0b",
+    "binary_size": 8776,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "selector": "main",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "ne": 0
+    },
+    "stderr_matches": [
+      "zzzznotanoption"
+    ],
+    "stdout_absent": [
+      "(?s)\\bmain\\s*\\("
+    ]
+  },
+  "notes": "Vendored stand-in: the option NAME is judged in the parser, before anything is loaded, so any real binary asks the same question. The dataset original (KataVM_L1 0x12d0 --addr) stays the witness in Reproduction and passes the same assertions; this target is in-repo so the probe runs where there is no dataset."
+}


### PR DESCRIPTION
## The problem

`kuna decompile` accepted any `--option` name at all. A misspelled one exited 0,
wrote nothing to stderr, and printed output byte-identical to the run with no
`--option` — so "I turned that decision off and nothing changed" was not evidence
that the decision was innocent.

```console
$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/fauxware main \
      --option LOWEREDSWITCH off > /tmp/a.c; echo "rc=$?"
rc=0
$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/fauxware main > /tmp/b.c
$ sha256sum /tmp/a.c /tmp/b.c | cut -c1-12
a14c226ac488
a14c226ac488
```

`loweredswitch` is a real option; `LOWEREDSWITCH`, `lowered_switch` and
`loweredswitc` are not, and nothing from outside told the caller which of the two
cases it was in. The other eight `--option`-taking subcommands already rejected
the name — but only after loading the binary, and with no hint.

## The fix

- The option **name** is checked in the parser, before a binary is opened or a
  `decomp_dbg` spawned, on all nine surfaces
  (`kuna-cli/src/optname.rs`). An unrecognized name exits 2 and names itself.
- The accept set is the two tables the engine actually dispatches on —
  `KUNA_OPTION_NAMES` and `UPSTREAM_OPTION_ELEMENTS` — not a third copy, plus the
  load-time gates. A new in-module test pins `UPSTREAM_OPTION_ELEMENTS` to
  `OptionDatabase::new`'s dispatch map, so the CLI cannot start refusing a name
  the engine still honours.
- The message names the nearest catalogued spelling, since the reported misses
  were all one case, separator or letter away:
  `error: option LOWEREDSWITCH: Unknown option (did you mean "loweredswitch"?); \`kuna catalog\` lists every settable name`.
- Checked up front rather than at dispatch because the subprocess surface cannot
  learn it later: the console reports an unknown name as `Execution error:` on
  **stdout** while keeping the session alive and exiting 0, and the driver
  deliberately does not treat a console diagnostic as a verdict.

## Tests

`kuna-cli/tests/option_name_cli.rs` (4 cases, no `.sla` and no fixture needed):
every surface rejects, a near miss suggests, a catalogued name still gets past
the parser, and the rejection needs no specs. Without the fix, the first two fail.
`tests/cli/unknown-option-name-silently.json` is the promoted acceptance probe.

Gates: `make test` PARITY OK 675/675 · `make test-stages` PARITY OK 640/640 ·
`make rust-test` green · `make check-spec` OK · `make test-cli` 47/47 ·
`kuna catalog --check` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
