### PR TITLE
[AUTOMATED] fix(cli): qualified-parameter-assertions-modify — a `<func>::` assertion binds to the function it names

### DIFF
--- a/decompiler/crates/kuna-analysis/src/analyzers/demangle/kuna_cppsig.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/demangle/kuna_cppsig.rs
@@ -575,6 +575,7 @@ fn build_pieces(
         innames,
         first_var_arg_slot,
         output_storage: None,
+        input_storage: Vec::new(),
     })
 }
 

--- a/decompiler/crates/kuna-analysis/src/analyzers/dwarf/kuna_cppproto.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/dwarf/kuna_cppproto.rs
@@ -261,6 +261,7 @@ pub(super) fn build_pieces(
         innames,
         first_var_arg_slot: res.first_var_arg_slot,
         output_storage: None,
+        input_storage: Vec::new(),
     })
 }
 

--- a/decompiler/crates/kuna-analysis/src/analyzers/dwarf/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/dwarf/mod.rs
@@ -880,6 +880,7 @@ fn build_pieces(
         innames,
         first_var_arg_slot,
         output_storage: None,
+        input_storage: Vec::new(),
     })
 }
 

--- a/decompiler/crates/kuna-analysis/src/analyzers/entry/kuna_entrymainproto.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/entry/kuna_entrymainproto.rs
@@ -325,5 +325,6 @@ fn prototype_for(arch: &Architecture, main: u64, slots: &[Slot]) -> Option<Proto
         innames,
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     })
 }

--- a/decompiler/crates/kuna-analysis/src/analyzers/entry/kuna_machomain.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/entry/kuna_machomain.rs
@@ -145,6 +145,7 @@ fn main_prototype(ctx: &AnalysisCtx) -> Option<PrototypePieces> {
         innames: vec!["argc".to_string(), "argv".to_string()],
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     })
 }
 

--- a/decompiler/crates/kuna-analysis/src/analyzers/formatstring/apply.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/formatstring/apply.rs
@@ -139,6 +139,7 @@ pub fn build_override_pieces(
         // installs a FunctionDefinitionDataType with no var-args flag set).
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     }))
 }
 

--- a/decompiler/crates/kuna-analysis/src/analyzers/objc/encoding.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/objc/encoding.rs
@@ -78,6 +78,7 @@ pub fn decode_method(
         innames,
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     })
 }
 

--- a/decompiler/crates/kuna-analysis/src/analyzers/protos/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/protos/mod.rs
@@ -166,6 +166,7 @@ fn build_pieces(
         innames,
         first_var_arg_slot: sig.vararg,
         output_storage: None,
+        input_storage: Vec::new(),
     })
 }
 

--- a/decompiler/crates/kuna-cli/src/assertdecl.rs
+++ b/decompiler/crates/kuna-cli/src/assertdecl.rs
@@ -68,6 +68,7 @@ pub(crate) enum Slot {
 }
 
 /// One directive rendered for the console script.
+#[derive(Debug)]
 pub(crate) struct ConsoleForm {
     pub(crate) slot: Slot,
     pub(crate) line: String,
@@ -324,9 +325,41 @@ pub(crate) fn parse_one(spec: &str) -> Result<Directive, String> {
     Ok(Directive { raw, body })
 }
 
-/// The console line(s) a directive lowers to, and the script slot they belong
-/// in.  `None` for a directive with no console spelling.
-pub(crate) fn console_form(d: &Directive) -> Option<ConsoleForm> {
+/// The function a directive names, when that is NOT the function this run
+/// selected.  `target` is `None` for an `--addr` run, where the CLI does not
+/// know the selected function's name until the script has run.
+fn names_another(func: &Option<String>, target: Option<&str>) -> Option<String> {
+    let f = func.as_deref()?;
+    match target {
+        Some(t) if t == f => None,
+        _ => Some(f.to_string()),
+    }
+}
+
+/// A qualified directive that cannot bind: it names a function this run did not
+/// decompile, and its kind (a local, a comment, a flow edge) has no meaning
+/// outside the function it belongs to.  Silently applying it to the SELECTED
+/// function instead is what made `--assert 'param callee::0 ECX char *maze'`
+/// rename the caller's parameters
+/// (`docs/re-needs/qualified-parameter-assertions-modify.md`).
+fn unbindable(func: &str) -> String {
+    format!(
+        "names {func}, which this run did not decompile (decompile {func}, or use \
+         a directive that crosses functions: prototype, param, return)"
+    )
+}
+
+/// The console line a directive lowers to, and the script slot it belongs in.
+///
+/// `target` is the function the run selected.  A `param`/`return` qualified with
+/// a DIFFERENT function is a statement about that function's prototype, so it
+/// lowers to the cross-function console spelling and moves to the program slot;
+/// every other qualified directive that names a function this run does not
+/// decompile is rejected rather than applied to the selected one.
+pub(crate) fn console_form(
+    d: &Directive,
+    target: Option<&str>,
+) -> Result<ConsoleForm, String> {
     let (slot, line) = match &d.body {
         Body::Function { start, end, name } => {
             let mut line = format!("function bounds {start:#x}");
@@ -349,24 +382,34 @@ pub(crate) fn console_form(d: &Directive) -> Option<ConsoleForm> {
             (Slot::Program, format!("map prototype {func} {}", semicolon(decl)))
         }
         Body::Data { addr, decl } => (Slot::Program, format!("map address {addr:#x} {decl}")),
-        Body::Param { index, storage, decl, .. } => {
-            (Slot::Function, format!("map param {index} {storage} {decl}"))
-        }
-        Body::Return { storage, decl, .. } => {
-            (Slot::Function, format!("map return {storage} {decl}"))
-        }
-        Body::Comment { addr, text, .. } => {
-            (Slot::Function, format!("comment instruction {addr:#x} {text}"))
-        }
-        Body::Flow { addr, kind, .. } => {
-            (Slot::Function, format!("override flow {addr:#x} {kind}"))
-        }
+        Body::Param { func, index, storage, decl } => match names_another(func, target) {
+            Some(f) => (Slot::Program, format!("map param {f}::{index} {storage} {decl}")),
+            None => (Slot::Function, format!("map param {index} {storage} {decl}")),
+        },
+        Body::Return { func, storage, decl } => match names_another(func, target) {
+            Some(f) => (Slot::Program, format!("map return {f}::{storage} {decl}")),
+            None => (Slot::Function, format!("map return {storage} {decl}")),
+        },
+        Body::Comment { func, addr, text } => match names_another(func, target) {
+            Some(f) => return Err(unbindable(&f)),
+            None => (Slot::Function, format!("comment instruction {addr:#x} {text}")),
+        },
+        Body::Flow { func, addr, kind } => match names_another(func, target) {
+            Some(f) => return Err(unbindable(&f)),
+            None => (Slot::Function, format!("override flow {addr:#x} {kind}")),
+        },
         Body::Readonly { addr, size } => (Slot::Image, format!("readonly {addr:#x} {size}")),
         Body::Volatile { addr, size } => (Slot::Image, format!("volatile {addr:#x} {size}")),
-        Body::Name { symbol, newname, .. } => (Slot::Symbol, format!("rename {symbol} {newname}")),
-        Body::Type { symbol, decl, .. } => (Slot::Symbol, format!("retype {symbol} {decl}")),
+        Body::Name { func, symbol, newname } => match names_another(func, target) {
+            Some(f) => return Err(unbindable(&f)),
+            None => (Slot::Symbol, format!("rename {symbol} {newname}")),
+        },
+        Body::Type { func, symbol, decl } => match names_another(func, target) {
+            Some(f) => return Err(unbindable(&f)),
+            None => (Slot::Symbol, format!("retype {symbol} {decl}")),
+        },
     };
-    Some(ConsoleForm { slot, line })
+    Ok(ConsoleForm { slot, line })
 }
 
 fn semicolon(decl: &str) -> String {
@@ -379,10 +422,10 @@ fn semicolon(decl: &str) -> String {
 }
 
 /// Does any directive need the script's second `decompile`?
-pub(crate) fn needs_second_pass(directives: &[Directive]) -> bool {
+pub(crate) fn needs_second_pass(directives: &[Directive], target: Option<&str>) -> bool {
     directives
         .iter()
-        .filter_map(console_form)
+        .filter_map(|d| console_form(d, target).ok())
         .any(|form| form.slot == Slot::Symbol)
 }
 
@@ -533,7 +576,7 @@ mod tests {
     #[test]
     fn a_prototype_that_renames_the_function_still_names_its_target() {
         let d = one("prototype sub_1400055e0 void * sha256(void *out,void *input)");
-        let form = console_form(&d).expect("has a console form");
+        let form = console_form(&d, Some("sub_1400055e0")).expect("has a console form");
         assert_eq!(
             form.line,
             "map prototype sub_1400055e0 void * sha256(void *out,void *input);"
@@ -545,7 +588,7 @@ mod tests {
     fn directives_lower_to_their_console_commands() {
         let lowered = |spec: &str| {
             let d = one(spec);
-            let f = console_form(&d).expect("has a console form");
+            let f = console_form(&d, Some("authenticate")).expect("has a console form");
             (f.slot, f.line)
         };
         assert_eq!(
@@ -637,14 +680,60 @@ mod tests {
         assert!(!implies_readonly_propagation(&[one("name v2 credbuf")]));
     }
 
+    /// A `param`/`return` qualified with a function OTHER than the selected one
+    /// is a statement about that function's prototype, so it lowers to the
+    /// cross-function console spelling and moves to the program slot.  Before
+    /// this the qualifier was dropped and `param callee::0 ECX char *maze`
+    /// retyped the CALLER
+    /// (`docs/re-needs/qualified-parameter-assertions-modify.md`).
+    #[test]
+    fn a_qualified_param_lowers_against_the_function_it_names() {
+        let d = one("param sub_401c50::0 ECX char *maze");
+        let form = console_form(&d, Some("sub_402020")).expect("has a console form");
+        assert_eq!(form.slot, Slot::Program);
+        assert_eq!(form.line, "map param sub_401c50::0 %ECX char *maze");
+
+        let form = console_form(&d, Some("sub_401c50")).expect("has a console form");
+        assert_eq!(form.slot, Slot::Function);
+        assert_eq!(form.line, "map param 0 %ECX char *maze");
+
+        let d = one("return sub_401c50::EAX int4");
+        let form = console_form(&d, Some("sub_402020")).expect("has a console form");
+        assert_eq!(form.slot, Slot::Program);
+        assert_eq!(form.line, "map return sub_401c50::%EAX int4");
+    }
+
+    /// `comment`, `flow`, `name` and `type` describe the inside of one function
+    /// body, so naming a function this run did not decompile cannot be honoured.
+    /// Rejecting says so; applying it to the SELECTED function silently is the
+    /// bug.
+    #[test]
+    fn a_qualified_body_directive_naming_another_function_is_rejected() {
+        for spec in [
+            "name sub_401c50::v2 credbuf",
+            "type sub_401c50::v2 char[16]",
+            "comment sub_401c50::0x401c60 checks the maze",
+            "flow sub_401c50::0x401c60 return",
+        ] {
+            let d = one(spec);
+            let detail = console_form(&d, Some("sub_402020")).expect_err("does not bind");
+            assert!(detail.contains("sub_401c50"), "{spec}: {detail}");
+            // The same directive against its own function still lowers.
+            assert!(console_form(&d, Some("sub_401c50")).is_ok(), "{spec}");
+        }
+    }
+
     /// The second `decompile` is emitted ONLY for a symbol-scoped directive, so
     /// every other invocation keeps its current cost.
     #[test]
     fn only_a_symbol_scoped_directive_forces_a_second_pass() {
-        assert!(!needs_second_pass(&[one("prototype f int4 f(void)")]));
-        assert!(!needs_second_pass(&[one("param 0 RDI int4 a")]));
-        assert!(needs_second_pass(&[one("name v2 buf")]));
-        assert!(needs_second_pass(&[one("prototype f int4 f(void)"), one("type v2 char[4]")]));
+        assert!(!needs_second_pass(&[one("prototype f int4 f(void)")], Some("f")));
+        assert!(!needs_second_pass(&[one("param 0 RDI int4 a")], Some("f")));
+        assert!(needs_second_pass(&[one("name v2 buf")], Some("f")));
+        assert!(needs_second_pass(
+            &[one("prototype f int4 f(void)"), one("type v2 char[4]")],
+            Some("f"),
+        ));
     }
 
     #[test]

--- a/decompiler/crates/kuna-cli/src/decompile.rs
+++ b/decompiler/crates/kuna-cli/src/decompile.rs
@@ -132,6 +132,19 @@ fn build_script(
     regions_path: Option<&Path>,
 ) -> String {
     let mut lines: Vec<String> = Vec::new();
+    // The function this run selected, when it was named rather than addressed:
+    // a directive qualified with it binds to the selection, and one qualified
+    // with any other function does not (`crate::assertdecl::console_form`).
+    let selected = if by_address { None } else { Some(target) };
+    // The console lines of one slot, in the order the caller gave them.  A
+    // directive that does not bind this run has no line and is reported by
+    // `assertion_outcomes` instead.
+    let forms = |slot| {
+        assertions
+            .iter()
+            .filter_map(|d| crate::assertdecl::console_form(d, selected).ok())
+            .filter(move |f| f.slot == slot)
+    };
     let image = console_path(binary);
     match bfd_target {
         Some(t) if !t.is_empty() => lines.push(format!("load file {t} {image}")),
@@ -164,10 +177,8 @@ fn build_script(
     // (kuna `--assert`) IMAGE-scoped directives -- a read-only or volatile
     // memory range -- must precede `read symbols`: mapping a symbol folds the
     // range property into its SymbolEntry and never looks at the range again.
-    for form in assertions.iter().filter_map(crate::assertdecl::console_form) {
-        if form.slot == crate::assertdecl::Slot::Image {
-            lines.push(form.line);
-        }
+    for form in forms(crate::assertdecl::Slot::Image) {
+        lines.push(form.line);
     }
     lines.push("read symbols".into());
     // `--define-function` AFTER the analysis commit and BEFORE the load: a
@@ -180,10 +191,8 @@ fn build_script(
     // (kuna `--assert`) The PROGRAM-scoped directives -- a parsed type, a
     // declared prototype, a named global -- go here, after the analysis commit
     // and before the selection, so the function is loaded against them.
-    for form in assertions.iter().filter_map(crate::assertdecl::console_form) {
-        if form.slot == crate::assertdecl::Slot::Program {
-            lines.push(form.line);
-        }
+    for form in forms(crate::assertdecl::Slot::Program) {
+        lines.push(form.line);
     }
     if by_address {
         match EntrySelector::parse(target) {
@@ -204,10 +213,8 @@ fn build_script(
     }
     // FUNCTION-scoped directives need a loaded function and are consumed at flow
     // time, so they precede the first `decompile`.
-    for form in assertions.iter().filter_map(crate::assertdecl::console_form) {
-        if form.slot == crate::assertdecl::Slot::Function {
-            lines.push(form.line);
-        }
+    for form in forms(crate::assertdecl::Slot::Function) {
+        lines.push(form.line);
     }
     for ka in kasserts {
         lines.push(format!("kassert {ka}"));
@@ -218,11 +225,9 @@ fn build_script(
     // `No symbol named: v2`), so they run between two decompiles. The second
     // `decompile` is emitted ONLY when there is such a directive, so every other
     // invocation keeps its current cost.
-    if crate::assertdecl::needs_second_pass(assertions) {
-        for form in assertions.iter().filter_map(crate::assertdecl::console_form) {
-            if form.slot == crate::assertdecl::Slot::Symbol {
-                lines.push(form.line);
-            }
+    if crate::assertdecl::needs_second_pass(assertions, selected) {
+        for form in forms(crate::assertdecl::Slot::Symbol) {
+            lines.push(form.line);
         }
         lines.push("decompile".into());
     }
@@ -484,15 +489,18 @@ fn find_pipeline_failure(out: &str) -> Option<(String, String)> {
 fn assertion_outcomes(
     out: &str,
     directives: &[kuna_console::assertions::Directive],
+    selected: Option<&str>,
 ) -> Vec<kuna_console::assertions::Outcome> {
     use kuna_console::assertions::Outcome;
     directives
         .iter()
         .map(|directive| {
             let (kind, phase, subphase) = directive.body.coords();
-            let detail = match crate::assertdecl::console_form(directive) {
-                Some(form) => command_failure(out, &form.line),
-                None => Some("no console spelling for this directive".to_string()),
+            let detail = match crate::assertdecl::console_form(directive, selected) {
+                Ok(form) => command_failure(out, &form.line),
+                // Nothing was emitted for it: the directive names a function this
+                // run did not decompile, and the reason is the report row.
+                Err(detail) => Some(detail),
             };
             Outcome {
                 directive: directive.raw.clone(),
@@ -632,6 +640,9 @@ fn decompile(args: &DecompileArgs) -> Result<DecompileOutcome, String> {
         .into_iter()
         .partition(|(name, _)| matches!(*name, "listing" | "errortoomanyinstructions"));
 
+    // The selected function's name, or `None` for an `--addr` run — what decides
+    // whether a `<func>::`-qualified directive binds to the selection.
+    let selected: Option<&str> = if by_address { None } else { Some(args.target.as_str()) };
     let attempt = |injected: &[(&'static str, &'static str)]| {
         let script = build_script(
             &binary,
@@ -871,7 +882,7 @@ fn decompile(args: &DecompileArgs) -> Result<DecompileOutcome, String> {
                     ),
                     regions: None,
                     failure: None,
-                    assertions: assertion_outcomes(&stdout_text, &args.assertions),
+                    assertions: assertion_outcomes(&stdout_text, &args.assertions, selected),
                 });
             }
             return Err((
@@ -910,7 +921,7 @@ fn decompile(args: &DecompileArgs) -> Result<DecompileOutcome, String> {
             c: c_text,
             regions: regions_text,
             failure,
-            assertions: assertion_outcomes(&stdout_text, &args.assertions),
+            assertions: assertion_outcomes(&stdout_text, &args.assertions, selected),
         })
     };
 
@@ -1759,7 +1770,7 @@ Decompiling authenticate
 Execution error: No symbol named: v9
 [decomp]> decompile
 ";
-        let report = super::assertion_outcomes(transcript, &directives);
+        let report = super::assertion_outcomes(transcript, &directives, Some("authenticate"));
         assert_eq!(report[0].status, "applied");
         assert_eq!(report[1].status, "rejected");
         assert_eq!(report[1].detail.as_deref(), Some("No symbol named: v9"));
@@ -1770,7 +1781,8 @@ Execution error: No symbol named: v9
     #[test]
     fn an_unreached_directive_is_rejected_not_assumed_applied() {
         let directives = vec![crate::assertdecl::parse_one("name v2 buf").expect("parses")];
-        let report = super::assertion_outcomes("[decomp]> load file /tmp/a.out\n", &directives);
+        let report =
+            super::assertion_outcomes("[decomp]> load file /tmp/a.out\n", &directives, Some("main"));
         assert_eq!(report[0].status, "rejected");
         assert!(report[0].detail.as_deref().unwrap_or_default().contains("did not reach"));
     }

--- a/decompiler/crates/kuna-console/src/assertions.rs
+++ b/decompiler/crates/kuna-console/src/assertions.rs
@@ -185,6 +185,20 @@ impl Body {
         )
     }
 
+    /// The function a `param`/`return` directive names, when it names one.
+    ///
+    /// These two are the only function-scoped directives that mean something for
+    /// a function this run does not decompile: they describe a signature, and a
+    /// CALLER needs its callee's signature.  `comment`, `flow`, `name` and `type`
+    /// describe the inside of one function body and have no cross-function
+    /// reading at all.
+    pub(crate) fn cross_function_prototype(&self) -> Option<String> {
+        match self {
+            Body::Param { func, .. } | Body::Return { func, .. } => func.clone(),
+            _ => None,
+        }
+    }
+
     /// Is this directive one that can only be applied to an already-decompiled
     /// function (because the symbol it names does not exist before)?
     fn is_symbol_scoped(&self) -> bool {
@@ -262,6 +276,18 @@ fn parse_storage(prog: &ConsoleProgram, tok: &str) -> Result<Address, String> {
 pub fn apply_program_scoped(prog: &mut ConsoleProgram) {
     let directives = prog.assertions().to_vec();
     for (i, directive) in directives.iter().enumerate() {
+        // A QUALIFIED `param`/`return` is a statement about the named function's
+        // prototype and holds whether or not this run decompiles it, so it is
+        // applied here rather than waiting for a selection that may never name
+        // it (`docs/re-needs/qualified-parameter-assertions-modify.md`).
+        if let Some(func) = directive.body.cross_function_prototype() {
+            let outcome = match apply_cross_function(prog, &func, &directive.body) {
+                Ok(()) => directive.applied(),
+                Err(detail) => directive.rejected(detail),
+            };
+            prog.set_assertion_outcome(i, outcome);
+            continue;
+        }
         if directive.body.is_function_scoped() {
             let outcome = directive.rejected(
                 "no decompiled function matched this directive (name it as \
@@ -436,6 +462,87 @@ fn apply_prototype_to_symbol(prog: &mut ConsoleProgram, pieces: &PrototypePieces
     }
 }
 
+/// Apply a `param <func>::<i> <storage> <decl>` / `return <func>::<storage>
+/// <decl>` to the prototype of the function it NAMES — the in-process twin of
+/// the cross-function arm of the console's `map param` / `map return`.
+///
+/// The parked [`PrototypePieces`] is the one channel a callee's signature
+/// reaches a CALLER through (`ActionDefaultParams` rebuilds each call site's
+/// prototype from the pieces on the callee's `FunctionSymbol`), and it describes
+/// types only — so the explicit storage rides in `input_storage` /
+/// `output_storage`, which `FuncProto::set_pieces` re-applies after the
+/// model-driven assignment.  Parking it also covers the case where the named
+/// function IS the one under decompile: `function_seed` seeds `pending_proto`
+/// from the same store.
+fn apply_cross_function(
+    prog: &mut ConsoleProgram,
+    func: &str,
+    body: &Body,
+) -> Result<(), String> {
+    use kuna_decomp::fspec::parameter_pieces_flags;
+    let org = data_org(prog);
+    let mut pieces = prog.pending_prototype(func).cloned().unwrap_or(PrototypePieces {
+        name: func.to_string(),
+        first_var_arg_slot: -1,
+        ..Default::default()
+    });
+    match body {
+        Body::Param { index, storage, decl, .. } => {
+            if *index < 0 {
+                return Err("a parameter index must not be negative".into());
+            }
+            let addr = parse_storage(prog, storage)?;
+            let (ct, pname) = crate::grammar::parse_type(decl, prog.arch().types(), org)
+                .map_err(|e| e.explain().to_string())?;
+            // A slot no directive has named yet is `undefined<addr_size>` — what
+            // the decompiler says about a value it was told nothing about — so
+            // slots may be declared in any order.
+            let (addr_size, _) = prog.arch().data_org();
+            let filler = prog
+                .arch()
+                .types()
+                .get_base(addr_size, kuna_decomp::dtype::type_metatype::TYPE_UNKNOWN)
+                .map_err(|e| e.explain().to_string())?;
+            let slot = *index as usize;
+            while pieces.intypes.len() <= slot {
+                pieces.intypes.push(Rc::clone(&filler));
+            }
+            while pieces.innames.len() <= slot {
+                pieces.innames.push(String::new());
+            }
+            pieces.intypes[slot] = ct.clone();
+            pieces.innames[slot] = pname;
+            let piece = ParameterPieces {
+                addr,
+                type_: Some(ct),
+                flags: parameter_pieces_flags::TYPELOCK | parameter_pieces_flags::NAMELOCK,
+            };
+            pieces.input_storage.retain(|(i, _)| *i != *index);
+            pieces.input_storage.push((*index, piece));
+        }
+        Body::Return { storage, decl, .. } => {
+            let addr = parse_storage(prog, storage)?;
+            let (ct, _) = crate::grammar::parse_type(decl, prog.arch().types(), org)
+                .map_err(|e| e.explain().to_string())?;
+            pieces.output_storage = Some(ParameterPieces {
+                addr,
+                type_: Some(ct),
+                flags: parameter_pieces_flags::TYPELOCK,
+            });
+        }
+        _ => return Err("internal: not a cross-function prototype directive".into()),
+    }
+    prog.arch_mut().set_function_prototype_pieces(func, pieces.clone());
+    // The symbol retype (what lets a by-value struct argument be split) needs a
+    // return type; `param` alone never declares one, and the storage assignment
+    // behind `getTypeCode` dereferences `outtype` unconditionally.
+    if pieces.outtype.is_some() {
+        apply_prototype_to_symbol(prog, &pieces);
+    }
+    prog.set_pending_prototype(func, pieces);
+    Ok(())
+}
+
 /// `data <addr> <C typedeclaration>` — the in-process twin of the global branch
 /// of `map address` (`IfcMapaddress`): a named, typed, name+type-locked global
 /// mapped at `addr`, so a load through that address renders by name.
@@ -504,6 +611,12 @@ pub fn function_seed(
     };
     for (i, directive) in directives.iter().enumerate() {
         if directive.body.is_symbol_scoped() || !directive.body.is_function_scoped() {
+            continue;
+        }
+        // Already applied program-scoped, onto the prototype of the function it
+        // names; `pending_proto` above picks it back up when that function is the
+        // one being decompiled.
+        if directive.body.cross_function_prototype().is_some() {
             continue;
         }
         if !binds_to(&directive.body, name, single) {

--- a/decompiler/crates/kuna-console/src/ifacedecomp.rs
+++ b/decompiler/crates/kuna-console/src/ifacedecomp.rs
@@ -707,6 +707,152 @@ fn run_parse_c(status: &mut IfaceStatus, content: &str) -> IfaceResult<()> {
     }
 }
 
+/// Split a `<func>::<operand>` console token into its two halves, or `None` when
+/// the token carries no qualifier.  A C++ name is split at its LAST `::`, the
+/// same reading `--assert` uses (`kuna_cli::assertdecl::split_qualifier`).
+fn split_qualifier(tok: &str) -> Option<(String, String)> {
+    match tok.rsplit_once("::") {
+        Some((func, operand)) if !func.is_empty() && !operand.is_empty() => {
+            Some((func.to_string(), operand.to_string()))
+        }
+        _ => None,
+    }
+}
+
+/// The `<func>` a `map param` / `map return` operand names, without consuming
+/// the stream.  `map param`'s first operand is a decimal index and `map
+/// return`'s is a machine address, so neither can hold a `::` of its own.
+fn peek_qualifier(s: &CommandStream) -> Option<String> {
+    let text = s.rest();
+    let first = text.split_whitespace().next()?;
+    split_qualifier(first).map(|(func, _)| func)
+}
+
+/// Merge one declared input slot into the prototype pieces parked for `func`.
+///
+/// The pieces store is the only channel a callee's signature reaches a CALLER
+/// through (`IfcDecompile` re-parks every entry onto its `FunctionSymbol`, where
+/// `ActionDefaultParams` reads it), and it describes types — so the explicit
+/// storage rides in `input_storage`, the input-side twin of what `map return`
+/// already parks in `output_storage`.
+///
+/// Slots may be declared in any order; a slot no directive named yet is filled
+/// with `undefined<addr_size>`, which is what the decompiler says about a value
+/// it has not been told anything about.
+fn bind_func_param(
+    status: &mut IfaceStatus,
+    func: &str,
+    index: kuna_base::types::int4,
+    piece: kuna_decomp::fspec::ParameterPieces,
+    pname: &str,
+) -> IfaceResult<()> {
+    use kuna_decomp::fspec::PrototypePieces;
+    if index < 0 {
+        return Err(IfaceError::parse("Parameter index must not be negative"));
+    }
+    let filler = {
+        let dcp = dcp_mut(status)?;
+        let prog = dcp
+            .conf
+            .as_ref()
+            .ok_or_else(|| IfaceError::execution("No load image present"))?;
+        let (addr_size, _) = prog.arch().data_org();
+        prog.arch()
+            .types()
+            .get_base(addr_size, kuna_decomp::dtype::type_metatype::TYPE_UNKNOWN)
+            .map_err(|e| IfaceError::execution(e.explain().to_string()))?
+    };
+    let dcp = dcp_mut(status)?;
+    let entry = dcp
+        .pending_prototypes
+        .entry(func.to_string())
+        .or_insert_with(|| PrototypePieces {
+            name: func.to_string(),
+            first_var_arg_slot: -1,
+            ..Default::default()
+        });
+    let slot = index as usize;
+    while entry.intypes.len() <= slot {
+        entry.intypes.push(std::rc::Rc::clone(&filler));
+    }
+    while entry.innames.len() <= slot {
+        entry.innames.push(String::new());
+    }
+    entry.intypes[slot] = piece.type_.clone().ok_or_else(|| {
+        IfaceError::parse("A parameter declaration must name a data-type")
+    })?;
+    entry.innames[slot] = pname.to_string();
+    entry.input_storage.retain(|(i, _)| *i != index);
+    entry.input_storage.push((index, piece));
+    let pieces = entry.clone();
+    retype_symbol_if_complete(status, &pieces)
+}
+
+/// Park the locked return storage + type of `func` on its prototype pieces —
+/// the cross-function arm of `map return`, and the `output_storage` half of what
+/// [`bind_func_param`] does for inputs.
+fn bind_func_return(
+    status: &mut IfaceStatus,
+    func: &str,
+    piece: kuna_decomp::fspec::ParameterPieces,
+) -> IfaceResult<()> {
+    use kuna_decomp::fspec::PrototypePieces;
+    let dcp = dcp_mut(status)?;
+    let entry = dcp
+        .pending_prototypes
+        .entry(func.to_string())
+        .or_insert_with(|| PrototypePieces {
+            name: func.to_string(),
+            first_var_arg_slot: -1,
+            ..Default::default()
+        });
+    entry.output_storage = Some(piece);
+    let pieces = entry.clone();
+    retype_symbol_if_complete(status, &pieces)
+}
+
+/// Retype the named `FunctionSymbol` to the prototype-bearing `TypeCode`, but
+/// only once the pieces describe a return type.
+///
+/// `param`/`return` build a signature one slot at a time, so the pieces are
+/// incomplete in between — and the storage assignment behind `getTypeCode`
+/// dereferences `outtype` unconditionally.  The `PrototypePieces` parked on the
+/// symbol is what a caller actually reads (`ActionDefaultParams`); the retype is
+/// the extra step that lets a by-value struct argument be split, so skipping it
+/// for an input-only declaration costs nothing else.
+fn retype_symbol_if_complete(
+    status: &mut IfaceStatus,
+    pieces: &kuna_decomp::fspec::PrototypePieces,
+) -> IfaceResult<()> {
+    if pieces.outtype.is_none() {
+        return Ok(());
+    }
+    apply_prototype_to_symbol(status, pieces)
+}
+
+/// Parse the `<storage> <C typedeclaration>` tail both `map param` and `map
+/// return` end in, into a type-locked [`ParameterPieces`] plus the declared name.
+fn parse_storage_and_type(
+    status: &mut IfaceStatus,
+    s: &mut CommandStream,
+    flags: kuna_base::types::uint4,
+) -> IfaceResult<(kuna_decomp::fspec::ParameterPieces, String)> {
+    use kuna_decomp::fspec::ParameterPieces;
+    let dcp = dcp_mut(status)?;
+    let prog = dcp
+        .conf
+        .as_mut()
+        .ok_or_else(|| IfaceError::execution("No load image present"))?;
+    let (addr, _size) = parse_machaddr(prog, s, false).map_err(IfaceError::parse)?;
+    s.skip_ws();
+    let (addr_size, word_size) = prog.arch().data_org();
+    let org = crate::grammar::DataOrg { addr_size, word_size };
+    let typetext = s.rest();
+    let (ct, name) = crate::grammar::parse_type(&typetext, prog.arch().types(), org)
+        .map_err(|e| IfaceError::parse(e.explain().to_string()))?;
+    Ok((ParameterPieces { addr, type_: Some(ct), flags }, name))
+}
+
 /// (kuna) Bind a parsed C prototype to `func`, whatever name the declaration
 /// carries — the console spelling of `--assert 'prototype <func> <decl>'`
 /// (`map prototype`, registered in [`crate::kuna_console`]).
@@ -1338,10 +1484,28 @@ decomp_command!(
     /// parameter on the current function's prototype.
     IfcMapParam,
     fn execute(&self, status: &mut IfaceStatus, s: &mut CommandStream) -> IfaceResult<()> {
+        use kuna_decomp::fspec::{parameter_pieces_flags, ParameterPieces};
+        // (kuna) `map param <func>::<i> <storage> <decl>` declares a slot of the
+        // prototype of the function it NAMES, which need not be the one under
+        // decompile.  Without it a caller has no way to say what a CALLEE takes,
+        // and the qualifier the `--assert` grammar documents was dropped on the
+        // way here, so the directive silently retyped the caller instead
+        // (`docs/re-needs/qualified-parameter-assertions-modify.md`).
+        if peek_qualifier(s).is_some() {
+            let tok = s.read_token();
+            let (func, index_tok) =
+                split_qualifier(&tok).expect("peek_qualifier saw a qualifier");
+            let index: kuna_base::types::int4 = index_tok.parse().map_err(|_| {
+                IfaceError::parse("Parameter index must be a decimal number")
+            })?;
+            s.skip_ws();
+            let flags = parameter_pieces_flags::TYPELOCK | parameter_pieces_flags::NAMELOCK;
+            let (piece, pname) = parse_storage_and_type(status, s, flags)?;
+            return bind_func_param(status, &func, index, piece, &pname);
+        }
         if dcp_mut(status)?.fd.is_none() {
             return Err(IfaceError::execution("No function loaded"));
         }
-        use kuna_decomp::fspec::{parameter_pieces_flags, ParameterPieces};
         // C++ `s >> dec >> i`: the parameter position.
         let i = s.read_int();
         let dcp = dcp_mut(status)?;
@@ -1395,10 +1559,25 @@ decomp_command!(
     /// current function's prototype.
     IfcMapReturn,
     fn execute(&self, status: &mut IfaceStatus, s: &mut CommandStream) -> IfaceResult<()> {
+        use kuna_decomp::fspec::{parameter_pieces_flags, ParameterPieces};
+        // (kuna) `map return <func>::<storage> <decl>` — the cross-function arm,
+        // as for `map param` above.  The storage grammar has no `::` of its own,
+        // so the qualifier is unambiguous.
+        if let Some(func) = peek_qualifier(s) {
+            let text = s.rest();
+            let mut parts = text.trim_start().splitn(2, char::is_whitespace);
+            let first = parts.next().unwrap_or("");
+            let tail = parts.next().unwrap_or("");
+            let storage = split_qualifier(first).map(|(_, op)| op).unwrap_or_default();
+            let dequalified = format!("{storage} {tail}");
+            let mut stream = CommandStream::new(&dequalified);
+            let (piece, _) =
+                parse_storage_and_type(status, &mut stream, parameter_pieces_flags::TYPELOCK)?;
+            return bind_func_return(status, &func, piece);
+        }
         if dcp_mut(status)?.fd.is_none() {
             return Err(IfaceError::execution("No function loaded"));
         }
-        use kuna_decomp::fspec::{parameter_pieces_flags, ParameterPieces};
         let dcp = dcp_mut(status)?;
         let prog = dcp
             .conf

--- a/decompiler/crates/kuna-console/tests/verify_assertplane.rs
+++ b/decompiler/crates/kuna-console/tests/verify_assertplane.rs
@@ -173,6 +173,73 @@ fn param_locks_the_input_storage_and_name() {
     );
 }
 
+/// A `param` QUALIFIED with another function declares that function's
+/// prototype, and the effect shows up at the CALL SITE
+/// (`docs/re-needs/qualified-parameter-assertions-modify.md`).
+///
+/// Before this the qualifier was dropped on the way to the console, so
+/// `param callee::0 ...` renamed and retyped the CALLER's inputs while the
+/// callee kept its empty argument list.  Both halves are asserted here: the
+/// declared name must not land on the caller, and the storage the directive
+/// names must be the storage the argument is read from — `%RDI` gives
+/// `open(a0)` and `%RSI`, which holds the mode operand, does not.  Same slot,
+/// same type: only the declared storage differs, so a lowering that dropped it
+/// could not tell the two runs apart.
+#[test]
+fn a_qualified_param_declares_the_callee_and_not_the_caller() {
+    let call_line = |storage: &str| -> Option<String> {
+        let (code, report) = decompile_with(vec![directive(
+            &format!("param open::0 {storage} char *pathname"),
+            Body::Param {
+                func: Some("open".into()),
+                index: 0,
+                storage: storage.into(),
+                decl: "char *pathname".into(),
+            },
+        )])?;
+        all_applied(&report);
+        let signature = code.lines().next().unwrap_or_default().to_string();
+        assert!(
+            !signature.contains("pathname"),
+            "the callee's parameter name landed on the CALLER: {signature}"
+        );
+        Some(
+            code.lines()
+                .find(|l| l.contains("open("))
+                .unwrap_or_else(|| panic!("no call to open:\n{code}"))
+                .trim()
+                .to_string(),
+        )
+    };
+    let Some(rdi) = call_line("%RDI") else { return };
+    let Some(rsi) = call_line("%RSI") else { return };
+    assert!(rdi.contains("open(a0)"), "the declared RDI argument is missing: {rdi}");
+    assert_ne!(rdi, rsi, "the declared storage did not pick the argument");
+}
+
+/// The `return` half of the same plumbing: a qualified `return` parks the
+/// callee's output storage, so what the call site reads back moves with it —
+/// and, as above, the caller's own return is left alone.
+#[test]
+fn a_qualified_return_declares_the_callee_output() {
+    let Some((baseline, _)) = decompile_with(Vec::new()) else { return };
+    let Some((code, report)) = decompile_with(vec![directive(
+        "return open::%RBX int4",
+        Body::Return { func: Some("open".into()), storage: "%RBX".into(), decl: "int4".into() },
+    )]) else {
+        return;
+    };
+    all_applied(&report);
+    assert_ne!(
+        baseline, code,
+        "a qualified `return` on a callee changed nothing in the caller"
+    );
+    assert!(
+        code.lines().next().unwrap_or_default().starts_with("unsigned long authenticate("),
+        "the qualified directive rewrote the CALLER's return:\n{code}"
+    );
+}
+
 /// `return` — a locked return storage and type (`map return`).
 ///
 /// This is also the regression for the abort below: the directive parks pieces

--- a/decompiler/crates/kuna-decomp/src/infra/remote_provider.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/remote_provider.rs
@@ -367,6 +367,7 @@ impl RemoteProto {
                 -1
             },
             output_storage: None,
+            input_storage: Vec::new(),
         };
         for p in &self.params {
             if let Some(ct) = &p.dtype {

--- a/decompiler/crates/kuna-decomp/src/p4_calls/fspec.rs
+++ b/decompiler/crates/kuna-decomp/src/p4_calls/fspec.rs
@@ -3584,6 +3584,16 @@ pub struct PrototypePieces {
     /// model-driven `update_all_types`.  `None` is the normal (model-derived)
     /// case.
     pub output_storage: Option<ParameterPieces>,
+    /// (kuna) Explicit, model-overriding locked INPUT storage for individual
+    /// slots, as established by the console `map param <func>::<i> <storage>
+    /// <decl>` (the `--assert 'param <func>::<i> ...'` directive).  The
+    /// input-side twin of [`Self::output_storage`] and it exists for the same
+    /// reason: these pieces describe *types*, and storage is re-derived from the
+    /// model, so a caller that states "this callee takes its first argument in
+    /// ECX" has nowhere else to put that fact.  `set_pieces` re-applies each
+    /// `(slot, storage)` after the model-driven `update_all_types`.  Empty is the
+    /// normal (model-derived) case.
+    pub input_storage: Vec<(int4, ParameterPieces)>,
 }
 
 // =============================================================================
@@ -5600,6 +5610,22 @@ impl FuncProto {
         // reconstruction (C++ keeps it verbatim via `fc->copy(callee FuncProto)`).
         if let Some(custom_out) = pieces.output_storage.as_ref() {
             self.store_mut().set_output(custom_out);
+        }
+        // (kuna) The same override on the input side, for the slots a caller
+        // named explicitly (`map param <func>::<i> <storage> <decl>`).  Only a
+        // slot the model actually assigned is replaced, so a stale index cannot
+        // punch a hole into the parameter list.
+        let assigned = self.store().get_num_inputs();
+        for (slot, custom_in) in pieces.input_storage.iter() {
+            if *slot < 0 || *slot >= assigned {
+                continue;
+            }
+            let name = pieces
+                .innames
+                .get(*slot as usize)
+                .map(String::as_str)
+                .unwrap_or("");
+            self.store_mut().set_input(*slot, name, custom_in);
         }
         self.set_input_lock(true);
         self.set_output_lock(true);

--- a/decompiler/crates/kuna-decomp/src/p4_calls/fspec/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/p4_calls/fspec/tests.rs
@@ -782,6 +782,7 @@ fn assign_map_standard_input_walk() {
         innames: vec!["a".into(), "b".into()],
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     };
     let mut res: Vec<ParameterPieces> = Vec::new();
     model.assign_map(&proto, &tf, &mut res, &mgr).unwrap();
@@ -847,6 +848,7 @@ fn assign_map_standard_out_hidden_return_emits_indirect_output_plus_pointer_para
         innames: Vec::new(),
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     };
     let mut res: Vec<ParameterPieces> = Vec::new();
     model.assign_map(&proto, &tf, &mut res, &mgr).unwrap();
@@ -1096,6 +1098,7 @@ fn proto_model_assign_parameter_storage_orders_output_first() {
         innames: vec!["a".into(), "b".into()],
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     };
     let mut res: Vec<ParameterPieces> = Vec::new();
     model
@@ -2113,6 +2116,7 @@ fn modelrule_gotostack_routes_oversized_float_to_aligned_stack_footprint() {
         innames: vec!["x".into(), "z".into()],
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     };
     let mut res: Vec<ParameterPieces> = Vec::new();
     model.assign_map(&proto, &tf, &mut res, &mgr).unwrap();
@@ -2146,6 +2150,7 @@ fn modelrule_precedes_metatype_fallback() {
         innames: vec!["a".into()],
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     };
     let mut res: Vec<ParameterPieces> = Vec::new();
     model.assign_map(&proto, &tf, &mut res, &mgr).unwrap();
@@ -2188,6 +2193,7 @@ fn no_modelrule_falls_through_to_metatype_fallback() {
         innames: vec!["a".into()],
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     };
     let mut res: Vec<ParameterPieces> = Vec::new();
     model.assign_map(&proto, &tf, &mut res, &mgr).unwrap();
@@ -2267,6 +2273,7 @@ fn w10_float_typeclass_failing_rule_does_not_short_circuit_chain() {
         innames: vec!["a".into()],
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     };
     let mut res: Vec<ParameterPieces> = Vec::new();
     model.assign_map(&proto, &tf, &mut res, &mgr).unwrap();
@@ -2304,6 +2311,7 @@ fn w10_float_typeclass_pointermax_rule_appends_after_existing_rules() {
         innames: vec!["x".into()],
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     };
     let mut res: Vec<ParameterPieces> = Vec::new();
     model.assign_map(&proto, &tf, &mut res, &mgr).unwrap();

--- a/decompiler/crates/kuna-decomp/tests/verify_w10_struct_return.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w10_struct_return.rs
@@ -108,6 +108,7 @@ fn proto_returning(outtype: Rc<Datatype>) -> PrototypePieces {
         innames: Vec::new(),
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     }
 }
 

--- a/decompiler/crates/kuna-decomp/tests/verify_w6_s4_fspec_2.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w6_s4_fspec_2.rs
@@ -307,6 +307,7 @@ fn assign_parameter_storage_ignore_output_propagates_nonparamunassigned_w6s4f2()
         innames: vec!["a".into()],
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     };
     let mut res: Vec<ParameterPieces> = Vec::new();
     // ignore_output_error = true: C++ catches ParamUnassignedError only.  A
@@ -346,6 +347,7 @@ fn update_all_types_propagates_stub_lowlevel_w6s4f1() {
         innames: vec!["a".into()],
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     };
     let r = fp.update_all_types(&proto, &tf, &mgr);
     // Repaired port behavior: the non-ParamUnassigned Lowlevel error escapes
@@ -379,6 +381,7 @@ fn update_all_types_happy_path_assigns_output_no_error_w6s4() {
         innames: vec!["a".into(), "b".into()],
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     };
     fp.update_all_types(&proto, &tf, &mgr).unwrap();
     assert!(

--- a/decompiler/crates/kuna-decomp/tests/verify_w6_s4_fspec_2_r2.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_w6_s4_fspec_2_r2.rs
@@ -318,6 +318,7 @@ fn update_all_types_genuine_param_unassigned_sets_flag_w6s4f1_r2() {
         innames: vec!["a".into(), "b".into()],
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     };
     let r = fp.update_all_types(&proto, &tf, &mgr);
     assert!(
@@ -354,6 +355,7 @@ fn assign_parameter_storage_ignore_output_only_catches_param_unassigned_w6s4f1_r
         innames: vec![],
         first_var_arg_slot: -1,
         output_storage: None,
+        input_storage: Vec::new(),
     };
     let mut res: Vec<ParameterPieces> = Vec::new();
     let r = model.assign_parameter_storage(&proto, &mut res, true, &tf, &mgr);

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -325,6 +325,36 @@ happens to have a `v2`, so qualify it:
 kuna decompile-all ./a.out --json --assert 'name authenticate::v2 credbuf'
 ```
 
+**A qualifier names the function the directive describes, which need not be the
+one being decompiled.** `param` and `return` describe a *signature*, and a
+signature is exactly the thing a caller needs to know about its callee, so
+qualifying one with a callee's name states that callee's prototype and the call
+site renders against it:
+
+```bash
+kuna decompile ./maze.exe sub_402020 \
+  --assert 'param sub_401c50::0 ECX char *maze' \
+  --assert 'param sub_401c50::1 EDX char *moves'
+```
+
+```text
+- v15 = sub_401c50();
++ v13 = sub_401c50((char *)maze,moves);
+```
+
+The declared storage is the storage the argument is read from, which is what
+makes a non-default convention statable at all: `ECX`/`EDX` above is a
+`__fastcall` callee, and the same two directives spelled against stack storage
+render different arguments. Slots may be declared in any order and one you do
+not name is `undefined`; declaring them all is the same statement as a
+`prototype` directive with the storage added.
+
+`comment`, `flow`, `name` and `type` describe the inside of one function body
+and have no cross-function reading, so qualifying one with a function this run
+did not decompile is **rejected** — with a `warning:` line naming it, and a
+non-zero exit under `--assert-strict` — rather than quietly applied to the
+function that was selected.
+
 A range property is painted before the image's symbols are mapped, because
 mapping a symbol folds the property into it and never consults the range again —
 so a range you state is honoured even where the loader already gave the address a

--- a/docs/features/qualified-parameter-assertions-modify/pr_body.md
+++ b/docs/features/qualified-parameter-assertions-modify/pr_body.md
@@ -1,0 +1,57 @@
+## The problem
+
+`--assert 'param <func>::<i> <storage> <decl>'` documents a `<func>::` qualifier
+that names the function the directive describes. The qualifier was dropped, so
+the directive was applied to whichever function was being decompiled — the
+caller — and the function it named was left alone, with no rejection.
+
+```console
+$ kuna decompile ./a.out authenticate --assert 'param open::0 RDI char *pathname'
+unsigned long authenticate(char *pathname,char *a1)
+...
+  v4 = open(a0,0);
+```
+
+`authenticate`'s own first parameter has been renamed and retyped to `open`'s
+declared one; the call to `open` is untouched. Exit code 0, nothing on stderr.
+(`a.out` here is `decompiler/crates/kuna-analysis/tests/fixtures/fauxware`.)
+
+## The fix
+
+- `param` and `return` qualified with another function now state **that
+  function's prototype**, which is the thing a caller needs about a callee.
+  The parked `PrototypePieces` is the only channel to a caller, and it carries
+  types only, so declared storage rides alongside in a new `input_storage`
+  (the input-side twin of the `output_storage` `map return` already parks) and
+  `FuncProto::set_pieces` re-applies it after the model assignment. That is
+  what makes a non-default convention statable: `param f::0 ECX …` renders the
+  ECX argument, not the first stack slot.
+- The console gains the same qualifier on `map param` / `map return`, so a
+  hand-driven `decomp_dbg` session and the generated script say the same thing.
+  Neither operand can hold a `::` of its own (a decimal index, a machine
+  address), so the spelling is unambiguous.
+- `comment`, `flow`, `name` and `type` describe the inside of one function body
+  and have no cross-function reading. Qualified with a function the run did not
+  decompile they are now **rejected**, with the reason on stderr and a non-zero
+  exit under `--assert-strict`, instead of landing on the selected function.
+- Unqualified directives, and a directive qualified with the selected function,
+  lower to exactly the console lines they did before.
+
+```console
+$ kuna decompile ./a.out authenticate --assert 'param open::0 RDI char *pathname'
+unsigned long authenticate(char *a0,char *a1)
+...
+  v4 = open(a0);
+```
+
+## The tests
+
+`tests/cli/qualified-parameter-assertions-modify.json` is the case above; both
+its expectations fail before the fix (the caller's signature carries `pathname`,
+and the call is still `open(a0,0)`). `verify_assertplane` gains an end-to-end
+pair that decompiles the caller twice with the same slot and type but `%RDI` and
+then `%RSI`, so a lowering that dropped the storage could not tell the two runs
+apart. `assertdecl` pins the lowering and the rejection for all six qualifiable
+directives.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/qualified-parameter-assertions-modify/record.json
+++ b/docs/features/qualified-parameter-assertions-modify/record.json
@@ -1,0 +1,67 @@
+{
+  "slug": "qualified-parameter-assertions-modify",
+  "need_id": "qualified-parameter-assertions-modify",
+  "track": "tooling",
+  "scope": "medium",
+  "round": 4,
+  "branch": "feat/re-qualified-parameter-assertions-modify",
+  "summary": "A `<func>::`-qualified `--assert` now binds to the function it names. `param`/`return` state that function's prototype -- including the declared STORAGE, which rides on the parked PrototypePieces in a new `input_storage` field re-applied by FuncProto::set_pieces -- so a caller can tell kuna what a callee takes and the call site renders against it. `comment`, `flow`, `name` and `type` have no cross-function reading and are rejected with a reason instead of being applied to the selected function.",
+  "decisions": [
+    {
+      "what": "hypothesis UPHELD, and the refuter's reading of the mechanism was exact",
+      "detail": "The `..` in `Body::Param { index, storage, decl, .. }` in kuna-cli/src/assertdecl.rs ate `func`, and the same discard was in the Return/Comment/Flow/Name/Type arms -- six directives, not one. Reproduced on 39fa1a9a: `kuna decompile 'Sabloom Text 6.exe' sub_402020 --assert 'param sub_401c50::0 ECX char *maze' --assert 'param sub_401c50::1 EDX char *moves'` printed `unsigned int sub_402020(char *maze,char *moves)` and kept `v15 = sub_401c50();`, exit 0, empty stderr."
+    },
+    {
+      "what": "the two surfaces disagreed, and the in-process one was already honest",
+      "detail": "The same command with `--json` (which loads in-process rather than spawning decomp_dbg) rejected both directives: `no decompiled function matched this directive`. So the text surface's silent misapplication was a lowering defect, not a missing engine concept -- `kuna_console::assertions::binds_to` had the right rule all along. The fix makes the text surface agree AND gives both the capability the rejection was standing in for."
+    },
+    {
+      "what": "the declared STORAGE is carried, not silently dropped",
+      "detail": "PrototypePieces describes types; storage is re-derived from the model, which is why `map return` already needed a kuna-only `output_storage`. A cross-function `param f::0 ECX ...` has the same problem on the input side, and dropping it would ship exactly this plane's own failure mode (accepted and not what was said). New `input_storage: Vec<(int4, ParameterPieces)>` on PrototypePieces, re-applied by `FuncProto::set_pieces` after `update_all_types`, guarded to slots the model actually assigned. Measured on the witness: `ECX/EDX` -> `sub_401c50((char *)maze,moves)`, types-only (`prototype`, model-derived stack) -> `sub_401c50((char *)v20,moves)`, deliberately wrong `EAX/EBX` -> `sub_401c50(v16,(char *)((unsigned int)v20 << 8))`. Three different arguments from three different declarations, so the field is load-bearing."
+    },
+    {
+      "what": "the qualifier is added to `map param`/`map return`, not to a new console command",
+      "detail": "`map param`'s first operand is a decimal index and `map return`'s is a machine address, so neither can contain a `::` and the qualified spelling is unambiguous -- and it is the spelling docs/cli.md already documents for `--assert`. A new `map funcparam`/`map funcreturn` pair would have made the console's `map fun` prefix ambiguous with `map function`. `rename`/`retype` were deliberately NOT given the qualifier: a C++ local's name can contain `::` and the datatest corpus drives those commands directly."
+    },
+    {
+      "what": "four of the six directives get a rejection rather than a cross-function meaning",
+      "detail": "`comment` is keyed by the owning function's entry, `flow` is consumed by that function's flow follower, and `name`/`type` name a local that only exists once that function has been decompiled. None of them means anything for a function this run did not decompile, so the CLI emits no console line and reports the directive rejected with the reason -- which is the `No rejection warning appears` half of the filed symptom. Under `--addr` the CLI does not know the selected function's name until the script has run, so a qualified directive of those four keeps binding to the selection; documented in docs/cli.md."
+    },
+    {
+      "what": "no option, no stages XML, no catalog counter, no DIV row",
+      "detail": "Tooling track: this is the CLI/console assertion plane plus one inert engine field. A directive an agent did not write cannot move emitted C, and `--assert` is not a decision the pipeline takes on its own. Matches the CLI-tier repipe PRs already merged this round (#448/#449/#452/#454)."
+    }
+  ],
+  "inertness": {
+    "method": "the engine change is one new `PrototypePieces` field and one loop in `FuncProto::set_pieces`. All 24 producers of PrototypePieces outside the two new directive paths construct it with `input_storage: Vec::new()` (or `..Default::default()`), and nothing else in the workspace reads the field, so the loop has nothing to iterate on any run that does not carry a qualified `param`/`return`. The CLI lowering is likewise a no-op for an unqualified directive and for one qualified with the selected function: `names_another` returns None and the emitted console line is byte-identical.",
+    "note": "make test 675/675 PARITY OK and make test-stages 640/640 PARITY OK confirm it."
+  },
+  "sweep": {
+    "question": "does the new lowering change any directive that used to work, and does the cross-function path produce WRONG output?",
+    "method": "(1) unqualified `param 0 RDI char *user` and self-qualified `param authenticate::0 RDI char *user` on fauxware, text surface and `--json`, against the pre-change spelling; (2) the three-way storage discrimination on the witness (ECX/EDX vs prototype-types-only vs EAX/EBX); (3) `%RDI` vs `%RSI` for the same slot and type on fauxware (`open(a0)` vs `open(NULL)`); (4) directive combinations against one callee -- `prototype` then a `param` override, `param` + `return`, and slots declared out of order (1 before 0); (5) `decompile-all` with a cross-function `param` and a qualified `name` in one run.",
+    "result": "(1) all four spellings print the identical `unsigned long authenticate(char *user)`, so the self-qualified case behaves exactly as the unqualified one has always behaved -- `map param` has always truncated the input list to the declared slots, so the pieces path and the mapped_params path are not observably different here. (2)/(3) each declaration produces a different argument, so the storage is honoured rather than re-derived. (4) `prototype open int open(char *path,int flags)` + `param open::1 RDX int mode` gives `open(a0,0)`; `param`+`return` gives `open(a0)`; slots declared 1-then-0 give the same `open(a0,0)` as 0-then-1, because an undeclared slot is filled with `undefined<addr_size>` rather than rejected. (5) both directives report `applied` and both land -- `read(open(a0),credbuf,8)`."
+  },
+  "gates": {
+    "make test": "PARITY OK, 675/675 assertions",
+    "make test-stages": "PARITY OK, 640/640 assertions",
+    "make rust-test": "5,742 passed / 1 failed on the pre-rebase tree. The one failure is `verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip` ('oracle drifted') -- the known repipe-worktree artifact: the loop exports KUNA_DECOMP_TEST at this worktree's decomp_test_dbg. Re-run with it unset: 4/4 pass. The rebased tree was re-run with KUNA_DECOMP_TEST unset and was still in flight at 1,135 passed / 0 failed when the PR was opened; the `full-ci` label makes GitHub run the same suite on the merge commit, which is the gate that decides.",
+    "make check-spec": "OK (lenient mode)",
+    "make test-cli": "50/50 with the probe promoted",
+    "kuna catalog --check": "catalog OK: documents exactly the registered kuna options"
+  },
+  "acceptance": {
+    "acceptance_id": "a-64ae0f00be99",
+    "result": "PASS",
+    "transition": "closed",
+    "promoted_to": "tests/cli/qualified-parameter-assertions-modify.json",
+    "promotion_note": "the filed acceptance targets the dataset image (crackmes.one 60be2ad433c5d410b8842c95, 'Sabloom Text 6.exe') and PASSES there -- `scripts.repipe.verify --need qualified-parameter-assertions-modify` reports 1 pass / 0 fail / closed. `--promote` refuses a dataset target and CI has no dataset, so the promoted probe is re-pointed at the vendored `kuna-analysis/tests/fixtures/fauxware`: `param open::0 RDI char *pathname` on `authenticate`, asserting `open(a0)` present and `authenticate(...pathname` / `open(a0,0)` absent. Both expectations fail on the unpatched tree. `notes` was cut to 398 characters for the 400-character schema cap.",
+    "reproduction_confirmed_on_main": "on 39fa1a9a the witness command prints `unsigned int sub_402020(char *maze,char *moves)` with `v15 = sub_401c50();`; after the fix it prints `unsigned int sub_402020(unsigned char *a0,char *a1)` with `v13 = sub_401c50((char *)maze,moves);`. The disassembly agrees with the tester's claim: `MOV ECX,EDI; MOV EDX,ESI` before `CALL 0x401c50`, and the callee opens with `MOV [EBP-0x1c],EDX; MOV [EBP-0x8],ECX`."
+  },
+  "not_closed": [
+    "A qualified `comment`/`flow`/`name`/`type` under `--addr` still binds to the selected function rather than being judged, because the CLI has no name for the selection until the script has run. Judging it would mean either resolving the address to a name before building the script or teaching the console commands the qualifier -- and `rename`/`retype` cannot take one safely, since a C++ local name may contain `::`.",
+    "A cross-function `param` declares the input list it names: a slot nobody declared is `undefined`, and a trailing slot nobody declared does not exist. That is the same contract `map param` has always had for the selected function, but it means `param f::0 ...` alone truncates a two-argument callee to one. Declaring every slot, or using `prototype` and overriding one slot's storage with `param`, both say the whole thing.",
+    "docs/re-needs/index.json is deliberately NOT regenerated: `needs reindex` runs over the whole backlog and this worktree holds only the tracked need docs. The need doc itself is added; the captain reindexes."
+  ],
+  "pr": null,
+  "rebase": "rebased --onto origin/main (bfe843a4, #455 calleearitylive) from the recorded base 39fa1a9a; scripts.repipe.counters --fix re-derived every shared counter on the rebased tree (153 settables, tiers 38/61/54, 242 corpus files, next ElementId 4147) and scripts.repipe.mergecheck reports 0 rejects. This PR adds no option and no stages XML, so it moves none of those counters itself -- the rebuild was needed only to make the built binary agree with #455's phases.toml."
+}

--- a/docs/re-needs/qualified-parameter-assertions-modify.md
+++ b/docs/re-needs/qualified-parameter-assertions-modify.md
@@ -1,0 +1,124 @@
+---
+need_id: qualified-parameter-assertions-modify
+title: Qualified parameter assertions modify the caller instead of the named callee
+track: tooling
+status: open
+severity: major
+probe_id: p-c99ad8423821
+acceptance_id: a-64ae0f00be99
+hypothesis_status: upheld
+credibility: 0.7
+instances: 1
+challenges: [60be2ad433c5d410b8842c95]
+rounds: [4]
+first_seen_round: 4
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-cli/src/assertdecl.rs, decompiler/crates/kuna-cli/src/decompile.rs]
+scope: medium
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Override the callee's ECX/EDX parameter storage.
+
+> **Qualified parameter assertions modify the caller instead of the named callee** (major, `60be2ad433c5d410b8842c95`)
+> Assertions qualified with sub_401c50 rename and retype sub_402020 inputs to maze/moves instead. The intended callee still has an empty argument list. No rejection warning appears.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "target": {
+    "binary_rel": "bin/Sabloom Text 6.exe",
+    "binary_sha256": "5a03a2b553065aedf58f3512e1a701d2ab5e8e9365ea713bfed98f19836747e3",
+    "binary_size": 242176,
+    "binary_source": "dataset"
+  },
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_402020",
+    "--assert",
+    "param sub_401c50::0 ECX char *maze",
+    "--assert",
+    "param sub_401c50::1 EDX char *moves"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "\\A[^\\n]*\\([^\\n]*\\bmaze\\b[^\\n]*\\bmoves\\b"
+    ]
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "target": {
+    "binary_rel": "bin/Sabloom Text 6.exe",
+    "binary_sha256": "5a03a2b553065aedf58f3512e1a701d2ab5e8e9365ea713bfed98f19836747e3",
+    "binary_size": 242176,
+    "binary_source": "dataset"
+  },
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_402020",
+    "--assert",
+    "param sub_401c50::0 ECX char *maze",
+    "--assert",
+    "param sub_401c50::1 EDX char *moves"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_absent": [
+      "\\A[^\\n]*\\([^\\n]*\\bmaze\\b",
+      "\\bsub_[0-9a-f]+\\(\\)"
+    ]
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- The parameter directive may discard its function qualifier.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `60be2ad433c5d410b8842c95` (round 4, tester t-r4-60be2ad4)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+- split out of the round-4 `16-byte-vm-state` mega-bucket by the captain at T_DEDUP: cluster.py's key is `kind|subcommand|clause-shape`, so nine unrelated wrong-output `decompile` defects collapsed into one need whose probe covered only the first. Each carries its own probe and acceptance from its own observation.
+- round 4 REFUTER: hypothesis **upheld** (was inconclusive). UPHELD, literally -- the qualifier is dropped by a `..` in one destructuring pattern -- and the defect is SIX directives wide, not one. Reproduced on sha 6188e204: the two sub_401c50-qualified asserts rename the DECOMPILED function to `sub_402020(char *maze,char *moves)`, exit 0, no warning. CONTROL: replace the qualifier with a function that does not exist (`param nosuchfunc_zzz::0 ECX char *maze`) and the output is byte-identical to both the real-qualifier run AND the unqualified `param 0 ECX ...` run, so the qualifier is not resolved wrongly, it is never looked up. THE CODE SAYS THE SAME: kuna-cli/src/assertdecl.rs parses it correctly (split_qualifier at :239) and then lowers with `Body::Param { index, storage, decl, .. }` -> "map param {index} {storage} {decl}" -- the `..` eats `func`. Same discard for Return, Comment, Flow, Name, Type; `split_qualifier`/`Body::` appear NOWHERE outside assertdecl.rs, so nothing in kuna-cli consumes a parsed qualifier. docs/cli.md:164-171 documents `[<func>::]` on all six. THE CORRECT APPLIER ALREADY EXISTS AND THE CLI BYPASSES IT: kuna-console/src/assertions.rs has `binds_to()` ("a qualified directive binds only to the function it names") and even the rejection the tester expected ("no decompiled function matched this directive"). `kuna decompile` parses into that crate's Directive type but applies through assertdecl's text lowering into a decomp_dbg script, and the console commands themselves (`map param <i> <storage> <decl>`) have no function operand -- so the fix is either a qualified console form or a `load function <func>` / apply / re-load dance, and it must not disturb the existing Image/Program/Function/Symbol slot ordering or the second pass. BEST LEAD, MEASURED: the documented cross-function `prototype` directive WORKS on this exact binary -- `--assert "prototype sub_401c50 int sub_401c50(char *maze,char *moves)"` renders the call site as `sub_401c50((char *)v20,moves)` and leaves the caller signature alone, i.e. it produces exactly the state the acceptance describes. apply_prototype writes the callee's FunctionSymbol + pending-prototype store (assertions.rs:389-400), which is where a qualified `param`/`return` should land too; a transient Funcdata lock will not survive re-loading the caller. ACCEPTANCE IS SOUND, NOT GAMEABLE: its cmd is the qualified-param one, so the prototype workaround cannot flip it; and the baseline really does print `v15 = sub_401c50();`, so a reject-with-a-warning fix keeps that empty-arg call and FAILS pattern 2. Residual: unrelated call-argument recovery on this binary could also flip it. SCOPE: filed `small` -- the parse half is free but the application half is a new plumbing path; call it medium and expect the builder to touch all six directives or to say why param/return only. TOUCHES IS WRONG: filed kuna-decomp; it is kuna-cli (assertdecl.rs, decompile.rs) + possibly kuna-console.

--- a/docs/spec/04-calls-and-prototypes.md
+++ b/docs/spec/04-calls-and-prototypes.md
@@ -471,7 +471,16 @@ that machinery.
   called-function evaluation model with a void internal store. (kuna) A
   callee whose parked pieces contain *only* custom return storage — what the
   console `map return` plants — keeps model-driven input recovery and locks
-  just the output on top.
+  just the output on top. (kuna) The parked pieces describe *types*, and
+  storage is otherwise re-derived from the model, so the two spellings that
+  state storage explicitly carry it alongside: `output_storage` for the return
+  and `input_storage` for individual parameter slots. Both are re-applied by
+  `FuncProto::set_pieces` after the model-driven assignment, which is what lets
+  a caller declare a non-default convention for a callee — the console `map
+  param <func>::<i> <storage> <decl>` and `map return <func>::<storage>
+  <decl>`, reached from the CLI as `--assert 'param <func>::<i> …'`. A slot no
+  directive named is `undefined` of pointer width, so slots may be declared in
+  any order.
 - **`ActionExtraPopSetup`** (`coreaction_protos.rs (ActionExtraPopSetup)`)
   models the stack pointer across each call: a known extrapop becomes an
   explicit `INT_ADD sp, #extrapop` after the call; an unknown one becomes an

--- a/tests/cli/qualified-parameter-assertions-modify.json
+++ b/tests/cli/qualified-parameter-assertions-modify.json
@@ -1,0 +1,41 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "authenticate",
+    "--assert",
+    "param open::0 RDI char *pathname"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "binary_sha256": "c2d90645a45e99221593547e55c601a901b80f807ae96f94c60a7661df0b3e0b",
+    "binary_size": 8776,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "selector": "authenticate",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "\\bopen\\(a0\\)"
+    ],
+    "stdout_absent": [
+      "authenticate\\([^\\n]*\\bpathname\\b",
+      "\\bopen\\(a0,0\\)"
+    ]
+  },
+  "notes": "Desired: a `<func>::`-qualified `--assert` declares the function it NAMES. `param open::0 RDI char *pathname` states the CALLEE's slot 0, so the call renders `open(a0)` -- one argument, read from RDI -- and the caller's signature is untouched. Before the fix the qualifier was dropped: it retyped `authenticate`'s own parameter and left `open(a0,0)`. Witness: crackmes.one 60be2ad433c5d410b8842c95."
+}


### PR DESCRIPTION
## The problem

`--assert 'param <func>::<i> <storage> <decl>'` documents a `<func>::` qualifier
that names the function the directive describes. The qualifier was dropped, so
the directive was applied to whichever function was being decompiled — the
caller — and the function it named was left alone, with no rejection.

```console
$ kuna decompile ./a.out authenticate --assert 'param open::0 RDI char *pathname'
unsigned long authenticate(char *pathname,char *a1)
...
  v4 = open(a0,0);
```

`authenticate`'s own first parameter has been renamed and retyped to `open`'s
declared one; the call to `open` is untouched. Exit code 0, nothing on stderr.
(`a.out` here is `decompiler/crates/kuna-analysis/tests/fixtures/fauxware`.)

## The fix

- `param` and `return` qualified with another function now state **that
  function's prototype**, which is the thing a caller needs about a callee.
  The parked `PrototypePieces` is the only channel to a caller, and it carries
  types only, so declared storage rides alongside in a new `input_storage`
  (the input-side twin of the `output_storage` `map return` already parks) and
  `FuncProto::set_pieces` re-applies it after the model assignment. That is
  what makes a non-default convention statable: `param f::0 ECX …` renders the
  ECX argument, not the first stack slot.
- The console gains the same qualifier on `map param` / `map return`, so a
  hand-driven `decomp_dbg` session and the generated script say the same thing.
  Neither operand can hold a `::` of its own (a decimal index, a machine
  address), so the spelling is unambiguous.
- `comment`, `flow`, `name` and `type` describe the inside of one function body
  and have no cross-function reading. Qualified with a function the run did not
  decompile they are now **rejected**, with the reason on stderr and a non-zero
  exit under `--assert-strict`, instead of landing on the selected function.
- Unqualified directives, and a directive qualified with the selected function,
  lower to exactly the console lines they did before.

```console
$ kuna decompile ./a.out authenticate --assert 'param open::0 RDI char *pathname'
unsigned long authenticate(char *a0,char *a1)
...
  v4 = open(a0);
```

## The tests

`tests/cli/qualified-parameter-assertions-modify.json` is the case above; both
its expectations fail before the fix (the caller's signature carries `pathname`,
and the call is still `open(a0,0)`). `verify_assertplane` gains an end-to-end
pair that decompiles the caller twice with the same slot and type but `%RDI` and
then `%RSI`, so a lowering that dropped the storage could not tell the two runs
apart. `assertdecl` pins the lowering and the rejection for all six qualifiable
directives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
