### PR TITLE
[AUTOMATED] fix(cli): accepted-sqrt-prototype-still — a prototype assertion at an entry address binds

### DIFF
--- a/decompiler/crates/kuna-cli/tests/decompile_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_cli.rs
@@ -669,3 +669,100 @@ fn a_prototype_declared_under_another_name_binds_on_both_surfaces() {
         "the two surfaces disagree about the same directive:\n{json}"
     );
 }
+
+/// RE-need `accepted-sqrt-prototype-still`: `<func>` may be an entry ADDRESS,
+/// and it binds on both surfaces.
+///
+/// An agent working a stripped or import-heavy binary has the address long
+/// before it has a name it trusts, and `--assert 'prototype 0x400664 …'` was
+/// accepted and then dropped: the pieces were parked under the literal key
+/// `"0x400664"`, which resolves to no `FunctionSymbol`, while the report still
+/// said `applied`. The callee case is the one the need was filed on — a PE
+/// import thunk whose call site kept `sqrt()` argumentless — and it is the case
+/// the by-name form cannot always state, because the thunk and the slot it
+/// jumps to are two symbols with the same name.
+#[test]
+fn a_prototype_at_an_entry_address_binds_on_both_surfaces() {
+    let bin = fauxware();
+    let run = |directive: &str, extra: &[&str]| -> Option<String> {
+        let mut argv: Vec<String> = vec![
+            "decompile".into(),
+            bin.clone(),
+            "authenticate".into(),
+            "--assert".into(),
+            directive.into(),
+            "--assert-strict".into(),
+            "--sleighpath".into(),
+            specs(),
+        ];
+        argv.extend(extra.iter().map(|s| s.to_string()));
+        let out = Command::new(env!("CARGO_BIN_EXE_kuna"))
+            .args(&argv)
+            .output()
+            .expect("failed to spawn the kuna binary");
+        let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+        if is_specs_skip(&stderr) {
+            eprintln!("skipping: specs-less environment: {stderr}");
+            return None;
+        }
+        assert_eq!(out.status.code(), Some(0), "kuna decompile failed: {stderr}");
+        assert!(!stderr.contains("rejected"), "the directive was rejected: {stderr}");
+        Some(String::from_utf8_lossy(&out.stdout).into_owned())
+    };
+
+    // The selected function itself, addressed by its entry.
+    let selected = "prototype 0x400664 void *hashit(void *out,void *input)";
+    for surface in [&[][..], &["--json"][..]] {
+        let Some(out) = run(selected, surface) else { return };
+        assert!(
+            out.contains("void * authenticate(void *out,void *input)"),
+            "the address-form signature did not reach 0x400664 ({surface:?}):\n{out}"
+        );
+    }
+
+    // A CALLEE, addressed by its entry — the need's own shape (a stub function
+    // the call site targets), and the read side's own key.
+    let callee = "prototype 0x400550 int4 strcmp(char *a,char *b,unsigned long n)";
+    for surface in [&[][..], &["--json"][..]] {
+        let Some(out) = run(callee, surface) else { return };
+        assert!(
+            out.contains("strcmp(a1,sneaky,"),
+            "the declared third argument never reached the call site ({surface:?}):\n{out}"
+        );
+    }
+}
+
+/// An explicitly `0x`-prefixed operand that starts no function is REJECTED with
+/// the address in the detail, on both surfaces — the whole family used to
+/// report it `applied` and do nothing, which leaves an agent no way to tell.
+#[test]
+fn a_prototype_address_that_starts_no_function_is_rejected() {
+    let bin = fauxware();
+    let out = Command::new(env!("CARGO_BIN_EXE_kuna"))
+        .args([
+            "decompile",
+            bin.as_str(),
+            "authenticate",
+            "--json",
+            "--assert",
+            "prototype 0x999999 int4 nope(void)",
+            "--sleighpath",
+            specs().as_str(),
+        ])
+        .output()
+        .expect("failed to spawn the kuna binary");
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    if is_specs_skip(&stderr) {
+        eprintln!("skipping: specs-less environment: {stderr}");
+        return;
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    assert!(
+        stdout.contains(r#""status": "rejected""#),
+        "an unbindable address was still reported applied:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("no function starts at 0x999999"),
+        "the rejection did not name the address:\n{stdout}"
+    );
+}

--- a/decompiler/crates/kuna-console/src/assertions.rs
+++ b/decompiler/crates/kuna-console/src/assertions.rs
@@ -412,6 +412,121 @@ fn with_semicolon(decl: &str) -> String {
     }
 }
 
+/// Which function a directive's `<func>` operand names, once the loaded program
+/// has been consulted.
+///
+/// `<func>` is a NAME first — that is what every existing directive meant — and
+/// an ENTRY ADDRESS second.  An agent working on a stripped or import-heavy
+/// binary has the address long before it has a name it trusts, and the address
+/// form used to be accepted and then discarded: nothing is called
+/// `0x140003ddf`, so the by-name park landed on no symbol at all and the call
+/// site kept its recovered signature
+/// (`docs/re-needs/accepted-sqrt-prototype-still.md`).
+///
+/// Address is also the key the READ side already uses
+/// (`ArchContext::callee_proto_pieces` looks a call spec's entry address up),
+/// which is why the address form reaches a callee the name form cannot: a
+/// PE import thunk and the IAT slot it jumps to are two FunctionSymbols with
+/// the SAME name, and the by-name query answers with the slot while every call
+/// in the program goes to the thunk.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum ProtoTarget {
+    /// Bind by name.  An unresolved name is still legal — it parks in the
+    /// pending store, which is what lets `map prototype main …` precede the
+    /// symbols it talks about.
+    Named(String),
+    /// Bind by entry address: the address to park at, and the resolved
+    /// function's own display name (the pending store and the printer are both
+    /// keyed by name, so the directive must not rename the function to its VMA).
+    At(Address, String),
+}
+
+impl ProtoTarget {
+    /// The name this prototype describes — the operand itself for the name
+    /// form, the resolved function's display name for the address form.
+    pub(crate) fn name(&self) -> &str {
+        match self {
+            ProtoTarget::Named(n) => n,
+            ProtoTarget::At(_, n) => n,
+        }
+    }
+}
+
+/// Resolve a `<func>` operand against the loaded program (see [`ProtoTarget`]).
+///
+/// An explicitly `0x`-prefixed operand that no function starts at is an ERROR
+/// rather than a silent park: `0x…` is not a C identifier, so such a directive
+/// is provably inert and the caller deserves to hear it.  A bare hex token
+/// (`140003ddf`) is ambiguous with a real identifier (`abc` is both), so it
+/// takes the address path only when it resolves and no function of that name
+/// exists, and never errors.
+pub(crate) fn resolve_proto_target(
+    prog: &ConsoleProgram,
+    func: &str,
+) -> Result<ProtoTarget, String> {
+    let named = match prog.arch().symboltab.get_global_scope() {
+        Some(g) => prog.arch().symboltab.query_function_by_name(g, func).is_some(),
+        None => false,
+    };
+    if named {
+        return Ok(ProtoTarget::Named(func.to_string()));
+    }
+    let hex = func.strip_prefix("0x").or_else(|| func.strip_prefix("0X"));
+    let explicit = hex.is_some();
+    let digits = hex.unwrap_or(func);
+    let vma = if !digits.is_empty() && digits.chars().all(|c| c.is_ascii_hexdigit()) {
+        u64::from_str_radix(digits, 16).ok()
+    } else {
+        None
+    };
+    if let Some(vma) = vma {
+        if let Some(addr) = code_addr(prog, vma) {
+            if let Some(name) = prog.arch().symboltab.function_display_name_across_scopes(&addr) {
+                return Ok(ProtoTarget::At(addr, name));
+            }
+        }
+        if explicit {
+            return Err(format!("no function starts at {func}"));
+        }
+    }
+    Ok(ProtoTarget::Named(func.to_string()))
+}
+
+/// Park `pieces` on the target's `FunctionSymbol`, which is where a CALLER's
+/// `ActionDefaultParams` reads a declared callee signature back from
+/// (`ArchContext::callee_proto_pieces`).
+///
+/// `pieces.name` is set to the target's name first, so a directive that
+/// renames — `prototype sub_1400055e0 void *sha256(…)` — still describes
+/// `sub_1400055e0`, and an address form describes the function that lives
+/// there rather than a function called `0x140003ddf`.
+pub(crate) fn park_proto_pieces(
+    prog: &mut ConsoleProgram,
+    target: &ProtoTarget,
+    pieces: &mut PrototypePieces,
+) {
+    pieces.name = target.name().to_string();
+    match target {
+        ProtoTarget::Named(name) => {
+            prog.arch_mut().set_function_prototype_pieces(name, pieces.clone())
+        }
+        ProtoTarget::At(addr, _) => {
+            prog.arch_mut().set_function_prototype_pieces_at(addr, pieces.clone())
+        }
+    }
+}
+
+/// The two things a full `prototype` directive does: park the pieces for the
+/// callers, and lock the signature onto the symbol itself.
+pub(crate) fn park_prototype(
+    prog: &mut ConsoleProgram,
+    target: &ProtoTarget,
+    pieces: &mut PrototypePieces,
+) {
+    park_proto_pieces(prog, target, pieces);
+    lock_prototype_on_symbol(prog, target, pieces);
+}
+
 /// `prototype <func> <C declaration>` — the in-process twin of `parse line
 /// extern <decl>` (`IfcParseLine`'s `setPrototype` branch).
 ///
@@ -424,7 +539,8 @@ fn with_semicolon(decl: &str) -> String {
 ///
 /// The `<func>` operand is authoritative over the name inside the declaration:
 /// it says *which* function this signature describes, so `prototype sub_1400
-/// int handler(char *)` binds to `sub_1400`.
+/// int handler(char *)` binds to `sub_1400`.  It may be a name or an entry
+/// address ([`resolve_proto_target`]).
 fn apply_prototype(prog: &mut ConsoleProgram, func: &str, decl: &str) -> Result<(), String> {
     use std::cell::RefCell;
     let org = data_org(prog);
@@ -438,24 +554,36 @@ fn apply_prototype(prog: &mut ConsoleProgram, func: &str, decl: &str) -> Result<
     let mut pieces = captured
         .into_inner()
         .ok_or_else(|| "not a function declaration".to_string())?;
-    pieces.name = func.to_string();
-    prog.arch_mut().set_function_prototype_pieces(func, pieces.clone());
-    apply_prototype_to_symbol(prog, &pieces);
-    prog.set_pending_prototype(func, pieces);
+    let target = resolve_proto_target(prog, func)?;
+    park_prototype(prog, &target, &mut pieces);
+    prog.set_pending_prototype(target.name(), pieces);
     Ok(())
 }
 
-/// Lock the parsed prototype onto the named `FunctionSymbol` by retyping it to
-/// the prototype-bearing `TypeCode` (C++ `Architecture::setPrototype`).  A
+/// Lock the parsed prototype onto the target's `FunctionSymbol` by retyping it
+/// to the prototype-bearing `TypeCode` (C++ `Architecture::setPrototype`).  A
 /// missing symbol is a no-op: the pending store above still carries the fact for
 /// the function's own decompile.
-fn apply_prototype_to_symbol(prog: &mut ConsoleProgram, pieces: &PrototypePieces) {
+pub(crate) fn lock_prototype_on_symbol(
+    prog: &mut ConsoleProgram,
+    target: &ProtoTarget,
+    pieces: &PrototypePieces,
+) {
     let arch = prog.arch_mut();
-    let Some(scope) = arch.symboltab.get_global_scope() else {
-        return;
-    };
-    let Some(sid) = arch.symboltab.query_function_by_name(scope, &pieces.name) else {
-        return;
+    let sid = match target {
+        ProtoTarget::Named(name) => {
+            let Some(scope) = arch.symboltab.get_global_scope() else {
+                return;
+            };
+            match arch.symboltab.query_function_by_name(scope, name) {
+                Some(sid) => sid,
+                None => return,
+            }
+        }
+        ProtoTarget::At(addr, _) => match arch.symboltab.find_function_across_scopes(addr) {
+            Some((sid, _)) => sid,
+            None => return,
+        },
     };
     if let Ok(tc) = arch.types().get_type_code_proto(pieces) {
         let _ = arch.symboltab.retype_symbol(sid, tc);
@@ -481,8 +609,9 @@ fn apply_cross_function(
 ) -> Result<(), String> {
     use kuna_decomp::fspec::parameter_pieces_flags;
     let org = data_org(prog);
-    let mut pieces = prog.pending_prototype(func).cloned().unwrap_or(PrototypePieces {
-        name: func.to_string(),
+    let target = resolve_proto_target(prog, func)?;
+    let mut pieces = prog.pending_prototype(target.name()).cloned().unwrap_or(PrototypePieces {
+        name: target.name().to_string(),
         first_var_arg_slot: -1,
         ..Default::default()
     });
@@ -532,14 +661,14 @@ fn apply_cross_function(
         }
         _ => return Err("internal: not a cross-function prototype directive".into()),
     }
-    prog.arch_mut().set_function_prototype_pieces(func, pieces.clone());
+    park_proto_pieces(prog, &target, &mut pieces);
     // The symbol retype (what lets a by-value struct argument be split) needs a
     // return type; `param` alone never declares one, and the storage assignment
     // behind `getTypeCode` dereferences `outtype` unconditionally.
     if pieces.outtype.is_some() {
-        apply_prototype_to_symbol(prog, &pieces);
+        lock_prototype_on_symbol(prog, &target, &pieces);
     }
-    prog.set_pending_prototype(func, pieces);
+    prog.set_pending_prototype(target.name(), pieces);
     Ok(())
 }
 

--- a/decompiler/crates/kuna-console/src/ifacedecomp.rs
+++ b/decompiler/crates/kuna-console/src/ifacedecomp.rs
@@ -864,6 +864,11 @@ fn parse_storage_and_type(
 /// the signature describes, which is what the in-process surface
 /// (`assertions::apply_prototype`) already did — the two surfaces disagreed
 /// about the same directive (`docs/re-needs/text-output-silently-ignores.md`).
+///
+/// `<func>` is a name or an entry address
+/// ([`crate::assertions::resolve_proto_target`]); the pieces are parked through
+/// the shared [`crate::assertions::park_prototype`] so both surfaces bind the
+/// same operand to the same function.
 pub(crate) fn bind_prototype(
     status: &mut IfaceStatus,
     func: &str,
@@ -898,9 +903,15 @@ pub(crate) fn bind_prototype(
     }
     let mut pieces =
         captured.ok_or_else(|| IfaceError::execution("Not a function declaration"))?;
-    pieces.name = func.to_string();
-    apply_prototype_to_symbol(status, &pieces)?;
-    dcp_mut(status)?.pending_prototypes.insert(func.to_string(), pieces);
+    let dcp = dcp_mut(status)?;
+    let prog = dcp
+        .conf
+        .as_mut()
+        .ok_or_else(|| IfaceError::execution("No load image present"))?;
+    let target = crate::assertions::resolve_proto_target(prog, func)
+        .map_err(IfaceError::execution)?;
+    crate::assertions::park_prototype(prog, &target, &mut pieces);
+    dcp.pending_prototypes.insert(target.name().to_string(), pieces);
     Ok(())
 }
 

--- a/decompiler/crates/kuna-console/tests/verify_assertplane.rs
+++ b/decompiler/crates/kuna-console/tests/verify_assertplane.rs
@@ -529,3 +529,94 @@ fn an_impossible_scalar_combination_is_rejected_by_name() {
         "the rejection did not name the combination: {detail}"
     );
 }
+
+/// `<func>` may be an ENTRY ADDRESS, not just a name — an agent has the address
+/// long before it has a name it trusts, and the address form used to be
+/// accepted and then dropped on the floor
+/// (`docs/re-needs/accepted-sqrt-prototype-still.md`): nothing is called
+/// `0x400664`, so the by-name park landed on no symbol at all while the report
+/// still said `applied`.
+#[test]
+fn a_prototype_at_an_entry_address_binds_to_the_function_there() {
+    let Some((code, report)) = decompile_with(vec![directive(
+        "prototype 0x400664 void *hashit(void *out,void *input)",
+        Body::Prototype {
+            func: "0x400664".into(),
+            decl: "void *hashit(void *out,void *input)".into(),
+        },
+    )]) else {
+        return;
+    };
+    all_applied(&report);
+    assert!(
+        code.contains("authenticate(void *out,void *input)"),
+        "the address-form signature did not reach the function at 0x400664:\n{code}"
+    );
+    assert!(!code.contains("hashit"), "the declaration's name became a function:\n{code}");
+}
+
+/// The address form is what reaches a CALLEE the name form can miss: the park
+/// is keyed by entry address, which is the key
+/// `ArchContext::callee_proto_pieces` already reads a call site back through.
+/// `strcmp` here is a PLT stub, the same shape as the PE import thunk the need
+/// was filed on.
+#[test]
+fn an_address_form_prototype_reaches_a_callee_at_that_address() {
+    let Some((baseline, _)) = decompile_with(Vec::new()) else { return };
+    assert!(baseline.contains("strcmp(a1,sneaky)"), "baseline moved:\n{baseline}");
+    let Some((code, report)) = decompile_with(vec![directive(
+        "prototype 0x400550 int4 strcmp(char *a,char *b,unsigned long n)",
+        Body::Prototype {
+            func: "0x400550".into(),
+            decl: "int4 strcmp(char *a,char *b,unsigned long n)".into(),
+        },
+    )]) else {
+        return;
+    };
+    all_applied(&report);
+    assert!(
+        code.contains("strcmp(a1,sneaky,"),
+        "the declared third argument never reached the call site:\n{code}"
+    );
+}
+
+/// An explicitly `0x`-prefixed operand that starts no function is REJECTED with
+/// the address in the detail.  `0x...` is not a C identifier, so such a
+/// directive can never bind, and reporting it `applied` — which is what the
+/// whole family did — leaves an agent with no way to tell.
+#[test]
+fn an_address_that_starts_no_function_is_rejected_by_address() {
+    let Some((_code, report)) = decompile_with(vec![directive(
+        "prototype 0x999999 int4 nope(void)",
+        Body::Prototype { func: "0x999999".into(), decl: "int4 nope(void)".into() },
+    )]) else {
+        return;
+    };
+    assert_eq!(report.len(), 1);
+    assert_eq!(report[0].status, "rejected", "{report:?}");
+    let detail = report[0].detail.clone().unwrap_or_default();
+    assert!(detail.contains("no function starts at 0x999999"), "unhelpful detail: {detail}");
+}
+
+/// A qualified `param` takes the same operand, so a callee can be typed by
+/// address as well as by name.
+#[test]
+fn a_qualified_param_accepts_an_entry_address_as_its_function() {
+    let Some((code, report)) = decompile_with(vec![directive(
+        "param 0x400560::0 %RDI char *pathname",
+        Body::Param {
+            func: Some("0x400560".into()),
+            index: 0,
+            storage: "%RDI".into(),
+            decl: "char *pathname".into(),
+        },
+    )]) else {
+        return;
+    };
+    all_applied(&report);
+    let call = code
+        .lines()
+        .find(|l| l.contains("open("))
+        .unwrap_or_else(|| panic!("no call to open:\n{code}"));
+    assert!(call.contains("open(a0)"), "the declared RDI argument is missing: {call}");
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -192,7 +192,7 @@ One directive per `--assert`, keyed by intent rather than by phase:
 
 | directive | what it states |
 |---|---|
-| `prototype <func> <C declaration>` | the signature of `<func>` (parameter names included) |
+| `prototype <func> <C declaration>` | the signature of `<func>` — a name or an entry address (parameter names included) |
 | `param [<func>::]<i> <storage> <C typedecl>` | the storage and type of one input |
 | `return [<func>::]<storage> <C typedecl>` | the storage and type of the return value |
 | `name [<func>::]<symbol> <newname>` | rename a local |
@@ -243,6 +243,26 @@ The console spelling is `map prototype <func> <C declaration>`, which is why
 `<func>` survives into a hand-driven `decomp_dbg` session too; `parse line
 extern <decl>` binds by the declared name and can only confirm a signature for
 a function that is already called that.
+
+**`<func>` may be an entry address instead of a name**, in `prototype` and in a
+`param`/`return` qualifier alike. A name is tried first, so nothing changes for
+a function you can name; an address is what you need when you cannot, and it is
+the only way to say which of two same-named functions you mean — a PE import
+thunk and the IAT slot it jumps to are both called `sqrt`, and every call in the
+program goes to the thunk:
+
+```bash
+kuna decompile ./KeyCheker.exe sub_140001890 \
+  --assert 'prototype 0x140003ddf float8 sqrt(float8 x)'
+```
+
+```text
+- v26 = (double)sqrt();
++ v26 = sqrt(v35._0_8_);
+```
+
+A `0x`-prefixed operand that starts no function is **rejected**, naming the
+address, rather than accepted and dropped.
 
 Widths come from the target's own compiler spec, so `long` is eight bytes on LP64
 and four on LLP64. Ghidra's sized spellings (`int4`, `uint8`, `float8`,

--- a/docs/features/accepted-sqrt-prototype-still/pr_body.md
+++ b/docs/features/accepted-sqrt-prototype-still/pr_body.md
@@ -62,7 +62,7 @@ address, and a `param` qualifier by address; the CLI ones assert the text and
 `--json` surfaces agree. All six fail on the unpatched tree.
 
 `make test` 675/675 PARITY OK · `make test-stages` PARITY OK · `make rust-test`
-5,768 passed · `make check-spec` OK · `make test-cli` 53/53 · `kuna catalog
+5,779 passed · `make check-spec` OK · `make test-cli` 54/54 · `kuna catalog
 --check` OK. No option, no baseline moved.
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/accepted-sqrt-prototype-still/pr_body.md
+++ b/docs/features/accepted-sqrt-prototype-still/pr_body.md
@@ -1,0 +1,68 @@
+## The problem
+
+`--assert 'prototype <func> …'` documents `<func>` as "which function this
+signature describes", but it was only ever looked up as a **name**. An address
+is not a name, so an assertion written at an address was parsed, reported
+`applied`, and then discarded — the call site kept whatever kuna had recovered.
+
+Against the vendored fixture, `accepted` at `0x4006ed` takes no arguments and
+the directive says it takes one:
+
+```
+$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/fauxware main \
+    --json --assert 'prototype 0x4006ed int4 accepted(int4 status)'
+```
+
+```
+"status": "applied", "detail": null
+...
+  v2 = authenticate(v1,v3);
+  if (v2) {
+    accepted();
+```
+
+Same shape on the reported image (crackmes.one `640a526833c5d447bc761899`), where
+`sqrt` is a PE import thunk at `0x140003ddf` and its four call sites read a value
+nothing assigns:
+
+```
+$ kuna decompile KeyCheker.exe sub_140001890 --option calloverlap full \
+    --assert 'prototype 0x140003ddf float8 sqrt(float8 x)'
+      v26 = (double)sqrt();
+```
+
+## The fix
+
+- `<func>` is resolved as a name first and an **entry address** second, by one
+  shared resolver both surfaces call — `kuna decompile`'s generated `map
+  prototype` script line and the in-process `--json` / `decompile-all` path had
+  already drifted apart once on this directive.
+- An address park goes through `set_function_prototype_pieces_at`, which is the
+  key the read side (`ArchContext::callee_proto_pieces`, consulted per call
+  site) already uses. That is also why the name form cannot always express this:
+  the thunk and the IAT slot it jumps to are two symbols both called `sqrt`, and
+  the by-name query answers with the slot while every call goes to the thunk.
+- A `0x`-prefixed operand that starts no function is now **rejected**, naming the
+  address. A bare hex token stays ambiguous with an identifier (`abc` is both),
+  so it takes the address path only when nothing of that name exists, and never
+  errors.
+- The same resolution serves the `param <func>::<i>` / `return <func>::<storage>`
+  qualifier.
+
+```
+      v26 = sqrt(v35._0_8_);
+```
+
+## The tests
+
+`tests/cli/accepted-sqrt-prototype-still.json` (promoted acceptance) plus four
+cases in `verify_assertplane.rs` and two in `decompile_cli.rs` — the selected
+function by address, a callee by address, an unbindable address rejected by
+address, and a `param` qualifier by address; the CLI ones assert the text and
+`--json` surfaces agree. All six fail on the unpatched tree.
+
+`make test` 675/675 PARITY OK · `make test-stages` PARITY OK · `make rust-test`
+5,768 passed · `make check-spec` OK · `make test-cli` 53/53 · `kuna catalog
+--check` OK. No option, no baseline moved.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/accepted-sqrt-prototype-still/record.json
+++ b/docs/features/accepted-sqrt-prototype-still/record.json
@@ -64,6 +64,6 @@
     "A `0x` operand issued BEFORE `read symbols` in a hand-driven console session is now rejected rather than parked, since no symbol exists yet to resolve it against. The generated script always emits `map prototype` after the analysis commit, so no `kuna` invocation can hit this.",
     "docs/re-needs/index.json is deliberately NOT regenerated: `needs reindex` runs over the whole backlog and this worktree holds only the tracked need docs. The captain reindexes."
   ],
-  "pr": null,
+  "pr": "https://github.com/Noelo-Lab/kuna/pull/470",
   "rebase": "rebased --onto origin/main (cf4b3e09, #469 string-ownership-misses-literal) from the recorded base c92dddbb; scripts.repipe.counters --fix reports 'no drift; nothing to fix' on the rebased tree (154 settables, tiers 39/61/54, 243 corpus files, next ElementId 4148) and scripts.repipe.mergecheck reports 0 rejects / merge guards clean. This PR adds no option and no stages XML, so it moves none of those counters itself."
 }

--- a/docs/features/accepted-sqrt-prototype-still/record.json
+++ b/docs/features/accepted-sqrt-prototype-still/record.json
@@ -1,0 +1,68 @@
+{
+  "slug": "accepted-sqrt-prototype-still",
+  "need_id": "accepted-sqrt-prototype-still",
+  "track": "tooling",
+  "filed_track": "quality",
+  "scope": "small",
+  "round": 4,
+  "branch": "feat/re-accepted-sqrt-prototype-still",
+  "summary": "`<func>` in a `prototype` / `param <func>::` / `return <func>::` assertion may now be an ENTRY ADDRESS, on both the script and the in-process surface. It was resolved by name only, so `--assert 'prototype 0x140003ddf float8 sqrt(float8 x)'` parked its pieces under a key no symbol carries, was reported `applied`, and left the call site argumentless. The park now goes through the address-keyed `set_function_prototype_pieces_at` -- the key `ArchContext::callee_proto_pieces` already reads back -- and a `0x`-prefixed operand that starts no function is rejected by address instead of accepted and dropped.",
+  "decisions": [
+    {
+      "what": "hypothesis OVERTURNED (as the round-3 refuter said), and the captain's p4_calls narrowing with it",
+      "detail": "The filed cause was 'whole-width XMM writes may defeat the locked scalar argument'. Nothing about XMM width is reached: instrumenting ActionDefaultParams on the witness shows all four sqrt call sites at entry 0x140003ddf with `pieces=None` and `has_model=false`, i.e. no declared callee prototype ever arrives and the default-model recovery runs exactly as it does without the directive. Not one line in p4_calls changed."
+    },
+    {
+      "what": "the real cause is one layer above even the refuter's reading",
+      "detail": "The refuter said 'the gap is upstream in the path that turns a --assert prototype into a locked FuncProto on the callee' and did not measure which of parse / attach / lock drops it. It is ATTACH. `Architecture::set_function_prototype_pieces(name)` resolves through `queryFunction(name)`, and `pieces.name` was set to the raw `<func>` operand -- `\"0x140003ddf\"`, which is not a C identifier and matches no symbol -- so the park was a total no-op while `bind_prototype` still returned Ok and the report still said `applied`."
+    },
+    {
+      "what": "the by-NAME form is broken here too, and is deliberately NOT fixed",
+      "detail": "`--assert 'prototype sqrt ...'` also fails on this image, for a different reason: `kuna functions` reports TWO FunctionSymbols named `sqrt` -- the import thunk at 0x140003ddf that all four calls target, and the IAT slot at 0x140005238 -- and the global by-name query answers with the slot. Measured: the callee-proto snapshot after the by-name park contains `off=0x140005238 name=sqrt` and nothing at 0x140003ddf. Disambiguating a duplicated import name would have to change the library-prototype pass (`bootstrap`'s step 5, which parks memcpy/malloc/sqrt by name) and could move both parity corpora. The address form is the sound way to say which one you mean, and it is what the need's own command already said."
+    },
+    {
+      "what": "name first, address second -- and only a `0x` prefix may error",
+      "detail": "`resolve_proto_target` tries the global by-name query first, so every existing directive is bit-identical. A `0x`-prefixed operand is unambiguous (not a C identifier) so it takes the address path and, when no function starts there, is REJECTED with the address in the detail -- an accepted-and-inert directive is the one failure an agent cannot see, which is this need. A BARE hex token is ambiguous with a real identifier (`abc` is both), so it takes the address path only when nothing of that name exists AND a function starts there, and never errors."
+    },
+    {
+      "what": "one resolver, both surfaces",
+      "detail": "The script surface (`kuna decompile` -> forked decomp_dbg -> `map prototype` -> `ifacedecomp::bind_prototype`) and the in-process surface (`decompile-all`/`--json` -> `assertions::apply_prototype`) had already drifted apart once on this exact directive (`text-output-silently-ignores`). Both now call the same `assertions::resolve_proto_target` + `assertions::park_prototype`, and the CLI test asserts the two agree rather than testing either alone. That also closes a smaller pre-existing gap: `bind_prototype` retyped the symbol but never parked the pieces, leaning on the by-name re-park at `decompile` time, which the address form has no key for."
+    },
+    {
+      "what": "no option, no stages XML, no catalog counter, no DIV row",
+      "detail": "Tooling track by mechanism even though the need was filed `quality`: the change is entirely in kuna-console's assertion plane. A directive an agent did not write cannot move emitted C -- `make test` 675/675 and `make test-stages` PARITY OK confirm it -- and `--assert` is not a decision the pipeline takes on its own, so there is no judgement call to gate. Matches the CLI-tier repipe PRs merged this round (#448/#452/#454/#457)."
+    }
+  ],
+  "inertness": {
+    "method": "The three new functions (`resolve_proto_target`, `park_prototype`, `lock_prototype_on_symbol`) have exactly three callers in the workspace -- `assertions::apply_prototype`, `assertions::apply_cross_function` and `ifacedecomp::bind_prototype` -- and those are reachable only from a `prototype`/`param`/`return` directive or the `map prototype` console command. A run with no assertion executes none of them.",
+    "note": "make test 675/675 PARITY OK and make test-stages PARITY OK confirm it; neither corpus carries an assertion directive."
+  },
+  "sweep": {
+    "question": "does the resolver change any operand that used to work, and can it bind the WRONG function?",
+    "method": "Six operand shapes on the vendored fauxware, text surface and --json: (1) a plain name; (2) a bare hex that resolves to a function entry; (3) an address INSIDE a function but not its entry; (4) a data address; (5) a `0x` address in no mapped range; (6) a cross-function `return <addr>::<storage>`. Plus the witness itself on the dataset image, and an A/B of the whole thing against a tree built with the two files reverted.",
+    "result": "(1) `prototype authenticate void *hashit(...)` -> `void * authenticate(void *out,void *input)`, unchanged from before the fix. (2) `prototype 400664 ...` binds, same output as the name form. (3) `0x400670` and (4) `0x600984` (the `sneaky` global) are both `rejected: no function starts at 0x...`, and the C is the unasserted baseline -- an interior or data address never binds. (5) `0x999999` likewise. (6) `return 0x400560::%RBX int4` applies and moves the caller exactly as `return open::%RBX int4` does. On the unpatched tree built from the same worktree, the fauxware probe prints `accepted();` and reports the directive `applied`, and `puts(\"Username: \")` ignores a declared second parameter."
+  },
+  "gates": {
+    "make test": "PARITY OK, 675/675 assertions",
+    "make test-stages": "PARITY OK",
+    "make rust-test": "5,768 passed / 1 failed. The one failure is `verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip` ('oracle promote_compare signature drifted') -- the known repipe-worktree artifact: the loop exports KUNA_DECOMP_TEST pointing at this worktree's decomp_test_dbg. Re-run with it unset: 4/4 pass, and the whole suite re-run with it unset is green.",
+    "make check-spec": "OK (lenient mode)",
+    "make test-cli": "53/53 with the probe promoted",
+    "kuna catalog --check": "catalog OK: documents exactly the registered kuna options"
+  },
+  "acceptance": {
+    "acceptance_id": "a-94788ed2c81d",
+    "previous_acceptance_id": "a-bb9896e9cfbb",
+    "result": "PASS",
+    "transition": "closed",
+    "promoted_to": "tests/cli/accepted-sqrt-prototype-still.json",
+    "promotion_note": "The filed acceptance targets the dataset image (crackmes.one 640a526833c5d447bc761899, KeyCheker.exe) and PASSES there after the fix -- `scripts.repipe.verify --need accepted-sqrt-prototype-still` reported 1 pass / 0 fail / closed on the original block before it was retargeted. `--promote` refuses a dataset target and CI has no dataset, so the acceptance was re-pointed at the vendored `kuna-analysis/tests/fixtures/fauxware`, whose `accepted` at 0x4006ed is argumentless for the same reason: `--assert 'prototype 0x4006ed int4 accepted(int4 status)'` must print `accepted(` and must not print `accepted()`. Re-cutting cmd+expect re-derived the id a-bb9896e9cfbb -> a-94788ed2c81d; the need's front matter and Decision log were updated in the same commit.",
+    "reproduction_confirmed_on_main": "On c92dddbb the witness prints `v26 = (double)sqrt();` four times with an empty stderr and exit 0; after the fix it prints `v26 = sqrt(v35._0_8_);`. The vendored twin on c92dddbb prints `accepted();` with the directive reported `applied`; after the fix, `accepted((int)v4);`."
+  },
+  "not_closed": [
+    "`--assert 'prototype sqrt ...'` still parks on the IAT slot rather than the thunk on this image, because two FunctionSymbols share the name. Fixing that means teaching the by-name park which of the two a caller reaches, which is the library-prototype pass's problem and reaches both parity corpora.",
+    "A `0x` operand issued BEFORE `read symbols` in a hand-driven console session is now rejected rather than parked, since no symbol exists yet to resolve it against. The generated script always emits `map prototype` after the analysis commit, so no `kuna` invocation can hit this.",
+    "docs/re-needs/index.json is deliberately NOT regenerated: `needs reindex` runs over the whole backlog and this worktree holds only the tracked need docs. The captain reindexes."
+  ],
+  "pr": null
+}

--- a/docs/features/accepted-sqrt-prototype-still/record.json
+++ b/docs/features/accepted-sqrt-prototype-still/record.json
@@ -43,11 +43,11 @@
     "result": "(1) `prototype authenticate void *hashit(...)` -> `void * authenticate(void *out,void *input)`, unchanged from before the fix. (2) `prototype 400664 ...` binds, same output as the name form. (3) `0x400670` and (4) `0x600984` (the `sneaky` global) are both `rejected: no function starts at 0x...`, and the C is the unasserted baseline -- an interior or data address never binds. (5) `0x999999` likewise. (6) `return 0x400560::%RBX int4` applies and moves the caller exactly as `return open::%RBX int4` does. On the unpatched tree built from the same worktree, the fauxware probe prints `accepted();` and reports the directive `applied`, and `puts(\"Username: \")` ignores a declared second parameter."
   },
   "gates": {
-    "make test": "PARITY OK, 675/675 assertions",
-    "make test-stages": "PARITY OK",
-    "make rust-test": "5,768 passed / 1 failed. The one failure is `verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip` ('oracle promote_compare signature drifted') -- the known repipe-worktree artifact: the loop exports KUNA_DECOMP_TEST pointing at this worktree's decomp_test_dbg. Re-run with it unset: 4/4 pass, and the whole suite re-run with it unset is green.",
+    "make test": "PARITY OK, 675/675 assertions (rebased tree)",
+    "make test-stages": "PARITY OK, 650/650 assertions (rebased tree)",
+    "make rust-test": "5,779 passed / 0 failed with KUNA_DECOMP_TEST unset. With the loop's own KUNA_DECOMP_TEST exported (it points at this worktree's decomp_test_dbg) the run is 5,768/1: verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip reports 'oracle promote_compare signature drifted', the known repipe-worktree artifact, and passes 4/4 with the variable unset. Re-run on the rebased tree.",
     "make check-spec": "OK (lenient mode)",
-    "make test-cli": "53/53 with the probe promoted",
+    "make test-cli": "54/54 with the probe promoted",
     "kuna catalog --check": "catalog OK: documents exactly the registered kuna options"
   },
   "acceptance": {
@@ -64,5 +64,6 @@
     "A `0x` operand issued BEFORE `read symbols` in a hand-driven console session is now rejected rather than parked, since no symbol exists yet to resolve it against. The generated script always emits `map prototype` after the analysis commit, so no `kuna` invocation can hit this.",
     "docs/re-needs/index.json is deliberately NOT regenerated: `needs reindex` runs over the whole backlog and this worktree holds only the tracked need docs. The captain reindexes."
   ],
-  "pr": null
+  "pr": null,
+  "rebase": "rebased --onto origin/main (cf4b3e09, #469 string-ownership-misses-literal) from the recorded base c92dddbb; scripts.repipe.counters --fix reports 'no drift; nothing to fix' on the rebased tree (154 settables, tiers 39/61/54, 243 corpus files, next ElementId 4148) and scripts.repipe.mergecheck reports 0 rejects / merge guards clean. This PR adds no option and no stages XML, so it moves none of those counters itself."
 }

--- a/docs/re-needs/accepted-sqrt-prototype-still.md
+++ b/docs/re-needs/accepted-sqrt-prototype-still.md
@@ -17,7 +17,7 @@ covered_by_option: null
 touches: [decompiler/crates/kuna-console/src/assertions.rs, decompiler/crates/kuna-console/src/ifacedecomp.rs]
 scope: small
 regression_of: null
-pr: null
+pr: https://github.com/Noelo-Lab/kuna/pull/470
 closed_in_round: null
 closing_pr: null
 reject_reason: null

--- a/docs/re-needs/accepted-sqrt-prototype-still.md
+++ b/docs/re-needs/accepted-sqrt-prototype-still.md
@@ -5,7 +5,7 @@ track: quality
 status: open
 severity: major
 probe_id: p-fd6d3fefafe2
-acceptance_id: a-bb9896e9cfbb
+acceptance_id: a-94788ed2c81d
 hypothesis_status: overturned
 credibility: 0.7
 instances: 1
@@ -14,7 +14,7 @@ rounds: [3]
 first_seen_round: 3
 attempts: 0
 covered_by_option: null
-touches: [decompiler/crates/kuna-decomp/src/p4_calls]
+touches: [decompiler/crates/kuna-console/src/assertions.rs, decompiler/crates/kuna-console/src/ifacedecomp.rs]
 scope: small
 regression_of: null
 pr: null
@@ -74,38 +74,45 @@ Force the known XMM0 double argument using an explicit prototype.
 {
   "schema": "re-probe/1",
   "kind": "cli",
-  "timeout_s": 60,
   "cmd": [
     "{{KUNA}}",
     "decompile",
     "{{BIN}}",
-    "sub_140001890",
-    "--option",
-    "calloverlap",
-    "full",
+    "main",
     "--assert",
-    "prototype 0x140003ddf float8 sqrt(float8 x)"
+    "prototype 0x4006ed int4 accepted(int4 status)"
   ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "binary_sha256": "c2d90645a45e99221593547e55c601a901b80f807ae96f94c60a7661df0b3e0b",
+    "binary_size": 8776,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "selector": "main",
+    "selector_kind": "name"
+  },
   "expect": {
     "exit_code": {
       "eq": 0
     },
-    "stderr_absent": [
-      "rejected"
-    ],
     "stdout_matches": [
-      "sqrt\\("
+      "accepted\\("
     ],
     "stdout_absent": [
-      "sqrt\\(\\s*\\)"
+      "accepted\\(\\s*\\)"
+    ],
+    "stderr_absent": [
+      "rejected"
     ]
   },
-  "target": {
-    "binary_rel": "bin/KeyCheker.exe",
-    "binary_sha256": "351e54ecaa80f0395111a90e332313c15bd1e19d1e12da87606a045efb5afecf",
-    "binary_size": 25600,
-    "binary_source": "dataset"
-  }
+  "notes": "Retargeted onto the in-repo fauxware fixture: same defect, no dataset. `accepted` at 0x4006ed renders `accepted()` and an address-form prototype assertion is reported `applied` while changing nothing; measured on c92dddbb. The dataset KeyCheker.exe sqrt() call stays the witness in Reproduction."
 }
 ```
 
@@ -133,3 +140,7 @@ _none recorded_
 captain T_TRIAGE r3: track quality CONFIRMED and touches narrowed to p4_calls: the prototype is accepted (the assert does not error), so the loss is in call input-trial/float-parameter recovery, not in the grammar -- unlike prototype-assertions-reject-ordinary, which is the grammar and is on the tooling track.
 captain T_TRIAGE r3: repaired the missing probe/acceptance `target` block (binary_rel + sha256 + size, source dataset) -- without it {{BIN}} could not resolve and the need was unclosable by B_DONE and invisible to regression detection. Verified: acceptance now RUNS and FAILS on cf5234ac, which is the state a filed need must be in.
 - round 3 REFUTER: hypothesis **overturned** (was inconclusive). OVERTURNED by measurement on the 20:01 release binary (arena/3/640a526833c5d447bc761899/target/KeyCheker.exe). The filed cause is 'whole-width XMM writes may defeat the locked scalar argument'. Nothing about XMM width is ever reached: the prototype assertion is a SILENT NO-OP at this call site. Three runs, same 4 call sites each time, output identical in all three: (a) the filed 'float8 sqrt(float8 x)' -> 'v26 = (double)sqrt();'; (b) 'float8 sqrt(float8 x, float8 y)' -> still zero arguments, and a locked 2-input prototype cannot print zero args; (c) 'int8 zzzmarker(int8 x)' -> the name is still sqrt and the cast is still (double). kuna functions puts a real 33-byte function 'sqrt' at exactly 0x140003ddf, so the address is right and the assert exits 0 with an empty stderr -- accepted and then discarded. The (double) cast and the sqrt name come from kuna's own recovery for that address, which is what makes the assertion look applied. A builder who follows the hypothesis into p4_calls float-parameter recovery would be fixing a mechanism that never runs; the T_TRIAGE narrowing to p4_calls rested on 'the assert does not error' and is wrong for the same reason. The gap is upstream in the path that turns a --assert prototype into a locked FuncProto on the callee (kuna decides nothing from it here); the argumentless call is the downstream symptom. Not measured: which of parse / attach-to-address / lock-the-input drops it. Note the relation to in-flight PR #421 (prototype-assertions-reject-ordinary): that one is the GRAMMAR rejecting ordinary C signatures; this one is a signature the grammar accepts being thrown away, so #421 merging will not close it.
+
+- round 4 BUILDER: the refuter is right and the cause is one line further up than even it said. `<func>` in a `prototype`/`param`/`return` directive was resolved by NAME ONLY (`Architecture::set_function_prototype_pieces` -> `queryFunction(name)`), and `0x140003ddf` is not a name, so the pieces were parked under a key nothing ever reads while the report still said `applied`. Fixed by resolving `<func>` as an entry address when it is not a name, and parking through the address-keyed `set_function_prototype_pieces_at` -- which is the key the READ side (`ArchContext::callee_proto_pieces`) already used. Nothing in p4_calls changed: the XMM0 input trial was never the problem, and `float8 sqrt(float8 x)` at 0x140003ddf now renders `sqrt(v35._0_8_)`.
+- round 4 BUILDER: the by-NAME form is still wrong here and is left open deliberately. This PE has TWO FunctionSymbols called `sqrt` -- the import thunk at 0x140003ddf that every call goes to, and the IAT slot at 0x140005238 -- and the global by-name query answers with the slot, so `--assert 'prototype sqrt ...'` parks on a symbol no call site reads. Disambiguating a duplicated import name touches the library-prototype pass and both parity corpora; the address form is the sound way to say it and is what this need closes.
+- round 4 BUILDER: acceptance retargeted onto the in-repo `fauxware` fixture (`accepted` at 0x4006ed, argumentless for the same reason) so the probe promotes into `tests/cli/` where CI has no dataset; `acceptance_id` re-derived a-bb9896e9cfbb -> a-94788ed2c81d. Measured on c92dddbb: `accepted();` with the directive reported `applied`.

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -843,6 +843,32 @@ had genuinely parsed. The console spelling of the directive is therefore
 `ifacedecomp.rs (bind_prototype)`), which takes the target as its first token and
 parks the pieces under it; `parse line extern` keeps its upstream meaning.
 
+(kuna) **`<func>` is a name first and an ENTRY ADDRESS second.** Both surfaces
+resolve the operand through
+`decompiler/crates/kuna-console/src/assertions.rs (resolve_proto_target)`: a
+`FunctionSymbol` of that name wins, and failing that a hexadecimal operand that a
+function starts at binds by address. The address form exists because parking by
+name is not always expressible. The park is the callee's `FunctionSymbol`, and
+the READ side — `ArchContext::callee_proto_pieces`, which `ActionDefaultParams`
+consults per call site — is keyed by the callee's ENTRY ADDRESS, so a by-name
+park has to resolve to the same symbol the call reaches. A PE import thunk and
+the IAT slot it jumps to are two FunctionSymbols with the same name; the global
+by-name query answers with one of them while every call in the program targets
+the other, and the directive was accepted, reported `applied`, and read back as
+nothing (`docs/re-needs/accepted-sqrt-prototype-still.md`). Stating the address
+removes the ambiguity, and the park goes through
+`Architecture::set_function_prototype_pieces_at`, the same address-keyed door the
+DWARF and demangled-signature passes use. `pieces.name` is set to the resolved
+function's own display name, so an address operand states a signature without
+renaming the function to its VMA. A `0x`-prefixed operand that starts no function
+is REJECTED with the address in the detail rather than parked under a key nothing
+reads: `0x…` is not a C identifier, so such a directive is provably inert, and an
+accepted-and-inert directive is the one failure an agent cannot see. A bare hex
+token is ambiguous with an identifier (`abc` is both), so it takes the address
+path only when it resolves and nothing of that name exists, and never errors.
+The same resolution serves the cross-function `param <func>::<i>` /
+`return <func>::<storage>` qualifier.
+
 (kuna) **The C the assertion plane accepts is the C it prints.** Six directives
 carry a C declaration, and every one of them goes through the console's
 C-declaration grammar (`decompiler/crates/kuna-console/src/grammar.rs (CParse)`),

--- a/tests/cli/accepted-sqrt-prototype-still.json
+++ b/tests/cli/accepted-sqrt-prototype-still.json
@@ -1,0 +1,43 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "main",
+    "--assert",
+    "prototype 0x4006ed int4 accepted(int4 status)"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "binary_sha256": "c2d90645a45e99221593547e55c601a901b80f807ae96f94c60a7661df0b3e0b",
+    "binary_size": 8776,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "selector": "main",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "accepted\\("
+    ],
+    "stdout_absent": [
+      "accepted\\(\\s*\\)"
+    ],
+    "stderr_absent": [
+      "rejected"
+    ]
+  },
+  "notes": "Retargeted onto the in-repo fauxware fixture: same defect, no dataset. `accepted` at 0x4006ed renders `accepted()` and an address-form prototype assertion is reported `applied` while changing nothing; measured on c92dddbb. The dataset KeyCheker.exe sqrt() call stays the witness in Reproduction."
+}


### PR DESCRIPTION
## The problem

`--assert 'prototype <func> …'` documents `<func>` as "which function this
signature describes", but it was only ever looked up as a **name**. An address
is not a name, so an assertion written at an address was parsed, reported
`applied`, and then discarded — the call site kept whatever kuna had recovered.

Against the vendored fixture, `accepted` at `0x4006ed` takes no arguments and
the directive says it takes one:

```
$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/fauxware main \
    --json --assert 'prototype 0x4006ed int4 accepted(int4 status)'
```

```
"status": "applied", "detail": null
...
  v2 = authenticate(v1,v3);
  if (v2) {
    accepted();
```

Same shape on the reported image (crackmes.one `640a526833c5d447bc761899`), where
`sqrt` is a PE import thunk at `0x140003ddf` and its four call sites read a value
nothing assigns:

```
$ kuna decompile KeyCheker.exe sub_140001890 --option calloverlap full \
    --assert 'prototype 0x140003ddf float8 sqrt(float8 x)'
      v26 = (double)sqrt();
```

## The fix

- `<func>` is resolved as a name first and an **entry address** second, by one
  shared resolver both surfaces call — `kuna decompile`'s generated `map
  prototype` script line and the in-process `--json` / `decompile-all` path had
  already drifted apart once on this directive.
- An address park goes through `set_function_prototype_pieces_at`, which is the
  key the read side (`ArchContext::callee_proto_pieces`, consulted per call
  site) already uses. That is also why the name form cannot always express this:
  the thunk and the IAT slot it jumps to are two symbols both called `sqrt`, and
  the by-name query answers with the slot while every call goes to the thunk.
- A `0x`-prefixed operand that starts no function is now **rejected**, naming the
  address. A bare hex token stays ambiguous with an identifier (`abc` is both),
  so it takes the address path only when nothing of that name exists, and never
  errors.
- The same resolution serves the `param <func>::<i>` / `return <func>::<storage>`
  qualifier.

```
      v26 = sqrt(v35._0_8_);
```

## The tests

`tests/cli/accepted-sqrt-prototype-still.json` (promoted acceptance) plus four
cases in `verify_assertplane.rs` and two in `decompile_cli.rs` — the selected
function by address, a callee by address, an unbindable address rejected by
address, and a `param` qualifier by address; the CLI ones assert the text and
`--json` surfaces agree. All six fail on the unpatched tree.

`make test` 675/675 PARITY OK · `make test-stages` PARITY OK · `make rust-test`
5,779 passed · `make check-spec` OK · `make test-cli` 54/54 · `kuna catalog
--check` OK. No option, no baseline moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
