### PR TITLE
[AUTOMATED] fix(cli): rejected-flow-override-exits — a refused flow override rejects the assertion, not the function

### DIFF
--- a/decompiler/crates/kuna-cli/src/decompile.rs
+++ b/decompiler/crates/kuna-cli/src/decompile.rs
@@ -496,11 +496,21 @@ fn assertion_outcomes(
         .iter()
         .map(|directive| {
             let (kind, phase, subphase) = directive.body.coords();
-            let detail = match crate::assertdecl::console_form(directive, selected) {
-                Ok(form) => command_failure(out, &form.line),
+            let (detail, fatal) = match crate::assertdecl::console_form(directive, selected) {
+                Ok(form) => match command_failure(out, &form.line) {
+                    Some(reason) => (Some(reason), false),
+                    // The console line itself ran clean, which for a DEFERRED
+                    // directive says only that it was taken: an `override flow`
+                    // answers "Successfully added override" and is applied later,
+                    // at flow time, where it can still be refused.
+                    None => match pipeline_refusal(out, &form.line) {
+                        Some(reason) => (Some(reason), true),
+                        None => (None, false),
+                    },
+                },
                 // Nothing was emitted for it: the directive names a function this
                 // run did not decompile, and the reason is the report row.
-                Err(detail) => Some(detail),
+                Err(detail) => (Some(detail), false),
             };
             Outcome {
                 directive: directive.raw.clone(),
@@ -509,6 +519,7 @@ fn assertion_outcomes(
                 subphase,
                 status: if detail.is_none() { "applied" } else { "rejected" },
                 detail,
+                fatal,
             }
         })
         .collect()
@@ -543,8 +554,58 @@ fn command_failure(out: &str, line: &str) -> Option<String> {
     if seen {
         None
     } else {
-        Some("the console script did not reach this directive".into())
+        Some(SCRIPT_NOT_REACHED.into())
     }
+}
+
+/// [`command_failure`]'s answer for a command whose echo never appears.
+const SCRIPT_NOT_REACHED: &str = "the console script did not reach this directive";
+
+/// The reason the pipeline REFUSED the directive that lowered to `line`, or
+/// `None` when it was not refused.
+///
+/// A `flow` override cannot be applied when the `override flow` command runs —
+/// there is no IR yet — so the console accepts it, tries it at flow time and, if
+/// `Funcdata::overrideFlow` will not take it, prints `Rejected <command>:
+/// <reason>` after the `decompile`.  Matching on the command's own spelling is
+/// what pairs the line back to the directive that sent it.
+fn pipeline_refusal(out: &str, line: &str) -> Option<String> {
+    let prefix = format!("Rejected {line}: ");
+    for raw in out.lines() {
+        let text = console_text(raw.trim());
+        if let Some(reason) = text.strip_prefix(&prefix) {
+            let reason = reason.trim();
+            if !reason.is_empty() {
+                return Some(reason.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// The per-function abort the console reported by RAISING on the `decompile`
+/// command, rather than by swallowing it into the `Skipping` notice
+/// ([`find_pipeline_failure`]).
+///
+/// Both leave the same thing behind — the previous, un-decompiled `Funcdata`,
+/// which `print C` renders as a brace-matched shell — so a text-surface caller
+/// that reads only stdout cannot tell either from a genuinely empty function.
+/// The JSON surface has always reported this one (it drives the engine in
+/// process and sees the error directly); the text surface exited 0 with an empty
+/// body and an empty stderr.
+fn decompile_command_failure(out: &str) -> Option<String> {
+    match command_failure(out, "decompile") {
+        Some(reason) if reason != SCRIPT_NOT_REACHED => Some(reason),
+        _ => None,
+    }
+}
+
+/// The function the console last announced (`Decompiling <name>`), so a failure
+/// report names the same function the JSON surface's does.
+fn decompiling_name(out: &str) -> Option<String> {
+    out.lines().rev().find_map(|raw| {
+        console_text(raw.trim()).strip_prefix("Decompiling ").map(|n| n.trim().to_string())
+    })
 }
 
 /// A unique temp path under the system temp dir (no external dep; mirrors
@@ -899,7 +960,14 @@ fn decompile(args: &DecompileArgs) -> Result<DecompileOutcome, String> {
         // alive and `print C` rendered the un-decompiled shell above, so the C
         // is non-empty and only this notice distinguishes the failure from a
         // genuinely empty function.  Report it; `run` exits non-zero.
-        let failure = find_pipeline_failure(&stdout_text).map(|(func, reason)| {
+        let failure = find_pipeline_failure(&stdout_text)
+            .or_else(|| {
+                let reason = decompile_command_failure(&stdout_text)?;
+                let func = decompiling_name(&stdout_text)
+                    .unwrap_or_else(|| args.target.clone());
+                Some((func, reason))
+            })
+            .map(|(func, reason)| {
             let mut msg = format!("decompilation failed for {func} in {binary}: {reason}");
             let note = stderr_text.trim();
             if !note.is_empty() {
@@ -968,13 +1036,17 @@ pub fn run(args: &DecompileArgs) -> i32 {
             // worked.  Emitting first keeps the stdout-then-stderr order.
             let written = crate::output::emit(&text);
             // A rejected assertion is reported and the run continues;
-            // `--assert-strict` makes it the verdict.
+            // `--assert-strict` makes it the verdict.  A directive the PIPELINE
+            // refused is the verdict either way: the C above was produced without
+            // it, and nothing in the C says so.
             let rejected = decompile_all::report_rejected_assertions(&out.assertions);
+            let refused = decompile_all::any_refused_assertion(&out.assertions);
             let status = match out.failure {
                 Some(msg) => {
                     eprintln!("error: {msg}");
                     1
                 }
+                None if refused => 1,
                 None if args.assert_strict && rejected => 1,
                 None => 0,
             };
@@ -1392,6 +1464,13 @@ fn decompile_json(args: &AllArgs, target: &str) -> Result<(String, Option<String
     // A rejected assertion is reported and the run continues; `--assert-strict`
     // makes it the run's verdict (see `report_rejected_assertions`).
     let rejected = decompile_all::report_rejected_assertions(&assertions);
+    // A directive the pipeline refused is the run's verdict AND belongs in the
+    // document: the caller asked for a decompile under that directive and did not
+    // get one, so the run-level `error` says so rather than leaving `assertions[]`
+    // as the only place a reader could notice.
+    if failure.is_none() && decompile_all::any_refused_assertion(&assertions) {
+        failure = Some(format!("--assert directive refused by the pipeline in {}", args.binary));
+    }
     let text = decompile_all::render_result_json(
         &args.binary,
         &funcs,
@@ -1408,8 +1487,9 @@ fn decompile_json(args: &AllArgs, target: &str) -> Result<(String, Option<String
 #[cfg(test)]
 mod tests {
     use super::{
-        arch_failure_reason, build_script, check_errors, console_path, decompile_all,
-        find_pipeline_failure, is_unknown_function, read_symbols_failure, reject_unquotable,
+        arch_failure_reason, build_script, check_errors, command_failure, console_path,
+        decompile_all, decompile_command_failure, decompiling_name, find_pipeline_failure,
+        is_unknown_function, pipeline_refusal, read_symbols_failure, reject_unquotable,
     };
     use std::borrow::Cow;
 
@@ -1613,6 +1693,52 @@ Decompilation complete
     fn body_text_is_not_a_failure() {
         let out = "[decomp]> print C\n  /* Skipping is fine here */\n";
         assert_eq!(find_pipeline_failure(out), None);
+    }
+
+    /// The console's OTHER per-function abort: `decompile` raised instead of
+    /// degrading into the swallowed `Skipping` notice.  It leaves the same
+    /// brace-matched shell behind, so a text-surface caller that reads only stdout
+    /// cannot tell it from a genuinely empty function -- and this surface used to
+    /// answer it with exit 0 and an empty stderr while `--json`, driving the same
+    /// engine in process, exited 1 (`docs/re-needs/rejected-flow-override-exits.md`).
+    #[test]
+    fn finds_a_raised_decompile_abort() {
+        let out = "[decomp]> decompile\nClearing old decompilation\nDecompiling sub_100054\n\
+                   Execution error: Could not apply flowoverride\n[decomp]> print C\n";
+        assert_eq!(find_pipeline_failure(out), None, "it is not the Skipping notice");
+        assert_eq!(
+            decompile_command_failure(out).as_deref(),
+            Some("Could not apply flowoverride")
+        );
+        assert_eq!(decompiling_name(out).as_deref(), Some("sub_100054"));
+    }
+
+    /// A clean `decompile` raises nothing, and a transcript that never reached the
+    /// command is not reported as one that failed it.
+    #[test]
+    fn a_clean_or_unreached_decompile_is_not_an_abort() {
+        let clean = "[decomp]> decompile\nDecompiling main\nDecompilation complete\n";
+        assert_eq!(decompile_command_failure(clean), None);
+        assert_eq!(decompile_command_failure("[decomp]> quit\n"), None);
+    }
+
+    /// A DEFERRED directive -- `override flow`, applied at flow time and not when
+    /// the command runs -- is refused under the `decompile` that discovered it, not
+    /// under its own echo.  `command_failure` therefore sees a clean command and the
+    /// ledger said `applied` for an override the engine had just thrown out.
+    #[test]
+    fn a_deferred_directive_refusal_is_paired_back_to_its_command() {
+        let out = "[decomp]> override flow 0x101dfb branch\nSuccessfully added override\n\
+                   [decomp]> decompile\nDecompiling sub_100054\n\
+                   Rejected override flow 0x101dfb branch: Could not apply flowoverride\n\
+                   Decompilation complete\n";
+        assert_eq!(command_failure(out, "override flow 0x101dfb branch"), None);
+        assert_eq!(
+            pipeline_refusal(out, "override flow 0x101dfb branch").as_deref(),
+            Some("Could not apply flowoverride")
+        );
+        // A different override in the same run is untouched.
+        assert_eq!(pipeline_refusal(out, "override flow 0x1405 call"), None);
     }
 
     /// A path without whitespace is emitted exactly as before — the corpus

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -741,8 +741,9 @@ pub fn run(argv: &[String]) -> i32 {
             // batching forty renames against a re-decompiled binary must not lose
             // all forty to one stale name); `--assert-strict` makes it fatal.
             let rejected = report_rejected_assertions(&run.assertions);
+            let refused = any_refused_assertion(&run.assertions);
             let status = emit_with_discovery_error(&text, discovery_error.as_deref());
-            if status == 0 && args.assert_strict && rejected {
+            if status == 0 && (refused || (args.assert_strict && rejected)) {
                 return 1;
             }
             status
@@ -767,13 +768,28 @@ pub(crate) fn report_rejected_assertions(
     let mut any = false;
     for outcome in outcomes.iter().filter(|o| o.status == "rejected") {
         any = true;
-        eprintln!(
-            "warning: --assert {:?} rejected: {}",
-            outcome.directive,
-            outcome.detail.as_deref().unwrap_or("no reason given")
-        );
+        let reason = outcome.detail.as_deref().unwrap_or("no reason given");
+        if outcome.fatal {
+            eprintln!(
+                "error: --assert {:?} refused by the pipeline: {reason} \
+                 (the C below was produced WITHOUT it)",
+                outcome.directive
+            );
+        } else {
+            eprintln!("warning: --assert {:?} rejected: {reason}", outcome.directive);
+        }
     }
     any
+}
+
+/// Did the pipeline REFUSE a directive it had already accepted
+/// (`kuna_console::assertions::Outcome::fatal`)?
+///
+/// That is the verdict of the run whether or not `--assert-strict` was passed:
+/// unlike a directive that never bound, the C came back looking healthy while
+/// describing a program the directive was never applied to.
+pub(crate) fn any_refused_assertion(outcomes: &[kuna_console::assertions::Outcome]) -> bool {
+    outcomes.iter().any(|o| o.fatal)
 }
 
 fn emit_with_discovery_error(text: &str, discovery_error: Option<&str>) -> i32 {
@@ -1777,6 +1793,7 @@ fn assertions_json(outcomes: &[kuna_console::assertions::Outcome]) -> Json {
                         "detail".into(),
                         o.detail.clone().map(Json::Str).unwrap_or(Json::Null),
                     ),
+                    ("fatal".into(), Json::Bool(o.fatal)),
                 ])
             })
             .collect(),

--- a/decompiler/crates/kuna-console/src/assertions.rs
+++ b/decompiler/crates/kuna-console/src/assertions.rs
@@ -135,6 +135,14 @@ pub struct Outcome {
     pub subphase: &'static str,
     pub status: &'static str,
     pub detail: Option<String>,
+    /// The pipeline ACCEPTED this directive, seeded it, and then refused it while
+    /// applying it -- today only a `flow` override the flow-follower could not
+    /// apply (`Funcdata::kuna_rejected_flow_overrides`).
+    ///
+    /// Such a rejection is fatal without `--assert-strict`, unlike one that never
+    /// bound: the C that came back describes a program the directive was never
+    /// applied to, and nothing in it says so.
+    pub fatal: bool,
 }
 
 impl Body {
@@ -216,6 +224,7 @@ impl Directive {
             subphase,
             status: "applied",
             detail: None,
+            fatal: false,
         }
     }
 
@@ -228,7 +237,14 @@ impl Directive {
             subphase,
             status: "rejected",
             detail: Some(detail.into()),
+            fatal: false,
         }
+    }
+
+    /// The outcome of a directive the pipeline took and then refused
+    /// (see [`Outcome::fatal`]).
+    fn refused(&self, detail: impl Into<String>) -> Outcome {
+        Outcome { fatal: true, ..self.rejected(detail) }
     }
 }
 
@@ -758,6 +774,41 @@ pub fn function_seed(
         prog.set_assertion_outcome(i, outcome);
     }
     seed
+}
+
+/// Downgrade the outcome of every `flow` directive bound to `name` that the flow
+/// follower REFUSED, from the `applied` [`function_seed`] recorded when it merely
+/// seeded it, to a fatal rejection carrying the engine's own reason.
+///
+/// The seed is collected before the pipeline runs, so `function_seed` can only
+/// say the directive was *taken*; whether `Funcdata::override_flow` could apply
+/// it is not known until flow has followed.  Without this the ledger reported
+/// `applied` for an override the engine had just refused, which is the one thing
+/// an agent reads to decide whether its assertion took effect.
+pub fn record_rejected_flow_overrides(
+    prog: &mut ConsoleProgram,
+    name: &str,
+    single: bool,
+    fd: &Funcdata,
+) {
+    let refused = fd.kuna_rejected_flow_overrides();
+    if refused.is_empty() {
+        return;
+    }
+    let directives = prog.assertions().to_vec();
+    for (i, directive) in directives.iter().enumerate() {
+        let Body::Flow { addr, kind, .. } = &directive.body else { continue };
+        if !binds_to(&directive.body, name, single) {
+            continue;
+        }
+        let type_ = kuna_decomp::overrides::Override::string_to_type(kind.as_bytes());
+        let Some(at) = code_addr(prog, *addr) else { continue };
+        let Some((_, _, reason)) = refused.iter().find(|(a, t, _)| a == &at && *t == type_) else {
+            continue;
+        };
+        let outcome = directive.refused(reason.clone());
+        prog.set_assertion_outcome(i, outcome);
+    }
 }
 
 fn seed_one(

--- a/decompiler/crates/kuna-console/src/ifacedecomp.rs
+++ b/decompiler/crates/kuna-console/src/ifacedecomp.rs
@@ -2218,7 +2218,26 @@ decomp_command!(
         dcp.conf = Some(prog);
         match result {
             Ok(fd) => {
+                // (kuna `--assert`) Every flow override the follower REFUSED, named
+                // in the console's own command spelling so a front-end driving
+                // `decomp_dbg` can pair each line with the `override flow` it sent.
+                // The refusal is reported here and not at `override flow` time
+                // because nothing can be applied until flow has followed.
+                let refusals: Vec<String> = fd
+                    .kuna_rejected_flow_overrides()
+                    .iter()
+                    .map(|(addr, type_, reason)| {
+                        format!(
+                            "Rejected override flow {:#x} {}: {reason}\n",
+                            addr.get_offset(),
+                            kuna_decomp::overrides::Override::type_to_string(*type_)
+                        )
+                    })
+                    .collect();
                 dcp.fd = Some(fd);
+                for line in &refusals {
+                    status.out(line);
+                }
                 // C++ res>=0 path: "Decompilation complete".
                 status.out("Decompilation complete\n");
                 Ok(())
@@ -2238,17 +2257,21 @@ decomp_command!(
                 // (e.g. "No function selected") still propagates.  The whole-corpus
                 // (675/675) is inert here: no datatest function aborts, so this arm
                 // is never reached for them.
-                if msg.contains("LOSS-131") {
-                    // Stamp the reason on the retained (un-decompiled) Funcdata:
-                    // it has no structured blocks, so a following `print C`
-                    // would otherwise emit the generic "structuring declined"
-                    // shell and hide the abort.  Guarded on the address so a
-                    // stale, unrelated function is never mislabeled.
-                    if let Some(fd) = dcp.fd.as_mut() {
-                        if fd.get_address() == &stamp_addr {
-                            fd.set_kuna_pipeline_failure(&msg);
-                        }
+                // Stamp the reason on the retained (un-decompiled) Funcdata: it
+                // has no structured blocks, so a following `print C` would
+                // otherwise emit the generic "structuring declined" shell and hide
+                // the abort.  Guarded on the address so a stale, unrelated function
+                // is never mislabeled.  Stamped for EVERY per-function abort, not
+                // only the swallowed one: a `decompile` that raised leaves the same
+                // shell behind, and a front-end that reads only the C (`kuna
+                // decompile`'s text surface) cannot otherwise tell it from a
+                // genuinely empty function.
+                if let Some(fd) = dcp.fd.as_mut() {
+                    if fd.get_address() == &stamp_addr {
+                        fd.set_kuna_pipeline_failure(&msg);
                     }
+                }
+                if msg.contains("LOSS-131") {
                     status.out(&format!("Skipping {name}: {msg}\n"));
                     Ok(())
                 } else {

--- a/decompiler/crates/kuna-console/src/project.rs
+++ b/decompiler/crates/kuna-console/src/project.rs
@@ -251,6 +251,14 @@ pub fn decompile_targets(
         };
         match result {
             Ok(fd) => {
+                // (kuna `--assert`) The flow overrides the follower REFUSED are only
+                // known now: `function_seed` recorded `applied` when it seeded them.
+                crate::assertions::record_rejected_flow_overrides(
+                    prog,
+                    &name,
+                    single_target,
+                    &fd,
+                );
                 // Render + extract under `catch_unwind`: the decompile drive only
                 // guards the pipeline (decompile_drive.rs), so a fail-fast invariant
                 // in the printer / type declarator on an exotic recovered function

--- a/decompiler/crates/kuna-console/tests/verify_assertflow.rs
+++ b/decompiler/crates/kuna-console/tests/verify_assertflow.rs
@@ -164,21 +164,47 @@ fn branch_and_callreturn_land_as_their_own_flow_types() {
 
 /// `call` at this site is the one the ENGINE refuses — an indirect call has no
 /// destination to make direct, so `Funcdata::overrideFlow` raises "Could not
-/// apply flowoverride".  That refusal is the evidence the directive reached the
-/// engine at all: the run reports a per-function error instead of quietly
-/// decompiling as if nothing had been asserted.
+/// apply flowoverride".
+///
+/// The refusal REJECTS the directive; it does not delete the function.  Nothing
+/// is mutated before `overrideFlow` gives up, so the IR that follows is the one
+/// the same run without the directive would have produced — and discarding it
+/// used to cost the caller a 55-line body plus, on the text CLI, any sign that
+/// anything had gone wrong at all (`docs/re-needs/rejected-flow-override-exits.md`).
 #[test]
-fn a_flow_type_the_engine_cannot_apply_surfaces_as_a_pipeline_error() {
-    let Some((_code, error, report)) =
+fn a_flow_type_the_engine_cannot_apply_is_rejected_and_keeps_the_body() {
+    let Some((code, error, report)) =
         run(&[SUB_13C9], vec![flow("flow 0x1405 call", None, INDIRECT_CALL, "call")])
     else {
         return;
     };
-    all_applied(&report);
+    assert_eq!(error, None, "the refusal aborted the function:\n{code}");
+    assert_eq!(report.len(), 1);
+    assert_eq!(report[0].status, "rejected");
+    assert!(report[0].fatal, "a pipeline refusal is fatal: {report:?}");
     assert!(
-        error.as_deref().unwrap_or_default().contains("flowoverride"),
-        "expected the engine's own refusal, got {error:?}"
+        report[0].detail.as_deref().unwrap_or_default().contains("flowoverride"),
+        "expected the engine's own refusal, got {:?}",
+        report[0].detail
     );
+    // The body the abort used to throw away.
+    assert!(code.contains("v25"), "the recovered body did not come back:\n{code}");
+}
+
+/// A directive the pipeline refused is `fatal`; one that merely did not bind is
+/// not.  The distinction is what `kuna decompile` reads to decide whether the run
+/// failed without `--assert-strict`: a refused `flow` means the C describes a
+/// control-flow graph other than the one asked for, and nothing in the C says so,
+/// while an unbound directive left a correct body un-annotated.
+#[test]
+fn only_a_pipeline_refusal_is_fatal() {
+    let Some((_code, report)) =
+        decompile_with(&[SUB_13C9], vec![flow("flow 0x1405 goto", None, INDIRECT_CALL, "goto")])
+    else {
+        return;
+    };
+    assert_eq!(report[0].status, "rejected");
+    assert!(!report[0].fatal, "a directive rejected before the pipeline is not fatal");
 }
 
 /// A spelling outside the four-word vocabulary is REJECTED with a reason, not

--- a/decompiler/crates/kuna-decomp/src/p2_lift/flow.rs
+++ b/decompiler/crates/kuna-decomp/src/p2_lift/flow.rs
@@ -1488,7 +1488,21 @@ truncating the fall-through here"
             }
             self.op_mark_start_instruction(firstop);
             if flowoverride != crate::overrides::flow_type::NONE {
-                self.data.override_flow(curaddr, flowoverride)?;
+                // (kuna) A refused override is a rejected caller assertion, not a
+                // dead function.  `override_flow` refuses before it mutates
+                // anything, so what follows is the IR this run would have produced
+                // with no override at all -- decompile it, and let the front-end
+                // report the refusal (`Funcdata::note_rejected_flow_override`).
+                // Aborting instead deleted the whole body and, on the text CLI,
+                // reported success for it.
+                if let Err(e) = self.data.override_flow(curaddr, flowoverride) {
+                    let reason = e.explain().to_string();
+                    self.data.note_rejected_flow_override(
+                        curaddr.clone(),
+                        flowoverride,
+                        &reason,
+                    );
+                }
             }
             self.xref_control_flow(Some(firstop), startbasic, &mut isfallthru)?;
         }

--- a/decompiler/crates/kuna-decomp/src/substrate/funcdata.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/funcdata.rs
@@ -365,6 +365,15 @@ pub struct Funcdata {
     /// ([`Self::set_kuna_pipeline_failure`]) so the printer says the pipeline
     /// failed, and why, instead of blaming structuring (`PrintC::emit_function_document`).
     kuna_pipeline_failure: Option<String>,
+    /// (kuna) The flow overrides `FlowInfo::process` asked for and
+    /// [`Self::override_flow`] refused, as `(instruction, flow type, reason)`.
+    ///
+    /// A refusal is a REJECTED caller assertion, not a reason to discard the
+    /// function: nothing was mutated before the refusal, so the IR is exactly the
+    /// one this run would have produced without the directive.  Recording it here
+    /// is what lets the front-ends report the rejection (`--assert` ledger, exit
+    /// code) while still emitting the C.
+    kuna_rejected_flow: Vec<(Address, kuna_base::types::uint4, String)>,
     /// (kuna, ghidra Phase 4) WIRE-ONLY symbols the encode-time link pass
     /// synthesized for named HighVariables the analysis deliberately left
     /// symbol-less — see [`crate::database::WireSymbol`].  They are encoded
@@ -495,6 +504,7 @@ impl Funcdata {
             union_map: std::collections::BTreeMap::new(),
             pending_comments: Vec::new(),
             kuna_pipeline_failure: None,
+            kuna_rejected_flow: Vec::new(),
             kuna_wire_symbols: Vec::new(),
             kuna_wire_symbol_for_high: std::collections::BTreeMap::new(),
             kuna_callee_ret_writes: std::collections::HashMap::new(),
@@ -631,6 +641,26 @@ impl Funcdata {
     /// (kuna) Why the decompile pipeline aborted for this function, if it did.
     pub fn kuna_pipeline_failure(&self) -> Option<&str> {
         self.kuna_pipeline_failure.as_deref()
+    }
+
+    /// (kuna) Record a flow override [`Self::override_flow`] refused at `addr`.
+    /// Idempotent per `(addr, type_)`, so a restart re-flow that re-attempts the
+    /// same override does not report it twice.
+    pub fn note_rejected_flow_override(
+        &mut self,
+        addr: Address,
+        type_: kuna_base::types::uint4,
+        reason: &str,
+    ) {
+        if self.kuna_rejected_flow.iter().any(|(a, t, _)| a == &addr && *t == type_) {
+            return;
+        }
+        self.kuna_rejected_flow.push((addr, type_, reason.to_string()));
+    }
+
+    /// (kuna) The flow overrides this function's flow follow refused.
+    pub fn kuna_rejected_flow_overrides(&self) -> &[(Address, kuna_base::types::uint4, String)] {
+        &self.kuna_rejected_flow
     }
 
     /// (kuna `rustabi`) Record what a probe of `entry`'s body proved about the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -313,8 +313,18 @@ the instruction as a jump — which is what puts an indirect call back through
 switch-table recovery — `call` as a call, `callreturn` as a call whose
 fall-through is dead (the "does not return" case), and `return` as the end of the
 function. A type the engine cannot apply at that instruction (`call` on an
-indirect call has no destination to make direct) is not silently dropped: the
-run reports the engine's own refusal as a per-function error.
+indirect call has no destination to make direct) is neither silently dropped nor
+fatal to the function: the override is rejected, the body you would have got
+without the directive still comes back, and the run exits non-zero with the
+engine's own reason.
+
+```console
+$ kuna decompile ./a.out --addr 0x13c9 --assert 'flow 0x1405 call'; echo "exit $?"
+int sub_13c9(void)
+...
+error: --assert "flow 0x1405 call" refused by the pipeline: Could not apply flowoverride (the C below was produced WITHOUT it)
+exit 1
+```
 
 **Every directive's fate is reported.** `--json` grows an `assertions` array — one
 row per directive, in the order you gave them, carrying the directive text, its
@@ -323,13 +333,20 @@ phase and sub-phase, `applied` or `rejected`, and a reason:
 ```json
 {"directive": "name v9 credbuf", "kind": "name", "phase": "P9",
  "subphase": "naming-policy", "status": "rejected",
- "detail": "No symbol named: v9"}
+ "detail": "No symbol named: v9", "fatal": false}
 ```
 
 A rejection is also printed on stderr, on both surfaces. It is **not** fatal by
 default — a batch of forty renames against a re-decompiled binary must not lose the
 other thirty-nine to one stale name — and `--assert-strict` makes any rejection
 exit non-zero.
+
+`"fatal": true` is the exception, and it exits non-zero on its own. It marks a
+directive kuna accepted and then **refused while applying it** — today a `flow`
+override the flow-follower could not apply. A rename that did not bind leaves a
+correct body one annotation short and you can see which; a refused flow override
+leaves C that describes a different control-flow graph than the one you asked for
+and looks exactly like the C you wanted, so it is reported as the run's verdict.
 
 **Order matters, and so does scoping.** Directives are applied in the order given:
 `type v2 char[16]` then `name v2 credbuf` retypes and then renames, where the

--- a/docs/features/rejected-flow-override-exits/pr_body.md
+++ b/docs/features/rejected-flow-override-exits/pr_body.md
@@ -1,0 +1,67 @@
+## The problem
+
+One `--assert 'flow ...'` that kuna cannot apply deletes the whole function and
+reports success. The text surface exits 0 with an empty stderr and a body that is
+not a body:
+
+```console
+$ kuna decompile ./aif_gap_x86_64 --addr 0x13c9 --assert 'flow 0x1405 call'; echo "exit $?"
+void sub_13c9(void)
+{
+  /* WARNING: structured blocks unavailable (structuring declined) */
+}
+exit 0
+```
+
+Drop the `--assert` and the same command prints 55 lines of real C. Add `--json`
+to the failing one and it exits 1 with `Could not apply flowoverride` — the two
+surfaces disagree about the same run, and the one a script is most likely to shell
+out to is the one that lies. The `--json` assertion ledger is no better: it reports
+`"status": "applied"` for the override the engine had just thrown out.
+
+(The fixture above is `decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64`,
+in the repo. The same three symptoms reproduce byte-for-byte on two crackmes, where
+the deleted body was 955 lines.)
+
+## The fix
+
+- A flow override the engine will not take is a **rejected assertion, not a dead
+  function**. `Funcdata::overrideFlow` gives up before it rewrites any opcode, so
+  the IR that follows is the one the same run without the directive would have
+  produced. `FlowInfo::process` now records the refused `(instruction, type,
+  reason)` and flow follows on; the recovered body comes back byte-identical to
+  the no-directive control.
+- The refusal is reported, not swallowed: the console prints
+  `Rejected <command>: <reason>` under the `decompile`, the ledger row becomes
+  `"status": "rejected"` with the engine's reason, and the row carries a new
+  `"fatal": true`.
+- **`fatal` exits non-zero without `--assert-strict`**, which the other rejections
+  still need. A rename that did not bind leaves a correct body one annotation
+  short and you can see which; a refused flow override leaves C that describes a
+  different control-flow graph than the one you asked for and looks exactly like
+  the C you wanted.
+- Separately, the text surface now notices a `decompile` that *raised* at all. It
+  only ever looked for the console's swallowed `Skipping <name>:` notice, so every
+  other per-function abort exited 0 with the printer's generic shell. Those aborts
+  are also stamped onto the retained `Funcdata`, so the shell names its reason
+  instead of blaming structuring.
+
+Deliberately not done: making an unappliable override a silent no-op. That
+restores the body and keeps exit 0 — which is the same lie in a nicer shirt.
+
+## The tests
+
+`tests/cli/rejected-flow-override-exits.json` (promoted acceptance: exit non-zero,
+body back, reason on stderr) and `tests/cli/flow-override-refusal-ledger.json`
+(the `--json` row is `rejected`/`fatal`, and the function record has no error).
+Both fail on the unpatched tree. `verify_assertflow`'s engine-refusal case is
+rewritten to the new contract and a `fatal`-vs-not case added; four transcript
+unit tests cover the two new scanners.
+
+Gates: `make test` 675/675 PARITY OK, `make test-stages` 650/650 PARITY OK,
+`make check-spec` OK, `make test-cli` 56/56, `kuna catalog --check` OK. A
+`decompile-all` before/after sweep over 134 in-repo fixtures with
+`noreturn_error`+`listing` on — the options that generate derived flow overrides —
+differs on 0 of them.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/rejected-flow-override-exits/record.json
+++ b/docs/features/rejected-flow-override-exits/record.json
@@ -1,0 +1,72 @@
+{
+  "slug": "rejected-flow-override-exits",
+  "need_id": "rejected-flow-override-exits",
+  "track": "tooling",
+  "scope": "small",
+  "round": 5,
+  "branch": "feat/re-rejected-flow-override-exits",
+  "summary": "A flow override the engine cannot apply is now a REJECTED assertion instead of a dead function: FlowInfo::process records the refusal and flow follows on, so the body that would otherwise decompile comes back byte-identical to the no-directive control, the assertion ledger reports `rejected` with the engine's reason and a new `fatal` flag, and the run exits non-zero on it with or without --assert-strict. Separately the text surface now notices a `decompile` that raised at all -- it only looked for the console's swallowed `Skipping` notice -- and every per-function abort is stamped onto the retained Funcdata so the printed shell names its reason.",
+  "family": [
+    "rejected-flow-override-exits (this need, acceptance a-b281b805aa2a)",
+    "branch-flow-assertion-discards (sibling acceptance a-81bb5e409470, held jointly per the dispatch brief)",
+    "conditional-indirect-branches-hide (its LEDGER leg only; the indirect-CALL-to-BRANCHIND promotion leg is quality/large and NOT touched here)"
+  ],
+  "decisions": [
+    {
+      "what": "hypothesis UPHELD -- text and JSON really do handle the same failure differently -- but the filed cause is only half of it",
+      "detail": "`kuna decompile` text drives decomp_dbg as a subprocess and reads the transcript; `--json` drives the engine in process and sees the KunaError directly. The transcript scanner (`find_pipeline_failure`) only ever recognized the console's SWALLOWED abort notice, `Skipping <name>: <reason>` (the LOSS-131 arm). A `decompile` that RAISED prints `Execution error: <reason>` and the session continues, so `print C` rendered the previous, un-decompiled Funcdata as `/* WARNING: structured blocks unavailable (structuring declined) */` and the CLI called that a successful run. That is the divergence. But it is a symptom of a second defect one layer down."
+    },
+    {
+      "what": "the root cause is in the engine, not the CLI: `override flow branch` on something already a branch is a hard abort",
+      "detail": "`Funcdata::override_flow` is byte-faithful to C++ `Funcdata::overrideFlow`: to override TO a branch it calls `findPrimaryBranch(findbranch=false, findcall=true, findreturn=true)` -- it looks for the CALL or RETURN to convert and deliberately skips a BRANCH/BRANCHIND. Both witnesses ask `branch` at an instruction that is ALREADY a BRANCHIND (keygenme.elf 0x101dfb is `JMP dword ptr [EAX*4 + 0x111358]`, Defender.exe 0x401904 is `JMP EBX`), so the search returns None and the C++ raises. Upstream that kills the function. Confirmed by asking for the other three words at the same address: `call`, `callreturn` and `return` all succeed there, only `branch` refuses."
+    },
+    {
+      "what": "the refusal is made non-fatal to the FUNCTION and fatal to the RUN -- the only shape that holds both acceptances",
+      "detail": "The dispatch brief pins two acceptances that pull opposite ways: this need wants exit != 0 with no --assert-strict, the sibling wants the recovered XOR loop back in stdout. Making the override a silent no-op passes the sibling and fails this one; keeping the hard abort passes this one and fails the sibling. `override_flow` returns Err before it mutates any opcode (all three error arms are ahead of every `op_set_opcode_code`), so the IR after a refusal is provably the no-directive IR -- which is what makes `decompile it anyway` correct rather than merely convenient. Verified: `kuna decompile <bin> <addr> --assert 'flow <addr2> branch'` is byte-identical to the same command without the --assert, on both the keygenme witness and the in-repo fixture."
+    },
+    {
+      "what": "`fatal` is a new Outcome field, not a new status value or a blanket policy change",
+      "detail": "docs/cli.md documents that a rejection is NOT fatal by default, for a real reason (a batch of forty renames must not lose thirty-nine to one stale name), and --assert-strict exists for callers who want it strict. Flipping every rejection to fatal would pass this acceptance by breaking that contract. The distinction drawn instead is by REJECTION SITE: a directive that never bound, or whose console command raised at issue time, stays a warning; a directive the pipeline ACCEPTED, seeded and then REFUSED while applying it is fatal. Today that is exactly the deferred class -- `flow` is the only directive applied at flow time -- and it is the only rejection a caller cannot see in the output. Serialized as `\"fatal\": bool` on every assertions[] row (additive; `status` keeps its two values)."
+    },
+    {
+      "what": "the ledger leg the report did not file is fixed on both surfaces, at the two places that know",
+      "detail": "In-process, `assertions::function_seed` writes `applied` when it SEEDS a flow directive, which is before the pipeline can have an opinion; `assertions::record_rejected_flow_overrides` now downgrades it after the decompile by matching (address, flow type) against `Funcdata::kuna_rejected_flow_overrides`. On the script surface the console prints `Rejected <the exact console command>: <reason>` under the `decompile`, and the CLI pairs it back to the directive by that spelling -- `command_failure` cannot, because it scans only the block under a command's OWN echo and `override flow` answers `Successfully added override` there."
+    },
+    {
+      "what": "no option, no stages XML, no catalog counter, no DIV row",
+      "detail": "Tooling track. A refusal path that today deletes a function and reports success is a strict bug fix, not a judgement call, and AGENTS.md gates only what CAN change emitted C on a run the caller did not steer. Nothing here fires without a caller-stated (or analysis-derived) flow override, and the 134-fixture sweep with the derived-override options ON shows 0 output diffs."
+    }
+  ],
+  "inertness": {
+    "method": "The engine edit is one `?` turned into an `if let Err`, reached only when `Funcdata::override_flow` returns Err -- which today aborts the function outright, so there is no run that reaches it and survives. The new Funcdata field is an empty Vec on every other path. The console edit adds output lines only when that Vec is non-empty, plus a stamp that is invisible unless the retained Funcdata has no structured blocks.",
+    "note": "make test 675/675 PARITY OK and make test-stages 650/650 PARITY OK on the pre-rebase tree."
+  },
+  "sweep": {
+    "question": "does letting a refused override through produce WRONG output -- either different C where the override used to abort, or different C anywhere else?",
+    "method": "(1) whole-corpus `decompile-all` before/after over every binary fixture in kuna-analysis/tests/fixtures (134 after filtering sources), with `--option noreturn_error on --option listing on` so the analysis-derived CALL_RETURN flow overrides are live and could hit the same refusal path; (2) byte-compare the refused-override run against the no-directive control on both witnesses; (3) re-run every APPLIED flow-override case in verify_assertflow, which asserts the emitted C changed against a measured baseline.",
+    "result": "(1) 0 of 134 differ. (2) byte-identical on keygenme.elf 0x100054 (955 lines) and on aif_gap_x86_64 sub_13c9 (55 lines) -- a refused override is exactly the run without it, which is the claim the design rests on. (3) all 8 verify_assertflow cases pass: `return` still collapses the body to one statement, `branch` and `callreturn` still land as their own distinct flow types. So the applied path is untouched and the refused path is the control."
+  },
+  "gates": {
+    "make test": "PARITY OK, 675/675 assertions",
+    "make test-stages": "PARITY OK, 650/650 assertions",
+    "make rust-test": "green: 5,789 passed / 0 failed (364 result blocks), run with KUNA_DECOMP_TEST unset so the verify_w10_* oracle resolves the main tree's decomp_test_dbg",
+    "make check-spec": "OK (lenient mode)",
+    "make test-cli": "56/56 with both probes added",
+    "kuna catalog --check": "catalog OK: documents exactly the registered kuna options",
+    "counters --check": "no drift"
+  },
+  "acceptance": {
+    "acceptance_id": "a-b281b805aa2a",
+    "result": "PASS",
+    "transition": "closed",
+    "promoted_to": "tests/cli/rejected-flow-override-exits.json",
+    "promotion_note": "The filed acceptance targeted the dataset keygenme.elf and carried no `target` block at all, so it was unrunnable as filed. Re-pointed at the vendored `kuna-analysis/tests/fixtures/aif_gap_x86_64`, where `flow 0x1405 call` is the same defect (an override overrideFlow refuses at sub_13c9's indirect call) and reproduces all three symptoms on 38c461d1: exit 0, empty stderr, `structured blocks unavailable` stub in place of a 55-line body. The expectation is strengthened past the filed `exit_code ne 0` to also require the body back and the reason on stderr, so the cheap wrong fix cannot pass it. The dataset keygenme.elf stays the witness in Reproduction. `--promote` needed --force because the need is still `open` in this worktree's copy of the backlog.",
+    "sibling_acceptance": "a-81bb5e409470 (branch-flow-assertion-discards) also flips: `kuna decompile Defender.exe 0x401746 --addr --assert 'flow 0x401904 branch' --assert-strict` now prints the 25-line body including two `^` lines (the XOR decrypt loop the report says disappears) and exits 1. Verified by hand on the arena image; it has no bound target so `scripts.repipe.verify` cannot run it here."
+  },
+  "not_closed": [
+    "The other leg of conditional-indirect-branches-hide -- promoting an indirect CALL to a multiway BRANCHIND in P2 behind a named option -- is untouched, per the dispatch brief that re-triaged it to quality/large.",
+    "`override flow <addr> branch` at an instruction that is ALREADY a branch is still REFUSED rather than treated as a satisfied no-op. That is upstream's rule (findPrimaryBranch skips the branch it is being asked to produce) and both witnesses ask for exactly it, so an agent that wants the switch-table reading of an indirect jump gets a rejection with a reason rather than a silent success. Changing the rule would be a behaviour change to a ported core routine and belongs behind a named option, not in a failure-path fix.",
+    "docs/re-needs/ is deliberately NOT committed: the round-5 need docs live on the captain's local main and are not in this branch's base. The retargeted acceptance block was written into the local copy so `scripts.repipe.verify --need` could run; the captain owns the backlog file."
+  ],
+  "pr": "https://github.com/Noelo-Lab/kuna/pull/472"
+}

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -913,6 +913,12 @@ directive that is accepted and does nothing is worse for an agent than one that
 errors. `--assert-strict` turns any rejection into a non-zero exit; without it a
 rejection is reported and the run continues, so a batch of forty renames against a
 re-decompiled binary does not lose the other thirty-nine to one stale name.
+One class of rejection is fatal without it, and the report marks it `fatal`: a
+directive the pipeline ACCEPTED and then REFUSED while applying it. A rename that
+did not bind leaves a correct body one annotation short, and the caller can see
+which one; a refused `flow` override leaves C that describes a control-flow graph
+other than the one asked for, looking exactly as healthy as the C the caller
+wanted, so silence there is the failure this plane exists to end.
 Durability is caller-carried, as it is for boundaries: `--assert @FILE` is the
 artifact.
 
@@ -934,8 +940,24 @@ command (`kuna-console/src/ifacedecomp.rs (IfcFlowOverride)`), whose facts the
 console re-seeds on every IR rebuild; the two surfaces render the same C. Because
 the override is read at flow time, a type the engine cannot honour at that
 instruction — `call` at an indirect call, which has no destination to make direct —
-raises `Could not apply flowoverride` and the run reports that as the function's
-error, rather than decompiling as though nothing had been asserted.
+raises `Could not apply flowoverride`. That refusal REJECTS the directive; it does
+not discard the function. `Funcdata::overrideFlow` gives up before it rewrites any
+opcode, so the IR that follows is the one the same run without the directive would
+have produced: `FlowInfo::process` records the refused `(instruction, flow type,
+reason)` on the `Funcdata` (`note_rejected_flow_override`) and flow follows on.
+Both surfaces then read that record back — the in-process one directly
+(`assertions::record_rejected_flow_overrides`), the script one from the
+`Rejected <command>: <reason>` line the console prints under the `decompile`
+(`IfcDecompile`) — and turn it into the directive's `rejected` row, which is
+`fatal`. This is the one refusal a caller cannot see in the output, so the C comes
+back and the exit code carries the verdict. Aborting instead deleted whole
+recovered bodies, and on the script surface it deleted them silently: nothing
+looks for a `decompile` that raised, so the run exited 0 with the printer's
+"structured blocks unavailable" shell and an empty stderr while `--json`, driving
+the same engine in process, exited 1 on the same command. Every per-function abort
+is now stamped onto the retained `Funcdata` (`set_kuna_pipeline_failure`) so that
+shell names its reason, and the script surface reports the raised abort the way it
+already reported the swallowed one.
 
 A `readonly` range is the one directive whose effect depends on a second switch:
 folding a read-only load into the value behind it is

--- a/tests/cli/flow-override-refusal-ledger.json
+++ b/tests/cli/flow-override-refusal-ledger.json
@@ -1,0 +1,70 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "--addr",
+    "0x13c9",
+    "--assert",
+    "flow 0x1405 call",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "binary_sha256": "1a592a85f424cc2db8953d5a38c86676bcee5e37b242b6fb6244a2c9fccfeeef",
+    "binary_size": 14408,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "selector": "0x13c9",
+    "selector_kind": "addr"
+  },
+  "expect": {
+    "exit_code": {
+      "ne": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "assertions[0].status",
+        "op": "eq",
+        "value": "rejected"
+      },
+      {
+        "path": "assertions[0].fatal",
+        "op": "eq",
+        "value": true
+      },
+      {
+        "path": "assertions[0].detail",
+        "op": "contains",
+        "value": "Could not apply flowoverride"
+      },
+      {
+        "path": "error",
+        "op": "contains",
+        "value": "refused by the pipeline"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "contains",
+        "value": "sub_1378"
+      },
+      {
+        "path": "functions[0].error",
+        "op": "eq",
+        "value": null
+      }
+    ]
+  },
+  "notes": "The assertion ledger must not report `applied` for a flow override the pipeline REFUSED -- it is the surface an agent reads to decide whether its assertion took. Companion to rejected-flow-override-exits, which pins the same run's text surface.",
+  "probe_id": "a-7f42e0ef2180"
+}

--- a/tests/cli/rejected-flow-override-exits.json
+++ b/tests/cli/rejected-flow-override-exits.json
@@ -1,0 +1,44 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "--addr",
+    "0x13c9",
+    "--assert",
+    "flow 0x1405 call"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "binary_sha256": "1a592a85f424cc2db8953d5a38c86676bcee5e37b242b6fb6244a2c9fccfeeef",
+    "binary_size": 14408,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64",
+    "selector": "0x13c9",
+    "selector_kind": "addr"
+  },
+  "expect": {
+    "exit_code": {
+      "ne": 0
+    },
+    "stdout_matches": [
+      "sub_1378"
+    ],
+    "stdout_absent": [
+      "structured blocks unavailable"
+    ],
+    "stderr_matches": [
+      "Could not apply flowoverride"
+    ]
+  },
+  "notes": "Retargeted onto the in-repo aif_gap_x86_64 fixture: same defect, no dataset. `flow 0x1405 call` at sub_13c9's indirect `call *%rdx` is an override Funcdata::overrideFlow refuses, exactly as `flow 0x101dfb branch` is on the dataset keygenme.elf. Measured on 38c461d1: exit 0, empty stderr, a `structured blocks unavailable` stub in place of the 55-line body."
+}


### PR DESCRIPTION
## The problem

One `--assert 'flow ...'` that kuna cannot apply deletes the whole function and
reports success. The text surface exits 0 with an empty stderr and a body that is
not a body:

```console
$ kuna decompile ./aif_gap_x86_64 --addr 0x13c9 --assert 'flow 0x1405 call'; echo "exit $?"
void sub_13c9(void)
{
  /* WARNING: structured blocks unavailable (structuring declined) */
}
exit 0
```

Drop the `--assert` and the same command prints 55 lines of real C. Add `--json`
to the failing one and it exits 1 with `Could not apply flowoverride` — the two
surfaces disagree about the same run, and the one a script is most likely to shell
out to is the one that lies. The `--json` assertion ledger is no better: it reports
`"status": "applied"` for the override the engine had just thrown out.

(The fixture above is `decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64`,
in the repo. The same three symptoms reproduce byte-for-byte on two crackmes, where
the deleted body was 955 lines.)

## The fix

- A flow override the engine will not take is a **rejected assertion, not a dead
  function**. `Funcdata::overrideFlow` gives up before it rewrites any opcode, so
  the IR that follows is the one the same run without the directive would have
  produced. `FlowInfo::process` now records the refused `(instruction, type,
  reason)` and flow follows on; the recovered body comes back byte-identical to
  the no-directive control.
- The refusal is reported, not swallowed: the console prints
  `Rejected <command>: <reason>` under the `decompile`, the ledger row becomes
  `"status": "rejected"` with the engine's reason, and the row carries a new
  `"fatal": true`.
- **`fatal` exits non-zero without `--assert-strict`**, which the other rejections
  still need. A rename that did not bind leaves a correct body one annotation
  short and you can see which; a refused flow override leaves C that describes a
  different control-flow graph than the one you asked for and looks exactly like
  the C you wanted.
- Separately, the text surface now notices a `decompile` that *raised* at all. It
  only ever looked for the console's swallowed `Skipping <name>:` notice, so every
  other per-function abort exited 0 with the printer's generic shell. Those aborts
  are also stamped onto the retained `Funcdata`, so the shell names its reason
  instead of blaming structuring.

Deliberately not done: making an unappliable override a silent no-op. That
restores the body and keeps exit 0 — which is the same lie in a nicer shirt.

## The tests

`tests/cli/rejected-flow-override-exits.json` (promoted acceptance: exit non-zero,
body back, reason on stderr) and `tests/cli/flow-override-refusal-ledger.json`
(the `--json` row is `rejected`/`fatal`, and the function record has no error).
Both fail on the unpatched tree. `verify_assertflow`'s engine-refusal case is
rewritten to the new contract and a `fatal`-vs-not case added; four transcript
unit tests cover the two new scanners.

Gates: `make test` 675/675 PARITY OK, `make test-stages` 650/650 PARITY OK,
`make check-spec` OK, `make test-cli` 56/56, `kuna catalog --check` OK. A
`decompile-all` before/after sweep over 134 in-repo fixtures with
`noreturn_error`+`listing` on — the options that generate derived flow overrides —
differs on 0 of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
