### PR TITLE
[AUTOMATED] fix(analysis): an imported API call through the IAT is a call edge

### DIFF
--- a/decompiler/crates/kuna-analysis/src/listing/xrefs.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/xrefs.rs
@@ -29,7 +29,9 @@
 //!    a decode-time constant is exported as a direct `ram` varnode, not a `LOAD`
 //!    — `MOV EAX,[RIP+0x2c3a]` lifts to `EAX = COPY (ram,0x4014,4)`. A `ram`
 //!    *input* is a [`XrefKind::Read`] of that address, a `ram` *output* a
-//!    [`XrefKind::Write`].
+//!    [`XrefKind::Write`] — unless the instruction's own indirect `CALL` takes
+//!    its destination from that operand, which makes it a [`XrefKind::Call`]
+//!    edge to the slot instead ([`is_indirect_call_slot`]).
 //!  * **A constant-space input varnode.** The value form: `LEA RDI,[RIP+0x36a]`
 //!    lifts to `RDI = COPY 0x13c9:8`, and a `LOAD`/`STORE` through a
 //!    computed-then-folded address carries the pointer as a constant. Scanning
@@ -1067,6 +1069,15 @@ fn assembly(translate: &dyn Translate, vma: u64, code_space: &Rc<AddrSpace>) -> 
 /// i.e. one `BRANCHIND` whose `in0` is the import slot, and dropping it left
 /// every import veneer in the program referencing nothing at all.
 ///
+/// A slot an indirect **CALL** takes its destination from is filed as a
+/// [`XrefKind::Call`] rather than as a read of the pointer, because that is the
+/// whole of what `CALL qword ptr [__imp_HeapAlloc]` does
+/// ([`is_indirect_call_slot`]). A `BRANCHIND` slot stays a read: that shape is
+/// the forwarding half of an import veneer, which the index already joins to
+/// its slot as one callable ([`XrefIndex::refs_to_unified`]) and the whole-binary
+/// document already reports as `forwardsTo`, so calling it an edge would say the
+/// same thing a third time.
+///
 /// `fall_through` (`vma + len`) is skipped as a value for the same reason: a
 /// call materializes its own return address, and every architecture spells that
 /// as this instruction's fall-through — x86 stores the constant to the stack,
@@ -1123,7 +1134,12 @@ fn data_refs(
                 continue;
             }
             if in_data_space(vn) {
-                out.push((vn.offset, XrefKind::Read));
+                let kind = if is_indirect_call_slot(ops, vn) {
+                    XrefKind::Call
+                } else {
+                    XrefKind::Read
+                };
+                out.push((vn.offset, kind));
                 follow(&mut out, vn.offset, read_width(op, i, vn));
                 continue;
             }
@@ -1152,6 +1168,47 @@ fn data_refs(
     out.sort_unstable();
     out.dedup();
     out
+}
+
+/// How many single-instruction `COPY`s may stand between a `CALLIND` and the
+/// memory operand it reads its destination out of. One covers x86's `CALL m64`;
+/// the slack past it is a scan over one instruction's ops and costs nothing, but
+/// it stays small so a long chain of temporaries inside a multi-operand
+/// instruction cannot be read as the operand fetch.
+const MAX_SLOT_COPIES: usize = 4;
+
+/// Does the indirect `CALL` in this one instruction read its destination out of
+/// `slot`?
+///
+/// `JMP qword ptr [__imp_X]` puts the slot in the flow op's own `in0`, but the
+/// call spelling does not: `CALL qword ptr [__imp_X]` lifts to `$U = COPY
+/// (ram,slot,8); ...; CALLIND $U`, so the slot is a `COPY` away from the op and
+/// the generic direct-memory-operand arm files the whole import call as a plain
+/// read of a pointer. Walking the chain is what tells that call site from an
+/// instruction that merely loads a global.
+fn is_indirect_call_slot(ops: &[FullOp], slot: &VarnodeData) -> bool {
+    let Some(dest) = ops
+        .iter()
+        .find(|op| op.opcode == OpCode::CPUI_CALLIND)
+        .and_then(|op| op.ins.first())
+    else {
+        return false;
+    };
+    let mut cur = dest;
+    for _ in 0..MAX_SLOT_COPIES {
+        if cur == slot {
+            return true;
+        }
+        let Some(def) = ops
+            .iter()
+            .find(|o| o.opcode == OpCode::CPUI_COPY && o.out.as_ref() == Some(cur))
+        else {
+            return false;
+        };
+        let Some(next) = def.ins.first() else { return false };
+        cur = next;
+    }
+    false
 }
 
 /// `ScalarOperandAnalyzer.checkOperands`' value filter.
@@ -1297,14 +1354,19 @@ mod tests {
     /// destination is read out of, not a static target, and no Call/Jump edge is
     /// filed for it. This is the whole import-veneer shape — `JMP qword ptr
     /// [__imp_X]` is one `BRANCHIND` on the slot — so skipping it loses the only
-    /// reference the instruction makes.
+    /// reference the instruction makes. A veneer's forwarding jump stays a read
+    /// of the slot: the index already joins the two into one callable.
     #[test]
     fn an_indirect_flow_ops_operand_is_the_slot_it_reads() {
         let (ram, _cst) = spaces();
-        for opcode in [OpCode::CPUI_BRANCHIND, OpCode::CPUI_CALLIND] {
+        // `CALLIND` straight off the slot is not a shape x86 emits, but the
+        // walk must not depend on which of the two it gets.
+        for (opcode, kind) in
+            [(OpCode::CPUI_BRANCHIND, XrefKind::Read), (OpCode::CPUI_CALLIND, XrefKind::Call)]
+        {
             assert_eq!(
                 refs(&ram, &[op(opcode, None, vec![vn(&ram, 0x1030)])]),
-                vec![(0x1030, XrefKind::Read)],
+                vec![(0x1030, kind)],
                 "{opcode:?} lost the slot it jumps through"
             );
         }
@@ -1312,6 +1374,48 @@ mod tests {
         let regs = Rc::new(AddrSpace::new_for_decode(spacetype::IPTR_INTERNAL));
         let ops = [op(OpCode::CPUI_BRANCHIND, None, vec![vn(&regs, 0x10)])];
         assert!(refs(&ram, &ops).is_empty());
+    }
+
+    /// `CALL qword ptr [__imp_X]` never puts the slot in the flow op's own
+    /// `in0`: SLEIGH copies the operand into a temporary first, and reading the
+    /// chain is the only thing that tells the import call from a plain load of
+    /// a global.
+    #[test]
+    fn a_call_through_a_slot_is_a_call_edge_across_the_copy() {
+        let (ram, _cst) = spaces();
+        let tmp = Rc::new(AddrSpace::new_for_decode(spacetype::IPTR_INTERNAL));
+        let ops = [
+            op(OpCode::CPUI_COPY, Some(vn(&tmp, 0x100)), vec![vn(&ram, 0x1030)]),
+            op(OpCode::CPUI_CALLIND, None, vec![vn(&tmp, 0x100)]),
+        ];
+        assert_eq!(refs(&ram, &ops), vec![(0x1030, XrefKind::Call)]);
+
+        // The same instruction reading an unrelated global still reads it: only
+        // the operand the destination actually comes from becomes an edge.
+        let ops = [
+            op(OpCode::CPUI_COPY, Some(vn(&tmp, 0x100)), vec![vn(&ram, 0x1030)]),
+            op(OpCode::CPUI_COPY, Some(vn(&tmp, 0x200)), vec![vn(&ram, 0x4010)]),
+            op(OpCode::CPUI_CALLIND, None, vec![vn(&tmp, 0x100)]),
+        ];
+        assert_eq!(
+            refs(&ram, &ops),
+            vec![(0x1030, XrefKind::Call), (0x4010, XrefKind::Read)]
+        );
+    }
+
+    /// The chain is bounded: a temporary the flow op reaches only through more
+    /// than [`MAX_SLOT_COPIES`] copies is not read as the operand fetch.
+    #[test]
+    fn the_copy_chain_to_a_slot_is_bounded() {
+        let (ram, _cst) = spaces();
+        let tmp = Rc::new(AddrSpace::new_for_decode(spacetype::IPTR_INTERNAL));
+        let mut ops =
+            vec![op(OpCode::CPUI_COPY, Some(vn(&tmp, 0)), vec![vn(&ram, 0x1030)])];
+        for i in 0..MAX_SLOT_COPIES as u64 {
+            ops.push(op(OpCode::CPUI_COPY, Some(vn(&tmp, i + 1)), vec![vn(&tmp, i)]));
+        }
+        ops.push(op(OpCode::CPUI_CALLIND, None, vec![vn(&tmp, MAX_SLOT_COPIES as u64)]));
+        assert_eq!(refs(&ram, &ops), vec![(0x1030, XrefKind::Read)]);
     }
 
     /// A `LOAD` through a constant pointer is a read of that address; the

--- a/decompiler/crates/kuna-analysis/tests/fixtures/README.md
+++ b/decompiler/crates/kuna-analysis/tests/fixtures/README.md
@@ -528,8 +528,13 @@ needs `Varnode::externref` on it). `bail`@`0x140001000` ends in that call; `tall
 is deliberately the next function in `.text` and deliberately contains a loop, so an overrun
 past the unbound call is visible in one line of C; `entry`@`0x140001040` calls `bail` under a
 condition, so the dead fall-through after the bound no-return call is visible too. ImageBase
-`0x140000000`, IAT slot `0x140005038`, MinGW `FF 25` veneer `0x140001070`. Built with
-MinGW-w64 in the `kuna-dev` container (the same toolchain as `pe_imports.exe`):
+`0x140000000`, IAT slot `0x140005038`, MinGW `FF 25` veneer `0x140001070`. The same two
+call sites make it the **IAT call-edge** fixture (`kuna-console/tests/verify_iatcall.rs`,
+CLI probe `tests/cli/imported-call-has-no-callee-edge.json`, GH-456): each is a call edge
+to `ExitProcess` rather than a read of a pointer, and the veneer's `JMP qword ptr
+[0x140005038]` — the same slot, but in the flow op's own operand — stays a read and is the
+control. Built with MinGW-w64 in the `kuna-dev` container (the same toolchain as
+`pe_imports.exe`):
 
 ```bash
 docker run --rm -v "$PWD":/w -w /w kuna-dev bash -lc \

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -433,9 +433,19 @@ impl CallGraph {
 
     /// The call-graph node a reference edge lands on, or `None` when the edge is
     /// not a call-graph edge at all.
+    ///
+    /// A flow edge falls back to the inventory ([`Self::owner_of`]) when the
+    /// walk has no node for the target. The walk only ever calls code a
+    /// function, and an import is reached through its **IAT/GOT slot**, which
+    /// lives in `.rdata`: `CALL qword ptr [__imp_HeapAlloc]` lands on an address
+    /// the walk correctly refuses to decode or attribute instructions to, but
+    /// which the inventory names and the document lists as a node. Without the
+    /// fallback every Windows API call in the program is silently not an edge.
     fn callee_of(&self, r: &Xref) -> Option<u64> {
         match r.kind {
-            XrefKind::Call | XrefKind::Jump => self.node_at(r.to),
+            XrefKind::Call | XrefKind::Jump => {
+                self.node_at(r.to).or_else(|| self.owner_of(r.to))
+            }
             XrefKind::Data => self.index.is_function_entry(r.to).then_some(r.to),
             XrefKind::Read | XrefKind::Write => None,
         }

--- a/decompiler/crates/kuna-console/tests/verify_iatcall.rs
+++ b/decompiler/crates/kuna-console/tests/verify_iatcall.rs
@@ -1,0 +1,121 @@
+//! End-to-end gate for the call edge an imported API call makes through its
+//! IAT slot (the on-demand xref query's data-reference projection).
+//!
+//! Fixture: `pe_noreturn_import.exe`, whose `bail` and `entry` both end in
+//! `CALL qword ptr [0x140005038]` — the shape MSVC emits for every Win32 call.
+//! SLEIGH lifts it to `$U = COPY (ram,0x140005038,8); ...; CALLIND $U`, so the
+//! slot is not the flow op's own operand and the walk used to file it as a plain
+//! read of a pointer: `kuna decompile-graph` reported one edge for the whole
+//! program and every import as called by nothing (GH-456).
+//!
+//! The forwarding veneer at `0x140001070` is the control. Its `JMP qword ptr
+//! [0x140005038]` puts the slot in the flow op's own operand and stays a read:
+//! that jump is the import's other half, which the index already folds into one
+//! callable, not a call site of it.
+//!
+//! ## `.sla` precondition
+//!
+//! Bootstrapping needs the built `x86` `.sla` under `specs/` (gitignored; `make
+//! specs`). When it is absent the bootstrap fails; the test prints that and
+//! returns early (a specs-less CI is a visible skip, never a false green).
+
+use std::path::PathBuf;
+
+use kuna_analysis::listing::xrefs::{self, XrefIndex, XrefKind};
+use kuna_console::engine::bootstrap_from_object;
+
+const FIXTURE: &str = "pe_noreturn_import.exe";
+
+/// The IAT slot the loader fills in with `KERNEL32!ExitProcess`.
+const SLOT: u64 = 0x140005038;
+/// The MinGW `FF 25` veneer that forwards through [`SLOT`].
+const VENEER: u64 = 0x140001070;
+/// `(the calling function, its `CALL qword ptr [SLOT]`)`.
+const CALL_SITES: [(u64, u64); 2] = [(0x140001000, 0x140001004), (0x140001040, 0x140001068)];
+/// The one direct call in the program, which was always an edge.
+const DIRECT_CALL: (u64, u64) = (0x14000104f, 0x140001010);
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+/// Bootstrap the fixture and build the index `kuna xrefs` answers out of.
+/// `None` is a visible skip when the `.sla` is missing.
+fn index() -> Option<XrefIndex> {
+    let bin =
+        repo_root().join("decompiler/crates/kuna-analysis/tests/fixtures").join(FIXTURE);
+    let specs = repo_root().join("specs");
+    let spec_roots = vec![specs.to_str().unwrap().to_string()];
+    let mut prog = match bootstrap_from_object(bin.to_str().unwrap(), "", &spec_roots) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "verify_iatcall: skipping {FIXTURE} (bootstrap failed, build `.sla` \
+                 with `make specs`): {}",
+                e.explain()
+            );
+            return None;
+        }
+    };
+    prog.commit_pending_analysis().expect("analysis commit succeeds");
+
+    let bytes = std::fs::read(&bin).expect("fixture readable");
+    let file = object::File::parse(&*bytes).expect("fixture parses");
+    let seeds: Vec<u64> =
+        prog.function_entries_canonical().iter().map(|e| e.addr.get_offset()).collect();
+    Some(xrefs::build(&file, prog.arch(), prog.arch().translate(), &seeds))
+}
+
+/// The defect: `CALL qword ptr [__imp_ExitProcess]` is a call site of the
+/// import, and the slot it reads its destination out of is where that edge
+/// lands. It used to come back as a read, which is not a call-graph edge.
+#[test]
+fn a_call_through_an_iat_slot_is_a_call_edge_to_the_import() {
+    let Some(idx) = index() else { return };
+    let refs: Vec<(u64, XrefKind)> =
+        idx.refs_to(SLOT).iter().map(|r| (r.from, r.kind)).collect();
+    for (func, site) in CALL_SITES {
+        assert!(
+            refs.contains(&(site, XrefKind::Call)),
+            "the call at {site:#x} reaches ExitProcess through {SLOT:#x}; got {refs:?}"
+        );
+        assert_eq!(
+            idx.function_containing(site),
+            Some(func),
+            "the call at {site:#x} belongs to the function entered at {func:#x}"
+        );
+    }
+}
+
+/// `kuna xrefs --to` the import answers over the whole alias class, so both call
+/// sites are there under either address and neither is a read.
+#[test]
+fn both_ends_of_the_import_answer_with_two_call_sites() {
+    let Some(idx) = index() else { return };
+    for target in [SLOT, VENEER] {
+        let mut rows: Vec<(u64, XrefKind)> =
+            idx.refs_to_unified(target).iter().map(|r| (r.from, r.kind)).collect();
+        rows.sort_unstable();
+        assert_eq!(
+            rows,
+            CALL_SITES.iter().map(|&(_, site)| (site, XrefKind::Call)).collect::<Vec<_>>(),
+            "--to {target:#x}"
+        );
+    }
+}
+
+/// The control. The veneer's own `JMP qword ptr [slot]` is the import's other
+/// half, not a call site of it, and it keeps the read it always filed — as does
+/// the direct call, which never went through a slot at all.
+#[test]
+fn the_forwarding_veneer_and_the_direct_call_are_unchanged() {
+    let Some(idx) = index() else { return };
+    let jump: Vec<(u64, XrefKind)> =
+        idx.refs_from_instruction(VENEER).iter().map(|r| (r.to, r.kind)).collect();
+    assert_eq!(jump, vec![(SLOT, XrefKind::Read)]);
+
+    let (site, callee) = DIRECT_CALL;
+    let direct: Vec<(u64, XrefKind)> =
+        idx.refs_from_instruction(site).iter().map(|r| (r.to, r.kind)).collect();
+    assert_eq!(direct, vec![(callee, XrefKind::Call)]);
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -593,7 +593,9 @@ answered with **`kuna xrefs`' own reference edges** (`kuna-analysis`'s
 them. A call, a tail jump, and an *address-taken function pointer* all count as
 edges — the third one matters: on a glibc ELF `_start` reaches `main` only
 through the pointer it hands `__libc_start_main`, and a callback registered with
-`CreateThread` or `atexit` is likewise code the caller reaches. A materialized
+`CreateThread` or `atexit` is likewise code the caller reaches. A `call qword ptr
+[__imp_X]` reaches the import it names, so a Windows program's API calls are
+edges like any other. A materialized
 address that does not land on a known function entry is a string or a global, not
 a callee, and is not an edge. The operand resolves as a name first and only then
 as bare hex, so a function genuinely called `abc` is never read as `0xabc`. A
@@ -825,7 +827,7 @@ act on and is answered; see below.
 
 | `kind` | What it is |
 |---|---|
-| `call` | A direct CALL to the target (a call site). |
+| `call` | A CALL to the target (a call site): a direct `CALL 0x1030`, or a `CALL qword ptr [slot]` that reads its destination out of a fixed slot — the shape every imported Windows API call has. The slot is where the edge lands, because the slot is what carries the import's name. |
 | `jump` | A direct branch to it: a tail call, a PLT thunk. Intra-function branches are control flow, not references, and are omitted from `--from`. |
 | `data` | The target's address is materialized as a value — address-taken: a function pointer, a string pointer, a global's address. Also the value of a **literal pool** word an instruction loads (`ldr r0,[0x86e4]` where 0x86e4 holds the string's address), which is how an ARM literal gets an owning function at all; the pool word itself is a separate `read` row from the same instruction. Only pointer-sized reads of *non-writable* memory are followed. |
 | `read` | The target is loaded from. |
@@ -863,7 +865,7 @@ jump, and the name only has to point the walk at the addresses to check.
 ```
 # 2 references to VirtualProtect @ 0x1400079b0
 # same import at 0x14000d234 (VirtualProtect) - a forwarding veneer and the pointer slot it jumps through
-0x140001a9e	read	__write_memory.part.0+0x18e	CALL qword ptr [0x14000d234]
+0x140001a9e	call	__write_memory.part.0+0x18e	CALL qword ptr [0x14000d234]
 0x140001cce	read	_pei386_runtime_relocator+0x19e	MOV R12,qword ptr [0x14000d234]
 ```
 
@@ -1417,10 +1419,10 @@ emitted. Two runs of one command are byte-identical.
 | `assembly` | The function's instruction listing, one `<vma>  <MNEMONIC operands>` per line — the `kuna disassemble` walk, so an undecodable byte inside the body is a `.byte 0x..` row rather than the end of the listing. Present whenever a body was attempted, including when the decompile failed: the listing is what is left to look at. |
 | `codeC` | The decompiled body, byte-identical to this function's `decompile-all --json` `code`. |
 | `error` | Why this function has no `codeC`, when the decompile was attempted and failed. `null` with a `null` `codeC` means no body was attempted: a bodyless `kind`, or a `--functions`/`--addr` narrowing that did not select it. |
-| `hasIndirectCalls` | The body contains a computed call (`CALLIND`), which files no edge because it has no static target. An indirect *branch* is not one — see `forwardsTo`. The call site is attributed to the row that contains it, the same rule that decides which function `kuna xrefs --from` lists an instruction under. |
+| `hasIndirectCalls` | The body contains a computed call (`CALLIND`). It files no edge when its destination is computed at run time; a `call qword ptr [slot]` through a fixed slot does file one, and sets this flag too. An indirect *branch* is not one — see `forwardsTo`. The call site is attributed to the row that contains it, the same rule that decides which function `kuna xrefs --from` lists an instruction under. |
 | `forwardsTo` | Where a forwarding entry sends control: the destination of a direct lone jump, or the fixed pointer slot an indirect one reads. The slot half needs the jump to name it as a decode-time constant, which an x86 `jmp [rip+disp]` stub does and an AArch64 `adrp`/`ldr`/`br x16` stub does not — a Mach-O `__stubs` entry is therefore `kind` `thunk` with a `null` `forwardsTo`, and the import slot it reaches is a row of its own found by name. `null` for anything that does not forward. |
 | `isEntryPoint` | This row is the image's declared entry point, resolved through the inventory so an ARM `e_entry` carrying the Thumb mode bit still lands on it, and rebased so a Mach-O `LC_MAIN` — which states a `__TEXT`-relative file offset rather than a VMA — marks the row it names. A format that declares no entry point marks no row. |
-| `edges[].kind` | The `kuna xrefs` kind, so the two surfaces cannot disagree: `call` a direct call; `jump` a tail call or a branch into a neighbouring entry; `data` an address handed to something else to call — the edge that gives `main` a caller, since `_start` passes it to `__libc_start_main` as a pointer rather than calling it. A caller that both calls and mentions one callee gets one edge carrying the strongest of the two. |
+| `edges[].kind` | The `kuna xrefs` kind, so the two surfaces cannot disagree: `call` a call, direct or through the fixed slot an imported API is called through; `jump` a tail call or a branch into a neighbouring entry; `data` an address handed to something else to call — the edge that gives `main` a caller, since `_start` passes it to `__libc_start_main` as a pointer rather than calling it. A caller that both calls and mentions one callee gets one edge carrying the strongest of the two. |
 | `edges[].calleeOrder` | Contiguous and zero-based per caller, in first-reference order, deduplicated on the callee. |
 
 Rows are entry-VMA ordered, and each caller's edges follow that caller's order.

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -2173,6 +2173,42 @@ computed, and which therefore lifts to a `LOAD` through a temporary); the class 
 never derived from a shared symbol name, which would fold genuinely distinct
 same-named functions together.
 
+(kuna) The **call** spelling of that first indirection needs a third rule, because
+it does not arrive in the shape the first one reads. `CALL qword ptr
+[__imp_HeapAlloc]` — what MSVC emits for every Win32 call — does not put the slot
+in the flow op's own `in0` the way `JMP` does: SLEIGH lowers it as `$U = COPY
+(ram,slot,8); ...; CALLIND $U`, so the slot reaches the generic
+direct-memory-operand arm and was filed as a `Read` of a pointer. A read is not a
+call-graph edge, so on the filing image — a Windows PE — a function Ghidra lists
+33 callees for came back with 9, and every one of the 24 missing was an imported
+API the function plainly calls. The walk now resolves a `CALLIND`'s destination
+back through the single-instruction `COPY` chain that materialised it
+(`decompiler/crates/kuna-analysis/src/listing/xrefs.rs (is_indirect_call_slot)`)
+and files the slot it lands on as a `Call`. The chain is bounded at four copies
+and never leaves the one instruction, so the rule can only re-label an operand
+that instruction genuinely fetched its destination from; every other data operand
+of the same instruction is judged exactly as before. The `Call` row **replaces**
+the `Read` rather than joining it: one instruction makes one reference, carrying
+the strongest claim it supports, which is already the collapse rule the
+whole-binary graph states (§9.7). The cost is that a caller filtering `--kind
+read` for data readers no longer sees the slot, which is the right trade — the
+instruction is a call site, and the slot is where the callee is named. A
+`BRANCHIND` through a slot keeps its `Read`: that shape is the forwarding veneer,
+which the alias class above already reports as the import's other half and the
+graph already reports as `forwardsTo`.
+
+(kuna) An edge also has to survive being resolved to a **node**, and the walk's
+function set is the wrong authority for this one. The walk calls nothing outside
+an executable section a function — an IAT slot lives in `.rdata`, so it is never
+one — while the inventory does name it, because `pe_iat` (§1.3) registered the
+import there. The graph therefore falls back from the walk's function set to the
+inventory extent containing the target
+(`decompiler/crates/kuna-cli/src/decompile_all.rs (CallGraph::callee_of)`), which
+is the same fold it already applies to every callee it reports. An address in
+neither is still not an edge. Measured over 120 in-tree images, seven changed and
+none lost an edge: on `pe_imports.exe` the functions reachable from the entry
+point went 47 -> 52 and those with no caller 115 -> 103.
+
 (kuna) The same two addresses make the import's **name** a selector that matches
 two entries, and the selector model's answer to that is a refusal naming every
 candidate — which would refuse a question that has exactly one answer, since either

--- a/docs/spec/09-emission.md
+++ b/docs/spec/09-emission.md
@@ -1065,14 +1065,18 @@ as a pointer, and dropping it would under-report exactly the indirection an
 obfuscated program leans on. A materialized address that does not land on a known
 function entry is not an edge (that is a string or a global, not a callee), and
 where a caller both calls a function and mentions its address, the one edge
-carries the stronger of the two kinds. A computed call has no static target and
-therefore no edge at all; it is reported as `hasIndirectCalls` on the row that
-contains the call site — `CALLIND` only, folded onto its function by the same
-ordered containment that decides which function an instruction's references are
-listed under
+carries the stronger of the two kinds. A computed call whose destination is not a
+decode-time constant has no static target and therefore no edge at all; it is
+reported as `hasIndirectCalls` on the row that contains the call site — `CALLIND`
+only, folded onto its function by the same ordered containment that decides which
+function an instruction's references are listed under
 (`decompiler/crates/kuna-analysis/src/listing/xrefs.rs (XrefIndex::has_indirect_calls)`)
 — while a forwarding veneer's `jmp [slot]` is an indirect *branch* whose
-destination is in fact known, and is reported as `forwardsTo` instead. That slot
+destination is in fact known, and is reported as `forwardsTo` instead. An
+imported API call, `call qword ptr [slot]`, is the case where a `CALLIND` *does*
+carry an edge: the slot is a decode-time constant the reference walk reads out of
+the instruction (§1.6), so the row is both an edge to the import and
+`hasIndirectCalls`. That slot
 is only recoverable where the jump names it as a decode-time constant, so an
 AArch64 stub that computes it across `adrp`/`ldr`/`br` is a `thunk` row with a
 null `forwardsTo`.

--- a/tests/cli/imported-call-has-no-callee-edge.json
+++ b/tests/cli/imported-call-has-no-callee-edge.json
@@ -1,0 +1,45 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/pe_noreturn_import.exe",
+    "binary_sha256": "4a4117bd2058e31261f72500c8f1ad5d251d3e9f16947e14a4776d4b0c06f697",
+    "binary_size": 6173,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/pe_noreturn_import.exe",
+    "selector": "0x140005038",
+    "selector_kind": "addr"
+  },
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "xrefs",
+    "{{BIN}}",
+    "--to",
+    "0x140005038",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "json": [
+      {
+        "path": "count",
+        "op": "eq",
+        "value": 2
+      },
+      {
+        "path": "xrefs[0].kind",
+        "op": "eq",
+        "value": "call"
+      },
+      {
+        "path": "xrefs[1].kind",
+        "op": "eq",
+        "value": "call"
+      }
+    ]
+  },
+  "notes": "0x140005038 is the IAT slot for KERNEL32!ExitProcess, and both rows are a CALL qword ptr [0x140005038] -- the shape MSVC emits for every Win32 call. Before the fix both came back as `read`, which is not a call-graph edge, so `kuna decompile-graph` reported the imports as called by nothing (GH-456)."
+}


### PR DESCRIPTION
## The problem

An imported API call produces no call-graph edge, so `kuna decompile-graph`
reports a function's callee list with every Windows API call missing — the
reporter's PE lists 33 callees under Ghidra and 9 under kuna. Against a fixture
already in the tree:

```
$ kuna xrefs decompiler/crates/kuna-analysis/tests/fixtures/pe_noreturn_import.exe --to 0x140005038
# 2 references to ExitProcess @ 0x140005038
0x140001004	read	bail+0x4	CALL qword ptr [0x140005038]
0x140001068	read	entry+0x28	CALL qword ptr [0x140005038]

$ kuna decompile-graph decompiler/crates/kuna-analysis/tests/fixtures/pe_noreturn_import.exe
...
"edges": [ {"callerAddress": 5368713280, "calleeAddress": 5368713232, "kind": "call", "calleeOrder": 0} ]
```

`read` on an instruction that is a call, and one edge for a program with three
call sites.

## The fix

- SLEIGH lowers `CALL qword ptr [slot]` as `$U = COPY (ram,slot,8); ...; CALLIND
  $U`, so the slot is never the flow op's own operand and fell through to the
  generic direct-memory-operand arm. The walk now resolves a `CALLIND`'s
  destination back through that `COPY` chain — bounded at four copies, never
  leaving the one instruction — and files the slot as a `call`.
- The `call` row replaces the `read` rather than joining it: one instruction
  makes one reference, carrying the strongest claim it supports, which is
  already how the graph collapses duplicate edges. The cost is that `--kind
  read` no longer finds the slot; the instruction is a call site, and the slot
  is where the callee is named.
- `CallGraph::callee_of` falls back from the walk's function set to the
  inventory extent containing the target. The walk calls nothing outside an
  executable section a function and an IAT slot lives in `.rdata`, so without
  this the corrected row still resolves to no node and the graph is unchanged.
- A `jmp [slot]` keeps its `read`. That shape is the forwarding veneer, which
  the index already folds into the import's alias class and the document already
  reports as `forwardsTo`.

Observational surface only — no emitted C changes, so no option row and no DIV
entry, per `decompile_graph.rs`'s own contract.

## Tests

`kuna-console/tests/verify_iatcall.rs` pins both call sites as call edges and
the veneer's jump as the unchanged control; two of its three cases fail without
the fix. `tests/cli/imported-call-has-no-callee-edge.json` is the CLI probe.
One existing unit test moves — it pinned today's `read` for a `CALLIND` slot.

Swept 121 in-tree images: 7 changed, none lost an edge (`pe_imports.exe` 47 → 52
reachable from the entry point, 115 → 103 with no callers). Row-level over 11 of
them, 2,445 functions: 0 reference sites lost, 0 added, 41 relabelled `read` →
`call`. `kuna functions --summary` on `pe_imports.exe` 256.1 → 252.9 ms, 21
interleaved repeats.

One of two PRs for #456. The other covers the jump-table half: case bodies
behind an MSVC PIC dispatch, whose calls are missing from the callee list for a
different reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jj8S7AwgGogy6Jz4PYUcj6
