### PR TITLE
[AUTOMATED] fix(cli): prototype-assertion-rejects-explicit — a prototype assertion may name the address the run selected

### DIFF
--- a/decompiler/crates/kuna-cli/src/decompile.rs
+++ b/decompiler/crates/kuna-cli/src/decompile.rs
@@ -78,6 +78,28 @@ pub(crate) fn looks_like_addr(target: &str) -> bool {
     target.starts_with("0x") || target.starts_with("0X")
 }
 
+/// The VMA a by-address run selected, or `None` when the target is an
+/// object-file coordinate (`.text+0x10`) or does not parse as an address.
+///
+/// The number grammar is `--addr`'s own — `0x`-prefixed or bare hex — which is
+/// the same one [`build_script`] uses to spell the `load addr` line.
+fn selected_vma(target: &str, by_address: bool) -> Option<u64> {
+    if !by_address {
+        return None;
+    }
+    if matches!(
+        EntrySelector::parse(target),
+        EntrySelector::SectionOffset { .. } | EntrySelector::SectionIndexOffset { .. }
+    ) {
+        return None;
+    }
+    let digits = target.strip_prefix("0x").or_else(|| target.strip_prefix("0X")).unwrap_or(target);
+    if digits.is_empty() || !digits.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    u64::from_str_radix(digits, 16).ok()
+}
+
 /// Quote a path for the console script when — and only when — it needs it.
 ///
 /// The console reads a filename with `CommandStream::read_filename`, which
@@ -189,6 +211,19 @@ fn build_script(
     // declared extent (`ConsoleProgram::declared_extent`).
     for decl in func_decls {
         lines.push(decl.console_line());
+    }
+    // (kuna, RE-need `prototype-assertion-rejects-explicit`) A by-address run
+    // DECLARES that a function starts where it points: `load addr` follows flow
+    // from the address without installing a `FunctionSymbol`, so a directive
+    // naming the very address this run decompiles was answered `no function
+    // starts at 0x…` while the body was emitted in full.  This is the same
+    // install `--define-function <start>` performs — skipped when the caller
+    // already declared that start, whose extent a second bare declaration would
+    // clear.
+    if let Some(vma) = selected_vma(target, by_address) {
+        if !func_decls.iter().any(|decl| decl.start == vma) {
+            lines.push(format!("function bounds {vma:#x}"));
+        }
     }
     // (kuna `--assert`) The PROGRAM-scoped directives -- a parsed type, a
     // declared prototype, a named global -- go here, after the analysis commit
@@ -1836,6 +1871,96 @@ Decompilation complete
                 < line("function bounds 0x1400 0x1480 as decrypt")
                     && line("function bounds 0x1400 0x1480 as decrypt") < line("load addr 0x1400"),
             "wrong order in:\n{script}"
+        );
+    }
+
+    /// A by-address run DECLARES the entry it points at, before the directives
+    /// that name it: `load addr` alone installs no `FunctionSymbol`, so
+    /// `prototype 0x…` for the very address being decompiled was rejected.
+    #[test]
+    fn build_script_declares_the_entry_a_by_address_run_selected() {
+        let directives = vec![crate::assertdecl::parse_one(
+            "prototype 0x401571 void decrypt(unsigned int key)",
+        )
+        .expect("parses")];
+        let script = build_script(
+            "/tmp/a.out",
+            "0x401571",
+            true,
+            None,
+            false,
+            Path::new("/tmp/kuna.c"),
+            LISTING,
+            &[],
+            &[],
+            &[],
+            &directives,
+            None,
+        );
+        let line = |needle: &str| {
+            script
+                .lines()
+                .position(|l| l == needle)
+                .unwrap_or_else(|| panic!("{needle:?} missing from:\n{script}"))
+        };
+        assert!(
+            line("read symbols") < line("function bounds 0x401571")
+                && line("function bounds 0x401571")
+                    < line("map prototype 0x401571 void decrypt(unsigned int key);"),
+            "wrong order in:\n{script}"
+        );
+    }
+
+    /// A bare hex target under `--addr` takes the same declaration, and a NAMED
+    /// selection takes none — the name path resolves through the symbol table
+    /// that already has the entry.
+    #[test]
+    fn only_an_addressed_selection_is_declared() {
+        let script = |target: &str, by_address: bool| {
+            build_script(
+                "/tmp/a.out",
+                target,
+                by_address,
+                None,
+                false,
+                Path::new("/tmp/kuna.c"),
+                LISTING,
+                &[],
+                &[],
+                &[],
+                &[],
+                None,
+            )
+        };
+        assert!(script("401571", true).contains("\nfunction bounds 0x401571\n"));
+        assert!(!script("authenticate", false).contains("function bounds"));
+        // An object-file coordinate is not a VMA, so there is nothing to declare.
+        assert!(!script(".text+0x10", true).contains("function bounds"));
+    }
+
+    /// A caller who declared the same start keeps the extent they declared: a
+    /// second, bare declaration of that entry would clear it back to unbounded.
+    #[test]
+    fn a_declared_start_is_not_re_declared_without_its_extent() {
+        let decls = crate::funcdecl::parse_flag("0x1400-0x1480=decrypt").expect("parses");
+        let script = build_script(
+            "/tmp/a.out",
+            "0x1400",
+            true,
+            None,
+            false,
+            Path::new("/tmp/kuna.c"),
+            LISTING,
+            &[],
+            &[],
+            &decls,
+            &[],
+            None,
+        );
+        assert_eq!(
+            script.lines().filter(|l| l.starts_with("function bounds")).count(),
+            1,
+            "the declared extent was re-declared away:\n{script}"
         );
     }
 

--- a/decompiler/crates/kuna-cli/tests/decompile_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_cli.rs
@@ -792,3 +792,85 @@ fn a_prototype_address_that_starts_no_function_is_rejected() {
         "the rejection did not name the address:\n{stdout}"
     );
 }
+
+/// RE-need `prototype-assertion-rejects-explicit`: a directive may name the
+/// address this run was pointed at.
+///
+/// `kuna decompile <bin> 0xADDR` emitted the function in full and answered
+/// `prototype 0xADDR …` with `rejected: no function starts at 0xADDR` — the
+/// address it had just decompiled. `load addr` follows flow from an address
+/// without installing a `FunctionSymbol`, so nothing in the by-address path
+/// registered the entry the directive resolves against; the same run selected
+/// BY NAME bound the identical directive. 0x400678 is an instruction boundary
+/// inside `authenticate` that discovery does not call a function start, which
+/// is the shape the need was filed on (a PE entry only the wider discovery
+/// bundle finds).
+#[test]
+fn a_prototype_binds_to_the_address_the_run_selected() {
+    let bin = fauxware();
+    let out = Command::new(env!("CARGO_BIN_EXE_kuna"))
+        .args([
+            "decompile",
+            bin.as_str(),
+            "0x400678",
+            "--addr",
+            "--assert-strict",
+            "--assert",
+            "prototype 0x400678 int4 checkpw(char *user,char *pass)",
+            "--sleighpath",
+            specs().as_str(),
+        ])
+        .output()
+        .expect("failed to spawn the kuna binary");
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    if is_specs_skip(&stderr) {
+        eprintln!("skipping: specs-less environment: {stderr}");
+        return;
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    assert!(
+        !stderr.contains("no function starts at 0x400678"),
+        "the run rejected the address it decompiled:\n{stderr}"
+    );
+    assert_eq!(out.status.code(), Some(0), "--assert-strict failed: {stderr}");
+    assert!(
+        stdout.contains("(char *user,char *pass)"),
+        "the declared signature never reached the selection:\n{stdout}"
+    );
+}
+
+/// The declaration is the SELECTION's, not an amnesty for every address: a
+/// directive naming an address this run never selected is still rejected, which
+/// is the only signal an agent gets that its directive is inert.
+#[test]
+fn an_unselected_address_that_starts_no_function_is_still_rejected() {
+    let bin = fauxware();
+    let out = Command::new(env!("CARGO_BIN_EXE_kuna"))
+        .args([
+            "decompile",
+            bin.as_str(),
+            "0x400678",
+            "--addr",
+            "--json",
+            "--assert",
+            "prototype 0x999999 int4 nope(void)",
+            "--sleighpath",
+            specs().as_str(),
+        ])
+        .output()
+        .expect("failed to spawn the kuna binary");
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    if is_specs_skip(&stderr) {
+        eprintln!("skipping: specs-less environment: {stderr}");
+        return;
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    assert!(
+        stdout.contains(r#""status": "rejected""#),
+        "an unbindable address was reported applied:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("no function starts at 0x999999"),
+        "the rejection did not name the address:\n{stdout}"
+    );
+}

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -1235,21 +1235,31 @@ impl ConsoleProgram {
     /// the name->address entry so the (binaryimage-symbol-backed) `load function`
     /// path can find a function the user mapped by hand.  Replaces any prior entry
     /// of the same name.
+    ///
+    /// Re-registering a name at the address it ALREADY holds keeps that entry's
+    /// provenance: an import's synthetic address is an `UndefinedExternal`, and
+    /// recomputing it as `Mapped` would make [`Self::resolve_entry`] answer "not
+    /// mapped in this input" for an entry it used to select.
     pub fn register_symbol(&mut self, name: &str, addr: Address) {
         // (kuna `symbolnamebound`) Same bound as the loader stream above, so an
         // analysis-discovered or hand-mapped name agrees with the scope path the
         // symbol table nests it under.
         let name = &*kuna_decomp::kuna_symbolnamebound::bound_scope_path(name, "::");
+        let prior = self
+            .symbols
+            .iter()
+            .find(|s| s.name == name && s.addr == addr)
+            .map(|s| s.provenance);
         self.symbols.retain(|s| s.name != name);
         let object_location = self.object_location_at(addr.get_offset());
         self.symbols.push(ProgramSymbol {
             name: name.to_string(),
             addr,
-            provenance: if object_location.is_some() {
+            provenance: prior.unwrap_or(if object_location.is_some() {
                 EntryProvenance::DefinedObject
             } else {
                 EntryProvenance::Mapped
-            },
+            }),
             object_location,
             binding: None,
         });
@@ -1339,12 +1349,24 @@ impl ConsoleProgram {
     /// keys a function by address, so adding a second symbol there would leave
     /// two names competing for one entry.  With no explicit name, an already-named
     /// address keeps its name and only the extent is recorded.
+    ///
+    /// The ARM/Thumb mode bit is folded out of `addr` first, so the declaration
+    /// lands on the address every later resolution of it uses
+    /// ([`Self::resolve_entry`] normalizes the same way) rather than on an odd
+    /// shadow entry the loads would never find.
     pub fn declare_function(
         &mut self,
         addr: Address,
         name: Option<&str>,
         size: int4,
     ) -> KunaResult<String> {
+        let addr = match addr.get_space() {
+            Some(space) => Address::new(
+                std::rc::Rc::clone(space),
+                self.thumb_normalized(addr.get_offset()),
+            ),
+            None => addr,
+        };
         let explicit = name.map(str::to_string).filter(|n| !n.is_empty());
         let name = match &explicit {
             Some(n) => n.clone(),

--- a/decompiler/crates/kuna-console/tests/verify_funcbounds.rs
+++ b/decompiler/crates/kuna-console/tests/verify_funcbounds.rs
@@ -256,3 +256,72 @@ fn an_unnamed_declaration_does_not_overwrite_an_existing_name() {
         .iter()
         .any(|e| e.addr.get_offset() == named && e.name == "_DT_FINI"));
 }
+
+/// Bootstrap an arbitrary fixture. `None` ⇒ specs-less skip.
+fn load_fixture(rel: &str) -> Option<ConsoleProgram> {
+    let root = repo_root();
+    let spec_roots = vec![root.join("specs").to_str().unwrap().to_string()];
+    let bin = root.join("decompiler/crates/kuna-analysis/tests/fixtures").join(rel);
+    let mut prog = match bootstrap_from_object(bin.to_str()?, "", &spec_roots) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("verify_funcbounds: skipping {rel} (bootstrap failed): {}", e.explain());
+            return None;
+        }
+    };
+    prog.commit_pending_analysis().expect("analysis commit succeeds");
+    Some(prog)
+}
+
+/// Declaring an entry keeps WHY that entry exists: an import's synthetic address
+/// is an `UndefinedExternal`, and re-registering its name as a plain mapped
+/// symbol made `resolve_entry` answer "not mapped in this input" for an address
+/// it used to select — so `kuna decompile <obj> 0xIMPORT --addr` lost its
+/// external-symbol note and exited non-zero.
+#[test]
+fn declaring_an_import_keeps_its_external_provenance() {
+    let Some(mut prog) = load_fixture("et_rel_status_arm.o") else { return };
+    let Some(import) = prog
+        .function_entries_canonical()
+        .into_iter()
+        .find(|e| e.provenance == kuna_console::engine::EntryProvenance::UndefinedExternal)
+    else {
+        eprintln!("verify_funcbounds: skipping (no undefined external in the fixture)");
+        return;
+    };
+    let vma = import.addr.get_offset();
+    let addr = code_addr(&prog, vma);
+    prog.declare_function(addr, None, 0).expect("declared");
+    let after = prog
+        .function_entries_canonical()
+        .into_iter()
+        .find(|e| e.addr.get_offset() == vma)
+        .expect("the import is still enumerated");
+    assert_eq!(
+        after.provenance,
+        kuna_console::engine::EntryProvenance::UndefinedExternal,
+        "the declaration downgraded an import to a mapped entry: {after:?}"
+    );
+}
+
+/// A declaration lands on the address every later resolution uses: an ARM caller
+/// legitimately holds a Thumb `entry|1` (an ELF symbol value, a DWARF entry PC),
+/// and declaring at the odd shadow left an entry no load would ever find.
+#[test]
+fn a_thumb_declaration_folds_the_mode_bit() {
+    let Some(mut prog) = load_fixture("arm_thumb_linked_le32") else { return };
+    let Some(entry) = prog
+        .function_entries_canonical()
+        .into_iter()
+        .find(|e| e.name == "compute")
+    else {
+        eprintln!("verify_funcbounds: skipping (the fixture lost its `compute` entry)");
+        return;
+    };
+    assert_eq!(entry.addr.get_offset() % 2, 0, "the enumeration reports the even entry");
+    let even = entry.addr.get_offset();
+    let addr = code_addr(&prog, even | 1);
+    prog.declare_function(addr, None, 0x10).expect("declared");
+    assert_eq!(prog.declared_extent(even), 0x10, "the extent missed the real entry");
+    assert_eq!(prog.declared_extent(even | 1), 0, "an odd shadow entry was declared");
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -289,7 +289,20 @@ kuna decompile ./KeyCheker.exe sub_140001890 \
 ```
 
 A `0x`-prefixed operand that starts no function is **rejected**, naming the
-address, rather than accepted and dropped.
+address, rather than accepted and dropped. The address you selected with `--addr`
+always counts as one: pointing `--addr` at an address declares that a function
+starts there, so a directive may name the very address this run is decompiling
+even when discovery never found an entry at it.
+
+```bash
+kuna decompile ./illusion.exe 0x401571 --assert-strict \
+  --assert 'prototype 0x401571 void decrypt(unsigned int key, unsigned int start, unsigned int end)'
+```
+
+```text
+- void sub_401571(unsigned int a0,int4 a1,int4 a2)
++ void sub_401571(uint4 key,uint4 start,uint4 end)
+```
 
 Widths come from the target's own compiler spec, so `long` is eight bytes on LP64
 and four on LLP64. Ghidra's sized spellings (`int4`, `uint8`, `float8`,

--- a/docs/features/prototype-assertion-rejects-explicit/pr_body.md
+++ b/docs/features/prototype-assertion-rejects-explicit/pr_body.md
@@ -1,0 +1,66 @@
+## The problem
+
+`kuna decompile` emits the function at an address and then rejects an assertion
+that names that same address. Any vendored fixture shows it — `0x400678` is an
+instruction boundary inside `authenticate` that discovery does not call a
+function start:
+
+```console
+$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/fauxware 0x400678 --addr \
+    --assert-strict --assert 'prototype 0x400678 int4 checkpw(char *user,char *pass)'
+warning: --assert "prototype 0x400678 int4 checkpw(char *user,char *pass)" rejected: no function starts at 0x400678
+unsigned long sub_400678(void) // return-dupe x2
+{
+  ...
+}
+$ echo $?
+1
+```
+
+The body is right there. Selecting the *same* function by name binds the
+identical directive.
+
+## The fix
+
+- `load addr <vma>` builds the `Funcdata` and follows flow without installing a
+  `FunctionSymbol`, so the by-address selection path left nothing for the
+  assertion plane to resolve against. Pointing `--addr` at an address is the
+  claim that a function starts there, so the generated console script now
+  declares that entry — the same install `--define-function <start>` performs.
+- The declaration sits between the caller's own `--define-function` lines and the
+  program-scoped directives, and is skipped when a `--define-function` already
+  names that start: a second bare declaration would clear the extent it asked
+  for (`declare_extent(vma, 0)` removes one).
+- Nothing in the resolver changed. An operand naming some *other* address that
+  starts no function is still rejected — that rejection is the only signal an
+  agent gets that a directive is inert.
+- Two latent defects in `ConsoleProgram::declare_function` that the new caller
+  exposed: declaring an import's synthetic address downgraded its
+  `UndefinedExternal` provenance to `Mapped`, after which `resolve_entry`
+  answered `not mapped in this input` for an entry it used to select; and the
+  ARM/Thumb mode bit was not folded, so a declaration at `entry|1` landed on an
+  odd shadow no load would find.
+
+```console
+$ kuna decompile ... 0x400678 --addr --assert-strict --assert 'prototype 0x400678 int4 checkpw(char *user,char *pass)'
+int sub_400678(char *user,char *pass) // return-dupe x2
+$ echo $?
+0
+```
+
+## The tests
+
+`tests/cli/prototype-assertion-rejects-explicit.json` (the promoted acceptance
+probe) plus four cargo tests: the end-to-end bind, the still-rejected unselected
+address, and one each for the provenance and Thumb guards. The bind test and both
+guards fail on the unpatched tree.
+
+Sweep: 464 by-address decompiles across 41 vendored fixtures (ELF x86-64/i386/
+ARM/Thumb/Cortex-M/PPC64, PE, Mach-O, ET_REL, COFF) plus the reporting image,
+before vs after — 0 differences in C, stderr or exit code.
+
+Gates: `make test` PARITY OK 675/675 · `make test-stages` PARITY OK 674/674 ·
+`make rust-test` green · `make check-spec` OK · `make test-cli` 63/63 ·
+`kuna catalog --check` OK.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/prototype-assertion-rejects-explicit/record.json
+++ b/docs/features/prototype-assertion-rejects-explicit/record.json
@@ -1,0 +1,68 @@
+{
+  "slug": "prototype-assertion-rejects-explicit",
+  "need_id": "prototype-assertion-rejects-explicit",
+  "track": "tooling",
+  "filed_track": "tooling",
+  "scope": "small",
+  "round": 6,
+  "branch": "feat/re-prototype-assertion-rejects-explicit",
+  "summary": "`kuna decompile <bin> 0xADDR` emitted the function in full and answered `--assert 'prototype 0xADDR ...'` with `rejected: no function starts at 0xADDR` -- the address it had just decompiled. `load addr` follows flow from an address without installing a FunctionSymbol, so nothing on the by-address selection path registered the entry the assertion plane resolves against; the identical directive bound the moment the same run selected the function by name. The generated script now declares the selected entry (`function bounds <vma>`) between the caller's own `--define-function` lines and the program-scoped directives, which is the same install `--define-function <start>` performs.",
+  "decisions": [
+    {
+      "what": "the round-5 refuter's diagnosis is CONFIRMED, and its prescription is what shipped",
+      "detail": "The filed hypothesis ('assertions resolve before the function is registered') is wrong: there is no ordering to move. Reordering was measured directly in decomp_dbg -- `function bounds 0x401571` / `load addr` / `map prototype` and `function bounds` / `map prototype` / `load addr` produce the identical `void sub_401571(uint4 key,uint4 start,uint4 end)`, and without ANY declaration the prototype is rejected in both orders, including AFTER `load addr` has already built and followed the function. Registration, not ordering, is the missing step -- exactly as the refuter said."
+    },
+    {
+      "what": "why the by-NAME run works, which the refuter got half right",
+      "detail": "The refuter said the by-name path installs the FunctionSymbol as a side effect of resolving a synthesized name. Measured, it is one level up: `load function sub_401571` MISSES on the first attempt (`no function matches`), and `kuna decompile`'s own retry (decompile.rs, the DIV-20/DIV-68 `funcstart_patterns`+`aif` bundle held back for a second attempt) then discovers 0x401571 as a real entry, which is what installs the symbol. A by-address run never misses -- `load addr` succeeds from any mapped address -- so it never retries and never gets the entry. Same conclusion, different mechanism; nothing in the retry logic changed."
+    },
+    {
+      "what": "the declaration is the SELECTION's, not an amnesty for the resolver",
+      "detail": "The guard the fix must not break: `prototype 0x999999 ...` on a genuinely bogus address stays `rejected` (kuna-cli/tests/decompile_cli.rs, kuna-console/tests/verify_assertplane.rs). Nothing in `resolve_proto_target` was touched -- it still reads the symbol table and still errors. Only the CLI's by-address selection now declares its own entry, so an operand naming any OTHER unregistered address is rejected exactly as before; `an_unselected_address_that_starts_no_function_is_still_rejected` pins that on a by-address run."
+    },
+    {
+      "what": "an existing `--define-function` for the same start wins",
+      "detail": "`ConsoleProgram::declare_extent(vma, 0)` REMOVES a declared extent, so an unconditional bare `function bounds <vma>` after `--define-function 0x1400-0x1480=decrypt` would silently clear the 0x80-byte bound the caller asked for. The declaration is skipped when any `--define-function` names the same start."
+    },
+    {
+      "what": "two latent defects in `declare_function` the new caller exposed, fixed with it",
+      "detail": "(1) `register_symbol` recomputed provenance, so declaring an import's synthetic address downgraded an `UndefinedExternal` to `Mapped` and `resolve_entry` then answered `address 0x402000 is not mapped in this input` for an entry it used to select -- caught by the fixture sweep on et_rel_status_arm.o, not by reasoning. It now keeps the provenance of the record it replaces at the same address. (2) `declare_function` did not fold the ARM/Thumb mode bit, so `function bounds 0x100b9` declared an odd shadow entry that every load (which normalizes) would miss; a Thumb `--addr entry|1` would otherwise have bound its prototype to that shadow. Both have their own test in verify_funcbounds.rs and both fail without the fix."
+    },
+    {
+      "what": "no option, no stages XML, no catalog counter, no DIV row",
+      "detail": "Tooling track: the change is one line of generated console script plus two guards in the console's declaration primitive. It cannot change emitted C for a run that carries no `--assert`/`--addr` -- `make test` 675/675 and `make test-stages` PARITY OK, and neither corpus reaches the CLI. Matches the CLI-tier repipe PRs merged in rounds 4-5."
+    }
+  ],
+  "inertness": {
+    "method": "`selected_vma` returns `None` for every by-NAME run, so the extra line exists only on `--addr`. `register_symbol`'s new `prior` lookup changes an outcome only when the SAME name is re-registered at the SAME address it already holds -- otherwise `prior` is `None` and the computed provenance is used verbatim. The Thumb fold is `vma & !1` gated on an ARM-family language description and is a no-op everywhere else.",
+    "note": "make test 675/675 PARITY OK and make test-stages PARITY OK confirm it; neither corpus goes through kuna-cli."
+  },
+  "sweep": {
+    "question": "does declaring the selected entry change any by-address decompile that used to work?",
+    "method": "Every by-address surface, before vs after, on 41 vendored fixtures plus the dataset witness: `kuna functions --json` for the entries, then up to 14 addresses per binary through `kuna decompile <bin> <addr> --addr`, diffing stdout, stderr and exit code. 464 targets. Fixtures span ELF x86-64/i386/ARM/Thumb/Cortex-M/PPC64, PE i386 and x86-64, Mach-O (fat, arm64e, objc, stripped), ET_REL and COFF objects.",
+    "result": "0 real differences. One transient (ptx.o 0x400470 hit the 600 s cap on the new side while a sibling builder's decbench sweep loaded the box; re-run head-to-head it is 0.18 s / 0.13 s and byte-identical C). The et_rel_status_arm.o import regression this sweep DID catch on the first pass is the provenance defect above, fixed and re-swept clean."
+  },
+  "gates": {
+    "make test": "PARITY OK, 675/675 assertions (rebased tree)",
+    "make test-stages": "PARITY OK, 674/674 assertions (rebased tree)",
+    "make rust-test": "exit 0, 5,927 passed / 0 failed with KUNA_DECOMP_TEST unset. With the loop's own KUNA_DECOMP_TEST exported (it points at this worktree's decomp_test_dbg) the same tree is 5,923/1: verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip reports 'oracle promote_compare signature drifted', the known repipe-worktree artifact, and passes 4/4 with the variable unset.",
+    "make check-spec": "OK (lenient mode)",
+    "make test-cli": "63/63 with the probe promoted",
+    "kuna catalog --check": "catalog OK: documents exactly the registered kuna options"
+  },
+  "acceptance": {
+    "acceptance_id": "a-df3bacaa5f17",
+    "result": "PASS",
+    "transition": "closed",
+    "promoted_to": "tests/cli/prototype-assertion-rejects-explicit.json",
+    "promotion_note": "The filed acceptance targets the dataset image (crackmes.one 64f1f7fad931496abf909535, illusion.exe) and PASSES there after the fix -- `scripts.repipe.verify --need prototype-assertion-rejects-explicit --json` reports 1 pass / 0 fail / closed. `--promote` refuses a dataset target and CI has no dataset, so the promoted copy is re-pointed at the vendored `kuna-analysis/tests/fixtures/fauxware`: 0x400678 is an instruction boundary inside `authenticate` that discovery does not call a function start, which is the same shape as illusion.exe's 0x401571 (an entry only the wider discovery bundle finds). Re-cutting cmd+expect derives the id a-a5a2238dff30.",
+    "reproduction_confirmed_on_main": "On 9c4c4508 the witness exits 1 with `rejected: no function starts at 0x401571` while printing `void sub_401571(unsigned int a0,int4 a1,int4 a2)`; after the fix it exits 0 and prints `void sub_401571(uint4 key,uint4 start,uint4 end)`. The vendored twin on 9c4c4508 exits 1 with `rejected: no function starts at 0x400678` and prints `unsigned long sub_400678(void)`; after the fix, `int sub_400678(char *user,char *pass)`."
+  },
+  "not_closed": [
+    "An object-file coordinate selector (`.text+0x10`, `2:0x40`) is not declared: `function bounds` takes a plain VMA and the CLI cannot resolve a section coordinate without loading the image. A directive naming such a selection's address is still rejected.",
+    "A hand-driven `decomp_dbg` session still has to say `function bounds <vma>` itself before `map prototype 0xVMA`; only the generated script declares the selection.",
+    "docs/re-needs/index.json is deliberately NOT regenerated: `needs reindex` runs over the whole backlog and this worktree holds only the tracked need docs. The captain reindexes."
+  ],
+  "pr": "https://github.com/Noelo-Lab/kuna/pull/484",
+  "rebase": "rebase --onto origin/main from the recorded base 9c4c4508 was a no-op (origin/main was still 9c4c4508); scripts.repipe.counters --fix reports 'no drift; nothing to fix' (158 settables, tiers 41/63/54, 249 corpus files, next ElementId 4151) and scripts.repipe.mergecheck reports 0 rejects / merge guards clean against origin/main. This PR adds no option and no stages XML, so it moves none of those counters itself."
+}

--- a/docs/re-needs/prototype-assertion-rejects-explicit.md
+++ b/docs/re-needs/prototype-assertion-rejects-explicit.md
@@ -1,0 +1,138 @@
+---
+need_id: prototype-assertion-rejects-explicit
+title: Prototype assertion rejects the explicit decompilation target
+track: tooling
+status: open
+severity: major
+probe_id: p-8450e40778a3
+acceptance_id: a-df3bacaa5f17
+hypothesis_status: overturned
+credibility: 0.7
+instances: 2
+challenges: [64f1f7fad931496abf909535, 5ab77f5d33c5d40ad448c6f6]
+rounds: [5, 6]
+first_seen_round: 5
+attempts: 1
+covered_by_option: null
+touches: [decompiler/crates/kuna-cli]
+scope: small
+regression_of: null
+pr: https://github.com/Noelo-Lab/kuna/pull/484
+closed_in_round: null
+closing_pr: https://github.com/Noelo-Lab/kuna/pull/484
+reject_reason: null
+---
+
+## Symptom
+
+Apply an address-based prototype to the function selected in the same invocation.
+
+> **Prototype assertion rejects the explicit decompilation target** (major, `64f1f7fad931496abf909535`)
+> Emits the function at 0x401571 but rejects its prototype with 'no function starts at 0x401571'. Adding --define-function for the same address makes the assertion succeed.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x401571",
+    "--assert-strict",
+    "--assert",
+    "prototype 0x401571 void decrypt(unsigned int key, unsigned int start, unsigned int end)"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 1
+    },
+    "stderr_matches": [
+      "rejected: no function starts at 0x401571"
+    ]
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x401571",
+    "--assert-strict",
+    "--assert",
+    "prototype 0x401571 void decrypt(unsigned int key, unsigned int start, unsigned int end)"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stderr_absent": [
+      "rejected: no function starts"
+    ],
+    "stdout_matches": [
+      "&key"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/illusion.exe",
+    "binary_sha256": "8093e4a899faa8283b1573f571834fffbee872c7e40da384bf36e6edb9b88a8e",
+    "binary_size": 1292288,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- Assertions may resolve before the explicitly selected function is registered.
+
+## Refutation
+
+Round 6 BUILDER: the round-5 refutation is CONFIRMED and is what shipped. Registration,
+not ordering, is the missing step -- measured directly in `decomp_dbg`: with a declaration
+in place both `function bounds` / `load addr` / `map prototype` and `function bounds` /
+`map prototype` / `load addr` produce the identical `void sub_401571(uint4 key,uint4
+start,uint4 end)`, and with NO declaration the directive is rejected in both orders,
+including after `load addr` has already built and followed the function. One correction to
+the refuter's account of WHY the by-name run works: it is not that resolving a synthesized
+name installs the symbol, it is that `load function sub_401571` MISSES on the first attempt
+and `kuna decompile`'s own retry with the wider `funcstart_patterns`+`aif` discovery bundle
+then finds 0x401571 as a real entry. A by-address run never misses, so it never retries.
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `64f1f7fad931496abf909535` (round 5, tester t-r5-64f1f7fa)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+- round 5 REFUTER: hypothesis **overturned** (was inconclusive). OVERTURNED -- the symptom stands, the ordering framing does not, and a 3-way A/B localizes the defect to something the filing never names: WHICH FORM THE TARGET WAS SELECTED IN. Symptom reproduced exactly on illusion.exe: kuna decompile <bin> 0x401571 --assert-strict --assert 'prototype 0x401571 void decrypt(...)' -> exit 1, 'rejected: no function starts at 0x401571', and the function is nonetheless emitted in full. THE A/B THAT SETTLES IT -- three runs, same binary, same assertion text, only the SELECTOR and the ASSERTION OPERAND vary. target 0x401571 + assert 'prototype 0x401571 ...' -> REJECTED, exit 1. target 0x401571 + assert 'prototype sub_401571 ...' -> BINDS, exit 0, void sub_401571(uint4 key,uint4 start,uint4 end). target sub_401571 + assert 'prototype 0x401571 ...' -> BINDS, exit 0, same signature. So the ADDRESS form of the assertion is not broken -- it works fine the moment the target was selected by name. The defect is that selecting the target BY ADDRESS leaves no FunctionSymbol at that address for the resolver to find. WHY 'RESOLVE LATER' IS THE WRONG LEVER. The filed hypothesis says assertions resolve BEFORE the function is registered, which presumes the failing run registers it eventually. Evidence says otherwise: in the by-name-selected run the symbol is there at resolution time, and in the by-address-selected run nothing installs one at all. This is a missing registration on one selection path, not a race between two ordered steps. A builder who goes hunting for a phase-ordering fix will find no ordering to move. THE SEAM, by name. kuna-console/src/assertions.rs:463 resolve_proto_target(). It tries symboltab.query_function_by_name() first, then for an 0x-prefixed operand code_addr() + symboltab.function_display_name_across_scopes(&addr), and returns Err('no function starts at {func}') when that display-name lookup comes back None. The lookup is against the DECOMPILER's symboltab, which is not the analysis tier's discovered-function list -- kuna functions illusion.exe --json reports sub_401571 at 0x401571 with size 475 among 1826 functions, so 'the function was never found' is false at the analysis tier and true at the symboltab the resolver reads. sub_401571 is a SYNTHESIZED name (no real symbol in the image), so the by-name selection path is resolving a synthesized name through the analysis tier AND installing the FunctionSymbol as a side effect; the by-address path skips that install. That asymmetry is the bug. --define-function 0x401571 works for the same reason: it is the explicit form of the install the by-address path is missing. GUARD THE FIX MUST NOT BREAK. Making an unresolvable 0x operand park silently is NOT acceptable -- kuna-cli/tests/decompile_cli.rs:765 and kuna-console/tests/verify_assertplane.rs:598 both assert 'no function starts at 0x999999' for a genuinely bogus address, and the doc comment above resolve_proto_target states the rule deliberately ('0x... is not a C identifier, so such a directive is provably inert and the caller deserves to hear it'). The fix has to make the CLI's by-address selection install the entry, not make the resolver lenient. RELATED, ALREADY-SHIPPED PRECEDENT worth reading before writing code: commit 38c461d1 (accepted-sqrt-prototype-still, 'a prototype assertion at an entry address binds') and 3e02a0dd (qualified-parameter-assertions-modify) are the same plane and the same file; this is the third member of that family and the first one keyed to the SELECTOR rather than to the operand.
+round 5 TRIAGE (captain): CONFIRMED AS FILED -- tooling / kuna-cli / small / major. DISPATCH CONSTRAINT: b-r5-rejected-flow-ov is live in the same assertion plane; do not dispatch this until that branch is merged or read.
+round 6 BUILDER: CLOSED. `kuna decompile`'s generated script now declares the entry a
+by-address run selected (`function bounds <vma>`), between the caller's own
+`--define-function` lines and the program-scoped directives, and skipped when a
+`--define-function` already names that start. `resolve_proto_target` is untouched, so a
+`0x` operand naming any other unregistered address is still rejected. Two latent
+`declare_function` defects surfaced by the fixture sweep were fixed with it: an import's
+`UndefinedExternal` provenance survives a declaration, and the ARM/Thumb mode bit is folded
+out of the declared address. Acceptance PASS; promoted to
+`tests/cli/prototype-assertion-rejects-explicit.json` retargeted onto the vendored fauxware
+(0x400678, an instruction boundary discovery does not call an entry) because CI has no
+dataset. Sweep: 464 by-address decompiles over 41 fixtures, 0 differences.

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -894,6 +894,31 @@ path only when it resolves and nothing of that name exists, and never errors.
 The same resolution serves the cross-function `param <func>::<i>` /
 `return <func>::<storage>` qualifier.
 
+(kuna) **A by-address selection DECLARES its own entry, so a directive can name
+it.** `load addr <vma>` builds the `Funcdata` and follows flow from an address
+without installing a `FunctionSymbol` there (the symbol-table `addFunction` is a
+later boundary), which is fine for printing C and fatal for the assertion plane:
+the resolution above reads the symbol table, so `kuna decompile <bin> 0x401571
+--assert 'prototype 0x401571 …'` emitted the function in full and answered
+`rejected: no function starts at 0x401571` — the address it had just decompiled —
+while the identical directive bound the moment the same run selected the function
+BY NAME. Pointing `--addr` at an address is itself the claim that a function
+starts there, so the generated script declares that entry
+(`decompiler/crates/kuna-cli/src/decompile.rs (build_script, selected_vma)` ->
+`function bounds <vma>` -> `ConsoleProgram::declare_function`) between the
+caller's own `--define-function` declarations and the program-scoped directives.
+It is the same install `--define-function <start>` performs, and it is skipped
+when the caller declared that start themselves, whose extent a second bare
+declaration would clear back to unbounded. The declaration is the SELECTION's
+alone: an operand naming some other address that starts no function is still
+rejected, which is the only signal an agent gets that a directive is inert
+(`docs/re-needs/prototype-assertion-rejects-explicit.md`). Declaring an entry
+preserves why that entry exists — an import's synthetic address stays an
+`UndefinedExternal`, so an addressed import keeps answering with its
+external-symbol note rather than `not mapped in this input` — and folds the
+ARM/Thumb mode bit out of the address, so the declaration lands where every later
+resolution of it looks.
+
 (kuna) **The C the assertion plane accepts is the C it prints.** Six directives
 carry a C declaration, and every one of them goes through the console's
 C-declaration grammar (`decompiler/crates/kuna-console/src/grammar.rs (CParse)`),

--- a/tests/cli/prototype-assertion-rejects-explicit.json
+++ b/tests/cli/prototype-assertion-rejects-explicit.json
@@ -1,0 +1,43 @@
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-a5a2238dff30",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x400678",
+    "--addr",
+    "--assert-strict",
+    "--assert",
+    "prototype 0x400678 int4 checkpw(char *user,char *pass)"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "binary_sha256": "c2d90645a45e99221593547e55c601a901b80f807ae96f94c60a7661df0b3e0b",
+    "binary_size": 8776,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "selector": "0x400678",
+    "selector_kind": "addr"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "\\(char \\*user,char \\*pass\\)"
+    ],
+    "stderr_absent": [
+      "rejected: no function starts"
+    ]
+  },
+  "notes": "Retargeted onto the in-repo fauxware fixture: same defect, no dataset. 0x400678 is an instruction boundary inside `authenticate` that discovery does not call a function start, so only the by-address selection puts a function there -- the dataset witness's shape (illusion.exe 0x401571). Before: exit 1, `rejected: no function starts at 0x400678`."
+}


### PR DESCRIPTION
## The problem

`kuna decompile` emits the function at an address and then rejects an assertion
that names that same address. Any vendored fixture shows it — `0x400678` is an
instruction boundary inside `authenticate` that discovery does not call a
function start:

```console
$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/fauxware 0x400678 --addr \
    --assert-strict --assert 'prototype 0x400678 int4 checkpw(char *user,char *pass)'
warning: --assert "prototype 0x400678 int4 checkpw(char *user,char *pass)" rejected: no function starts at 0x400678
unsigned long sub_400678(void) // return-dupe x2
{
  ...
}
$ echo $?
1
```

The body is right there. Selecting the *same* function by name binds the
identical directive.

## The fix

- `load addr <vma>` builds the `Funcdata` and follows flow without installing a
  `FunctionSymbol`, so the by-address selection path left nothing for the
  assertion plane to resolve against. Pointing `--addr` at an address is the
  claim that a function starts there, so the generated console script now
  declares that entry — the same install `--define-function <start>` performs.
- The declaration sits between the caller's own `--define-function` lines and the
  program-scoped directives, and is skipped when a `--define-function` already
  names that start: a second bare declaration would clear the extent it asked
  for (`declare_extent(vma, 0)` removes one).
- Nothing in the resolver changed. An operand naming some *other* address that
  starts no function is still rejected — that rejection is the only signal an
  agent gets that a directive is inert.
- Two latent defects in `ConsoleProgram::declare_function` that the new caller
  exposed: declaring an import's synthetic address downgraded its
  `UndefinedExternal` provenance to `Mapped`, after which `resolve_entry`
  answered `not mapped in this input` for an entry it used to select; and the
  ARM/Thumb mode bit was not folded, so a declaration at `entry|1` landed on an
  odd shadow no load would find.

```console
$ kuna decompile ... 0x400678 --addr --assert-strict --assert 'prototype 0x400678 int4 checkpw(char *user,char *pass)'
int sub_400678(char *user,char *pass) // return-dupe x2
$ echo $?
0
```

## The tests

`tests/cli/prototype-assertion-rejects-explicit.json` (the promoted acceptance
probe) plus four cargo tests: the end-to-end bind, the still-rejected unselected
address, and one each for the provenance and Thumb guards. The bind test and both
guards fail on the unpatched tree.

Sweep: 464 by-address decompiles across 41 vendored fixtures (ELF x86-64/i386/
ARM/Thumb/Cortex-M/PPC64, PE, Mach-O, ET_REL, COFF) plus the reporting image,
before vs after — 0 differences in C, stderr or exit code.

Gates: `make test` PARITY OK 675/675 · `make test-stages` PARITY OK 674/674 ·
`make rust-test` green · `make check-spec` OK · `make test-cli` 63/63 ·
`kuna catalog --check` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
