### PR TITLE
[AUTOMATED] perf(cli): disassembling-40-instructions-takes — a bounded listing does not pay for the discovery walk

### DIFF
--- a/decompiler/crates/kuna-analysis/src/analyzers/pdb/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/pdb/mod.rs
@@ -161,14 +161,17 @@ fn open_fingerprint_matched(
         if locate::fingerprint_ok(cv, &guid, info.age) {
             return Some(pdb);
         }
-        eprintln!(
-            "[kuna pdb] {}: age {} guid {} does not match the image's CodeView record \
-             (age {} guid {}); not applied",
-            path.display(),
-            info.age,
-            guid.to_uppercase(),
-            cv.age(),
-            cv.guid_string().unwrap_or_else(|| "<none, NB10 record>".to_string()),
+        kuna_base::notes::say_once(
+            &path.display().to_string(),
+            &format!(
+                "[kuna pdb] {}: age {} guid {} does not match the image's CodeView record \
+                 (age {} guid {}); not applied",
+                path.display(),
+                info.age,
+                guid.to_uppercase(),
+                cv.age(),
+                cv.guid_string().unwrap_or_else(|| "<none, NB10 record>".to_string()),
+            ),
         );
     }
     None

--- a/decompiler/crates/kuna-analysis/src/loadimage_object.rs
+++ b/decompiler/crates/kuna-analysis/src/loadimage_object.rs
@@ -420,7 +420,7 @@ impl ObjectLoadImage {
         let target = target.and_then(explicit_language_target);
         if emit_diagnostics {
             if let Some(note) = target.and_then(|t| target_endian_note(&file, t)) {
-                eprintln!("[kuna target] {filename}: {note}");
+                kuna_base::notes::say_once(filename, &format!("[kuna target] {filename}: {note}"));
             }
         }
         let effective_arch = effective_architecture(&file, bytes);
@@ -698,14 +698,20 @@ impl ObjectLoadImage {
         // backing at all otherwise), and both halves get a foldable range.
         let fpconst = crate::loader::kuna_msvcfpconst::plan(file, &layout);
         for w in &fpconst.warnings {
-            eprintln!("[kuna msvcfpconst] {filename}: {w}");
+            kuna_base::notes::say_once(
+                filename,
+                &format!("[kuna msvcfpconst] {filename}: {w}"),
+            );
         }
 
         // One bounded report per loader construction. Analysis-side consumers
         // may construct another layout for address rebasing, but never print it.
         if emit_diagnostics {
             for line in layout.diagnostics.report_lines() {
-                eprintln!("[kuna ET_REL loader] {filename}: {line}");
+                kuna_base::notes::say_once(
+                    filename,
+                    &format!("[kuna ET_REL loader] {filename}: {line}"),
+                );
             }
         }
 

--- a/decompiler/crates/kuna-base/src/lib.rs
+++ b/decompiler/crates/kuna-base/src/lib.rs
@@ -29,6 +29,7 @@ pub mod marshal;
 pub mod space;
 pub mod address;
 pub mod cfmt;
+pub mod notes;
 pub mod crc32;
 pub mod compression;
 pub mod filemanage;

--- a/decompiler/crates/kuna-base/src/notes.rs
+++ b/decompiler/crates/kuna-base/src/notes.rs
@@ -1,0 +1,32 @@
+//! Say a loader note once per process, however often the image is loaded.
+//!
+//! (kuna) The loader's tolerance notes — a section table it recovered from, a
+//! data directory it clamped, an ET_REL layout it reports — are facts about the
+//! *image*, not about a load. A surface that loads the same image twice in one
+//! process (`kuna disassemble` answers a caller-bounded window without the
+//! discovery walk and reloads with it when only the walk can answer) would
+//! otherwise announce each of them twice, which reads as two different findings.
+//!
+//! Keyed by the image the note is about, so two images whose notes happen to
+//! read alike each get theirs.
+
+use std::collections::BTreeSet;
+use std::sync::{Mutex, OnceLock};
+
+fn said() -> &'static Mutex<BTreeSet<String>> {
+    static SAID: OnceLock<Mutex<BTreeSet<String>>> = OnceLock::new();
+    SAID.get_or_init(|| Mutex::new(BTreeSet::new()))
+}
+
+/// Print `message` on stderr the first time this process says it about `about`.
+pub fn say_once(about: &str, message: &str) {
+    let key = format!("{about}\u{1}{message}");
+    let fresh = match said().lock() {
+        Ok(mut set) => set.insert(key),
+        // A poisoned set is not a reason to swallow a diagnostic.
+        Err(_) => true,
+    };
+    if fresh {
+        eprintln!("{message}");
+    }
+}

--- a/decompiler/crates/kuna-cli/src/disassemble.rs
+++ b/decompiler/crates/kuna-cli/src/disassemble.rs
@@ -281,9 +281,33 @@ fn run_as(argv: &[String], default_view: ViewRequest) -> i32 {
 /// boundary, so the listing is testable without a subprocess.
 pub(crate) fn render(args: &DisArgs) -> Result<Listing, String> {
     let options = mode_options_for_binary(args.mode.as_deref(), &args.binary, args.options.clone())?;
+
+    // A caller-bounded window is answerable without the program-wide discovery
+    // walk, so try it there first and keep the answer only if it is already the
+    // one the full inventory would give ([`windowed_answer_is_final`]).
+    if window_is_caller_bounded(args) {
+        let load = load_args(args, windowed_options(&options, &args.options));
+        let prog = load_program(&load, DriverDefaults::Inventory)?;
+        if let Ok(region) = resolve_region(&prog, args) {
+            let section = section_flags_at(&prog, region.start);
+            if windowed_answer_is_final(&region, section, args.view.unwrap_or(ViewRequest::Auto)) {
+                return listing_for(args, &prog, region);
+            }
+        }
+    }
+
     // The inventory bundle: this surface enumerates entries to resolve a name
     // and to bound a function, and decompiles nothing.
-    let load = Args {
+    let load = load_args(args, options);
+    let prog = load_program(&load, DriverDefaults::Inventory)?;
+
+    let region = resolve_region(&prog, args)?;
+    listing_for(args, &prog, region)
+}
+
+/// The load arguments this surface takes, with `options` already resolved.
+fn load_args(args: &DisArgs, options: Vec<(String, String)>) -> Args {
+    Args {
         binary: args.binary.clone(),
         json: args.json,
         names: None,
@@ -298,10 +322,11 @@ pub(crate) fn render(args: &DisArgs) -> Result<Listing, String> {
         target: args.target.clone(),
         sleighpath: args.sleighpath.clone(),
         isa: args.isa,
-    };
-    let prog = load_program(&load, DriverDefaults::Inventory)?;
+    }
+}
 
-    let region = resolve_region(&prog, args)?;
+/// Render the listing for an already-resolved target.
+fn listing_for(args: &DisArgs, prog: &ConsoleProgram, region: Region) -> Result<Listing, String> {
     // A packed image is the common way to hold an address that is real in the
     // program and absent from the file, so the failure names the move that fixes
     // it rather than leaving the caller to guess.
@@ -312,10 +337,10 @@ pub(crate) fn render(args: &DisArgs) -> Result<Listing, String> {
             region.start, args.binary
         ));
     }
-    let (view, mut notes) = choose_view(&prog, &region, args.view.unwrap_or(ViewRequest::Auto));
+    let (view, mut notes) = choose_view(prog, &region, args.view.unwrap_or(ViewRequest::Auto));
     let text = match view {
         View::Code => {
-            let (rows, truncated, folded) = walk(&prog, &region, args.count);
+            let (rows, truncated, folded) = walk(prog, &region, args.count);
             if folded > 0 {
                 notes.push(pool_note(folded));
             }
@@ -326,7 +351,7 @@ pub(crate) fn render(args: &DisArgs) -> Result<Listing, String> {
             }
         }
         View::Data => {
-            let (rows, truncated) = walk_data(&prog, &region, args.count);
+            let (rows, truncated) = walk_data(prog, &region, args.count);
             if args.json {
                 format!(
                     "{}\n",
@@ -338,6 +363,65 @@ pub(crate) fn render(args: &DisArgs) -> Result<Listing, String> {
         }
     };
     Ok(Listing { text, notes })
+}
+
+// --- the windowed load --------------------------------------------------------
+
+/// The whole-image discovery passes a caller-bounded listing does not need.
+///
+/// These two are the gates of the analysis tier's deferred Listing build
+/// (`kuna_analysis::passes::run_listing_consumers`); every other discovery pass a
+/// `--mode` preset turns on — `funcstart_patterns`, `aif`, `ptrentry`,
+/// `tailcallentry`, `poolentry` — is a consumer of that build and is inert once
+/// they are off.
+const WINDOW_SUPPRESSED: [&str; 2] = ["listing", "fast_funcdisc"];
+
+/// Did the caller bound the listing themselves — `--count`, `--bytes`, or an
+/// explicit `start-end` range?
+///
+/// A window the caller did not bound is the function extent the inventory
+/// reports (`function_extent_at`), so there is nothing to answer without it.
+fn window_is_caller_bounded(args: &DisArgs) -> bool {
+    args.count.is_some() || args.bytes.is_some() || split_range(args.spec.trim()).is_some()
+}
+
+/// `options` with the whole-image discovery passes turned off, unless the caller
+/// named one — then their word stands.
+///
+/// What turns them on here is the resolved `--mode` preset, and that preset is a
+/// whole-binary *decompilation* policy: `auto` selects `fast` from 2 MiB up, and
+/// the walk `fast` retains (`fast_funcdisc`) decodes every executable byte in the
+/// image. On a 9.4 MB PE whose `.text` is 99.4% of the file that is 20 s of
+/// recursive descent to print 40 instructions, and the listing itself reads
+/// nothing the walk produces. `explicit` is the caller's own `--option` list,
+/// before the preset was merged into it.
+fn windowed_options(
+    options: &[(String, String)],
+    explicit: &[(String, String)],
+) -> Vec<(String, String)> {
+    let mut out = options.to_vec();
+    for name in WINDOW_SUPPRESSED {
+        if !explicit.iter().any(|(option, _)| option == name) {
+            out.push((name.to_string(), "off".to_string()));
+        }
+    }
+    out
+}
+
+/// Is the windowed load's answer already the one the full inventory would give?
+///
+/// The discovery walk reaches a caller-bounded listing through exactly two
+/// values: the target's `name`, and `from_entry`, which forces the instruction
+/// view. So the windowed answer stands when the program named the target from a
+/// fact it already held, and when the view it picked does not turn on an entry
+/// the walk might have found there. Everything else — a name only discovery
+/// invents, a bare address in a data section — falls back and pays for the walk,
+/// which is why the fallback is what keeps this from being the variant swap that
+/// loses `kuna disassemble <generated name>` on a stripped image.
+fn windowed_answer_is_final(region: &Region, section: Option<u32>, want: ViewRequest) -> bool {
+    region.name.is_some()
+        && (region.from_entry
+            || decide_view(want, false, section) == decide_view(want, true, section))
 }
 
 // --- which view ---------------------------------------------------------------
@@ -1344,6 +1428,109 @@ mod tests {
                 decide_view(want, from_entry, flags),
                 expect,
                 "{want:?} / from_entry {from_entry} / flags {flags:?}"
+            );
+        }
+    }
+
+    fn dis_args(spec: &str, count: Option<usize>, bytes: Option<u64>) -> DisArgs {
+        DisArgs {
+            binary: "bin".into(),
+            spec: spec.into(),
+            by_address: false,
+            view: None,
+            count,
+            bytes,
+            json: false,
+            options: Vec::new(),
+            func_decls: Vec::new(),
+            mode: None,
+            slice: None,
+            target: None,
+            sleighpath: None,
+            isa: None,
+        }
+    }
+
+    #[test]
+    fn a_window_is_the_callers_when_count_bytes_or_a_range_bounds_it() {
+        for (spec, count, bytes, expect) in [
+            ("main", Some(8), None, true),
+            ("main", None, Some(64), true),
+            ("0x401000", Some(1), None, true),
+            ("0x401000-0x401040", None, None, true),
+            ("0x401000..0x401040", None, None, true),
+            // Nothing bounds these but the inventory's own function extent.
+            ("main", None, None, false),
+            ("0x401000", None, None, false),
+        ] {
+            assert_eq!(
+                window_is_caller_bounded(&dis_args(spec, count, bytes)),
+                expect,
+                "{spec:?} / count {count:?} / bytes {bytes:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_windowed_load_turns_the_discovery_walk_off_unless_the_caller_named_it() {
+        let preset: Vec<(String, String)> =
+            vec![("listing".into(), "off".into()), ("fast_funcdisc".into(), "on".into())];
+
+        let suppressed = windowed_options(&preset, &[]);
+        for name in WINDOW_SUPPRESSED {
+            assert_eq!(
+                suppressed.iter().filter(|(o, _)| o == name).next_back().map(|(_, v)| v.as_str()),
+                Some("off"),
+                "{name} must end the list off"
+            );
+        }
+
+        // The caller's own `--option` is the last word: naming one skips it.
+        let named: Vec<(String, String)> = vec![("fast_funcdisc".into(), "on".into())];
+        let mut merged = preset.clone();
+        merged.extend(named.clone());
+        let kept = windowed_options(&merged, &named);
+        assert_eq!(
+            kept.iter().filter(|(o, _)| o == "fast_funcdisc").next_back().map(|(_, v)| v.as_str()),
+            Some("on")
+        );
+        assert_eq!(
+            kept.iter().filter(|(o, _)| o == "listing").next_back().map(|(_, v)| v.as_str()),
+            Some("off")
+        );
+    }
+
+    #[test]
+    fn the_windowed_answer_stands_only_when_the_walk_could_not_have_changed_it() {
+        let data = section_flags::DATA | section_flags::READONLY;
+        let code = section_flags::CODE;
+        let region = |name: Option<&str>, from_entry: bool| Region {
+            start: 0x401000,
+            end: Some(0x401040),
+            name: name.map(str::to_string),
+            derived: false,
+            from_entry,
+        };
+        use ViewRequest::{Auto, Data as WantData};
+        for (name, from_entry, section, want, expect) in [
+            // Named from a fact the windowed load already held, in a section
+            // whose view does not depend on there being an entry.
+            (Some("main"), true, Some(code), Auto, true),
+            (Some("sub_401000"), true, Some(data), Auto, true),
+            (Some("g_table"), false, Some(code), Auto, true),
+            (Some("g_table"), false, None, Auto, true),
+            // Only the walk could name this one.
+            (None, false, Some(code), Auto, false),
+            // A data section renders as bytes here and as instructions if the
+            // walk finds an entry, so the answer is not settled yet.
+            (Some("g_table"), false, Some(data), Auto, false),
+            // ...unless the caller pinned the view, which outranks the entry.
+            (Some("g_table"), false, Some(data), WantData, true),
+        ] {
+            assert_eq!(
+                windowed_answer_is_final(&region(name, from_entry), section, want),
+                expect,
+                "{name:?} / from_entry {from_entry} / section {section:?} / {want:?}"
             );
         }
     }

--- a/decompiler/crates/kuna-cli/tests/disassemble_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/disassemble_cli.rs
@@ -863,3 +863,68 @@ fn the_cli_reports_a_missing_binary_as_exit_one() {
         "the reason must be legible, got: {stderr}"
     );
 }
+
+// --- the windowed load --------------------------------------------------------
+//
+// A caller-bounded listing is answered without the program-wide discovery walk,
+// and falls back to it when the walk is the only thing that can answer. These
+// pin both halves: the fallback still resolves a name only discovery invents,
+// and the fast half agrees with the walk it skipped.
+
+/// The stripped x86-64 fixture whose `sub_1190` exists ONLY because the Listing
+/// tier's discovery walk found it: `kuna functions` lists 20 entries with the
+/// walk on and 19 with it off, and `sub_1190` is the difference.
+fn stripped_dynamic() -> String {
+    fixture("stripped_dynamic_x86_64")
+}
+
+/// The name the discovery walk invents still resolves, by either spelling.
+///
+/// This is the regression the windowed load could have shipped: skip the walk
+/// for a bounded window and `kuna disassemble sub_1190 --count 4` answers "no
+/// symbol named" for a name `kuna functions` prints (RE-need
+/// `analysis-generated-function-name`).
+#[test]
+fn a_name_only_the_discovery_walk_invents_still_resolves() {
+    let Some(by_name) = listing(&[&stripped_dynamic(), "sub_1190", "--count", "4"])
+    else {
+        return;
+    };
+    assert_eq!(rows(&by_name).len(), 4, "{by_name}");
+    assert!(by_name.contains("sub_1190 @ 0x1190"), "{by_name}");
+
+    // The address spelling of the same target: the windowed load has no name for
+    // it either, so it must fall back too rather than print a nameless header.
+    let by_addr = listing(&[&stripped_dynamic(), "0x1190", "--addr", "--count", "4"])
+        .expect("the same load already succeeded");
+    assert_eq!(rows(&by_addr), rows(&by_name), "{by_addr}");
+    assert!(by_addr.contains("sub_1190 @ 0x1190"), "{by_addr}");
+}
+
+/// The bounded listing is the same one the discovery walk would have produced.
+///
+/// The right-hand side names both walk options, which the windowed load leaves
+/// alone (the caller's word is the last one), so it is the full-inventory answer
+/// — and the left-hand side is the windowed one.
+#[test]
+fn a_bounded_listing_agrees_with_the_walk_it_skipped() {
+    let walk = ["--option", "listing", "on", "--option", "fast_funcdisc", "on"];
+    for (binary, target, bound) in [
+        (fauxware(), "main", ["--count", "6"]),
+        (fauxware(), "main", ["--bytes", "24"]),
+        (fauxware(), "0x40071d", ["--addr", "--count"]),
+        (stripped_dynamic(), "sub_1020", ["--count", "6"]),
+        (stripped_dynamic(), "0x1020-0x1040", ["--count", "6"]),
+    ] {
+        // `0x40071d --addr` needs its count spelled after the flag pair above.
+        let bound: Vec<&str> =
+            if bound[1] == "--count" { vec![bound[0], bound[1], "6"] } else { bound.to_vec() };
+        let mut plain = vec![binary.as_str(), target];
+        plain.extend(bound.iter().copied());
+        let Some(windowed) = listing(&plain) else { return };
+        let mut full = plain.clone();
+        full.extend(walk.iter().copied());
+        let full = listing(&full).expect("the same load already succeeded");
+        assert_eq!(windowed, full, "{plain:?}");
+    }
+}

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -2196,7 +2196,7 @@ pub fn bootstrap_from_object_with_isa(
     // same recovered view. A file with a usable section table is untouched.
     let (bytes, shdr_note) = kuna_analysis::loader::elf_shdr::tolerate_unusable_section_table(bytes);
     if let Some(note) = shdr_note {
-        eprintln!("[kuna] {note}");
+        kuna_base::notes::say_once(path, &format!("[kuna] {note}"));
     }
     // (kuna) PE data-directory tolerance: the same normalization one format over.
     // A PE's `NumberOfRvaAndSizes` is declared separately from the room its own
@@ -2208,7 +2208,7 @@ pub fn bootstrap_from_object_with_isa(
     let (bytes, datadir_note) =
         kuna_analysis::loader::pe_datadirs::tolerate_oversized_data_directories(bytes);
     if let Some(note) = datadir_note {
-        eprintln!("[kuna] {note}");
+        kuna_base::notes::say_once(path, &format!("[kuna] {note}"));
     }
     let explicit_isa = isa.is_some();
     // LoadImageBfd(filename) + open(): parse the ELF (machine, segments, symbols).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1184,6 +1184,20 @@ emitted C changes. Verified against `objdump -d`: 19,368 instructions across fou
 binaries — a 32-bit x86 ELF, an x86-64 ELF, a stripped x86-64 PIE and an x86-64
 PE — byte-identical at every address, with the same instruction boundaries.
 
+A window the caller bounded — `--count`, `--bytes`, or an explicit `start-end`
+range — does not pay for the program-wide function-discovery walk. That walk is
+what `--mode` turns on for a whole-binary *decompilation*, and on a large image it
+dominates: `auto` selects `fast` from 2 MiB up, whose retained discovery pass
+decodes every executable byte, so listing 40 instructions of a 9.4 MB PE whose
+`.text` is 99.4% of the file took 20.1 s, of which 40 instructions were 0.1 s.
+Such a listing is answered from the load's own symbols instead (1.4 s, the same
+bytes). The walk is not skipped, only deferred: when it is the only thing that can
+answer — a name it invents (`sub_1190` on a stripped image), an address it alone
+knows, a bare address in a data section whose view depends on there being an entry
+— the command falls back to it and answers exactly as before. Naming `--option
+listing` or `--option fast_funcdisc` yourself keeps your setting either way, and a
+listing whose length came from the function extent always takes the full walk.
+
 Exit codes follow the house contract: a listing is `0`; an unresolvable name or
 an address with nothing mapped behind it is `1` with the reason on stderr (on a
 packed image, run `kuna unpack` first — the original addresses do not exist until

--- a/docs/features/disassembling-40-instructions-takes/pr_body.md
+++ b/docs/features/disassembling-40-instructions-takes/pr_body.md
@@ -1,0 +1,58 @@
+## The problem
+
+`kuna disassemble` at a raw address pays for a whole-image function-discovery
+walk before it prints a single row, so on a large binary a 40-instruction
+listing takes as long as decompiling the program would. On a 9.4 MB PE32+ whose
+`.text` is 99.4% of the file:
+
+```
+$ time kuna disassemble ./crackme_shroud.exe 0x140001000 --addr --count 40 --json | head -3
+{
+  "binary": "./crackme_shroud.exe",
+  "kind": "code",
+
+real    0m20.128s
+```
+
+Nothing in that is per-instruction: `--count 1` costs 20.4 s and `--count 400`
+costs 20.2 s. It is the discovery walk `--mode auto` turns on — `auto` selects
+`fast` from 2 MiB up, and the pass `fast` retains (`fast_funcdisc`) decodes every
+executable byte in the image.
+
+## The fix
+
+- A window the caller bounded — `--count`, `--bytes`, or an explicit
+  `start-end` range — is loaded with the analysis tier's two discovery gates
+  (`listing`, `fast_funcdisc`) off. Naming either option yourself still wins.
+- The walk is deferred, not dropped. It reaches a bounded listing through
+  exactly two values — the target's name, and whether it resolved to an entry
+  (which forces the instruction view) — so the windowed answer is kept only when
+  the program named the target from a fact it already held **and** the view it
+  chose does not depend on there being an entry at that address. Anything else
+  reloads with the full bundle: a name only discovery invents (`sub_1190` on a
+  stripped image), an address only it knows, a bare address in a data section.
+  That fallback is why this is not the variant swap that breaks
+  `kuna disassemble <generated name>`.
+- A listing whose length is the function extent was never caller-bounded, so it
+  always takes the full walk.
+- Loader tolerance notes (`[kuna] ELF section table unusable…`, the PE
+  data-directory clamp, the ET_REL report) are now said once per process per
+  image. They are facts about the image, and a surface that loads it twice was
+  announcing each of them twice.
+
+## The tests
+
+`tests/cli/disassembling-40-instructions-takes.json` is the acceptance probe,
+repointed from its 9.4 MB dataset image to the largest in-repo fixture that
+reproduces the shape (CI has no dataset) and recalibrated on it. Two cargo
+tests in `kuna-cli`: `sub_1190` — a name only the discovery walk invents — still
+resolves by both spellings, and a bounded listing is byte-identical to the one
+the walk it skipped would have produced. Three unit tests pin the three
+predicates.
+
+Measured: 20.1 s → 1.4 s on the witness, byte-identical stdout. Sweep of 3,838
+`disassemble`/`read` invocations over 139 in-repo binaries (every format and
+architecture in the tree, name / address / range / mid-function / `--as data`
+targets): **0 stdout differences, 0 exit-code differences**.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/disassembling-40-instructions-takes/record.json
+++ b/docs/features/disassembling-40-instructions-takes/record.json
@@ -1,0 +1,98 @@
+{
+  "slug": "disassembling-40-instructions-takes",
+  "need_id": "disassembling-40-instructions-takes",
+  "track": "perf",
+  "scope": "small",
+  "scope_filed": "large",
+  "worker": "b-r6-disassembling-40",
+  "round": 6,
+  "attempt": 1,
+  "date": "2026-09-07",
+  "symptom": "Disassembling 40 instructions takes about 21 seconds (major, 1 instance, challenge 69d7f15a8afd9d6c48b48871). `kuna disassemble ./crackme_shroud.exe 0x140001000 --addr --count 40 --json` returned 40 instructions in 20.9154 s and 20.7541 s.",
+  "hypothesis_filed": "Address-based disassembly pays for whole-image analysis.",
+  "hypothesis_verdict": "upheld, and the round-5 refuter's correction of it is exact",
+  "decisions": [
+    {
+      "what": "the refuter's five findings all reproduced, and its point (3) is what made the fix findable",
+      "detail": "--count 1 / 40 / 400 all cost ~20 s, so nothing is per-instruction; `--option listing off` is byte-identical AND no faster. The reason listing is inert is that a 9.4 MB file resolves `--mode auto` to `fast`, whose FAST_OVERRIDES set `listing off` + `fast_funcdisc on`. `fast_funcdisc` is the second gate of `run_listing_consumers`, so the deferred Listing is built anyway. `--option fast_funcdisc off` gives 1.54 s and BYTE-IDENTICAL json. A 24-sample gdb-as-parent profile of the default run: 16/24 in `Listing::build_with_meta`, 14/24 in `run_listing_consumers`, the rest in the SLEIGH decode underneath."
+    },
+    {
+      "what": "the filed scope of `large` was overturned; the design the refuter asked for is one file",
+      "detail": "The refuter's point (5) -- 'give disassemble a lighter DriverDefaults and you pass the acceptance while breaking name resolution' -- is right about a VARIANT SWAP and does not apply to a lazy one. The fallback makes the two answers provably equal: the discovery walk reaches a caller-bounded listing through exactly two values (the target name and `from_entry`, which forces the view), both of which `resolve_region` already computes, so the windowed answer can be tested against the walk's before it is kept. No new pass, no new module, no `DriverDefaults` variant -- the suppression rides the existing `--option` list, which `load_program` already applies AFTER the driver defaults."
+    },
+    {
+      "what": "the derived-window case is not attempted at all, rather than attempted and rolled back",
+      "detail": "`kuna disassemble <target>` with no `--count`/`--bytes`/range takes its stop from `function_extent_at`, which the walk can shorten by discovering a closer next entry. That is decided from argv before any load, so the full walk runs FIRST and the double load never happens there: measured +0.6% (noise) on the witness."
+    },
+    {
+      "what": "the loader tolerance notes had to become say-once, or the invariance claim was false",
+      "detail": "The first sweep found 21 differences in 3,838 cases, ALL stderr and ALL the same shape: a second load of the same image re-announces `[kuna] ELF section table unusable ...`, the PE data-directory clamp, and the ET_REL report. Routed the six loader-note sites through a new `kuna_base::notes::say_once`, keyed by the image so two images with identical note text each get theirs. Re-swept: 0 differences."
+    }
+  ],
+  "mechanism": "`disassemble::render` runs a windowed load first when `window_is_caller_bounded` (--count | --bytes | an explicit start-end range). `windowed_options` appends `listing off` + `fast_funcdisc off` -- the two gates of `kuna_analysis::passes::run_listing_consumers` -- to the resolved `--mode` option list, skipping any the caller named. `windowed_answer_is_final` keeps that answer only when the region carries a name AND (it came from a function entry OR `decide_view` agrees for both settings of `from_entry`). Otherwise the command reloads with the full bundle and answers exactly as before.",
+  "measurement": {
+    "method": "interleaved base/new, same shell, taskset-pinned to one core, warmup + 5 reps (9 on the small fixtures)",
+    "targets": [
+      {
+        "target": "crackme_shroud.exe (9.4 MB PE32+, 99.4% .text) 0x140001000 --addr --count 40",
+        "base_median_ms": 19692.9,
+        "new_median_ms": 1170.0,
+        "delta_pct": -94.1,
+        "output": "byte-identical"
+      },
+      {
+        "target": "the same by generated name, sub_140001000 --count 40",
+        "base_median_ms": 19677.7,
+        "new_median_ms": 1158.8,
+        "delta_pct": -94.1
+      },
+      {
+        "target": "ssh-sk-helper (in-repo, 461 KB) 0x5000 --addr --count 40",
+        "base_median_ms": 838.9,
+        "new_median_ms": 323.7,
+        "delta_pct": -61.4
+      },
+      {
+        "target": "pe_imports.exe (in-repo, 499 KB) 0x140001000 --addr --count 40",
+        "base_median_ms": 200.7,
+        "new_median_ms": 150.7,
+        "delta_pct": -24.9
+      },
+      {
+        "target": "crackme_shroud.exe 0x140001000 --addr, NO --count (derived window)",
+        "base_median_ms": 19695.7,
+        "new_median_ms": 19812.0,
+        "delta_pct": 0.6,
+        "note": "not attempted -- decided from argv, so no windowed load runs"
+      },
+      {
+        "target": "crackme_shroud.exe 0x140001007 --addr --count 3 (mid-function, escalates)",
+        "base_median_ms": 19734.0,
+        "new_median_ms": 20921.6,
+        "delta_pct": 6.0,
+        "note": "the honest cost of the fallback: one extra minimal load (1.16 s here) on top of the walk. Bounded by the minimal load, so it is 6% of a 20 s walk on this image and tens of ms elsewhere."
+      }
+    ]
+  },
+  "acceptance": "scripts.repipe.verify --need disassembling-40-instructions-takes --json -- PASS on the rebased tree (wall_ms median 1873.9 < 10000; 1 closed, 0 regressed)",
+  "tests": [
+    "tests/cli/disassembling-40-instructions-takes.json (repointed to the in-repo ssh-sk-helper fixture, min of 5 < 600 ms -- 833 ms on base; CI has no dataset)",
+    "decompiler/crates/kuna-cli/tests/disassemble_cli.rs::a_name_only_the_discovery_walk_invents_still_resolves",
+    "decompiler/crates/kuna-cli/tests/disassemble_cli.rs::a_bounded_listing_agrees_with_the_walk_it_skipped",
+    "decompiler/crates/kuna-cli/src/disassemble.rs::tests::a_window_is_the_callers_when_count_bytes_or_a_range_bounds_it",
+    "decompiler/crates/kuna-cli/src/disassemble.rs::tests::the_windowed_load_turns_the_discovery_walk_off_unless_the_caller_named_it",
+    "decompiler/crates/kuna-cli/src/disassemble.rs::tests::the_windowed_answer_stands_only_when_the_walk_could_not_have_changed_it"
+  ],
+  "sweep": "3,838 `kuna disassemble` / `kuna read` invocations over 139 in-repo binaries (ELF/PE/Mach-O/COFF, x86-64/i386/ARM/AArch64/Thumb/MIPS/PPC/RISC-V/SPARC, executables, shared objects and relocatable objects), base vs new, comparing stdout, stderr and exit code. Targets per binary: `main` bounded and unbounded, and for five entries each (first, a generated `sub_*`, a symbol-named one, the last) the address form bounded by --count/--bytes/range/unbounded, the address+1 mid-function form, the `--as data` form, `kuna read`, and the name form. Result: 0 stdout differences, 0 exit-code differences, 0 stderr differences.",
+  "no_div_row": "No DIV row: the registry records why a kuna DEFAULT differs from upstream, and this changes no default and no output -- `kuna disassemble` has no upstream counterpart at all, and the DIV-15/DIV-20/DIV-68 driver bundles are untouched for every surface. The behaviour is described in docs/spec/00-overview.md and docs/cli.md instead. (`counter:div` was also held by a live builder this round.)",
+  "gates": {
+    "make test": "PARITY OK, datatests 675/675 assertions passed (post-rebase)",
+    "make test-stages": "PARITY OK (post-rebase)",
+    "make check-spec": "check-spec OK",
+    "make test-cli": "tests/cli 65/65 passed (includes the promoted probe)",
+    "kuna catalog --check": "catalog OK: documents exactly the registered kuna options",
+    "make rust-test": "369 suites green; the single failure is kuna-decomp::verify_w10_proto_unlock::w10_proto_unlock_const_return_collapses_no_tied_roundtrip, the known KUNA_DECOMP_TEST artifact -- the repipe launcher points the C++ oracle at kuna's own decomp_test_dbg, and the assertion requires `xunknown4` which no kuna build prints. Falsified per the recipe: `env -u KUNA_DECOMP_TEST cargo test -p kuna-decomp --test verify_w10_proto_unlock` is 4/4 green, which is how CI runs it (no C++ tree exists there).",
+    "scripts.repipe.mergecheck --against origin/main": "merge guards clean, 0 rejects; all shared counters re-derived and agree (159 settables, tiers 41/64/54, 250 corpus files, next ElementId 4151)"
+  },
+  "status": "merged-pending"
+}

--- a/docs/re-needs/disassembling-40-instructions-takes.md
+++ b/docs/re-needs/disassembling-40-instructions-takes.md
@@ -1,0 +1,133 @@
+---
+need_id: disassembling-40-instructions-takes
+title: Disassembling 40 instructions takes about 21 seconds
+track: perf
+status: open
+severity: major
+probe_id: p-677eed496307
+acceptance_id: a-c4f6f7e7667f
+hypothesis_status: upheld
+credibility: 0.7
+instances: 1
+challenges: [69d7f15a8afd9d6c48b48871]
+rounds: [5]
+first_seen_round: 5
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-cli/src/disassemble.rs, decompiler/crates/kuna-analysis]
+scope: large
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Inspect 160 bytes of the prologue interactively.
+
+> **Disassembling 40 instructions takes about 21 seconds** (major, `69d7f15a8afd9d6c48b48871`)
+> Identical requests returned 40 instructions in 20.9154 and 20.7541 seconds, recorded in notes/toolcalls.jsonl.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "disassemble",
+    "{{BIN}}",
+    "0x140001000",
+    "--addr",
+    "--count",
+    "40",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "json": [
+      {
+        "path": "count",
+        "op": "eq",
+        "value": 40
+      }
+    ],
+    "wall_ms": {
+      "stat": "median",
+      "gt": 10000
+    }
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "disassemble",
+    "{{BIN}}",
+    "0x140001000",
+    "--addr",
+    "--count",
+    "40",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "json": [
+      {
+        "path": "count",
+        "op": "eq",
+        "value": 40
+      }
+    ],
+    "wall_ms": {
+      "stat": "median",
+      "lt": 10000
+    }
+  },
+  "target": {
+    "binary_rel": "bin/crackme_shroud.exe",
+    "binary_sha256": "36bfae11c18fb5fa214110d7f17cdc92026bce53e28e9a1965b4193e59c1a6a1",
+    "binary_size": 9384960,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- Address-based disassembly pays for whole-image analysis.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `69d7f15a8afd9d6c48b48871` (round 5, tester t-r5-69d7f15a)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+- round 5 REFUTER: hypothesis **upheld** (was inconclusive). UPHELD in substance, with the mechanism corrected in two places. Measured on the arena binary (.kuna-repipe/arena/5/69d7f15a8afd9d6c48b48871/target/crackme_shroud.exe, PE32+ 9,384,960 bytes whose .text alone is 9,325,806 bytes = 99.4% of the image). Every number below is a RATIO comparison, so the two concurrent builder cargo builds on this box cannot change any conclusion. (1) THE 21s IS NOT DISASSEMBLY, IT IS FIXED SETUP: --count 1 = 20.44s, --count 40 = 20.56s, --count 400 = 20.16s. Four hundred instructions cost the same as one. The title's 'disassembling 40 instructions' is a misattribution; nothing in it is per-instruction. (2) THE SEAM: kuna-cli/src/disassemble.rs:293 calls load_program(&load, DriverDefaults::Inventory) -- the same in-process load decompile-all uses. kuna functions on the same binary costs 20.69s and kuna strings costs 31.39s, i.e. every Inventory surface pays the identical fixed toll. (3) THE LEADING CANDIDATE IS DEAD -- IT IS NOT THE DIV-15 LISTING. --option listing off gives BYTE-IDENTICAL json (diff = 0 lines) AND NO SPEEDUP (20.47s vs 21.23s). --mode fast does not help either (20.79s). Do not let a builder start from 'turn the Listing off'; the doc comment in decompile_all.rs already says the Listing is entry-neutral on x86-64 and this measures it. (4) WHAT IT ACTUALLY IS: the whole-.text discovery walk inside bootstrap_from_object. kuna xrefs, which takes DriverDefaults::Query and explicitly builds NO Listing, still costs 12.65s on this binary -- so >60% of the toll is upstream of the Listing. It also is not raw file size: /bin/bash (1,396,520 B ELF) costs 0.33s while illusion.exe (1,292,288 B PE) costs 5.76s, a 17x difference at equal size. It tracks EXECUTABLE bytes: 32 KB PE 0.16s, 1.29 MB PE 5.76s, 9.38 MB PE 20.26s. This binary is an obfuscation crackme that is 99.4% .text, which is why it is the one that surfaced this. (5) THE WRONG-OUTPUT TRAP, AND IT IS THE REASON TO READ THIS BEFORE BRIEFING ANYONE: the obvious fix -- give disassemble a lighter DriverDefaults, or skip the load entirely for a bare --addr target -- would pass the <10s acceptance and break real behaviour. Swapping to Query is not even a win (12.65s still fails the 10s bound). Dropping the discovery bundle loses the inventory that resolve_region / name_at (disassemble.rs:722) / function_extent_at depend on, and on non-x86-64 that bundle IS the discovery: decompile_all.rs's own comment records the exact regression (kuna disassemble <name> answering 'no function matches' for a name kuna functions prints -- RE-need analysis-generated-function-name). THE FIX SHAPE MUST BE LAZINESS OR A CHEAPER WALK, NOT A VARIANT SWAP: decode only the requested window for a bare-address or explicit-range target and pay for the inventory only when the target is a name, or make the .text discovery walk itself cheaper. (6) SCOPE IS WRONG. This is filed scope:small; a lazy-load seam through load_program that keeps every name-resolution consumer honest is not small.
+round 5 TRIAGE (captain): SCOPE small -> large, TOUCHES [] -> kuna-cli/src/disassemble.rs + kuna-analysis. The refuter's point (5) is the reason: every cheap fix -- a lighter DriverDefaults, skipping the load for a bare --addr target -- PASSES the <10s acceptance and breaks name resolution, and decompile_all.rs already records that exact regression. A lazy-load seam through load_program that keeps resolve_region / name_at / function_extent_at honest is a design decision, so this goes to a [PROPOSAL] draft PR before anyone writes code. TOUCHES was empty, which meant the need carried NO path lease at all. Track perf is right. NOTE FOR B_VERIFY: the acceptance is a wall_ms median bound and is the one probe in this round that needs a quiet box -- see [[kuna-repipe-phantom-perf-regression]].

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -254,6 +254,31 @@ Four front-ends drive one engine assembly:
   and `__TEXT,__const` decode perfectly well into `ADD`/`OR` rows that describe
   nothing in the program, which is what sent two RE-loop testers to `xxd` and
   `objdump -s` (`docs/re-needs/cli-mode-read-raw.md`).
+
+  (kuna) **A window the caller bounded is answered without the discovery walk.**
+  `--count`, `--bytes` and an explicit `start-end` range each bound the listing on
+  their own (`decompiler/crates/kuna-cli/src/disassemble.rs
+  (window_is_caller_bounded)`), so such a target does not need the program-wide
+  function inventory the whole-binary driver defaults build. It is loaded once
+  with the analysis tier's two discovery gates — `listing` and `fast_funcdisc` —
+  turned off (`decompiler/crates/kuna-cli/src/disassemble.rs
+  (windowed_options)`), unless the caller named either option, in which case their
+  word stands. The walk is deferred, not dropped: the inventory reaches a bounded
+  listing through exactly two values, the target's name and whether it resolved to
+  an entry, so the windowed answer is kept only when the program named the target
+  from a fact it already held AND the view it chose does not depend on there being
+  an entry at that address (`decompiler/crates/kuna-cli/src/disassemble.rs
+  (windowed_answer_is_final)`). Anything else — a name only discovery invents, an
+  address only it knows, a bare address in a data section — reloads with the full
+  bundle and answers exactly as it did before, which is what keeps `kuna
+  disassemble sub_1190` from becoming the "no function matches" regression
+  `docs/re-needs/analysis-generated-function-name.md` records. A listing whose
+  length is the function extent is never bounded by the caller, so it always takes
+  the full walk. The motive is that the walk is priced by the image, not by the
+  request: `--mode auto` selects `fast` from 2 MiB up, whose retained
+  `fast_funcdisc` pass decodes every executable byte, and on a 9.4 MB PE that is
+  99.4% `.text` printing 40 instructions cost 20.1 s
+  (`docs/re-needs/disassembling-40-instructions-takes.md`).
 - **`kuna_ghidra`** (`decompiler/crates/kuna-ghidra/src/bin/kuna_ghidra.rs`) —
   the ghidra-mode process front-end: the stock Ghidra GUI spawns it as its
   decompiler core and talks the burst-framed stdin/stdout protocol

--- a/tests/cli/disassembling-40-instructions-takes.json
+++ b/tests/cli/disassembling-40-instructions-takes.json
@@ -1,0 +1,53 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "disassemble",
+    "{{BIN}}",
+    "0x5000",
+    "--addr",
+    "--count",
+    "40",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 120,
+  "repeat": 5,
+  "target": {
+    "binary_rel": "tests/hang-repro/ssh-sk-helper",
+    "binary_sha256": "e03a07c44cc41d6f08bbe4b0275ddd1037c973d116ece33e6f14b66a0712b25b",
+    "binary_size": 461448,
+    "binary_source": "in-repo",
+    "in_repo_path": "tests/hang-repro/ssh-sk-helper",
+    "selector": "0x5000",
+    "selector_kind": "addr"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "count",
+        "op": "eq",
+        "value": 40
+      },
+      {
+        "path": "target.name",
+        "op": "eq",
+        "value": "_DT_INIT"
+      }
+    ],
+    "wall_ms": {
+      "stat": "min",
+      "lt": 600
+    }
+  },
+  "notes": "Acceptance of RE-need disassembling-40-instructions-takes, repointed from its dataset image (9.4 MB PE32+, 99.4% .text, 19,693 -> 1,170 ms median) to the largest in-repo fixture under the 500 KiB threshold that turns the discovery walk on: CI has no dataset. Bound recalibrated, min of 5: 833 ms before, 318 after. `target.name` too -- the cheap way to pass a wall bound here is to lose the name."
+}


### PR DESCRIPTION
## The problem

`kuna disassemble` at a raw address pays for a whole-image function-discovery
walk before it prints a single row, so on a large binary a 40-instruction
listing takes as long as decompiling the program would. On a 9.4 MB PE32+ whose
`.text` is 99.4% of the file:

```
$ time kuna disassemble ./crackme_shroud.exe 0x140001000 --addr --count 40 --json | head -3
{
  "binary": "./crackme_shroud.exe",
  "kind": "code",

real    0m20.128s
```

Nothing in that is per-instruction: `--count 1` costs 20.4 s and `--count 400`
costs 20.2 s. It is the discovery walk `--mode auto` turns on — `auto` selects
`fast` from 2 MiB up, and the pass `fast` retains (`fast_funcdisc`) decodes every
executable byte in the image.

## The fix

- A window the caller bounded — `--count`, `--bytes`, or an explicit
  `start-end` range — is loaded with the analysis tier's two discovery gates
  (`listing`, `fast_funcdisc`) off. Naming either option yourself still wins.
- The walk is deferred, not dropped. It reaches a bounded listing through
  exactly two values — the target's name, and whether it resolved to an entry
  (which forces the instruction view) — so the windowed answer is kept only when
  the program named the target from a fact it already held **and** the view it
  chose does not depend on there being an entry at that address. Anything else
  reloads with the full bundle: a name only discovery invents (`sub_1190` on a
  stripped image), an address only it knows, a bare address in a data section.
  That fallback is why this is not the variant swap that breaks
  `kuna disassemble <generated name>`.
- A listing whose length is the function extent was never caller-bounded, so it
  always takes the full walk.
- Loader tolerance notes (`[kuna] ELF section table unusable…`, the PE
  data-directory clamp, the ET_REL report) are now said once per process per
  image. They are facts about the image, and a surface that loads it twice was
  announcing each of them twice.

## The tests

`tests/cli/disassembling-40-instructions-takes.json` is the acceptance probe,
repointed from its 9.4 MB dataset image to the largest in-repo fixture that
reproduces the shape (CI has no dataset) and recalibrated on it. Two cargo
tests in `kuna-cli`: `sub_1190` — a name only the discovery walk invents — still
resolves by both spellings, and a bounded listing is byte-identical to the one
the walk it skipped would have produced. Three unit tests pin the three
predicates.

Measured: 20.1 s → 1.4 s on the witness, byte-identical stdout. Sweep of 3,838
`disassemble`/`read` invocations over 139 in-repo binaries (every format and
architecture in the tree, name / address / range / mid-function / `--as data`
targets): **0 stdout differences, 0 exit-code differences**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
