### PR TITLE
[AUTOMATED] feat(cli): prototype-assertion-parser-rejects — accept and honor a calling convention in a prototype assertion

### DIFF
--- a/decompiler/crates/kuna-console/src/assertions.rs
+++ b/decompiler/crates/kuna-console/src/assertions.rs
@@ -78,7 +78,7 @@ use std::rc::Rc;
 use kuna_base::address::Address;
 use kuna_base::types::{int4, uint4};
 use kuna_decomp::dtype::Datatype;
-use kuna_decomp::fspec::{ParameterPieces, PrototypePieces};
+use kuna_decomp::fspec::{ParameterPieces, ProtoModel, PrototypePieces};
 use kuna_decomp::funcdata::Funcdata;
 
 use crate::engine::ConsoleProgram;
@@ -333,7 +333,8 @@ fn apply_one_program_scoped(prog: &mut ConsoleProgram, body: &Body) -> Result<()
         Body::Typedef { decl } => {
             let org = data_org(prog);
             let text = with_semicolon(decl);
-            crate::grammar::parse_c(&text, prog.arch().types(), org, |_| Ok(()))
+            let models = model_names(prog);
+            crate::grammar::parse_c(&text, prog.arch().types(), org, &models, |_, _| Ok(()))
                 .map_err(|e| e.explain().to_string())
         }
         Body::Prototype { func, decl } => apply_prototype(prog, func, decl),
@@ -532,15 +533,18 @@ pub(crate) fn park_proto_pieces(
     }
 }
 
-/// The two things a full `prototype` directive does: park the pieces for the
-/// callers, and lock the signature onto the symbol itself.
+/// The three things a full `prototype` directive does: park the pieces for the
+/// callers, record the calling convention it named, and lock the signature onto
+/// the symbol itself.
 pub(crate) fn park_prototype(
     prog: &mut ConsoleProgram,
     target: &ProtoTarget,
     pieces: &mut PrototypePieces,
+    model: Option<&Rc<ProtoModel>>,
 ) {
     park_proto_pieces(prog, target, pieces);
-    lock_prototype_on_symbol(prog, target, pieces);
+    park_proto_model(prog, target, model);
+    lock_prototype_on_symbol(prog, target, pieces, model);
 }
 
 /// `prototype <func> <C declaration>` — the in-process twin of `parse line
@@ -561,19 +565,55 @@ fn apply_prototype(prog: &mut ConsoleProgram, func: &str, decl: &str) -> Result<
     use std::cell::RefCell;
     let org = data_org(prog);
     let text = format!("extern {}", with_semicolon(decl));
-    let captured: RefCell<Option<PrototypePieces>> = RefCell::new(None);
-    crate::grammar::parse_c(&text, prog.arch().types(), org, |pieces| {
-        *captured.borrow_mut() = Some(pieces);
+    let captured: RefCell<Option<(PrototypePieces, String)>> = RefCell::new(None);
+    let models = model_names(prog);
+    crate::grammar::parse_c(&text, prog.arch().types(), org, &models, |pieces, model| {
+        *captured.borrow_mut() = Some((pieces, model.to_string()));
         Ok(())
     })
     .map_err(|e| e.explain().to_string())?;
-    let mut pieces = captured
+    let (mut pieces, model) = captured
         .into_inner()
         .ok_or_else(|| "not a function declaration".to_string())?;
     let target = resolve_proto_target(prog, func)?;
-    park_prototype(prog, &target, &mut pieces);
+    let model = declared_model(prog, &model);
+    park_prototype(prog, &target, &mut pieces, model.as_ref());
     prog.set_pending_prototype(target.name(), pieces);
     Ok(())
+}
+
+/// The prototype-model names the loaded program's architecture has registered,
+/// as the C declaration parser needs them (`glb->hasModel`).
+pub(crate) fn model_names(prog: &ConsoleProgram) -> Vec<String> {
+    prog.arch().proto_model_names().map(str::to_string).collect()
+}
+
+/// The calling convention a declaration named, resolved against the loaded
+/// compiler spec's model registry.  `None` when the declaration named none; a
+/// name the registry does not carry cannot reach here, because the parser only
+/// classified it as a convention *because* the registry named it.
+pub(crate) fn declared_model(prog: &ConsoleProgram, model: &str) -> Option<Rc<ProtoModel>> {
+    if model.is_empty() {
+        return None;
+    }
+    prog.arch().get_model(model).cloned()
+}
+
+/// Record the calling convention a `prototype` directive named, so the
+/// function's own decompile is seeded under it rather than under the
+/// architecture default.
+///
+/// Keyed by the target's NAME, which is the key the arch handle joins against
+/// the parked pieces — those carry `pieces.name == target.name()`
+/// ([`park_proto_pieces`]).
+pub(crate) fn park_proto_model(
+    prog: &mut ConsoleProgram,
+    target: &ProtoTarget,
+    model: Option<&Rc<ProtoModel>>,
+) {
+    let Some(m) = model else { return };
+    let name = target.name().to_string();
+    prog.arch_mut().set_function_prototype_model(&name, Rc::clone(m));
 }
 
 /// Lock the parsed prototype onto the target's `FunctionSymbol` by retyping it
@@ -584,6 +624,7 @@ pub(crate) fn lock_prototype_on_symbol(
     prog: &mut ConsoleProgram,
     target: &ProtoTarget,
     pieces: &PrototypePieces,
+    model: Option<&Rc<ProtoModel>>,
 ) {
     let arch = prog.arch_mut();
     let sid = match target {
@@ -601,7 +642,15 @@ pub(crate) fn lock_prototype_on_symbol(
             None => return,
         },
     };
-    if let Ok(tc) = arch.types().get_type_code_proto(pieces) {
+    // The prototype-bearing `TypeCode` is what a CALLER reads a declared callee's
+    // signature back from (`ArchContext::query_callee_proto`), so the declared
+    // convention has to be baked in here: the storage the caller sees for each
+    // argument is assigned when this `FuncProto` is built.
+    let tc = match model {
+        Some(m) => arch.types_impl().get_type_code_proto_model(pieces, Rc::clone(m)),
+        None => arch.types().get_type_code_proto(pieces),
+    };
+    if let Ok(tc) = tc {
         let _ = arch.symboltab.retype_symbol(sid, tc);
     }
 }
@@ -682,7 +731,8 @@ fn apply_cross_function(
     // return type; `param` alone never declares one, and the storage assignment
     // behind `getTypeCode` dereferences `outtype` unconditionally.
     if pieces.outtype.is_some() {
-        lock_prototype_on_symbol(prog, &target, &pieces);
+        let model = prog.arch().function_prototype_model(target.name()).cloned();
+        lock_prototype_on_symbol(prog, &target, &pieces, model.as_ref());
     }
     prog.set_pending_prototype(target.name(), pieces);
     Ok(())

--- a/decompiler/crates/kuna-console/src/grammar.rs
+++ b/decompiler/crates/kuna-console/src/grammar.rs
@@ -942,6 +942,12 @@ impl TypeDeclarator {
         &self.ident
     }
 
+    /// C++ `getModel` (`grammar.hh:185`): the calling convention the
+    /// declaration named, or `""` when it named none.
+    pub fn get_model(&self) -> &str {
+        &self.model
+    }
+
     /// C++ `hasProperty` (`grammar.hh:187`).
     pub fn has_property(&self, mask: uint4) -> bool {
         (self.flags & mask) != 0
@@ -1223,6 +1229,10 @@ enum PToken {
     Scoperes,
 }
 
+/// The empty prototype-model registry — the classification a parse with no
+/// architecture behind it gets ([`CParse::new`]).
+const NO_MODELS: &[String] = &[];
+
 /// The C-declaration parser (C++ `CParse`, `grammar.hh:207-286` +
 /// `grammar.cc:861-1387`).
 ///
@@ -1232,6 +1242,11 @@ enum PToken {
 /// through the by-value AST), so they are dropped.
 pub struct CParse<'a> {
     factory: &'a dyn TypeFactory,
+    /// The prototype-model names the loaded `Architecture` has registered
+    /// (C++ `glb->protoModels`, read by `lookupIdentifier`'s `glb->hasModel`).
+    /// Empty when the caller has no architecture, which is the classification
+    /// this parser had before the registry was reachable.
+    models: &'a [String],
     /// The data-organization record (the `glb` state `build_type`/`get_prototype`
     /// read).  In C++ this is part of the `Architecture *glb` the parser holds; the
     /// kuna split carries it alongside the factory.  // STUB(w6-fspec-2)
@@ -1271,6 +1286,7 @@ impl<'a> CParse<'a> {
         keywords.insert("enum".to_string(), flags::F_ENUM);
         CParse {
             factory,
+            models: NO_MODELS,
             org,
             keywords,
             lexer: GrammarLexer::new(maxbuf),
@@ -1281,6 +1297,20 @@ impl<'a> CParse<'a> {
             lastdecls: None,
             pushed: None,
         }
+    }
+
+    /// [`CParse::new`] with the architecture's registered prototype-model names,
+    /// so `__stdcall` and friends classify as function specifiers rather than as
+    /// bare identifiers (C++ `CParse` reaches them through its `glb`).
+    pub fn with_models(
+        factory: &'a dyn TypeFactory,
+        org: DataOrg,
+        maxbuf: int4,
+        models: &'a [String],
+    ) -> CParse<'a> {
+        let mut p = CParse::new(factory, org, maxbuf);
+        p.models = models;
+        p
     }
 
     /// C++ `getError` (`grammar.hh:283`).
@@ -1360,9 +1390,11 @@ impl<'a> CParse<'a> {
         if let Ok(Some(tp)) = self.factory.find_by_name(nm) {
             return IdentClass::TypeName(tp);
         }
-        // glb->hasModel(nm) -> FUNCTION_SPECIFIER.  The kuna Architecture has no
-        // model registry, so this never fires (it would classify e.g.
-        // "__stdcall" as a function specifier).  // STUB(w6-fspec-2)
+        // glb->hasModel(nm) -> FUNCTION_SPECIFIER (grammar.cc:1268): an identifier
+        // the Architecture knows as a prototype model names a calling convention.
+        if self.models.iter().any(|m| m == nm) {
+            return IdentClass::FunctionSpecifier;
+        }
         IdentClass::Identifier
     }
 
@@ -1450,26 +1482,40 @@ impl<'a> CParse<'a> {
     // -- grammar.y reduce actions (grammar.cc:900-1190) -----------------------
 
     /// C++ `mergeSpecDec(TypeSpecifiers*,TypeDeclarator*)` (`grammar.cc:900-907`).
-    fn merge_spec_dec(spec: &TypeSpecifiers, mut dec: TypeDeclarator) -> TypeDeclarator {
+    ///
+    /// (kuna) The declarator may already carry a calling convention of its own
+    /// ([`CParse::declarator_model`]), so the specifier run only overwrites when
+    /// it names one; naming a convention in both places is the same mistake
+    /// `addFuncSpecifier` rejects.
+    fn merge_spec_dec(&mut self, spec: &TypeSpecifiers, mut dec: TypeDeclarator) -> TypeDeclarator {
         dec.basetype = spec.type_specifier.clone();
-        dec.model = spec.function_specifier.clone();
+        if !spec.function_specifier.is_empty() {
+            if !dec.model.is_empty() {
+                self.set_error("Multiple parameter models");
+            }
+            dec.model = spec.function_specifier.clone();
+        }
         dec.flags |= spec.flags;
         dec
     }
 
     /// C++ `mergeSpecDec(TypeSpecifiers*)` (`grammar.cc:909-915`).
-    fn merge_spec_dec_empty(spec: &TypeSpecifiers) -> TypeDeclarator {
-        Self::merge_spec_dec(spec, TypeDeclarator::new())
+    fn merge_spec_dec_empty(&mut self, spec: &TypeSpecifiers) -> TypeDeclarator {
+        self.merge_spec_dec(spec, TypeDeclarator::new())
     }
 
     /// C++ `mergeSpecDecVec(TypeSpecifiers*,vector*)` (`grammar.cc:917-923`).
-    fn merge_spec_dec_vec(spec: &TypeSpecifiers, declist: Vec<TypeDeclarator>) -> Vec<TypeDeclarator> {
-        declist.into_iter().map(|d| Self::merge_spec_dec(spec, d)).collect()
+    fn merge_spec_dec_vec(
+        &mut self,
+        spec: &TypeSpecifiers,
+        declist: Vec<TypeDeclarator>,
+    ) -> Vec<TypeDeclarator> {
+        declist.into_iter().map(|d| self.merge_spec_dec(spec, d)).collect()
     }
 
     /// C++ `mergeSpecDecVec(TypeSpecifiers*)` (`grammar.cc:925-935`).
-    fn merge_spec_dec_vec_empty(spec: &TypeSpecifiers) -> Vec<TypeDeclarator> {
-        vec![Self::merge_spec_dec_empty(spec)]
+    fn merge_spec_dec_vec_empty(&mut self, spec: &TypeSpecifiers) -> Vec<TypeDeclarator> {
+        vec![self.merge_spec_dec_empty(spec)]
     }
 
     /// C++ `convertFlag(string*)` (`grammar.cc:937-947`).
@@ -1567,12 +1613,12 @@ impl<'a> CParse<'a> {
         match self.peek()? {
             PToken::Punct(c) if *c == b';' => {
                 self.next()?;
-                Ok(Self::merge_spec_dec_vec_empty(&spec))
+                Ok(self.merge_spec_dec_vec_empty(&spec))
             }
             _ => {
                 let declist = self.init_declarator_list()?;
                 self.expect_punct(b';')?;
-                Ok(Self::merge_spec_dec_vec(&spec, declist))
+                Ok(self.merge_spec_dec_vec(&spec, declist))
             }
         }
     }
@@ -1882,7 +1928,7 @@ impl<'a> CParse<'a> {
         let spec = self.specifier_qualifier_list()?;
         let declist = self.struct_declarator_list()?;
         self.expect_punct(b';')?;
-        Ok(Self::merge_spec_dec_vec(&spec, declist))
+        Ok(self.merge_spec_dec_vec(&spec, declist))
     }
 
     /// `specifier_qualifier_list` (`grammar.y:117-122`).
@@ -2008,13 +2054,69 @@ impl<'a> CParse<'a> {
     /// `declarator: direct_declarator | pointer direct_declarator`
     /// (`grammar.y:152-155`).
     fn declarator(&mut self) -> KunaResult<TypeDeclarator> {
-        if matches!(self.peek()?, PToken::Punct(b'*')) {
+        // (kuna) A calling convention may sit on either side of the pointer run:
+        // `int4 (__stdcall *cb)(int4)` is the Win32 callback spelling,
+        // `void * __stdcall f(void)` the pointer-returning-function one.
+        let mut model = self.declarator_model()?;
+        let mut dec = if matches!(self.peek()?, PToken::Punct(b'*')) {
             let ptr = self.pointer()?;
+            let after = self.declarator_model()?;
+            if !after.is_empty() {
+                if !model.is_empty() {
+                    self.set_error("Multiple parameter models");
+                    return Err(KunaError::parse(self.lasterror.clone()));
+                }
+                model = after;
+            }
             let dec = self.direct_declarator()?;
-            Ok(Self::merge_pointer(&ptr, dec))
+            Self::merge_pointer(&ptr, dec)
         } else {
-            self.direct_declarator()
+            self.direct_declarator()?
+        };
+        if !model.is_empty() {
+            dec.model = model;
         }
+        Ok(dec)
+    }
+
+    /// (kuna) A calling convention named in DECLARATOR position — the
+    /// `void * __stdcall LoadLibraryExW(...)` spelling that Windows headers,
+    /// MSVC and Ghidra's own listings use.  The C-standard grammar admits a
+    /// function specifier only in `declaration_specifiers`, which sits *before*
+    /// the `*`, so a pointer-returning function has nowhere to put its
+    /// convention and the whole declaration is rejected as bad syntax.
+    ///
+    /// Returns the empty string when the lookahead names no convention.  Only a
+    /// registered prototype model is taken here; a reserved specifier
+    /// (`inline`) is left for the productions that own it.
+    /// Does the lookahead name a calling convention (as opposed to a reserved
+    /// function specifier like `inline`)?
+    fn peek_is_model(&mut self) -> KunaResult<bool> {
+        let nm = match self.peek()? {
+            PToken::FunctionSpecifier(s) => s.clone(),
+            _ => return Ok(false),
+        };
+        Ok(!self.keywords.contains_key(&nm))
+    }
+
+    fn declarator_model(&mut self) -> KunaResult<String> {
+        let mut model = String::new();
+        loop {
+            let nm = match self.peek()? {
+                PToken::FunctionSpecifier(s) => s.clone(),
+                _ => break,
+            };
+            if self.keywords.contains_key(&nm) {
+                break;
+            }
+            self.next()?;
+            if !model.is_empty() {
+                self.set_error("Multiple parameter models");
+                return Err(KunaError::parse(self.lasterror.clone()));
+            }
+            model = nm;
+        }
+        Ok(model)
     }
 
     /// `var_identifier: IDENTIFIER (SCOPERES IDENTIFIER)*` (`grammar.y:157-160`):
@@ -2168,28 +2270,28 @@ impl<'a> CParse<'a> {
                         // Could be a (possibly abstract) declarator continuation.
                         let inner = self.declarator_or_abstract_after_pointer()?;
                         let dec = Self::merge_pointer(&ptr, inner);
-                        Ok(Self::merge_spec_dec(&spec, dec))
+                        Ok(self.merge_spec_dec(&spec, dec))
                     }
                     _ => {
                         // abstract_declarator: pointer  (grammar.y:201)
                         let dec = Self::merge_pointer(&ptr, TypeDeclarator::new());
-                        Ok(Self::merge_spec_dec(&spec, dec))
+                        Ok(self.merge_spec_dec(&spec, dec))
                     }
                 }
             }
             PToken::Identifier(_) => {
                 let dec = self.declarator()?;
-                Ok(Self::merge_spec_dec(&spec, dec))
+                Ok(self.merge_spec_dec(&spec, dec))
             }
             PToken::Punct(b'(') | PToken::Punct(b'[') => {
                 // direct_abstract_declarator (or a parenthesised concrete
                 // declarator).  Try the (abstract-or-concrete) direct declarator.
                 let dec = self.direct_abstract_or_concrete()?;
-                Ok(Self::merge_spec_dec(&spec, dec))
+                Ok(self.merge_spec_dec(&spec, dec))
             }
             _ => {
                 // declaration_specifiers alone (grammar.y:196).
-                Ok(Self::merge_spec_dec_empty(&spec))
+                Ok(self.merge_spec_dec_empty(&spec))
             }
         }
     }
@@ -2218,14 +2320,18 @@ impl<'a> CParse<'a> {
                 // '(' declarator ')'  OR  '(' abstract_declarator ')'  OR
                 // a function suffix '(' parameter_type_list ')' on an EMPTY
                 // direct_abstract_declarator (grammar.y:206-211).
-                match self.peek()? {
-                    PToken::Punct(b'*') | PToken::Identifier(_) => {
+                // A leading calling convention (`(__stdcall *cb)`) makes this a
+                // parenthesised declarator, not a function suffix.
+                let paren_declarator = self.peek_is_model()?
+                    || matches!(self.peek()?, PToken::Punct(b'*') | PToken::Identifier(_));
+                match paren_declarator {
+                    true => {
                         // Parenthesised (abstract-or-concrete) declarator.
                         let inner = self.declarator_or_abstract_or_empty()?;
                         self.expect_punct(b')')?;
                         inner
                     }
-                    _ => {
+                    false => {
                         // '(' parameter_type_list ')' suffix on an empty
                         // abstract declarator: the leading '(' starts a function.
                         let declist = self.parameter_type_list()?;
@@ -2247,18 +2353,31 @@ impl<'a> CParse<'a> {
     /// Inside `(...)`: a declarator that may carry a leading pointer and may be
     /// abstract or concrete.
     fn declarator_or_abstract_or_empty(&mut self) -> KunaResult<TypeDeclarator> {
-        if matches!(self.peek()?, PToken::Punct(b'*')) {
+        let mut model = self.declarator_model()?;
+        let mut dec = if matches!(self.peek()?, PToken::Punct(b'*')) {
             let ptr = self.pointer()?;
+            let after = self.declarator_model()?;
+            if !after.is_empty() {
+                if !model.is_empty() {
+                    self.set_error("Multiple parameter models");
+                    return Err(KunaError::parse(self.lasterror.clone()));
+                }
+                model = after;
+            }
             match self.peek()? {
                 PToken::Identifier(_) | PToken::Punct(b'(') | PToken::Punct(b'[') => {
                     let inner = self.direct_abstract_or_concrete()?;
-                    Ok(Self::merge_pointer(&ptr, inner))
+                    Self::merge_pointer(&ptr, inner)
                 }
-                _ => Ok(Self::merge_pointer(&ptr, TypeDeclarator::new())),
+                _ => Self::merge_pointer(&ptr, TypeDeclarator::new()),
             }
         } else {
-            self.direct_abstract_or_concrete()
+            self.direct_abstract_or_concrete()?
+        };
+        if !model.is_empty() {
+            dec.model = model;
         }
+        Ok(dec)
     }
 
     /// `assignment_expression: NUMBER` (`grammar.y:214-216`).
@@ -2519,9 +2638,11 @@ pub fn parse_protopieces(
 /// data straight into the data structures (a `parse line`/`parse file` body).
 ///
 /// The C++ `Architecture *glb` is split into the [`TypeFactory`] (the construction
-/// store-writes go through it), the [`DataOrg`], and `set_prototype` — a callback
-/// standing in for `glb->setPrototype(pieces)` (which needs `symboltab`/`Funcdata`,
-/// surfaces the console owns, not the grammar).  The construction itself (struct/
+/// store-writes go through it), the [`DataOrg`], the registered prototype-model
+/// names (`glb->hasModel`), and `set_prototype` — a callback standing in for
+/// `glb->setPrototype(pieces)` (which needs `symboltab`/`Funcdata`, surfaces the
+/// console owns, not the grammar).  The callback also receives the calling
+/// convention the declaration named (`""` when it named none).  The construction itself (struct/
 /// union/enum stub + `assignRawFields`/`setEnumValues`; typedef -> `setName`/
 /// `getTypedef`) is fully wired into the factory.
 ///
@@ -2533,9 +2654,10 @@ pub fn parse_c(
     input: &str,
     factory: &dyn TypeFactory,
     org: DataOrg,
-    set_prototype: impl FnOnce(PrototypePieces) -> KunaResult<()>,
+    models: &[String],
+    set_prototype: impl FnOnce(PrototypePieces, &str) -> KunaResult<()>,
 ) -> KunaResult<()> {
-    let mut parser = CParse::new(factory, org, 4096);
+    let mut parser = CParse::with_models(factory, org, 4096, models);
     if !parser.parse_stream(input.as_bytes().to_vec(), DocType::Declaration)? {
         return Err(KunaError::parse(parser.get_error().to_string()));
     }
@@ -2557,7 +2679,7 @@ pub fn parse_c(
         if !decl.get_prototype(&mut pieces, factory, &org)? {
             return Err(KunaError::parse("Did not parse prototype as expected"));
         }
-        set_prototype(pieces)?;
+        set_prototype(pieces, decl.get_model())?;
     } else if decl.has_property(flags::F_TYPEDEF) {
         let ct = decl.build_type(factory, &org)?;
         if decl.get_identifier().is_empty() {

--- a/decompiler/crates/kuna-console/src/grammar/tests.rs
+++ b/decompiler/crates/kuna-console/src/grammar/tests.rs
@@ -564,7 +564,7 @@ fn struct_construction_lands_in_factory() {
     // computed size (two int4 fields => 8 bytes) and completed (no longer
     // incomplete).
     let f = factory();
-    super::parse_c("struct mystruct { int4 a; int4 b; };", &f, org(), |_| {
+    super::parse_c("struct mystruct { int4 a; int4 b; };", &f, org(), &[], |_, _| {
         panic!("a bare struct is not an extern prototype")
     })
     .expect("struct construction should succeed");
@@ -585,7 +585,7 @@ fn enum_construction_lands_in_factory() {
     // the size-0 mask would collapse all values, exactly as the C++ would.
     let f = factory();
     f.setup_sizes(Some(4), 4, 4);
-    super::parse_c("enum mycolor { RED=1, GREEN=2, BLUE };", &f, org(), |_| {
+    super::parse_c("enum mycolor { RED=1, GREEN=2, BLUE };", &f, org(), &[], |_, _| {
         panic!("a bare enum is not an extern prototype")
     })
     .expect("enum construction should succeed");
@@ -601,7 +601,7 @@ fn typedef_lands_in_factory() {
     // `parse line typedef int4 myint;` creates a typedef interned under the new
     // name.
     let f = factory();
-    super::parse_c("typedef int4 myint;", &f, org(), |_| {
+    super::parse_c("typedef int4 myint;", &f, org(), &[], |_, _| {
         panic!("a typedef is not an extern prototype")
     })
     .expect("typedef should succeed");
@@ -927,4 +927,98 @@ fn a_scalar_keyword_with_no_declared_width_is_a_parse_error() {
         err.explain()
     );
     assert_eq!(parse_type("unsigned int x", &f, org()).unwrap().0.get_name(), "uint4");
+}
+
+// ===========================================================================
+// Calling conventions (`glb->hasModel` -> FUNCTION_SPECIFIER)
+// ===========================================================================
+
+/// The prototype-model names an x86 Windows compiler spec registers.
+fn win_models() -> Vec<String> {
+    ["__stdcall", "__cdecl", "__fastcall", "__thiscall"].iter().map(|s| s.to_string()).collect()
+}
+
+/// Parse one `extern` declaration and report the convention it named.
+fn proto_model(decl: &str, models: &[String]) -> Result<String, String> {
+    use std::cell::RefCell;
+    let f = factory();
+    let seen: RefCell<Option<String>> = RefCell::new(None);
+    super::parse_c(decl, &f, org(), models, |_, model| {
+        *seen.borrow_mut() = Some(model.to_string());
+        Ok(())
+    })
+    .map_err(|e| e.explain().to_string())?;
+    seen.into_inner().ok_or_else(|| "not a prototype".to_string())
+}
+
+#[test]
+fn convention_after_a_pointer_return_parses() {
+    // The reported spelling: a `__stdcall` on a pointer-returning Win32 import.
+    // The convention sits in DECLARATOR position, after the `*`, which the
+    // C-standard specifier run cannot reach.
+    assert_eq!(
+        proto_model("extern void * __stdcall LoadLibraryExW(uint2 *n,void *f,uint4 g);",
+                    &win_models()),
+        Ok("__stdcall".to_string())
+    );
+}
+
+#[test]
+fn convention_before_the_return_type_parses() {
+    assert_eq!(
+        proto_model("extern int4 __fastcall f(int4 a);", &win_models()),
+        Ok("__fastcall".to_string())
+    );
+}
+
+#[test]
+fn a_declaration_naming_no_convention_reports_none() {
+    assert_eq!(proto_model("extern int4 f(int4 a);", &win_models()), Ok(String::new()));
+}
+
+#[test]
+fn an_unregistered_convention_is_still_a_syntax_error() {
+    // The classification is the registry's: a spelling the loaded compiler spec
+    // does not declare stays a plain identifier and the declaration is rejected,
+    // so a typo cannot be silently dropped on the floor.
+    let err = proto_model("extern int4 __pascal f(int4 a);", &win_models()).unwrap_err();
+    assert!(!err.is_empty(), "an unknown convention must not parse");
+}
+
+#[test]
+fn a_convention_needs_a_registry_to_be_one() {
+    // With no architecture behind the parse (no models registered) the
+    // declaration is rejected exactly as it was before the registry was
+    // reachable -- this is the behaviour the fix flips.
+    let err = proto_model("extern void * __stdcall f(int4 a);", &[]).unwrap_err();
+    assert!(!err.is_empty(), "no registry means no convention");
+}
+
+#[test]
+fn two_conventions_in_one_declaration_are_rejected() {
+    let err =
+        proto_model("extern int4 __stdcall __cdecl f(int4 a);", &win_models()).unwrap_err();
+    assert!(
+        err.contains("Multiple parameter models"),
+        "expected the duplicate-model diagnostic, got {err:?}"
+    );
+    let err =
+        proto_model("extern int4 __stdcall * __cdecl f(int4 a);", &win_models()).unwrap_err();
+    assert!(
+        err.contains("Multiple parameter models"),
+        "expected the duplicate-model diagnostic, got {err:?}"
+    );
+}
+
+#[test]
+fn a_convention_on_a_function_pointer_parameter_parses_as_it_did_without_one() {
+    // `__stdcall` inside a parenthesised declarator (`int4 (__stdcall *cb)(int4)`)
+    // is the callback spelling every Win32 header uses.  The convention on a
+    // function-pointer PARAMETER is dropped (the parameter's type is a code
+    // pointer, which carries no model in this port), but it must not change how
+    // the declaration parses.
+    assert_eq!(
+        proto_model("extern int4 f(int4 (__stdcall *cb)(int4));", &win_models()),
+        proto_model("extern int4 f(int4 (*cb)(int4));", &win_models())
+    );
 }

--- a/decompiler/crates/kuna-console/src/ifacedecomp.rs
+++ b/decompiler/crates/kuna-console/src/ifacedecomp.rs
@@ -615,6 +615,7 @@ fn mark_property_range(
 fn apply_prototype_to_symbol(
     status: &mut IfaceStatus,
     pieces: &kuna_decomp::fspec::PrototypePieces,
+    model: Option<&std::rc::Rc<kuna_decomp::fspec::ProtoModel>>,
 ) -> IfaceResult<()> {
     let dcp = dcp_mut(status)?;
     let prog = match dcp.conf.as_mut() {
@@ -635,7 +636,13 @@ fn apply_prototype_to_symbol(
     // getTypeCode(pieces): the prototype-bearing TypeCode the symbol's
     // getPrototype() will return.  A build failure (no proto context) is a
     // no-op — fall back to the stashed-pieces path.
-    let type_code = match arch.types().get_type_code_proto(pieces) {
+    // A declaration that named a calling convention is built under it, so the
+    // storage a CALLER sees for each argument is the declared convention's.
+    let built = match model {
+        Some(m) => arch.types_impl().get_type_code_proto_model(pieces, std::rc::Rc::clone(m)),
+        None => arch.types().get_type_code_proto(pieces),
+    };
+    let type_code = match built {
         Ok(tc) => tc,
         Err(_) => return Ok(()),
     };
@@ -659,8 +666,10 @@ fn run_parse_c(status: &mut IfaceStatus, content: &str) -> IfaceResult<()> {
         let org = crate::grammar::DataOrg { addr_size, word_size };
         // setPrototype branch: stash the parsed pieces (applied below, against the
         // mutable `dcp`); the symbol existence check mirrors C++ queryFunction.
-        let captured: RefCell<Option<kuna_decomp::fspec::PrototypePieces>> = RefCell::new(None);
-        let res = crate::grammar::parse_c(content, arch.types(), org, |pieces| {
+        let captured: RefCell<Option<(kuna_decomp::fspec::PrototypePieces, String)>> =
+            RefCell::new(None);
+        let models: Vec<String> = arch.proto_model_names().map(str::to_string).collect();
+        let res = crate::grammar::parse_c(content, arch.types(), org, &models, |pieces, model| {
             // C++ Architecture::setPrototype resolves the function via queryFunction
             // (which lazily builds the Funcdata from the function symbol) and locks
             // the prototype.  In the kuna console boundary the named function may live
@@ -670,7 +679,7 @@ fn run_parse_c(status: &mut IfaceStatus, content: &str) -> IfaceResult<()> {
             // pieces are captured here and stashed (applied at load time) rather
             // than rejected — letting `parse line extern` take effect and the test
             // proceed to decompile.  // STUB(W4 queryFunction/FuncProto restore)
-            *captured.borrow_mut() = Some(pieces);
+            *captured.borrow_mut() = Some((pieces, model.to_string()));
             Ok(())
         });
         (org, captured.into_inner(), res)
@@ -678,7 +687,7 @@ fn run_parse_c(status: &mut IfaceStatus, content: &str) -> IfaceResult<()> {
     let _ = org; // org is consumed by parse_c; kept for symmetry with the C++ glb
     match parse_result {
         Ok(()) => {
-            if let Some(pieces) = extern_pieces {
+            if let Some((pieces, model)) = extern_pieces {
                 // C++ `Architecture::setPrototype(pieces)` (architecture.cc:393):
                 // resolve the FunctionSymbol by name and lock the parsed prototype
                 // onto it (`fd->getFuncProto().setPieces(pieces)`).  In kuna the
@@ -691,7 +700,24 @@ fn run_parse_c(status: &mut IfaceStatus, content: &str) -> IfaceResult<()> {
                 // param type and `RulePieceStructure` cannot split its CONCAT into
                 // per-field writes.  (Generic over the signature: keyed by the
                 // declared name only, exactly as the C++ `queryFunction(basename)`.)
-                apply_prototype_to_symbol(status, &pieces)?;
+                // The calling convention the declaration named (`__stdcall` &c.),
+                // so parameter storage is assigned under it rather than under the
+                // architecture default.
+                let model = {
+                    let dcp = dcp_mut(status)?;
+                    match dcp.conf.as_mut() {
+                        Some(prog) => {
+                            let m = crate::assertions::declared_model(prog, &model);
+                            if let Some(m) = m.as_ref() {
+                                prog.arch_mut()
+                                    .set_function_prototype_model(&pieces.name, m.clone());
+                            }
+                            m
+                        }
+                        None => None,
+                    }
+                };
+                apply_prototype_to_symbol(status, &pieces, model.as_ref())?;
                 // Also stash for re-application when THIS function is the one being
                 // decompiled (the IR is rebuilt on `decompile`, discarding the
                 // symbol-table proto link for the active Funcdata).
@@ -827,7 +853,16 @@ fn retype_symbol_if_complete(
     if pieces.outtype.is_none() {
         return Ok(());
     }
-    apply_prototype_to_symbol(status, pieces)
+    // A convention a previous `prototype` directive named for this function is
+    // kept: the incremental `param`/`return` rebuild must not silently revert
+    // the signature to the architecture default.
+    let model = {
+        let dcp = dcp_mut(status)?;
+        dcp.conf
+            .as_ref()
+            .and_then(|prog| prog.arch().function_prototype_model(&pieces.name).cloned())
+    };
+    apply_prototype_to_symbol(status, pieces, model.as_ref())
 }
 
 /// Parse the `<storage> <C typedeclaration>` tail both `map param` and `map
@@ -890,9 +925,11 @@ pub(crate) fn bind_prototype(
         let arch = prog.arch();
         let (addr_size, word_size) = arch.data_org();
         let org = crate::grammar::DataOrg { addr_size, word_size };
-        let captured: RefCell<Option<kuna_decomp::fspec::PrototypePieces>> = RefCell::new(None);
-        let parsed = crate::grammar::parse_c(&text, arch.types(), org, |pieces| {
-            *captured.borrow_mut() = Some(pieces);
+        let captured: RefCell<Option<(kuna_decomp::fspec::PrototypePieces, String)>> =
+            RefCell::new(None);
+        let models: Vec<String> = arch.proto_model_names().map(str::to_string).collect();
+        let parsed = crate::grammar::parse_c(&text, arch.types(), org, &models, |pieces, model| {
+            *captured.borrow_mut() = Some((pieces, model.to_string()));
             Ok(())
         });
         (parsed, captured.into_inner())
@@ -901,7 +938,7 @@ pub(crate) fn bind_prototype(
         status.out(&format!("Error in C syntax: {}\n", e.explain()));
         return Err(IfaceError::execution("Bad C syntax"));
     }
-    let mut pieces =
+    let (mut pieces, model) =
         captured.ok_or_else(|| IfaceError::execution("Not a function declaration"))?;
     let dcp = dcp_mut(status)?;
     let prog = dcp
@@ -910,7 +947,8 @@ pub(crate) fn bind_prototype(
         .ok_or_else(|| IfaceError::execution("No load image present"))?;
     let target = crate::assertions::resolve_proto_target(prog, func)
         .map_err(IfaceError::execution)?;
-    crate::assertions::park_prototype(prog, &target, &mut pieces);
+    let model = crate::assertions::declared_model(prog, &model);
+    crate::assertions::park_prototype(prog, &target, &mut pieces, model.as_ref());
     dcp.pending_prototypes.insert(target.name().to_string(), pieces);
     Ok(())
 }

--- a/decompiler/crates/kuna-decomp/src/infra/architecture.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/architecture.rs
@@ -1611,6 +1611,13 @@ pub struct Architecture {
     /// A `BTreeMap` (ADR 0002) for deterministic iteration matching the C++
     /// `map<string,ProtoModel*>` ordered traversal in `parseCompilerConfig`.
     proto_models: std::collections::BTreeMap<String, Rc<ProtoModel>>,
+    /// The calling convention a function was DECLARED under, by function name
+    /// (`--assert 'prototype f void * __stdcall f(...)'`, `parse line extern`).
+    /// Joined against the parked [`crate::fspec::PrototypePieces`] in
+    /// [`Self::build_arch_handle`] so a caller's `ActionDefaultParams` assigns
+    /// the callee's parameter storage under the declared convention instead of
+    /// the architecture default.  Empty when no declaration named one.
+    declared_proto_models: std::collections::BTreeMap<String, Rc<ProtoModel>>,
     /// The default prototype model (C++ `defaultfp`).  `None` until a cspec is
     /// parsed (or a default is seeded by [`build_default_proto`]).
     defaultfp: Option<Rc<ProtoModel>>,
@@ -1963,6 +1970,7 @@ impl Architecture {
             types: Rc::new(TypeFactoryImpl::new()),
             print: PrintC::new(),
             proto_models: std::collections::BTreeMap::new(),
+            declared_proto_models: std::collections::BTreeMap::new(),
             defaultfp: None,
             evalfp_current: None,
             evalfp_current_spec: None,
@@ -3400,6 +3408,23 @@ impl Architecture {
         // `ActionDefaultParams` copies a known callee's locked `FuncProto` into the
         // call site (C++ `coreaction.cc:2385` `fc->copy(otherfunc->getFuncProto())`).
         ctx.callee_protos = self.symboltab.build_callee_proto_pieces();
+        // (kuna) The convention each of those callees was DECLARED under, keyed
+        // the same way the pieces are (entry address).  The declaration names the
+        // function, the parked pieces carry that name, and the read side
+        // (`ArchContext::callee_proto_model`) is address-keyed — so the join
+        // happens here, once per drive, rather than at every call site.
+        ctx.callee_proto_models = if self.declared_proto_models.is_empty() {
+            Vec::new()
+        } else {
+            ctx.callee_protos
+                .iter()
+                .filter_map(|(space_index, offset, pieces)| {
+                    self.declared_proto_models
+                        .get(&pieces.name)
+                        .map(|m| (*space_index, *offset, Rc::clone(m)))
+                })
+                .collect()
+        };
         // Carry the constant-pointer-inference config (C++ `glb->infer_pointers` /
         // `infer_funcentry`) and the ordered inferable-pointer spaces (C++
         // `glb->inferPtrSpaces`, built by cacheAddrSpaceProperties) so
@@ -4293,6 +4318,17 @@ impl Architecture {
     /// to `defaultfp` when unset (C++ `evalfp_current==0 ? defaultfp : …`).
     pub fn eval_fp_current(&self) -> Option<&Rc<ProtoModel>> {
         self.evalfp_current.as_ref().or(self.defaultfp.as_ref())
+    }
+
+    /// Record the calling convention `name` was declared under (see
+    /// [`Self::declared_proto_models`]).
+    pub fn set_function_prototype_model(&mut self, name: &str, model: Rc<ProtoModel>) {
+        self.declared_proto_models.insert(name.to_string(), model);
+    }
+
+    /// The calling convention `name` was declared under, or `None`.
+    pub fn function_prototype_model(&self, name: &str) -> Option<&Rc<ProtoModel>> {
+        self.declared_proto_models.get(name)
     }
 
     /// Register a prototype model under its name (C++ `protoModels[name] =`).

--- a/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs
@@ -1039,8 +1039,14 @@ pub fn decompile_func_full_with_override_dyn_prefollowed(
             // pieces so parameter storage is assigned under the SAME
             // convention the database committed (see
             // `Architecture::kuna_pending_proto_model`); `None` everywhere
-            // else keeps the architecture default.
-            fd.apply_locked_prototype_with_model(pieces, staged_proto_model.clone())?;
+            // else keeps the architecture default.  Standalone, the same slot
+            // carries a convention the declaration itself named
+            // (`void * __stdcall f(...)`), so the function decompiles under the
+            // convention it was declared with rather than the default one.
+            let declared_model = staged_proto_model
+                .clone()
+                .or_else(|| fd.get_arch().callee_proto_model(&entry_addr));
+            fd.apply_locked_prototype_with_model(pieces, declared_model)?;
         }
         // Re-seed any console `map param <i> <addr> <typedecl>` storage locks (lost
         // when the IR is rebuilt, like `pending_proto`/`mapped_symbols`).  This makes

--- a/decompiler/crates/kuna-decomp/src/substrate/context.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/context.rs
@@ -1137,6 +1137,14 @@ pub struct ArchContext {
     /// `fc->copy(otherfunc->getFuncProto())` (`coreaction.cc:2385`).  Empty for
     /// hand-built fixtures and undeclared callees.
     pub callee_protos: Vec<(int4, kuna_base::types::uintb, crate::fspec::PrototypePieces)>,
+    /// The calling convention each declared callee was declared under, keyed the
+    /// same way [`Self::callee_protos`] is.  Snapshotted at `build_arch_handle`
+    /// from the architecture's declared-convention map and read back by
+    /// [`Self::callee_proto_model`], so `ActionDefaultParams` seeds the locked
+    /// callee pieces under the declared convention rather than `defaultfp`.
+    /// Empty when no declaration named a convention.
+    pub callee_proto_models:
+        Vec<(int4, kuna_base::types::uintb, Rc<crate::fspec::ProtoModel>)>,
     /// Snapshot of the engine's tracked-register database (C++ `glb->context`'s
     /// track base, populated by `set track <reg> <val> [start end]`).  The
     /// per-function `glb` skeleton does not hold the `ContextDatabase`, so
@@ -1169,6 +1177,7 @@ impl ArchContext {
             lanerecords: Vec::new(),
             opbehaviors: Vec::new(),
             floatformats: Vec::new(),
+            callee_proto_models: Vec::new(),
             defaultfp: None,
             evalfp_current: None,
             default_return_addr: None,
@@ -1456,16 +1465,25 @@ impl ArchContext {
     /// to copy the locked callee prototype into the call site.  Matched by
     /// `(space_index, offset)` — the ArchContext carries no `Rc<AddrSpace>` identities for
     /// the global scope, only the snapshotted indices.
-    /// (kuna, Phase 3) The host-declared prototype MODEL of a locked callee
-    /// signature (ghidra-mode `<prototype model=…>`), when the remote provider
-    /// resolved one — the model `ActionDefaultParams` seeds the locked pieces
-    /// under instead of `defaultfp`.  `None` on the standalone path (the CLI's
-    /// `parse line extern` pieces are model-less), keeping it byte-identical.
+    /// The prototype MODEL a locked callee signature was declared under — the
+    /// model `ActionDefaultParams` seeds the locked pieces under instead of
+    /// `defaultfp`.  Two sources: ghidra-mode's host `<prototype model=…>`
+    /// (Phase 3), and a standalone declaration that named a calling convention
+    /// (`--assert 'prototype f void * __stdcall f(...)'`).  `None` when the
+    /// declaration named none, which keeps the default-model seed.
     pub fn callee_proto_model(
         &self,
         addr: &Address,
     ) -> Option<std::rc::Rc<crate::fspec::ProtoModel>> {
-        self.remote_scope.as_ref()?.callee_model_at(addr)
+        if let Some(remote) = &self.remote_scope {
+            return remote.callee_model_at(addr);
+        }
+        let space_index = addr.get_space()?.get_index();
+        let offset = addr.get_offset();
+        self.callee_proto_models
+            .iter()
+            .find(|(sp, off, _)| *sp == space_index && *off == offset)
+            .map(|(_, _, m)| std::rc::Rc::clone(m))
     }
 
     pub fn callee_proto_pieces(&self, addr: &Address) -> Option<crate::fspec::PrototypePieces> {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -219,7 +219,7 @@ One directive per `--assert`, keyed by intent rather than by phase:
 
 | directive | what it states |
 |---|---|
-| `prototype <func> <C declaration>` | the signature of `<func>` — a name or an entry address (parameter names included) |
+| `prototype <func> <C declaration>` | the signature of `<func>` — a name or an entry address (parameter names and calling convention included) |
 | `param [<func>::]<i> <storage> <C typedecl>` | the storage and type of one input |
 | `return [<func>::]<storage> <C typedecl>` | the storage and type of the return value |
 | `name [<func>::]<symbol> <newname>` | rename a local |
@@ -303,6 +303,23 @@ kuna decompile ./illusion.exe 0x401571 --assert-strict \
 - void sub_401571(unsigned int a0,int4 a1,int4 a2)
 + void sub_401571(uint4 key,uint4 start,uint4 end)
 ```
+
+**A prototype may name its calling convention**, in either of the two C
+positions — before the return type, or between the return type's `*` and the
+function name, which is where Windows headers put it:
+
+```bash
+kuna decompile ./Cube.exe sub_401ba0 \
+  --assert 'prototype 0x4050a6 void * __stdcall LoadLibraryExW(unsigned short *n,void *f,unsigned int g)'
+```
+
+The conventions you may name are the ones the target's compiler spec declares —
+`__stdcall`, `__cdecl`, `__fastcall` and `__thiscall` on x86 Windows,
+`__stdcall`, `MSABI` and `syscall` on x86-64 gcc. The convention decides where
+each argument lives, so declaring one on a callee changes what the caller's
+arguments resolve to. A spelling the spec does not declare is **rejected**
+rather than ignored, so a misremembered convention name cannot silently leave
+the default in place.
 
 Widths come from the target's own compiler spec, so `long` is eight bytes on LP64
 and four on LLP64. Ghidra's sized spellings (`int4`, `uint8`, `float8`,

--- a/docs/features/prototype-assertion-parser-rejects/pr_body.md
+++ b/docs/features/prototype-assertion-parser-rejects/pr_body.md
@@ -1,0 +1,55 @@
+## The problem
+
+A prototype assertion that names a calling convention is rejected as bad C
+syntax. Every Windows API declaration worth pasting carries one, and the
+`__stdcall` spelling is exactly what an agent repairing stack arguments reaches
+for:
+
+```bash
+kuna decompile ./Cube.exe sub_401ba0 --assert-strict \
+  --assert 'prototype 0x4050a6 void * __stdcall LoadLibraryExW(unsigned short *n,void *f,unsigned int g)'
+```
+
+```text
+warning: --assert "prototype 0x4050a6 void * __stdcall LoadLibraryExW(...)" rejected: Bad C syntax
+$ echo $?
+1
+```
+
+Dropping `__stdcall` from the same declaration is accepted, so the convention is
+the only thing in the way — and nothing in `kuna docs`, the assertion reference
+or the option catalog offers another way to state one.
+
+## The fix
+
+- `CParse::lookup_identifier` classifies an identifier the loaded compiler spec
+  registered as a prototype model into a function specifier, which is upstream's
+  `glb->hasModel` arm — a stub since the port, for want of a model registry the
+  `Architecture` has had for a while. The registry decides: a spelling the spec
+  does not declare stays an identifier and is still rejected, so a misremembered
+  convention cannot be silently dropped.
+- The C-standard specifier run ends at the `*`, so a pointer-returning function
+  has nowhere to put its convention. The declarator accepts one on either side
+  of the pointer run, which also covers the Win32 callback shape
+  `int (__stdcall *cb)(int)`.
+- The named convention is resolved against the registry and recorded against the
+  function. It drives storage in both directions: the function's own prototype
+  is seeded under it, and the prototype-bearing `TypeCode` locked onto the symbol
+  is built under it — which is the copy a *caller* reads, so declaring a callee
+  `__fastcall` moves where the caller's arguments come from. Accepting the
+  keyword without that second half would be a directive that parses and does
+  nothing.
+
+## The tests
+
+Seven parser cases in `kuna-console` (both specifier positions, the callback
+shape, an unregistered convention still rejected, two conventions rejected, and
+the no-registry parse rejected exactly as before). Two promoted probes on the
+in-repo `fauxware` fixture: `prototype-assertion-parser-rejects.json` is the
+acceptance, and `prototype-convention-is-honored.json` is the anti-swallow guard
+— declaring `accepted()` `MSABI` renders `accepted(a3)` instead of
+`accepted((int)v4)`, which a fix that lexed the keyword and dropped it would
+fail. Gates: `make test` 675/675 PARITY OK, `make test-stages` 677/677 PARITY
+OK, `make test-cli` 70/70, `make check-spec` OK, `kuna catalog --check` OK.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/prototype-assertion-parser-rejects/record.json
+++ b/docs/features/prototype-assertion-parser-rejects/record.json
@@ -1,0 +1,47 @@
+{
+  "need_id": "prototype-assertion-parser-rejects",
+  "track": "tooling",
+  "scope": "small",
+  "worker": "b-r7-prototype-assert",
+  "branch": "feat/re-prototype-assertion-parser-rejects",
+  "summary": "A prototype assertion naming a calling convention (`void * __stdcall f(...)`) parses, and the named convention drives parameter storage for the function and for its callers.",
+  "decisions": [
+    {
+      "what": "The filed hypothesis is upheld and the named file/line was right.",
+      "detail": "`CParse::lookup_identifier` (grammar.rs) returned `IdentClass::Identifier` where upstream returns FUNCTION_SPECIFIER for `glb->hasModel(nm)` -- a STUB(w6-fspec-2) left when the Architecture had no model registry. It has one now (`Architecture::get_model`/`proto_model_names`, fed by the cspec `<prototype name=...>` decode), so the arm is a lookup, not a feature."
+    },
+    {
+      "what": "The refuter's warning drove the design: the acceptance is satisfiable by a fix that does nothing.",
+      "detail": "Restoring only the lookup would let `__stdcall` lex and be dropped, keeping the default model. The convention is therefore resolved to an `Rc<ProtoModel>` and used at BOTH seeding sites: `Funcdata::apply_locked_prototype_with_model` for the function's own prototype, and the prototype-bearing `TypeCode` built by `lock_prototype_on_symbol` / `apply_prototype_to_symbol`, which is what a caller reads back through `ArchContext::query_callee_proto`. Measured: on the witness binary, declaring LoadLibraryExW `__fastcall` renders `LoadLibraryExW(name,file,v1 + (int)file)` where `__stdcall`/`__cdecl`/no-convention all render `LoadLibraryExW((unsigned short *)(v1 + v6),file,flags)`."
+    },
+    {
+      "what": "Second grammar gap found while implementing, not in the filing.",
+      "detail": "The reported spelling puts the convention in DECLARATOR position (after the return type's `*`), which upstream's `declaration_specifiers` run cannot reach. `CParse::declarator` / `declarator_or_abstract_or_empty` now accept a convention on either side of the pointer run, and the parenthesised-declarator lookahead in `direct_abstract_or_concrete` admits one so `int (__stdcall *cb)(int)` is a declarator rather than a function suffix."
+    },
+    {
+      "what": "No option row, no stage test.",
+      "detail": "Tooling track: the change is reachable only through an explicit operator directive (`--assert prototype` / `map prototype` / `parse line extern`), so it cannot move default output. `make test` 675/675 and `make test-stages` 677/677 confirm zero movement."
+    },
+    {
+      "what": "Files another builder holds were avoided.",
+      "detail": "`decompiler/crates/kuna-decomp/src/p4_calls` is leased by `defined-payload-function-loses`. The natural C++-faithful shape (a `model` field on `PrototypePieces`) lives there, so the convention rides an address-keyed side channel instead: `Architecture::declared_proto_models` joined onto the parked pieces in `build_arch_handle` and read through the EXISTING `ArchContext::callee_proto_model` seam, which `ActionDefaultParams` already consumes. Zero p4_calls edits."
+    }
+  ],
+  "acceptance": {
+    "probe": "a-75f3ebee0ff0",
+    "status": "PASS",
+    "promoted": [
+      "tests/cli/prototype-assertion-parser-rejects.json",
+      "tests/cli/prototype-convention-is-honored.json"
+    ],
+    "note": "The recorded acceptance targets a dataset binary, so `verify --promote` refuses it. Both promoted probes are retargeted onto the in-repo `fauxware` fixture (the pattern `accepted-sqrt-prototype-still.json` established); x86-64-gcc.cspec names its default model `__stdcall` and also registers `MSABI`, so the same post-pointer position and the same honoring check run with no dataset."
+  },
+  "gates": {
+    "make test": "PARITY OK, 675/675",
+    "make test-stages": "PARITY OK, 677/677",
+    "make test-cli": "70/70",
+    "make check-spec": "OK",
+    "kuna catalog --check": "OK",
+    "make rust-test": "green with `env -u KUNA_DECOMP_TEST`. With the launcher's KUNA_DECOMP_TEST set, `verify_w10_proto_unlock` fails 'oracle promote_compare signature drifted' -- the oracle becomes kuna itself and the assertion requires the removed C++ tree's `xunknown4` spelling, so it cannot pass for any kuna build. CI skips that block."
+  }
+}

--- a/docs/re-needs/prototype-assertion-parser-rejects.md
+++ b/docs/re-needs/prototype-assertion-parser-rejects.md
@@ -1,0 +1,143 @@
+---
+need_id: prototype-assertion-parser-rejects
+title: Prototype assertion parser rejects __stdcall
+track: tooling
+status: open
+severity: major
+probe_id: p-2bf0ba72577a
+acceptance_id: a-75f3ebee0ff0
+hypothesis_status: upheld
+credibility: 0.3
+instances: 1
+challenges: [6442366033c5d43938912a85]
+rounds: [7]
+first_seen_round: 7
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-cli]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Specify the Windows API calling convention while repairing stack arguments.
+
+> **Prototype assertion parser rejects __stdcall** (major, `?`)
+> Rejects the address-targeted __stdcall declaration as Bad C syntax, exit 1. The declaration without __stdcall succeeds. Help, assertion documentation, and catalog revealed no documented convention override.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_401ba0",
+    "--assert",
+    "prototype 0x4050a6 void * __stdcall LoadLibraryExW(unsigned short *name,void *file,unsigned int flags)",
+    "--assert-strict"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 1
+    },
+    "stderr_matches": [
+      "rejected",
+      "Bad C syntax"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/Cube.exe",
+    "binary_sha256": "6b80dcaa066884e4f7b71373f85aabcdb824d27593c1e4adf113a80e47062aeb",
+    "binary_size": 193024,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_401ba0",
+    "--assert",
+    "prototype 0x4050a6 void * __stdcall LoadLibraryExW(unsigned short *name,void *file,unsigned int flags)",
+    "--assert-strict"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stderr_absent": [
+      "rejected"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/Cube.exe",
+    "binary_sha256": "6b80dcaa066884e4f7b71373f85aabcdb824d27593c1e4adf113a80e47062aeb",
+    "binary_size": 193024,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- The assertion parser may not support calling-convention qualifiers.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `?` (round ?, tester ?)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+- round 7 REFUTER: hypothesis **upheld** (was inconclusive). REFUTED IN-TICK 2026-09-07 ~10:45Z by the captain. VERDICT: UPHELD, AND THE GAP IS AN EXPLICITLY-NAMED PORT STUB THAT MENTIONS __stdcall BY NAME. This is the cheapest need in the round-7 backlog and it is worth more than its 'major/cred 0.3' filing suggests -- see 3.
+
+REPRO (same arena binary as resource-loader-c-retains: arena/7/6442366033c5d43938912a85/target/Cube.exe):
+  kuna decompile $B sub_401ba0 --assert 'prototype 0x4050a6 void * __stdcall LoadLibraryExW(unsigned short *name,void *file,unsigned int flags)' --assert-strict
+  -> warning: ... rejected: Bad C syntax
+Drop the __stdcall and the SAME declaration is accepted. Reproduces at HEAD.
+
+1. FILE AND LINE. decompiler/crates/kuna-console/src/grammar.rs:1362-1366, CParse::lookup_identifier:
+    // glb->hasModel(nm) -> FUNCTION_SPECIFIER. The kuna Architecture has no
+    // model registry, so this never fires (it would classify e.g.
+    // "__stdcall" as a function specifier).  // STUB(w6-fspec-2)
+    IdentClass::Identifier
+Upstream classifies any identifier the Architecture knows as a prototype model into a FUNCTION_SPECIFIER token; kuna returns plain Identifier, so '__stdcall' lands where the grammar expects a type specifier and the parse dies as 'Bad C syntax'. Nothing else is missing: the REST OF THE PATH IS ALREADY PORTED -- TypeSpecifiers::function_specifier (grammar.rs:1074), the duplicate guard at 1503-1506 ('Multiple parameter models'), and merge_spec_dec copying it into TypeDeclarator::model (1455) all exist and are dead for want of the lookup. And the models themselves exist: specs/Ghidra/Processors/x86/data/languages/x86win.cspec declares __stdcall, __cdecl, __fastcall and __thiscall. So this is a registry lookup, not a feature.
+
+2. THE ACCEPTANCE IS SATISFIABLE BY A FIX THAT DOES NOTHING -- FLAG THIS AT B_DONE. The acceptance asserts only exit 0 + stderr_absent 'rejected'. A patch that merely SWALLOWS the keyword (lexes it, drops it on the floor, keeps the default __cdecl model) passes verbatim while the declared convention is silently ignored -- which on i386 is the difference between callee-pops and caller-pops and would MIS-model the stack. Require the acceptance (or a stage test) to prove the convention is HONORED: assert a __stdcall-declared callee actually changes the caller's stack behaviour vs the same declaration without it, not just that the error stopped. Same rule the refute-tick memory records for absence needs.
+
+3. WHY THIS NEED IS UNDERPRICED, AND THE CROSS-NEED LINK. It was filed as the tester's WORKAROUND for resource-loader-c-retains (same binary, same API, address 0x4050a6 is the LoadLibraryExW import). I measured the workaround this tick: the plain, convention-less assertion
+  --assert 'prototype 0x4050a6 void * LoadLibraryExW(unsigned short *name,void *file,unsigned int flags)'
+turns 'LoadLibraryExW();' into 'LoadLibraryExW((unsigned short *)(v1 + v6),file,flags);'. So a locked prototype IS the lever that recovers Win32 import arguments today, and this stub is the only thing standing between an agent and using it in the conventional spelling. Fixing it makes the second, larger need workaroundable from the CLI even before that need is fixed.
+
+TRACK/SCOPE: tooling, small, and it stays small -- one lookup arm plus wherever TypeDeclarator::model has to reach the FuncProto. Do not let it grow into 'add a model registry to Architecture' without a proposal; the cspec already holds the models and the lookup only needs to ask the loaded ProtoModel set.
+- captain r7 B_PLAN: challenges was [] so resolve_binary had no hexid and the bound target could not resolve; filled from rounds/7/gate.json (the observation that filed this need).
+- round 7 REFUTER: hypothesis **upheld**. CAPTAIN r7 B_PLAN: acceptance is now TARGET-BOUND (challenges/6442366033c5d43938912a85/bin/Cube.exe, sha 6b80dcaa0668...); the record's challenges list was EMPTY, so the probe could not resolve {{BIN}} at all until I filled it from rounds/7/gate.json. Re-measured runnable and still FAILING at sha 0bd41f10: exit_code 1 and stderr still contains 'rejected'. Note credibility is only 0.3 on a single instance -- confirm the symptom reproduces before building, and note that several siblings in this family already shipped (prototype-assertion-rejects-explicit, qualified-parameter-assertions-modify, prototype-assertions-reject-ordinary are all closed), so read their PRs first: the __stdcall keyword may be one row in an existing grammar rather than new machinery.

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -977,6 +977,31 @@ that happens to be spelled with a keyword resolve to exactly the interned type
 they always did. Only combinations, and the keywords the type factory does not
 name, take the width-driven path.
 
+(kuna) **A `prototype` declaration may name its calling convention**, which is
+the other half of speaking the target's own C: on Windows every declaration
+worth pasting carries one. An identifier the loaded compiler spec registered as
+a prototype model is classified as a function specifier rather than as a bare
+identifier (`decompiler/crates/kuna-console/src/grammar.rs
+(CParse::lookup_identifier)`, upstream's `glb->hasModel`), so `__stdcall`,
+`__cdecl`, `__fastcall` and `__thiscall` parse on an x86 Windows target and
+`MSABI` or `syscall` parse on x86-64 gcc — while a spelling the spec does not
+declare stays an identifier and the declaration is still rejected, so a
+misremembered name cannot be silently dropped. C admits the specifier in two
+positions and both are accepted: before the return type (`int __fastcall
+f(int)`) and in declarator position, after the return type's `*` and before the
+name (`void * __stdcall LoadLibraryExW(...)`, the spelling Windows headers and
+Ghidra's own listings use, which the C-standard specifier run cannot reach
+because it ends at the `*`). The same allowance covers a parenthesised
+declarator, so the callback shape `int (__stdcall *cb)(int)` parses too. Naming
+two conventions in one declaration is the error `addFuncSpecifier` already had a
+diagnostic for, `Multiple parameter models`.
+
+Where the named convention goes is §4: it is resolved against the architecture's
+model registry and rides with the parked prototype, so the declared function's
+parameter storage — and, for a callee, the storage a *caller* reads its arguments
+out of — is assigned under the convention the operator declared rather than
+under the target's default.
+
 A directive that names no function binds to the function being decompiled, which
 is unambiguous only when the run selected exactly one; on a whole-binary run it
 would silently mean *every* function that happens to have a `v2`, so it is

--- a/docs/spec/04-calls-and-prototypes.md
+++ b/docs/spec/04-calls-and-prototypes.md
@@ -64,8 +64,23 @@ default under that name — and the name rule then gives the clone
 `hasThisPointer`. Aliasing a merged model, or an alias of an alias, is refused
 exactly as upstream refuses it.
 
-Registration selects nothing. Which model a function is evaluated with is
-unchanged by the presence of the named ones: nothing reads the registry except
+Registration selects nothing by itself. Which model a function is evaluated with
+is unchanged by the presence of the named ones; three things read the registry.
+The first is a **declaration that names its convention** — `--assert 'prototype
+<func> void * __stdcall f(...)'` and the console `map prototype` / `parse line
+extern` behind it (00 §0.2). The parser only classifies an identifier as a
+convention because the registry names it, so the resolution cannot fail: the
+resolved `ProtoModel` is recorded against the function
+(`decompiler/crates/kuna-decomp/src/infra/architecture.rs
+(Architecture::set_function_prototype_model)`) and used in both directions. The
+function's own prototype is seeded under it rather than under `defaultfp`, and
+the prototype-bearing `TypeCode` the declaration locks onto the symbol is built
+under it too — which is the copy a CALLER reads (`ArchContext::query_callee_proto`
+/ `ArchContext::callee_proto_model`,
+`decompiler/crates/kuna-decomp/src/substrate/context.rs`), so declaring a callee
+`__fastcall` moves where the caller's arguments come from. Without that second
+half the keyword would parse and change nothing, which is the failure mode the
+directive exists to avoid. The other two are
 `option defaultprototype` / `option protoeval`
 (`decompiler/crates/kuna-decomp/src/p0_knowledge/options.rs (OptionDefaultPrototype,
 OptionProtoEval)`) — the ABI-trust knob of the `abi-trust` sub-phase row in
@@ -426,7 +441,9 @@ unknown. Before any of it, the drive
 (`decompiler/crates/kuna-decomp/src/infra/decompile_drive.rs`) asks whether the
 signature is already known, and locks it if so
 (`decompiler/crates/kuna-decomp/src/substrate/funcdata.rs
-(Funcdata::apply_locked_prototype)`). Two sources, in precedence order: a
+(Funcdata::apply_locked_prototype)`). The model it is locked under is the one the
+declaration named when it named one (§4.1), else the architecture default. Two
+sources, in precedence order: a
 prototype the operator declared for this run (`parse line extern …` /
 `map prototype <func> …`, 00 §0.2), then the
 prototype parked on the function's own global `FunctionSymbol` — which is where

--- a/tests/cli/prototype-assertion-parser-rejects.json
+++ b/tests/cli/prototype-assertion-parser-rejects.json
@@ -1,0 +1,39 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "main",
+    "--assert",
+    "prototype 0x4006ed void * __stdcall accepted(int4 status)",
+    "--assert-strict"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "binary_sha256": "c2d90645a45e99221593547e55c601a901b80f807ae96f94c60a7661df0b3e0b",
+    "binary_size": 8776,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "selector": "main",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stderr_absent": [
+      "rejected",
+      "Bad C syntax"
+    ]
+  },
+  "notes": "Retargeted onto the in-repo fauxware fixture: same defect, no dataset. The dataset witness is Cube.exe sub_401ba0 with 'prototype 0x4050a6 void * __stdcall LoadLibraryExW(...)'; x86-64-gcc.cspec names its default model __stdcall too, so the same post-pointer position hits the same lookup. Before the fix: 'rejected: Bad C syntax', exit 1. Paired with prototype-convention-is-honored.json."
+}

--- a/tests/cli/prototype-convention-is-honored.json
+++ b/tests/cli/prototype-convention-is-honored.json
@@ -1,0 +1,44 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "main",
+    "--assert",
+    "prototype 0x4006ed int4 MSABI accepted(int4 status)",
+    "--assert-strict"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "binary_sha256": "c2d90645a45e99221593547e55c601a901b80f807ae96f94c60a7661df0b3e0b",
+    "binary_size": 8776,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "selector": "main",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "accepted\\(a3\\)"
+    ],
+    "stdout_absent": [
+      "accepted\\(\\(int\\)"
+    ],
+    "stderr_absent": [
+      "rejected"
+    ]
+  },
+  "notes": "The anti-swallow guard for prototype-assertion-parser-rejects: accepting the keyword is not enough, it has to drive storage. x86-64-gcc.cspec registers MSABI (RCX/RDX/R8/R9) beside the System V default; declaring accepted() MSABI moves its argument off the stack and the call renders accepted(a3), not accepted((int)v4). Lexing the keyword and dropping it fails here."
+}


### PR DESCRIPTION
## The problem

A prototype assertion that names a calling convention is rejected as bad C
syntax. Every Windows API declaration worth pasting carries one, and the
`__stdcall` spelling is exactly what an agent repairing stack arguments reaches
for:

```bash
kuna decompile ./Cube.exe sub_401ba0 --assert-strict \
  --assert 'prototype 0x4050a6 void * __stdcall LoadLibraryExW(unsigned short *n,void *f,unsigned int g)'
```

```text
warning: --assert "prototype 0x4050a6 void * __stdcall LoadLibraryExW(...)" rejected: Bad C syntax
$ echo $?
1
```

Dropping `__stdcall` from the same declaration is accepted, so the convention is
the only thing in the way — and nothing in `kuna docs`, the assertion reference
or the option catalog offers another way to state one.

## The fix

- `CParse::lookup_identifier` classifies an identifier the loaded compiler spec
  registered as a prototype model into a function specifier, which is upstream's
  `glb->hasModel` arm — a stub since the port, for want of a model registry the
  `Architecture` has had for a while. The registry decides: a spelling the spec
  does not declare stays an identifier and is still rejected, so a misremembered
  convention cannot be silently dropped.
- The C-standard specifier run ends at the `*`, so a pointer-returning function
  has nowhere to put its convention. The declarator accepts one on either side
  of the pointer run, which also covers the Win32 callback shape
  `int (__stdcall *cb)(int)`.
- The named convention is resolved against the registry and recorded against the
  function. It drives storage in both directions: the function's own prototype
  is seeded under it, and the prototype-bearing `TypeCode` locked onto the symbol
  is built under it — which is the copy a *caller* reads, so declaring a callee
  `__fastcall` moves where the caller's arguments come from. Accepting the
  keyword without that second half would be a directive that parses and does
  nothing.

## The tests

Seven parser cases in `kuna-console` (both specifier positions, the callback
shape, an unregistered convention still rejected, two conventions rejected, and
the no-registry parse rejected exactly as before). Two promoted probes on the
in-repo `fauxware` fixture: `prototype-assertion-parser-rejects.json` is the
acceptance, and `prototype-convention-is-honored.json` is the anti-swallow guard
— declaring `accepted()` `MSABI` renders `accepted(a3)` instead of
`accepted((int)v4)`, which a fix that lexed the keyword and dropped it would
fail. Gates: `make test` 675/675 PARITY OK, `make test-stages` 677/677 PARITY
OK, `make test-cli` 70/70, `make check-spec` OK, `kuna catalog --check` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
