### PR TITLE
[AUTOMATED] feat(cli): decompile a headerless image at an explicit target and base

### DIFF
--- a/decompiler/crates/kuna-cli/src/decompile.rs
+++ b/decompiler/crates/kuna-cli/src/decompile.rs
@@ -463,8 +463,16 @@ fn selection_failure(out: &str) -> Option<String> {
 /// The architecture arm must stay ahead of the analysis-commit arm: a failed
 /// `load file` leaves no image, so every later command — `read symbols`
 /// included — answers `No load image present`, which is a consequence, not the
-/// reason.
-fn check_errors(out: &str, target: &str, binary: &str, by_address: bool) -> Option<String> {
+/// reason. `unmapped_is_external` is false for raw images because their seeds
+/// are known to be mapped; a short or undecodable raw image can produce the
+/// same loader diagnostic while failing to decode a real entry.
+fn check_errors(
+    out: &str,
+    target: &str,
+    binary: &str,
+    by_address: bool,
+    unmapped_is_external: bool,
+) -> Option<String> {
     if out.contains("Could not discover root of Ghidra installation") {
         return Some(
             "decomp_dbg could not find SLEIGH specs; pass --sleighpath or set SLEIGHHOME".into(),
@@ -501,8 +509,10 @@ fn check_errors(out: &str, target: &str, binary: &str, by_address: bool) -> Opti
     // report names every candidate. Return it verbatim: the transcript dump the
     // caller falls back to is capped at its FIRST 2000 characters, which in the
     // default mode is all option chatter, so the answer would be cut off. The
-    // unmapped-entry probe stays ahead of it — an external is not a bad selector.
-    if !is_unmapped_entry(out) {
+    // For object inputs, the unmapped-entry probe stays ahead of it — an
+    // external is not a bad selector. Raw entries were range-validated at load,
+    // so the same text is a decode failure and must remain an error.
+    if !(unmapped_is_external && is_unmapped_entry(out)) {
         if let Some(reason) = selection_failure(out) {
             return Some(reason);
         }
@@ -526,10 +536,11 @@ fn is_unknown_function(out: &str) -> bool {
 /// (`LoadImage::load_fill`'s "Unable to load N bytes at <addr>", raised the
 /// moment the flow-follower asks for the first instruction).
 ///
-/// That is the signature of an **external**: an entry that carries an address
-/// for call naming but whose definition is in another module. It is not
-/// reachable for a real function — a mapped entry that fails mid-pipeline
-/// surfaces as the `Skipping <name>` notice below instead.
+/// For an object-backed input, that is the signature of an **external**: an
+/// entry that carries an address for call naming but whose definition is in
+/// another module. A raw image can emit the same diagnostic when a mapped entry
+/// reaches EOF or undecodable trailing bytes, so callers must not apply this
+/// shortcut to raw inputs.
 fn is_unmapped_entry(out: &str) -> bool {
     out.contains("Unable to load ") && out.contains(" bytes at ")
 }
@@ -1011,7 +1022,13 @@ fn decompile(args: &DecompileArgs) -> Result<DecompileOutcome, String> {
         let stdout_text = String::from_utf8_lossy(&output.stdout).into_owned();
         let stderr_text = String::from_utf8_lossy(&output.stderr).into_owned();
         let combined = format!("{stdout_text}\n{stderr_text}");
-        if let Some(msg) = check_errors(&combined, &args.target, &binary, by_address) {
+        if let Some(msg) = check_errors(
+            &combined,
+            &args.target,
+            &binary,
+            by_address,
+            !args.raw_image,
+        ) {
             return Err((msg, !by_address && is_unknown_function(&combined)));
         }
 
@@ -1030,7 +1047,7 @@ fn decompile(args: &DecompileArgs) -> Result<DecompileOutcome, String> {
             // way through `kuna_console::project::decompile_targets`, which asks
             // the engine directly (`ConsoleProgram::entry_bytes_mapped`); this
             // path drives `decomp_dbg` as a subprocess and so reads its report.
-            if is_unmapped_entry(&combined) {
+            if !args.raw_image && is_unmapped_entry(&combined) {
                 return Ok(DecompileOutcome {
                     c: format!(
                         "// {}: external symbol -- no code at this address in this module",
@@ -1739,7 +1756,7 @@ Decompilation complete
     #[test]
     fn load_failure_matches_the_in_process_wording() {
         assert_eq!(
-            check_errors(EMPTY_SCOPE, "main", "/x/hostile_scope_x86_64", false).as_deref(),
+            check_errors(EMPTY_SCOPE, "main", "/x/hostile_scope_x86_64", false, true).as_deref(),
             Some(
                 "could not build an architecture for /x/hostile_scope_x86_64: \
                  Non-global scope has empty name"
@@ -1753,7 +1770,7 @@ Decompilation complete
         let out = "Could not create architecture\n";
         assert_eq!(arch_failure_reason(out), None);
         assert_eq!(
-            check_errors(out, "main", "/x/a.out", false).as_deref(),
+            check_errors(out, "main", "/x/a.out", false, true).as_deref(),
             Some("could not build an architecture for /x/a.out (unsupported/!recognized binary)")
         );
     }
@@ -1765,7 +1782,7 @@ Decompilation complete
         let out = "[decomp]> load file /x/a.out\nCould not create architecture\n[decomp]> quit\n";
         assert_eq!(arch_failure_reason(out), None);
         assert!(
-            check_errors(out, "main", "/x/a.out", false)
+            check_errors(out, "main", "/x/a.out", false, true)
                 .expect("still an error")
                 .ends_with("(unsupported/!recognized binary)")
         );
@@ -1780,7 +1797,7 @@ Decompilation complete
             Some("g_a symbol created with zero size type")
         );
         assert_eq!(
-            check_errors(COMMIT_FAILED, "main", "/x/sz.elf", false).as_deref(),
+            check_errors(COMMIT_FAILED, "main", "/x/sz.elf", false, true).as_deref(),
             Some("read symbols (analysis commit) failed: g_a symbol created with zero size type")
         );
     }
@@ -1798,7 +1815,7 @@ Execution error: Unknown function name: nosuch
 ";
         assert_eq!(read_symbols_failure(other), None);
         assert!(
-            check_errors(EMPTY_SCOPE, "main", "/x/hostile_scope_x86_64", false)
+            check_errors(EMPTY_SCOPE, "main", "/x/hostile_scope_x86_64", false, true)
                 .expect("still an error")
                 .starts_with("could not build an architecture"),
             "the load failure wins over the No-load-image consequence"
@@ -1818,7 +1835,7 @@ Decompilation complete
 ";
         assert_eq!(read_symbols_failure(out), None);
         assert_eq!(arch_failure_reason(out), None);
-        assert_eq!(check_errors(out, "main", "/x/a.out", false), None);
+        assert_eq!(check_errors(out, "main", "/x/a.out", false, true), None);
     }
 
     /// The real console transcript shape (`decomp_dbg` echoes the prompt, then

--- a/decompiler/crates/kuna-cli/src/decompile.rs
+++ b/decompiler/crates/kuna-cli/src/decompile.rs
@@ -55,6 +55,10 @@ pub struct DecompileArgs {
     pub slice: Option<String>,
     /// Explicit ARM instruction-set state for every mapped code section.
     pub isa: Option<ArmIsa>,
+    /// Treat the input as a headerless contiguous image.
+    pub raw_image: bool,
+    /// Address assigned to raw file offset zero.
+    pub base: Option<u64>,
 }
 
 /// Whether an `--option` value selects the "on" state (the `on_or_off` token set
@@ -100,6 +104,15 @@ fn selected_vma(target: &str, by_address: bool) -> Option<u64> {
     u64::from_str_radix(digits, 16).ok()
 }
 
+fn parse_cli_address(value: &str) -> Result<u64, String> {
+    let value = value.trim();
+    let digits = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+        .unwrap_or(value);
+    u64::from_str_radix(digits, 16).map_err(|_| format!("invalid address {value:?}"))
+}
+
 /// Quote a path for the console script when — and only when — it needs it.
 ///
 /// The console reads a filename with `CommandStream::read_filename`, which
@@ -141,11 +154,13 @@ fn reject_unquotable(what: &str, path: &str) -> Result<(), String> {
 }
 
 /// Build the stdin script fed to `decomp_dbg` — port of `_build_script`.
-fn build_script(
+fn build_script_for_input(
     binary: &str,
     target: &str,
     by_address: bool,
     bfd_target: Option<&str>,
+    raw_image: bool,
+    base: Option<u64>,
     raw: bool,
     out_path: &Path,
     injected: &[(&'static str, &'static str)],
@@ -170,9 +185,15 @@ fn build_script(
             .filter(move |f| f.slot == slot)
     };
     let image = console_path(binary);
-    match bfd_target {
-        Some(t) if !t.is_empty() => lines.push(format!("load file {t} {image}")),
-        _ => lines.push(format!("load file {image}")),
+    if raw_image {
+        let language = bfd_target.expect("raw parser requires --target");
+        let base = base.expect("raw parser requires --base");
+        lines.push(format!("load raw {language} 0x{base:x} {target} {image}"));
+    } else {
+        match bfd_target {
+            Some(t) if !t.is_empty() => lines.push(format!("load file {t} {image}")),
+            _ => lines.push(format!("load file {image}")),
+        }
     }
     // `option` lines MUST precede `read symbols`: the kuna_analysis passes are
     // committed (gated by the per-pass `--option <id> on|off` flags) inside
@@ -284,6 +305,27 @@ fn build_script(
     }
     lines.push("quit".into());
     lines.join("\n") + "\n"
+}
+
+#[cfg(test)]
+fn build_script(
+    binary: &str,
+    target: &str,
+    by_address: bool,
+    bfd_target: Option<&str>,
+    raw: bool,
+    out_path: &Path,
+    injected: &[(&'static str, &'static str)],
+    options: &[(String, String)],
+    kasserts: &[String],
+    func_decls: &[crate::funcdecl::FuncDecl],
+    assertions: &[kuna_console::assertions::Directive],
+    regions_path: Option<&Path>,
+) -> String {
+    build_script_for_input(
+        binary, target, by_address, bfd_target, false, None, raw, out_path, injected, options,
+        kasserts, func_decls, assertions, regions_path,
+    )
 }
 
 /// The console prompt `decomp_dbg` writes before echoing each command; a
@@ -748,11 +790,13 @@ fn decompile(args: &DecompileArgs) -> Result<DecompileOutcome, String> {
     // whether a `<func>::`-qualified directive binds to the selection.
     let selected: Option<&str> = if by_address { None } else { Some(args.target.as_str()) };
     let attempt = |injected: &[(&'static str, &'static str)]| {
-        let script = build_script(
+        let script = build_script_for_input(
             &binary,
             &args.target,
             by_address,
             args.bfd_target.as_deref(),
+            args.raw_image,
+            args.base,
             args.raw,
             &out_path,
             injected,
@@ -1144,6 +1188,8 @@ pub fn main(argv: &[String]) -> i32 {
     let mut sleighpath: Option<String> = None;
     let mut slice: Option<String> = None;
     let mut isa: Option<ArmIsa> = None;
+    let mut raw_image = false;
+    let mut base: Option<u64> = None;
 
     let mut i = 0;
     while i < argv.len() {
@@ -1152,6 +1198,17 @@ pub fn main(argv: &[String]) -> i32 {
             "--addr" => addr = true,
             "--json" => json = true,
             "--raw" => raw = true,
+            "--raw-image" => raw_image = true,
+            "--base" => match take_value(argv, &mut i, "--base") {
+                Some(value) => match parse_cli_address(&value) {
+                    Ok(value) => base = Some(value),
+                    Err(error) => {
+                        eprintln!("error: {error}");
+                        return 2;
+                    }
+                },
+                None => return 2,
+            },
             "--regions" => regions = true,
             "--slice" => slice = take_value(argv, &mut i, "--slice"),
             "--isa" => match take_value(argv, &mut i, "--isa") {
@@ -1294,6 +1351,29 @@ pub fn main(argv: &[String]) -> i32 {
     }
     addr |= looks_like_addr(&target);
 
+    if raw_image {
+        if bfd_target.as_deref().is_none_or(|value| value.trim().is_empty()) {
+            eprintln!("error: --raw-image requires --target <SLEIGH-language-id>");
+            return 2;
+        }
+        if base.is_none() {
+            eprintln!("error: --raw-image requires --base <address>");
+            return 2;
+        }
+        if parse_cli_address(&target).is_err() {
+            eprintln!("error: --raw-image requires a numeric entry address");
+            return 2;
+        }
+        if slice.is_some() {
+            eprintln!("error: --slice does not apply to --raw-image input");
+            return 2;
+        }
+        addr = true;
+    } else if base.is_some() {
+        eprintln!("error: --base requires --raw-image");
+        return 2;
+    }
+
     if json {
         // Refused, not ignored: each of these is a `decomp_dbg` transcript the
         // in-process JSON path never produces, and silently dropping half a
@@ -1318,6 +1398,8 @@ pub fn main(argv: &[String]) -> i32 {
             bfd_target: bfd_target.as_deref(),
             slice: slice.as_deref(),
             sleighpath: sleighpath.as_deref(),
+            raw_image,
+            base,
         });
     }
 
@@ -1360,6 +1442,8 @@ pub fn main(argv: &[String]) -> i32 {
         sleighpath,
         slice,
         isa,
+        raw_image,
+        base,
     })
 }
 
@@ -1383,6 +1467,7 @@ fn usage() {
          \x20                     [--assert DIRECTIVE|@FILE].. [--assert-strict] \\\n\
          \x20                     [--isa auto|arm|thumb] [--slice ARCH] [--target T] \\\n\
          \x20                     [--sleighpath D] [--decomp-dbg P]\n\
+         \x20                     [--raw-image --target T --base VMA]\n\
          \n\
          Decompile ONE function.  The target is a name, or an address with --addr\n\
          (a `0x`-prefixed target implies it).  --json emits the decompile-all record\n\
@@ -1430,6 +1515,8 @@ struct JsonRequest<'a> {
     bfd_target: Option<&'a str>,
     slice: Option<&'a str>,
     sleighpath: Option<&'a str>,
+    raw_image: bool,
+    base: Option<u64>,
 }
 
 /// `kuna decompile --json`: `decompile-all`'s in-process load narrowed to the one
@@ -1453,6 +1540,11 @@ fn run_json(req: &JsonRequest) -> i32 {
     } else {
         argv.push("--functions".into());
         argv.push(req.target.to_string());
+    }
+    if req.raw_image {
+        argv.push("--raw-image".into());
+        argv.push("--base".into());
+        argv.push(format!("0x{:x}", req.base.expect("raw parser requires --base")));
     }
     argv.extend(req.forwarded.iter().cloned());
     for (flag, value) in [

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -651,13 +651,17 @@ fn summary_json(
     summary: &Summary,
     selected: usize,
     error: Option<&str>,
+    display_address: &dyn Fn(u64) -> u64,
 ) -> String {
     let entry = match &summary.entry {
-        Some((vma, name)) => Json::Object(vec![
-            ("name".into(), Json::Str(name.clone())),
-            ("address".into(), Json::Number(vma.to_string())),
-            ("address_hex".into(), Json::Str(format!("0x{vma:x}"))),
-        ]),
+        Some((vma, name)) => {
+            let address = display_address(*vma);
+            Json::Object(vec![
+                ("name".into(), Json::Str(name.clone())),
+                ("address".into(), Json::Number(address.to_string())),
+                ("address_hex".into(), Json::Str(format!("0x{address:x}"))),
+            ])
+        }
         None => Json::Null,
     };
     let buckets = Json::Array(
@@ -703,20 +707,26 @@ fn summary_json(
                     ("no_callers".into(), Json::Number(summary.no_callers.to_string())),
                     ("code_bytes".into(), Json::Number(summary.code_bytes.to_string())),
                     ("size_buckets".into(), buckets),
-                    ("largest".into(), entries_json(&summary.largest)),
+                    ("largest".into(), entries_json(&summary.largest, display_address)),
                 ])
             ),
         ]))
     )
 }
 
-fn summary_text(binary: &str, summary: &Summary, selected: usize) -> String {
+fn summary_text(
+    binary: &str,
+    summary: &Summary,
+    selected: usize,
+    display_address: &dyn Fn(u64) -> u64,
+) -> String {
     let mut out = String::new();
     let _ = writeln!(out, "binary\t{binary}");
     let _ = writeln!(out, "functions\t{selected} selected / {} discovered", summary.total);
     match &summary.entry {
         Some((vma, name)) => {
-            let _ = writeln!(out, "entry\t0x{vma:x}\t{name}");
+            let address = display_address(*vma);
+            let _ = writeln!(out, "entry\t0x{address:x}\t{name}");
         }
         None => {
             let _ = writeln!(out, "entry\t(none declared)");
@@ -733,7 +743,8 @@ fn summary_text(binary: &str, summary: &Summary, selected: usize) -> String {
     }
     let _ = writeln!(out, "largest:");
     for e in &summary.largest {
-        let _ = writeln!(out, "  0x{:x}\t{}\t{}", e.addr.get_offset(), e.size, e.name);
+        let address = display_address(e.addr.get_offset());
+        let _ = writeln!(out, "  0x{address:x}\t{}\t{}", e.size, e.name);
     }
     out
 }
@@ -871,7 +882,13 @@ pub fn run_functions(argv: &[String]) -> i32 {
                 }
             };
             let text = if args.json {
-                functions_json(&args.binary, &entries, total, discovery_error.as_deref())
+                functions_json(
+                    &args.binary,
+                    &entries,
+                    total,
+                    discovery_error.as_deref(),
+                    &|address| prog.output_code_offset(address),
+                )
             } else {
                 let mut text = String::new();
                 for e in &entries {
@@ -882,7 +899,8 @@ pub fn run_functions(argv: &[String]) -> i32 {
                     } else {
                         format!("\t({})", e.aliases.join(", "))
                     };
-                    let _ = writeln!(text, "0x{:x}\t{}{extra}", e.addr.get_offset(), e.name);
+                    let address = prog.output_code_offset(e.addr.get_offset());
+                    let _ = writeln!(text, "0x{address:x}\t{}{extra}", e.name);
                 }
                 text
             };
@@ -925,9 +943,20 @@ fn run_summary(args: &Args, filters: &Filters) -> i32 {
     };
     let summary = summarize(&prog, &args.binary, args.slice_pref(), filters, &graph, &all, &selected);
     let text = if args.json {
-        summary_json(&args.binary, &summary, selected.len(), discovery_error.as_deref())
+        summary_json(
+            &args.binary,
+            &summary,
+            selected.len(),
+            discovery_error.as_deref(),
+            &|address| prog.output_code_offset(address),
+        )
     } else {
-        summary_text(&args.binary, &summary, selected.len())
+        summary_text(
+            &args.binary,
+            &summary,
+            selected.len(),
+            &|address| prog.output_code_offset(address),
+        )
     };
     emit_with_discovery_error(&text, discovery_error.as_deref())
 }
@@ -1804,6 +1833,7 @@ fn functions_json(
     entries: &[FunctionEntry],
     total: usize,
     error: Option<&str>,
+    display_address: &dyn Fn(u64) -> u64,
 ) -> String {
     format!(
         "{}\n",
@@ -1812,19 +1842,19 @@ fn functions_json(
             ("count".into(), Json::Number(entries.len().to_string())),
             ("total".into(), Json::Number(total.to_string())),
             ("error".into(), error_json(error)),
-            ("functions".into(), entries_json(entries)),
+            ("functions".into(), entries_json(entries, display_address)),
         ]))
     )
 }
 
 /// The inventory-record array shared by the `functions` listing and the
 /// `--summary` document's `largest`.
-fn entries_json(entries: &[FunctionEntry]) -> Json {
+fn entries_json(entries: &[FunctionEntry], display_address: &dyn Fn(u64) -> u64) -> Json {
     Json::Array(
         entries
             .iter()
             .map(|e| {
-                let a = e.addr.get_offset();
+                let a = display_address(e.addr.get_offset());
                 Json::Object(vec![
                     ("name".into(), Json::Str(e.name.clone())),
                     ("address".into(), Json::Number(a.to_string())),
@@ -2030,6 +2060,7 @@ mod provenance_json_tests {
         let function = FuncResult {
             name: "f".into(),
             address: 0x401000,
+            byte_address: 0x401000,
             size: 12,
             code: Some("int f(int x)\n{\n  return x;\n}".into()),
             error: None,
@@ -2659,9 +2690,15 @@ mod discovery_tests {
     /// reads it unconditionally rather than inferring failure from `count`.
     #[test]
     fn the_run_level_error_field_is_always_present() {
-        let healthy = functions_json("fixture", &[], 0, None);
+        let healthy = functions_json("fixture", &[], 0, None, &|address| address);
         assert!(healthy.contains("\"error\": null"), "{healthy}");
-        let failed = functions_json("fixture", &[], 0, Some("no functions discovered in fixture"));
+        let failed = functions_json(
+            "fixture",
+            &[],
+            0,
+            Some("no functions discovered in fixture"),
+            &|address| address,
+        );
         assert!(
             failed.contains("\"error\": \"no functions discovered in fixture\""),
             "{failed}"

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -87,8 +87,8 @@ use std::fmt::Write as _;
 use kuna_analysis::listing::xrefs::{Xref, XrefIndex, XrefKind};
 use kuna_analysis::loader::macho_fat::SlicePref;
 use kuna_console::engine::{
-    bootstrap_from_object_with_isa, ArmIsa, ConsoleProgram, EntryLookupError, EntrySelector,
-    FunctionEntry, ObjectLocation,
+    bootstrap_from_object_with_isa, bootstrap_from_raw, ArmIsa, ConsoleProgram, EntryLookupError,
+    EntrySelector, FunctionEntry, ObjectLocation,
 };
 // The decompile loop + result shape live in the shared decompile-project core
 // (`kuna_console::project` — also reused by the `kuna_wasm` front-end).
@@ -145,6 +145,10 @@ pub(crate) struct Args {
     pub(crate) target: Option<String>,
     pub(crate) sleighpath: Option<String>,
     pub(crate) isa: Option<ArmIsa>,
+    /// Treat the input as one headerless, contiguous code image.
+    pub(crate) raw_image: bool,
+    /// Address assigned to raw file offset zero.
+    pub(crate) base: Option<u64>,
 }
 
 impl Args {
@@ -1175,16 +1179,42 @@ pub(crate) fn load_program(
 
     let spec_roots = spec_roots(args.sleighpath.as_deref());
     let target = args.target.as_deref().unwrap_or("");
-    let mut prog =
-        bootstrap_from_object_with_isa(&binary, target, &spec_roots, args.isa).map_err(|e| {
-            let reason = e.explain();
-            let msg = format!("could not build an architecture for {binary}: {reason}");
-            if reason.contains("No sleigh specification") {
-                format!("{msg}\nnote: {}", paths::SPECS_HINT)
-            } else {
-                msg
-            }
-        })?;
+    let mut prog = if args.raw_image {
+        let entries: Vec<u64> = args
+            .addrs
+            .iter()
+            .filter_map(|selector| match selector {
+                EntrySelector::Numeric(entry) => Some(*entry),
+                _ => None,
+            })
+            .collect();
+        bootstrap_from_raw(
+            &binary,
+            target,
+            args.base.expect("raw parser requires --base"),
+            &entries,
+            args.isa,
+            &spec_roots,
+        )
+    } else {
+        bootstrap_from_object_with_isa(&binary, target, &spec_roots, args.isa)
+    }
+    .map_err(|e| {
+        let detail = e.explain();
+        let msg = format!("could not build an architecture for {binary}: {detail}");
+        if detail.contains("No sleigh specification") {
+            return format!("{msg}\nnote: {}", paths::SPECS_HINT);
+        }
+        let raw_hint = if !args.raw_image
+            && (detail.contains("not in recognized object file format")
+                || detail.contains("Unsupported file format"))
+        {
+            "; for a headerless image use --raw-image --target <SLEIGH-language-id> --base <address> and at least one --entry/--addr <address>"
+        } else {
+            ""
+        };
+        format!("{msg}{raw_hint}")
+    })?;
 
     for (name, value) in driver_default_options(
         &binary,
@@ -1237,7 +1267,15 @@ pub(crate) fn resolve_targets(
 
     // Resolve every address form through the program's shared selector model.
     for selector in &args.addrs {
-        targets.push(prog.resolve_entry(selector).map_err(|error| error.to_string())?);
+        let selector = match (args.raw_image, selector) {
+            (true, EntrySelector::Numeric(entry)) => EntrySelector::Numeric(
+                prog.input_code_offset(*entry)
+                    .map_err(|error| error.explain().to_string())?,
+            ),
+            (true, _) => unreachable!("raw parser requires numeric entries"),
+            (false, selector) => selector.clone(),
+        };
+        targets.push(prog.resolve_entry(&selector).map_err(|error| error.to_string())?);
     }
 
     // `--functions a,b,c`: intersect names with the enumerated set.  An ALIAS
@@ -2135,6 +2173,9 @@ pub(crate) fn parse_args_with_filters(
     let mut target: Option<String> = None;
     let mut sleighpath: Option<String> = None;
     let mut isa: Option<ArmIsa> = None;
+    let mut raw_image = false;
+    let mut base: Option<u64> = None;
+    let mut saw_entry = false;
     let mut saw_language = false;
 
     let mut i = 0;
@@ -2147,8 +2188,10 @@ pub(crate) fn parse_args_with_filters(
                 let v = take(argv, &mut i, "--functions")?;
                 names = Some(v.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect());
             }
-            "--addr" => {
-                let v = take(argv, &mut i, "--addr")?;
+            "--addr" | "--entry" => {
+                let flag = a;
+                saw_entry |= flag == "--entry";
+                let v = take(argv, &mut i, flag)?;
                 addrs.push(parse_entry_selector(&v)?);
             }
             "--define-function" => {
@@ -2221,6 +2264,8 @@ pub(crate) fn parse_args_with_filters(
             "--mode" => mode = Some(take(argv, &mut i, "--mode")?),
             "--slice" => slice = Some(take(argv, &mut i, "--slice")?),
             "--isa" => isa = ArmIsa::parse(&take(argv, &mut i, "--isa")?)?,
+            "--raw-image" => raw_image = true,
+            "--base" => base = Some(parse_hex(&take(argv, &mut i, "--base")?)?),
             "--target" => target = Some(take(argv, &mut i, "--target")?),
             "--sleighpath" => sleighpath = Some(take(argv, &mut i, "--sleighpath")?),
             "-h" | "--help" => {
@@ -2244,6 +2289,40 @@ pub(crate) fn parse_args_with_filters(
     }
 
     let binary = binary.ok_or_else(|| format!("{cmd} requires <binary>"))?;
+
+    if raw_image {
+        if cmd == "decompile-graph" {
+            return Err("--raw-image is not supported by decompile-graph".into());
+        }
+        if target.as_deref().is_none_or(|value| value.trim().is_empty()) {
+            return Err("--raw-image requires --target <SLEIGH-language-id>".into());
+        }
+        if base.is_none() {
+            return Err("--raw-image requires --base <address>".into());
+        }
+        if names.is_some() {
+            return Err("--raw-image uses explicit --entry/--addr seeds, not --functions".into());
+        }
+        if addrs.is_empty() {
+            return Err("--raw-image requires at least one --entry or --addr".into());
+        }
+        if addrs.iter().any(|selector| !matches!(selector, EntrySelector::Numeric(_))) {
+            return Err("raw image entries must be numeric addresses".into());
+        }
+        if slice.is_some() {
+            return Err("--slice does not apply to --raw-image input".into());
+        }
+        if filters.reachable_from.is_some() || filters.summary {
+            return Err("--reachable-from and --summary require object-file metadata and do not apply to --raw-image input".into());
+        }
+    } else {
+        if base.is_some() {
+            return Err("--base requires --raw-image".into());
+        }
+        if saw_entry {
+            return Err("--entry requires --raw-image".into());
+        }
+    }
 
     // (kuna outlang, DIV-80) The auto policy: with no `--language` and no
     // explicit `--option setlanguage`, follow the binary. `decompile-project` and
@@ -2303,6 +2382,8 @@ pub(crate) fn parse_args_with_filters(
             target,
             sleighpath,
             isa,
+            raw_image,
+            base,
         },
         filters,
     ))
@@ -2346,6 +2427,7 @@ fn usage_decompile_all() {
          \x20                   [--reachable-from <name|0xaddr>] [--sort addr|size|name] [--limit N] \\\n\
          \x20                   [--summary] [--define-function S[-E][=N]|@FILE].. \\\n\
          \x20                   [--option N V].. [--isa auto|arm|thumb] [--slice ARCH] [--target T] [--sleighpath D]\n\
+         \x20                   [--raw-image --target T --base VMA (--entry|--addr VMA)..]\n\
          \n\
          Decompile every CODE-backed function in one in-process load (load-once,\n\
          decompile-many).  --json emits {{binary,count,functions:[{{name,address,code,variables,..}}]}};\n\
@@ -2379,6 +2461,7 @@ fn usage_functions() {
          \x20               [--reachable-from <name|0xaddr>] [--sort addr|size|name] [--limit N] \\\n\
          \x20               [--define-function S[-E][=N]|@FILE].. \\\n\
          \x20               [--mode auto|reliable|aggressive|fast] [--isa auto|arm|thumb] [--slice ARCH] [--target T] [--sleighpath D]\n\
+         \x20               [--raw-image --target T --base VMA (--entry|--addr VMA)..]\n\
          \n\
          List every function kuna discovers in a binary as `<addr>\\t<name>` (or\n\
          --json: {{binary,count,total,functions:[{{name,address,address_hex,aliases,size}}]}}).\n\

--- a/decompiler/crates/kuna-cli/src/decompile_graph.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_graph.rs
@@ -172,7 +172,7 @@ fn export(args: &Args, label: &str) -> Result<String, String> {
         }
     }
     let by_address: BTreeMap<u64, &FuncResult> =
-        results.iter().map(|result| (result.address, result)).collect();
+        results.iter().map(|result| (result.byte_address, result)).collect();
 
     let bytes = crate::decompile_all::image_bytes(&args.binary, args.slice_pref())?;
     let file = kuna_analysis::loadimage_object::parse_object(&*bytes)

--- a/decompiler/crates/kuna-cli/src/decompile_project.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_project.rs
@@ -99,6 +99,7 @@ fn usage() {
          \x20                   [--addr 0xVMA].. [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] \\\n\
          \x20                   [--define-function S[-E][=N]|@FILE].. \\\n\
          \x20                   [--option N V].. [--isa auto|arm|thumb] [--slice ARCH] [--target T] [--sleighpath D]\n\
+         \x20                   [--raw-image --target T --base VMA (--entry|--addr VMA)..]\n\
          \n\
          Decompile a whole binary in one in-process load and write a project folder\n\
          (default `<binary-filename>.kuna/` next to the binary; -o DIR overrides):\n\

--- a/decompiler/crates/kuna-cli/src/disassemble.rs
+++ b/decompiler/crates/kuna-cli/src/disassemble.rs
@@ -322,6 +322,8 @@ fn load_args(args: &DisArgs, options: Vec<(String, String)>) -> Args {
         target: args.target.clone(),
         sleighpath: args.sleighpath.clone(),
         isa: args.isa,
+        raw_image: false,
+        base: None,
     }
 }
 

--- a/decompiler/crates/kuna-cli/src/funcdecl.rs
+++ b/decompiler/crates/kuna-cli/src/funcdecl.rs
@@ -54,6 +54,7 @@ pub(crate) struct FuncDecl {
 impl FuncDecl {
     /// The declared byte extent, or `0` for "unbounded" (the engine-wide
     /// `UNBOUNDED_SIZE` convention).
+    #[cfg(test)]
     pub(crate) fn size(&self) -> u64 {
         self.end.map(|end| end - self.start).unwrap_or(0)
     }
@@ -153,8 +154,31 @@ pub(crate) fn apply(
         return Err("--define-function: the loaded program has no default code space".into());
     };
     for decl in decls {
-        let addr = kuna_base::address::Address::new(std::rc::Rc::clone(&space), decl.start);
-        prog.declare_function(addr, decl.name.as_deref(), decl.size() as kuna_base::types::int4)
+        let start = prog
+            .input_code_offset(decl.start)
+            .map_err(|e| format!("--define-function {:#x}: {}", decl.start, e.explain()))?;
+        let size = match decl.end {
+            None => 0,
+            Some(end) => {
+                let end = prog.input_code_offset(end).map_err(|e| {
+                    format!("--define-function {:#x}: {}", decl.start, e.explain())
+                })?;
+                let size = end.checked_sub(start).filter(|size| *size > 0).ok_or_else(|| {
+                    format!(
+                        "--define-function {:#x}: end must be above start after target address conversion",
+                        decl.start
+                    )
+                })?;
+                kuna_base::types::int4::try_from(size).map_err(|_| {
+                    format!(
+                        "--define-function {:#x}: byte extent {size:#x} exceeds the supported range",
+                        decl.start
+                    )
+                })?
+            }
+        };
+        let addr = kuna_base::address::Address::new(std::rc::Rc::clone(&space), start);
+        prog.declare_function(addr, decl.name.as_deref(), size)
             .map_err(|e| {
                 format!("--define-function {:#x}: {}", decl.start, e.explain())
             })?;

--- a/decompiler/crates/kuna-cli/src/main.rs
+++ b/decompiler/crates/kuna-cli/src/main.rs
@@ -95,11 +95,11 @@ fn usage() {
     eprintln!(
         "usage: kuna <decompile|decompile-all|decompile-project|decompile-graph|functions|disassemble|read|xrefs|strings|unpack|docs|test|catalog|modes|specs|fid> ...\n\
          \n\
-         kuna decompile <binary> [--isa auto|arm|thumb] <func> [--addr] [--json] [--slice ARCH] [--language auto|c|rust] [--mode auto|reliable|aggressive|fast] [--option NAME VALUE]... [--kassert ARGS]... [--define-function S[-E][=N]|@FILE]... [--assert DIRECTIVE|@FILE]...\n\
-         kuna decompile-all <binary> [--isa auto|arm|thumb] [--json] [--functions a,b,..] [--addr 0xVMA]... [--no-vars] [--language auto|c|rust] [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] [--option N V]... [--define-function S[-E][=N]|@FILE]... [--assert DIRECTIVE|@FILE]...\n\
-         kuna decompile-project <binary> [--isa auto|arm|thumb] [-o DIR] [--functions a,b,..] [--addr 0xVMA]... [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] [--option N V]... [--define-function S[-E][=N]|@FILE]... [--assert DIRECTIVE|@FILE]...\n\
+         kuna decompile <binary> [--isa auto|arm|thumb] <func> [--addr] [--json] [--slice ARCH] [--language auto|c|rust] [--mode auto|reliable|aggressive|fast] [--option NAME VALUE]... [--kassert ARGS]... [--define-function S[-E][=N]|@FILE]... [--assert DIRECTIVE|@FILE]... [--raw-image --target T --base VMA]\n\
+         kuna decompile-all <binary> [--isa auto|arm|thumb] [--json] [--functions a,b,..] [--addr 0xVMA]... [--no-vars] [--language auto|c|rust] [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] [--option N V]... [--define-function S[-E][=N]|@FILE]... [--assert DIRECTIVE|@FILE]... [--raw-image --target T --base VMA (--entry|--addr VMA)...]\n\
+         kuna decompile-project <binary> [--isa auto|arm|thumb] [-o DIR] [--functions a,b,..] [--addr 0xVMA]... [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] [--option N V]... [--define-function S[-E][=N]|@FILE]... [--assert DIRECTIVE|@FILE]... [--raw-image --target T --base VMA (--entry|--addr VMA)...]\n\
          kuna decompile-graph <binary> [--isa auto|arm|thumb] [-o FILE] [--label TEXT] [--max-fn-seconds N] [--mode auto|reliable|aggressive|fast] [--option N V]... [--define-function S[-E][=N]|@FILE]...\n\
-         kuna functions <binary> [--isa auto|arm|thumb] [--json] [--mode auto|reliable|aggressive|fast] [--define-function S[-E][=N]|@FILE]...\n\
+         kuna functions <binary> [--isa auto|arm|thumb] [--json] [--mode auto|reliable|aggressive|fast] [--define-function S[-E][=N]|@FILE]... [--raw-image --target T --base VMA (--entry|--addr VMA)...]\n\
          kuna xrefs <binary> [--isa auto|arm|thumb] (--to <name|0xaddr> | --from <name|0xaddr>) [--json] [--kind call,jump,data,read,write] [--mode auto|reliable|aggressive|fast]\n\
          kuna unpack <binary> [-o OUT] [--json]\n\
          kuna strings <binary> [--isa auto|arm|thumb] [--json] [--min-length N] [--filter REGEX] [--encoding ascii|utf16|all] [--section NAME] [--no-xrefs]\n\

--- a/decompiler/crates/kuna-cli/src/strings.rs
+++ b/decompiler/crates/kuna-cli/src/strings.rs
@@ -190,6 +190,8 @@ fn attribute(
         target: args.target.clone(),
         sleighpath: args.sleighpath.clone(),
         isa: args.isa,
+        raw_image: false,
+        base: None,
     };
     let prog = load_program(&load, DriverDefaults::Inventory)?;
     // The inventory, read ONCE. `ConsoleProgram::find_entry_at` rebuilds and

--- a/decompiler/crates/kuna-cli/src/xrefs.rs
+++ b/decompiler/crates/kuna-cli/src/xrefs.rs
@@ -199,6 +199,8 @@ fn query(args: &XrefArgs) -> Result<String, String> {
         target: args.target.clone(),
         sleighpath: args.sleighpath.clone(),
         isa: args.isa,
+        raw_image: false,
+        base: None,
     };
     let prog = load_program(&load, DriverDefaults::Query)?;
 

--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -1301,6 +1301,16 @@ fn raw_image_decompile_scales_word_addressed_selector() {
     assert!(stdout.contains("sub_101"), "{stdout}");
 
     let (stdout, stderr, ok) = run_kuna(&[
+        "decompile", &binary, "0x101", "--regions", "--raw-image", "--target",
+        "avr8:LE:16:default", "--base", "0x100", "--sleighpath", &sp,
+    ]);
+    assert!(ok, "word-addressed raw regions failed: {stderr}");
+    assert!(stdout.contains("[0x101]"), "{stdout}");
+    assert!(stdout.contains("region head=0x101"), "{stdout}");
+    assert!(!stdout.contains("[0x202]"), "{stdout}");
+    assert!(!stdout.contains("region head=0x202"), "{stdout}");
+
+    let (stdout, stderr, ok) = run_kuna(&[
         "decompile", &binary, "0x101", "--json", "--raw-image", "--target",
         "avr8:LE:16:default", "--base", "0x100", "--sleighpath", &sp,
     ]);

--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -9,6 +9,8 @@
 //! the test prints that and returns early (a specs-less CI is a visible skip,
 //! never a false green).
 
+mod common;
+
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -1179,6 +1181,141 @@ fn dwarf_source_line_comments_stay_opt_in_under_every_mode() {
         opted_in.contains("/* debug_symbol.c:124 */"),
         "`--option dwarf_lines on` must still annotate source lines:\n{opted_in}"
     );
+}
+
+#[test]
+fn raw_image_supported_surfaces_share_seed_and_base_semantics() {
+    let path = common::scratch_file("raw thumb image", "bin");
+    std::fs::write(&path, [0x07, 0x20, 0x70, 0x47]).unwrap();
+    let binary = path.to_string_lossy().into_owned();
+    let sp = specs();
+    let target = "ARM:LE:32:v4t:default";
+    let spec = PathBuf::from(&sp).join("Ghidra/Processors/ARM/data/languages/ARM8_le.sla");
+    if !spec.exists() {
+        eprintln!("raw_image CLI: skipping (no ARM `.sla`)");
+        let _ = std::fs::remove_file(path);
+        return;
+    }
+
+    let (stdout, stderr, ok) = run_kuna(&[
+        "functions", &binary, "--json", "--raw-image", "--target", target, "--base",
+        "0x4000", "--entry", "0x4001", "--isa", "thumb", "--sleighpath", &sp,
+    ]);
+    assert!(ok, "raw functions failed: {stderr}");
+    assert!(stdout.contains("\"count\": 1"), "{stdout}");
+    assert!(stdout.contains("\"address_hex\": \"0x4000\""), "{stdout}");
+
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile-all", &binary, "--raw-image", "--target", target, "--base", "0x4000",
+        "--addr", "0x4001", "--isa", "thumb", "--sleighpath", &sp,
+    ]);
+    assert!(ok, "raw decompile-all failed: {stderr}");
+    assert!(stdout.contains("return 7;"), "unexpected raw body:\n{stdout}");
+
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile", &binary, "0x4001", "--json", "--raw-image", "--target", target,
+        "--base", "0x4000", "--isa", "thumb", "--sleighpath", &sp,
+    ]);
+    assert!(ok, "raw decompile --json failed: {stderr}");
+    assert!(stdout.contains("\"address\": 16384"), "{stdout}");
+    assert!(stdout.contains("return 7;"), "{stdout}");
+
+    let out_dir = common::scratch_file("raw-project", "dir");
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile-project", &binary, "-o", out_dir.to_str().unwrap(), "--raw-image",
+        "--target", target, "--base", "0x4000", "--entry", "0x4001", "--isa",
+        "thumb", "--sleighpath", &sp,
+    ]);
+    assert!(ok, "raw project export failed: {stderr}");
+    assert!(stdout.contains("functions: 1 ok, 0 failed"), "{stdout}");
+    let artifacts: Vec<String> = std::fs::read_dir(&out_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(artifacts.iter().any(|name| name.ends_with(".c")), "{artifacts:?}");
+    assert!(artifacts.iter().any(|name| name.ends_with(".asm")), "{artifacts:?}");
+    assert!(artifacts.iter().any(|name| name == "README.md"), "{artifacts:?}");
+
+    std::fs::remove_dir_all(out_dir).unwrap();
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn raw_image_decompile_scales_word_addressed_selector() {
+    let path = common::scratch_file("raw-avr-return", "bin");
+    std::fs::write(&path, [0, 0, 0x08, 0x95]).unwrap();
+    let binary = path.to_string_lossy().into_owned();
+    let sp = specs();
+    let spec = PathBuf::from(&sp).join("Ghidra/Processors/Atmel/data/languages/avr8.sla");
+    if !spec.exists() {
+        eprintln!("raw_image CLI: skipping (no AVR8 `.sla`)");
+        let _ = std::fs::remove_file(path);
+        return;
+    }
+
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile-all", &binary, "--raw-image", "--target", "avr8:LE:16:default",
+        "--base", "0x100", "--entry", "0x101", "--sleighpath", &sp,
+    ]);
+    assert!(ok, "word-addressed raw selector failed: {stderr}");
+    assert!(stdout.contains("sub_202"), "{stdout}");
+
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile", &binary, "0x101", "--raw-image", "--target", "avr8:LE:16:default",
+        "--base", "0x100", "--sleighpath", &sp,
+    ]);
+    assert!(ok, "word-addressed raw text decompile failed: {stderr}");
+    assert!(stdout.contains("sub_202"), "{stdout}");
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn raw_image_rejects_missing_metadata_and_object_only_surfaces() {
+    let path = common::scratch_file("raw-parser", "bin");
+    std::fs::write(&path, [0x07, 0x20, 0x70, 0x47]).unwrap();
+    let binary = path.to_string_lossy().into_owned();
+    let target = "ARM:LE:32:v4t:default";
+    let cases: &[(&[&str], &str)] = &[
+        (&["functions", &binary, "--raw-image", "--base", "0", "--entry", "0"],
+         "--raw-image requires --target"),
+        (&["functions", &binary, "--raw-image", "--target", target, "--entry", "0"],
+         "--raw-image requires --base"),
+        (&["functions", &binary, "--raw-image", "--target", target, "--base", "0"],
+         "--raw-image requires at least one"),
+        (&["functions", &binary, "--base", "0"], "--base requires --raw-image"),
+        (&["functions", &binary, "--entry", "0"], "--entry requires --raw-image"),
+        (&["functions", &binary, "--raw-image", "--target", target, "--base", "0",
+           "--functions", "main"], "not --functions"),
+        (&["functions", &binary, "--raw-image", "--target", target, "--base", "0",
+           "--addr", "main"], "invalid address"),
+        (&["functions", &binary, "--raw-image", "--target", target, "--base", "0",
+           "--addr", ".text+0"], "raw image entries must be numeric"),
+        (&["functions", &binary, "--raw-image", "--target", target, "--base", "0",
+           "--entry", "0", "--slice", "arm"], "--slice does not apply"),
+        (&["decompile-all", &binary, "--raw-image", "--target", target, "--base", "0",
+           "--entry", "0", "--summary"], "require object-file metadata"),
+        (&["decompile-graph", &binary, "--raw-image", "--target", target, "--base", "0",
+           "--entry", "0"], "not supported by decompile-graph"),
+        (&["disassemble", &binary, "0", "--raw-image", "--target", target, "--base", "0"],
+         "unknown option --raw-image"),
+    ];
+    for (args, expected) in cases {
+        let (_stdout, stderr, ok) = run_kuna(args);
+        assert!(!ok, "{args:?} unexpectedly succeeded");
+        assert!(stderr.contains(expected), "{args:?}: expected {expected:?}, got {stderr:?}");
+    }
+
+    let (_stdout, stderr, ok) = run_kuna(&["functions", &binary]);
+    assert!(!ok, "headerless input without raw flags unexpectedly loaded");
+    assert!(stderr.contains("--raw-image") && stderr.contains("--base"),
+            "unknown-format diagnostic omitted raw guidance: {stderr}");
+
+    let (_stdout, stderr, ok) = run_kuna(&[
+        "decompile", &binary, "main", "--raw-image", "--target", target, "--base", "0",
+    ]);
+    assert!(!ok, "named raw decompile entry unexpectedly succeeded");
+    assert!(stderr.contains("requires a numeric entry"), "{stderr}");
+    std::fs::remove_file(path).unwrap();
 }
 
 /// Every `"size": N` in a `--json` document, in document order.

--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -1323,7 +1323,7 @@ fn raw_image_decompile_scales_word_addressed_selector() {
     let (stdout, stderr, ok) = run_kuna(&[
         "decompile-project", &binary, "-o", out_dir.to_str().unwrap(), "--raw-image",
         "--target", "avr8:LE:16:default", "--base", "0x100", "--entry", "0x101",
-        "--sleighpath", &sp,
+        "--assert", "data 0x101 int foo", "--sleighpath", &sp,
     ]);
     assert!(ok, "word-addressed raw project failed: {stderr}");
     assert!(stdout.contains("functions: 1 ok, 0 failed"), "{stdout}");
@@ -1344,6 +1344,11 @@ fn raw_image_decompile_scales_word_addressed_selector() {
     assert!(c.contains("// Function: sub_101 @ 0x101"), "{c}");
     assert!(asm.contains("sub_101:  ; 0x101"), "{asm}");
     assert!(asm.contains("00000101:"), "{asm}");
+    let data_tail = asm.split("; --- data ---").nth(1).expect("project data tail");
+    assert!(data_tail.contains("foo:  ; 0x101"), "{data_tail}");
+    assert!(data_tail.contains("  00000101:"), "{data_tail}");
+    assert!(!data_tail.contains("foo:  ; 0x202"), "{data_tail}");
+    assert!(!data_tail.contains("  00000202:"), "{data_tail}");
     std::fs::remove_dir_all(out_dir).unwrap();
     std::fs::remove_file(path).unwrap();
 }

--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -1376,7 +1376,7 @@ fn raw_project_preserves_byte_addressed_data_coordinates() {
     let (stdout, stderr, ok) = run_kuna(&[
         "decompile-project", &binary, "-o", out_dir.to_str().unwrap(), "--raw-image",
         "--target", "avr8:LE:16:default", "--base", "0", "--entry", "0",
-        "--sleighpath", &sp,
+        "--assert", "data 0x80 int foo", "--sleighpath", &sp,
     ]);
     assert!(ok, "word-addressed raw data project failed: {stderr}");
     assert!(stdout.contains("functions: 1 ok, 0 failed"), "{stdout}");
@@ -1394,8 +1394,10 @@ fn raw_project_preserves_byte_addressed_data_coordinates() {
     .unwrap();
     assert!(c.contains("dat_100"), "{c}");
     let data_tail = asm.split("; --- data ---").nth(1).expect("project data tail");
+    assert!(data_tail.contains("foo:  ; 0x80"), "{data_tail}");
     assert!(data_tail.contains("dat_100:  ; 0x100"), "{data_tail}");
     assert!(data_tail.contains("  00000100:"), "{data_tail}");
+    assert!(!data_tail.contains("foo:  ; 0x80 = dat_100"), "{data_tail}");
     assert!(!data_tail.contains("dat_100:  ; 0x80"), "{data_tail}");
     std::fs::remove_dir_all(out_dir).unwrap();
     std::fs::remove_file(path).unwrap();
@@ -1483,6 +1485,20 @@ fn raw_text_decode_failure_is_not_reported_as_an_external() {
     assert!(!ok, "truncated mapped raw entry unexpectedly succeeded");
     assert!(!stdout.contains("external symbol"), "{stdout}");
     assert!(stderr.contains("Unable to load"), "{stderr}");
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn raw_text_unknown_format_hint_handles_a_leading_lt_byte() {
+    let path = common::scratch_file("raw-leading-lt", "bin");
+    std::fs::write(&path, [0x3c, 0x00, 0xc3]).unwrap();
+    let binary = path.to_string_lossy().into_owned();
+    let (_stdout, stderr, ok) = run_kuna(&["decompile", &binary, "0"]);
+    assert!(!ok, "headerless input without raw flags unexpectedly loaded");
+    assert!(
+        stderr.contains("--raw-image") && stderr.contains("--target") && stderr.contains("--base"),
+        "leading-< diagnostic omitted raw guidance: {stderr}"
+    );
     std::fs::remove_file(path).unwrap();
 }
 

--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -126,6 +126,9 @@ fn noreturn_error_fixture() -> String {
 /// Run the built `kuna` binary, returning `(stdout, stderr, success)`.
 fn run_kuna(args: &[&str]) -> (String, String, bool) {
     let out = Command::new(env!("CARGO_BIN_EXE_kuna"))
+        .env_remove("KUNA_DECOMP_DBG")
+        .env_remove("KUNA_DECOMP_TEST")
+        .env_remove("KUNA_SLACOMP")
         .args(args)
         .output()
         .expect("failed to spawn the kuna binary");
@@ -143,6 +146,9 @@ fn run_kuna(args: &[&str]) -> (String, String, bool) {
 fn run_kuna_with_timeout(args: &[&str], cap: Duration) -> Option<(String, String, bool)> {
     use std::io::Read;
     let mut child = Command::new(env!("CARGO_BIN_EXE_kuna"))
+        .env_remove("KUNA_DECOMP_DBG")
+        .env_remove("KUNA_DECOMP_TEST")
+        .env_remove("KUNA_SLACOMP")
         .args(args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -1206,6 +1212,15 @@ fn raw_image_supported_surfaces_share_seed_and_base_semantics() {
     assert!(stdout.contains("\"address_hex\": \"0x4000\""), "{stdout}");
 
     let (stdout, stderr, ok) = run_kuna(&[
+        "functions", &binary, "--json", "--raw-image", "--target", target, "--base",
+        "0x4000", "--entry", "0x4001", "--isa", "thumb", "--option", "namestyle",
+        "ghidra", "--filter", "^func_", "--sleighpath", &sp,
+    ]);
+    assert!(ok, "raw functions with ghidra names failed: {stderr}");
+    assert!(stdout.contains("\"count\": 1"), "{stdout}");
+    assert!(stdout.contains("\"name\": \"func_"), "{stdout}");
+
+    let (stdout, stderr, ok) = run_kuna(&[
         "decompile-all", &binary, "--raw-image", "--target", target, "--base", "0x4000",
         "--addr", "0x4001", "--isa", "thumb", "--sleighpath", &sp,
     ]);
@@ -1258,14 +1273,37 @@ fn raw_image_decompile_scales_word_addressed_selector() {
         "--base", "0x100", "--entry", "0x101", "--sleighpath", &sp,
     ]);
     assert!(ok, "word-addressed raw selector failed: {stderr}");
-    assert!(stdout.contains("sub_202"), "{stdout}");
+    assert!(stdout.contains("sub_101"), "{stdout}");
 
     let (stdout, stderr, ok) = run_kuna(&[
         "decompile", &binary, "0x101", "--raw-image", "--target", "avr8:LE:16:default",
         "--base", "0x100", "--sleighpath", &sp,
     ]);
     assert!(ok, "word-addressed raw text decompile failed: {stderr}");
-    assert!(stdout.contains("sub_202"), "{stdout}");
+    assert!(stdout.contains("sub_101"), "{stdout}");
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn raw_text_decode_failure_is_not_reported_as_an_external() {
+    let path = common::scratch_file("raw-truncated-x86", "bin");
+    std::fs::write(&path, [0x90]).unwrap();
+    let binary = path.to_string_lossy().into_owned();
+    let sp = specs();
+    let spec = PathBuf::from(&sp).join("Ghidra/Processors/x86/data/languages/x86-64.sla");
+    if !spec.exists() {
+        eprintln!("raw_image CLI: skipping (no x86-64 `.sla`)");
+        let _ = std::fs::remove_file(path);
+        return;
+    }
+
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile", &binary, "0", "--raw-image", "--target", "x86:LE:64:default",
+        "--base", "0", "--sleighpath", &sp,
+    ]);
+    assert!(!ok, "truncated mapped raw entry unexpectedly succeeded");
+    assert!(!stdout.contains("external symbol"), "{stdout}");
+    assert!(stderr.contains("Unable to load"), "{stderr}");
     std::fs::remove_file(path).unwrap();
 }
 

--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -1239,7 +1239,7 @@ fn raw_image_supported_surfaces_share_seed_and_base_semantics() {
     let (stdout, stderr, ok) = run_kuna(&[
         "decompile-project", &binary, "-o", out_dir.to_str().unwrap(), "--raw-image",
         "--target", target, "--base", "0x4000", "--entry", "0x4001", "--isa",
-        "thumb", "--sleighpath", &sp,
+        "thumb", "--assert", "data 0x4001 char odd_data", "--sleighpath", &sp,
     ]);
     assert!(ok, "raw project export failed: {stderr}");
     assert!(stdout.contains("functions: 1 ok, 0 failed"), "{stdout}");
@@ -1250,6 +1250,12 @@ fn raw_image_supported_surfaces_share_seed_and_base_semantics() {
     assert!(artifacts.iter().any(|name| name.ends_with(".c")), "{artifacts:?}");
     assert!(artifacts.iter().any(|name| name.ends_with(".asm")), "{artifacts:?}");
     assert!(artifacts.iter().any(|name| name == "README.md"), "{artifacts:?}");
+    let asm_name = artifacts.iter().find(|name| name.ends_with(".asm")).unwrap();
+    let asm = std::fs::read_to_string(out_dir.join(asm_name)).unwrap();
+    let data_tail = asm.split("; --- data ---").nth(1).expect("project data tail");
+    assert!(data_tail.contains("odd_data:  ; 0x4001"), "{data_tail}");
+    assert!(data_tail.contains("  00004001:"), "{data_tail}");
+    assert!(!data_tail.contains("odd_data:  ; 0x4000"), "{data_tail}");
 
     std::fs::remove_dir_all(out_dir).unwrap();
     std::fs::remove_file(path).unwrap();
@@ -1349,6 +1355,48 @@ fn raw_image_decompile_scales_word_addressed_selector() {
     assert!(data_tail.contains("  00000101:"), "{data_tail}");
     assert!(!data_tail.contains("foo:  ; 0x202"), "{data_tail}");
     assert!(!data_tail.contains("  00000202:"), "{data_tail}");
+    std::fs::remove_dir_all(out_dir).unwrap();
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn raw_project_preserves_byte_addressed_data_coordinates() {
+    let path = common::scratch_file("raw-avr-data-reference", "bin");
+    std::fs::write(&path, [0x80, 0x91, 0x00, 0x01, 0x08, 0x95]).unwrap();
+    let binary = path.to_string_lossy().into_owned();
+    let sp = specs();
+    let spec = PathBuf::from(&sp).join("Ghidra/Processors/Atmel/data/languages/avr8.sla");
+    if !spec.exists() {
+        eprintln!("raw_image CLI: skipping (no AVR8 `.sla`)");
+        let _ = std::fs::remove_file(path);
+        return;
+    }
+
+    let out_dir = common::scratch_file("raw-avr-data-project", "dir");
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile-project", &binary, "-o", out_dir.to_str().unwrap(), "--raw-image",
+        "--target", "avr8:LE:16:default", "--base", "0", "--entry", "0",
+        "--sleighpath", &sp,
+    ]);
+    assert!(ok, "word-addressed raw data project failed: {stderr}");
+    assert!(stdout.contains("functions: 1 ok, 0 failed"), "{stdout}");
+    let files: Vec<_> = std::fs::read_dir(&out_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect();
+    let c = std::fs::read_to_string(
+        files.iter().find(|path| path.extension().is_some_and(|ext| ext == "c")).unwrap(),
+    )
+    .unwrap();
+    let asm = std::fs::read_to_string(
+        files.iter().find(|path| path.extension().is_some_and(|ext| ext == "asm")).unwrap(),
+    )
+    .unwrap();
+    assert!(c.contains("dat_100"), "{c}");
+    let data_tail = asm.split("; --- data ---").nth(1).expect("project data tail");
+    assert!(data_tail.contains("dat_100:  ; 0x100"), "{data_tail}");
+    assert!(data_tail.contains("  00000100:"), "{data_tail}");
+    assert!(!data_tail.contains("dat_100:  ; 0x80"), "{data_tail}");
     std::fs::remove_dir_all(out_dir).unwrap();
     std::fs::remove_file(path).unwrap();
 }

--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -1269,11 +1269,29 @@ fn raw_image_decompile_scales_word_addressed_selector() {
     }
 
     let (stdout, stderr, ok) = run_kuna(&[
+        "functions", &binary, "--json", "--raw-image", "--target",
+        "avr8:LE:16:default", "--base", "0x100", "--entry", "0x101",
+        "--sleighpath", &sp,
+    ]);
+    assert!(ok, "word-addressed raw inventory failed: {stderr}");
+    assert!(stdout.contains("\"address\": 257"), "{stdout}");
+    assert!(stdout.contains("\"address_hex\": \"0x101\""), "{stdout}");
+    assert!(!stdout.contains("\"address_hex\": \"0x202\""), "{stdout}");
+
+    let (stdout, stderr, ok) = run_kuna(&[
+        "functions", &binary, "--raw-image", "--target", "avr8:LE:16:default",
+        "--base", "0x100", "--entry", "0x101", "--sleighpath", &sp,
+    ]);
+    assert!(ok, "word-addressed raw text inventory failed: {stderr}");
+    assert!(stdout.contains("0x101\tsub_101"), "{stdout}");
+
+    let (stdout, stderr, ok) = run_kuna(&[
         "decompile-all", &binary, "--raw-image", "--target", "avr8:LE:16:default",
         "--base", "0x100", "--entry", "0x101", "--sleighpath", &sp,
     ]);
     assert!(ok, "word-addressed raw selector failed: {stderr}");
     assert!(stdout.contains("sub_101"), "{stdout}");
+    assert!(stdout.contains("@ 0x101"), "{stdout}");
 
     let (stdout, stderr, ok) = run_kuna(&[
         "decompile", &binary, "0x101", "--raw-image", "--target", "avr8:LE:16:default",
@@ -1281,7 +1299,105 @@ fn raw_image_decompile_scales_word_addressed_selector() {
     ]);
     assert!(ok, "word-addressed raw text decompile failed: {stderr}");
     assert!(stdout.contains("sub_101"), "{stdout}");
+
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile", &binary, "0x101", "--json", "--raw-image", "--target",
+        "avr8:LE:16:default", "--base", "0x100", "--sleighpath", &sp,
+    ]);
+    assert!(ok, "word-addressed raw JSON decompile failed: {stderr}");
+    assert!(stdout.contains("\"address\": 257"), "{stdout}");
+    assert!(stdout.contains("\"address_hex\": \"0x101\""), "{stdout}");
+    assert!(stdout.contains("\"addresses\": [\n            257"), "{stdout}");
+
+    let out_dir = common::scratch_file("raw-avr-project", "dir");
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile-project", &binary, "-o", out_dir.to_str().unwrap(), "--raw-image",
+        "--target", "avr8:LE:16:default", "--base", "0x100", "--entry", "0x101",
+        "--sleighpath", &sp,
+    ]);
+    assert!(ok, "word-addressed raw project failed: {stderr}");
+    assert!(stdout.contains("functions: 1 ok, 0 failed"), "{stdout}");
+    let files: Vec<_> = std::fs::read_dir(&out_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect();
+    let c_path = files
+        .iter()
+        .find(|path| path.extension().is_some_and(|ext| ext == "c"))
+        .expect("project C file");
+    let asm_path = files
+        .iter()
+        .find(|path| path.extension().is_some_and(|ext| ext == "asm"))
+        .expect("project asm file");
+    let c = std::fs::read_to_string(c_path).unwrap();
+    let asm = std::fs::read_to_string(asm_path).unwrap();
+    assert!(c.contains("// Function: sub_101 @ 0x101"), "{c}");
+    assert!(asm.contains("sub_101:  ; 0x101"), "{asm}");
+    assert!(asm.contains("00000101:"), "{asm}");
+    std::fs::remove_dir_all(out_dir).unwrap();
     std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn raw_address_directives_use_target_units() {
+    let sp = specs();
+    let avr_spec = PathBuf::from(&sp).join("Ghidra/Processors/Atmel/data/languages/avr8.sla");
+    let arm_spec = PathBuf::from(&sp).join("Ghidra/Processors/ARM/data/languages/ARM8_le.sla");
+    if !avr_spec.exists() || !arm_spec.exists() {
+        eprintln!("raw_image CLI: skipping (no AVR8 or ARM `.sla`)");
+        return;
+    }
+
+    let avr_path = common::scratch_file("raw-avr-directives", "bin");
+    std::fs::write(&avr_path, [0, 0, 0x08, 0x95]).unwrap();
+    let avr = avr_path.to_string_lossy().into_owned();
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile", &avr, "0x101", "--json", "--raw-image", "--target",
+        "avr8:LE:16:default", "--base", "0x100", "--define-function",
+        "0x101-0x102=bounded", "--assert", "comment 0x101 WORD_COMMENT", "--sleighpath",
+        &sp,
+    ]);
+    assert!(ok, "word-addressed raw directives failed: {stderr}");
+    assert!(stdout.contains("\"name\": \"bounded\""), "{stdout}");
+    assert!(stdout.contains("\"address\": 257"), "{stdout}");
+    assert!(stdout.contains("\"size\": 2"), "{stdout}");
+    assert!(stdout.contains("/* WORD_COMMENT */"), "{stdout}");
+
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile", &avr, "0x101", "--raw-image", "--target", "avr8:LE:16:default",
+        "--base", "0x100", "--define-function", "0x101-0x102=bounded", "--assert",
+        "comment 0x101 WORD_COMMENT", "--sleighpath", &sp,
+    ]);
+    assert!(ok, "word-addressed raw text directives failed: {stderr}");
+    assert!(stdout.contains("bounded"), "{stdout}");
+    assert!(stdout.contains("/* WORD_COMMENT */"), "{stdout}");
+    std::fs::remove_file(avr_path).unwrap();
+
+    let arm_path = common::scratch_file("raw-thumb-directives", "bin");
+    std::fs::write(&arm_path, [0x07, 0x20, 0x70, 0x47]).unwrap();
+    let arm = arm_path.to_string_lossy().into_owned();
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile", &arm, "0x4001", "--json", "--raw-image", "--target",
+        "ARM:LE:32:v4t:default", "--base", "0x4000", "--isa", "thumb", "--assert",
+        "function 0x4001-0x4003=thumb_bounded", "--assert",
+        "comment 0x4001 THUMB_COMMENT", "--sleighpath", &sp,
+    ]);
+    assert!(ok, "odd-Thumb raw directives failed: {stderr}");
+    assert!(stdout.contains("\"name\": \"thumb_bounded\""), "{stdout}");
+    assert!(stdout.contains("\"address\": 16384"), "{stdout}");
+    assert!(stdout.contains("\"size\": 2"), "{stdout}");
+    assert!(stdout.contains("/* THUMB_COMMENT */"), "{stdout}");
+
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile", &arm, "0x4001", "--raw-image", "--target", "ARM:LE:32:v4t:default",
+        "--base", "0x4000", "--isa", "thumb", "--assert",
+        "function 0x4001-0x4003=thumb_bounded", "--assert",
+        "comment 0x4001 THUMB_COMMENT", "--sleighpath", &sp,
+    ]);
+    assert!(ok, "odd-Thumb raw text directives failed: {stderr}");
+    assert!(stdout.contains("thumb_bounded"), "{stdout}");
+    assert!(stdout.contains("/* THUMB_COMMENT */"), "{stdout}");
+    std::fs::remove_file(arm_path).unwrap();
 }
 
 #[test]

--- a/decompiler/crates/kuna-cli/tests/decompile_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_cli.rs
@@ -18,6 +18,8 @@
 
 #![cfg(unix)]
 
+mod common;
+
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -54,12 +56,15 @@ fn stub_decomp_dbg(tag: &str, c_body: &str, transcript: &str, stderr_text: &str)
     let script = format!(
         "#!/bin/sh\n\
          out=\n\
+         saw_load=0\n\
          if [ \"${{KUNA_EXPECT_ARM_ISA+x}}\" = x ] && [ \"$KUNA_ARM_ISA\" != \"$KUNA_EXPECT_ARM_ISA\" ]; then exit 9; fi\n\
          while IFS= read -r line; do\n\
+         \x20 if [ \"${{KUNA_EXPECT_LOAD_LINE+x}}\" = x ] && [ \"$line\" = \"$KUNA_EXPECT_LOAD_LINE\" ]; then saw_load=1; fi\n\
          \x20 case \"$line\" in\n\
          \x20   'openfile write '*) out=${{line#openfile write }} ;;\n\
          \x20 esac\n\
          done\n\
+         if [ \"${{KUNA_EXPECT_LOAD_LINE+x}}\" = x ] && [ \"$saw_load\" != 1 ]; then exit 8; fi\n\
          [ -n \"$out\" ] && cat > \"$out\" <<'KUNA_C_EOF'\n{c_body}\nKUNA_C_EOF\n\
          cat <<'KUNA_OUT_EOF'\n{transcript}\nKUNA_OUT_EOF\n\
          cat >&2 <<'KUNA_ERR_EOF'\n{stderr_text}\nKUNA_ERR_EOF\n\
@@ -164,6 +169,49 @@ fn arm_isa_override_reaches_single_function_engine() {
         .expect("run kuna decompile with --isa thumb");
     let _ = std::fs::remove_file(&stub);
     assert!(out.status.success(), "--isa did not reach decomp_dbg");
+}
+
+#[test]
+fn raw_image_flags_reach_single_function_engine_with_quoted_path() {
+    let raw = common::scratch_file("raw single image", "bin");
+    std::fs::write(&raw, [0x07, 0x20, 0x70, 0x47]).unwrap();
+    let stub = stub_decomp_dbg(
+        "raw_input",
+        "unsigned int sub_4000(void)\n{\n  return 7;\n}",
+        "[decomp]> decompile\nDecompiling sub_4000\nDecompilation complete\n[decomp]> print C",
+        "",
+    );
+    let expected = format!(
+        "load raw ARM:LE:32:v4t:default 0x4000 0x4001 \"{}\"",
+        raw.display()
+    );
+    let out = Command::new(env!("CARGO_BIN_EXE_kuna"))
+        .env("KUNA_EXPECT_ARM_ISA", "thumb")
+        .env("KUNA_EXPECT_LOAD_LINE", expected)
+        .args([
+            "decompile",
+            raw.to_str().unwrap(),
+            "0x4001",
+            "--raw-image",
+            "--target",
+            "ARM:LE:32:v4t:default",
+            "--base",
+            "0x4000",
+            "--isa",
+            "thumb",
+            "--decomp-dbg",
+            stub.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run kuna decompile over raw input");
+    let _ = std::fs::remove_file(&stub);
+    let _ = std::fs::remove_file(&raw);
+    assert!(
+        out.status.success(),
+        "raw load command did not reach decomp_dbg: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(String::from_utf8_lossy(&out.stdout).contains("return 7;"));
 }
 
 /// An empty `print C` keeps the pre-existing "no C output" error (that path is

--- a/decompiler/crates/kuna-console/src/assertions.rs
+++ b/decompiler/crates/kuna-console/src/assertions.rs
@@ -266,10 +266,16 @@ fn data_org(prog: &ConsoleProgram) -> DataOrg {
     DataOrg { addr_size, word_size }
 }
 
-/// Build an [`Address`] in the program's default code space.
-fn code_addr(prog: &ConsoleProgram, vma: u64) -> Option<Address> {
-    let space = prog.arch().manage().get_default_code_space().cloned()?;
-    Some(Address::new(space, vma))
+/// Convert a user-facing address and build it in the default code space.
+fn code_addr(prog: &ConsoleProgram, vma: u64) -> Result<Address, String> {
+    let vma = prog.input_code_offset(vma).map_err(|e| e.explain().to_string())?;
+    let space = prog
+        .arch()
+        .manage()
+        .get_default_code_space()
+        .cloned()
+        .ok_or_else(|| "the loaded program has no default code space".to_string())?;
+    Ok(Address::new(space, vma))
 }
 
 /// Parse a storage token (`%RDI`, `[stack,-0x18,8]`, `s0x10`) through the
@@ -323,9 +329,24 @@ pub fn apply_program_scoped(prog: &mut ConsoleProgram) {
 fn apply_one_program_scoped(prog: &mut ConsoleProgram, body: &Body) -> Result<(), String> {
     match body {
         Body::Function { start, end, name } => {
-            let addr = code_addr(prog, *start)
-                .ok_or_else(|| "the loaded program has no default code space".to_string())?;
-            let size = end.map(|e| e - *start).unwrap_or(0) as int4;
+            let addr = code_addr(prog, *start)?;
+            let size = match end {
+                None => 0,
+                Some(end) => {
+                    let end = prog
+                        .input_code_offset(*end)
+                        .map_err(|e| e.explain().to_string())?;
+                    let size = end
+                        .checked_sub(addr.get_offset())
+                        .filter(|size| *size > 0)
+                        .ok_or_else(|| {
+                            "function end must be above start after target address conversion"
+                                .to_string()
+                        })?;
+                    int4::try_from(size)
+                        .map_err(|_| "function byte extent exceeds the supported range".to_string())?
+                }
+            };
             prog.declare_function(addr, name.as_deref(), size)
                 .map(|_| ())
                 .map_err(|e| e.explain().to_string())
@@ -371,18 +392,18 @@ fn paint_property(
     if size <= 0 {
         return Err("a range needs a size of at least one byte".into());
     }
-    let first = code_addr(prog, vma)
-        .ok_or_else(|| "the loaded program has no default code space".to_string())?;
+    let first = code_addr(prog, vma)?;
     let space = first
         .get_space()
         .cloned()
         .ok_or_else(|| "the loaded program has no default code space".to_string())?;
-    let end = vma
+    let end = first
+        .get_offset()
         .checked_add(size as u64)
         .ok_or_else(|| "the range wraps past the end of the address space".to_string())?;
     let last_open = Address::new(Rc::clone(&space), end);
     prog.arch_mut().symboltab.set_property_range(flag, &first, &last_open);
-    repaint_covered_symbols(prog, &space, vma, end, flag);
+    repaint_covered_symbols(prog, &space, first.get_offset(), end, flag);
     Ok(())
 }
 
@@ -497,10 +518,9 @@ pub(crate) fn resolve_proto_target(
         None
     };
     if let Some(vma) = vma {
-        if let Some(addr) = code_addr(prog, vma) {
-            if let Some(name) = prog.arch().symboltab.function_display_name_across_scopes(&addr) {
-                return Ok(ProtoTarget::At(addr, name));
-            }
+        let addr = code_addr(prog, vma)?;
+        if let Some(name) = prog.arch().symboltab.function_display_name_across_scopes(&addr) {
+            return Ok(ProtoTarget::At(addr, name));
         }
         if explicit {
             return Err(format!("no function starts at {func}"));
@@ -744,8 +764,7 @@ fn apply_cross_function(
 fn apply_data(prog: &mut ConsoleProgram, vma: u64, decl: &str) -> Result<(), String> {
     use kuna_decomp::varnode::varnode_flags;
     let org = data_org(prog);
-    let addr = code_addr(prog, vma)
-        .ok_or_else(|| "the loaded program has no default code space".to_string())?;
+    let addr = code_addr(prog, vma)?;
     let (ct, name) = crate::grammar::parse_type(decl, prog.arch().types(), org)
         .map_err(|e| e.explain().to_string())?;
     if name.is_empty() {
@@ -852,7 +871,7 @@ pub fn record_rejected_flow_overrides(
             continue;
         }
         let type_ = kuna_decomp::overrides::Override::string_to_type(kind.as_bytes());
-        let Some(at) = code_addr(prog, *addr) else { continue };
+        let Ok(at) = code_addr(prog, *addr) else { continue };
         let Some((_, _, reason)) = refused.iter().find(|(a, t, _)| a == &at && *t == type_) else {
             continue;
         };
@@ -906,8 +925,7 @@ fn seed_one(
             Ok(())
         }
         Body::Comment { addr, text, .. } => {
-            let at = code_addr(prog, *addr)
-                .ok_or_else(|| "the loaded program has no default code space".to_string())?;
+            let at = code_addr(prog, *addr)?;
             let arch = prog.arch_mut();
             let ctype = arch.print().instruction_comment_flags();
             arch.commentdb.add_comment(ctype, entry, &at, text);
@@ -920,8 +938,7 @@ fn seed_one(
                     "Bad override type: {kind} (want branch, call, callreturn or return)"
                 ));
             }
-            let at = code_addr(prog, *addr)
-                .ok_or_else(|| "the loaded program has no default code space".to_string())?;
+            let at = code_addr(prog, *addr)?;
             seed.flow_overrides.push((at, type_));
             Ok(())
         }

--- a/decompiler/crates/kuna-console/src/assertions.rs
+++ b/decompiler/crates/kuna-console/src/assertions.rs
@@ -278,6 +278,18 @@ fn code_addr(prog: &ConsoleProgram, vma: u64) -> Result<Address, String> {
     Ok(Address::new(space, vma))
 }
 
+/// Scale a user address without treating its low bit as a function state bit.
+fn data_addr(prog: &ConsoleProgram, vma: u64) -> Result<Address, String> {
+    let vma = prog.input_address_offset(vma).map_err(|e| e.explain().to_string())?;
+    let space = prog
+        .arch()
+        .manage()
+        .get_default_code_space()
+        .cloned()
+        .ok_or_else(|| "the loaded program has no default code space".to_string())?;
+    Ok(Address::new(space, vma))
+}
+
 /// Parse a storage token (`%RDI`, `[stack,-0x18,8]`, `s0x10`) through the
 /// console's own machine-address grammar, so `--assert` and the console spell
 /// storage the same way.
@@ -392,7 +404,7 @@ fn paint_property(
     if size <= 0 {
         return Err("a range needs a size of at least one byte".into());
     }
-    let first = code_addr(prog, vma)?;
+    let first = data_addr(prog, vma)?;
     let space = first
         .get_space()
         .cloned()
@@ -764,7 +776,7 @@ fn apply_cross_function(
 fn apply_data(prog: &mut ConsoleProgram, vma: u64, decl: &str) -> Result<(), String> {
     use kuna_decomp::varnode::varnode_flags;
     let org = data_org(prog);
-    let addr = code_addr(prog, vma)?;
+    let addr = data_addr(prog, vma)?;
     let (ct, name) = crate::grammar::parse_type(decl, prog.arch().types(), org)
         .map_err(|e| e.explain().to_string())?;
     if name.is_empty() {

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -45,6 +45,7 @@ use kuna_base::xml::{DocumentStorage, Element};
 
 use kuna_decomp::architecture::Architecture;
 use kuna_decomp::options::register_option_elements;
+use kuna_decomp::raw_arch::RawBinaryArchitectureCapability;
 use kuna_decomp::sleigh_arch::{register_sleigh_arch_ids, LanguageDatabase, SleighArchitecture};
 use kuna_decomp::xml_arch::XmlArchitectureCapability;
 
@@ -338,6 +339,8 @@ pub struct ConsoleProgram {
     /// the decompile loop, because the drive rebuilds the `Funcdata` and the
     /// symbol-table prototype link does not survive that rebuild.
     pending_prototypes: BTreeMap<String, kuna_decomp::fspec::PrototypePieces>,
+    /// Raw-input address-unit width and whether bit zero is an ARM state bit.
+    raw_address_units: Option<(u64, bool)>,
 }
 
 impl ConsoleProgram {
@@ -369,6 +372,19 @@ impl ConsoleProgram {
     /// C++ `conf->getDescription()` — the load-success description line.
     pub fn description(&self) -> &str {
         &self.description
+    }
+
+    /// Convert a user-facing code address to the engine's byte offset.
+    pub fn input_code_offset(&self, value: u64) -> KunaResult<u64> {
+        let Some((word_size, arm32)) = self.raw_address_units else {
+            return Ok(value);
+        };
+        let units = if arm32 { value & !1 } else { value };
+        units.checked_mul(word_size).ok_or_else(|| {
+            KunaError::lowlevel(format!(
+                "raw entry 0x{value:x} overflows the target's {word_size}-byte code-space units"
+            ))
+        })
     }
 
     /// Resolve a function entry address by symbol name (the `queryFunction`
@@ -2139,6 +2155,7 @@ pub fn bootstrap_program(
         assertions: Vec::new(),
         assertion_outcomes: Vec::new(),
         pending_prototypes: BTreeMap::new(),
+        raw_address_units: None,
     };
     // C++ `conf->readLoaderSymbols("::")` (testfunction.cc:160 / consolemain.cc:104):
     // install the binaryimage symbols as FunctionSymbols so a CALL to one resolves
@@ -2189,10 +2206,19 @@ fn input_isa_paints(
     arch_id: &str,
     isa: Option<ArmIsa>,
 ) -> KunaResult<Vec<kuna_analysis::pass::ContextPaint>> {
+    input_isa_paints_for_ranges(&loader.executable_ranges(), arch, arch_id, isa)
+}
+
+fn input_isa_paints_for_ranges(
+    ranges: &[(u64, u64)],
+    arch: &Architecture,
+    arch_id: &str,
+    isa: Option<ArmIsa>,
+) -> KunaResult<Vec<kuna_analysis::pass::ContextPaint>> {
     let Some(isa) = isa else {
         return Ok(Vec::new());
     };
-    if !arch_id.starts_with("ARM:") {
+    if !arch_id.starts_with("ARM:") || arch_id.split(':').nth(2) != Some("32") {
         return Err(KunaError::lowlevel(format!(
             "--isa {} requires a 32-bit ARM SLEIGH target (resolved {arch_id})",
             isa.as_str()
@@ -2207,10 +2233,9 @@ fn input_isa_paints(
         };
     }
 
-    Ok(loader
-        .executable_ranges()
-        .into_iter()
-        .filter_map(|(addr, size)| {
+    Ok(ranges
+        .iter()
+        .filter_map(|&(addr, size)| {
             if size == 0 {
                 return None;
             }
@@ -2223,6 +2248,171 @@ fn input_isa_paints(
             })
         })
         .collect())
+}
+
+/// Bootstrap a headerless byte image at a caller-supplied target and base.
+pub fn bootstrap_from_raw(
+    path: &str,
+    target: &str,
+    base: u64,
+    entries: &[u64],
+    isa: Option<ArmIsa>,
+    spec_roots: &[String],
+) -> KunaResult<ConsoleProgram> {
+    if target.trim().is_empty() {
+        return Err(KunaError::lowlevel(
+            "raw image input requires --target <SLEIGH-language-id>",
+        ));
+    }
+    if entries.is_empty() {
+        return Err(KunaError::lowlevel(
+            "raw image input requires at least one --entry or --addr",
+        ));
+    }
+
+    let registry = build_registry();
+    let capability = RawBinaryArchitectureCapability::new();
+    let mut raw = capability.build_architecture(path, target);
+    let db = scan_language_database(spec_roots, &registry)?;
+    raw.resolve_architecture(&db)?;
+    if raw.sleigh().language_index() < 0 {
+        return Err(KunaError::lowlevel(format!(
+            "No sleigh specification for architecture {target}"
+        )));
+    }
+    build_engine_and_init(raw.sleigh_mut(), &db)?;
+
+    let code_space = Rc::clone(
+        raw.sleigh()
+            .base()
+            .unwrap()
+            .manage()
+            .get_default_code_space()
+            .ok_or_else(|| KunaError::lowlevel("no default code space after init"))?,
+    );
+    let word_size = u64::from(code_space.get_word_size());
+    let address_to_byte = |value: u64, label: &str| {
+        value.checked_mul(word_size).ok_or_else(|| {
+            KunaError::lowlevel(format!(
+                "raw {label} 0x{value:x} overflows the target's {word_size}-byte code-space units"
+            ))
+        })
+    };
+    let base_bytes = address_to_byte(base, "base")?;
+    raw.build_loader_at(Rc::clone(&code_space), base)?;
+    let loader = raw
+        .loader()
+        .ok_or_else(|| KunaError::lowlevel("raw loader vanished after open"))?;
+    let image_base = loader.vma();
+    if image_base != base_bytes {
+        return Err(KunaError::lowlevel(
+            "raw loader and code-space base conversion disagree",
+        ));
+    }
+    let image_size = loader.file_size();
+    if image_size == 0 {
+        return Err(KunaError::lowlevel("raw image is empty"));
+    }
+    let image_end = image_base
+        .checked_add(image_size)
+        .ok_or_else(|| KunaError::lowlevel("raw image base plus file size overflows"))?;
+    if image_end - 1 > code_space.get_highest() {
+        return Err(KunaError::lowlevel(format!(
+            "raw image range 0x{image_base:x}..0x{image_end:x} exceeds the target address space"
+        )));
+    }
+
+    let arch_id = raw.sleigh().arch_id().to_string();
+    let arm32 = arch_id.starts_with("ARM:") && arch_id.split(':').nth(2) == Some("32");
+    if arm32 && isa.is_none() {
+        return Err(KunaError::lowlevel(
+            "raw ARM32 input requires --isa arm or --isa thumb",
+        ));
+    }
+    let mut normalized_entries = Vec::new();
+    for &entry in entries {
+        let entry_units = if arm32 { entry & !1 } else { entry };
+        let normalized = address_to_byte(entry_units, "entry")?;
+        if normalized < image_base || normalized >= image_end {
+            return Err(KunaError::lowlevel(format!(
+                "raw entry 0x{entry:x} is outside mapped range 0x{image_base:x}..0x{image_end:x}"
+            )));
+        }
+        if !normalized_entries.contains(&normalized) {
+            normalized_entries.push(normalized);
+        }
+    }
+
+    let ranges = [(image_base, image_size)];
+    let input_context_paints = input_isa_paints_for_ranges(
+        &ranges,
+        raw.sleigh().base().unwrap(),
+        &arch_id,
+        isa,
+    )?;
+    raw.sleigh_mut().base_mut().unwrap().input_arm_isa_override = isa.is_some();
+    for paint in &input_context_paints {
+        let begin = Address::new(Rc::clone(&code_space), paint.addr);
+        let end = paint
+            .end
+            .map(|end| Address::new(Rc::clone(&code_space), end));
+        raw.sleigh().base().unwrap().with_context_db_mut(|db| match end {
+            Some(end) => {
+                db.set_variable_region(paint.var.as_bytes(), &begin, &end, paint.value)
+            }
+            None => db.set_variable(paint.var.as_bytes(), &begin, paint.value),
+        })?;
+    }
+
+    let symbols = normalized_entries
+        .into_iter()
+        .map(|entry| ProgramSymbol {
+            name: format!("sub_{entry:x}"),
+            addr: Address::new(Rc::clone(&code_space), entry),
+            object_location: None,
+            binding: None,
+            provenance: EntryProvenance::Mapped,
+        })
+        .collect();
+    let description = raw
+        .sleigh()
+        .base()
+        .unwrap()
+        .get_description()
+        .to_string();
+    let image = raw
+        .take_loader()
+        .ok_or_else(|| KunaError::lowlevel("raw loader vanished after validation"))?;
+    raw.sleigh_mut()
+        .base_mut()
+        .unwrap()
+        .set_loader(Box::new(image));
+
+    let mut pending_analysis = Vec::new();
+    if !input_context_paints.is_empty() {
+        let mut explicit = kuna_analysis::pass::AnalysisOutput::default();
+        explicit.context_paints = input_context_paints;
+        pending_analysis.push(("input_isa", explicit));
+    }
+    let mut prog = ConsoleProgram {
+        arch: raw.into_sleigh(),
+        registry,
+        symbols,
+        object_sections: Vec::new(),
+        description,
+        pending_analysis,
+        analysis_code_space: Some(code_space),
+        dwarf_locals: Vec::new(),
+        analysis_image: None,
+        loader_data_objects: Vec::new(),
+        declared_extents: BTreeMap::new(),
+        assertions: Vec::new(),
+        assertion_outcomes: Vec::new(),
+        pending_prototypes: BTreeMap::new(),
+        raw_address_units: Some((word_size, arm32)),
+    };
+    prog.read_loader_symbols()?;
+    Ok(prog)
 }
 
 /// Bootstrap a [`ConsoleProgram`] from a **real object-format** binary on disk
@@ -2541,6 +2731,7 @@ pub fn bootstrap_from_object_with_isa(
         assertions: Vec::new(),
         assertion_outcomes: Vec::new(),
         pending_prototypes: BTreeMap::new(),
+        raw_address_units: None,
     };
     // conf->readLoaderSymbols("::"): install the ELF symbols as FunctionSymbols.
     // The deferred analysis commit at `read symbols` REQUIRES this to have run
@@ -3311,6 +3502,17 @@ pub fn bootstrap_from_file(
         // Real object-format binary (ELF / PE / Mach-O / COFF): drive the
         // object-crate loader.
         return bootstrap_from_object(path, target, spec_roots);
+    }
+    if !bytes
+        .iter()
+        .copied()
+        .skip_while(u8::is_ascii_whitespace)
+        .next()
+        .is_some_and(|byte| byte == b'<')
+    {
+        return Err(KunaError::lowlevel(
+            "unrecognized input format; for a headerless image use --raw-image --target <SLEIGH-language-id> --base <address> and at least one --entry/--addr <address>",
+        ));
     }
     let mut store = DocumentStorage::new();
     let root = store.parse_document(&bytes)?.get_root().clone();

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -387,17 +387,26 @@ impl ConsoleProgram {
         &self.description
     }
 
-    /// Convert a user-facing code address to the engine's byte offset.
-    pub fn input_code_offset(&self, value: u64) -> KunaResult<u64> {
-        let Some((word_size, arm32)) = self.raw_address_units else {
+    /// Scale a user-facing raw address to the engine's byte offset without
+    /// interpreting any low bits as processor state.
+    pub fn input_address_offset(&self, value: u64) -> KunaResult<u64> {
+        let Some((word_size, _)) = self.raw_address_units else {
             return Ok(value);
         };
-        let units = if arm32 { value & !1 } else { value };
-        units.checked_mul(word_size).ok_or_else(|| {
+        value.checked_mul(word_size).ok_or_else(|| {
             KunaError::lowlevel(format!(
                 "raw address 0x{value:x} overflows the target's {word_size}-byte code-space units"
             ))
         })
+    }
+
+    /// Convert a user-facing code pointer to the engine's byte offset.
+    pub fn input_code_offset(&self, value: u64) -> KunaResult<u64> {
+        let units = match self.raw_address_units {
+            Some((_, true)) => value & !1,
+            _ => value,
+        };
+        self.input_address_offset(units)
     }
 
     /// Finish normalization after the console address grammar has already
@@ -429,6 +438,17 @@ impl ConsoleProgram {
             Some((word_size, _)) => code_offset_in_target_units(value, word_size),
             None => value,
         }
+    }
+
+    /// Convert an engine address to its own space's target units for raw input.
+    pub fn output_address_offset(&self, address: &Address) -> u64 {
+        let value = address.get_offset();
+        if self.raw_address_units.is_none() {
+            return value;
+        }
+        address.get_space().map_or(value, |space| {
+            code_offset_in_target_units(value, u64::from(space.get_word_size()))
+        })
     }
 
     /// Convert an exclusive engine byte end to target address units, rounding
@@ -1252,6 +1272,17 @@ impl ConsoleProgram {
         self.read_bytes_into(vma, size, &mut bytes).then_some(bytes)
     }
 
+    /// Read bytes at an address while preserving its address-space identity.
+    pub fn read_bytes_at(&self, address: &Address, size: usize) -> Option<Vec<u8>> {
+        if size > i32::MAX as usize {
+            return None;
+        }
+        let mut bytes = vec![0; size];
+        let loader_rc = self.arch().translate().loader_rc();
+        loader_rc.borrow_mut().load_fill(&mut bytes, address).ok()?;
+        Some(bytes)
+    }
+
     /// (kuna) Read `size` raw image bytes at code-space VMA `vma` into a
     /// caller-owned buffer, retaining its allocation across calls.
     ///
@@ -1296,6 +1327,14 @@ impl ConsoleProgram {
     /// string symbols) is kept. `type_size` is the mapped datatype's byte size.
     /// Sorted by VMA.
     pub fn global_data_symbols(&self) -> Vec<(String, u64, i64)> {
+        self.global_data_symbol_addresses()
+            .into_iter()
+            .map(|(name, address, size)| (name, address.get_offset(), size))
+            .collect()
+    }
+
+    /// Global data symbols with their address-space identity retained.
+    pub fn global_data_symbol_addresses(&self) -> Vec<(String, Address, i64)> {
         use kuna_decomp::dtype::type_metatype;
         let arch = self.arch();
         let Some(scope) = arch.symboltab.get_global_scope() else {
@@ -1305,14 +1344,14 @@ impl ConsoleProgram {
             return Vec::new();
         };
         let space_index = data_space.get_index() as usize;
-        let mut out: Vec<(String, u64, i64)> = arch
+        let mut out: Vec<(String, Address, i64)> = arch
             .symboltab
             .scope_space_symbol_specs(scope, space_index)
             .into_iter()
             .filter(|(_, ct, _, _)| ct.get_metatype() != type_metatype::TYPE_CODE)
-            .map(|(name, ct, addr, _)| (name, addr.get_offset(), i64::from(ct.get_size())))
+            .map(|(name, ct, addr, _)| (name, addr, i64::from(ct.get_size())))
             .collect();
-        out.sort_by(|a, b| (a.1, &a.0).cmp(&(b.1, &b.0)));
+        out.sort_by(|a, b| (&a.1, &a.0).cmp(&(&b.1, &b.0)));
         out
     }
 

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -387,9 +387,49 @@ impl ConsoleProgram {
         let units = if arm32 { value & !1 } else { value };
         units.checked_mul(word_size).ok_or_else(|| {
             KunaError::lowlevel(format!(
-                "raw entry 0x{value:x} overflows the target's {word_size}-byte code-space units"
+                "raw address 0x{value:x} overflows the target's {word_size}-byte code-space units"
             ))
         })
+    }
+
+    /// Finish normalization after the console address grammar has already
+    /// converted address units to bytes. Raw ARM code pointers still carry a
+    /// state bit that is not part of the mapped byte address.
+    pub fn normalize_parsed_code_address(&self, address: Address) -> Address {
+        let Some((_, true)) = self.raw_address_units else {
+            return address;
+        };
+        let Some(space) = address.get_space() else {
+            return address;
+        };
+        let in_default_space = self
+            .arch()
+            .manage()
+            .get_default_code_space()
+            .is_some_and(|default| Rc::ptr_eq(space, default));
+        if in_default_space {
+            Address::new(Rc::clone(space), address.get_offset() & !1)
+        } else {
+            address
+        }
+    }
+
+    /// Convert an engine byte offset back to the address units accepted by the
+    /// raw CLI. Object-backed programs already expose byte VMAs and are unchanged.
+    pub fn output_code_offset(&self, value: u64) -> u64 {
+        match self.raw_address_units {
+            Some((word_size, _)) => value / word_size,
+            None => value,
+        }
+    }
+
+    /// Convert an exclusive engine byte end to target address units, rounding
+    /// up when the final code unit is only partially present.
+    pub fn output_code_end_offset(&self, value: u64) -> u64 {
+        match self.raw_address_units {
+            Some((word_size, _)) => value / word_size + u64::from(value % word_size != 0),
+            None => value,
+        }
     }
 
     /// Resolve a function entry address by symbol name (the `queryFunction`

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -348,6 +348,14 @@ pub struct ConsoleProgram {
     raw_address_units: Option<(u64, bool)>,
 }
 
+fn code_offset_in_target_units(value: u64, word_size: u64) -> u64 {
+    value / word_size
+}
+
+fn code_end_in_target_units(value: u64, word_size: u64) -> u64 {
+    value / word_size + u64::from(value % word_size != 0)
+}
+
 impl ConsoleProgram {
     /// Borrow the `Architecture` god object (C++ `dcp->conf`, viewed as the base).
     pub fn arch(&self) -> &Architecture {
@@ -418,7 +426,7 @@ impl ConsoleProgram {
     /// raw CLI. Object-backed programs already expose byte VMAs and are unchanged.
     pub fn output_code_offset(&self, value: u64) -> u64 {
         match self.raw_address_units {
-            Some((word_size, _)) => value / word_size,
+            Some((word_size, _)) => code_offset_in_target_units(value, word_size),
             None => value,
         }
     }
@@ -427,7 +435,7 @@ impl ConsoleProgram {
     /// up when the final code unit is only partially present.
     pub fn output_code_end_offset(&self, value: u64) -> u64 {
         match self.raw_address_units {
-            Some((word_size, _)) => value / word_size + u64::from(value % word_size != 0),
+            Some((word_size, _)) => code_end_in_target_units(value, word_size),
             None => value,
         }
     }
@@ -2380,9 +2388,11 @@ pub fn bootstrap_from_raw(
     let image_end = image_base
         .checked_add(image_size)
         .ok_or_else(|| KunaError::lowlevel("raw image base plus file size overflows"))?;
+    let display_image_base = code_offset_in_target_units(image_base, word_size);
+    let display_image_end = code_end_in_target_units(image_end, word_size);
     if image_end - 1 > code_space.get_highest() {
         return Err(KunaError::lowlevel(format!(
-            "raw image range 0x{image_base:x}..0x{image_end:x} exceeds the target address space"
+            "raw image range 0x{display_image_base:x}..0x{display_image_end:x} exceeds the target address space"
         )));
     }
 
@@ -2399,7 +2409,7 @@ pub fn bootstrap_from_raw(
         let normalized = address_to_byte(entry_units, "entry")?;
         if normalized < image_base || normalized >= image_end {
             return Err(KunaError::lowlevel(format!(
-                "raw entry 0x{entry:x} is outside mapped range 0x{image_base:x}..0x{image_end:x}"
+                "raw entry 0x{entry:x} is outside mapped range 0x{display_image_base:x}..0x{display_image_end:x}"
             )));
         }
         if !normalized_entries.contains(&normalized) {

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -240,9 +240,14 @@ pub struct ConsoleProgram {
     /// The marshaling id registry (C++ `ElementId` global table) for option-name
     /// resolution.
     registry: IdRegistry,
-    /// The binaryimage's function symbols (name → entry address), read once at
-    /// load (the `readLoaderSymbols` hook).
+    /// The program's function symbols (name → entry address), installed through
+    /// the `readLoaderSymbols` hook. Object/XML names are collected at load;
+    /// synthetic raw names are collected after options are applied.
     symbols: Vec<ProgramSymbol>,
+    /// Raw-image entry addresses awaiting synthetic names. Raw inputs have no
+    /// source names, so their names are generated at `read symbols`, after the
+    /// CLI has applied options such as `namestyle`.
+    pending_raw_entries: Vec<Address>,
     /// Original-to-synthetic section map for relocatable objects.
     object_sections: Vec<ObjectSectionLocation>,
     /// A human-readable description of the loaded program (C++
@@ -363,8 +368,8 @@ impl ConsoleProgram {
         &self.registry
     }
 
-    /// The number of function symbols read from the binaryimage (what the
-    /// `readLoaderSymbols` hook yields).
+    /// The number of function symbols collected for the `readLoaderSymbols`
+    /// hook.
     pub fn num_symbols(&self) -> usize {
         self.symbols.len()
     }
@@ -1554,6 +1559,9 @@ impl ConsoleProgram {
     /// runs AFTER the CLI's `option` lines, so a disabled pass's facts are
     /// dropped here rather than committed.
     ///
+    /// Raw-image entries are named and installed here for the same ordering
+    /// reason: their synthetic names must honor the active `namestyle` option.
+    ///
     /// Drains the stash (so a second `read symbols` does not re-commit), merges
     /// only the **enabled** passes' outputs in pass order, and commits the merged
     /// [`AnalysisOutput`] via [`commit_analysis_output`]. A no-op when nothing is
@@ -1568,6 +1576,21 @@ impl ConsoleProgram {
     /// defensively re-gated facts merge into the same `merged` output committed
     /// below. With Listing off, this whole block is skipped.
     pub fn commit_pending_analysis(&mut self) -> KunaResult<()> {
+        if !self.pending_raw_entries.is_empty() {
+            let entries = std::mem::take(&mut self.pending_raw_entries);
+            let symbols = entries
+                .into_iter()
+                .map(|addr| ProgramSymbol {
+                    name: self.arch().name_function(&addr),
+                    addr,
+                    object_location: None,
+                    binding: None,
+                    provenance: EntryProvenance::Mapped,
+                })
+                .collect::<Vec<_>>();
+            self.symbols.extend(symbols);
+            self.read_loader_symbols()?;
+        }
         if self.pending_analysis.is_empty() && self.loader_data_objects.is_empty() {
             // Drop the deferred-Listing stash too: nothing to commit against, and
             // a session with no analysis tier (XML path) must not build a Listing.
@@ -2143,6 +2166,7 @@ pub fn bootstrap_program(
         arch: arch.into_sleigh(),
         registry,
         symbols,
+        pending_raw_entries: Vec::new(),
         object_sections: Vec::new(),
         description,
         pending_analysis: Vec::new(),
@@ -2364,15 +2388,9 @@ pub fn bootstrap_from_raw(
         })?;
     }
 
-    let symbols = normalized_entries
+    let pending_raw_entries = normalized_entries
         .into_iter()
-        .map(|entry| ProgramSymbol {
-            name: format!("sub_{entry:x}"),
-            addr: Address::new(Rc::clone(&code_space), entry),
-            object_location: None,
-            binding: None,
-            provenance: EntryProvenance::Mapped,
-        })
+        .map(|entry| Address::new(Rc::clone(&code_space), entry))
         .collect();
     let description = raw
         .sleigh()
@@ -2394,10 +2412,11 @@ pub fn bootstrap_from_raw(
         explicit.context_paints = input_context_paints;
         pending_analysis.push(("input_isa", explicit));
     }
-    let mut prog = ConsoleProgram {
+    let prog = ConsoleProgram {
         arch: raw.into_sleigh(),
         registry,
-        symbols,
+        symbols: Vec::new(),
+        pending_raw_entries,
         object_sections: Vec::new(),
         description,
         pending_analysis,
@@ -2411,7 +2430,6 @@ pub fn bootstrap_from_raw(
         pending_prototypes: BTreeMap::new(),
         raw_address_units: Some((word_size, arm32)),
     };
-    prog.read_loader_symbols()?;
     Ok(prog)
 }
 
@@ -2712,6 +2730,7 @@ pub fn bootstrap_from_object_with_isa(
         arch: sleigh,
         registry,
         symbols,
+        pending_raw_entries: Vec::new(),
         object_sections,
         description,
         // Stash the per-pass analysis facts + the code space for the gated commit

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -3584,11 +3584,14 @@ fn select_macho_slice(bytes: Vec<u8>, target: &str) -> Vec<u8> {
     peel_fat_image(bytes, slice_pref(None, Some(target)))
 }
 
+const RAW_IMAGE_INPUT_HINT: &str =
+    "unrecognized input format; for a headerless image use --raw-image --target <SLEIGH-language-id> --base <address> and at least one --entry/--addr <address>";
+
 /// Bootstrap from a file path (the `decomp_dbg` `load file [<target>] <path>`
 /// body).  Detects the format by its leading bytes: an object-format magic
 /// ([`is_object_binary`]) routes to the real-binary [`ObjectLoadImage`] path;
-/// anything else is parsed as the XML `<binaryimage>`/`<decompilertest>` corpus
-/// format.
+/// a non-object is accepted as XML only when it parses and contains the corpus's
+/// `<binaryimage>` element. Other bytes receive the raw-image command guidance.
 ///
 /// This mirrors the C++ `ArchitectureCapability::findCapability` dispatch: the
 /// `xml` capability's `isFileMatch` claims a `<bi…` document, otherwise the BFD
@@ -3618,12 +3621,18 @@ pub fn bootstrap_from_file(
         .next()
         .is_some_and(|byte| byte == b'<')
     {
-        return Err(KunaError::lowlevel(
-            "unrecognized input format; for a headerless image use --raw-image --target <SLEIGH-language-id> --base <address> and at least one --entry/--addr <address>",
-        ));
+        return Err(KunaError::lowlevel(RAW_IMAGE_INPUT_HINT));
     }
     let mut store = DocumentStorage::new();
-    let root = store.parse_document(&bytes)?.get_root().clone();
+    let root = match store.parse_document(&bytes) {
+        Ok(document) => document.get_root().clone(),
+        Err(error) => {
+            return Err(KunaError::lowlevel(format!("{error}; {RAW_IMAGE_INPUT_HINT}")));
+        }
+    };
+    if find_binaryimage(&root).is_none() {
+        return Err(KunaError::lowlevel(RAW_IMAGE_INPUT_HINT));
+    }
     bootstrap_from_root(&root, spec_roots)
 }
 

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -2517,6 +2517,7 @@ pub fn bootstrap_from_raw(
         assertions: Vec::new(),
         assertion_outcomes: Vec::new(),
         pending_prototypes: BTreeMap::new(),
+        declared_entries: BTreeSet::new(),
         raw_address_units: Some((word_size, arm32)),
     };
     Ok(prog)

--- a/decompiler/crates/kuna-console/src/ifacedecomp.rs
+++ b/decompiler/crates/kuna-console/src/ifacedecomp.rs
@@ -404,6 +404,16 @@ pub(crate) fn parse_machaddr(
     Ok((res, defaultsize))
 }
 
+/// Parse a user code address. The address-space parser already scales target
+/// units to bytes; raw ARM inputs additionally need their state bit removed.
+fn parse_input_code_address(
+    prog: &ConsoleProgram,
+    s: &mut CommandStream,
+) -> Result<(kuna_base::address::Address, int4), String> {
+    let (address, size) = parse_machaddr(prog, s, false)?;
+    Ok((prog.normalize_parsed_code_address(address), size))
+}
+
 /// C++ `parse_varnode(istream &s,int4 &size,Address &pc,uintm &uq,
 /// const TypeFactory &typegrp)` (`grammar.cc:3055-3084`): scan a specific
 /// varnode specifier — a storage address, then `(` [`i` | defining-pc] [`:`uniq]
@@ -573,7 +583,7 @@ fn mark_property_range(
     let dcp = dcp_mut(status)?;
     let prog = dcp.conf.as_mut().expect("conf checked non-None above");
     // C++ Address addr = parse_machaddr(s,size,*dcp->conf->types).
-    let (addr, mut size) = parse_machaddr(prog, s, false).map_err(IfaceError::parse)?;
+    let (addr, mut size) = parse_input_code_address(prog, s).map_err(IfaceError::parse)?;
     // (kuna) An explicit size may follow the address.  The C++ takes the size
     // only from the bracketed `[space,offset,size]` form, which forces a caller
     // that wants a sized range to also name the address space; `--assert
@@ -1497,7 +1507,8 @@ decomp_command!(
             use kuna_decomp::varnode::varnode_flags;
             let dcp = dcp_mut(status)?;
             let prog = dcp.conf.as_mut().expect("conf checked non-None above");
-            let (addr, _size) = parse_machaddr(prog, s, false).map_err(IfaceError::parse)?;
+            let (addr, _size) =
+                parse_input_code_address(prog, s).map_err(IfaceError::parse)?;
             s.skip_ws();
             let (addr_size, word_size) = prog.arch().data_org();
             let org = crate::grammar::DataOrg { addr_size, word_size };
@@ -1517,7 +1528,7 @@ decomp_command!(
         }
         let dcp = dcp_mut(status)?;
         let prog = dcp.conf.as_mut().expect("conf checked non-None above");
-        let (addr, _size) = parse_machaddr(prog, s, false).map_err(IfaceError::parse)?;
+        let (addr, _size) = parse_input_code_address(prog, s).map_err(IfaceError::parse)?;
         s.skip_ws();
         // Parse the required type + name (C++ parse_type).
         let (addr_size, word_size) = prog.arch().data_org();
@@ -3287,7 +3298,7 @@ decomp_command!(
         let dcp = dcp_mut(status)?;
         let prog = dcp.conf.as_ref().expect("conf present when fd present");
         // C++ Address addr( parse_machaddr(s,discard,*dcp->conf->types) ).
-        let (addr, _size) = parse_machaddr(prog, s, false).map_err(IfaceError::parse)?;
+        let (addr, _size) = parse_input_code_address(prog, s).map_err(IfaceError::parse)?;
         s.skip_ws();
         let token = s.read_token();
         if token.is_empty() {
@@ -3587,7 +3598,7 @@ decomp_command!(
         }
         let dcp = dcp_mut(status)?;
         let prog = dcp.conf.as_ref().expect("conf checked non-None above");
-        let (addr, _size) = parse_machaddr(prog, s, false).map_err(IfaceError::parse)?;
+        let (addr, _size) = parse_input_code_address(prog, s).map_err(IfaceError::parse)?;
         // C++ skips ws then reads char-by-char to EOL as the comment body.
         s.skip_ws();
         let comment = s.rest();

--- a/decompiler/crates/kuna-console/src/ifacedecomp.rs
+++ b/decompiler/crates/kuna-console/src/ifacedecomp.rs
@@ -583,7 +583,7 @@ fn mark_property_range(
     let dcp = dcp_mut(status)?;
     let prog = dcp.conf.as_mut().expect("conf checked non-None above");
     // C++ Address addr = parse_machaddr(s,size,*dcp->conf->types).
-    let (addr, mut size) = parse_input_code_address(prog, s).map_err(IfaceError::parse)?;
+    let (addr, mut size) = parse_machaddr(prog, s, false).map_err(IfaceError::parse)?;
     // (kuna) An explicit size may follow the address.  The C++ takes the size
     // only from the bracketed `[space,offset,size]` form, which forces a caller
     // that wants a sized range to also name the address space; `--assert
@@ -1507,8 +1507,7 @@ decomp_command!(
             use kuna_decomp::varnode::varnode_flags;
             let dcp = dcp_mut(status)?;
             let prog = dcp.conf.as_mut().expect("conf checked non-None above");
-            let (addr, _size) =
-                parse_input_code_address(prog, s).map_err(IfaceError::parse)?;
+            let (addr, _size) = parse_machaddr(prog, s, false).map_err(IfaceError::parse)?;
             s.skip_ws();
             let (addr_size, word_size) = prog.arch().data_org();
             let org = crate::grammar::DataOrg { addr_size, word_size };
@@ -1528,7 +1527,7 @@ decomp_command!(
         }
         let dcp = dcp_mut(status)?;
         let prog = dcp.conf.as_mut().expect("conf checked non-None above");
-        let (addr, _size) = parse_input_code_address(prog, s).map_err(IfaceError::parse)?;
+        let (addr, _size) = parse_machaddr(prog, s, false).map_err(IfaceError::parse)?;
         s.skip_ws();
         // Parse the required type + name (C++ parse_type).
         let (addr_size, word_size) = prog.arch().data_org();

--- a/decompiler/crates/kuna-console/src/ifacedecomp.rs
+++ b/decompiler/crates/kuna-console/src/ifacedecomp.rs
@@ -1770,7 +1770,7 @@ decomp_command!(
         }
         let dcp = dcp_mut(status)?;
         let prog = dcp.conf.as_mut().expect("conf checked non-None above");
-        let (addr, _size) = parse_machaddr(prog, s, false).map_err(IfaceError::parse)?;
+        let (addr, _size) = parse_input_code_address(prog, s).map_err(IfaceError::parse)?;
         s.skip_ws();
         let mut name = s.read_token(); // optional
         if name.is_empty() {

--- a/decompiler/crates/kuna-console/src/ifacedecomp.rs
+++ b/decompiler/crates/kuna-console/src/ifacedecomp.rs
@@ -72,7 +72,9 @@
 //! `Architecture`), each `engine_unavailable` site is the single place to wire
 //! the real call; the surrounding faithful structure does not change.
 
-use crate::engine::{bootstrap_from_file, ConsoleProgram, UNBOUNDED_SIZE};
+use crate::engine::{
+    bootstrap_from_file, bootstrap_from_raw, ArmIsa, ConsoleProgram, UNBOUNDED_SIZE,
+};
 use crate::interface::{
     CommandStream, IfaceCommandAction, IfaceData, IfaceError, IfaceResult, IfaceStatus,
 };
@@ -1194,6 +1196,71 @@ decomp_command!(
                 // C++ on init failure: print the error + "Could not create
                 // architecture", then leave conf null (NOT a thrown error).
                 status.out(&format!("{}\n", e.explain()));
+                status.out("Could not create architecture\n");
+                Ok(())
+            }
+        }
+    }
+);
+
+fn parse_raw_address(token: &str) -> Result<u64, IfaceError> {
+    let token = token.trim();
+    let digits = token
+        .strip_prefix("0x")
+        .or_else(|| token.strip_prefix("0X"))
+        .unwrap_or(token);
+    u64::from_str_radix(digits, 16)
+        .map_err(|_| IfaceError::parse(format!("Invalid raw address {token:?}")))
+}
+
+decomp_command!(
+    /// Load a headerless image with explicit language, base, and entry seeds.
+    IfcLoadRaw,
+    fn execute(&self, status: &mut IfaceStatus, s: &mut CommandStream) -> IfaceResult<()> {
+        let target = s.read_token();
+        let base_token = s.read_token();
+        let entries_token = s.read_token();
+        let filename = s.read_filename();
+        s.skip_ws();
+        if target.is_empty()
+            || base_token.is_empty()
+            || entries_token.is_empty()
+            || filename.is_empty()
+        {
+            return Err(IfaceError::parse(
+                "usage: load raw <target> <base> <entry[,entry...]> <filename>",
+            ));
+        }
+        if !s.eof() {
+            return Err(IfaceError::parse("Unexpected argument after raw image filename"));
+        }
+        let base = parse_raw_address(&base_token)?;
+        let entries = entries_token
+            .split(',')
+            .map(parse_raw_address)
+            .collect::<Result<Vec<_>, _>>()?;
+        let isa = std::env::var(crate::engine::ARM_ISA_ENV)
+            .ok()
+            .map(|value| ArmIsa::parse(&value))
+            .transpose()
+            .map_err(IfaceError::parse)?
+            .flatten();
+        {
+            let dcp = dcp_mut(status)?;
+            if dcp.conf.is_some() {
+                return Err(IfaceError::execution("Load image already present"));
+            }
+        }
+        let spec_roots = dcp_mut(status)?.spec_roots.clone();
+        match bootstrap_from_raw(&filename, &target, base, &entries, isa, &spec_roots) {
+            Ok(prog) => {
+                let desc = prog.description().to_string();
+                dcp_mut(status)?.conf = Some(prog);
+                status.out(&format!("{filename} successfully loaded: {desc}\n"));
+                Ok(())
+            }
+            Err(error) => {
+                status.out(&format!("{}\n", error.explain()));
                 status.out("Could not create architecture\n");
                 Ok(())
             }
@@ -4084,6 +4151,7 @@ pub fn register_decomp_commands(status: &mut IfaceStatus) {
 /// matching a console where the command was never added).
 pub fn register_console_commands(status: &mut IfaceStatus) {
     status.register_com(Box::new(IfcLoadFile), &["load", "file"]);
+    status.register_com(Box::new(IfcLoadRaw), &["load", "raw"]);
 }
 
 // ===========================================================================

--- a/decompiler/crates/kuna-console/src/kuna_console.rs
+++ b/decompiler/crates/kuna-console/src/kuna_console.rs
@@ -1098,18 +1098,25 @@ struct IfcKunaRegionTree;
 
 impl IfaceCommandAction for IfcKunaRegionTree {
     fn execute(&self, status: &mut IfaceStatus, _s: &mut CommandStream) -> IfaceResult<()> {
-        let dcp = dcp_mut(status)?;
-        let fd = match dcp.fd.as_ref() {
-            Some(fd) => fd,
-            None => return Err(IfaceError::execution("No function selected")),
+        let os = {
+            let dcp = dcp_mut(status)?;
+            let fd = match dcp.fd.as_ref() {
+                Some(fd) => fd,
+                None => return Err(IfaceError::execution("No function selected")),
+            };
+            let prog = dcp
+                .conf
+                .as_ref()
+                .ok_or_else(|| IfaceError::execution("No load image present"))?;
+            let fname = fd.get_name().to_string();
+            let ri = build_region_identifier(fd)?;
+            let mut os = String::new();
+            os.push_str("Region tree for ");
+            os.push_str(&fname);
+            os.push_str(":\n");
+            os.push_str(&ri.render_tree_with(&|address| prog.output_code_offset(address)));
+            os
         };
-        let fname = fd.get_name().to_string();
-        let ri = build_region_identifier(fd)?;
-        let mut os = String::new();
-        os.push_str("Region tree for ");
-        os.push_str(&fname);
-        os.push_str(":\n");
-        os.push_str(&ri.render_tree());
         status.file_out(&os);
         Ok(())
     }
@@ -1124,30 +1131,38 @@ struct IfcKunaRegionBlocks;
 
 impl IfaceCommandAction for IfcKunaRegionBlocks {
     fn execute(&self, status: &mut IfaceStatus, _s: &mut CommandStream) -> IfaceResult<()> {
-        let dcp = dcp_mut(status)?;
-        let fd = match dcp.fd.as_ref() {
-            Some(fd) => fd,
-            None => return Err(IfaceError::execution("No function selected")),
-        };
-        let fname = fd.get_name().to_string();
-        let ri = build_region_identifier(fd)?;
-        let lists = ri.get_regions_by_block_addrs();
-        let mut os = String::new();
-        os.push_str("Regions for ");
-        os.push_str(&fname);
-        os.push_str(": ");
-        os.push_str(&lists.len().to_string());
-        os.push('\n');
-        for list in lists {
-            os.push('[');
-            for (i, a) in list.iter().enumerate() {
-                if i != 0 {
-                    os.push_str(", ");
+        let os = {
+            let dcp = dcp_mut(status)?;
+            let fd = match dcp.fd.as_ref() {
+                Some(fd) => fd,
+                None => return Err(IfaceError::execution("No function selected")),
+            };
+            let prog = dcp
+                .conf
+                .as_ref()
+                .ok_or_else(|| IfaceError::execution("No load image present"))?;
+            let fname = fd.get_name().to_string();
+            let ri = build_region_identifier(fd)?;
+            let lists = ri.get_regions_by_block_addrs();
+            let mut os = String::new();
+            os.push_str("Regions for ");
+            os.push_str(&fname);
+            os.push_str(": ");
+            os.push_str(&lists.len().to_string());
+            os.push('\n');
+            for list in lists {
+                os.push('[');
+                for (i, address) in list.iter().enumerate() {
+                    if i != 0 {
+                        os.push_str(", ");
+                    }
+                    let address = prog.output_code_offset(*address);
+                    os.push_str(&format!("0x{address:x}"));
                 }
-                os.push_str(&format!("0x{a:x}"));
+                os.push_str("]\n");
             }
-            os.push_str("]\n");
-        }
+            os
+        };
         status.file_out(&os);
         Ok(())
     }
@@ -1158,12 +1173,12 @@ impl IfaceCommandAction for IfcKunaRegionBlocks {
 
 /// Visitor for `region walk`: pushes a `walk 0x<addr>` line per leaf block.
 struct RegionWalkVisitor {
-    out: String,
+    addresses: Vec<u64>,
 }
 
 impl kuna_decomp::kuna_regionid::KunaRegionVisitor for RegionWalkVisitor {
     fn visit_block(&mut self, _block: Option<kuna_decomp::context::BlockId>, addr: u64) {
-        self.out.push_str(&format!("walk 0x{addr:x}\n"));
+        self.addresses.push(addr);
     }
 }
 
@@ -1173,21 +1188,31 @@ struct IfcKunaRegionWalk;
 
 impl IfaceCommandAction for IfcKunaRegionWalk {
     fn execute(&self, status: &mut IfaceStatus, _s: &mut CommandStream) -> IfaceResult<()> {
-        let dcp = dcp_mut(status)?;
-        let fd = match dcp.fd.as_ref() {
-            Some(fd) => fd,
-            None => return Err(IfaceError::execution("No function selected")),
+        let os = {
+            let dcp = dcp_mut(status)?;
+            let fd = match dcp.fd.as_ref() {
+                Some(fd) => fd,
+                None => return Err(IfaceError::execution("No function selected")),
+            };
+            let prog = dcp
+                .conf
+                .as_ref()
+                .ok_or_else(|| IfaceError::execution("No load image present"))?;
+            let fname = fd.get_name().to_string();
+            let ri = build_region_identifier(fd)?;
+            let mut visitor = RegionWalkVisitor { addresses: Vec::new() };
+            ri.walk_blocks(&mut visitor)
+                .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
+            let mut os = String::new();
+            os.push_str("Region walk for ");
+            os.push_str(&fname);
+            os.push_str(":\n");
+            for address in visitor.addresses {
+                let address = prog.output_code_offset(address);
+                os.push_str(&format!("walk 0x{address:x}\n"));
+            }
+            os
         };
-        let fname = fd.get_name().to_string();
-        let ri = build_region_identifier(fd)?;
-        let mut visitor = RegionWalkVisitor { out: String::new() };
-        ri.walk_blocks(&mut visitor)
-            .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
-        let mut os = String::new();
-        os.push_str("Region walk for ");
-        os.push_str(&fname);
-        os.push_str(":\n");
-        os.push_str(&visitor.out);
         status.file_out(&os);
         Ok(())
     }
@@ -1210,10 +1235,13 @@ impl IfaceCommandAction for IfcKunaFunctions {
             prog.commit_pending_analysis()
                 .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
             prog.function_entries_executable()
+                .into_iter()
+                .map(|entry| (prog.output_code_offset(entry.addr.get_offset()), entry.name))
+                .collect::<Vec<_>>()
         };
         let mut out = String::new();
-        for entry in entries {
-            out.push_str(&format!("{:#x} {}\n", entry.addr.get_offset(), entry.name));
+        for (address, name) in entries {
+            out.push_str(&format!("{address:#x} {name}\n"));
         }
         status.file_out(&out);
         Ok(())

--- a/decompiler/crates/kuna-console/src/kuna_console.rs
+++ b/decompiler/crates/kuna-console/src/kuna_console.rs
@@ -1271,20 +1271,38 @@ impl IfaceCommandAction for IfcKunaFunctionBounds {
         } else {
             return Err(IfaceError::parse(format!("Unexpected token {tok:?} (expected 'as')")));
         };
-        let size = match end {
-            None => 0,
-            Some(end) if end > start => (end - start) as kuna_base::types::int4,
-            Some(end) => {
+        if let Some(end) = end {
+            if end <= start {
                 return Err(IfaceError::parse(format!(
                     "function bounds: end {end:#x} must be above start {start:#x}"
-                )))
+                )));
             }
-        };
+        }
+        let display_start = start;
         let dcp = dcp_mut(status)?;
         let prog = dcp
             .conf
             .as_mut()
             .ok_or_else(|| IfaceError::execution("No load image present"))?;
+        let start = prog
+            .input_code_offset(start)
+            .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
+        let size = match end {
+            None => 0,
+            Some(end) => {
+                let end = prog
+                    .input_code_offset(end)
+                    .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
+                let size = end.checked_sub(start).filter(|size| *size > 0).ok_or_else(|| {
+                    IfaceError::parse(
+                        "function bounds: end must be above start after target address conversion",
+                    )
+                })?;
+                kuna_base::types::int4::try_from(size).map_err(|_| {
+                    IfaceError::execution("function bounds: byte extent exceeds supported range")
+                })?
+            }
+        };
         let space = prog
             .arch()
             .manage()
@@ -1295,7 +1313,9 @@ impl IfaceCommandAction for IfcKunaFunctionBounds {
         let name = prog
             .declare_function(addr, name.as_deref(), size)
             .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
-        status.out(&format!("Declared {name} at {start:#x} spanning {size} bytes\n"));
+        status.out(&format!(
+            "Declared {name} at {display_start:#x} spanning {size} bytes\n"
+        ));
         Ok(())
     }
 

--- a/decompiler/crates/kuna-console/src/project.rs
+++ b/decompiler/crates/kuna-console/src/project.rs
@@ -847,9 +847,9 @@ fn emit_data_tail(
             Some(s) if s > 0 => s as u64,
             _ => {
                 let next_label = data
-                    .keys()
-                    .map(|&(addr, _)| addr)
-                    .find(|&addr| addr > display_vma);
+                    .range((display_vma.saturating_add(1), i32::MIN)..)
+                    .next()
+                    .map(|(&(addr, _), _)| addr);
                 let sec_end = sections
                     .iter()
                     .find(|&&(sv, ss, _)| byte_vma >= sv && byte_vma < sv.saturating_add(ss))

--- a/decompiler/crates/kuna-console/src/project.rs
+++ b/decompiler/crates/kuna-console/src/project.rs
@@ -47,7 +47,10 @@ pub fn default_fn_budget_seconds(mode: &str, whole_binary: bool) -> u64 {
 /// `error`).
 pub struct FuncResult {
     pub name: String,
+    /// User-facing address, in the target's address units for a raw image.
     pub address: u64,
+    /// Engine address, always stored as a byte offset.
+    pub byte_address: u64,
     /// The entry's byte extent, carried through from
     /// [`FunctionEntry::size`](crate::engine::FunctionEntry::size) so this
     /// surface and the `functions` inventory report ONE number with one meaning.
@@ -105,7 +108,8 @@ pub fn decompile_targets(
         ..
     } in targets
     {
-        let address = entry.get_offset();
+        let byte_address = entry.get_offset();
+        let address = prog.output_code_offset(byte_address);
         // (kuna) An entry with no mapped bytes is an EXTERNAL, not a decompile
         // failure: a relocatable object's undefined symbols (and a PE import
         // slot) carry an address only so a call to one renders by name, and the
@@ -123,6 +127,7 @@ pub fn decompile_targets(
                 )),
                 name,
                 address,
+                byte_address,
                 size: size as i64,
                 error: None,
                 proto: None,
@@ -137,6 +142,7 @@ pub fn decompile_targets(
             out.push(FuncResult {
                 name,
                 address,
+                byte_address,
                 size: size as i64,
                 code: None,
                 error: Some("entry address is not mapped in this input".into()),
@@ -152,7 +158,7 @@ pub fn decompile_targets(
         // `-g` binary renders DWARF names/types) and decompile.  The drive itself
         // catches un-ported-seam panics and returns Err, so a single bad function
         // degrades to an `error` record instead of aborting the binary.
-        let mapped = prog.dwarf_locals_for(address);
+        let mapped = prog.dwarf_locals_for(byte_address);
         // (kuna, Ghidra-gap) `CALL_RETURN` flow overrides for the binary's
         // `call error(nonzero,…)` sites — prune the fall-through so the flow-follower
         // stops at the no-return call (Ghidra "Subroutine does not return") instead of
@@ -186,7 +192,7 @@ pub fn decompile_targets(
         // A caller-declared extent (`function bounds` / `kuna --define-function`)
         // bounds this function's flow follow; 0 — the usual case — is the natural,
         // unbounded extent.
-        let declared = prog.declared_extent(address);
+        let declared = prog.declared_extent(byte_address);
         // (kuna `--assert`) The caller-declared facts this function is decompiled
         // AGAINST: a `prototype`/`param`/`return` directive is consumed at flow
         // time, so it has to be seeded here rather than applied afterwards. Every
@@ -278,6 +284,11 @@ pub fn decompile_targets(
                     let mut variables =
                         if no_vars { Vec::new() } else { extract_variables(prog.arch(), &fd) };
                     provenance.apply_to_variables(&fd, &mut variables);
+                    for variable in &mut variables {
+                        for address in &mut variable.addresses {
+                            *address = prog.output_code_offset(*address);
+                        }
+                    }
                     // The prototype must be captured HERE (fd is dropped at the
                     // end of the iteration) and inside the same guard (the
                     // declarator walk shares the printer's fail-fast invariants).
@@ -286,12 +297,19 @@ pub fn decompile_targets(
                     } else {
                         None
                     };
-                    (code, variables, proto, provenance.line_mappings)
+                    let mut line_mappings = provenance.line_mappings;
+                    for mapping in &mut line_mappings {
+                        for address in &mut mapping.addresses {
+                            *address = prog.output_code_offset(*address);
+                        }
+                    }
+                    (code, variables, proto, line_mappings)
                 }));
                 match rendered {
                     Ok((code, variables, proto, line_mappings)) => out.push(FuncResult {
                         name,
                         address,
+                        byte_address,
                         size: size as i64,
                         code: Some(code),
                         error: None,
@@ -304,6 +322,7 @@ pub fn decompile_targets(
                     Err(_) => out.push(FuncResult {
                         name,
                         address,
+                        byte_address,
                         size: size as i64,
                         code: None,
                         error: Some("panic while rendering C / extracting variables".into()),
@@ -318,6 +337,7 @@ pub fn decompile_targets(
             Err(e) => out.push(FuncResult {
                 name,
                 address,
+                byte_address,
                 size: size as i64,
                 code: None,
                 error: Some(e.explain().to_string()),
@@ -559,7 +579,7 @@ pub fn build_asm(
 
     let mut labels: LabelMap = BTreeMap::new();
     for r in results {
-        labels.entry(normalize(r.address)).or_default().push(r);
+        labels.entry(normalize(r.byte_address)).or_default().push(r);
     }
 
     let sections = prog.sections();
@@ -576,7 +596,11 @@ pub fn build_asm(
     let mut scratch = AssemblyScratch::new();
     for (vma, size) in code_secs {
         let end = vma.saturating_add(size);
-        out.push_str(&format!("\n; --- code section 0x{vma:x}..0x{end:x} ---\n"));
+        let display_vma = prog.output_code_offset(vma);
+        let display_end = prog.output_code_end_offset(end);
+        out.push_str(&format!(
+            "\n; --- code section 0x{display_vma:x}..0x{display_end:x} ---\n"
+        ));
         sweep_code(prog, &labels, vma, end, &mut scratch, &mut out);
     }
 
@@ -614,17 +638,17 @@ fn sweep_code(
             Ok(len) if len > 0 && addr + len as u64 <= next_stop => {
                 scratch.flush_db(out);
                 prog.read_bytes_into(addr, len as usize, &mut scratch.raw);
-                scratch.emit_instruction(addr, out);
+                scratch.emit_instruction(prog.output_code_offset(addr), out);
                 addr += len as u64;
             }
             _ => {
                 // Decode failure (or a decode that would cross the next label):
                 // one raw byte, coalesced into up-to-8-byte `db` lines.
                 if prog.read_bytes_into(addr, 1, &mut scratch.raw) {
-                    scratch.push_db(addr, scratch.raw[0], out);
+                    scratch.push_db(prog.output_code_offset(addr), scratch.raw[0], out);
                 } else {
                     scratch.flush_db(out);
-                    scratch.emit_unreadable(addr, out);
+                    scratch.emit_unreadable(prog.output_code_offset(addr), out);
                 }
                 addr += 1;
             }

--- a/decompiler/crates/kuna-console/src/project.rs
+++ b/decompiler/crates/kuna-console/src/project.rs
@@ -442,7 +442,8 @@ pub fn build_c(file_name: &str, results: &[FuncResult]) -> String {
 /// `dat_` + 1+ lowercase-hex chars, and the char after the hex run must not
 /// be an identifier char either (so a user symbol like `dat_foo` or
 /// `dat_12x3` never false-positives — the printer's tokens are exact by
-/// construction).  Returns the parsed VMAs.
+/// construction). Returns the presentation coordinates exactly as printed;
+/// they are not engine byte offsets on a word-addressed target.
 pub fn collect_dat_addrs(results: &[FuncResult]) -> BTreeSet<u64> {
     fn is_ident(b: u8) -> bool {
         b.is_ascii_alphanumeric() || b == b'_'
@@ -805,23 +806,29 @@ fn emit_data_tail(
     dat_addrs: &BTreeSet<u64>,
     out: &mut String,
 ) {
-    let mut data: BTreeMap<u64, DataLabel> = BTreeMap::new();
+    let mut data: BTreeMap<(u64, i32), DataLabel> = BTreeMap::new();
     for (name, address, type_size) in prog.global_data_symbol_addresses() {
-        let vma = address.get_offset();
-        // First named symbol at a VMA wins (global_data_symbols is
-        // (vma, name)-sorted; duplicates at one address are aliases).
-        data.entry(vma).or_insert(DataLabel {
+        let display_vma = prog.output_address_offset(&address);
+        let space_index = address.get_space().map_or(i32::MAX, |space| space.get_index());
+        // First named symbol at a displayed address wins (global_data_symbols
+        // is address/name-sorted; duplicates at one address are aliases).
+        data.entry((display_vma, space_index)).or_insert(DataLabel {
             name,
             type_size: Some(type_size),
             dat_alias: false,
             address: Some(address),
         });
     }
-    for &vma in dat_addrs {
-        data.entry(vma)
+    let data_space_index = prog
+        .arch()
+        .manage()
+        .get_default_data_space()
+        .map_or(i32::MAX, |space| space.get_index());
+    for &display_vma in dat_addrs {
+        data.entry((display_vma, data_space_index))
             .and_modify(|l| l.dat_alias = true)
             .or_insert_with(|| DataLabel {
-                name: format!("dat_{vma:x}"),
+                name: format!("dat_{display_vma:x}"),
                 type_size: None,
                 dat_alias: false,
                 address: None,
@@ -832,27 +839,36 @@ fn emit_data_tail(
     }
 
     out.push_str("\n; --- data ---\n");
-    let addrs: Vec<u64> = data.keys().copied().collect();
-    for (idx, (&vma, label)) in data.iter().enumerate() {
-        let display_vma = label
-            .address
-            .as_ref()
-            .map_or(vma, |address| prog.output_address_offset(address));
+    for (&(display_vma, _space_index), label) in &data {
+        let byte_vma = label.address.as_ref().map_or(display_vma, Address::get_offset);
         // Size: a typed symbol's datatype size; a bare `dat_` gets
         // min(gap to the next label / containing-section end, 32), floor 1.
         let size = match label.type_size {
             Some(s) if s > 0 => s as u64,
             _ => {
-                let next_label = addrs.get(idx + 1).copied();
+                let next_label = data
+                    .keys()
+                    .map(|&(addr, _)| addr)
+                    .find(|&addr| addr > display_vma);
                 let sec_end = sections
                     .iter()
-                    .find(|&&(sv, ss, _)| vma >= sv && vma < sv.saturating_add(ss))
-                    .map(|&(sv, ss, _)| sv + ss);
+                    .find(|&&(sv, ss, _)| byte_vma >= sv && byte_vma < sv.saturating_add(ss))
+                    .map(|&(sv, ss, _)| sv.saturating_add(ss))
+                    .map(|byte_end| {
+                        label
+                            .address
+                            .as_ref()
+                            .and_then(Address::get_space)
+                            .cloned()
+                            .map_or(byte_end, |space| {
+                                prog.output_address_offset(&Address::new(space, byte_end))
+                            })
+                    });
                 let bound = [next_label, sec_end]
                     .into_iter()
                     .flatten()
-                    .filter(|&b| b > vma)
-                    .map(|b| b - vma)
+                    .filter(|&b| b > display_vma)
+                    .map(|b| b - display_vma)
                     .min()
                     .unwrap_or(DAT_SIZE_CAP);
                 bound.clamp(1, DAT_SIZE_CAP)
@@ -861,7 +877,7 @@ fn emit_data_tail(
         out.push('\n');
         if label.dat_alias {
             out.push_str(&format!(
-                "{}:  ; 0x{display_vma:x} = dat_{vma:x}\n",
+                "{}:  ; 0x{display_vma:x} = dat_{display_vma:x}\n",
                 label.name
             ));
         } else {
@@ -869,7 +885,7 @@ fn emit_data_tail(
         }
         let bytes = match label.address.as_ref() {
             Some(address) => prog.read_bytes_at(address, size as usize),
-            None => prog.read_bytes(vma, size as usize),
+            None => prog.read_bytes(byte_vma, size as usize),
         };
         match bytes {
             Some(bytes) => {
@@ -880,7 +896,7 @@ fn emit_data_tail(
                         .iter()
                         .map(|&b| if (0x20..0x7f).contains(&b) { b as char } else { '.' })
                         .collect();
-                    let byte_offset = vma + row as u64 * 16;
+                    let byte_offset = byte_vma + row as u64 * 16;
                     let display_offset = match label.address.as_ref() {
                         Some(address) => {
                             let space = address
@@ -890,7 +906,7 @@ fn emit_data_tail(
                             let row_address = Address::new(space, byte_offset);
                             prog.output_address_offset(&row_address)
                         }
-                        None => byte_offset,
+                        None => display_vma + row as u64 * 16,
                     };
                     out.push_str(&format!("  {display_offset:08x}: {hex:<47}  |{ascii}|\n"));
                 }

--- a/decompiler/crates/kuna-console/src/project.rs
+++ b/decompiler/crates/kuna-console/src/project.rs
@@ -825,6 +825,7 @@ fn emit_data_tail(
     out.push_str("\n; --- data ---\n");
     let addrs: Vec<u64> = data.keys().copied().collect();
     for (idx, (&vma, label)) in data.iter().enumerate() {
+        let display_vma = prog.output_code_offset(vma);
         // Size: a typed symbol's datatype size; a bare `dat_` gets
         // min(gap to the next label / containing-section end, 32), floor 1.
         let size = match label.type_size {
@@ -847,9 +848,12 @@ fn emit_data_tail(
         };
         out.push('\n');
         if label.dat_alias {
-            out.push_str(&format!("{}:  ; 0x{vma:x} = dat_{vma:x}\n", label.name));
+            out.push_str(&format!(
+                "{}:  ; 0x{display_vma:x} = dat_{vma:x}\n",
+                label.name
+            ));
         } else {
-            out.push_str(&format!("{}:  ; 0x{vma:x}\n", label.name));
+            out.push_str(&format!("{}:  ; 0x{display_vma:x}\n", label.name));
         }
         match prog.read_bytes(vma, size as usize) {
             Some(bytes) => {
@@ -862,13 +866,13 @@ fn emit_data_tail(
                         .collect();
                     out.push_str(&format!(
                         "  {:08x}: {hex:<47}  |{ascii}|\n",
-                        vma + row as u64 * 16
+                        prog.output_code_offset(vma + row as u64 * 16)
                     ));
                 }
             }
             None => {
                 out.push_str(&format!(
-                    "  {vma:08x}: ?? (uninitialized/unmapped, {size} bytes)\n"
+                    "  {display_vma:08x}: ?? (uninitialized/unmapped, {size} bytes)\n"
                 ));
             }
         }

--- a/decompiler/crates/kuna-console/src/project.rs
+++ b/decompiler/crates/kuna-console/src/project.rs
@@ -15,6 +15,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 use std::path::Path;
 
+use kuna_base::address::Address;
 use kuna_decomp::decompile_drive::{
     extract_variables, print_c, print_c_prototype, print_c_with_provenance, LineMapping, VarInfo,
 };
@@ -792,6 +793,7 @@ struct DataLabel {
     name: String,
     type_size: Option<i64>,
     dat_alias: bool,
+    address: Option<Address>,
 }
 
 /// `; --- data ---`: address-sorted deduped labels (named globals ∪ `dat_`
@@ -804,10 +806,16 @@ fn emit_data_tail(
     out: &mut String,
 ) {
     let mut data: BTreeMap<u64, DataLabel> = BTreeMap::new();
-    for (name, vma, type_size) in prog.global_data_symbols() {
+    for (name, address, type_size) in prog.global_data_symbol_addresses() {
+        let vma = address.get_offset();
         // First named symbol at a VMA wins (global_data_symbols is
         // (vma, name)-sorted; duplicates at one address are aliases).
-        data.entry(vma).or_insert(DataLabel { name, type_size: Some(type_size), dat_alias: false });
+        data.entry(vma).or_insert(DataLabel {
+            name,
+            type_size: Some(type_size),
+            dat_alias: false,
+            address: Some(address),
+        });
     }
     for &vma in dat_addrs {
         data.entry(vma)
@@ -816,6 +824,7 @@ fn emit_data_tail(
                 name: format!("dat_{vma:x}"),
                 type_size: None,
                 dat_alias: false,
+                address: None,
             });
     }
     if data.is_empty() {
@@ -825,7 +834,10 @@ fn emit_data_tail(
     out.push_str("\n; --- data ---\n");
     let addrs: Vec<u64> = data.keys().copied().collect();
     for (idx, (&vma, label)) in data.iter().enumerate() {
-        let display_vma = prog.output_code_offset(vma);
+        let display_vma = label
+            .address
+            .as_ref()
+            .map_or(vma, |address| prog.output_address_offset(address));
         // Size: a typed symbol's datatype size; a bare `dat_` gets
         // min(gap to the next label / containing-section end, 32), floor 1.
         let size = match label.type_size {
@@ -855,7 +867,11 @@ fn emit_data_tail(
         } else {
             out.push_str(&format!("{}:  ; 0x{display_vma:x}\n", label.name));
         }
-        match prog.read_bytes(vma, size as usize) {
+        let bytes = match label.address.as_ref() {
+            Some(address) => prog.read_bytes_at(address, size as usize),
+            None => prog.read_bytes(vma, size as usize),
+        };
+        match bytes {
             Some(bytes) => {
                 for (row, chunk) in bytes.chunks(16).enumerate() {
                     let hex =
@@ -864,10 +880,19 @@ fn emit_data_tail(
                         .iter()
                         .map(|&b| if (0x20..0x7f).contains(&b) { b as char } else { '.' })
                         .collect();
-                    out.push_str(&format!(
-                        "  {:08x}: {hex:<47}  |{ascii}|\n",
-                        prog.output_code_offset(vma + row as u64 * 16)
-                    ));
+                    let byte_offset = vma + row as u64 * 16;
+                    let display_offset = match label.address.as_ref() {
+                        Some(address) => {
+                            let space = address
+                                .get_space()
+                                .cloned()
+                                .expect("mapped data label has an address space");
+                            let row_address = Address::new(space, byte_offset);
+                            prog.output_address_offset(&row_address)
+                        }
+                        None => byte_offset,
+                    };
+                    out.push_str(&format!("  {display_offset:08x}: {hex:<47}  |{ascii}|\n"));
                 }
             }
             None => {

--- a/decompiler/crates/kuna-console/tests/verify_raw_image.rs
+++ b/decompiler/crates/kuna-console/tests/verify_raw_image.rs
@@ -1,0 +1,258 @@
+//! Headerless raw-image bootstrap and address-translation regressions.
+
+mod common;
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use kuna_console::engine::{bootstrap_from_raw, ArmIsa};
+use kuna_console::project::decompile_targets;
+
+struct RawFixture(PathBuf);
+
+impl RawFixture {
+    fn thumb_return_7() -> Self {
+        Self::new("raw-thumb", &[0x07, 0x20, 0x70, 0x47])
+    }
+
+    fn new(stem: &str, bytes: &[u8]) -> Self {
+        let path = common::scratch_file(stem, "bin");
+        std::fs::write(&path, bytes).unwrap();
+        Self(path)
+    }
+
+    fn thumb_return_7_with_spaces() -> Self {
+        let path = common::scratch_file("raw thumb image", "bin");
+        std::fs::write(&path, [0x07, 0x20, 0x70, 0x47]).unwrap();
+        Self(path)
+    }
+}
+
+impl Drop for RawFixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .canonicalize()
+        .unwrap()
+}
+
+fn specs() -> Vec<String> {
+    vec![std::env::var("KUNA_SPECS")
+        .unwrap_or_else(|_| repo_root().join("specs").to_string_lossy().into_owned())]
+}
+
+#[test]
+fn raw_thumb_maps_base_zero_and_nonzero() {
+    let fixture = RawFixture::thumb_return_7();
+    let path = fixture.0.to_string_lossy();
+    for (base, selected) in [(0, 0), (0x4000, 0x4001)] {
+        let mut program = match bootstrap_from_raw(
+            &path,
+            "ARM:LE:32:v4t:default",
+            base,
+            &[base, selected],
+            Some(ArmIsa::Thumb),
+            &specs(),
+        ) {
+            Ok(program) => program,
+            Err(error) => {
+                eprintln!(
+                    "verify_raw_image: skipping (build the ARM `.sla`): {}",
+                    error.explain()
+                );
+                return;
+            }
+        };
+        program.commit_pending_analysis().unwrap();
+        assert_eq!(program.sections(), vec![(base, 4, 4)]);
+        assert_eq!(program.num_symbols(), 1);
+        let entry = program
+            .find_entry_at(selected)
+            .expect("seeded raw entry must resolve");
+        assert_eq!(entry.addr.get_offset(), base);
+        assert!(program.entry_bytes_mapped(&entry.addr));
+
+        let results = decompile_targets(&mut program, vec![entry], true, false, false);
+        assert_eq!(results.len(), 1);
+        assert!(results[0].error.is_none(), "{:?}", results[0].error);
+        let code = results[0].code.as_deref().unwrap();
+        assert!(
+            code.contains("return 7;"),
+            "unexpected raw Thumb body:\n{code}"
+        );
+    }
+}
+
+#[test]
+fn word_addressed_targets_scale_base_and_entries_to_byte_offsets() {
+    let fixture = RawFixture::new("raw-avr-nops", &[0, 0, 0, 0]);
+    let path = fixture.0.to_string_lossy();
+
+    let at_nonzero_base =
+        match bootstrap_from_raw(&path, "avr8:LE:16:default", 0x100, &[0x100], None, &specs()) {
+            Ok(program) => program,
+            Err(error) => {
+                eprintln!(
+                    "verify_raw_image: skipping (build the AVR8 `.sla`): {}",
+                    error.explain()
+                );
+                return;
+            }
+        };
+    assert_eq!(at_nonzero_base.sections(), vec![(0x200, 4, 4)]);
+    let entry = at_nonzero_base
+        .find_entry_at(0x200)
+        .expect("word-addressed base must become a byte VMA");
+    assert!(at_nonzero_base.entry_bytes_mapped(&entry.addr));
+
+    let at_second_word = bootstrap_from_raw(&path, "avr8:LE:16:default", 0, &[1], None, &specs())
+        .expect("same built AVR8 specification");
+    let entry = at_second_word
+        .find_entry_at(2)
+        .expect("entry word 1 must select file byte offset 2");
+    assert_eq!(entry.addr.get_offset(), 2);
+    assert!(at_second_word.entry_bytes_mapped(&entry.addr));
+}
+
+#[test]
+fn console_load_raw_preserves_whitespace_in_final_filename() {
+    let fixture = RawFixture::thumb_return_7_with_spaces();
+    let roots = specs();
+    if !PathBuf::from(&roots[0])
+        .join("Ghidra/Processors/ARM/data/languages/ARM8_le.sla")
+        .exists()
+    {
+        eprintln!("verify_raw_image: skipping whitespace path test (no ARM `.sla`)");
+        return;
+    }
+    let mut child = Command::new(env!("CARGO_BIN_EXE_decomp_dbg"))
+        .args(["-sleighpath", &roots[0]])
+        .env(kuna_console::engine::ARM_ISA_ENV, "thumb")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn decomp_dbg");
+    writeln!(
+        child.stdin.as_mut().expect("console stdin"),
+        "load raw ARM:LE:32:v4t:default 0x4000 0x4001 \"{}\"\nquit",
+        fixture.0.display()
+    )
+    .expect("write console commands");
+    let output = child.wait_with_output().expect("wait for decomp_dbg");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "{stdout}\n{stderr}");
+    assert!(stdout.contains("successfully loaded"), "{stdout}\n{stderr}");
+}
+
+#[test]
+fn raw_input_rejects_missing_metadata_and_unmapped_entries() {
+    let fixture = RawFixture::thumb_return_7();
+    let path = fixture.0.to_string_lossy();
+
+    let missing_target = bootstrap_from_raw(&path, "", 0, &[0], None, &specs())
+        .err()
+        .expect("missing target must fail")
+        .explain()
+        .to_string();
+    assert!(missing_target.contains("requires --target"));
+
+    let error = match bootstrap_from_raw(
+        &path,
+        "ARM:LE:32:v4t:default",
+        0x4000,
+        &[0x4000],
+        None,
+        &specs(),
+    ) {
+        Ok(_) => panic!("raw ARM input without --isa unexpectedly loaded"),
+        Err(error) => error.explain().to_string(),
+    };
+    if error.contains("No sleigh specification") {
+        eprintln!("verify_raw_image: skipping (build the ARM `.sla`): {error}");
+        return;
+    }
+    assert!(
+        error.contains("requires --isa"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn raw_input_rejects_entry_at_end_of_mapping() {
+    let fixture = RawFixture::thumb_return_7();
+    let path = fixture.0.to_string_lossy();
+    let error = match bootstrap_from_raw(
+        &path,
+        "ARM:LE:32:v4t:default",
+        0x4000,
+        &[0x4004],
+        Some(ArmIsa::Thumb),
+        &specs(),
+    ) {
+        Ok(_) => panic!("out-of-range raw entry unexpectedly loaded"),
+        Err(error) => error.explain().to_string(),
+    };
+    if error.contains("No sleigh specification") {
+        eprintln!("verify_raw_image: skipping (build the ARM `.sla`): {error}");
+        return;
+    }
+    assert!(
+        error.contains("outside mapped range"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn raw_input_rejects_empty_images() {
+    let fixture = RawFixture::new("raw-empty", &[]);
+    let path = fixture.0.to_string_lossy();
+    let error = match bootstrap_from_raw(
+        &path,
+        "ARM:LE:32:v4t:default",
+        0,
+        &[0],
+        Some(ArmIsa::Thumb),
+        &specs(),
+    ) {
+        Ok(_) => panic!("empty raw image unexpectedly loaded"),
+        Err(error) => error.explain().to_string(),
+    };
+    if error.contains("No sleigh specification") {
+        eprintln!("verify_raw_image: skipping (build the ARM `.sla`): {error}");
+        return;
+    }
+    assert!(
+        error.contains("raw image is empty"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn raw_input_rejects_mapping_overflow() {
+    let fixture = RawFixture::thumb_return_7();
+    let path = fixture.0.to_string_lossy();
+    let error = match bootstrap_from_raw(
+        &path,
+        "ARM:LE:32:v4t:default",
+        u64::MAX,
+        &[u64::MAX],
+        Some(ArmIsa::Thumb),
+        &specs(),
+    ) {
+        Ok(_) => panic!("overflowing raw mapping unexpectedly loaded"),
+        Err(error) => error.explain().to_string(),
+    };
+    if error.contains("No sleigh specification") {
+        eprintln!("verify_raw_image: skipping (build the ARM `.sla`): {error}");
+        return;
+    }
+    assert!(error.contains("overflows"), "unexpected error: {error}");
+}

--- a/decompiler/crates/kuna-console/tests/verify_raw_image.rs
+++ b/decompiler/crates/kuna-console/tests/verify_raw_image.rs
@@ -94,7 +94,7 @@ fn word_addressed_targets_scale_base_and_entries_to_byte_offsets() {
     let fixture = RawFixture::new("raw-avr-nops", &[0, 0, 0, 0]);
     let path = fixture.0.to_string_lossy();
 
-    let at_nonzero_base =
+    let mut at_nonzero_base =
         match bootstrap_from_raw(&path, "avr8:LE:16:default", 0x100, &[0x100], None, &specs()) {
             Ok(program) => program,
             Err(error) => {
@@ -105,14 +105,16 @@ fn word_addressed_targets_scale_base_and_entries_to_byte_offsets() {
                 return;
             }
         };
+    at_nonzero_base.commit_pending_analysis().unwrap();
     assert_eq!(at_nonzero_base.sections(), vec![(0x200, 4, 4)]);
     let entry = at_nonzero_base
         .find_entry_at(0x200)
         .expect("word-addressed base must become a byte VMA");
     assert!(at_nonzero_base.entry_bytes_mapped(&entry.addr));
 
-    let at_second_word = bootstrap_from_raw(&path, "avr8:LE:16:default", 0, &[1], None, &specs())
+    let mut at_second_word = bootstrap_from_raw(&path, "avr8:LE:16:default", 0, &[1], None, &specs())
         .expect("same built AVR8 specification");
+    at_second_word.commit_pending_analysis().unwrap();
     let entry = at_second_word
         .find_entry_at(2)
         .expect("entry word 1 must select file byte offset 2");

--- a/decompiler/crates/kuna-console/tests/verify_raw_image.rs
+++ b/decompiler/crates/kuna-console/tests/verify_raw_image.rs
@@ -47,6 +47,32 @@ fn specs() -> Vec<String> {
         .unwrap_or_else(|_| repo_root().join("specs").to_string_lossy().into_owned())]
 }
 
+fn run_console(script: &str, isa: Option<&str>) -> std::process::Output {
+    let roots = specs();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_decomp_dbg"));
+    command
+        .args(["-sleighpath", &roots[0]])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    match isa {
+        Some(isa) => {
+            command.env(kuna_console::engine::ARM_ISA_ENV, isa);
+        }
+        None => {
+            command.env_remove(kuna_console::engine::ARM_ISA_ENV);
+        }
+    }
+    let mut child = command.spawn().expect("spawn decomp_dbg");
+    child
+        .stdin
+        .as_mut()
+        .expect("console stdin")
+        .write_all(script.as_bytes())
+        .expect("write console commands");
+    child.wait_with_output().expect("wait for decomp_dbg")
+}
+
 #[test]
 fn raw_thumb_maps_base_zero_and_nonzero() {
     let fixture = RawFixture::thumb_return_7();
@@ -123,6 +149,71 @@ fn word_addressed_targets_scale_base_and_entries_to_byte_offsets() {
     assert_eq!(entry.addr.get_offset(), 2);
     assert_eq!(at_second_word.output_code_offset(entry.addr.get_offset()), 1);
     assert!(at_second_word.entry_bytes_mapped(&entry.addr));
+}
+
+#[test]
+fn raw_console_reports_word_addresses_in_target_units() {
+    let fixture = RawFixture::new("raw-word-report", &[0, 0, 0x08, 0x95]);
+    let roots = specs();
+    if !PathBuf::from(&roots[0])
+        .join("Ghidra/Processors/Atmel/data/languages/avr8.sla")
+        .exists()
+    {
+        eprintln!("verify_raw_image: skipping console report test (no AVR8 `.sla`)");
+        return;
+    }
+    let script = format!(
+        "load raw avr8:LE:16:default 0x100 0x101 \"{}\"\n\
+         read symbols\n\
+         functions\n\
+         load addr 0x101\n\
+         decompile\n\
+         region blocks\n\
+         region tree\n\
+         region walk\n\
+         quit\n",
+        fixture.0.display()
+    );
+    let output = run_console(&script, None);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "{stdout}\n{stderr}");
+    for expected in ["0x101 sub_101", "[0x101]", "region head=0x101", "walk 0x101"] {
+        assert!(stdout.contains(expected), "missing {expected:?}:\n{stdout}\n{stderr}");
+    }
+    for byte_address in ["0x202 sub_101", "[0x202]", "region head=0x202", "walk 0x202"] {
+        assert!(
+            !stdout.contains(byte_address),
+            "leaked byte address {byte_address:?}:\n{stdout}\n{stderr}"
+        );
+    }
+}
+
+#[test]
+fn raw_map_function_normalizes_an_odd_thumb_pointer() {
+    let fixture = RawFixture::thumb_return_7();
+    let roots = specs();
+    if !PathBuf::from(&roots[0])
+        .join("Ghidra/Processors/ARM/data/languages/ARM8_le.sla")
+        .exists()
+    {
+        eprintln!("verify_raw_image: skipping map function test (no ARM `.sla`)");
+        return;
+    }
+    let script = format!(
+        "load raw ARM:LE:32:v4t:default 0x4000 0x4000 \"{}\"\n\
+         map function 0x4001 mapped_thumb\n\
+         decompile\n\
+         print C\n\
+         quit\n",
+        fixture.0.display()
+    );
+    let output = run_console(&script, Some("thumb"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "{stdout}\n{stderr}");
+    assert!(stdout.contains("mapped_thumb"), "{stdout}\n{stderr}");
+    assert!(stdout.contains("return 7;"), "{stdout}\n{stderr}");
 }
 
 #[test]
@@ -213,6 +304,32 @@ fn raw_input_rejects_entry_at_end_of_mapping() {
         error.contains("outside mapped range"),
         "unexpected error: {error}"
     );
+}
+
+#[test]
+fn word_addressed_mapping_errors_report_target_units() {
+    let fixture = RawFixture::new("raw-word-bounds", &[0, 0, 0, 0]);
+    let path = fixture.0.to_string_lossy();
+    let error = match bootstrap_from_raw(
+        &path,
+        "avr8:LE:16:default",
+        0x100,
+        &[0x103],
+        None,
+        &specs(),
+    ) {
+        Ok(_) => panic!("out-of-range word-addressed entry unexpectedly loaded"),
+        Err(error) => error.explain().to_string(),
+    };
+    if error.contains("No sleigh specification") {
+        eprintln!("verify_raw_image: skipping target-unit bounds test (no AVR8 `.sla`): {error}");
+        return;
+    }
+    assert!(
+        error.contains("raw entry 0x103 is outside mapped range 0x100..0x102"),
+        "unexpected error: {error}"
+    );
+    assert!(!error.contains("0x200..0x204"), "byte bounds leaked: {error}");
 }
 
 #[test]

--- a/decompiler/crates/kuna-console/tests/verify_raw_image.rs
+++ b/decompiler/crates/kuna-console/tests/verify_raw_image.rs
@@ -45,6 +45,13 @@ fn repo_root() -> PathBuf {
         .unwrap()
 }
 
+/// A missing `.sla` is a visible skip; any other bootstrap failure is the test
+/// failing, so a regression can never present as a green skip.
+fn skip_or_fail(reason: &str, spec: &str) {
+    assert!(reason.contains("No sleigh specification"), "raw bootstrap failed: {reason}");
+    eprintln!("verify_raw_image: skipping (build the {spec} `.sla`): {reason}");
+}
+
 fn specs() -> Vec<String> {
     vec![std::env::var("KUNA_SPECS")
         .unwrap_or_else(|_| repo_root().join("specs").to_string_lossy().into_owned())]
@@ -91,10 +98,7 @@ fn raw_thumb_maps_base_zero_and_nonzero() {
         ) {
             Ok(program) => program,
             Err(error) => {
-                eprintln!(
-                    "verify_raw_image: skipping (build the ARM `.sla`): {}",
-                    error.explain()
-                );
+                skip_or_fail(&error.explain().to_string(), "ARM");
                 return;
             }
         };
@@ -132,10 +136,7 @@ fn raw_arm_data_addresses_preserve_their_low_bit() {
     ) {
         Ok(program) => program,
         Err(error) => {
-            eprintln!(
-                "verify_raw_image: skipping (build the ARM `.sla`): {}",
-                error.explain()
-            );
+            skip_or_fail(&error.explain().to_string(), "ARM");
             return;
         }
     };
@@ -176,10 +177,7 @@ fn word_addressed_targets_scale_base_and_entries_to_byte_offsets() {
         match bootstrap_from_raw(&path, "avr8:LE:16:default", 0x100, &[0x100], None, &specs()) {
             Ok(program) => program,
             Err(error) => {
-                eprintln!(
-                    "verify_raw_image: skipping (build the AVR8 `.sla`): {}",
-                    error.explain()
-                );
+                skip_or_fail(&error.explain().to_string(), "AVR8");
                 return;
             }
         };

--- a/decompiler/crates/kuna-console/tests/verify_raw_image.rs
+++ b/decompiler/crates/kuna-console/tests/verify_raw_image.rs
@@ -6,8 +6,11 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
+use kuna_base::address::Address;
+use kuna_console::assertions::{self, Body, Directive};
 use kuna_console::engine::{bootstrap_from_raw, ArmIsa};
 use kuna_console::project::decompile_targets;
+use kuna_decomp::varnode::varnode_flags;
 
 struct RawFixture(PathBuf);
 
@@ -116,6 +119,55 @@ fn raw_thumb_maps_base_zero_and_nonzero() {
 }
 
 #[test]
+fn raw_arm_data_addresses_preserve_their_low_bit() {
+    let fixture = RawFixture::thumb_return_7();
+    let path = fixture.0.to_string_lossy();
+    let mut program = match bootstrap_from_raw(
+        &path,
+        "ARM:LE:32:v4t:default",
+        0x4000,
+        &[0x4001],
+        Some(ArmIsa::Thumb),
+        &specs(),
+    ) {
+        Ok(program) => program,
+        Err(error) => {
+            eprintln!(
+                "verify_raw_image: skipping (build the ARM `.sla`): {}",
+                error.explain()
+            );
+            return;
+        }
+    };
+    program.commit_pending_analysis().unwrap();
+    assert_eq!(program.input_address_offset(0x4001).unwrap(), 0x4001);
+    assert_eq!(program.input_code_offset(0x4001).unwrap(), 0x4000);
+    program.set_assertions(vec![
+        Directive {
+            raw: "data 0x4001 char odd_data".into(),
+            body: Body::Data { addr: 0x4001, decl: "char odd_data".into() },
+        },
+        Directive {
+            raw: "volatile 0x4001+1".into(),
+            body: Body::Volatile { addr: 0x4001, size: 1 },
+        },
+    ]);
+    assertions::apply_program_scoped(&mut program);
+    assert!(program.assertion_outcomes().iter().all(|outcome| outcome.status == "applied"));
+    let (_, address, _) = program
+        .global_data_symbol_addresses()
+        .into_iter()
+        .find(|(name, _, _)| name == "odd_data")
+        .expect("odd-address data symbol");
+    assert_eq!(address.get_offset(), 0x4001);
+    let code = program.arch().manage().get_default_code_space().unwrap();
+    let odd = Address::new(std::rc::Rc::clone(code), 0x4001);
+    let even = Address::new(std::rc::Rc::clone(code), 0x4000);
+    assert_ne!(program.arch().symboltab.get_property(&odd) & varnode_flags::volatil, 0);
+    assert_eq!(program.arch().symboltab.get_property(&even) & varnode_flags::volatil, 0);
+}
+
+#[test]
 fn word_addressed_targets_scale_base_and_entries_to_byte_offsets() {
     let fixture = RawFixture::new("raw-avr-nops", &[0, 0, 0, 0]);
     let path = fixture.0.to_string_lossy();
@@ -214,6 +266,40 @@ fn raw_map_function_normalizes_an_odd_thumb_pointer() {
     assert!(output.status.success(), "{stdout}\n{stderr}");
     assert!(stdout.contains("mapped_thumb"), "{stdout}\n{stderr}");
     assert!(stdout.contains("return 7;"), "{stdout}\n{stderr}");
+}
+
+#[test]
+fn raw_map_address_preserves_an_odd_arm_data_address() {
+    let fixture = RawFixture::new(
+        "raw-thumb-odd-data",
+        &[0x01, 0x48, 0x00, 0x78, 0x70, 0x47, 0, 0, 0x01, 0x40, 0, 0],
+    );
+    let roots = specs();
+    if !PathBuf::from(&roots[0])
+        .join("Ghidra/Processors/ARM/data/languages/ARM8_le.sla")
+        .exists()
+    {
+        eprintln!("verify_raw_image: skipping map address test (no ARM `.sla`)");
+        return;
+    }
+    let script = format!(
+        "load raw ARM:LE:32:v4t:default 0x4000 0x4001 \"{}\"\n\
+         map address 0x4001 char odd_data\n\
+         readonly 0x4008 4\n\
+         option readonly on\n\
+         read symbols\n\
+         load addr 0x4001\n\
+         decompile\n\
+         print C\n\
+         quit\n",
+        fixture.0.display()
+    );
+    let output = run_console(&script, Some("thumb"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "{stdout}\n{stderr}");
+    assert!(stdout.contains("return odd_data;"), "{stdout}\n{stderr}");
+    assert!(!stdout.contains("return dat_4001;"), "{stdout}\n{stderr}");
 }
 
 #[test]

--- a/decompiler/crates/kuna-console/tests/verify_raw_image.rs
+++ b/decompiler/crates/kuna-console/tests/verify_raw_image.rs
@@ -111,6 +111,8 @@ fn word_addressed_targets_scale_base_and_entries_to_byte_offsets() {
         .find_entry_at(0x200)
         .expect("word-addressed base must become a byte VMA");
     assert!(at_nonzero_base.entry_bytes_mapped(&entry.addr));
+    assert_eq!(at_nonzero_base.output_code_offset(entry.addr.get_offset()), 0x100);
+    assert_eq!(at_nonzero_base.output_code_end_offset(0x201), 0x101);
 
     let mut at_second_word = bootstrap_from_raw(&path, "avr8:LE:16:default", 0, &[1], None, &specs())
         .expect("same built AVR8 specification");
@@ -119,6 +121,7 @@ fn word_addressed_targets_scale_base_and_entries_to_byte_offsets() {
         .find_entry_at(2)
         .expect("entry word 1 must select file byte offset 2");
     assert_eq!(entry.addr.get_offset(), 2);
+    assert_eq!(at_second_word.output_code_offset(entry.addr.get_offset()), 1);
     assert!(at_second_word.entry_bytes_mapped(&entry.addr));
 }
 

--- a/decompiler/crates/kuna-decomp/src/p1_partition/raw_arch.rs
+++ b/decompiler/crates/kuna-decomp/src/p1_partition/raw_arch.rs
@@ -132,6 +132,11 @@ impl RawBinaryArchitecture {
         &mut self.sleigh
     }
 
+    /// Consume the raw frontend after its loader has been handed to the engine.
+    pub fn into_sleigh(self) -> SleighArchitecture {
+        self.sleigh
+    }
+
     /// The VMA adjustment (C++ `adjustvma`).
     pub fn adjustvma(&self) -> i64 {
         self.adjustvma
@@ -173,6 +178,25 @@ impl RawBinaryArchitecture {
             ldr.adjust_vma(self.adjustvma);
         }
         self.loader = Some(ldr);
+        Ok(())
+    }
+
+    /// Build a raw-image loader at an explicit address-space base.
+    ///
+    /// The live CLI path attaches the resolved code space before applying the
+    /// VMA so [`RawLoadImage::adjust_vma`] can scale address units correctly.
+    pub fn build_loader_at(
+        &mut self,
+        default_code_space: Rc<AddrSpace>,
+        base: u64,
+    ) -> KunaResult<()> {
+        let mut loader = RawLoadImage::new(self.sleigh.get_filename());
+        loader.open()?;
+        loader.attach_to_space(default_code_space);
+        if base != 0 {
+            loader.adjust_vma(base as i64);
+        }
+        self.loader = Some(loader);
         Ok(())
     }
 

--- a/decompiler/crates/kuna-decomp/src/p7_regions/kuna_regionid.rs
+++ b/decompiler/crates/kuna-decomp/src/p7_regions/kuna_regionid.rs
@@ -2205,21 +2205,35 @@ impl KunaRegionIdentifier {
     /// the text is deterministic.  Returns the empty string if `compute()` has
     /// not run.
     pub fn render_tree(&self) -> String {
+        self.render_tree_with(&|address| address)
+    }
+
+    /// Render the region tree after mapping each internal block address to its
+    /// presentation coordinate.
+    pub fn render_tree_with(&self, display_address: &dyn Fn(uintb) -> uintb) -> String {
         let mut os = String::new();
         if let Some(top) = self.top_region {
-            self.render_region(top, 0, &mut os);
+            self.render_region(top, 0, display_address, &mut os);
         }
         os
     }
 
     /// Recursive helper for [`render_tree`].
-    fn render_region(&self, region_id: RegionPayloadId, depth: usize, os: &mut String) {
+    fn render_region(
+        &self,
+        region_id: RegionPayloadId,
+        depth: usize,
+        display_address: &dyn Fn(uintb) -> uintb,
+        os: &mut String,
+    ) {
         let region = &self.region_pool[region_id.0 as usize];
         for _ in 0..depth {
             os.push_str("  ");
         }
         os.push_str("region head=0x");
-        let head_addr = region.get_head().map(|h| self.pool.get(h).get_addr()).unwrap_or(0);
+        let head_addr = display_address(
+            region.get_head().map(|h| self.pool.get(h).get_addr()).unwrap_or(0),
+        );
         os.push_str(&format!("{head_addr:x}"));
         os.push_str(" nodes=");
         os.push_str(&region.graph.num_nodes().to_string());
@@ -2232,7 +2246,7 @@ impl KunaRegionIdentifier {
             let node = self.pool.get(mk.id);
             if node.is_region() {
                 if let Some(sub) = node.get_region() {
-                    self.render_region(sub, depth + 1, os);
+                    self.render_region(sub, depth + 1, display_address, os);
                 }
             } else if node.is_multi() {
                 let chain: Vec<KunaNodeId> = node.get_chain().to_vec();
@@ -2241,7 +2255,7 @@ impl KunaRegionIdentifier {
                         os.push_str("  ");
                     }
                     os.push_str("block 0x");
-                    os.push_str(&format!("{:x}", self.pool.get(m).get_addr()));
+                    os.push_str(&format!("{:x}", display_address(self.pool.get(m).get_addr())));
                     os.push('\n');
                 }
             } else if node.get_kind() == NodeKind::Block {
@@ -2249,7 +2263,7 @@ impl KunaRegionIdentifier {
                     os.push_str("  ");
                 }
                 os.push_str("block 0x");
-                os.push_str(&format!("{:x}", node.get_addr()));
+                os.push_str(&format!("{:x}", display_address(node.get_addr())));
                 os.push('\n');
             }
         }
@@ -2601,4 +2615,3 @@ mod tests {
         }
     }
 }
-

--- a/decompiler/crates/kuna-decomp/src/p7_regions/kuna_regionid.rs
+++ b/decompiler/crates/kuna-decomp/src/p7_regions/kuna_regionid.rs
@@ -2203,13 +2203,8 @@ impl KunaRegionIdentifier {
     /// `block 0x..` per leaf block, indent 2 spaces per depth.  The members are
     /// iterated in `KunaNodeOrder` (the `node_keys` order the walker uses), so
     /// the text is deterministic.  Returns the empty string if `compute()` has
-    /// not run.
-    pub fn render_tree(&self) -> String {
-        self.render_tree_with(&|address| address)
-    }
-
-    /// Render the region tree after mapping each internal block address to its
-    /// presentation coordinate.
+    /// not run.  `display_address` maps each internal block address to its
+    /// presentation coordinate (identity for a byte-addressed program).
     pub fn render_tree_with(&self, display_address: &dyn Fn(uintb) -> uintb) -> String {
         let mut os = String::new();
         if let Some(top) = self.top_region {
@@ -2218,7 +2213,7 @@ impl KunaRegionIdentifier {
         os
     }
 
-    /// Recursive helper for [`render_tree`].
+    /// Recursive helper for [`render_tree_with`].
     fn render_region(
         &self,
         region_id: RegionPayloadId,

--- a/decompiler/crates/kuna-sleigh/src/loadimage.rs
+++ b/decompiler/crates/kuna-sleigh/src/loadimage.rs
@@ -33,6 +33,7 @@
 //! with its previous contents — so an OS-level I/O failure has no defined
 //! oracle behavior; the port surfaces it as `KunaError::Lowlevel`.
 
+use std::cell::Cell;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::rc::Rc;
@@ -255,7 +256,8 @@ pub trait LoadImage {
 /// This is probably the simplest loadimage.  Bytes from the image are read
 /// directly from a file stream.  The address associated with each byte is
 /// determined by a single value, the vma, which is the address of the first
-/// byte in the file.  No symbols or sections are supported
+/// byte in the file. No symbols are supported; the complete mapped file is
+/// published as one synthetic code section.
 #[derive(Debug)]
 pub struct RawLoadImage {
     /// Name of the loadimage (the `LoadImage` base-class member)
@@ -269,6 +271,8 @@ pub struct RawLoadImage {
     /// Address space that the file bytes are mapped to (C++ raw pointer,
     /// null until `attachToSpace`)
     spaceid: Option<Rc<AddrSpace>>,
+    /// Cursor for the synthetic whole-file section record.
+    cursection: Cell<bool>,
 }
 
 impl RawLoadImage {
@@ -280,12 +284,23 @@ impl RawLoadImage {
             thefile: None,
             filesize: 0,
             spaceid: None,
+            cursection: Cell::new(false),
         }
     }
 
     /// Attach the raw image to a particular space
     pub fn attach_to_space(&mut self, id: Rc<AddrSpace>) {
         self.spaceid = Some(id);
+    }
+
+    /// Number of bytes mapped by this raw image after [`Self::open`].
+    pub fn file_size(&self) -> u64 {
+        self.filesize
+    }
+
+    /// Byte address assigned to file offset zero.
+    pub fn vma(&self) -> u64 {
+        self.vma
     }
 
     /// Open the raw file for reading.
@@ -383,6 +398,24 @@ impl LoadImage for RawLoadImage {
         b"unknown".to_vec()
     }
 
+    fn open_section_info(&self) {
+        self.cursection.set(false);
+    }
+
+    fn get_next_section(&self, record: &mut LoadImageSection) -> bool {
+        if self.cursection.replace(true) || self.filesize == 0 {
+            return false;
+        }
+        let space = self
+            .spaceid
+            .as_ref()
+            .expect("RawLoadImage::getNextSection before attachToSpace (C++ null space)");
+        record.address = Address::new(Rc::clone(space), self.vma);
+        record.size = self.filesize;
+        record.flags = section_flags::CODE;
+        false
+    }
+
     fn adjust_vma(&mut self, adjust: i64) {
         // C++ dereferences the (possibly null) `spaceid` pointer — UB when
         // adjustVma is called before attachToSpace (ADR 0004: panic)
@@ -442,6 +475,14 @@ mod tests {
         img.open().unwrap();
         assert_eq!(img.get_arch_type(), b"unknown".to_vec());
         assert_eq!(img.get_file_name(), path.to_str().unwrap());
+        assert_eq!(img.file_size(), 16);
+        assert_eq!(img.vma(), 0);
+        img.open_section_info();
+        let mut section = LoadImageSection::default();
+        assert!(!img.get_next_section(&mut section));
+        assert_eq!(section.address.get_offset(), 0);
+        assert_eq!(section.size, 16);
+        assert_eq!(section.flags, section_flags::CODE);
 
         // vma defaults to 0: address == file offset
         let mut buf = [0xaau8; 4];

--- a/decompiler/crates/kuna-wasm/src/lib.rs
+++ b/decompiler/crates/kuna-wasm/src/lib.rs
@@ -163,7 +163,9 @@ pub fn run_with(
                 /* want_provenance= */ false,
             );
             let kinds: Vec<&'static str> =
-                out.iter().map(|f| classifier.kind(&prog, &f.name, f.address)).collect();
+                out.iter()
+                    .map(|f| classifier.kind(&prog, &f.name, f.byte_address))
+                    .collect();
             Ok(result_json(binary, &out, &kinds))
         }
     }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -602,6 +602,42 @@ With no mode evidence, decoding uses the selected language's default context; us
 `strings --no-xrefs` decodes nothing, so the pair is a usage error rather than a
 silently dropped flag.
 
+### Headerless raw images
+
+`--raw-image` loads a file that has no object header. It is separate from
+`decompile --raw`, which still means “also print raw p-code.” A raw image must
+name its decoder with `--target <SLEIGH-language-id>`, map file offset zero with
+`--base <address>`, and supply at least one numeric entry. `decompile` uses its
+positional address; the other supported commands accept repeatable `--entry` or
+`--addr` values.
+
+```bash
+kuna decompile payload.bin 0x4001 --raw-image \
+  --target ARM:LE:32:v4t:default --base 0x4000 --isa thumb
+
+kuna functions payload.bin --json --raw-image \
+  --target ARM:LE:32:v4t:default --base 0x4000 \
+  --entry 0x4001 --isa thumb
+```
+
+The whole nonempty file is one contiguous executable `CODE` mapping. Base and
+entry values use the selected language's address units, so address `1` in a
+two-byte word-addressed code space selects file byte offset `2`. The mapping is
+checked for arithmetic and address-space overflow, and an entry outside its
+half-open range is rejected. Duplicate entries collapse. ARM32 raw input requires
+`--isa arm|thumb`; odd ARM function pointers are normalized to their underlying
+even byte address before validation.
+
+Raw images carry no symbols or trustworthy boundary metadata, so `functions`
+reports the explicit seeds. Named `--functions`, section-relative selectors,
+`--slice`, `--summary`, and `--reachable-from` are rejected. Support is limited
+to `decompile` (text and JSON), `decompile-all`, `functions`, and
+`decompile-project`; `decompile-graph`, `disassemble`/`read`, `xrefs`, and
+`strings` require object metadata. A headerless file used without `--raw-image`
+reports the required raw-image command shape. Quoted console filenames preserve
+paths containing whitespace; the interactive spelling is
+`load raw <target> <base> <entry[,entry...]> <filename>`.
+
 **Failure contract (DIV-45).** A function whose decompile pipeline aborts is
 *loud*:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -635,9 +635,10 @@ reports the explicit seeds. Named `--functions`, section-relative selectors,
 to `decompile` (text and JSON), `decompile-all`, `functions`, and
 `decompile-project`; `decompile-graph`, `disassemble`/`read`, `xrefs`, and
 `strings` require object metadata. A headerless file used without `--raw-image`
-reports the required raw-image command shape. Quoted console filenames preserve
-paths containing whitespace; the interactive spelling is
-`load raw <target> <base> <entry[,entry...]> <filename>`.
+reports the required raw-image command shape, including when its first byte is
+`<`; only a parsed document containing `<binaryimage>` is treated as XML. Quoted
+console filenames preserve paths containing whitespace; the interactive spelling
+is `load raw <target> <base> <entry[,entry...]> <filename>`.
 
 **Failure contract (DIV-45).** A function whose decompile pipeline aborts is
 *loud*:
@@ -1532,7 +1533,8 @@ binary and attempt recompilation:
   storage, undecodable bytes as `db` lines, and a `; --- data ---` tail labeling named
   globals plus every `dat_<hex>` the `.c` references, with raw bytes. Data-tail addresses
   use their source address space's units; a `dat_<hex>` label retains the coordinate
-  printed in C.
+  printed in C, and aliases a named symbol only in the same address space at the same
+  displayed coordinate.
 - `README.md` — size, arch id, entry point, function counts, sections table, file
   inventory.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -626,7 +626,8 @@ two-byte word-addressed code space selects file byte offset `2`. The mapping is
 checked for arithmetic and address-space overflow, and an entry outside its
 half-open range is rejected. Duplicate entries collapse. ARM32 raw input requires
 `--isa arm|thumb`; odd ARM function pointers are normalized to their underlying
-even byte address before validation.
+even byte address before validation. Other addresses retain every input bit, so
+an odd ARM data or property address still selects the odd byte.
 
 Raw images carry no symbols or trustworthy boundary metadata, so `functions`
 reports the explicit seeds. Named `--functions`, section-relative selectors,
@@ -1529,7 +1530,9 @@ binary and attempt recompilation:
 - `<name>.asm` — labeled linear disassembly of every CODE section: labels match the `.c`
   function names, per-function `; arg:`/`; stack:` comments map decompiled variables to
   storage, undecodable bytes as `db` lines, and a `; --- data ---` tail labeling named
-  globals plus every `dat_<hex>` the `.c` references, with raw bytes.
+  globals plus every `dat_<hex>` the `.c` references, with raw bytes. Data-tail addresses
+  use their source address space's units; a `dat_<hex>` label retains the coordinate
+  printed in C.
 - `README.md` — size, arch id, entry point, function counts, sections table, file
   inventory.
 

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -2895,7 +2895,11 @@ the C++ inheritance chain modeled by composition:
   through the deferred analysis commit. Function pointers consume the ARM state bit,
   while data and property addresses preserve it. Presentation converts an address with
   its own address space's word size; data-space `dat_<hex>` tokens retain the coordinate
-  emitted in C rather than inheriting the code space's word size.
+  emitted in C rather than inheriting the code space's word size, and merge with a named
+  data label only when both the address space and presentation coordinate match. An
+  ordinary load accepts XML only after parsing a document containing `<binaryimage>`;
+  parse failures retain the headerless-image command guidance even when the first byte
+  is `<`.
 
 The real-binary path of §1.2 is the fourth binding, console-side: `bootstrap_from_object`
 plays the leaf role itself — it resolves the language from the object header

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -2884,7 +2884,15 @@ the C++ inheritance chain modeled by composition:
   (RawBinaryArchitecture)` is the catch-all leaf for a raw byte image: its file
   match always succeeds (so capability sorting pushes it last), the language must
   be supplied by the target, and the loader is a plain offset-mapped
-  `RawLoadImage`.
+  `RawLoadImage`. The live CLI reaches it only through `--raw-image`, with an
+  explicit target, base, and one or more numeric entry seeds. It resolves and
+  initializes the language first, attaches the default code space, and only then
+  applies the VMA. This order gives nonzero bases defined word-addressed behavior.
+  Base and entry values arrive in code-space address units and are checked before
+  conversion to internal byte offsets. The complete nonempty file is published as
+  one `CODE` section, and only caller-supplied entries are installed. ARM32 also
+  requires an explicit ARM/Thumb state, painted across that section and preserved
+  through the deferred analysis commit.
 
 The real-binary path of §1.2 is the fourth binding, console-side: `bootstrap_from_object`
 plays the leaf role itself — it resolves the language from the object header

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -2892,7 +2892,10 @@ the C++ inheritance chain modeled by composition:
   conversion to internal byte offsets. The complete nonempty file is published as
   one `CODE` section, and only caller-supplied entries are installed. ARM32 also
   requires an explicit ARM/Thumb state, painted across that section and preserved
-  through the deferred analysis commit.
+  through the deferred analysis commit. Function pointers consume the ARM state bit,
+  while data and property addresses preserve it. Presentation converts an address with
+  its own address space's word size; data-space `dat_<hex>` tokens retain the coordinate
+  emitted in C rather than inheriting the code space's word size.
 
 The real-binary path of §1.2 is the fourth binding, console-side: `bootstrap_from_object`
 plays the leaf role itself — it resolves the language from the object header


### PR DESCRIPTION
kuna could only load a file that carries an object header, so a firmware
dump, a shellcode blob, or a carved code region had no way in.

```sh
printf '\x07\x20\x70\x47' > raw-thumb.bin
kuna decompile raw-thumb.bin 0x4001 --raw-image \
  --target ARM:LE:32:v4t:default --base 0x4000 --isa thumb
```

On `main`:

```
error: unknown option --raw-image
```

On this branch:

```c
unsigned int sub_4000(void)
{
  return 7;
}
```

## The change

- `--raw-image` maps the whole file as one executable CODE region at
  `--base`, seeded only by the numeric entries the caller names —
  `decompile` uses its positional address, the other commands take
  repeatable `--entry`/`--addr`.
- Base and entry values are in the language's own address units, and every
  reported address comes back in those units: an AVR `--base 0x100` is file
  byte 0x200 and still prints as `0x100`.
- ARM32 raw input requires `--isa arm|thumb`. An odd function pointer loses
  its state bit; an odd data or property address keeps it.
- `decompile` (text and JSON), `decompile-all`, `functions` and
  `decompile-project` accept the flag; the commands that need object
  metadata reject it by name instead of ignoring it. A headerless file used
  *without* the flag now names the command shape it needs, rather than
  failing as malformed XML.

## Tests

`verify_raw_image.rs` covers the bootstrap, the word-addressed scaling, and
each rejection; the two `*_cli.rs` suites drive the four supported commands
end to end over synthetic ARM32, x86-64 and AVR images. All four gates plus
`kuna catalog --check` and `make test-cli` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AZ6xqryvdHijzATycm311
