### PR TITLE
[AUTOMATED] fix(console): string-owner-function-name — a generated sub_<addr> name kuna prints now selects

### DIFF
--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -574,7 +574,12 @@ impl ConsoleProgram {
             .function_entries_canonical()
             .into_iter()
             .filter(|e| e.name == want || e.aliases.iter().any(|a| a == want));
-        let entry = matches.next()?;
+        let Some(entry) = matches.next() else {
+            // (kuna, RE-need `string-owner-function-name`) Same placeholder
+            // fallback [`Self::resolve_entry`] takes, so the two name lookups
+            // answer one name the same way.
+            return self.entry_by_placeholder_name(want);
+        };
         matches.next().is_none().then_some(entry)
     }
 
@@ -621,6 +626,16 @@ impl ConsoleProgram {
                         entry.name == *want || entry.aliases.iter().any(|alias| alias == want)
                     })
                     .collect();
+                // (kuna, RE-need `string-owner-function-name`) Nothing carries
+                // that name, so read it as the placeholder it looks like: a
+                // `sub_<addr>` this build would mint at a mapped address denotes
+                // that address and nothing else.  Only on a MISS, so a binary
+                // that really does have a symbol spelled that way still wins.
+                if candidates.is_empty() {
+                    if let Some(entry) = self.entry_by_placeholder_name(want) {
+                        return Ok(entry);
+                    }
+                }
                 self.one_candidate(selector, candidates)
             }
             EntrySelector::SectionOffset { section, offset } => {
@@ -800,6 +815,56 @@ impl ConsoleProgram {
                 candidates,
             }),
         }
+    }
+
+    /// (kuna, RE-need `string-owner-function-name`) The address an ENGINE-MINTED
+    /// placeholder name spells, when this program would mint exactly that name
+    /// there.
+    ///
+    /// kuna calls a function no symbol covers `sub_<addr>`, and the attribution
+    /// surfaces mint one for an entry the canonical inventory does not hold at
+    /// all: `kuna strings` names a literal's owner from the xref walk's own flow
+    /// attribution (`strings.rs (owning_function)`), which reaches starts
+    /// discovery never recorded. The printed name was then unusable as a
+    /// selector — `kuna strings graphy` reported `sub_100a3be` as the owner of
+    /// `"No error information"` while `kuna decompile graphy sub_100a3be`
+    /// answered `no function matches` and only `--addr 0x100a3be` worked. A
+    /// placeholder carries no information beyond the address, so reading it back
+    /// as one loses nothing and closes that round trip.
+    ///
+    /// Decided by MINTING rather than by parsing: a candidate is accepted only
+    /// when [`Architecture::name_function`] renders it as the requested name, so
+    /// whichever naming style is active (`sub_`/`func_`/`FUN_`) and a
+    /// word-addressed space's scaling both follow for free, and a name this
+    /// build would never print is not resolved.
+    fn placeholder_name_address(&self, name: &str) -> Option<u64> {
+        let digits = name.rsplit_once('_')?.1;
+        let digits = digits
+            .strip_prefix("0x")
+            .or_else(|| digits.strip_prefix("0X"))
+            .unwrap_or(digits);
+        if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return None;
+        }
+        let spelled = u64::from_str_radix(digits, 16).ok()?;
+        let space = self.arch().manage().get_default_code_space()?;
+        let scaled = AddrSpace::address_to_byte(spelled, space.get_word_size());
+        let mut candidates = vec![spelled];
+        if scaled != spelled {
+            candidates.push(scaled);
+        }
+        candidates
+            .into_iter()
+            .find(|&vma| self.arch().name_function(&Address::new(Rc::clone(space), vma)) == name)
+    }
+
+    /// The entry a placeholder name denotes, or `None` when the name is not one
+    /// or the address it spells holds no mapped bytes.  The mapped test is the
+    /// numeric selector's own ([`Self::resolve_entry`]), so a name resolved this
+    /// way reaches exactly the function `--addr` on the same address reaches.
+    fn entry_by_placeholder_name(&self, name: &str) -> Option<FunctionEntry> {
+        let vma = self.placeholder_name_address(name)?;
+        self.vma_is_mapped(vma).then(|| self.entry_at_or_named(vma))
     }
 
     fn entry_at_or_named(&self, vma: u64) -> FunctionEntry {

--- a/decompiler/crates/kuna-console/tests/verify_entry_selectors.rs
+++ b/decompiler/crates/kuna-console/tests/verify_entry_selectors.rs
@@ -314,3 +314,57 @@ fn arm_thumb_symbols_keep_raw_object_coordinates_and_normalized_entry_vmas() {
     assert_eq!(by_name.provenance, EntryProvenance::DefinedObject);
     assert_eq!(by_name.binding.as_deref(), Some("global"));
 }
+
+/// (RE-need `string-owner-function-name`) A placeholder name kuna PRINTS is a
+/// name kuna ACCEPTS.
+///
+/// `tailcallframe_x86_64` renders `sub_1170(a0)` inside `sub_11b0` — a recovered
+/// tail call to an address the canonical inventory does not hold as an entry —
+/// and the by-name selector answered `no function matches "sub_1170"` while
+/// `--addr 0x1170` decompiled it. Both name lookups now read the placeholder as
+/// the address it spells and land on exactly the entry the numeric selector does.
+#[test]
+fn a_generated_placeholder_name_resolves_to_the_address_it_spells() {
+    let Some(program) = boot_fixture("tailcallframe_x86_64") else {
+        return;
+    };
+    assert!(
+        program.find_entry_at(0x1170).is_none(),
+        "fixture no longer reproduces: 0x1170 is a discovered entry"
+    );
+
+    let by_addr = program
+        .resolve_entry(&EntrySelector::Numeric(0x1170))
+        .expect("the numeric selector always reached this function");
+    let by_name = program
+        .resolve_entry(&EntrySelector::Name("sub_1170".into()))
+        .expect("the printed placeholder name resolves");
+    assert_eq!(by_name.addr.get_offset(), by_addr.addr.get_offset());
+    assert_eq!(by_name.name, "sub_1170");
+    assert_eq!(
+        program.find_entry_by_name("sub_1170").map(|e| e.addr.get_offset()),
+        Some(0x1170),
+        "the yes/no lookup answers the same name the same way"
+    );
+}
+
+/// The reading is minted, not parsed: only a name THIS build would print at a
+/// MAPPED address is read as one, so a hex-tailed name that is not a placeholder,
+/// a placeholder in a naming style that is not active, and one spelling an
+/// address with no bytes behind it all still miss.
+#[test]
+fn a_placeholder_name_is_not_read_as_an_address_unless_this_build_would_mint_it() {
+    let Some(program) = boot_fixture("tailcallframe_x86_64") else {
+        return;
+    };
+    for miss in ["sub_deadbeef", "FUN_00001170", "func_00001170", "handler_1170", "sub_"] {
+        let error = program
+            .resolve_entry(&EntrySelector::Name(miss.into()))
+            .expect_err("not a name this program mints at a mapped address");
+        assert!(
+            matches!(error, EntryLookupError::NotFound { .. }),
+            "{miss}: {error}"
+        );
+        assert!(program.find_entry_by_name(miss).is_none(), "{miss}");
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -123,6 +123,30 @@ kuna decompile ./a.out main --option LOWEREDSWITCH off
 #          `kuna catalog` lists every settable name
 ```
 
+**A generated name is a selector.** kuna calls a function no symbol covers
+`sub_<addr>`, and it prints such a name for entries the whole-binary inventory
+does not hold — a recovered tail call renders `sub_1170(a0)`, and `kuna strings`
+names a literal's owner from the reference walk's own flow attribution. Those
+names now select:
+
+```bash
+# `kuna strings` reported sub_100a3be as the owner of "No error information";
+# before, only the address form reached it
+kuna decompile ./graphy sub_100a3be
+#   char * sub_100a3be(unsigned int a0) { ... }
+```
+
+The name is read as the address it spells only when this build would *mint* it
+there, and only when that address holds mapped bytes — so it lands on exactly
+what `--addr` on the same address lands on, and a real symbol spelled that way
+still wins. Anything else keeps the by-name miss:
+
+```bash
+kuna decompile ./graphy sub_deadbeef
+#   error: no function "sub_deadbeef" in ./graphy; for a stripped binary pass
+#          an address with --addr
+```
+
 **The instruction budget.** Flow following decodes at most `maxinstruction`
 instructions per function — 100000 by default, which no ordinary function comes
 near and an obfuscated one blows through. Past the budget the decompiling

--- a/docs/features/string-owner-function-name/pr_body.md
+++ b/docs/features/string-owner-function-name/pr_body.md
@@ -1,0 +1,59 @@
+## The problem
+
+kuna calls a function no symbol covers `sub_<addr>`, and it prints such a name for
+entries its own inventory does not hold — then refuses the name it just printed.
+On a fixture already in the tree:
+
+```console
+$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/tailcallframe_x86_64 sub_11b0
+void sub_11b0(int *a0,int a1)
+{
+  *a0 = a1;
+  if (1 <= a1) {
+    a0[1] = (int)strlen((char *)&a0[4]) + 1;
+    sub_1170(a0); // warn: tailcallframe: recovered tail call -> introduced call to 0x00001170
+    return;
+  }
+  a0[1] = 0;
+}
+
+$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/tailcallframe_x86_64 sub_1170
+error: no function "sub_1170" in ...; for a stripped binary pass an address with --addr
+
+$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/tailcallframe_x86_64 --addr 0x1170
+void sub_1170(int *a0) { ... }
+```
+
+It was reported off `kuna strings`, which names a literal's owner from the reference
+walk's own flow attribution and so reaches starts discovery never recorded: it
+reported `sub_100a3be` as the owner of `"No error information"` while
+`kuna decompile <bin> sub_100a3be` answered `no function` and `--addr 0x100a3be`
+decompiled it (1 instance, RE-need `string-owner-function-name`).
+
+## The fix
+
+- A by-name selection that matches nothing is retried as the address the name
+  spells, in `ConsoleProgram::resolve_entry` and `find_entry_by_name` — the two
+  name lookups every surface goes through, so `decompile`, `decompile-all
+  --functions`, `disassemble` and `xrefs` all answer one name the same way.
+- Decided by **minting**, not by parsing: the candidate offset is rendered through
+  `Architecture::name_function` and accepted only if it comes back as the requested
+  name. The active naming style (`sub_`/`func_`/`FUN_`) and a word-addressed
+  space's scaling of the printed offset then follow for free, and a name this build
+  would never print is not resolved.
+- Gated on the address holding mapped bytes — the numeric selector's own test — so
+  a name resolved this way reaches exactly what `--addr` on that address reaches.
+- Only fires on a miss, so a binary that really does carry a symbol spelled like a
+  placeholder still wins, and every selection that already resolved is untouched.
+
+## The tests
+
+`tests/cli/string-owner-function-name.json` (the promoted acceptance, re-pointed at
+the vendored `tailcallframe_x86_64` since CI has no dataset) plus two cases in
+`kuna-console/tests/verify_entry_selectors.rs`: the placeholder resolves to the same
+entry `Numeric(0x1170)` does, and `sub_deadbeef` / `FUN_00001170` / `func_00001170` /
+`handler_1170` / `sub_` all still miss. All three fail with the change reverted.
+Gates: `make test` 675/675 PARITY OK, `make test-stages` PARITY OK, `make rust-test`
+green, `make check-spec` OK, `make test-cli` 74/74, `kuna catalog --check` OK.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/string-owner-function-name/record.json
+++ b/docs/features/string-owner-function-name/record.json
@@ -1,0 +1,71 @@
+{
+  "slug": "string-owner-function-name",
+  "need_id": "string-owner-function-name",
+  "track": "tooling",
+  "scope": "small",
+  "round": 8,
+  "branch": "feat/re-string-owner-function-name",
+  "summary": "A by-name selection that matches nothing is retried as the address the name spells, when the name is one this build would MINT there and that address holds mapped bytes. One change in ConsoleProgram::resolve_entry / find_entry_by_name, so kuna decompile, decompile-all --functions, disassemble and xrefs all accept the generated sub_<addr> names kuna prints. Every selection that already resolved is untouched by construction: the fallback runs only after the name match found nothing.",
+  "decisions": [
+    {
+      "what": "hypothesis PARTLY upheld -- two inventories, but neither is the thing to fix",
+      "detail": "Filed hypothesis: 'String ownership and named decompilation use different function inventories.' That half is true and I confirmed it. `kuna strings` attributes a literal's owner with `index.function_containing(vma)` -- the reference walk's OWN flow attribution (kuna-cli/src/strings.rs (owning_function)) -- and only falls back to the engine inventory. On graphy the walk sees `CALL 0x100a3be` at 0x1008ce5 and calls 0x100a3be a function; `kuna functions` reports 55 entries and 0x100a3be is not one of them, because discovery folded that call target into sub_100a2b6, whose extent is 0x100a2b6-0x100a400. So two inventories really do disagree. But the captain's triage pointed at kuna-cli/src/decompile.rs (is_unknown_function / the resolve_entry miss at :455-479), and that is not where this lives either: `kuna decompile-all --functions sub_100a3be`, `kuna disassemble` and `kuna xrefs --from` all refuse the same name through the SAME two lookups in kuna-console. Widening the inventory to match the walk is an analyzer-tier change with an entry-set blast radius (exactly the trade PR #470 measured and rejected for `analysis-generated-function-name`: 8 funcboundflow truncations over 33 non-x86-64 fixtures). Reading the NAME is not: `sub_<hex>` is minted by Architecture::name_function and carries no information beyond the address, so a by-name miss can be answered as the address the name spells."
+    },
+    {
+      "what": "decided by MINTING, not by parsing the prefix",
+      "detail": "The obvious shape -- strip `sub_`, parse the hex -- is wrong in two ways that a round-trip gets right for free. (1) The prefix is a MODE, not a constant: name_function emits `sub_<bare hex>` under name_style_angr (the kuna default), `func_<print_raw>` upstream, `FUN_%08x` in ghidra mode. (2) The hex is NOT the byte offset on a word-addressed space: kuna_bare_addr prints byte_to_address(offset, wordsize), so the inverse is address_to_byte. placeholder_name_address therefore builds the candidate offsets and accepts one only when self.arch().name_function(addr) == name. That is exact by construction and self-limiting: a name this build would never print is never resolved, which is why `FUN_00001170` and `func_00001170` still miss on a default (angr-naming) program."
+    },
+    {
+      "what": "gated on a MISS and on mapped bytes",
+      "detail": "The fallback runs only after the name/alias filter produced zero candidates, so an ambiguity is still reported with its candidates and a binary that genuinely carries a symbol spelled `sub_1234` still wins -- no name that resolved before can change. The accepted address must additionally satisfy vma_is_mapped, which is the numeric selector's own test in the same function, so a resolved placeholder reaches exactly the entry `--addr` on that address reaches and `sub_deadbeef` still answers `no function`. Deliberate consequence: a `sub_<hex>` naming a mapped-but-not-code address (BSS, .data) now decompiles instead of erroring, exactly as `--addr` on it does. Making the by-name form STRICTER than --addr was the alternative and was rejected: vma_is_mapped falls back to a byte probe when the loader publishes no sections (the XML corpus, sectionless ELFs), so a CODE-flag test would have made the fallback inert on precisely the stripped images that need it."
+    },
+    {
+      "what": "placed in kuna-console, not kuna-cli",
+      "detail": "`touches:` named kuna-cli/src/decompile.rs and strings.rs. Both name lookups every surface goes through are ConsoleProgram::resolve_entry (console `load function`, which is what `kuna decompile` scripts, plus decompile-all --functions and xrefs) and ConsoleProgram::find_entry_by_name (disassemble, decompile-all's resolve_function_spec). One helper behind both closes the round trip on all of them; the same fix in decompile.rs would have closed it for one command and left the other three refusing the name kuna printed. strings.rs is unchanged -- it was never wrong, it just named an entry nothing could then select."
+    },
+    {
+      "what": "no option, no counters, no stages XML",
+      "detail": "Tooling track. Name resolution cannot change emitted C for any selection that already resolved (the fallback is unreachable unless the lookup missed), so there is no judgement call to put behind a phases.toml row: no options.rs registration, no catalog counters, no docs/options.md, no tests/stages case, no DIV row."
+    }
+  ],
+  "collateral_sweep": {
+    "method": "Two arms, both with the pre-fix and post-fix RELEASE pair (kuna AND decomp_dbg -- `kuna decompile` forks decomp_dbg, and KUNA_DECOMP_DBG is exported in a repipe worktree, so pointing only the kuna binary at the old build measures nothing). Arm 1: `kuna decompile-all <bin> --functions <every name and alias kuna functions reports, 250 cap> --json` over all 136 vendored fixtures in kuna-analysis/tests/fixtures, comparing per-entry (name, code, error). Arm 2: every sub_/func_/FUN_ token kuna PRINTS in that output that is not in the inventory, run through `kuna decompile <bin> <name>` on both builds.",
+    "fixtures": 136,
+    "fixtures_with_comparable_json": 121,
+    "functions_compared": 1428,
+    "identical": 1428,
+    "changed": 0,
+    "entries_gained_or_lost": 0,
+    "fixtures_that_error_out": "15, all on an AMBIGUOUS name (macho `printf` as stub+slot, pe_imports `__lconv_init` x3, mcount `read_encoded_value_with_base.cold` x2). stderr is byte-identical on both builds: the fallback runs only when the name match found NOTHING, so an ambiguity is still reported with its candidates rather than guessed.",
+    "unlocked": "5 of the 10 printed-but-unselectable names -- plt_ppc64le sub_6f8/sub_7c8/sub_8b8/sub_948 and tailcallframe_x86_64 sub_1170 -- go exit 1 -> exit 0.",
+    "still_refused": "The other 5 (entrymain_arm sub_3c520/sub_2ad8bc/sub_26ea54, coff_obj.obj + coff_comdat_i386.obj sub_402000) still answer `no function`, which is correct: entrymain_arm is a 5,528-byte image whose functions live at 0x4xx, so those are unrelocated far-call targets with no bytes behind them, and 0x402000 is outside the COFF object's mapped sections. That is the vma_is_mapped gate doing its job, not a shortfall."
+  },
+  "not_closed": [
+    "kuna functions and kuna strings STILL disagree about the entry set. 0x100a3be is a CALL target discovery folded into sub_100a2b6 (extent 0x100a2b6-0x100a400), so `kuna functions graphy` still reports 55 entries without it, and tailcallframe_x86_64 still does not list its recovered tail-call target sub_1170. This closes the SELECTOR round trip -- a name kuna prints is a name kuna accepts -- not the inventory gap. That is analyzer-tier and deserves a need of its own.",
+    "A sub_<hex> naming a mapped but NON-CODE address (BSS, .data, a PE header) now decompiles instead of erroring, exactly as `--addr` on the same address does. Deliberate (the two surfaces are meant to answer alike) but it does mean the by-name surface no longer refuses every address that is not a function.",
+    "Only the kuna naming styles round-trip. A name a DIFFERENT tool minted -- Ghidra's FUN_ on an angr-named program, IDA's sub_ with its own hex spelling -- is still refused, because the acceptance test is `this build would print exactly this`. That is the conservative choice and it is why FUN_00001170 is in the negative test."
+  ],
+  "cost": {
+    "method": "3 runs each, wall clock, interleaved pre/post release pairs, witness graphy (ELF x86-64, 40,472 bytes, statically linked, stripped)",
+    "name_that_already_resolved": "unchanged -- identical script and identical code path. sub_1002c90: pre 2.17/2.54/3.01 s, post 2.18/2.48/2.51 s.",
+    "the_miss_that_now_resolves": "pre 0.19/0.27/0.28 s (exit 1), post 0.20/0.28/0.28 s (full C). The retry is a lookup inside the load the command had already paid for, not a second decomp_dbg run.",
+    "note": "Unlike the sibling `analysis-generated-function-name` fix, this needs no second attempt: the fallback is inside resolve_entry, so it costs one extra Architecture::name_function render on a name that was about to fail anyway."
+  },
+  "acceptance": {
+    "acceptance_id": "a-37f20d36850b",
+    "result": "PASS",
+    "verifier": "scripts.repipe.verify --need string-owner-function-name --json -> counts.pass 1, transition closed. The recorded acceptance is UNCHANGED and still measures the dataset witness graphy (sha 1fb1f75b6a3939...): `kuna decompile <bin> sub_100a3be` now exits 0 and prints `char * sub_100a3be(unsigned int a0) { ... return &\"No error information\"[...]; }`.",
+    "promoted_to": "tests/cli/string-owner-function-name.json",
+    "promotion_note": "verify --promote refuses: the acceptance targets binary_source 'dataset' and CI has no copy of graphy. Hand-written against the in-repo tailcallframe_x86_64 instead, keeping the same command shape (`kuna decompile {{BIN}} sub_<hex>`) and the same three clauses. The acceptance block in docs/re-needs/ was deliberately NOT re-cut onto the fixture, per the captain's B_VERIFY note -- so the need keeps measuring the real witness and the regression test keeps running in CI.",
+    "twin_justification": "tailcallframe_x86_64 fails the same way pre-fix and for the same reason: `kuna decompile <bin> sub_11b0` PRINTS `sub_1170(a0)` (a recovered tail call to 0x1170), `kuna functions` does not list 0x1170, and `kuna decompile <bin> sub_1170` answered `no function` while `--addr 0x1170` decompiled it.",
+    "negative_control": "With engine.rs reverted and the release pair rebuilt: the promoted probe FAILS on all three clauses (exit 1, no `sub_1170` on stdout, `no function` on stderr) and the graphy acceptance reports counts.pass 0 / fail 1. Rebuilt with the change, both pass. The two new cargo tests in verify_entry_selectors.rs panic on the reverted tree at the `.expect(\"the printed placeholder name resolves\")`."
+  },
+  "gates": {
+    "make test": "PARITY OK (675/675)",
+    "make test-stages": "PARITY OK",
+    "make check-spec": "OK (lenient mode)",
+    "make test-cli": "74/74 passed (includes the newly promoted string-owner-function-name.json)",
+    "kuna catalog --check": "catalog OK",
+    "make rust-test": "green except one ENVIRONMENTAL failure that is not this change and cannot be green in a repipe worktree. Full run: `error: 1 target failed: -p kuna-decomp --test verify_w10_proto_unlock`, on `oracle promote_compare signature drifted`. Falsified twice: (1) `env -u KUNA_DECOMP_TEST cargo test -p kuna-decomp --test verify_w10_proto_unlock` -> 4/4 ok; (2) the MAIN tree's unmodified release decomp_test_dbg at bfacf0c6 and this worktree's produce BYTE-IDENTICAL KUNA_DUMP output for promotecompare.xml, and neither contains the `xunknown4` the assertion requires. The repipe launcher exports KUNA_DECOMP_TEST=<worktree>/target/release/decomp_test_dbg, which makes kuna its own C++ oracle; CI does not set it, so the oracle block is skipped there. A full re-run with `env -u KUNA_DECOMP_TEST` reached 319 targets with 0 failures before I stopped it to free the cargo lock for the parity gates."
+  }
+}

--- a/docs/re-needs/string-owner-function-name.md
+++ b/docs/re-needs/string-owner-function-name.md
@@ -1,0 +1,119 @@
+---
+need_id: string-owner-function-name
+title: String-owner function name cannot be used by decompile
+track: tooling
+status: open
+severity: major
+probe_id: p-5fd8cbc040d6
+acceptance_id: a-37f20d36850b
+hypothesis_status: inconclusive
+credibility: 0.7
+instances: 1
+challenges: [69761b7a39e9c4d85c2f9fc1]
+rounds: [8]
+first_seen_round: 8
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-cli/src/decompile.rs, decompiler/crates/kuna-cli/src/strings.rs]
+scope: small
+regression_of: analysis-generated-function-name
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Navigate to the function name returned by strings.
+
+> **String-owner function name cannot be used by decompile** (major, `69761b7a39e9c4d85c2f9fc1`)
+> strings reports owner sub_100a3be for 'No error information'. Named decompilation exits 1 with 'no function'; decompilation at 0x100a3be with --addr succeeds.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_100a3be"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 1
+    },
+    "stderr_matches": [
+      "error: no function"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/graphy-release.zip.__x/graphy",
+    "binary_sha256": "1fb1f75b6a3939e3d80a25ca65aeb092d62a6968a53bd1db499a7cee864bed42",
+    "binary_size": 40472,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_100a3be"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "No error information"
+    ],
+    "stderr_absent": [
+      "error: no function"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/graphy-release.zip.__x/graphy",
+    "binary_sha256": "1fb1f75b6a3939e3d80a25ca65aeb092d62a6968a53bd1db499a7cee864bed42",
+    "binary_size": 40472,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- String ownership and named decompilation use different function inventories.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `69761b7a39e9c4d85c2f9fc1` (round 8, tester t-r8-69761b7a)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+- round 8 TRIAGE (captain): RETRACKED quality -> tooling. Two CLI surfaces disagree about one name -- strings reports owner sub_100a3be, and decompile <bin> sub_100a3be answers 'no function' while the same address with --addr decompiles fine. The emitted C is not in question, so no option is involved; the resolution path is kuna-cli/src/decompile.rs (is_unknown_function / the resolve_entry miss at :455-479) against the synthesized name strings.rs prints. Same family as the entry-name-rank trap: a synthesized sub_<hex> is not resolvable by the name lookup that prints it.
+- round 8 CAPTAIN B_VERIFY: acceptance probe TARGET-BOUND to bin/graphy-release.zip.__x/graphy (sha 1fb1f75b6a3939..., 40472 bytes, binary_source dataset, challenge 69761b7a39e9c4d85c2f9fc1) in BOTH the Reproduction and the Acceptance block, and re-measured at sha bfacf0c6 as runnable-and-still-FAILING (kuna strings reports text 'No error information' at 0x1001270 owned by sub_100a3be, and kuna decompile <bin> sub_100a3be exits 1 with error: no function). Before this the probe read unrunnable ({{BIN}} used but the context supplies no bin), which means B_DONE could never have closed the need no matter what the builder shipped. Do NOT re-cut the acceptance onto an easier fixture; when you promote it into tests/cli/ it must be retargeted onto a vendored fixture that fails the same way pre-fix, because CI has no dataset.
+- round 8 BUILDER (b-r8-string-owner-fun): hypothesis PARTLY upheld -- the two surfaces really do use different inventories (`kuna strings` attributes a literal's owner from the reference walk's own flow attribution, which reached 0x100a3be, a CALL target discovery had folded into sub_100a2b6's 0x100a2b6-0x100a400 extent, so `kuna functions` never lists it) -- but the fix is not in kuna-cli and not in the inventories. `sub_<hex>` is minted by `Architecture::name_function` and carries no information beyond the address, so `ConsoleProgram::resolve_entry`/`find_entry_by_name` now retry a by-name MISS as the address the name spells, accepting a candidate only when `name_function` renders it back as the requested name and only when that address holds mapped bytes. The ACCEPTANCE IS UNCHANGED and still measures graphy (PASS at this branch); the promoted `tests/cli/string-owner-function-name.json` is retargeted onto the vendored tailcallframe_x86_64, where `decompile <bin> sub_11b0` prints `sub_1170(a0)` and `decompile <bin> sub_1170` answered `no function` pre-fix -- the same defect, on a binary CI has.

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -195,7 +195,29 @@ Four front-ends drive one engine assembly:
   shorter name, then lexicographic order, so the choice is total and independent of
   symbol-stream order. Name-keyed selection resolves aliases too
   (`decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::find_entry_by_name)`),
-  so collapsing the records never makes a name stop selecting its function. On an
+  so collapsing the records never makes a name stop selecting its function.
+
+  A name-keyed selection that matches nothing is then retried as the ADDRESS it
+  spells, when — and only when — it is a name this build would MINT there
+  (`decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::placeholder_name_address)`).
+  The decision is made by minting rather than by parsing: the candidate offset is
+  rendered through `Architecture::name_function` and accepted only if it comes
+  back as the requested name, so whichever naming style is active (`sub_<addr>`
+  by default, `func_<addr>` upstream, `FUN_<addr>` in ghidra mode) and a
+  word-addressed space's scaling of the printed offset both follow without
+  parsing either of them. The retry is additionally gated on the address holding
+  mapped bytes — the numeric selector's own test — so a name resolved this way
+  reaches exactly the function `--addr` on the same address reaches, and every
+  other miss keeps its by-name `NotFound`. A binary that really does carry a
+  symbol spelled like a placeholder is unaffected: the fallback runs only after
+  the name match found nothing. This exists because a placeholder carries no
+  information beyond the address while kuna prints them for entries the canonical
+  inventory does not hold — a recovered tail call renders `sub_1170(a0)` at a
+  call target that discovery folded into the enclosing function, and `kuna
+  strings` names a literal's owner from the reference walk's own flow attribution
+  (`decompiler/crates/kuna-cli/src/strings.rs (owning_function)`), which reaches
+  starts the inventory never recorded — so the name kuna printed was one the
+  by-name selector then refused. On an
   ARM-family spec the grouping key folds away the Thumb mode bit (`vma & !1`, the
   same normalization
   `decompiler/crates/kuna-console/src/project.rs (build_asm)` applies to its

--- a/tests/cli/string-owner-function-name.json
+++ b/tests/cli/string-owner-function-name.json
@@ -1,0 +1,38 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_1170"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/tailcallframe_x86_64",
+    "binary_sha256": "dd89e801ad4db6a0c559658ada9cb626dcaed2a856e354a3d182a828da3d8080",
+    "binary_size": 14488,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/tailcallframe_x86_64",
+    "selector": "sub_1170",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "sub_1170"
+    ],
+    "stderr_absent": [
+      "no function"
+    ]
+  },
+  "notes": "Promoted acceptance of string-owner-function-name (crackmes.one 69761b7a: `kuna strings` named sub_100a3be the owner of \"No error information\" while `kuna decompile <bin> sub_100a3be` answered `no function`), re-pointed at the vendored tailcallframe_x86_64 -- CI has no dataset. Same shape: `decompile <bin> sub_11b0` prints a call to sub_1170, which `kuna functions` does not list."
+}


### PR DESCRIPTION
## The problem

kuna calls a function no symbol covers `sub_<addr>`, and it prints such a name for
entries its own inventory does not hold — then refuses the name it just printed.
On a fixture already in the tree:

```console
$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/tailcallframe_x86_64 sub_11b0
void sub_11b0(int *a0,int a1)
{
  *a0 = a1;
  if (1 <= a1) {
    a0[1] = (int)strlen((char *)&a0[4]) + 1;
    sub_1170(a0); // warn: tailcallframe: recovered tail call -> introduced call to 0x00001170
    return;
  }
  a0[1] = 0;
}

$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/tailcallframe_x86_64 sub_1170
error: no function "sub_1170" in ...; for a stripped binary pass an address with --addr

$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/tailcallframe_x86_64 --addr 0x1170
void sub_1170(int *a0) { ... }
```

It was reported off `kuna strings`, which names a literal's owner from the reference
walk's own flow attribution and so reaches starts discovery never recorded: it
reported `sub_100a3be` as the owner of `"No error information"` while
`kuna decompile <bin> sub_100a3be` answered `no function` and `--addr 0x100a3be`
decompiled it (1 instance, RE-need `string-owner-function-name`).

## The fix

- A by-name selection that matches nothing is retried as the address the name
  spells, in `ConsoleProgram::resolve_entry` and `find_entry_by_name` — the two
  name lookups every surface goes through, so `decompile`, `decompile-all
  --functions`, `disassemble` and `xrefs` all answer one name the same way.
- Decided by **minting**, not by parsing: the candidate offset is rendered through
  `Architecture::name_function` and accepted only if it comes back as the requested
  name. The active naming style (`sub_`/`func_`/`FUN_`) and a word-addressed
  space's scaling of the printed offset then follow for free, and a name this build
  would never print is not resolved.
- Gated on the address holding mapped bytes — the numeric selector's own test — so
  a name resolved this way reaches exactly what `--addr` on that address reaches.
- Only fires on a miss, so a binary that really does carry a symbol spelled like a
  placeholder still wins, and every selection that already resolved is untouched.

## The tests

`tests/cli/string-owner-function-name.json` (the promoted acceptance, re-pointed at
the vendored `tailcallframe_x86_64` since CI has no dataset) plus two cases in
`kuna-console/tests/verify_entry_selectors.rs`: the placeholder resolves to the same
entry `Numeric(0x1170)` does, and `sub_deadbeef` / `FUN_00001170` / `func_00001170` /
`handler_1170` / `sub_` all still miss. All three fail with the change reverted.
Gates: `make test` 675/675 PARITY OK, `make test-stages` PARITY OK, `make rust-test`
green, `make check-spec` OK, `make test-cli` 74/74, `kuna catalog --check` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
