### PR TITLE
[AUTOMATED] fix(console): prototype-parser-rejects-previously — accept a declared struct tag as a type

### DIFF
--- a/decompiler/crates/kuna-console/src/grammar.rs
+++ b/decompiler/crates/kuna-console/src/grammar.rs
@@ -1866,19 +1866,33 @@ impl<'a> CParse<'a> {
         }
     }
 
+    /// (kuna) The optional tag of a `struct`/`union`/`enum` specifier.
+    ///
+    /// A tag that has already been interned reaches the parser as `TYPE_NAME`,
+    /// not `IDENTIFIER`, because [`CParse::lookup_identifier`] classifies every
+    /// identifier the type factory names through `findByName`.  Accepting it
+    /// here is what lets a struct be named a second time; the position is
+    /// unambiguous, since a type name after `STRUCT` matched no production
+    /// before, and the `old*`/`new*` actions re-check the kind by name.
+    fn tag_identifier(&mut self) -> KunaResult<String> {
+        match self.peek()? {
+            PToken::Identifier(_) => match self.next()? {
+                PToken::Identifier(s) => Ok(s),
+                _ => unreachable!(),
+            },
+            PToken::TypeName(_) => match self.next()? {
+                PToken::TypeName(tp) => Ok(tp.get_name().to_string()),
+                _ => unreachable!(),
+            },
+            _ => Ok(String::new()),
+        }
+    }
+
     /// `struct_or_union_specifier` (`grammar.y:99-106`).
     fn struct_or_union_specifier(&mut self) -> KunaResult<Rc<Datatype>> {
         let is_struct = matches!(self.next()?, PToken::Struct);
         // optional IDENTIFIER, then optional '{' struct_declaration_list '}'.
-        let ident = if let PToken::Identifier(_) = self.peek()? {
-            if let PToken::Identifier(s) = self.next()? {
-                s
-            } else {
-                unreachable!()
-            }
-        } else {
-            String::new()
-        };
+        let ident = self.tag_identifier()?;
         if matches!(self.peek()?, PToken::Punct(b'{')) {
             self.next()?;
             let declist = self.struct_declaration_list()?;
@@ -1988,15 +2002,7 @@ impl<'a> CParse<'a> {
     /// `enum_specifier` (`grammar.y:134-140`).
     fn enum_specifier(&mut self) -> KunaResult<Rc<Datatype>> {
         self.next()?; // ENUM
-        let ident = if let PToken::Identifier(_) = self.peek()? {
-            if let PToken::Identifier(s) = self.next()? {
-                s
-            } else {
-                unreachable!()
-            }
-        } else {
-            String::new()
-        };
+        let ident = self.tag_identifier()?;
         if matches!(self.peek()?, PToken::Punct(b'{')) {
             self.next()?;
             let vecenum = self.enumerator_list()?;

--- a/decompiler/crates/kuna-console/src/grammar/tests.rs
+++ b/decompiler/crates/kuna-console/src/grammar/tests.rs
@@ -483,6 +483,60 @@ fn struct_pointer_param_resolves_named_type() {
 }
 
 // ===========================================================================
+// Tag references to an already-interned struct / union / enum
+// ===========================================================================
+
+#[test]
+fn struct_tag_return_type_resolves_interned_tag() {
+    // `struct JSValue { ... };` interns the tag, after which the lexer hands
+    // `JSValue` back as a TYPE_NAME; `struct JSValue` as a return type used to
+    // be a syntax error.
+    let f = factory();
+    f.get_type_struct("JSValue").unwrap();
+    let p = parse_protopieces("extern struct JSValue jsv(void *ctx);", &f, org()).unwrap();
+    assert_eq!(p.outtype.as_ref().unwrap().get_name(), "JSValue");
+    assert_eq!(p.outtype.as_ref().unwrap().get_metatype(), meta::TYPE_STRUCT);
+    assert_eq!(p.intypes.len(), 1);
+}
+
+#[test]
+fn struct_tag_pointer_param_resolves_interned_tag() {
+    let f = factory();
+    f.get_type_struct("JSValue").unwrap();
+    let p = parse_protopieces("extern void take(struct JSValue *v);", &f, org()).unwrap();
+    assert_eq!(p.intypes.len(), 1);
+    assert_eq!(p.intypes[0].get_metatype(), meta::TYPE_PTR);
+    assert_eq!(p.intypes[0].get_ptr_to().unwrap().get_name(), "JSValue");
+}
+
+#[test]
+fn union_tag_return_type_resolves_interned_tag() {
+    let f = factory();
+    f.get_type_union("myunion").unwrap();
+    let p = parse_protopieces("extern union myunion pick(int4 n);", &f, org()).unwrap();
+    assert_eq!(p.outtype.as_ref().unwrap().get_name(), "myunion");
+    assert_eq!(p.outtype.as_ref().unwrap().get_metatype(), meta::TYPE_UNION);
+}
+
+#[test]
+fn enum_tag_param_type_resolves_interned_tag() {
+    let f = factory();
+    f.get_type_enum("mode").unwrap();
+    let p = parse_protopieces("extern void set(enum mode m);", &f, org()).unwrap();
+    assert_eq!(p.intypes.len(), 1);
+    assert_eq!(p.intypes[0].get_name(), "mode");
+}
+
+#[test]
+fn struct_tag_type_parses_outside_a_prototype() {
+    let f = factory();
+    f.get_type_struct("JSValue").unwrap();
+    let t = parse_type("struct JSValue *", &f, org()).unwrap();
+    assert_eq!(t.0.get_metatype(), meta::TYPE_PTR);
+    assert_eq!(t.0.get_ptr_to().unwrap().get_name(), "JSValue");
+}
+
+// ===========================================================================
 // Rejection / error-text paths
 // ===========================================================================
 
@@ -527,12 +581,16 @@ fn reject_old_struct_not_a_struct() {
 }
 
 #[test]
-fn reject_struct_type_name_is_syntax_error() {
-    // `struct int4`: int4 is a TYPE_NAME, so neither `STRUCT IDENTIFIER` nor
-    // `STRUCT '{' ... '}'` matches -> syntax error (matches C++).
+fn reject_struct_type_name_of_the_wrong_kind() {
+    // `struct int4`: int4 is a TYPE_NAME, and a type name in tag position is
+    // read as the tag, so the kind check rejects it rather than the grammar.
     let f = factory();
     let err = parse_protopieces("extern struct int4 f(void);", &f, org()).unwrap_err();
-    assert!(err.explain().contains("Syntax error"), "got: {}", err.explain());
+    assert!(
+        err.explain().contains("Identifier does not represent a struct as required"),
+        "got: {}",
+        err.explain()
+    );
 }
 
 #[test]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -291,6 +291,17 @@ kuna decompile ./a.out sub_140004dcc --json \
   --assert 'prototype VirtualAlloc void *VirtualAlloc(void *p,unsigned int n,unsigned int a,unsigned int b)'
 ```
 
+A tag you declared earlier in the same run is usable as a type, in the `struct
+X` / `union X` / `enum X` spelling as well as by bare name — including as a
+return type, which is how a function returning a small struct by value gets its
+field accesses back:
+
+```bash
+kuna decompile ./qjs main \
+  --assert 'typedef struct JSValue { unsigned long payload; long tag; };' \
+  --assert 'prototype sub_875e0 struct JSValue JS_ReadObject(void *ctx,char *buf,unsigned long len,unsigned int flags)'
+```
+
 **`<func>` is what the prototype binds to, not the name inside the
 declaration.** The reason to state a signature at all is usually that the
 function has no name worth keeping, so the declaration gets written under the

--- a/docs/features/prototype-parser-rejects-previously/pr_body.md
+++ b/docs/features/prototype-parser-rejects-previously/pr_body.md
@@ -1,0 +1,62 @@
+## The problem
+
+A struct tag that kuna has just accepted cannot be used as a type. Declare
+`struct JSValue`, then name it as a prototype's return type, and the prototype
+is thrown away as a syntax error — a typedef alias for the same structure works,
+which is what makes it look arbitrary.
+
+```bash
+kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/fauxware main \
+  --assert 'typedef struct JSValue { unsigned long payload; long tag; };' \
+  --assert 'prototype authenticate struct JSValue authenticate(char *user, char *pass)' \
+  --assert-strict
+```
+
+```
+  v2 = authenticate(v1,v3);
+  ...
+warning: --assert "prototype authenticate struct JSValue authenticate(char *user, char *pass)" rejected: Bad C syntax
+exit 1
+```
+
+The console shows it without the CLI in the way:
+
+```
+[decomp]> parse line struct JSValue { unsigned long payload; long tag; };
+[decomp]> parse line struct JSValue v;
+Error in C syntax: Syntax error at line 0 in stream
+struct JSValue
+       ^--
+```
+
+## The fix
+
+- The lexer classifies an identifier by asking the type factory for it, so
+  interning the tag is what stops `JSValue` reaching the parser as an
+  identifier: it comes back as a type name, and `struct_or_union_specifier`
+  read its tag from the identifier terminal alone. The tag position now accepts
+  a type name too (`CParse::tag_identifier`), and `enum_specifier` reads its tag
+  through the same helper.
+- The position is unambiguous rather than a guess: a type name after `struct` /
+  `union` / `enum` matched no production before, with or without a body, so
+  every input this newly accepts used to be a syntax error.
+- Which type the tag names is still decided by the construction action, not by
+  the token. `oldStruct` re-checks the kind by name, so `struct int4` is now
+  refused for saying `struct` ("Identifier does not represent a struct as
+  required") instead of for being unparseable.
+
+## The tests
+
+Five cases in `kuna-console/src/grammar/tests.rs` cover the tag as a return
+type, as a pointer parameter, outside a prototype, and for `union` / `enum`;
+each fails without the change. `reject_struct_type_name_is_syntax_error` pinned
+the old expectation and now asserts the kind error under its new name.
+`tests/cli/prototype-parser-rejects-previously.json` is the promoted probe.
+
+Gates on the rebased tree: `make test` PARITY OK 675/675, `make test-stages`
+PARITY OK, `make rust-test` green, `make check-spec` OK, `make test-cli` 81/81,
+`kuna catalog --check` OK. All 263 `parse line` / `parse file` payloads in
+`tests/datatests` + `tests/stages` were replayed through the old and new
+`decomp_dbg` in their original per-file order: zero output differences.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/prototype-parser-rejects-previously/record.json
+++ b/docs/features/prototype-parser-rejects-previously/record.json
@@ -1,0 +1,44 @@
+{
+  "need_id": "prototype-parser-rejects-previously",
+  "track": "tooling",
+  "scope": "small",
+  "branch": "feat/re-prototype-parser-rejects-previously",
+  "worker": "b-r9-prototype-parser",
+  "round": 9,
+  "summary": "A struct/union/enum tag stops being usable the moment it is declared: interning it makes the lexer return it as a type name, and the tag position of struct_or_union_specifier only read the identifier terminal. CParse::tag_identifier accepts either.",
+  "files": [
+    "decompiler/crates/kuna-console/src/grammar.rs",
+    "decompiler/crates/kuna-console/src/grammar/tests.rs",
+    "tests/cli/prototype-parser-rejects-previously.json",
+    "docs/spec/00-overview.md",
+    "docs/cli.md"
+  ],
+  "decisions": [
+    "The need offered no hypothesis. The cause is not the CLI and not the prototype path: `parse line struct JSValue v;` fails the same way once the tag is interned, and `parse line struct JSValue { ... };` succeeds only because the tag is still unknown at that point. lookup_identifier resolves every identifier through TypeFactory::findByName, so declaring the tag is exactly what removes it from the identifier terminal the tag position reads.",
+    "Fixed in the parser rather than the lexer. A context-sensitive lexer (suppress findByName right after a struct/union/enum keyword) would need parser state threaded into lex(); accepting TypeName in the one position that could never match a production is local and provably non-widening.",
+    "The tag is passed to old_struct/new_struct by NAME, not as the Rc the token carried, so the existing kind check still runs. This turns `struct int4` from a syntax error into the C++ oldStruct kind error, which is the only expectation that moved: reject_struct_type_name_is_syntax_error was renamed and re-pointed.",
+    "Redeclaring a completed struct is now reachable and errors with `Trying to alter definition of type` (assign_raw_fields_struct), where it used to be a syntax error. Still an error either way, so no behaviour regressed; making an identical redefinition idempotent is a separate type-factory question and was left alone.",
+    "No option row: a declaration grammar that previously refused the input cannot change emitted C on any input it already accepted (tooling track).",
+    "The acceptance probe was retargeted from the dataset crackme onto the vendored fixture decompiler/crates/kuna-analysis/tests/fixtures/fauxware so it could be promoted; acceptance_id re-derived to a-907674c07f28. The fixture's `main` calls `authenticate`, so the probe asserts the struct return actually applies (`authenticate(...).payload`) rather than only that no error was printed."
+  ],
+  "refutation": {
+    "question": "Can the new arm produce wrong output rather than only turn an error into a success?",
+    "answer": "No. In the else-branch the old code did not consume the token, so a TypeName in tag position left `ident` empty and then failed the `{` test as well -- both `STRUCT TYPE_NAME` and `STRUCT TYPE_NAME '{' ... '}'` reached syntax_error(). Every input the arm newly accepts was previously rejected. The type it yields is the type the bare TypeName token already carried, because find_by_name is an exact (name,id) lookup and the tag is re-resolved through the same call.",
+    "sweep": "All 263 `parse line`/`parse file` payloads across tests/datatests + tests/stages (95 files) replayed in per-file order through the pre- and post-change decomp_dbg against a common fixture: 0 differing files."
+  },
+  "acceptance": {
+    "probe_id": "p-0fb156776be6",
+    "acceptance_id": "a-907674c07f28",
+    "result": "PASS",
+    "promoted_to": "tests/cli/prototype-parser-rejects-previously.json"
+  },
+  "speed": "No measurable cost: one extra match arm on a token already peeked, on a path that runs once per asserted declaration.",
+  "gates": {
+    "make test": "PARITY OK, 675/675 assertions",
+    "make test-stages": "PARITY OK, 687/687 assertions",
+    "make rust-test": "green with `env -u KUNA_DECOMP_TEST`. The launcher-exported KUNA_DECOMP_TEST points the C++-oracle block at kuna's own decomp_test_dbg, so verify_w10_proto_unlock:202 fails asking the 'oracle' for `xunknown4 promote_compare(char *` when kuna prints `unsigned int` in every build. kuna-decomp does not depend on kuna-console, so this change cannot reach it; the target is green with the variable unset.",
+    "make check-spec": "OK (lenient mode)",
+    "make test-cli": "81/81 passed, including the promoted probe",
+    "kuna catalog --check": "catalog OK (no option added)"
+  }
+}

--- a/docs/re-needs/prototype-parser-rejects-previously.md
+++ b/docs/re-needs/prototype-parser-rejects-previously.md
@@ -1,0 +1,137 @@
+---
+need_id: prototype-parser-rejects-previously
+title: Prototype parser rejects a previously declared struct tag as return type
+track: tooling
+status: open
+severity: minor
+probe_id: p-0fb156776be6
+acceptance_id: a-907674c07f28
+hypothesis_status: inconclusive
+credibility: 0.7
+instances: 1
+challenges: [673da52e9b533b4c22bd2eeb]
+rounds: [8]
+first_seen_round: 8
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-console/src/grammar, decompiler/crates/kuna-cli/src/assertdecl.rs]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Use struct JSValue as a prototype return type.
+
+> **Prototype parser rejects a previously declared struct tag as return type** (minor, `673da52e9b533b4c22bd2eeb`)
+> Accepted the struct declaration but rejected the prototype with Bad C syntax. A typedef alias for the same structure works.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "target": {
+    "binary_rel": "bin/crackme.x86_64.elf",
+    "binary_sha256": "19351f6b9a6b8af7399470a3ff22ddf1b2b8f44a85f1e0497cbb6e4ed20fbb8a",
+    "binary_size": 977264,
+    "binary_source": "dataset"
+  },
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_9d9c0",
+    "--assert",
+    "typedef struct JSValue { unsigned long payload; long tag; };",
+    "--assert",
+    "prototype sub_875e0 struct JSValue sub_875e0(void *ctx, char *buf, unsigned long len, unsigned int flags)",
+    "--assert-strict"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 1
+    },
+    "stderr_matches": [
+      "prototype .*struct JSValue.*rejected: Bad C syntax"
+    ]
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "main",
+    "--assert",
+    "typedef struct JSValue { unsigned long payload; long tag; };",
+    "--assert",
+    "prototype authenticate struct JSValue authenticate(char *user, char *pass)",
+    "--assert-strict"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "binary_sha256": "c2d90645a45e99221593547e55c601a901b80f807ae96f94c60a7661df0b3e0b",
+    "binary_size": 8776,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "selector": "main",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "authenticate\\(.*\\)\\.payload"
+    ],
+    "stderr_absent": [
+      "rejected: Bad C syntax"
+    ]
+  },
+  "notes": "Desired: a struct tag declared in an earlier --assert is usable as a prototype return type. Dataset witness: crackmes.one 673da52e9b533b4c22bd2eeb (sub_875e0 returning struct JSValue). Once the tag is interned the lexer hands it back as a type name, so `struct JSValue` matched no production and the prototype was dropped with Bad C syntax."
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+_none offered_
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `673da52e9b533b4c22bd2eeb` (round 8, tester t-r8-673da52e)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+- round 8 TRIAGE (captain): RETOUCHED to kuna-console/src/grammar/ (+ kuna-cli/src/assertdecl.rs for the directive form) -- see the sibling prototype-parser-rejects-valid. Same parser, different rule: a struct tag accepted as a declaration is refused as a return type while a typedef alias for the same structure works. Track stays tooling. Worth telling the builder that the two are one grammar and can honestly ship together.

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -1028,6 +1028,21 @@ that happens to be spelled with a keyword resolve to exactly the interned type
 they always did. Only combinations, and the keywords the type factory does not
 name, take the width-driven path.
 
+(kuna) **A tag survives being declared.** `findByName` is also how the lexer
+classifies every other identifier, so the moment `struct JSValue { … };` interns
+the tag, `JSValue` stops reaching the parser as an identifier and comes back as
+a type name. Upstream's `struct_or_union_specifier` reads its tag from the
+identifier terminal alone, which made the second mention of any struct — `struct
+JSValue` as a return type, a parameter, a field — a bare syntax error, while a
+typedef alias for the same structure worked. The tag position therefore accepts
+a type name as well (`decompiler/crates/kuna-console/src/grammar.rs
+(CParse::tag_identifier)`), and `enum` reads its tag the same way. The position
+is unambiguous: a type name after `struct`, `union` or `enum` matched no
+production before, with or without a body. Which type the tag names is still
+decided by the construction action, not by the token — `oldStruct` rejects a tag
+that names something other than a struct with the kind error it always had, so
+`struct int4` is refused for saying `struct`, not for being unparseable.
+
 (kuna) **A `prototype` declaration may name its calling convention**, which is
 the other half of speaking the target's own C: on Windows every declaration
 worth pasting carries one. An identifier the loaded compiler spec registered as

--- a/tests/cli/prototype-parser-rejects-previously.json
+++ b/tests/cli/prototype-parser-rejects-previously.json
@@ -1,0 +1,43 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "main",
+    "--assert",
+    "typedef struct JSValue { unsigned long payload; long tag; };",
+    "--assert",
+    "prototype authenticate struct JSValue authenticate(char *user, char *pass)",
+    "--assert-strict"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "binary_sha256": "c2d90645a45e99221593547e55c601a901b80f807ae96f94c60a7661df0b3e0b",
+    "binary_size": 8776,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "selector": "main",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "authenticate\\(.*\\)\\.payload"
+    ],
+    "stderr_absent": [
+      "rejected: Bad C syntax"
+    ]
+  },
+  "notes": "Desired: a struct tag declared in an earlier --assert is usable as a prototype return type. Dataset witness: crackmes.one 673da52e9b533b4c22bd2eeb (sub_875e0 returning struct JSValue). Once the tag is interned the lexer hands it back as a type name, so `struct JSValue` matched no production and the prototype was dropped with Bad C syntax."
+}


### PR DESCRIPTION
## The problem

A struct tag that kuna has just accepted cannot be used as a type. Declare
`struct JSValue`, then name it as a prototype's return type, and the prototype
is thrown away as a syntax error — a typedef alias for the same structure works,
which is what makes it look arbitrary.

```bash
kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/fauxware main \
  --assert 'typedef struct JSValue { unsigned long payload; long tag; };' \
  --assert 'prototype authenticate struct JSValue authenticate(char *user, char *pass)' \
  --assert-strict
```

```
  v2 = authenticate(v1,v3);
  ...
warning: --assert "prototype authenticate struct JSValue authenticate(char *user, char *pass)" rejected: Bad C syntax
exit 1
```

The console shows it without the CLI in the way:

```
[decomp]> parse line struct JSValue { unsigned long payload; long tag; };
[decomp]> parse line struct JSValue v;
Error in C syntax: Syntax error at line 0 in stream
struct JSValue
       ^--
```

## The fix

- The lexer classifies an identifier by asking the type factory for it, so
  interning the tag is what stops `JSValue` reaching the parser as an
  identifier: it comes back as a type name, and `struct_or_union_specifier`
  read its tag from the identifier terminal alone. The tag position now accepts
  a type name too (`CParse::tag_identifier`), and `enum_specifier` reads its tag
  through the same helper.
- The position is unambiguous rather than a guess: a type name after `struct` /
  `union` / `enum` matched no production before, with or without a body, so
  every input this newly accepts used to be a syntax error.
- Which type the tag names is still decided by the construction action, not by
  the token. `oldStruct` re-checks the kind by name, so `struct int4` is now
  refused for saying `struct` ("Identifier does not represent a struct as
  required") instead of for being unparseable.

## The tests

Five cases in `kuna-console/src/grammar/tests.rs` cover the tag as a return
type, as a pointer parameter, outside a prototype, and for `union` / `enum`;
each fails without the change. `reject_struct_type_name_is_syntax_error` pinned
the old expectation and now asserts the kind error under its new name.
`tests/cli/prototype-parser-rejects-previously.json` is the promoted probe.

Gates on the rebased tree: `make test` PARITY OK 675/675, `make test-stages`
PARITY OK, `make rust-test` green, `make check-spec` OK, `make test-cli` 81/81,
`kuna catalog --check` OK. All 263 `parse line` / `parse file` payloads in
`tests/datatests` + `tests/stages` were replayed through the old and new
`decomp_dbg` in their original per-file order: zero output differences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
