### PR TITLE
[AUTOMATED] fix(console): prototype-parser-rejects-valid — accept a declarator named after a type

### DIFF
--- a/decompiler/crates/kuna-console/src/grammar.rs
+++ b/decompiler/crates/kuna-console/src/grammar.rs
@@ -1632,25 +1632,29 @@ impl<'a> CParse<'a> {
             return self.syntax_error();
         }
         // Subsequent specifiers continue while the lookahead begins one.
-        while self.declaration_specifier_starts()? {
+        while self.declaration_specifier_starts(&spec)? {
             self.declaration_specifier_one(&mut spec)?;
         }
         Ok(spec)
     }
 
-    /// Does the lookahead begin a `declaration_specifiers` element?
-    fn declaration_specifier_starts(&mut self) -> KunaResult<bool> {
-        Ok(matches!(
-            self.peek()?,
+    /// Does the lookahead begin a further `declaration_specifiers` element?
+    ///
+    /// (kuna) Once the run has named a type, a following `TYPE_NAME` is the
+    /// declarator's own name and not a second specifier — see
+    /// [`CParse::declarator_identifier`].
+    fn declaration_specifier_starts(&mut self, spec: &TypeSpecifiers) -> KunaResult<bool> {
+        Ok(match self.peek()? {
             PToken::StorageClassSpecifier(_)
-                | PToken::TypeQualifier(_)
-                | PToken::FunctionSpecifier(_)
-                | PToken::TypeName(_)
-                | PToken::ScalarSpecifier(_)
-                | PToken::Struct
-                | PToken::Union
-                | PToken::Enum
-        ))
+            | PToken::TypeQualifier(_)
+            | PToken::FunctionSpecifier(_)
+            | PToken::ScalarSpecifier(_)
+            | PToken::Struct
+            | PToken::Union
+            | PToken::Enum => true,
+            PToken::TypeName(_) => spec.type_specifier.is_none(),
+            _ => false,
+        })
     }
 
     /// Consume one `declaration_specifiers` element into `spec`.  Returns `false`
@@ -1951,6 +1955,9 @@ impl<'a> CParse<'a> {
         let mut any = false;
         loop {
             match self.peek()? {
+                // (kuna) A TYPE_NAME after the list already named a type is the
+                // member's name, not a second specifier.
+                PToken::TypeName(_) if spec.type_specifier.is_some() => break,
                 PToken::TypeName(_)
                 | PToken::ScalarSpecifier(_)
                 | PToken::Struct
@@ -2044,6 +2051,7 @@ impl<'a> CParse<'a> {
     fn enumerator(&mut self) -> KunaResult<Enumerator> {
         let nm = match self.next()? {
             PToken::Identifier(s) => s,
+            PToken::TypeName(tp) => tp.get_name().to_string(),
             _ => return self.syntax_error(),
         };
         if matches!(self.peek()?, PToken::Punct(b'=')) {
@@ -2136,22 +2144,48 @@ impl<'a> CParse<'a> {
                     name.push_str("::");
                     name.push_str(&s);
                 }
+                PToken::TypeName(tp) => {
+                    name.push_str("::");
+                    name.push_str(tp.get_name());
+                }
                 _ => return self.syntax_error(),
             }
         }
         Ok(name)
     }
 
+    /// (kuna) Consume a `var_identifier` in *name* position, whose head the
+    /// lexer may have classified as a type name.
+    ///
+    /// A variable may be named after a type — `unsigned char *code`, where
+    /// `code` is one of the factory's own core types — and C reads the
+    /// declarator's identifier as a new name that hides the type.
+    /// [`CParse::lookup_identifier`] classifies every spelling `findByName`
+    /// answers as `TYPE_NAME`, so the name position has to take that token too.
+    /// Only the unparenthesised position is taken: `int4 (code)` stays a
+    /// function of one `code`, which is what C reads it as.
+    fn declarator_identifier(&mut self) -> KunaResult<String> {
+        match self.next()? {
+            PToken::Identifier(s) => self.var_identifier(s),
+            PToken::TypeName(tp) => {
+                let nm = tp.get_name().to_string();
+                self.var_identifier(nm)
+            }
+            _ => self.syntax_error(),
+        }
+    }
+
     /// `direct_declarator` (`grammar.y:162-170`): the base name or
     /// parenthesised declarator, followed by array `[...]` and function `(...)`
     /// suffixes (left-recursion unrolled to a loop).
     fn direct_declarator(&mut self) -> KunaResult<TypeDeclarator> {
-        let mut dec = match self.next()? {
-            PToken::Identifier(s) => {
-                let name = self.var_identifier(s)?;
+        let mut dec = match self.peek()? {
+            PToken::Identifier(_) | PToken::TypeName(_) => {
+                let name = self.declarator_identifier()?;
                 TypeDeclarator::with_ident(&name)
             }
             PToken::Punct(b'(') => {
+                self.next()?; // '('
                 let inner = self.declarator()?;
                 self.expect_punct(b')')?;
                 inner
@@ -2272,7 +2306,7 @@ impl<'a> CParse<'a> {
                 // pointer, then optional direct_(abstract_)declarator.
                 let ptr = self.pointer()?;
                 match self.peek()? {
-                    PToken::Identifier(_) | PToken::Punct(b'(') => {
+                    PToken::Identifier(_) | PToken::TypeName(_) | PToken::Punct(b'(') => {
                         // Could be a (possibly abstract) declarator continuation.
                         let inner = self.declarator_or_abstract_after_pointer()?;
                         let dec = Self::merge_pointer(&ptr, inner);
@@ -2285,7 +2319,7 @@ impl<'a> CParse<'a> {
                     }
                 }
             }
-            PToken::Identifier(_) => {
+            PToken::Identifier(_) | PToken::TypeName(_) => {
                 let dec = self.declarator()?;
                 Ok(self.merge_spec_dec(&spec, dec))
             }
@@ -2313,13 +2347,9 @@ impl<'a> CParse<'a> {
     /// parenthesised-abstract; both share the array/function suffix loop.
     fn direct_abstract_or_concrete(&mut self) -> KunaResult<TypeDeclarator> {
         let dec = match self.peek()? {
-            PToken::Identifier(_) => {
-                if let PToken::Identifier(s) = self.next()? {
-                    let name = self.var_identifier(s)?;
-                    TypeDeclarator::with_ident(&name)
-                } else {
-                    unreachable!()
-                }
+            PToken::Identifier(_) | PToken::TypeName(_) => {
+                let name = self.declarator_identifier()?;
+                TypeDeclarator::with_ident(&name)
             }
             PToken::Punct(b'(') => {
                 self.next()?; // '('
@@ -2371,7 +2401,10 @@ impl<'a> CParse<'a> {
                 model = after;
             }
             match self.peek()? {
-                PToken::Identifier(_) | PToken::Punct(b'(') | PToken::Punct(b'[') => {
+                PToken::Identifier(_)
+                | PToken::TypeName(_)
+                | PToken::Punct(b'(')
+                | PToken::Punct(b'[') => {
                     let inner = self.direct_abstract_or_concrete()?;
                     Self::merge_pointer(&ptr, inner)
                 }

--- a/decompiler/crates/kuna-console/src/grammar/tests.rs
+++ b/decompiler/crates/kuna-console/src/grammar/tests.rs
@@ -1080,3 +1080,138 @@ fn a_convention_on_a_function_pointer_parameter_parses_as_it_did_without_one() {
         proto_model("extern int4 f(int4 (*cb)(int4));", &win_models())
     );
 }
+
+// ===========================================================================
+// (kuna) A declarator named after a type
+// ===========================================================================
+
+/// [`factory_sized`] plus `code`, the core type every compiler spec registers
+/// for a function body.  It is also an ordinary English word, so it is the
+/// name an agent reaches for when it declares an interpreter's instruction
+/// stream — and the collision is what made the declaration unparseable.
+fn factory_with_code() -> TypeFactoryImpl {
+    let f = factory_sized(8);
+    f.set_core_type("code", 1, meta::TYPE_CODE, false).unwrap();
+    f.cache_core_types().unwrap();
+    f
+}
+
+#[test]
+fn a_pointer_parameter_may_be_named_after_a_type() {
+    let f = factory_with_code();
+    let p = parse_protopieces(
+        "extern unsigned long vm(unsigned char *code,unsigned int index,void *ctx);",
+        &f,
+        org(),
+    )
+    .expect("`code` is a parameter name here, not a second type specifier");
+    assert_eq!(p.name, "vm");
+    assert_eq!(p.innames, vec!["code", "index", "ctx"]);
+    assert_eq!(p.intypes[0].get_ptr_to().unwrap().get_name(), "uint1");
+    assert_eq!(p.intypes[1].get_name(), "uint4");
+    assert_eq!(p.intypes[2].get_metatype(), meta::TYPE_PTR);
+}
+
+#[test]
+fn a_value_parameter_may_be_named_after_a_type() {
+    // Without the pointer the collision lands in `declaration_specifiers`
+    // instead of the declarator, and used to read "Multiple type specifiers".
+    let f = factory_with_code();
+    for (decl, want_type) in
+        [("unsigned char code", "uint1"), ("int4 code", "int4"), ("char *code", "char")]
+    {
+        let (ty, name) = parse_type(decl, &f, org()).unwrap_or_else(|e| {
+            panic!("{decl:?} must parse: {}", e.explain());
+        });
+        let base = ty.get_ptr_to().unwrap_or(ty);
+        assert_eq!(base.get_name(), want_type, "{decl:?}");
+        assert_eq!(name, "code", "{decl:?}");
+    }
+}
+
+#[test]
+fn a_type_named_declarator_works_through_pointers_and_arrays() {
+    // A function-POINTER parameter named after a type needs a factory with a
+    // prototype model behind it, so that half is pinned end-to-end in
+    // `kuna-console/tests/verify_assertplane.rs` instead.
+    let f = factory_with_code();
+    for decl in [
+        "extern int4 f(unsigned char **code);",
+        "extern int4 f(unsigned char *code[4]);",
+        "extern int4 f(unsigned char *code,unsigned char code2);",
+    ] {
+        parse_protopieces(decl, &f, org()).unwrap_or_else(|e| {
+            panic!("{decl:?} must parse: {}", e.explain());
+        });
+    }
+    // ... and in a struct member, where `specifier_qualifier_list` is the
+    // greedy run rather than `declaration_specifiers`.
+    let (ty, _) = parse_type("struct s { unsigned char *code; int4 len; } v", &f, org())
+        .expect("a struct member may be named after a type");
+    assert_eq!(ty.get_metatype(), meta::TYPE_STRUCT);
+    // `org()` is a 4-byte address space, so the pointer and the int4 are 4 each.
+    assert_eq!(ty.get_size(), 8);
+}
+
+#[test]
+fn a_type_name_is_still_a_type_in_type_position() {
+    // The fix only reaches the declarator's NAME; the first specifier of a run
+    // is unchanged, so `code` still names the core type where a type belongs.
+    let f = factory_with_code();
+    let (ty, name) = parse_type("code *p", &f, org()).expect("`code *p` is a pointer to code");
+    assert_eq!(ty.get_ptr_to().unwrap().get_metatype(), meta::TYPE_CODE);
+    assert_eq!(name, "p");
+    let p = parse_protopieces("extern code *j(code c);", &f, org()).expect("code in both slots");
+    assert_eq!(p.intypes[0].get_metatype(), meta::TYPE_CODE);
+    assert_eq!(p.outtype.as_ref().unwrap().get_metatype(), meta::TYPE_PTR);
+}
+
+#[test]
+fn a_parenthesised_type_name_is_still_read_as_a_type() {
+    // `int4 (code)` is ambiguous in C and resolves to the abstract reading -- a
+    // function of one `code`, not a variable named `code`.  Only the
+    // unparenthesised name position moved, so this must not have changed.
+    //
+    // Pinned by outcome rather than by the built type: a function type needs a
+    // prototype model this bare factory has none of, so the function reading is
+    // exactly the one that reports `getTypeCode`.  `int4 (p)` is the contrast --
+    // a parenthesised declarator naming `p`, which builds fine.
+    let f = factory_with_code();
+    let took_the_function_reading = |decl: &str| match parse_type(decl, &f, org()) {
+        Ok((ty, name)) => Err(format!("{}/{name}", ty.get_name())),
+        Err(e) => Ok(e.explain().contains("getTypeCode")),
+    };
+    assert_eq!(took_the_function_reading("int4 (code)"), Ok(true), "`int4 (code)`");
+    assert_eq!(
+        took_the_function_reading("int4 (code)"),
+        took_the_function_reading("int4 (int4)"),
+        "`int4 (code)` must read exactly like the unambiguous abstract spelling"
+    );
+    assert_eq!(
+        took_the_function_reading("int4 (p)"),
+        Err("int4/p".to_string()),
+        "an ordinary identifier in parentheses is still a declarator name"
+    );
+}
+
+#[test]
+fn a_type_name_may_head_an_enumerator() {
+    // `setup_sizes` for the same reason `enum_construction_lands_in_factory`
+    // calls it: the enum width comes from there, and a zero one masks every
+    // auto-assigned constant to the same value.
+    let f = factory_with_code();
+    f.setup_sizes(Some(4), 4, 4);
+    super::parse_c("enum e { code, other };", &f, org(), &[], |_, _| {
+        panic!("a bare enum is not an extern prototype")
+    })
+    .expect("an enum constant may be named after a type");
+    assert!(f.find_by_name("e").unwrap().expect("enum e is interned").is_enum_type());
+}
+
+#[test]
+fn a_type_name_may_end_a_scoped_name() {
+    let f = factory_with_code();
+    let p = parse_protopieces("extern int4 ns::code(int4 a);", &f, org())
+        .expect("a scoped name may end in a type name");
+    assert_eq!(p.name, "ns::code");
+}

--- a/decompiler/crates/kuna-console/tests/verify_assertplane.rs
+++ b/decompiler/crates/kuna-console/tests/verify_assertplane.rs
@@ -620,3 +620,41 @@ fn a_qualified_param_accepts_an_entry_address_as_its_function() {
         .unwrap_or_else(|| panic!("no call to open:\n{code}"));
     assert!(call.contains("open(a0)"), "the declared RDI argument is missing: {call}");
 }
+
+/// A parameter may be named after a type
+/// (`docs/re-needs/prototype-parser-rejects-valid.md`).  `code` is one of the
+/// core types every compiler spec registers, so the lexer handed it to the
+/// parser as `TYPE_NAME` and `unsigned char *code` was a syntax error with the
+/// caret on the name -- while the same declaration with the parameter renamed
+/// applied.  Every interned name is in that class: the core types, a tag or
+/// typedef declared earlier in the same run, and on a `-g` binary every DWARF
+/// type name the program uses.
+#[test]
+fn a_parameter_named_after_a_type_reaches_the_emitted_c() {
+    let Some((code, report)) = decompile_with(vec![
+        directive(
+            "prototype authenticate unsigned int authenticate(char *code,char *pass)",
+            Body::Prototype {
+                func: TARGET.into(),
+                decl: "unsigned int authenticate(char *code,char *pass)".into(),
+            },
+        ),
+        // A function-pointer parameter named after a type: the same name
+        // position, reached through the parenthesised declarator.  It needs a
+        // real prototype model behind the factory, which is why it is pinned
+        // here rather than in the grammar unit tests.
+        directive(
+            "prototype read int read(int4 (*code)(int4 n))",
+            Body::Prototype { func: "read".into(), decl: "int read(int4 (*code)(int4 n))".into() },
+        ),
+    ]) else {
+        return;
+    };
+    all_applied(&report);
+    let sig = code
+        .lines()
+        .find(|l| l.contains("authenticate("))
+        .unwrap_or_else(|| panic!("no signature:\n{code}"));
+    assert!(sig.contains("char *code"), "the declared name did not reach the C: {sig}");
+    assert!(sig.contains("char *pass"), "the second parameter moved too: {sig}");
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -291,6 +291,19 @@ kuna decompile ./a.out sub_140004dcc --json \
   --assert 'prototype VirtualAlloc void *VirtualAlloc(void *p,unsigned int n,unsigned int a,unsigned int b)'
 ```
 
+**A parameter may be named after a type.** kuna interns a type called `code`,
+and a `-g` binary interns every DWARF type name it uses, so the name you want
+for a parameter is often already a type name; the declaration still reads it as
+the parameter's name, exactly as C does:
+
+```bash
+kuna decompile ./graphy 0x1005350 --addr --json \
+  --assert 'prototype 0x1005350 unsigned long vm(unsigned char *code,unsigned int index,void *ctx)'
+```
+
+Only the parenthesised form stays a type: `int4 (code)` is a function of one
+`code`, which is what C reads it as.
+
 A tag you declared earlier in the same run is usable as a type, in the `struct
 X` / `union X` / `enum X` spelling as well as by bare name — including as a
 return type, which is how a function returning a small struct by value gets its

--- a/docs/features/prototype-parser-rejects-valid/pr_body.md
+++ b/docs/features/prototype-parser-rejects-valid/pr_body.md
@@ -1,0 +1,67 @@
+## The problem
+
+A parameter cannot be named after a type. `code` is one of the core types every
+compiler spec registers, so a declaration that names a parameter after it is
+rejected with the caret on the parameter's own name:
+
+```bash
+kuna decompile ./fauxware authenticate --json \
+  --assert 'prototype authenticate unsigned long vm(unsigned char *code,unsigned int index,void *ctx)' \
+  --assert 'prototype read int read(unsigned char code)'
+```
+
+```text
+warning: --assert "prototype authenticate unsigned long vm(unsigned char *code,unsigned int index,void *ctx)" rejected: Syntax error at line 0 in stream
+extern unsigned long vm(unsigned char *code,
+                                       ^--
+
+warning: --assert "prototype read int read(unsigned char code)" rejected: Multiple type specifiers at line 0 in stream
+extern int read(unsigned char code)
+                              ^--
+```
+
+Renaming `code` to anything else makes the same declaration apply. Every
+interned name is in this class, not just the core types: a tag or `typedef`
+declared earlier in the same run, and on a `-g` binary every DWARF type name the
+program uses.
+
+## The fix
+
+`CParse::lookup_identifier` classifies any spelling `findByName` answers as
+`TYPE_NAME`, and two positions had to learn that C reads such a token as a name
+when a name is what belongs there:
+
+- The specifier run stops at a `TYPE_NAME` once it has already named a type
+  (`declaration_specifier_starts`, and its `specifier_qualifier_list` twin
+  inside a struct body). That is the `unsigned char code` half.
+- The declarator's name position takes one (`declarator_identifier`), reached
+  from `direct_declarator`, `parameter_declaration` and the abstract-declarator
+  paths. That is the `unsigned char *code` half, and it also covers
+  `int4 (*code)(void)`, a struct field, an enum constant and the tail of an
+  `a::b` scoped name.
+
+Only the *unparenthesised* name position moved. `int4 (code)` is genuinely
+ambiguous in C and keeps its abstract reading — a function of one `code` — so
+the one case where a heuristic would have to guess is left alone.
+
+The change is monotone: both positions it touches were hard errors before
+("Syntax error", "Multiple type specifiers"), so no declaration that parsed
+parses differently. The 263 `parse line` payloads across `tests/datatests/` and
+`tests/stages/` were replayed through the old and new `decomp_dbg` byte-for-byte
+identically.
+
+## The tests
+
+Six cases in `kuna-console/src/grammar/tests.rs` (both spellings, through
+pointers/arrays/function pointers, a struct member, an enum constant, a scoped
+name) plus the pins that `code *p` is still a pointer to `code` and `int4 (code)`
+is still a function; one end-to-end case in `verify_assertplane.rs` asserting the
+declared name reaches the emitted C; and the promoted probe
+`tests/cli/prototype-parser-rejects-valid.json`, whose two directives both read
+`rejected` on the unpatched tree.
+
+Gates: `make test` PARITY OK 675/675 · `make test-stages` PARITY OK ·
+`make rust-test` green · `make check-spec` green · `make test-cli` 91/91 (including the promoted probe) ·
+`kuna catalog --check` OK.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/prototype-parser-rejects-valid/record.json
+++ b/docs/features/prototype-parser-rejects-valid/record.json
@@ -1,0 +1,38 @@
+{
+  "schema": "re-builder-record/1",
+  "need_id": "prototype-parser-rejects-valid",
+  "worker": "b-r10-prototype-parser",
+  "round": 10,
+  "track": "tooling",
+  "scope": "small",
+  "branch": "feat/re-prototype-parser-rejects-valid",
+  "base_sha": "7e77fb8c9dcaab167c592fc1d25ad230b9e4ad24",
+  "hypothesis_status": "refined",
+  "decisions": [
+    "The filed hypothesis -- 'the parser treats code as an internal reserved word' -- is wrong in its mechanism and right in its consequence. `code` is not a keyword; it is a core data-type that `Architecture::setup_types` registers (`set_core_type(\"code\", 1, TYPE_CODE, false)`), and `CParse::lookup_identifier` classifies every spelling `findByName` answers as TYPE_NAME. So the class is not one reserved word but every interned type name: the ~23 core types, any tag or typedef declared earlier in the same run, and on a -g binary every DWARF type name the program uses.",
+    "The symptom has two distinct halves with two distinct diagnostics, and the filed probe only shows one. `unsigned char *code` dies in `direct_declarator` ('Syntax error'); `unsigned char code` dies in the greedy specifier run ('Multiple type specifiers'). Fixing only the reported half would have left the value-parameter spelling broken, so both are fixed and the promoted probe asserts both.",
+    "The change is monotone by construction: both edited positions unconditionally called `set_error` before (`add_type_specifier` on a second specifier, `syntax_error` in the name position), so every declaration that parsed before parses to the same type. Verified empirically by replaying all 263 `parse line` payloads in tests/datatests + tests/stages through the old and new decomp_dbg -- byte-identical output, zero files differing.",
+    "`int4 (code)` is deliberately NOT changed. Parenthesised, it is genuinely ambiguous in C and resolves to the abstract reading (a function of one `code`); only the unparenthesised name position, where no other production matched, was opened up. A test pins the old reading.",
+    "Track tooling as filed: this corrects a parser that was wrong on its own terms, so no phases.toml option, no stage XML and no catalog counters -- the same shape PR #421 shipped for the sibling need prototype-assertions-reject-ordinary.",
+    "Out of scope, found while testing: `Datatype::assign_values` loops forever when the enum size is 0 (`calc_mask(0)` is 0, so every auto-assigned constant masks to the same value and the `while nmap.contains_key` loop never breaks). It bites any caller that parses an `enum { ... }` through a TypeFactory whose `setup_sizes` was never called. Pre-existing, entirely in kuna-decomp, and upstream-faithful; not touched here.",
+    "make rust-test in a repipe worktree reports one unrelated failure, verify_w10_proto_unlock 'oracle promote_compare signature drifted'. It is the launcher's KUNA_DECOMP_TEST pointing the C++ oracle at kuna's own decomp_test_dbg, whose modern spelling ('unsigned int') cannot contain the 'xunknown4' the assertion requires. Falsified per the recipe: `env -u KUNA_DECOMP_TEST cargo test -p kuna-decomp --test verify_w10_proto_unlock` is 4/4 green. CI has no decomp_test_dbg at the default path and skips the oracle block entirely."
+  ],
+  "acceptance": {
+    "id": "a-555cfdcc80e2",
+    "status": "PASS",
+    "retargeted": "The filed acceptance ran against a dataset binary (graphy), which `verify --promote` refuses because CI has no dataset. Retargeted verbatim in shape onto the in-repo fauxware fixture and re-derived the id; both directives measured `rejected` on the unpatched tree at 7e77fb8c."
+  },
+  "tests": [
+    "decompiler/crates/kuna-console/src/grammar/tests.rs -- 6 cases",
+    "decompiler/crates/kuna-console/tests/verify_assertplane.rs -- 1 end-to-end case",
+    "tests/cli/prototype-parser-rejects-valid.json -- the promoted acceptance"
+  ],
+  "gates": {
+    "make test": "PARITY OK 675/675",
+    "make test-stages": "PARITY OK",
+    "make check-spec": "OK",
+    "make test-cli": "91/91 including the promoted probe",
+    "kuna catalog --check": "catalog OK",
+    "make rust-test": "green with env -u KUNA_DECOMP_TEST (the worktree oracle-env trap is the only difference)"
+  }
+}

--- a/docs/re-needs/prototype-parser-rejects-valid.md
+++ b/docs/re-needs/prototype-parser-rejects-valid.md
@@ -1,0 +1,163 @@
+---
+need_id: prototype-parser-rejects-valid
+title: Prototype parser rejects a valid parameter named code
+track: tooling
+status: closed
+severity: minor
+probe_id: p-4a5243ba1588
+acceptance_id: a-555cfdcc80e2
+hypothesis_status: overturned
+credibility: 0.7
+instances: 1
+challenges: [69761b7a39e9c4d85c2f9fc1]
+rounds: [8]
+first_seen_round: 8
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-console/src/grammar, decompiler/crates/kuna-cli/src/assertdecl.rs]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: 10
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Specify the interpreter's code pointer through a prototype assertion.
+
+> **Prototype parser rejects a valid parameter named code** (minor, `69761b7a39e9c4d85c2f9fc1`)
+> The assertion is rejected with a syntax-error caret at code. Changing only code to bytes makes the declaration apply. Separately, the known checker-discards-live-allocation issue was encountered and repaired with an allocator prototype; it is not re-filed.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "target": {
+    "binary_rel": "bin/graphy-release.zip.__x/graphy",
+    "binary_sha256": "1fb1f75b6a3939e3d80a25ca65aeb092d62a6968a53bd1db499a7cee864bed42",
+    "binary_size": 40472,
+    "binary_source": "dataset"
+  },
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x1005350",
+    "--addr",
+    "--assert",
+    "prototype 0x1005350 unsigned long vm(unsigned char *code,unsigned int index,void *ctx)",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "assertions[0].status",
+        "op": "eq",
+        "value": "rejected"
+      }
+    ],
+    "stderr_matches": [
+      "Syntax error"
+    ]
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-555cfdcc80e2",
+  "kind": "cli",
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "binary_sha256": "c2d90645a45e99221593547e55c601a901b80f807ae96f94c60a7661df0b3e0b",
+    "binary_size": 8776,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "selector": "authenticate",
+    "selector_kind": "name"
+  },
+  "timeout_s": 120,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "authenticate",
+    "--json",
+    "--assert",
+    "prototype authenticate unsigned long vm(unsigned char *code,unsigned int index,void *ctx)",
+    "--assert",
+    "prototype read int read(unsigned char code)"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "assertions",
+        "op": "len_eq",
+        "value": 2
+      },
+      {
+        "path": "assertions[0].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "assertions[1].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "contains",
+        "value": "unsigned char *code"
+      }
+    ],
+    "stderr_absent": [
+      "Syntax error",
+      "Multiple type specifiers",
+      "Bad C syntax"
+    ]
+  },
+  "notes": "Desired: a parameter may be named after a type. `code` is a core type every compiler spec registers, so the lexer hands it over as TYPE_NAME; both spellings were rejected -- `unsigned char *code` as a Syntax error on the name, `unsigned char code` as Multiple type specifiers. Retargeted onto the in-repo fauxware fixture so it runs with no dataset; both measured rejected on 7e77fb8c."
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- The parser treats code as an internal reserved word.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `69761b7a39e9c4d85c2f9fc1` (round 8, tester t-r8-69761b7a)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+- round 8 TRIAGE (captain): RETOUCHED from the coarse [kuna-cli] to the actual parser. The 'Bad C syntax' answer is raised in kuna-console/src/ifacedecomp.rs and the C dialect it enforces is kuna-console/src/grammar/; kuna-cli/src/assertdecl.rs only forms the directive line. track stays tooling: accepting a valid parameter name corrects a parser that is wrong on its own terms, so it is a strict fix with no option.
+- closed: acceptance a-555cfdcc80e2 now PASSES at 7e77fb8c9dca
+- round 10 REFUTER: hypothesis **overturned** (was inconclusive). Mechanism overturned, symptom stands. `code` is not a reserved word: Architecture::setup_types registers it as a core data-type (set_core_type("code", 1, TYPE_CODE, false)), and CParse::lookup_identifier classifies every spelling findByName answers as TYPE_NAME. The class is therefore every interned type name -- the core types, any tag/typedef declared earlier in the run, and on a -g binary every DWARF type name. The symptom also has two halves with two diagnostics, not one: `unsigned char *code` dies in direct_declarator (Syntax error) and `unsigned char code` dies in the greedy specifier run (Multiple type specifiers).

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -1043,6 +1043,29 @@ decided by the construction action, not by the token — `oldStruct` rejects a t
 that names something other than a struct with the kind error it always had, so
 `struct int4` is refused for saying `struct`, not for being unparseable.
 
+(kuna) **A name that is also a type name is still a name.** The same
+`findByName` classification reaches the declarator, where C says the identifier
+being declared hides any type of that spelling. Upstream's `direct_declarator`
+reads only the identifier terminal, so a variable or parameter named after an
+interned type was a syntax error with the caret on its own name — and `code`,
+one of the core types every compiler spec registers, is also the word an agent
+reaches for when it declares an interpreter's instruction stream. The same
+collision covers a tag or typedef declared earlier in the run, and on a `-g`
+binary every DWARF type name the program uses. Two positions therefore admit a
+type name: the specifier run stops at one once it has already named a type
+(`decompiler/crates/kuna-console/src/grammar.rs
+(CParse::declaration_specifier_starts)`, and its `specifier_qualifier_list`
+twin inside a struct body), and the name position takes it
+(`decompiler/crates/kuna-console/src/grammar.rs (CParse::declarator_identifier)`),
+which together cover `unsigned char code`, `unsigned char *code`, `int4
+(*code)(void)`, a struct field, an enum constant and the tail of a `a::b`
+scoped name. Only the *unparenthesised* name position moved: `int4 (code)` is
+genuinely ambiguous in C and keeps its abstract reading, a function of one
+`code`. Every declaration that parsed before parses to the same type — the
+first specifier of a run is unchanged, so `code *p` is still a pointer to
+`code`, and the two positions that changed were both hard errors ("Syntax
+error" and "Multiple type specifiers") before.
+
 (kuna) **A `prototype` declaration may name its calling convention**, which is
 the other half of speaking the target's own C: on Windows every declaration
 worth pasting carries one. An identifier the loaded compiler spec registered as

--- a/tests/cli/prototype-parser-rejects-valid.json
+++ b/tests/cli/prototype-parser-rejects-valid.json
@@ -1,0 +1,60 @@
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-555cfdcc80e2",
+  "kind": "cli",
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "binary_sha256": "c2d90645a45e99221593547e55c601a901b80f807ae96f94c60a7661df0b3e0b",
+    "binary_size": 8776,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/fauxware",
+    "selector": "authenticate",
+    "selector_kind": "name"
+  },
+  "timeout_s": 120,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "authenticate",
+    "--json",
+    "--assert",
+    "prototype authenticate unsigned long vm(unsigned char *code,unsigned int index,void *ctx)",
+    "--assert",
+    "prototype read int read(unsigned char code)"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "json": [
+      {
+        "path": "assertions",
+        "op": "len_eq",
+        "value": 2
+      },
+      {
+        "path": "assertions[0].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "assertions[1].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "contains",
+        "value": "unsigned char *code"
+      }
+    ],
+    "stderr_absent": [
+      "Syntax error",
+      "Multiple type specifiers",
+      "Bad C syntax"
+    ]
+  },
+  "notes": "Desired: a parameter may be named after a type. `code` is a core type every compiler spec registers, so the lexer hands it over as TYPE_NAME; both spellings were rejected -- `unsigned char *code` as a Syntax error on the name, `unsigned char code` as Multiple type specifiers. Retargeted onto the in-repo fauxware fixture so it runs with no dataset; both measured rejected on 7e77fb8c."
+}


### PR DESCRIPTION
## The problem

A parameter cannot be named after a type. `code` is one of the core types every
compiler spec registers, so a declaration that names a parameter after it is
rejected with the caret on the parameter's own name:

```bash
kuna decompile ./fauxware authenticate --json \
  --assert 'prototype authenticate unsigned long vm(unsigned char *code,unsigned int index,void *ctx)' \
  --assert 'prototype read int read(unsigned char code)'
```

```text
warning: --assert "prototype authenticate unsigned long vm(unsigned char *code,unsigned int index,void *ctx)" rejected: Syntax error at line 0 in stream
extern unsigned long vm(unsigned char *code,
                                       ^--

warning: --assert "prototype read int read(unsigned char code)" rejected: Multiple type specifiers at line 0 in stream
extern int read(unsigned char code)
                              ^--
```

Renaming `code` to anything else makes the same declaration apply. Every
interned name is in this class, not just the core types: a tag or `typedef`
declared earlier in the same run, and on a `-g` binary every DWARF type name the
program uses.

## The fix

`CParse::lookup_identifier` classifies any spelling `findByName` answers as
`TYPE_NAME`, and two positions had to learn that C reads such a token as a name
when a name is what belongs there:

- The specifier run stops at a `TYPE_NAME` once it has already named a type
  (`declaration_specifier_starts`, and its `specifier_qualifier_list` twin
  inside a struct body). That is the `unsigned char code` half.
- The declarator's name position takes one (`declarator_identifier`), reached
  from `direct_declarator`, `parameter_declaration` and the abstract-declarator
  paths. That is the `unsigned char *code` half, and it also covers
  `int4 (*code)(void)`, a struct field, an enum constant and the tail of an
  `a::b` scoped name.

Only the *unparenthesised* name position moved. `int4 (code)` is genuinely
ambiguous in C and keeps its abstract reading — a function of one `code` — so
the one case where a heuristic would have to guess is left alone.

The change is monotone: both positions it touches were hard errors before
("Syntax error", "Multiple type specifiers"), so no declaration that parsed
parses differently. The 263 `parse line` payloads across `tests/datatests/` and
`tests/stages/` were replayed through the old and new `decomp_dbg` byte-for-byte
identically.

## The tests

Six cases in `kuna-console/src/grammar/tests.rs` (both spellings, through
pointers/arrays/function pointers, a struct member, an enum constant, a scoped
name) plus the pins that `code *p` is still a pointer to `code` and `int4 (code)`
is still a function; one end-to-end case in `verify_assertplane.rs` asserting the
declared name reaches the emitted C; and the promoted probe
`tests/cli/prototype-parser-rejects-valid.json`, whose two directives both read
`rejected` on the unpatched tree.

Gates: `make test` PARITY OK 675/675 · `make test-stages` PARITY OK ·
`make rust-test` green · `make check-spec` green · `make test-cli` 91/91 (including the promoted probe) ·
`kuna catalog --check` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
