### PR TITLE
[AUTOMATED] Clarify dev-viz and credit community contributions

### DIFF
--- a/integrations/web/README.md
+++ b/integrations/web/README.md
@@ -88,6 +88,25 @@ asset path is relative, so a project subpath just works.
 | `kuna-worker-client.js` | The page-side RPC client. Cancellation terminates/recreates its Worker and rehydrates the retained binary on the next request. |
 | `zip.js` | Dependency-free STORE-only ZIP writer (CRC-32, UTF-8 names, fixed timestamp → deterministic), invoked inside the Worker for Download Binary Source. |
 | `vendor/browser_wasi_shim/` | Vendored [`@bjorn3/browser_wasi_shim`](https://github.com/bjorn3/browser_wasi_shim) (MIT/Apache-2.0) — a pure-JS WASI **preview1** implementation. Pinned in `VERSION`. |
+
+The development chart spaces active UTC days equally and marks omitted dates below
+the axis. Ghidra’s two catalog source labels are combined in both the counts and
+the source filter. Community counts come from `dev-viz/community.json`: a reviewed
+list of merged outside PRs and merged PRs linked to outside issue reports. Each PR
+counts once, only when it appears in the checked-out commit history. The list’s
+review date is shown on the page; builds do not query GitHub. When updating it,
+check PR authorship, merge status, and the report-to-fix link in the issue discussion;
+closing an issue alone does not qualify. Timeline entries live in `generate.py`;
+the August 8 benchmark date is maintainer-supplied and links to the live DecBench
+site, not an archived score table.
+
+For a page-only preview (Python 3.11+), without rebuilding WebAssembly:
+
+```bash
+python3 integrations/web/dev-viz/generate.py
+node integrations/web/test/dev-viz.mjs ../
+python3 -m http.server 8000 --directory integrations/web
+```
 | `build.sh` | Builds `kuna_wasm.wasm`, copies the full runtime SLEIGH tree + the shim + both pages + `assets/` into `dist/`, and bundles the small spec files into `specs-small.json`. `wasm-opt -Oz` is applied if present. |
 | `test/` | Automated gates (below) + committed ELF/Mach-O fixtures. |
 | `dist/` | Assembled output (gitignored — regenerate with `build.sh`). |

--- a/integrations/web/dev-viz/app.js
+++ b/integrations/web/dev-viz/app.js
@@ -6,7 +6,8 @@ const longDate = new Intl.DateTimeFormat('en-US', { month: 'long', day: 'numeric
 const $ = (id) => document.getElementById(id);
 const esc = (value) => String(value).replace(/[&<>"']/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 const title = (slug) => slug.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-const sourceLabel = (source) => ({'ghidra-upstream':'Ghidra upstream','ghidra':'Ghidra','angr':'angr','ida':'IDA','kuna':'Kuna','oxidizer':'Oxidizer'}[source] || title(source));
+const sourceKey = (source) => source === 'ghidra-upstream' ? 'ghidra' : source;
+const sourceLabel = (source) => ({'ghidra':'Ghidra','angr':'angr','ida':'IDA','kuna':'Kuna','oxidizer':'Oxidizer'}[sourceKey(source)] || title(source));
 const iso = (date) => new Date(`${date}T00:00:00Z`);
 const repoLink = (path, line = '') => `${REPO}/blob/main/${path}${line ? `#L${line}` : ''}`;
 
@@ -34,7 +35,7 @@ function summarize(data) {
   $('stat-agent').textContent = `${Math.round(agent / commits * 100)}%`;
   $('stat-options').textContent = number.format(data.options.length);
   $('stat-tests').textContent = number.format(upstream[1] + stages[1]);
-  $('snapshot').innerHTML = `Snapshot <a href="${REPO}/commit/${data.meta.sha}">${data.meta.sha.slice(0, 8)}</a> · ${longDate.format(iso(data.meta.end))} UTC · generated from tracked history and evidence files`;
+  $('snapshot').innerHTML = `Repository snapshot <a href="${REPO}/commit/${data.meta.sha}">${data.meta.sha.slice(0, 8)}</a> · ${longDate.format(iso(data.meta.end))} UTC`;
   $('data-note').innerHTML = `Generated from Kuna commit <a href="${REPO}/commit/${data.meta.sha}">${data.meta.sha.slice(0, 8)}</a>. Commit attribution counts explicit <code>[AUTOMATED]</code> markers or agent co-author trailers; source churn is added plus removed Rust/C/C++ lines in non-merge commits.`;
   $('decbench-options').textContent = number.format(data.options.filter((o) => o.decbench).length);
   $('novel-cases').textContent = data.novelPool.cases == null ? '—' : number.format(data.novelPool.cases);
@@ -52,22 +53,25 @@ function summarize(data) {
 function renderMilestones(data) {
   $('milestones').innerHTML = data.milestones.map((m) => `<li>
     <time datetime="${m.date}">${shortDate.format(iso(m.date))}</time>
-    <h3><a href="${REPO}/commit/${m.commit}">${esc(m.title)}</a></h3>
+    <h3><a href="${esc(m.url || `${REPO}/commit/${m.commit}`)}">${esc(m.title)}</a></h3>
     <p>${esc(m.detail)}</p>
   </li>`).join('');
 }
 
 function dailyRows(data) {
-  const grouped = new Map(daysBetween(data.meta.start, data.meta.end).map((date) => [date, {date, commits:0, agent:0, added:0, removed:0}]));
+  const grouped = new Map();
   for (const commit of data.commits) {
+    if (!grouped.has(commit.date)) grouped.set(commit.date, {date:commit.date, commits:0, agent:0, added:0, removed:0});
     const row = grouped.get(commit.date);
-    if (!row) continue;
     row.commits++;
     row.agent += commit.agent ? 1 : 0;
     row.added += commit.added;
     row.removed += commit.removed;
   }
-  return [...grouped.values()];
+  return [...grouped.values()].sort((a, b) => a.date.localeCompare(b.date)).map((row, i, rows) => ({
+    ...row,
+    skipped: i ? Math.round((iso(row.date) - iso(rows[i - 1].date)) / 86400000) - 1 : 0,
+  }));
 }
 
 function renderPace(data) {
@@ -84,18 +88,20 @@ function renderPace(data) {
   canvas.height = cssHeight * ratio;
   const ctx = canvas.getContext('2d');
   ctx.scale(ratio, ratio);
-  const pad = {left:44,right:48,top:30,bottom:48};
+  const pad = {left:44,right:48,top:30,bottom:62};
   const width = cssWidth - pad.left - pad.right;
   const height = cssHeight - pad.top - pad.bottom;
   const step = width / rows.length;
   const maxCommit = Math.max(...rows.map((r) => r.commits));
   const maxChurn = Math.max(...rows.map((r) => r.added + r.removed));
-  const portStart = rows.findIndex((r) => r.date === '2026-06-10');
-  const portEnd = rows.findIndex((r) => r.date === data.meta.portEnd);
-  ctx.fillStyle = '#F7F4F3';
-  ctx.fillRect(pad.left + portStart * step, pad.top, (portEnd - portStart + 1) * step, height);
-  ctx.fillStyle = '#6E6663'; ctx.font = '10px "Roboto Mono", monospace';
-  ctx.fillText('RUST PORT', pad.left + portStart * step + 6, pad.top + 13);
+  const portDays = rows.map((r, i) => r.date >= '2026-06-10' && r.date <= data.meta.portEnd ? i : -1).filter((i) => i >= 0);
+  ctx.font = '10px "Roboto Mono", monospace';
+  if (portDays.length) {
+    ctx.fillStyle = '#F7F4F3';
+    ctx.fillRect(pad.left + portDays[0] * step, pad.top, portDays.length * step, height);
+    ctx.fillStyle = '#6E6663';
+    ctx.fillText('RUST PORT', pad.left + portDays[0] * step + 6, pad.top + 13);
+  }
   ctx.strokeStyle = '#E4DDDB'; ctx.lineWidth = 1;
   for (let i = 0; i <= 4; i++) {
     const y = pad.top + height * i / 4;
@@ -117,30 +123,52 @@ function renderPace(data) {
     i ? ctx.lineTo(x, y) : ctx.moveTo(x, y);
   });
   ctx.strokeStyle = '#B80D1E'; ctx.lineWidth = 2; ctx.stroke();
-  const ticks = rows.filter((_, i) => i % 14 === 0 || i === rows.length - 1);
+  const tickStride = Math.max(1, Math.ceil(72 / step));
+  const ticks = rows.filter((_, i) => i % tickStride === 0 && i < rows.length - tickStride || i === rows.length - 1);
   ctx.fillStyle = '#6E6663'; ctx.font = '10px "Roboto Mono", monospace';
   for (const row of ticks) {
     const i = rows.indexOf(row), x = pad.left + (i + .5) * step;
-    ctx.fillText(shortDate.format(iso(row.date)), Math.min(x, cssWidth - 80), cssHeight - 18);
+    ctx.fillText(shortDate.format(iso(row.date)), Math.min(x, cssWidth - 80), cssHeight - 32);
   }
-  const active = rows.filter((r) => r.commits);
-  const peak = active.reduce((a, b) => b.commits > a.commits ? b : a);
-  $('pace-summary').textContent = `${number.format(data.commits.length)} non-merge commits across ${active.length} active UTC days. Peak: ${peak.commits} commits on ${longDate.format(iso(peak.date))}. Source churn counts additions and removals, including the verified Rust port.`;
+  const breaks = rows.filter((row) => row.skipped);
+  ctx.fillStyle = '#B80D1E';
+  for (const row of breaks) {
+    const x = pad.left + rows.indexOf(row) * step;
+    ctx.fillText('//', x - 6, pad.top + height + 13);
+  }
+  ctx.fillStyle = '#6E6663';
+  ctx.fillText('Active days (UTC) · // date jump', pad.left, cssHeight - 9);
+  $('pace-breaks').textContent = breaks.length ? 'Date jumps: ' + breaks.map((row) => {
+    const previous = rows[rows.indexOf(row) - 1];
+    return `${shortDate.format(iso(previous.date))} → ${shortDate.format(iso(row.date))} (${row.skipped} ${row.skipped === 1 ? 'day' : 'days'} without commits)`;
+  }).join(' · ') + '.' : 'No days without commits in this snapshot.';
+  const peak = rows.reduce((a, b) => b.commits > a.commits ? b : a);
+  const summary = `${number.format(data.commits.length)} non-merge commits across ${rows.length} active UTC days. Peak: ${peak.commits} commits on ${longDate.format(iso(peak.date))}. Lines changed includes both additions and removals.`;
+  $('pace-summary').textContent = summary;
+  let selected = rows.length - 1;
 
-  function inspect(event) {
-    const rect = canvas.getBoundingClientRect();
-    const x = event.clientX - rect.left;
-    const index = Math.max(0, Math.min(rows.length - 1, Math.floor((x - pad.left) / step)));
+  function inspect(index) {
+    selected = index;
     const row = rows[index];
     tip.hidden = false;
-    tip.innerHTML = `<b>${longDate.format(iso(row.date))}</b><br>${row.commits} commit${row.commits === 1 ? '' : 's'} · ${row.agent} agent-attributed<br><em>${number.format(row.added + row.removed)} source lines changed</em>`;
+    const description = `${longDate.format(iso(row.date))} UTC: ${row.commits} commits; ${row.agent} marked as agent-assisted; ${number.format(row.added + row.removed)} source lines changed.${row.skipped ? ` ${row.skipped} days without commits omitted before this date.` : ''}`;
+    tip.innerHTML = `<b>${longDate.format(iso(row.date))} UTC</b><br>${row.commits} commits · ${row.agent} agent-assisted<br><em>${number.format(row.added + row.removed)} source lines changed</em>${row.skipped ? `<br>${row.skipped} days without commits omitted` : ''}`;
     const left = Math.max(8, Math.min(cssWidth - 205, pad.left + index * step - shell.scrollLeft));
     tip.style.left = `${left + shell.scrollLeft}px`; tip.style.top = '38px';
-    $('pace-summary').textContent = tip.textContent;
+    $('pace-summary').textContent = description;
   }
-  canvas.onpointermove = inspect;
-  canvas.onpointerleave = () => { tip.hidden = true; };
-  canvas.onfocus = () => inspect({clientX: canvas.getBoundingClientRect().left + pad.left + width / 2});
+  canvas.onpointermove = (event) => inspect(Math.max(0, Math.min(rows.length - 1, Math.floor((event.clientX - canvas.getBoundingClientRect().left - pad.left) / step))));
+  const dismiss = () => { tip.hidden = true; $('pace-summary').textContent = summary; };
+  canvas.onpointerleave = dismiss;
+  canvas.onblur = dismiss;
+  canvas.onfocus = () => inspect(selected);
+  canvas.onkeydown = (event) => {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+    event.preventDefault();
+    const next = event.key === 'Home' ? 0 : event.key === 'End' ? rows.length - 1 : selected + (event.key === 'ArrowLeft' ? -1 : 1);
+    inspect(Math.max(0, Math.min(rows.length - 1, next)));
+    shell.scrollLeft = Math.max(0, pad.left + (selected + .5) * step - shell.clientWidth / 2);
+  };
 }
 
 function weeklyPhase(data) {
@@ -193,7 +221,10 @@ function renderHeatmap(data) {
 
 function renderProvenance(data) {
   const groups = new Map();
-  for (const option of data.options) groups.set(option.source, (groups.get(option.source) || 0) + 1);
+  for (const option of data.options) {
+    const source = sourceKey(option.source);
+    groups.set(source, (groups.get(source) || 0) + 1);
+  }
   const ordered = [...groups].sort((a, b) => b[1] - a[1]);
   const max = ordered[0][1];
   $('prov-bars').innerHTML = ordered.map(([source, count]) => `<div class="prov-row"><span>${esc(sourceLabel(source))}</span><div class="prov-track"><div class="prov-fill" style="width:${count / max * 100}%"></div></div><strong>${count}</strong></div>`).join('');
@@ -206,8 +237,8 @@ function renderProvenance(data) {
   function render() {
     const query = search.value.trim().toLowerCase();
     const source = select.value;
-    const filtered = data.options.filter((o) => (!source || o.source === source) && (!query || [o.name,o.phase,o.source,o.inspiration,o.summary].some((v) => String(v).toLowerCase().includes(query))));
-    $('catalog-list').innerHTML = filtered.length ? filtered.slice(0, limit).map((o) => `<article class="catalog-item"><header><a href="${repoLink('decompiler/crates/kuna-decomp/phases.toml', o.line)}">${esc(o.name)}</a><span class="tag">${o.phase}</span><span class="tag">${esc(sourceLabel(o.source))}</span>${o.decbench ? '<span class="tag">decbench</span>' : ''}</header><p>${esc(o.inspiration)}</p></article>`).join('') : '<p class="catalog-empty">No decisions match that filter.</p>';
+    const filtered = data.options.filter((o) => (!source || sourceKey(o.source) === source) && (!query || [o.name,o.phase,o.source,o.inspiration,o.summary].some((v) => String(v).toLowerCase().includes(query))));
+    $('catalog-list').innerHTML = filtered.length ? filtered.slice(0, limit).map((o) => `<article class="catalog-item"><header><a href="${repoLink('decompiler/crates/kuna-decomp/phases.toml', o.line)}">${esc(o.name)}</a><span class="tag">${o.phase}</span><span class="tag">${esc(sourceLabel(o.source))}</span>${o.decbench ? '<span class="tag">decbench</span>' : ''}</header><p>${esc(o.inspiration)}</p></article>`).join('') : '<p class="catalog-empty">No options match that filter.</p>';
     more.hidden = filtered.length <= limit;
     more.textContent = `Show ${Math.min(24, filtered.length - limit)} more of ${filtered.length}`;
   }
@@ -217,13 +248,22 @@ function renderProvenance(data) {
   render();
 }
 
+function renderContributions(data) {
+  const {changes, checkedThrough} = data.community;
+  const authored = changes.filter((c) => c.externalPr).length;
+  $('community-count').textContent = number.format(changes.length);
+  $('community-summary').textContent = `${authored} PRs submitted by outside contributors and ${changes.length - authored} other PRs prompted by their issue reports.`;
+  $('community-list').innerHTML = changes.map((c) => `<li><a href="${REPO}/pull/${c.pr}">#${c.pr}: ${esc(c.title)}</a> <span>— ${c.externalPr ? 'PR by' : 'reported by'} <a href="https://github.com/${esc(c.contributor)}">${esc(c.contributor)}</a>${c.issues.length ? ` · ${c.issues.map((id) => `<a href="${REPO}/issues/${id}">issue #${id}</a>`).join(', ')}` : ''}</span></li>`).join('');
+  $('community-note').innerHTML = `Reviewed through ${longDate.format(iso(checkedThrough))}. Each merged PR counts once, including agent-assisted submissions and partial fixes. This is a documented minimum based on the <a href="${repoLink('integrations/web/dev-viz/community.json')}">linked PRs and reports</a>.`;
+}
+
 function renderGed(data) {
   const rows = data.records.filter((r) => r.ged && Number.isFinite(r.ged.before) && Number.isFinite(r.ged.after))
     .sort((a, b) => (b.ged.before - b.ged.after) - (a.ged.before - a.ged.after));
   const max = Math.max(...rows.flatMap((r) => [r.ged.before, r.ged.after]));
   $('ged-chart').innerHTML = rows.map((r) => {
     const delta = r.ged.after - r.ged.before;
-    const result = delta < 0 ? `<span class="down">${Math.abs(delta)} lower</span>` : delta === 0 ? 'held' : `${delta} higher`;
+    const result = delta < 0 ? `<span class="down">${Math.abs(delta)} lower</span>` : delta === 0 ? 'unchanged' : `${delta} higher`;
     return `<div class="ged-row"><div class="ged-name"><a href="${repoLink(r.path)}">${esc(title(r.slug))}</a><small>${esc(r.ged.case)}</small></div><div class="ged-track" title="before ${r.ged.before}; after ${r.ged.after}"><span class="ged-before" style="width:${r.ged.before / max * 100}%"></span><span class="ged-after" style="width:${r.ged.after / max * 100}%"></span></div><p class="ged-value"><strong>${r.ged.before} → ${r.ged.after}</strong><br>${result}</p></div>`;
   }).join('');
 }
@@ -233,7 +273,7 @@ async function main() {
     const response = await fetch('./data.json');
     if (!response.ok) throw new Error(`snapshot request failed: ${response.status}`);
     const data = await response.json();
-    summarize(data); renderMilestones(data); renderPace(data); renderHeatmap(data); renderProvenance(data); renderGed(data);
+    summarize(data); renderMilestones(data); renderPace(data); renderHeatmap(data); renderProvenance(data); renderContributions(data); renderGed(data);
     let timer;
     addEventListener('resize', () => { clearTimeout(timer); timer = setTimeout(() => renderPace(data), 100); });
   } catch (error) {

--- a/integrations/web/dev-viz/community.json
+++ b/integrations/web/dev-viz/community.json
@@ -1,0 +1,28 @@
+{
+  "checkedThrough": "2026-09-08",
+  "changes": [
+    {"pr": 198, "title": "Decompile each function once when it has several names", "contributor": "rdmmf", "externalPr": false, "issues": [197]},
+    {"pr": 272, "title": "Decode 15-byte x86 NOPs", "contributor": "jannschu", "externalPr": false, "issues": [271]},
+    {"pr": 284, "title": "Recover call parameters that overlap wider register writes", "contributor": "jannschu", "externalPr": false, "issues": [275]},
+    {"pr": 315, "title": "Recover call arguments saved to the stack", "contributor": "jannschu", "externalPr": false, "issues": [275]},
+    {"pr": 336, "title": "Handle closed output pipes", "contributor": "phix33", "externalPr": true, "issues": []},
+    {"pr": 350, "title": "Preserve loader selectors", "contributor": "phix33", "externalPr": true, "issues": []},
+    {"pr": 352, "title": "Apply Ghidra’s locked parameter types", "contributor": "psifertex", "externalPr": true, "issues": []},
+    {"pr": 363, "title": "Accept file paths containing spaces", "contributor": "shreethaar", "externalPr": true, "issues": [362]},
+    {"pr": 368, "title": "Apply architecture-specific ELF object relocations", "contributor": "phix33", "externalPr": true, "issues": []},
+    {"pr": 401, "title": "Export decompilation graphs as JSON", "contributor": "dobin", "externalPr": true, "issues": []},
+    {"pr": 408, "title": "Avoid invalid register queries in the Ghidra extension", "contributor": "Tiecoon", "externalPr": false, "issues": [388]},
+    {"pr": 409, "title": "Keep chained PE code fragments in their owning function", "contributor": "dobin", "externalPr": false, "issues": [403]},
+    {"pr": 410, "title": "Correct basic blocks at truncated function boundaries", "contributor": "dobin", "externalPr": false, "issues": [403]},
+    {"pr": 446, "title": "Load Thumb PE/COFF files and select the ARM instruction set", "contributor": "phix33", "externalPr": true, "issues": []},
+    {"pr": 447, "title": "Fix V850 register lookup in the Ghidra extension", "contributor": "TsingShui", "externalPr": true, "issues": []},
+    {"pr": 476, "title": "Find bundled tools and specs in release archives", "contributor": "CloudyTabzy", "externalPr": false, "issues": [468]},
+    {"pr": 477, "title": "Label INT3 padding in decompiled output", "contributor": "CloudyTabzy", "externalPr": false, "issues": [468]},
+    {"pr": 478, "title": "Find and apply adjacent PDB files", "contributor": "CloudyTabzy", "externalPr": false, "issues": [468]},
+    {"pr": 479, "title": "Keep the selector when reconstructing a switch", "contributor": "CloudyTabzy", "externalPr": false, "issues": [468]},
+    {"pr": 480, "title": "Include imported calls in the call graph", "contributor": "dobin", "externalPr": false, "issues": [456]},
+    {"pr": 482, "title": "Follow delta-encoded jump tables in the call graph", "contributor": "dobin", "externalPr": false, "issues": [456]},
+    {"pr": 483, "title": "Add an option to remove MSVC stack-cookie checks", "contributor": "CloudyTabzy", "externalPr": false, "issues": [468]},
+    {"pr": 492, "title": "Decompile headerless images with a specified target and base", "contributor": "phix33", "externalPr": true, "issues": []}
+  ]
+}

--- a/integrations/web/dev-viz/dev-viz.css
+++ b/integrations/web/dev-viz/dev-viz.css
@@ -1,13 +1,12 @@
 .devviz{--activity:#B80D1E;--activity-soft:#F5D9DC;--blue:#1E5961;}
 .devviz h1,.devviz h2{font-family:var(--disp);font-weight:300;letter-spacing:-.03em;line-height:1.08;}
-.devviz h1{font-size:clamp(2.8rem,7vw,5.8rem);max-width:10ch;margin-top:18px;}
+.devviz h1{font-size:clamp(2.8rem,5.8vw,4.8rem);font-weight:700;max-width:16ch;margin:0;text-wrap:balance;}
 .devviz h2{font-size:clamp(2rem,4vw,3.15rem);max-width:13ch;}
 .devviz h3{font-size:.8rem;line-height:1.35;letter-spacing:.09em;text-transform:uppercase;}
 .devviz button,.devviz input,.devviz select{font:inherit;}
-.signal{width:9px;height:9px;border:2px solid var(--red);display:inline-block;position:relative;}
-.signal::after{content:"";position:absolute;inset:2px;background:var(--red);}
-.record-hero{min-height:650px;display:grid;grid-template-columns:minmax(0,1fr) minmax(260px,360px);gap:clamp(40px,7vw,100px);align-items:center;padding:clamp(64px,10vw,132px) 0 82px;}
-.record-hero .lede{margin-top:30px;max-width:66ch;font-size:1rem;line-height:1.85;color:var(--ink-2);}
+.record-hero{min-height:650px;display:grid;grid-template-columns:minmax(0,1fr) minmax(260px,360px);gap:36px clamp(40px,7vw,100px);align-items:start;padding:clamp(64px,10vw,132px) 0 82px;}
+.record-hero h1{grid-column:1/-1;max-width:22ch;}
+.record-hero .lede{margin-top:0;max-width:66ch;font-size:1rem;line-height:1.85;color:var(--ink-2);}
 .snapshot{margin-top:28px;color:var(--muted);font-size:.72rem;letter-spacing:.03em;}
 .hero-proof{border-top:1px solid var(--ink);}
 .hero-proof div{display:grid;grid-template-columns:125px 1fr;align-items:baseline;gap:18px;padding:19px 0;border-bottom:1px solid var(--rule);}
@@ -27,8 +26,9 @@
 .chart-tip{position:absolute;z-index:3;pointer-events:none;min-width:185px;background:var(--ink);color:var(--paper);padding:11px 13px;font-size:.68rem;line-height:1.65;box-shadow:0 6px 30px #0003;}
 .chart-tip b{color:#fff}.chart-tip em{font-style:normal;color:var(--on-ink-red);}
 .chart-summary{min-height:38px;padding:9px 18px;border-top:1px solid var(--rule);font-size:.68rem;color:var(--muted);}
-.milestones{list-style:none;margin:28px 0 0;padding:0;display:grid;grid-template-columns:repeat(5,1fr);border-top:1px solid var(--rule-2);}
-.milestones li{padding:18px 18px 0 0;position:relative;}
+.chart-dates{padding:0 18px 12px;font-size:.64rem;line-height:1.8;color:var(--muted);}
+.milestones{list-style:none;margin:28px 0 0;padding:0;display:grid;grid-template-columns:repeat(4,1fr);gap:28px 0;}
+.milestones li{padding:18px 18px 0 0;position:relative;border-top:1px solid var(--rule-2);}
 .milestones li::before{content:"";position:absolute;top:-4px;width:7px;height:7px;background:var(--red);}
 .milestones time{font-size:.62rem;color:var(--red);letter-spacing:.08em;}
 .milestones h3{margin-top:8px;}.milestones p{font-size:.68rem;line-height:1.55;color:var(--muted);margin-top:7px;}
@@ -58,6 +58,12 @@
 .novel-strip{margin-top:48px;padding:24px;border:1px solid #544B48;display:grid;grid-template-columns:minmax(210px,.6fr) minmax(300px,1fr);gap:24px 42px;align-items:start;}
 .novel-strip .eyebrow{margin-bottom:10px}.novel-strip>div>h3{color:#fff;max-width:34ch;}.novel-strip>.fineprint{grid-column:1/-1;margin-top:0;padding-top:16px;border-top:1px solid #3D3633;}
 .novel-list{display:flex;flex-wrap:wrap;gap:7px;}.novel-list a{color:#fff;text-decoration:none;border:1px solid #704248;padding:7px 9px;font-size:.62rem;}.novel-list a:hover{background:var(--on-ink-red);border-color:var(--on-ink-red);}
+.contributions{display:grid;grid-template-columns:1fr auto;gap:18px 28px;margin-top:36px;padding:24px;border:1px solid #544B48;}
+.contributions h3{color:#fff;}.contributions .eyebrow{margin-bottom:10px;}
+.contribution-total{display:flex;align-items:baseline;gap:12px;}.contribution-total strong{font:400 2.5rem/1 var(--disp);color:#fff;}.contribution-total span{font-size:.65rem;}
+.contributions>p:not(.contribution-total),.contributions>details{grid-column:1/-1;font-size:.7rem;}
+.contributions .fineprint{margin-top:0;max-width:100%;font-size:.64rem!important;}
+.contributions summary{cursor:pointer;color:#fff;}.contributions ul{list-style:none;padding:0;margin:18px 0 0;display:grid;gap:12px;}.contributions li{font-size:.68rem;line-height:1.7;}.contributions li>span{color:#AFA4A0;}
 .catalog-tools{display:flex;align-items:end;justify-content:space-between;gap:20px;margin-top:56px;padding-bottom:13px;border-bottom:1px solid #544B48;}
 .catalog-tools>label{font-size:.7rem;text-transform:uppercase;letter-spacing:.13em;color:#fff;font-weight:700;}
 .catalog-tools>div{display:flex;gap:8px;flex:1;justify-content:flex-end;}
@@ -83,14 +89,15 @@
 .evidence-grid article{background:var(--paper);padding:26px;}.evidence-grid .metric{color:var(--muted);font-size:.75rem;margin-bottom:18px;}.evidence-grid .metric strong{font:300 2.2rem/1 var(--disp);color:var(--ink);}.evidence-grid h3{margin-bottom:9px;}.evidence-grid article>p:last-child{font-size:.67rem;line-height:1.65;color:var(--muted);}
 .devfoot .wrap{align-items:flex-start}.devfoot p{max-width:70ch;}
 @media(max-width:800px){
-  .record-hero{min-height:0;grid-template-columns:1fr;padding-top:70px}.record-hero h1{max-width:9ch}.hero-proof{margin-bottom:18px}
-  .section-intro,.prov-layout,.novel-strip{grid-template-columns:1fr}.section-intro{gap:20px}.milestones{grid-template-columns:repeat(2,1fr);gap:22px 0}.milestones li:last-child{grid-column:1/-1}
+  .record-hero{min-height:0;grid-template-columns:1fr;padding-top:70px}.record-hero h1{max-width:16ch}.hero-proof{margin-bottom:18px}
+  .section-intro,.prov-layout,.novel-strip{grid-template-columns:1fr}.section-intro{gap:20px}.milestones{grid-template-columns:repeat(2,1fr);gap:22px 0}
   .catalog-tools{align-items:stretch;flex-direction:column}.catalog-tools>div{justify-content:stretch}.catalog-tools input{width:100%}.catalog-list{grid-template-columns:1fr}
   .loop{grid-template-columns:1fr 1fr}.loop li{border-bottom:1px solid var(--rule)}.loop li+li{padding-left:0;border-left:0}.loop li:nth-child(even){padding-left:18px;border-left:1px solid var(--rule)}.loop li:last-child{grid-column:1/-1}
   .evidence-grid{grid-template-columns:1fr}.phase-detail{grid-template-columns:70px 1fr}.phase-detail .phase-metric{grid-column:2;text-align:left}
 }
 @media(max-width:560px){
   .brand .at{display:none}.record-hero{padding-bottom:58px}.hero-proof div{grid-template-columns:110px 1fr}.chart-legend{gap:12px}.milestones{grid-template-columns:1fr}.milestones li:last-child{grid-column:auto}
+  .contributions{grid-template-columns:1fr}.contribution-total{grid-row:2}.catalog-item header{flex-wrap:wrap;}
   .catalog-tools>div{flex-direction:column}.catalog-tools select{max-width:none}.ged-row{grid-template-columns:1fr 70px;gap:10px}.ged-track{grid-column:1/-1;grid-row:2}.ged-value{grid-column:2;grid-row:1}.loop{grid-template-columns:1fr}.loop li:nth-child(even){padding-left:0;border-left:0}.loop li:last-child{grid-column:auto}
 }
 @media(prefers-reduced-motion:reduce){.heat-cell{transition:none;}}

--- a/integrations/web/dev-viz/generate.py
+++ b/integrations/web/dev-viz/generate.py
@@ -2,7 +2,8 @@
 """Export a reproducible, public development snapshot from tracked Kuna evidence.
 
 Requires Python 3.11+ and complete git history. No GitHub API, private campaign
-state, author identities, or local binary paths are included in the output.
+state, commit author emails, or local binary paths are included in the output.
+Community credits use public GitHub handles from a reviewed record file.
 """
 from __future__ import annotations
 
@@ -41,7 +42,11 @@ MILESTONES = [
     {"date": "2026-06-20", "title": "Rust takes over", "commit": "9346a1a5",
      "detail": "The C++ engine is removed after verification; Rust is the engine."},
     {"date": "2026-07-04", "title": "DecBench loop", "commit": "6b270a3e",
-     "detail": "Real-binary benchmark differences drive the mine, triage and rescore loop."},
+     "detail": "The benchmark loop starts finding, reproducing, and measuring changes on compiled programs."},
+    {"date": "2026-08-08", "title": "Top of optimized C", "url": "https://decbench.com/",
+     "detail": "Kuna ranks first on DecBench’s optimized C dataset."},
+    {"date": "2026-08-31", "title": "RE-needs pipeline starts", "commit": "63a124ae",
+     "detail": "The first run records problems found while using Kuna for reverse engineering; fixes follow from the re-needs backlog."},
 ]
 
 
@@ -203,6 +208,10 @@ def export(repo: Path) -> dict:
     novel_text = (repo / "docs/decbench/novel.md").read_text()
     novel_match = re.search(r"([\d,]+) cases in ([\d,]+) groups", novel_text)
     phase_counts = Counter(o["phase"] for o in options)
+    community = json.loads((repo / "integrations/web/dev-viz/community.json").read_text())
+    merged_prs = {int(m[1]) for c in commits
+                  if (m := re.search(r"\(#(\d+)\)$", c["subject"]))}
+    community["changes"] = [c for c in community["changes"] if c["pr"] in merged_prs]
     return {
         "schemaVersion": 1,
         "meta": {"sha": sha, "repository": "https://github.com/Noelo-Lab/kuna",
@@ -211,6 +220,7 @@ def export(repo: Path) -> dict:
         "phases": [{"id": pid, "name": name, "description": desc, "options": phase_counts[pid]}
                    for pid, name, desc in PHASES],
         "milestones": MILESTONES,
+        "community": community,
         "commits": commits,
         "options": options,
         "records": records,

--- a/integrations/web/dev-viz/index.html
+++ b/integrations/web/dev-viz/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>development record — Kuna</title>
-<meta name="description" content="Explore how Kuna develops: phase activity, commit cadence, feature provenance, benchmark-led research, and the evidence gates behind an agent-first decompiler.">
+<title>Kuna Development Visualizer</title>
+<meta name="description" content="Kuna’s development history: commits, phase activity, option sources, outside contributions, and recorded benchmark results.">
 <meta name="theme-color" content="#ffffff">
 <link rel="icon" type="image/png" href="../assets/img/favicon.png">
 <link rel="stylesheet" href="../assets/css/site.css">
@@ -18,7 +18,7 @@
     <a class="brand" href="../">
       <img src="../assets/img/kuna-mark.png" alt="">
       <span class="wordmark">Kuna</span>
-      <span class="at">development record</span>
+      <span class="at">development visualizer</span>
     </a>
     <nav class="nav" aria-label="Primary">
       <a href="./" class="here" aria-current="page">/dev-viz</a>
@@ -31,17 +31,16 @@
 <main id="main">
   <div class="wrap">
     <section class="record-hero">
+      <h1>Kuna Development Visualizer</h1>
       <div>
-        <p class="shead"><span class="signal" aria-hidden="true"></span><span class="name">the public development record</span></p>
-        <h1>Watch a decompiler learn.</h1>
-        <p class="lede">Kuna is built by agents against visible evidence: regression corpora, real-binary benchmarks, explicit phase decisions, and records of where an idea came from. This page derives its numbers from the repository at build time.</p>
+        <p class="lede">Kuna is a decompiler developed with coding agents and human direction. This page shows its commit history, where changes happen, where ideas come from, and recorded test results. The data is collected from the repository when the site is built.</p>
         <p class="snapshot" id="snapshot">Loading repository snapshot…</p>
       </div>
-      <div class="hero-proof" aria-label="Development evidence summary">
+      <div class="hero-proof" aria-label="Repository totals">
         <div><strong id="stat-commits">—</strong><span>non-merge commits</span></div>
-        <div><strong id="stat-agent">—</strong><span>explicitly agent-attributed</span></div>
-        <div><strong id="stat-options">—</strong><span>flippable decisions</span></div>
-        <div><strong id="stat-tests">—</strong><span>pinned assertions</span></div>
+        <div><strong id="stat-agent">—</strong><span>commits marked as agent-assisted</span></div>
+        <div><strong id="stat-options">—</strong><span>configurable options</span></div>
+        <div><strong id="stat-tests">—</strong><span>regression assertions</span></div>
       </div>
     </section>
   </div>
@@ -50,10 +49,10 @@
     <section class="sec viz-section" id="cadence">
       <div class="section-intro">
         <div>
-          <p class="eyebrow">01 / cadence</p>
-          <h2>A research system that ships daily</h2>
+          <p class="eyebrow">01 / history</p>
+          <h2>Development activity</h2>
         </div>
-        <p>Each black bar is a day’s non-merge commits. The red line is source churn on a logarithmic scale, so both focused fixes and the early port remain visible. Hover or focus a day for its exact evidence.</p>
+        <p>Each black bar counts one active day’s non-merge commits. Days without commits are omitted; date jumps are marked below the chart. The red line shows lines added or removed on a logarithmic scale. Hover, or focus the chart and use the arrow keys, for daily totals.</p>
       </div>
       <div class="chart-shell">
         <div class="chart-legend" aria-hidden="true">
@@ -62,10 +61,11 @@
           <span><i class="legend-port"></i> Rust port</span>
         </div>
         <div class="canvas-scroll" id="pace-scroll">
-          <canvas id="pace-chart" width="1060" height="340" tabindex="0" aria-label="Daily commit frequency and source churn chart"></canvas>
+          <canvas id="pace-chart" width="1060" height="340" tabindex="0" aria-label="Commits and source lines changed per active UTC day. Days without commits are omitted. Use left and right arrow keys to inspect dates."></canvas>
           <div class="chart-tip" id="pace-tip" hidden></div>
         </div>
         <p class="chart-summary" id="pace-summary" aria-live="polite"></p>
+        <p class="chart-dates" id="pace-breaks"></p>
       </div>
       <ol class="milestones" id="milestones" aria-label="Project milestones"></ol>
     </section>
@@ -76,13 +76,13 @@
       <div class="section-intro">
         <div>
           <p class="eyebrow">02 / phase model</p>
-          <h2>Where development lands</h2>
+          <h2>Changes by phase</h2>
         </div>
-        <p>The rows follow Kuna’s P0–P9 model; columns are UTC weeks. Color measures source lines added or removed by commits that can be assigned to a phase. Activity shows attention, not percent complete.</p>
+        <p>Rows are Kuna’s P0–P9 phases; columns are UTC weeks. Color shows source lines added or removed in files assigned to each phase. This measures code activity, not completion or quality.</p>
       </div>
       <div class="heatmap-shell">
         <div class="heatmap" id="phase-heatmap" aria-label="Weekly source activity by decompiler phase"></div>
-        <div class="heat-legend"><span>quiet</span><i></i><i></i><i></i><i></i><i></i><span>high churn</span></div>
+        <div class="heat-legend"><span>fewer lines changed</span><i></i><i></i><i></i><i></i><i></i><span>more</span></div>
       </div>
       <div class="phase-detail" id="phase-detail" aria-live="polite"></div>
     </section>
@@ -93,38 +93,46 @@
       <section class="viz-section provenance" id="provenance">
         <div class="section-intro">
           <div>
-            <p class="eyebrow">03 / provenance</p>
-            <h2>Ideas keep their receipts</h2>
+            <p class="eyebrow">03 / sources</p>
+            <h2>Where changes come from</h2>
           </div>
-          <p>Every flippable decision names its source and inspiration. The catalog separates work derived from other decompilers from behavior developed inside Kuna, while DecBench case IDs link learned behavior back to the function that exposed it.</p>
+          <p>The option catalog records a source and inspiration for each option. These counts group options by their recorded source. Some also name the DecBench function that prompted the change.</p>
         </div>
         <div class="prov-layout">
           <div>
             <div class="prov-bars" id="prov-bars" aria-label="Option provenance counts"></div>
-            <p class="fineprint">Counts are the current option catalog’s <code>source_decompiler</code> field. “Kuna” means the implementation’s recorded source, even when its inspiration cites prior research.</p>
+            <p class="fineprint">Ghidra includes both <code>ghidra</code> and <code>ghidra-upstream</code> entries. “Kuna” is the catalog’s recorded implementation source; it does not mean the idea has no prior work. These are option counts, not shares of the codebase.</p>
           </div>
           <div class="research-counters">
-            <article><strong id="decbench-options">—</strong><span>options tied to an exact DecBench case</span></article>
-            <article><strong id="novel-cases">—</strong><span>NOVEL-pool cases where Kuna is co-best or best, yet still imperfect</span></article>
-            <article><strong id="novel-features">—</strong><span>feature records grown from NOVEL-pool triage</span></article>
+            <article><strong id="decbench-options">—</strong><span>options referencing a DecBench case</span></article>
+            <article><strong id="novel-cases">—</strong><span>benchmark cases labeled NOVEL</span></article>
+            <article><strong id="novel-features">—</strong><span>feature records from those cases</span></article>
           </div>
         </div>
 
         <div class="novel-strip">
-          <div><p class="eyebrow">from the NOVEL pool</p><h3>Kuna led the comparison and still found work to do</h3></div>
+          <div><p class="eyebrow">NOVEL benchmark cases</p><h3>Changes from cases where Kuna already scored best</h3></div>
           <div class="novel-list" id="novel-list"></div>
-          <p class="fineprint">NOVEL is a mining label: at the recorded snapshot, Kuna was best or co-best among the available outputs but still had structural or readability defects. It identifies self-directed research opportunities; it is not a claim that an idea has no prior art.</p>
+          <p class="fineprint">NOVEL labels cases where Kuna scored best or tied among the available outputs but still had structural or readability problems. It is a benchmark category, not a claim of a new invention.</p>
+        </div>
+
+        <div class="contributions">
+          <div><p class="eyebrow">Outside contributions</p><h3>Changes from community issues and PRs</h3></div>
+          <p class="contribution-total"><strong id="community-count">—</strong><span>merged changes</span></p>
+          <p id="community-summary"></p>
+          <details><summary>View the counted changes</summary><ul id="community-list"></ul></details>
+          <p class="fineprint" id="community-note"></p>
         </div>
 
         <div class="catalog-tools">
-          <label for="catalog-search">Inspect the decision catalog</label>
+          <label for="catalog-search">Browse the option catalog</label>
           <div>
             <input id="catalog-search" type="search" placeholder="Search option, phase, source, or inspiration">
             <select id="catalog-source" aria-label="Filter options by provenance"><option value="">all sources</option></select>
           </div>
         </div>
         <div class="catalog-list" id="catalog-list"></div>
-        <button class="text-button" id="catalog-more" type="button" hidden>Show more decisions</button>
+        <button class="text-button" id="catalog-more" type="button" hidden>Show more options</button>
       </section>
     </div>
   </div>
@@ -133,13 +141,13 @@
     <section class="sec viz-section" id="outcomes">
       <div class="section-intro">
         <div>
-          <p class="eyebrow">04 / measured outcomes</p>
-          <h2>The score has to move—or hold</h2>
+          <p class="eyebrow">04 / measurements</p>
+          <h2>Recorded benchmark changes</h2>
         </div>
-        <p>Recorded feature witnesses are rescored with graph edit distance (GED): lower is structurally closer to the original source, and zero is exact. Unchanged cases matter because they make limits visible.</p>
+        <p>These feature records compare graph edit distance (GED) before and after a change. Lower means the measured control-flow graph is closer to the source’s graph. Zero means matching graph structure, not identical source code or proof of correctness.</p>
       </div>
       <div class="ged-chart" id="ged-chart" aria-label="Recorded before and after graph edit distances"></div>
-      <p class="fineprint light">These are per-function feature records, not a cross-tool leaderboard. Each row links to its committed measurement; benchmark columns collected at different dates are used for mining, not publication claims.</p>
+      <p class="fineprint light">Gray bars show the earlier measurement; red bars show the later one. Each row links to the feature’s recorded result for one function. These examples do not measure overall decompiler quality.</p>
     </section>
   </div>
 
@@ -148,31 +156,31 @@
       <div class="section-intro">
         <div>
           <p class="eyebrow">05 / method</p>
-          <h2>Autonomy with a harness</h2>
+          <h2>How changes are tested</h2>
         </div>
-        <p>The system is autonomous because the next problem, the implementation, and much of the verification can be agent-run. It stays research-grade because every stage leaves inspectable evidence.</p>
+        <p>Coding agents can select problems, implement changes, and run checks. People set the direction and review results. The benchmark loop records test cases, measurements, and the reasons for a change.</p>
       </div>
       <ol class="loop">
-        <li><span>01</span><h3>Mine</h3><p>Find functions where another decompiler wins, or where Kuna leads but remains imperfect.</p></li>
-        <li><span>02</span><h3>Triage</h3><p>Reproduce on today’s engine, compare structure, and test the proposed mechanism.</p></li>
-        <li><span>03</span><h3>Implement</h3><p>Place behavior in its phase and expose judgment calls as per-run options.</p></li>
-        <li><span>04</span><h3>Challenge</h3><p>Run two-pass stage cases, the 675-assertion oracle, workspace tests, and spec checks.</p></li>
-        <li><span>05</span><h3>Measure</h3><p>Rescore the witness, audit every changed function, and retain provenance.</p></li>
+        <li><span>01</span><h3>Find</h3><p>Find functions with poor output through benchmarks, RE sessions, or issue reports.</p></li>
+        <li><span>02</span><h3>Reproduce</h3><p>Check the problem on the current engine and identify its cause.</p></li>
+        <li><span>03</span><h3>Implement</h3><p>Add the change to its phase. Make optional behavior configurable per run.</p></li>
+        <li><span>04</span><h3>Test</h3><p>Run regression cases, workspace tests, and specification checks.</p></li>
+        <li><span>05</span><h3>Measure</h3><p>Compare output and speed before and after, and record the results.</p></li>
       </ol>
       <div class="evidence-grid">
         <article>
           <p class="metric"><strong id="oracle-count">—</strong> / <span id="oracle-total">—</span></p>
-          <h3>Upstream parity</h3>
-          <p>The original Ghidra regression assertions remain pinned. The baseline is not moved to absorb regressions.</p>
+          <h3>Ghidra regression baseline</h3>
+          <p>Passing assertions in the recorded baseline. These tests check behavior inherited from Ghidra; they do not cover every binary.</p>
         </article>
         <article>
           <p class="metric"><strong id="stage-count">—</strong> / <span id="stage-total">—</span></p>
-          <h3>Kuna-owned assertions</h3>
-          <p>New behavior gets an end-to-end witness, including an option-off contrast when output can change.</p>
+          <h3>Kuna regression baseline</h3>
+          <p>Passing assertions in Kuna’s recorded stage-test baseline. Option-gated changes include comparisons with the option disabled.</p>
         </article>
         <article>
           <p class="metric"><strong id="triage-count">—</strong> records</p>
-          <h3>Public triage trail</h3>
+          <h3>Benchmark triage records</h3>
           <p id="triage-summary">Repository records show what became a candidate, what an existing option covered, and what was already fixed.</p>
         </article>
       </div>
@@ -182,7 +190,7 @@
 
 <footer class="foot devfoot">
   <div class="wrap">
-    <p id="data-note">Evidence snapshot loading…</p>
+    <p id="data-note">Loading repository data…</p>
     <span class="links">
       <a href="https://github.com/Noelo-Lab/kuna">source</a>
       <a href="https://github.com/Noelo-Lab/kuna/blob/main/docs/history.md">history</a>

--- a/integrations/web/test/dev-viz.mjs
+++ b/integrations/web/test/dev-viz.mjs
@@ -1,8 +1,9 @@
 // Validate the generated public evidence bundle without duplicating its logic.
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
+import { runInNewContext } from 'node:vm';
 
-const root = new URL('../dist/', import.meta.url);
+const root = new URL(process.argv[2] || '../dist/', import.meta.url);
 const data = JSON.parse(await readFile(new URL('dev-viz/data.json', root), 'utf8'));
 const html = await readFile(new URL('dev-viz/index.html', root), 'utf8');
 const app = await readFile(new URL('dev-viz/app.js', root), 'utf8');
@@ -21,6 +22,24 @@ assert.ok(data.options.every((o) => /^P[0-9]$/.test(o.phase) && o.line > 0));
 assert.ok(data.commits.every((c) => /^\d{4}-\d{2}-\d{2}$/.test(c.date)));
 assert.ok(data.records.some((r) => r.ged?.before > r.ged?.after));
 assert.ok(data.records.some((r) => r.novel));
+assert.equal(new Set(data.community.changes.map((c) => c.pr)).size, data.community.changes.length);
+assert.ok(data.community.changes.every((c) => c.externalPr || c.issues.length > 0));
+assert.ok(data.community.changes.every((c) => data.commits.some((commit) => commit.subject.endsWith(`(#${c.pr})`))));
+assert.ok(data.milestones.some((m) => m.date === '2026-08-08' && m.title.includes('optimized C')));
+assert.ok(data.milestones.some((m) => m.date === '2026-08-31' && m.commit === '63a124ae'));
+
+const {dailyRows, sourceKey} = runInNewContext(app.replace(/main\(\);\s*$/, '') + '\n({dailyRows, sourceKey})');
+const day = (date, added, removed = 0, agent = false) => ({date, added, removed, agent});
+const rows = dailyRows({commits: [day('2026-07-04', 10), day('2026-06-30', 3, 2), day('2026-07-01', 4), day('2026-07-04', 5, 2, true)]});
+assert.deepEqual(JSON.parse(JSON.stringify(rows)), [
+  {date:'2026-06-30', commits:1, agent:0, added:3, removed:2, skipped:0},
+  {date:'2026-07-01', commits:1, agent:0, added:4, removed:0, skipped:0},
+  {date:'2026-07-04', commits:2, agent:1, added:15, removed:2, skipped:2},
+]);
+assert.equal(dailyRows(data).reduce((sum, row) => sum + row.commits, 0), data.commits.length);
+assert.ok(dailyRows(data).every((row) => row.commits > 0));
+assert.equal(sourceKey('ghidra-upstream'), sourceKey('ghidra'));
+assert.notEqual(sourceKey('kuna'), sourceKey('ghidra'));
 
 const serialized = JSON.stringify(data);
 assert.doesNotMatch(serialized, /\/(Users|home)\//, 'local paths leaked into public data');
@@ -29,4 +48,4 @@ assert.match(html, /id="phase-heatmap"/);
 assert.match(html, /id="catalog-search"/);
 assert.match(app, /fetch\('\.\/data\.json'\)/);
 
-console.log(`dev-viz OK: ${data.commits.length} commits, ${data.options.length} options, ${data.records.length} records`);
+console.log(`dev-viz OK: ${data.commits.length} commits, ${data.options.length} options, ${data.records.length} records, ${data.community.changes.length} community changes`);


### PR DESCRIPTION
## Page

At `/dev-viz/`, “Watch a decompiler learn.” becomes a bold “Kuna Development Visualizer,” with plain descriptions and totals aligned beside the introductory text. The activity chart shows only days with commits, with date jumps marked below it.

## Changes

- Combine Ghidra’s two catalog labels in the counts and source filter.
- Add the August 8 optimized-C benchmark milestone and August 31 RE-needs pipeline start.
- Credit 23 distinct merged changes: 9 outside PRs and 14 PRs prompted by outside reports. The reviewed records link each contribution and show their review date.
- Add keyboard navigation for the daily chart and document page-only previews and count maintenance.

## Tests

Page checks and browser interactions pass at 390, 768, 1024, and 1440 px. Upstream assertions: 675/675; stage assertions: 704/704; spec and catalog checks pass.

The full Rust suite has one unrelated failure: `header_syntax_checks_with_cc` in `decompile_project_cli` rejects the generated `void main(void)` declaration. It also fails when run separately; no engine files changed.
