### PR TITLE
[AUTOMATED] perf(analysis): skip the disassembly render nothing reads on the fast discovery path

### DIFF
--- a/decompiler/crates/kuna-analysis/src/analyzers/aif/kuna_poolentry.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/aif/kuna_poolentry.rs
@@ -294,7 +294,7 @@ pub fn run_pool_pass(
         pools.iter().copied().filter(|p| follows_return(&ends, p.lo)).collect();
 
     let mut added = Vec::new();
-    let hist = super::build_fingerprint_histogram(listing);
+    let hist = super::build_fingerprint_histogram(listing, &mut decoder);
     if hist.values().any(|&c| c >= super::FINGERPRINT_THRESHOLD) {
         let mut accepted: BTreeSet<u64> = BTreeSet::new();
         for p in &add_pools {

--- a/decompiler/crates/kuna-analysis/src/analyzers/aif/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/aif/mod.rs
@@ -230,7 +230,9 @@ impl<'a> GapDecoder<'a> {
         if !self.in_exec(vma) {
             return None;
         }
-        let decoded = decode_one(self.translate, vma, &self.code_space).ok()?;
+        // `want_assembly = true`: the prologue fingerprint below is built from the
+        // mnemonic text.
+        let decoded = decode_one(self.translate, vma, &self.code_space, true).ok()?;
         if decoded.len == 0 {
             return None;
         }
@@ -268,21 +270,41 @@ impl<'a> GapDecoder<'a> {
 }
 
 /// Compute the function-start fingerprint at `entry` over the BUILT Listing (a
-/// discovered function whose prologue is already decoded). The histogram half reads
-/// the Listing's instruction model (no speculative decode needed — these are
-/// reachable functions).
-fn fingerprint_in_listing(listing: &Listing, entry: u64) -> Option<Fingerprint> {
+/// discovered function whose prologue is already decoded). Membership and lengths
+/// come from the Listing's instruction model — these are reachable functions, so
+/// each of the [`FINGERPRINT_INSNS`] steps must be a decoded instruction START
+/// there, exactly as before.
+///
+/// The mnemonic TEXT comes from the Listing when it carries any, and otherwise is
+/// re-decoded one address at a time through `decoder`. The Listing captures
+/// disassembly text only when a text-reading consumer asked for it (see
+/// `listing::decode::decode_one`), and this fingerprint needs just the first
+/// `FINGERPRINT_INSNS` instructions of each function — re-decoding those is ~2 per
+/// function instead of text for every instruction in the image. Equivalent either
+/// way: decoding the same address under the same painted context yields the same
+/// mnemonic the walk would have recorded, and an empty one still rejects.
+fn fingerprint_in_listing(
+    listing: &Listing,
+    decoder: &mut GapDecoder,
+    entry: u64,
+) -> Option<Fingerprint> {
     let mut mnems: Vec<String> = Vec::with_capacity(FINGERPRINT_INSNS);
     let mut total_len: u64 = 0;
     let mut vma = entry;
     for _ in 0..FINGERPRINT_INSNS {
         let insn = listing.instruction_at(vma)?;
-        if insn.mnemonic.is_empty() {
+        let len = insn.len;
+        let mnemonic = if listing.has_assembly() {
+            insn.mnemonic.clone()
+        } else {
+            decoder.probe(vma)?.mnemonic
+        };
+        if mnemonic.is_empty() {
             return None;
         }
-        mnems.push(insn.mnemonic.clone());
-        total_len += insn.len as u64;
-        vma = vma.checked_add(insn.len as u64)?;
+        mnems.push(mnemonic);
+        total_len += len as u64;
+        vma = vma.checked_add(len as u64)?;
     }
     Some((mnems, total_len))
 }
@@ -290,10 +312,13 @@ fn fingerprint_in_listing(listing: &Listing, entry: u64) -> Option<Fingerprint> 
 /// Build the function-start fingerprint histogram over every DISCOVERED function
 /// (Ghidra's `funcStartMap`): map each prologue fingerprint to the number of
 /// discovered functions that share it.
-fn build_fingerprint_histogram(listing: &Listing) -> BTreeMap<Fingerprint, usize> {
+fn build_fingerprint_histogram(
+    listing: &Listing,
+    decoder: &mut GapDecoder,
+) -> BTreeMap<Fingerprint, usize> {
     let mut hist: BTreeMap<Fingerprint, usize> = BTreeMap::new();
     for (&entry, _) in listing.functions() {
-        if let Some(fp) = fingerprint_in_listing(listing, entry) {
+        if let Some(fp) = fingerprint_in_listing(listing, decoder, entry) {
             *hist.entry(fp).or_insert(0) += 1;
         }
     }
@@ -477,12 +502,12 @@ pub fn run_aif(
         return Vec::new();
     }
 
-    let hist = build_fingerprint_histogram(listing);
+    let mut decoder = GapDecoder::new(translate, code_space, exec_ranges);
+    let hist = build_fingerprint_histogram(listing, &mut decoder);
     if !hist.values().any(|&c| c >= FINGERPRINT_THRESHOLD) {
         return Vec::new();
     }
 
-    let mut decoder = GapDecoder::new(translate, code_space, exec_ranges);
     let mut accepted: BTreeSet<u64> = BTreeSet::new();
     let mut claimed: BTreeSet<u64> = BTreeSet::new();
 
@@ -591,12 +616,12 @@ pub(crate) fn validate_pointer_targets(
     exec_ranges: &[(u64, u64)],
     candidates: impl IntoIterator<Item = u64>,
 ) -> Vec<u64> {
-    let hist = build_fingerprint_histogram(listing);
+    let mut decoder = GapDecoder::new(translate, code_space, exec_ranges);
+    let hist = build_fingerprint_histogram(listing, &mut decoder);
     if !hist.values().any(|&count| count >= FINGERPRINT_THRESHOLD) {
         return Vec::new();
     }
 
-    let mut decoder = GapDecoder::new(translate, code_space, exec_ranges);
     let mut accepted = BTreeSet::new();
     let mut claimed = BTreeSet::new();
     for target in candidates {

--- a/decompiler/crates/kuna-analysis/src/analyzers/fid/build.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/fid/build.rs
@@ -227,7 +227,8 @@ fn decode_extent(
         }
         guard -= 1;
 
-        let Ok(dec) = decode_one(translate, vma, code_space) else {
+        // `want_assembly = false`: the extent clip reads only `len` and `ops`.
+        let Ok(dec) = decode_one(translate, vma, code_space, false) else {
             break; // an undecodable byte ends the clip
         };
         let len = dec.len.max(1); // never advance by 0 (avoid an infinite loop)

--- a/decompiler/crates/kuna-analysis/src/listing/decode.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/decode.rs
@@ -78,10 +78,19 @@ pub struct Decoded {
 /// errs after `one_instruction` succeeded, the instruction is still returned
 /// (with whatever mnemonic was captured, possibly empty) — the p-code (and thus
 /// the flow classification) is the load-bearing output.
+///
+/// `want_assembly` selects whether the assembly TEXT is captured at all.
+/// `print_assembly` is a **second, full SLEIGH parse** of the same bytes, so it
+/// roughly doubles the per-instruction decode cost and adds two heap `String`s per
+/// instruction. Only the text-reading consumers need it (`noreturn_propagate`,
+/// `tailcallentry` and `poolentry` off [`super::Insn`], and the AIF prologue
+/// fingerprinter); pass `false` wherever only `len`/`ops` are read and the two
+/// text fields come back empty.
 pub fn decode_one(
     translate: &dyn Translate,
     vma: u64,
     code_space: &Rc<AddrSpace>,
+    want_assembly: bool,
 ) -> KunaResult<Decoded> {
     let addr = Address::new(Rc::clone(code_space), vma);
 
@@ -89,9 +98,11 @@ pub fn decode_one(
     let len = translate.one_instruction(&mut cap, &addr)?;
 
     let mut asm = AsmCapture::default();
-    // The mnemonic is non-essential to flow; if the disassembly emit errs we
-    // keep the (possibly empty) captured string rather than failing the decode.
-    let _ = translate.print_assembly(&mut asm, &addr);
+    if want_assembly {
+        // The mnemonic is non-essential to flow; if the disassembly emit errs we
+        // keep the (possibly empty) captured string rather than failing the decode.
+        let _ = translate.print_assembly(&mut asm, &addr);
+    }
 
     Ok(Decoded { len: len.max(0) as u32, ops: cap.ops, mnemonic: asm.mnemonic, operands: asm.operands })
 }

--- a/decompiler/crates/kuna-analysis/src/listing/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/mod.rs
@@ -18,8 +18,15 @@
 //! the engine** (PR2) and has **no `--option` flag** (PR1) and **no
 //! `AnalysisCtx` change** (PR1). `context.rs` (ARM/MIPS decode-context paint) is
 //! PR5; x86-64 (the PR0 target) needs no context. The CodeUnit partition
-//! *queries* are PR3, but the [`model::CodeUnit`] type and the
-//! `covered`/`exec_ranges` fields are defined here now.
+//! *queries* are PR3, but the [`model::CodeUnit`] type and the `exec_ranges`
+//! field are defined here now.
+//!
+//! Instruction-byte coverage is **derived**, never stored: `insns` already maps
+//! each VMA to its length, so [`Listing::first_undefined_after`] and the AIF gap
+//! walk read coverage straight off that map. An earlier `covered: RangeList`
+//! mirror was write-only, and — because `RangeList` merges overlapping but not
+//! *adjacent* ranges — a straight-line instruction run cost one B-tree node per
+//! decoded instruction.
 
 pub mod classify;
 pub mod context;
@@ -37,11 +44,10 @@ pub mod walk;
 // the same decode this tier performs, not a pass; nothing commits its output.
 pub mod xrefs;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Bound;
 use std::rc::Rc;
 
-use kuna_base::address::RangeList;
 use kuna_decomp::architecture::Architecture;
 use kuna_sleigh::translate::Translate;
 
@@ -61,11 +67,10 @@ pub struct Listing {
     refs_from: BTreeMap<u64, Vec<Reference>>,
     /// Discovered/seeded functions, keyed by entry VMA (ordered).
     funcs: BTreeMap<u64, DiscoveredFunction>,
-    /// Instruction-byte coverage (`[vma, vma+len-1]` per decoded insn).
-    #[allow(dead_code)] // gap = exec_ranges - covered: a PR7 (AIF) consumer.
-    covered: RangeList,
     /// The coverage universe for the partition / gap walk (sorted, disjoint).
     exec_ranges: Vec<(u64, u64)>,
+    /// Whether the instruction model carries disassembly text.
+    has_assembly: bool,
 }
 
 impl Listing {
@@ -78,6 +83,8 @@ impl Listing {
     /// `seed_names` is an optional `(addr, name)` overlay for the seed functions
     /// (e.g. from `existing_function_addrs` / entry-name overlays). `from_symbol`
     /// is recorded for every seed listed in `funcsym_seeds`.
+    ///
+    /// Captures assembly text (see [`Listing::build_with_meta`]'s `want_assembly`).
     pub fn build(
         file: &object::File,
         _image: &ObjectLoadImage,
@@ -85,7 +92,7 @@ impl Listing {
         translate: &dyn Translate,
         seeds: &[u64],
     ) -> Listing {
-        Self::build_with_meta(file, _image, arch, translate, seeds, &[], &[])
+        Self::build_with_meta(file, _image, arch, translate, seeds, &[], &[], true)
     }
 
     /// A Listing assembled from a partition someone else already decoded.
@@ -107,14 +114,21 @@ impl Listing {
             refs_to: BTreeMap::new(),
             refs_from: BTreeMap::new(),
             funcs,
-            covered: RangeList::default(),
             exec_ranges,
+            has_assembly: true,
         }
     }
 
     /// Like [`Listing::build`], but with seed metadata: `funcsym_seeds` is the
     /// subset of `seeds` that came from a real funcsym (sets `from_symbol`), and
     /// `seed_names` is an `(addr, name)` overlay for naming seed functions.
+    ///
+    /// `want_assembly` selects whether each [`Insn`] carries its disassembly text.
+    /// Every consumer that reads it runs behind `--option listing on`, except AIF's
+    /// prologue fingerprint, which re-decodes the two addresses it needs; the
+    /// `fast_funcdisc`-only path therefore passes `false` and skips a second full
+    /// SLEIGH parse per instruction (see [`decode::decode_one`]).
+    #[allow(clippy::too_many_arguments)]
     pub fn build_with_meta(
         file: &object::File,
         _image: &ObjectLoadImage,
@@ -123,6 +137,7 @@ impl Listing {
         seeds: &[u64],
         funcsym_seeds: &[u64],
         seed_names: &[(u64, String)],
+        want_assembly: bool,
     ) -> Listing {
         // The executable-range universe (design §2.4 / §3.4 out-of-bounds gate),
         // sorted by low VMA so the partition / gap queries can binary-search it.
@@ -142,15 +157,19 @@ impl Listing {
                     refs_to: BTreeMap::new(),
                     refs_from: BTreeMap::new(),
                     funcs: BTreeMap::new(),
-                    covered: RangeList::new(),
                     exec_ranges,
+                    has_assembly: want_assembly,
                 };
             }
         };
 
-        // Build the seed metadata map.
+        // Build the seed metadata map. `funcsym_seeds` is indexed first: a linear
+        // `contains` per seed is O(|seeds| x |funcsym_seeds|), which on a
+        // several-hundred-thousand-seed image is a membership test in the billions
+        // of comparisons.
         let name_of: BTreeMap<u64, String> =
             seed_names.iter().map(|(a, n)| (*a, n.clone())).collect();
+        let funcsym_set: BTreeSet<u64> = funcsym_seeds.iter().copied().collect();
         let mut seed_funcs: BTreeMap<u64, DiscoveredFunction> = BTreeMap::new();
         for &entry in seeds {
             seed_funcs.insert(
@@ -158,7 +177,7 @@ impl Listing {
                 DiscoveredFunction {
                     entry,
                     name: name_of.get(&entry).cloned(),
-                    from_symbol: funcsym_seeds.contains(&entry),
+                    from_symbol: funcsym_set.contains(&entry),
                     has_no_return: false,
                     call_fixup: None,
                 },
@@ -187,6 +206,7 @@ impl Listing {
             &seed_funcs,
             &painter,
             &local_entries,
+            want_assembly,
         );
 
         let mut refs_to = st.refs_to;
@@ -204,8 +224,8 @@ impl Listing {
             refs_to,
             refs_from,
             funcs: st.funcs,
-            covered: st.covered,
             exec_ranges,
+            has_assembly: want_assembly,
         }
     }
 
@@ -286,6 +306,13 @@ impl Listing {
     /// gap decode (`memory.contains` / executable-block guard).
     pub fn exec_ranges(&self) -> &[(u64, u64)] {
         &self.exec_ranges
+    }
+
+    /// Whether [`Insn::mnemonic`]/[`Insn::operands`] carry disassembly text. False
+    /// for a Listing built with `want_assembly = false`, whose only text reader
+    /// (AIF's prologue fingerprint) re-decodes the addresses it needs.
+    pub fn has_assembly(&self) -> bool {
+        self.has_assembly
     }
 
     /// The decoded instruction whose `[addr, addr+len)` byte span contains `vma`
@@ -494,8 +521,8 @@ mod tests {
             refs_to: BTreeMap::new(),
             refs_from: BTreeMap::new(),
             funcs: BTreeMap::new(),
-            covered: RangeList::new(),
             exec_ranges: Vec::new(),
+            has_assembly: true,
         };
         let addrs = |start, end| {
             listing

--- a/decompiler/crates/kuna-analysis/src/listing/walk.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/walk.rs
@@ -18,7 +18,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
-use kuna_base::address::RangeList;
 use kuna_base::space::AddrSpace;
 use kuna_decomp::architecture::Architecture;
 use kuna_sleigh::translate::Translate;
@@ -39,8 +38,6 @@ pub(super) struct WalkState {
     pub refs_from: BTreeMap<u64, Vec<Reference>>,
     /// Discovered/seeded functions, keyed by entry VMA (ordered).
     pub funcs: BTreeMap<u64, DiscoveredFunction>,
-    /// Instruction-byte coverage (`[vma, vma+len-1]` per decoded insn).
-    pub covered: RangeList,
 }
 
 impl WalkState {
@@ -50,7 +47,6 @@ impl WalkState {
             refs_to: BTreeMap::new(),
             refs_from: BTreeMap::new(),
             funcs: BTreeMap::new(),
-            covered: RangeList::new(),
         }
     }
 
@@ -84,6 +80,10 @@ pub(super) fn in_exec(exec_ranges: &[(u64, u64)], vma: u64) -> bool {
 /// by the local entry VMA: a CALL landing on one of those is a call into the
 /// INTERIOR of the function at its value, so no function is claimed there. Empty
 /// on every other architecture and whenever the option is off.
+///
+/// `want_assembly` is forwarded to [`decode_one`]: `false` leaves every
+/// [`Insn::mnemonic`]/[`Insn::operands`] empty and skips the second SLEIGH parse
+/// that produces them (see [`decode_one`] for the cost).
 pub(super) fn walk(
     translate: &dyn Translate,
     arch: &Architecture,
@@ -93,6 +93,7 @@ pub(super) fn walk(
     seed_funcs: &BTreeMap<u64, DiscoveredFunction>,
     painter: &ContextPainter,
     local_entries: &BTreeMap<u64, u64>,
+    want_assembly: bool,
 ) -> WalkState {
     // Paint the decode-mode context (ARM TMode / MIPS ISA_MODE) into the engine's
     // ContextDatabase BEFORE we decode a single instruction — the timing the
@@ -132,7 +133,7 @@ pub(super) fn walk(
                 continue; // out-of-bounds gate (flow.rs:891 analog)
             }
 
-            let decoded = match decode_one(translate, vma, code_space) {
+            let decoded = match decode_one(translate, vma, code_space, want_assembly) {
                 Ok(d) => d,
                 Err(_) => continue, // decode error: stop this path (mark gap)
             };
@@ -155,7 +156,6 @@ pub(super) fn walk(
                     pcode: None,
                 },
             );
-            st.covered.insert_range(Rc::clone(code_space), vma, vma + decoded.len as u64 - 1);
 
             // Successor edges.
             for &t in &c.flows {

--- a/decompiler/crates/kuna-analysis/src/passes.rs
+++ b/decompiler/crates/kuna-analysis/src/passes.rs
@@ -538,6 +538,13 @@ pub fn run_listing_consumers(
     }
     let seed_names = funcsym_names(&file);
     let funcsym_seeds = crate::entry::existing_function_addrs(&file, bytes);
+    // Every consumer that reads an `Insn`'s disassembly text — the
+    // `listing_consumer_passes`, `tailcallentry` and `poolentry` below — is itself
+    // gated on `analysis_listing`. When only `fast_funcdisc` asked for this Listing
+    // there is no text reader left (AIF's fingerprint re-decodes the two addresses
+    // it needs), so the walk skips capturing text: a second SLEIGH parse per
+    // instruction. See `listing::decode::decode_one`.
+    let want_assembly = arch.analysis_listing;
     let mut listing = crate::listing::Listing::build_with_meta(
         &file,
         image,
@@ -546,6 +553,7 @@ pub fn run_listing_consumers(
         &seeds,
         &funcsym_seeds,
         &seed_names,
+        want_assembly,
     );
     // (kuna, Stage-2 ARM discovery) Raw, UNPAIRED Thumb-prologue gap seeding — the
     // angr `CFGFast._func_addrs_from_prologues()` mirror. After the first walk, scan
@@ -584,6 +592,7 @@ pub fn run_listing_consumers(
                         &seeds,
                         &funcsym_seeds,
                         &seed_names,
+                        want_assembly,
                     );
                 }
             }
@@ -628,6 +637,7 @@ pub fn run_listing_consumers(
                         &seeds,
                         &funcsym_seeds,
                         &seed_names,
+                        want_assembly,
                     );
                 }
             }

--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -1725,3 +1725,46 @@ fn instruction_budget_overrun_truncates_instead_of_failing() {
         "`--option errortoomanyinstructions on` must restore the hard failure:\n{failed}"
     );
 }
+
+/// Fast discovery must not depend on the Listing carrying disassembly text.
+///
+/// `--mode fast` builds the Listing for `fast_funcdisc` alone, and that walk
+/// captures no assembly text — nothing left in the mode reads it except AIF's
+/// prologue fingerprint, which re-decodes the two instructions it needs. Drop that
+/// fallback and the fingerprint histogram comes back empty, which silently takes
+/// every pointer-validated function with it: on `aif_gap_x86_64` the target
+/// reachable only through a function-pointer table (`0x13ae`) simply stops being
+/// enumerated.
+#[test]
+fn fast_discovery_finds_the_pointer_only_target() {
+    let bin = repo_root()
+        .join("decompiler/crates/kuna-analysis/tests/fixtures/aif_gap_x86_64")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let sp = specs();
+    let args = ["functions", &bin, "--json", "--sleighpath", &sp, "--mode", "fast"];
+    let (stdout, stderr, ok) = run_kuna(&args);
+    if !ok {
+        if is_specs_skip(&stderr) {
+            eprintln!("fast_discovery_finds_the_pointer_only_target: skipping (no `.sla`)");
+            return;
+        }
+        panic!("kuna functions failed: {stderr}");
+    }
+    let fast = json_addresses(&stdout);
+    assert!(
+        fast.contains(&0x13ae),
+        "`--mode fast` must enumerate the pointer-only function 0x13ae: {fast:x?}"
+    );
+
+    // The control: with the fast walk off, nothing finds it.
+    let mut off = args.to_vec();
+    off.extend_from_slice(&["--option", "fast_funcdisc", "off"]);
+    let (stdout, stderr, ok) = run_kuna(&off);
+    assert!(ok, "kuna functions failed: {stderr}");
+    assert!(
+        !json_addresses(&stdout).contains(&0x13ae),
+        "0x13ae must come from the fast walk alone:\n{stdout}"
+    );
+}

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -2289,6 +2289,28 @@ load-bearing gotchas are worth restating: a constant-space branch operand is
 p-code-relative (an intra-instruction branch), never a VMA; fall-through is decided
 by the *last* op only; and delay slots are already folded into the reported length.
 
+Two things the walk deliberately does **not** always produce. First, the human
+assembly text on each instruction: capturing it means a *second* full SLEIGH parse
+of the same bytes (`Translate::print_assembly`) plus two heap strings per
+instruction, which roughly doubles the cost of the walk and is pure waste whenever
+nothing reads the text. Every bulk consumer of it — `noreturn_propagate`'s
+call/NOP idiom checks, `tailcallentry`, and `poolentry`'s literal-load operands —
+sits behind `listing`, so the walk captures text exactly when `listing` is on and
+leaves the fields empty on the `fast_funcdisc`-only path, which is the path a
+whole-binary export takes on any image large enough for `--mode auto` to resolve
+to `fast`. The one other reader is AIF's function-start fingerprint (§1.5), which
+needs the mnemonics of just the first two instructions of each *discovered*
+function; rather than force whole-image capture for that, it falls back to
+re-decoding those addresses through its own gap decoder when the Listing carries
+no text. Re-decoding an address under the same painted context yields the mnemonic
+the walk would have stored, so the histogram — and every gap-walk and
+pointer-target decision keyed off it — is unchanged, which is what keeps the
+pointer-only entries `fast_funcdisc` exists to find. Second, instruction-byte
+coverage, which is *derived* from the instruction map rather than mirrored into a
+range list: because a range list merges overlapping but not adjacent ranges, a
+straight-line run of instructions would cost one node per instruction, and the
+undefined-gap queries already answer from the instruction map.
+
 **Fast function discovery with conservative pointer validation** (`fast_funcdisc`, default-off;
 `decompiler/crates/kuna-analysis/src/analyzers/fast_funcdisc/mod.rs
 (pointer_table_seeds)`) reuses that one walk without enabling the full Listing


### PR DESCRIPTION
Enumerating the functions in a large binary spends a third of its time rendering
assembly text that no enabled pass reads. Against kuna's own 18 MB binary (any
image at or above 2 MiB shows it):

```
$ /usr/bin/time -f "%e s  %M KB" ./decompiler/target/release/kuna functions \
      ./decompiler/target/release/kuna --json > /dev/null
17.63 s  1459424 KB
```

At 2 MiB and up `--mode auto` resolves to `fast`, which turns `listing` off and
leaves `fast_funcdisc` on. The fast walk still decodes the whole image, and each
instruction was parsed twice — once for p-code, once by `print_assembly` for text
only the disabled passes would have read. Same command after: **12.52 s, 1.26 GiB**.
On the `mpengine.dll` of #510: 55.68 s → 51.27 s CPU, 2.40 GiB → 1.97 GiB, same
33,214 functions.

### The fix

- `decode_one` takes `want_assembly`, threaded through `walk` / `build_with_meta`
  and true exactly when a text consumer runs — every one of them is gated on
  `listing`.
- AIF's prologue fingerprint is the single text reader still reachable with the
  Listing off, so it re-decodes the two instructions it needs per discovered
  function instead of forcing whole-image capture. Gating on `listing` alone empties
  the fingerprint histogram, and every pointer-validated function goes with it.
- Drop the write-only `covered` range list — one node per decoded instruction, and
  coverage is already derived from the instruction map — and index `funcsym_seeds`
  instead of a linear `contains` per seed.

### Tests

`fast_discovery_finds_the_pointer_only_target` is the two-pass guard: without the
fingerprint fallback, `--mode fast` stops enumerating `aif_gap_x86_64`'s
pointer-only `0x13ae`. Output does not move — `functions --json` byte-identical over
155 binary x mode cells on 41 binaries (x86-64/i386/ARM/Thumb/AArch64/MIPS/RISC-V,
ELF/PE/Mach-O), `decompile-all --json` byte-identical over 2,910 records on 8
targets including mpengine's first 1,500 functions. Both timings are medians of 6
interleaved pairs with the arm order alternating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFpP8jNwKT29DnbXG3neNb
