### PR TITLE
[AUTOMATED] fix(console): changing-namestyle-invalidates-discovered — a generated name selects its function in every naming style

### DIFF
--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -1073,10 +1073,18 @@ impl ConsoleProgram {
     /// as one loses nothing and closes that round trip.
     ///
     /// Decided by MINTING rather than by parsing: a candidate is accepted only
-    /// when [`Architecture::name_function`] renders it as the requested name, so
-    /// whichever naming style is active (`sub_`/`func_`/`FUN_`) and a
-    /// word-addressed space's scaling both follow for free, and a name this
-    /// build would never print is not resolved.
+    /// when some naming style renders it as the requested name
+    /// ([`minted_function_names`]), so a word-addressed space's scaling follows
+    /// for free and a name no style would print is not resolved.
+    ///
+    /// (kuna, RE-need `changing-namestyle-invalidates-discovered`) EVERY style,
+    /// not just the active one: `option namestyle` decides how a name is
+    /// PRINTED, and a placeholder holds nothing but the address whichever
+    /// vocabulary spelled it. Matching only the active style made the styles
+    /// disjoint name spaces — `kuna functions` reports `sub_15dc` and ignores
+    /// namestyle, so `kuna decompile BIN sub_15dc --option namestyle ghidra`
+    /// answered `no function matches` for a function the same run decompiles
+    /// under `func_0x000015dc`.
     fn placeholder_name_address(&self, name: &str) -> Option<u64> {
         let digits = name.rsplit_once('_')?.1;
         let digits = digits
@@ -1093,9 +1101,9 @@ impl ConsoleProgram {
         if scaled != spelled {
             candidates.push(scaled);
         }
-        candidates
-            .into_iter()
-            .find(|&vma| self.arch().name_function(&Address::new(Rc::clone(space), vma)) == name)
+        candidates.into_iter().find(|&vma| {
+            minted_function_names(&Address::new(Rc::clone(space), vma)).iter().any(|m| m == name)
+        })
     }
 
     /// The entry a placeholder name denotes, or `None` when the name is not one
@@ -2090,6 +2098,25 @@ fn analysis_pass_enabled(arch: &Architecture, pass_id: &str) -> bool {
         "pdb" => arch.analysis_pdb,
         _ => true,
     }
+}
+
+/// (kuna, RE-need `changing-namestyle-invalidates-discovered`) Every default
+/// function name kuna's naming vocabularies would mint at `addr` — the angr
+/// `sub_<addr>`, the upstream `func_<raw-addr>` and the ghidra-mode `FUN_%08x`.
+///
+/// One per [`kuna_decomp::database::KunaNameStyle`] arm, in the order
+/// [`Architecture::name_function`] decides them, and rendered by the same three
+/// functions it calls so a change to any spelling reaches both. Used to read a
+/// placeholder name BACK to its address: `option namestyle` decides which of
+/// these gets printed, and a selector must not depend on that choice.
+fn minted_function_names(addr: &Address) -> [String; 3] {
+    [
+        kuna_decomp::database::ghidra_function_name(addr),
+        kuna_decomp::database::kuna_function_name(addr),
+        // Errors only on the fspec/iop spaces, which never hold a function; an
+        // unrenderable address simply matches no name.
+        kuna_decomp::printc::generic_function_name(addr).unwrap_or_default(),
+    ]
 }
 
 /// The FID label gate: is `name` an engine-generated placeholder a FID match may

--- a/decompiler/crates/kuna-console/tests/verify_entry_selectors.rs
+++ b/decompiler/crates/kuna-console/tests/verify_entry_selectors.rs
@@ -348,16 +348,72 @@ fn a_generated_placeholder_name_resolves_to_the_address_it_spells() {
     );
 }
 
-/// The reading is minted, not parsed: only a name THIS build would print at a
-/// MAPPED address is read as one, so a hex-tailed name that is not a placeholder,
-/// a placeholder in a naming style that is not active, and one spelling an
+/// (RE-need `changing-namestyle-invalidates-discovered`) A placeholder resolves
+/// in EVERY naming style, not only the active one.
+///
+/// `option namestyle` decides how a synthesized name is PRINTED; a selector must
+/// not depend on that choice, or the styles become disjoint name spaces. The
+/// tester hit it the other way round: `kuna functions` reports `sub_15dc` and
+/// ignores namestyle, so feeding that name back with `--option namestyle ghidra`
+/// answered `no function matches` for a function the same run decompiles under
+/// `func_0x000015dc`.
+#[test]
+fn a_placeholder_resolves_in_every_naming_style() {
+    let Some(program) = boot_fixture("tailcallframe_x86_64") else {
+        return;
+    };
+    // The default (angr) style is active, so the other two vocabularies' names
+    // are the ones a style flip would put in an agent's hands.
+    for name in ["sub_1170", "func_0x00001170", "FUN_00001170"] {
+        let entry = program
+            .resolve_entry(&EntrySelector::Name(name.into()))
+            .unwrap_or_else(|error| panic!("{name}: {error}"));
+        assert_eq!(entry.addr.get_offset(), 0x1170, "{name}");
+        assert_eq!(
+            program.find_entry_by_name(name).map(|e| e.addr.get_offset()),
+            Some(0x1170),
+            "{name}: the yes/no lookup answers the same name the same way"
+        );
+    }
+}
+
+/// The tester's exact round trip: a name taken from the default-style
+/// enumeration is fed back to a run whose naming style has been flipped.
+///
+/// `option namestyle ghidra` clears `name_style_angr`, which is what used to
+/// take `sub_1170` out of the resolvable set entirely.
+#[test]
+fn a_default_style_name_survives_a_namestyle_flip() {
+    let Some(mut program) = boot_fixture("tailcallframe_x86_64") else {
+        return;
+    };
+    let default_style_name = "sub_1170";
+    program.arch_mut().name_style_angr = false;
+    assert_eq!(
+        program.arch().name_function(
+            &program.resolve_entry(&EntrySelector::Numeric(0x1170)).unwrap().addr
+        ),
+        "func_0x00001170",
+        "the flip must actually change what this build mints, or the test is vacuous"
+    );
+    let entry = program
+        .resolve_entry(&EntrySelector::Name(default_style_name.into()))
+        .expect("a name the default style printed still selects its function");
+    assert_eq!(entry.addr.get_offset(), 0x1170);
+}
+
+/// The reading is minted, not parsed: only a name SOME naming style would print
+/// at a MAPPED address is read as one, so a hex-tailed name that is not a
+/// placeholder, a placeholder misspelled for every style, and one spelling an
 /// address with no bytes behind it all still miss.
 #[test]
 fn a_placeholder_name_is_not_read_as_an_address_unless_this_build_would_mint_it() {
     let Some(program) = boot_fixture("tailcallframe_x86_64") else {
         return;
     };
-    for miss in ["sub_deadbeef", "FUN_00001170", "func_00001170", "handler_1170", "sub_"] {
+    // `func_00001170` misses on its `0x`: the upstream style prints
+    // `func_0x00001170`, and `FUN_` is the only style without the prefix.
+    for miss in ["sub_deadbeef", "FUN_1170", "func_00001170", "handler_1170", "sub_"] {
         let error = program
             .resolve_entry(&EntrySelector::Name(miss.into()))
             .expect_err("not a name this program mints at a mapped address");

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -136,10 +136,20 @@ kuna decompile ./graphy sub_100a3be
 #   char * sub_100a3be(unsigned int a0) { ... }
 ```
 
-The name is read as the address it spells only when this build would *mint* it
-there, and only when that address holds mapped bytes — so it lands on exactly
-what `--addr` on the same address lands on, and a real symbol spelled that way
-still wins. Anything else keeps the by-name miss:
+The name is read as the address it spells only when some naming style would
+*mint* it there, and only when that address holds mapped bytes — so it lands on
+exactly what `--addr` on the same address lands on, and a real symbol spelled
+that way still wins. All three styles count, not just the run's own, because
+`--option namestyle` decides how a generated name is *printed* and `kuna
+functions` reports the default spelling whatever the run asks for:
+
+```bash
+kuna functions ./a.out --json          # ... "name": "sub_15dc" ...
+kuna decompile ./a.out sub_15dc --option namestyle ghidra
+#   unsigned long sub_15dc(void) { ... }   # same function as func_0x000015dc
+```
+
+Anything else keeps the by-name miss:
 
 ```bash
 kuna decompile ./graphy sub_deadbeef

--- a/docs/features/changing-namestyle-invalidates-discovered/pr_body.md
+++ b/docs/features/changing-namestyle-invalidates-discovered/pr_body.md
@@ -1,0 +1,58 @@
+`kuna functions` prints a name for every function it finds; feeding one of those
+names back to `kuna decompile` stops working the moment the run also asks for a
+different naming style.
+
+```bash
+$ kuna functions ./stripped_dynamic_x86_64 --json | grep 1249
+    {"name": "sub_1249", "address_hex": "0x1249", "aliases": [], "size": 270}
+
+$ kuna decompile ./stripped_dynamic_x86_64 sub_1249 --option namestyle ghidra
+error: no function "sub_1249" in ./stripped_dynamic_x86_64; for a stripped binary
+pass an address with --addr
+$ echo $?
+1
+
+$ kuna decompile ./stripped_dynamic_x86_64 func_0x00001249 --option namestyle ghidra
+void * func_0x00001249(void *param_1)          # the same function, decompiled in full
+```
+
+(`decompiler/crates/kuna-analysis/tests/fixtures/stripped_dynamic_x86_64` is in
+the repo. Reported by an agent against a 14 KB crackme, where the name was
+`sub_15dc`.)
+
+## The fix
+
+- A generated name like `sub_1249` holds nothing but an address, so a by-name
+  miss is already retried as the address it spells. That retry accepted the name
+  only if the *active* naming style would mint it — and `option namestyle`
+  changes which style is active, which made the styles disjoint name spaces.
+- `ConsoleProgram::placeholder_name_address` now accepts the name if **any**
+  style would mint it there: `sub_<addr>`, `func_<addr>` or `FUN_<addr>`. The
+  three spellings come from the same three functions `Architecture::name_function`
+  calls, so nothing is parsed and nothing can drift.
+- Unchanged: the retry still runs only after the name match found nothing, and
+  still requires mapped bytes at the address. A binary that really carries a
+  symbol spelled that way still wins, `sub_deadbeef` still misses, and no name
+  that already resolved can move.
+- `kuna functions` is deliberately untouched — it reports the default spelling
+  whatever the run asks for, and now that spelling always selects.
+
+## Tests
+
+`tests/cli/changing-namestyle-invalidates-discovered.json` (promoted, over the
+in-repo fixture) and two cases in `verify_entry_selectors.rs`: a placeholder
+resolves in all three styles, and a default-style name survives a namestyle
+flip. All three fail on the unpatched tree. One existing case moved — it asserted
+that `FUN_00001170` misses under angr naming, which is the behaviour this
+changes; `func_00001170` (wrong spelling for every style) still misses in its
+place.
+
+Swept every name and alias `kuna functions` reports across all 181 vendored
+fixtures, at both naming styles, on the pre- and post-fix binaries: 4,856
+selections, 3,566 identical, 1,290 exit 1 -> exit 0, 0 changed. Every unlocked
+one is a `namestyle ghidra` run; the default-style column is byte-identical.
+
+Gates: `make test` 675/675, `make test-stages` 714/714, `make test-cli` 103/103,
+`make rust-test` green, `check-spec --strict` OK, `catalog --check` OK.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/changing-namestyle-invalidates-discovered/record.json
+++ b/docs/features/changing-namestyle-invalidates-discovered/record.json
@@ -1,0 +1,55 @@
+{
+  "slug": "changing-namestyle-invalidates-discovered",
+  "need_id": "changing-namestyle-invalidates-discovered",
+  "track": "tooling",
+  "scope": "small",
+  "round": 11,
+  "branch": "feat/re-changing-namestyle-invalidates-discovered",
+  "summary": "A generated function name is read back as the address it spells if ANY naming style would mint it there, not only the style the run has active. One predicate change in ConsoleProgram::placeholder_name_address, so every by-name surface (kuna decompile, decompile-all --functions, disassemble, xrefs) accepts the sub_<addr> name kuna functions prints regardless of what --option namestyle asks for.",
+  "decisions": [
+    {
+      "what": "hypothesis UPHELD; the refuter's mechanism confirmed exactly",
+      "detail": "Filed: 'Selector resolution may occur after presentation names change without retaining discovered aliases.' Reproduced on the arena binary and on an in-repo fixture. It is not a broken selector and not a lost alias: `option namestyle ghidra` clears Architecture::name_style_angr, so the SAME function is installed and enumerated under func_0x000015dc, and `sub_15dc` -- which kuna functions reports whatever the run asks for, since that surface takes no naming option -- matched nothing. The `func_0x` spelling resolved and decompiled in full at the same moment the `sub_` one answered `no function matches`."
+    },
+    {
+      "what": "the defect is in the retry that already existed, not in aliases",
+      "detail": "PR #499 (RE-need string-owner-function-name) had already made a by-name MISS retry as the address the name spells, deciding by MINTING rather than by parsing: placeholder_name_address rendered the candidate offset through self.arch().name_function(addr) and accepted it only on an exact match. That is what tied the retry to the ACTIVE style. Widening the render set to all three styles is a one-predicate change and needs no new state; the alternative -- populating FunctionEntry.aliases with the other styles' spellings at enumeration time -- would put three synthetic names on every un-symboled entry in `kuna functions --json` output, which is a visible schema change for no extra reach."
+    },
+    {
+      "what": "all three styles, rendered by the same functions name_function calls",
+      "detail": "engine.rs (minted_function_names) returns ghidra_function_name / kuna_function_name / printc::generic_function_name for an address -- one per KunaNameStyle arm, the same three calls Architecture::name_function dispatches between. Deriving them rather than formatting them locally means a change to any spelling reaches the selector for free, and the existing word-addressed-space candidate loop (spelled vs address_to_byte-scaled) is untouched. Placed in kuna-console rather than kuna-cli: kuna-cli only translates the console's miss into its error text (decompile.rs:505), and a fix there would have closed the round trip for `kuna decompile` while disassemble/xrefs/decompile-all kept refusing the same name."
+    },
+    {
+      "what": "nothing that already resolved can change",
+      "detail": "The retry is reached only when the name/alias filter produced ZERO candidates and only when the address holds mapped bytes -- both gates predate this change and are untouched. So the change can only turn a by-name MISS into a hit; an ambiguity is still reported with its candidates, a real symbol spelled like a placeholder still wins, and sub_deadbeef still misses. One existing test case moved as a direct consequence: verify_entry_selectors asserted `FUN_00001170` misses under angr naming, which is precisely the behaviour being fixed. `func_00001170` -- misspelled for every style, since the upstream form is func_0x00001170 -- replaces it in the miss list."
+    },
+    {
+      "what": "no option, no counters, no stages XML, no DIV row",
+      "detail": "Tooling track. Name resolution cannot change emitted C for any selection that already resolved, so there is no judgement call to gate: no phases.toml row, no options.rs registration, no catalog counters, no docs/options.md regeneration, no tests/stages case. docs/spec/00-overview.md owns the paragraph that described the old minting rule and was updated in the same commit; docs/cli.md's 'A generated name is a selector' section gained the namestyle round trip."
+    }
+  ],
+  "collateral_sweep": {
+    "method": "Pre-fix and post-fix RELEASE pairs (kuna AND decomp_dbg -- `kuna decompile` forks decomp_dbg and KUNA_DECOMP_DBG is exported in a repipe worktree, so swapping only the kuna binary measures nothing). For every vendored fixture in kuna-analysis/tests/fixtures, every name and alias `kuna functions --json` reports (40-entry cap) was run through `kuna decompile <bin> <name>` on both builds, twice: at the default naming style and with `--option namestyle ghidra`. Compared on (exit code, stdout).",
+    "identical": 3566,
+    "unlocked": 1290,
+    "changed": 0,
+    "fixtures": 181,
+    "selections_compared": 4856,
+    "reading": "Every one of the 1,290 unlocked selections is a `--option namestyle ghidra` run, which the arithmetic pins without listing them: the two style columns are 2,428 selections each, and 3,566 identical = 2,428 (default column, byte-identical throughout) + 1,138 (ghidra column). So the default naming style is untouched and every change is a MISS becoming a hit on the exact name `kuna functions` prints -- which is the defect. Nothing regressed and no already-resolving selection moved, as the gating makes structural: the retry is unreachable unless the name match found nothing."
+  },
+  "acceptance": {
+    "id": "a-2f69533e66cc",
+    "verifier": "scripts.repipe.verify --need changing-namestyle-invalidates-discovered --json -> counts.pass 1, transition closed. The recorded acceptance is UNCHANGED and still measures the dataset witness 0xJam3z-Medium (sha c1e78f2a0ba7...): `kuna decompile <bin> sub_15dc --option namestyle ghidra` exits 0 and prints the body containing 'Correct! You solved the challenge.'",
+    "promoted_to": "tests/cli/changing-namestyle-invalidates-discovered.json"
+  },
+  "gates": {
+    "make test": "PARITY OK, 675/675 assertions",
+    "make test-stages": "PARITY OK, 714/714 assertions",
+    "make rust-test": "green (rc 0, 379 suites ok, 0 FAILED)",
+    "make check-spec": "OK lenient and --strict",
+    "make test-cli": "103/103 passed (includes the newly promoted probe; 102/103 with the probe present on the unpatched engine)",
+    "kuna catalog --check": "catalog OK: documents exactly the registered kuna options",
+    "scripts.repipe.counters": "no drift: every hard-coded site agrees with the derived truth",
+    "scripts.repipe.mergecheck --against origin/main": "merge guards clean"
+  }
+}

--- a/docs/re-needs/changing-namestyle-invalidates-discovered.md
+++ b/docs/re-needs/changing-namestyle-invalidates-discovered.md
@@ -1,0 +1,172 @@
+---
+need_id: changing-namestyle-invalidates-discovered
+title: Changing namestyle invalidates a discovered function name
+track: tooling
+status: open
+severity: minor
+probe_id: p-e0fd907be6d0
+acceptance_id: a-2f69533e66cc
+hypothesis_status: upheld
+credibility: 0.7
+instances: 1
+challenges: [6927c8d12d267f28f69b8131]
+rounds: [11]
+first_seen_round: 11
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-cli/src/decompile.rs, decompiler/crates/kuna-decomp/src/p9_emit/kuna_naming.rs]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Decompile a name returned by functions while changing the emitted naming convention.
+
+> **Changing namestyle invalidates a discovered function name** (minor, `6927c8d12d267f28f69b8131`)
+> Default decompile accepts sub_15dc. Adding namestyle ghidra exits 1 with no function. Selecting 0x15dc --addr succeeds.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_15dc",
+    "--option",
+    "namestyle",
+    "ghidra"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 1
+    },
+    "stderr_matches": [
+      "no function"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/0xjam3z-evolvingsbox.zip.__x/0xJam3z-Medium",
+    "binary_sha256": "c1e78f2a0ba7a15d9bf6a563f0874656437112b617b94d42cd858e3e477ef665",
+    "binary_size": 14440,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_15dc",
+    "--option",
+    "namestyle",
+    "ghidra"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "Correct!"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/0xjam3z-evolvingsbox.zip.__x/0xJam3z-Medium",
+    "binary_sha256": "c1e78f2a0ba7a15d9bf6a563f0874656437112b617b94d42cd858e3e477ef665",
+    "binary_size": 14440,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- Selector resolution may occur after presentation names change without retaining discovered aliases.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `6927c8d12d267f28f69b8131` (round 11, tester t-r11-6927c8d1)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+- round 11 REFUTER: hypothesis **upheld** (was inconclusive). Refuted in-tick by the captain (round 11). VERDICT UPHELD, mechanism pinned, and one piece of BOOKKEEPING IS WRONG.
+
+SYMPTOM REPRODUCED exactly on the need's own arena binary
+(.kuna-repipe/arena/11/6927c8d12d267f28f69b8131/target/0xjam3z-evolvingsbox.zip.__x/0xJam3z-Medium):
+default `kuna decompile BIN sub_15dc` = rc 0, full body; adding `--option namestyle ghidra` = rc 1,
+'no function "sub_15dc" ... pass an address with --addr'.
+
+MECHANISM: this is NOT a broken selector, it is a name-space swap. Under namestyle ghidra the same
+function resolves BY ITS OTHER NAME: `kuna decompile BIN func_0x000015dc --option namestyle ghidra`
+returns rc 0 and the full body. So lookup works; the synthesized name is simply regenerated in the
+upstream style (func_0x%08x, see architecture.rs and tests/verify_w4_fw_architecture.rs:79) and the
+default-style name sub_15dc is not retained as an alias. The tester's filed hypothesis is upheld.
+Do NOT guess Ghidra's own prefix: `FUN_000015dc` is rc 1 as well; kuna's upstream style is func_0x.
+
+THE TWO SURFACES DISAGREE BY CONSTRUCTION: `kuna functions --json` ignores namestyle and always
+reports {"name": "sub_15dc", "aliases": []}. That empty `aliases` field already exists in the schema
+and is the natural carrier for a fix.
+
+ACCEPTANCE VERIFIED SOUND (recipe check (v), by control rather than by simulation):
+`kuna decompile BIN 0x15dc --addr --option namestyle ghidra` gives rc 0 with "Correct!" present
+once in stdout -- exactly the shape the acceptance demands. A correct fix flips it. Contrast
+live-simd-string-copies, whose acceptance cannot be flipped.
+
+*** regression_of: analysis-generated-function-name IS FALSE AND IS INFLATING THE RANK. *** That
+round-2 need was closed by PR #377 and its acceptance still PASSES on current main (measured this
+tick: verify --acceptance-suite --need analysis-generated-function-name -> passed true), and the
+default-namestyle case works on this binary too. This is an uncovered case, not a regression -- the
+known title-similarity trap. The link is what scores this need 1055.5 against 43.9 for the runner-up,
+i.e. it is currently #1 in the build queue on a false premise. Clear regression_of at T_TRIAGE and let
+it re-rank (it lands near 13.9, alongside the other single-instance needs).
+
+TOUCHES IS UNPROVEN: filed as decompiler/crates/kuna-cli. The name lookup happens inside the forked
+decomp_dbg -- kuna-cli only translates the console's unknown-function output into that message at
+kuna-cli/src/decompile.rs:505. A CLI-tier fix (resolve the name to an address against the analysis
+function list before forking) and a decomp-tier fix (keep the default-style name as an alias) are both
+plausible. Confirm at T_TRIAGE before the lease algebra aims a builder at one tree.
+- round 11 TRIAGE (captain): cleared regression_of=analysis-generated-function-name -- the refuter measured that need's acceptance still PASSING on main, so the link was title-similarity, not a regression; it was scoring this need 1055.5 vs 43.9 for the runner-up. touches was filed kuna-cli alone and the refuter left it unproven; recorded BOTH candidate seams, since kuna-analysis names the function at load and namestyle is applied AFTER the load (kuna_entrymainproto.rs:84), so the rename that breaks the lookup happens in kuna-decomp while the error text is produced at kuna-cli/src/decompile.rs:505. touches carries no lease (select.PATH_RESOURCES leases only phases.toml/options.rs/tests-stages/history.md), so naming two seams costs no scheduling breadth. track stays tooling: the fix may land in kuna-decomp but the defect is a CLI round-trip gap, not emitted C.
+- round 11 BUILDER (b-r11-changing-namesty): hypothesis UPHELD and the refuter's mechanism confirmed
+  exactly. Not a lost alias and not a broken selector: PR #499 (RE-need `string-owner-function-name`)
+  already retries a by-name MISS as the address the name spells, and decides by MINTING -- it rendered
+  the candidate offset through `self.arch().name_function(addr)` and accepted it only on an exact
+  match, which tied the retry to the style the run happens to have ACTIVE. `option namestyle ghidra`
+  clears `name_style_angr`, so `sub_15dc` stopped being a name this build would mint and the two
+  styles became disjoint name spaces. Closed in `ConsoleProgram::placeholder_name_address` (kuna-console,
+  not kuna-cli: kuna-cli only translates the console's miss into its error text at decompile.rs:505,
+  and a fix there would have left `disassemble`/`xrefs`/`decompile-all --functions` refusing the same
+  name) by rendering the candidate in ALL THREE styles -- `minted_function_names`, one call per
+  `KunaNameStyle` arm, the same three functions `name_function` dispatches between. Both pre-existing
+  gates are untouched, so the change can only turn a MISS into a hit. The ACCEPTANCE IS UNCHANGED and
+  still measures 0xJam3z-Medium (PASS on this branch); the promoted
+  `tests/cli/changing-namestyle-invalidates-discovered.json` is retargeted onto the vendored
+  `stripped_dynamic_x86_64`, where `sub_1249 --option namestyle ghidra` answered `no function` pre-fix
+  -- the same defect, on a binary CI has. No option, no counters, no stages case, no DIV row.

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -212,11 +212,20 @@ Four front-ends drive one engine assembly:
   spells, when — and only when — it is a name this build would MINT there
   (`decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::placeholder_name_address)`).
   The decision is made by minting rather than by parsing: the candidate offset is
-  rendered through `Architecture::name_function` and accepted only if it comes
-  back as the requested name, so whichever naming style is active (`sub_<addr>`
-  by default, `func_<addr>` upstream, `FUN_<addr>` in ghidra mode) and a
-  word-addressed space's scaling of the printed offset both follow without
-  parsing either of them. The retry is additionally gated on the address holding
+  rendered in EVERY naming style — `sub_<addr>` (the default), `func_<addr>`
+  (upstream) and `FUN_<addr>` (ghidra mode), the three arms of
+  `Architecture::name_function` gathered by
+  `decompiler/crates/kuna-console/src/engine.rs (minted_function_names)` — and
+  accepted only if one of them comes back as the requested name, so a
+  word-addressed space's scaling of the printed offset follows without parsing
+  it. All three rather than only the ACTIVE one because `option namestyle`
+  decides how a placeholder is PRINTED and a placeholder holds nothing but the
+  address whichever vocabulary spelled it; matching one style made the styles
+  disjoint name spaces, so a name taken from `kuna functions` — which reports the
+  default style and takes no naming option — stopped selecting its function the
+  moment a run asked for the other style, and the same binary answered
+  `no function matches "sub_15dc"` while decompiling `func_0x000015dc` in full.
+  The retry is additionally gated on the address holding
   mapped bytes — the numeric selector's own test — so a name resolved this way
   reaches exactly the function `--addr` on the same address reaches, and every
   other miss keeps its by-name `NotFound`. A binary that really does carry a

--- a/tests/cli/changing-namestyle-invalidates-discovered.json
+++ b/tests/cli/changing-namestyle-invalidates-discovered.json
@@ -1,0 +1,42 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_1249",
+    "--option",
+    "namestyle",
+    "ghidra"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/stripped_dynamic_x86_64",
+    "binary_sha256": "f899ab7509c55cc0c5e4e2f7b2e7f781ac1fb1aac6c4f7a2e27b4dba256e1c0a",
+    "binary_size": 14480,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/stripped_dynamic_x86_64",
+    "selector": "sub_1249",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "sub_1249\\(void \\*param_1\\)",
+      "perror\\(\"malloc failed\"\\)"
+    ],
+    "stderr_absent": [
+      "no function"
+    ]
+  },
+  "notes": "Desired: a name `kuna functions` reports still selects its function when the run changes how names are PRINTED. Dataset witness: crackmes.one 6927c8d12d267f28f69b8131 (0xJam3z-Medium @0x15dc), where `sub_15dc --option namestyle ghidra` answered `no function matches` for the function the same run decompiles as `func_0x000015dc`. `param_1` pins that the style really applied."
+}


### PR DESCRIPTION
`kuna functions` prints a name for every function it finds; feeding one of those
names back to `kuna decompile` stops working the moment the run also asks for a
different naming style.

```bash
$ kuna functions ./stripped_dynamic_x86_64 --json | grep 1249
    {"name": "sub_1249", "address_hex": "0x1249", "aliases": [], "size": 270}

$ kuna decompile ./stripped_dynamic_x86_64 sub_1249 --option namestyle ghidra
error: no function "sub_1249" in ./stripped_dynamic_x86_64; for a stripped binary
pass an address with --addr
$ echo $?
1

$ kuna decompile ./stripped_dynamic_x86_64 func_0x00001249 --option namestyle ghidra
void * func_0x00001249(void *param_1)          # the same function, decompiled in full
```

(`decompiler/crates/kuna-analysis/tests/fixtures/stripped_dynamic_x86_64` is in
the repo. Reported by an agent against a 14 KB crackme, where the name was
`sub_15dc`.)

## The fix

- A generated name like `sub_1249` holds nothing but an address, so a by-name
  miss is already retried as the address it spells. That retry accepted the name
  only if the *active* naming style would mint it — and `option namestyle`
  changes which style is active, which made the styles disjoint name spaces.
- `ConsoleProgram::placeholder_name_address` now accepts the name if **any**
  style would mint it there: `sub_<addr>`, `func_<addr>` or `FUN_<addr>`. The
  three spellings come from the same three functions `Architecture::name_function`
  calls, so nothing is parsed and nothing can drift.
- Unchanged: the retry still runs only after the name match found nothing, and
  still requires mapped bytes at the address. A binary that really carries a
  symbol spelled that way still wins, `sub_deadbeef` still misses, and no name
  that already resolved can move.
- `kuna functions` is deliberately untouched — it reports the default spelling
  whatever the run asks for, and now that spelling always selects.

## Tests

`tests/cli/changing-namestyle-invalidates-discovered.json` (promoted, over the
in-repo fixture) and two cases in `verify_entry_selectors.rs`: a placeholder
resolves in all three styles, and a default-style name survives a namestyle
flip. All three fail on the unpatched tree. One existing case moved — it asserted
that `FUN_00001170` misses under angr naming, which is the behaviour this
changes; `func_00001170` (wrong spelling for every style) still misses in its
place.

Swept every name and alias `kuna functions` reports across all 181 vendored
fixtures, at both naming styles, on the pre- and post-fix binaries: 4,856
selections, 3,566 identical, 1,290 exit 1 -> exit 0, 0 changed. Every unlocked
one is a `namestyle ghidra` run; the default-style column is byte-identical.

Gates: `make test` 675/675, `make test-stages` 714/714, `make test-cli` 103/103,
`make rust-test` green, `check-spec --strict` OK, `catalog --check` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
