### PR TITLE
[AUTOMATED] perf(p0): reuse the global-symbol snapshot while the symbol table has not moved

### DIFF
--- a/decompiler/crates/kuna-decomp/src/infra/architecture.rs
+++ b/decompiler/crates/kuna-decomp/src/infra/architecture.rs
@@ -43,6 +43,7 @@
 //! them through the option surface.  Public getters/setters are provided so the
 //! p0-pack can read/flip each without owning the struct layout.
 
+use std::cell::RefCell;
 use std::rc::Rc;
 
 use kuna_base::address::Address;
@@ -1652,6 +1653,14 @@ pub struct Architecture {
     /// `ArchContext` by `build_arch_handle` and consulted by the flow
     /// environment's callee-name/no-return queries.
     pub remote_scope: Option<Rc<crate::remote_provider::RemoteScope>>,
+    /// The two whole-`symboltab` derivations [`Architecture::build_arch_handle`]
+    /// hands every `Funcdata`, memoized on the symbol table's mutation
+    /// generation (no C++ analogue -- the C++ `glb` *is* the live symbol table
+    /// and derives nothing per function).
+    symbol_snapshots: RefCell<SymbolSnapshots>,
+    /// False re-derives both on every handle (`KUNA_NO_SYMBOL_SNAPSHOT_CACHE`),
+    /// so the memoized and re-derived paths can be compared.
+    kuna_snapshot_cache: bool,
     /// Options that can be configured (C++ `options`).
     pub options: OptionDatabase,
     /// Actions that can be applied in this architecture (C++ `allacts`).
@@ -1791,6 +1800,25 @@ pub struct Architecture {
     translate: Box<dyn EngineTranslate>,
 }
 
+/// The memoized whole-`symboltab` derivations [`Architecture::build_arch_handle`]
+/// attaches to every per-function [`ArchContext`].
+///
+/// Both are pure functions of the [`Database`], and re-deriving them is the
+/// dominant per-function cost once the symbol table is large.  `generation` is
+/// the [`Database::kuna_generation`] they were taken at; a mismatch means the
+/// symbol table moved and both are stale.
+#[derive(Default)]
+struct SymbolSnapshots {
+    generation: Option<u64>,
+    global_query: Option<Rc<crate::context::GlobalQuery>>,
+    callee_protos: Option<CalleeProtoSnapshot>,
+}
+
+/// Every declared callee's parked prototype, keyed by `(space index, entry
+/// offset)` -- the [`ArchContext::callee_protos`](crate::context::ArchContext)
+/// snapshot, shared rather than copied per function.
+type CalleeProtoSnapshot = Rc<Vec<(int4, uintb, crate::fspec::PrototypePieces)>>;
+
 impl Architecture {
     /// Construct an `Architecture` over an already-initialized disassembly
     /// engine (C++ `Architecture::Architecture` + the `restoreFromSpec` subsystem
@@ -1844,6 +1872,9 @@ impl Architecture {
         let mut arch = Architecture {
             archid: archid.to_string(),
             input_arm_isa_override: false,
+
+            symbol_snapshots: RefCell::new(SymbolSnapshots::default()),
+            kuna_snapshot_cache: std::env::var_os("KUNA_NO_SYMBOL_SNAPSHOT_CACHE").is_none(),
 
             trim_recurse_max: 0,
             max_implied_ref: 0,
@@ -3576,7 +3607,10 @@ impl Architecture {
         // kuna `glb` is a skeleton, so the global scope is wired here, after every
         // `map addr`).  Global-mapped varnodes then pick up `persist`/`addrtied`
         // and their stores survive `ActionDeadCode`.
-        ctx.global_query = Some(Rc::new(self.symboltab.build_global_query()));
+        // Both whole-`symboltab` derivations come from one memoized read, so they
+        // are always the same generation of the database as each other.
+        let (global_query, callee_protos) = self.symbol_snapshots();
+        ctx.global_query = Some(global_query);
         // (kuna, Phase 3) the ghidra-mode lazy provider rides the handle so the
         // global reads above query through it; None on the standalone path.
         ctx.remote_scope = self.remote_scope.clone();
@@ -3584,7 +3618,7 @@ impl Architecture {
         // FunctionSymbols by `set_function_prototype_pieces`) so the per-function
         // `ActionDefaultParams` copies a known callee's locked `FuncProto` into the
         // call site (C++ `coreaction.cc:2385` `fc->copy(otherfunc->getFuncProto())`).
-        ctx.callee_protos = self.symboltab.build_callee_proto_pieces();
+        ctx.callee_protos = callee_protos;
         // (kuna) The convention each of those callees was DECLARED under, keyed
         // the same way the pieces are (entry address).  The declaration names the
         // function, the parked pieces carry that name, and the read side
@@ -3615,6 +3649,41 @@ impl Architecture {
         // function entry address through the detached per-function skeleton.
         ctx.tracked_sets = self.with_context_db_mut(|db| db.clone_trackbase());
         Rc::new(ctx)
+    }
+
+    /// The two whole-`symboltab` derivations for the `Funcdata` being built,
+    /// reusing the ones the previous function got while `symboltab` has not
+    /// moved since (`Database::kuna_generation`).
+    fn symbol_snapshots(&self) -> (Rc<crate::context::GlobalQuery>, CalleeProtoSnapshot) {
+        if !self.kuna_snapshot_cache {
+            return (
+                Rc::new(self.symboltab.build_global_query()),
+                Rc::new(self.symboltab.build_callee_proto_pieces()),
+            );
+        }
+        let mut slot = self.symbol_snapshots.borrow_mut();
+        let generation = self.symboltab.kuna_generation();
+        if slot.generation != Some(generation) {
+            *slot = SymbolSnapshots { generation: Some(generation), ..SymbolSnapshots::default() };
+        }
+        (
+            Rc::clone(
+                slot.global_query
+                    .get_or_insert_with(|| Rc::new(self.symboltab.build_global_query())),
+            ),
+            Rc::clone(
+                slot.callee_protos
+                    .get_or_insert_with(|| Rc::new(self.symboltab.build_callee_proto_pieces())),
+            ),
+        )
+    }
+
+    /// Turn the `build_arch_handle` symbol-snapshot memoization on or off (on by
+    /// default; `KUNA_NO_SYMBOL_SNAPSHOT_CACHE` turns it off at construction).
+    /// The two paths must agree -- this exists so a test can compare them.
+    pub fn set_symbol_snapshot_cache(&mut self, on: bool) {
+        self.kuna_snapshot_cache = on;
+        *self.symbol_snapshots.borrow_mut() = SymbolSnapshots::default();
     }
 
     /// Insert the analysis-only fspec/iop/join spaces into the single engine

--- a/decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs
+++ b/decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs
@@ -1180,6 +1180,14 @@ impl From<DuplicateFunctionError> for KunaError {
 /// the hierarchical walk).  A property map ([`PartMap`]) labels memory ranges
 /// with boolean properties (`read-only`, `volatile`) independent of symbols.
 pub struct Database {
+    /// Monotone mutation counter, bumped by every `&mut self` entry point on
+    /// `Database` (no C++ analogue).  A consumer that derives a whole-database
+    /// snapshot — [`Architecture::build_arch_handle`](crate::architecture::Architecture::build_arch_handle),
+    /// once per decompiled function — reuses the previous snapshot while this
+    /// has not moved.  Correctness rests on the bump being exhaustive;
+    /// `tests::kuna_gen_bumped_by_every_mutator` enforces that against the
+    /// source of this file.
+    kuna_gen: u64,
     /// All scopes, owned by the database (replaces the C++ scope `delete` graph).
     scopes: slotmap::SlotMap<ScopeId, Scope>,
     /// All symbols, owned by the database (the C++ `nametree` owns `Symbol *`;
@@ -1198,9 +1206,15 @@ pub struct Database {
 }
 
 impl Database {
+    /// The snapshot-invalidation generation (see [`Database::kuna_gen`]).
+    pub fn kuna_generation(&self) -> u64 {
+        self.kuna_gen
+    }
+
     /// C++ `Database(Architecture *g,bool idByName)` (`database.cc:2954-2961`).
     pub fn new(id_by_name: bool) -> Database {
         Database {
+            kuna_gen: 0,
             scopes: slotmap::SlotMap::with_key(),
             symbols: slotmap::SlotMap::with_key(),
             globalscope: None,
@@ -1228,6 +1242,7 @@ impl Database {
     /// stack space indexes past the maptable end.  Growing only (C++ `resize`
     /// never shrinks a populated table here, since spaces are only added).
     pub fn adjust_caches(&mut self, num_spaces: int4) {
+        self.kuna_gen += 1;
         let n = if num_spaces < 0 { 0 } else { num_spaces as usize };
         for (_id, scope) in self.scopes.iter_mut() {
             if scope.maptable.len() < n {
@@ -1251,6 +1266,7 @@ impl Database {
 
     /// Mutably borrow a scope by id.
     pub fn scope_mut(&mut self, id: ScopeId) -> &mut Scope {
+        self.kuna_gen += 1;
         &mut self.scopes[id]
     }
 
@@ -1261,6 +1277,7 @@ impl Database {
 
     /// Mutably borrow a symbol by id.
     pub fn symbol_mut(&mut self, id: SymbolId) -> &mut Symbol {
+        self.kuna_gen += 1;
         &mut self.symbols[id]
     }
 
@@ -1276,6 +1293,7 @@ impl Database {
 
     /// Replace the property map (C++ `setProperties`).
     pub fn set_properties(&mut self, newflags: PartMap<Address, uint4>) {
+        self.kuna_gen += 1;
         self.flagbase = newflags;
     }
 
@@ -1283,6 +1301,7 @@ impl Database {
     /// `new ScopeInternal(id,nm,glb)`); the id/name/space-count come from the
     /// caller.  Inserted into the arena; *not* yet attached.
     fn build_sub_scope(&mut self, id: uint8, nm: &str, num_spaces: int4) -> ScopeId {
+        self.kuna_gen += 1;
         self.scopes.insert(Scope::new(id, nm, num_spaces))
     }
 
@@ -1291,6 +1310,7 @@ impl Database {
     /// The new Scope must be initially empty.  Passing `None` for `parent`
     /// registers the global Scope (which must have an empty name and be unique).
     pub fn attach_scope(&mut self, newscope: ScopeId, parent: Option<ScopeId>) -> KunaResult<()> {
+        self.kuna_gen += 1;
         let unique_id = self.scopes[newscope].unique_id;
         let name_empty = self.scopes[newscope].name.is_empty();
         match parent {
@@ -1336,6 +1356,7 @@ impl Database {
         parent: Option<ScopeId>,
         num_spaces: int4,
     ) -> KunaResult<ScopeId> {
+        self.kuna_gen += 1;
         if let Some(res) = self.resolve_scope(id) {
             return Ok(res);
         }
@@ -1498,6 +1519,7 @@ impl Database {
     /// C++ `ScopeInternal::insertNameTree` (`database.cc:2742-2757`): insert a
     /// Symbol into the nametree, establishing a dedup id on name collision.
     fn insert_name_tree(&mut self, scope: ScopeId, sym: SymbolId) -> KunaResult<()> {
+        self.kuna_gen += 1;
         use std::collections::btree_map::Entry;
         use std::ops::Bound::Included;
         self.symbols[sym].name_dedup = 0;
@@ -1540,6 +1562,7 @@ impl Database {
     /// symbol id, fill an undefined name, validate the type, and enter the symbol
     /// into the nametree and category tables.
     fn add_symbol_internal(&mut self, scope: ScopeId, sym: SymbolId) -> KunaResult<()> {
+        self.kuna_gen += 1;
         if self.symbols[sym].symbol_id == 0 {
             let unique_id = self.scopes[scope].unique_id;
             let next = self.scopes[scope].next_unique_id;
@@ -1596,6 +1619,7 @@ impl Database {
     /// `cat == 0` (function parameters) the caller's `ind` is honored so a recovered
     /// parameter lands at its 0-based slot.
     pub fn set_category(&mut self, scope: ScopeId, sym: SymbolId, cat: int4, ind: int4) {
+        self.kuna_gen += 1;
         let old_cat = self.symbols[sym].category;
         if old_cat >= 0 {
             let oc = old_cat as usize;
@@ -1763,6 +1787,7 @@ impl Database {
         sz: int4,
         uselim: &RangeList,
     ) -> KunaResult<EntryRef> {
+        self.kuna_gen += 1;
         let space = addr
             .get_space()
             .cloned()
@@ -1822,6 +1847,7 @@ impl Database {
         sz: int4,
         uselim: &RangeList,
     ) -> EntryRef {
+        self.kuna_gen += 1;
         let entry = SymbolEntry::new_dynamic(sym, exfl, hash, off, sz, uselim.clone());
         let slot = self.scopes[scope].dynamicentry.len();
         self.scopes[scope].dynamicentry.push(Some(entry));
@@ -1928,6 +1954,7 @@ impl Database {
         scope: ScopeId,
         mut entry: SymbolEntry,
     ) -> KunaResult<EntryRef> {
+        self.kuna_gen += 1;
         let sym = entry.symbol;
         // First set persistence based on scope (database.cc:1136-1147).
         if self.scopes[scope].is_global() {
@@ -2053,6 +2080,7 @@ impl Database {
         addr: &Address,
         usepoint: &Address,
     ) -> KunaResult<EntryRef> {
+        self.kuna_gen += 1;
         let mut entry = SymbolEntry::new_unintegrated(sym);
         if !usepoint.is_invalid() {
             let space = usepoint
@@ -2079,6 +2107,7 @@ impl Database {
         nm: &str,
         ct: Rc<Datatype>,
     ) -> KunaResult<SymbolId> {
+        self.kuna_gen += 1;
         let sym = self.symbols.insert(Symbol::new(scope, nm, Some(ct)));
         self.add_symbol_internal(scope, sym)?;
         Ok(sym)
@@ -2094,6 +2123,7 @@ impl Database {
         addr: &Address,
         usepoint: &Address,
     ) -> KunaResult<(SymbolId, EntryRef)> {
+        self.kuna_gen += 1;
         // C++ strips a "stripped" type first; the W6 Datatype stub has no
         // hasStripped yet, so it is a no-op here (STUB(W6)).
         let sym = self.symbols.insert(Symbol::new(scope, nm, Some(ct)));
@@ -2112,6 +2142,7 @@ impl Database {
         min_funcsymbol_size: int4,
         type_code: Rc<Datatype>,
     ) -> KunaResult<SymbolId> {
+        self.kuna_gen += 1;
         // C++ warns (printMessage) on overlap; the message channel is W5, so the
         // overlap query is performed but the warning is dropped (STUB(W5)).
         let mut sym = Symbol::new_empty(scope);
@@ -2138,6 +2169,7 @@ impl Database {
     /// recompute its `size_typelock`.  The console `map` commands lock the symbols
     /// they create as name/type-locked.
     pub fn set_attribute(&mut self, sym: SymbolId, attr: uint4) {
+        self.kuna_gen += 1;
         let mask = varnode_flags::typelock
             | varnode_flags::namelock
             | varnode_flags::readonly
@@ -2158,6 +2190,7 @@ impl Database {
         nm: &str,
         lab_type: Rc<Datatype>,
     ) -> KunaResult<SymbolId> {
+        self.kuna_gen += 1;
         let mut sym = Symbol::new_empty(scope);
         sym.dtype = Some(lab_type); // LabSymbol::buildType -> getBase(1, TYPE_UNKNOWN)
         sym.name = nm.to_string();
@@ -2179,6 +2212,7 @@ impl Database {
         caddr: &Address,
         hash: uint8,
     ) -> KunaResult<SymbolId> {
+        self.kuna_gen += 1;
         let sz = ct.get_size();
         let sym = self.symbols.insert(Symbol::new(scope, nm, Some(ct)));
         self.add_symbol_internal(scope, sym)?;
@@ -2203,6 +2237,7 @@ impl Database {
         hash: uint8,
         base1_unknown: Rc<Datatype>,
     ) -> KunaResult<SymbolId> {
+        self.kuna_gen += 1;
         // C++ EquateSymbol ctor.
         let mut sym = Symbol::new(scope, nm, Some(base1_unknown));
         sym.category = symbol_category::EQUATE;
@@ -2229,6 +2264,7 @@ impl Database {
         addr: &Address,
         hash: uint8,
     ) -> KunaResult<SymbolId> {
+        self.kuna_gen += 1;
         let mut sym = Symbol::new(scope, nm, Some(dt));
         sym.category = symbol_category::UNION_FACET;
         sym.kind = SymbolKind::UnionFacet { field_num, addr_based: false };
@@ -2664,6 +2700,7 @@ impl Database {
     /// `infd->getFuncProto().setInline(val)` reached via `OptionInline::apply`).
     /// No-op on a non-Function symbol.
     pub fn set_function_inline(&mut self, sid: SymbolId, val: bool) {
+        self.kuna_gen += 1;
         if let SymbolKind::Function { inline_func, .. } = &mut self.symbols[sid].kind {
             *inline_func = val;
         }
@@ -2673,6 +2710,7 @@ impl Database {
     /// `infd->getFuncProto().setNoReturn(val)` reached via `OptionNoReturn::apply`).
     /// No-op on a non-Function symbol.
     pub fn set_function_no_return(&mut self, sid: SymbolId, val: bool) {
+        self.kuna_gen += 1;
         if let SymbolKind::Function { no_return, .. } = &mut self.symbols[sid].kind {
             *no_return = val;
         }
@@ -2682,6 +2720,7 @@ impl Database {
     /// `fd->getFuncProto().setInjectId(injectid)` reached via `IfcFixupApply`).
     /// No-op on a non-Function symbol.
     pub fn set_function_inject_id(&mut self, sid: SymbolId, injectid: int4) {
+        self.kuna_gen += 1;
         if let SymbolKind::Function { inject_id, .. } = &mut self.symbols[sid].kind {
             *inject_id = injectid;
         }
@@ -2709,6 +2748,7 @@ impl Database {
         sid: SymbolId,
         pieces: crate::fspec::PrototypePieces,
     ) {
+        self.kuna_gen += 1;
         if let SymbolKind::Function { proto_pieces, .. } = &mut self.symbols[sid].kind {
             *proto_pieces = Some(Box::new(pieces));
         }
@@ -3271,6 +3311,7 @@ impl Database {
     /// C++ `Database::clearResolve` (`database.cc:2900-2919`): remove a namespace
     /// scope's owned ranges from the resolve map.
     fn clear_resolve(&mut self, scope: ScopeId) {
+        self.kuna_gen += 1;
         if Some(scope) == self.globalscope {
             return;
         }
@@ -3289,6 +3330,7 @@ impl Database {
 
     /// C++ `Database::fillResolve` (`database.cc:2938-2949`).
     fn fill_resolve(&mut self, scope: ScopeId) {
+        self.kuna_gen += 1;
         if Some(scope) == self.globalscope {
             return;
         }
@@ -3307,6 +3349,7 @@ impl Database {
 
     /// C++ `Database::setRange` (`database.cc:3062-3068`).
     pub fn set_range(&mut self, scope: ScopeId, rlist: RangeList) {
+        self.kuna_gen += 1;
         self.clear_resolve(scope);
         self.scopes[scope].rangetree = rlist;
         self.fill_resolve(scope);
@@ -3319,6 +3362,7 @@ impl Database {
     }
 
     pub fn add_range(&mut self, scope: ScopeId, spc: Rc<AddrSpace>, first: uintb, last: uintb) {
+        self.kuna_gen += 1;
         self.clear_resolve(scope);
         self.scopes[scope].rangetree.insert_range(spc, first, last);
         self.fill_resolve(scope);
@@ -3326,6 +3370,7 @@ impl Database {
 
     /// C++ `Database::removeRange` (`database.cc:3090-3096`).
     pub fn remove_range(&mut self, scope: ScopeId, spc: Rc<AddrSpace>, first: uintb, last: uintb) {
+        self.kuna_gen += 1;
         self.clear_resolve(scope);
         self.scopes[scope].rangetree.remove_range(spc, first, last);
         self.fill_resolve(scope);
@@ -3356,6 +3401,7 @@ impl Database {
         sz: int4,
         parameter: bool,
     ) {
+        self.kuna_gen += 1;
         let addr = Address::new(Rc::clone(&space), first);
         // Remove any symbols under range (C++ findOverlap/removeSymbol loop).
         while let Some(eref) = self.find_overlap(scope, &addr, sz) {
@@ -3388,6 +3434,7 @@ impl Database {
     /// (the architecture-relative one-past-the-end address; the caller supplies it
     /// since the AddrSpaceManager lives in the ArchContext).
     pub fn set_property_range(&mut self, flags: uint4, addr1: &Address, addr2: &Address) {
+        self.kuna_gen += 1;
         self.flagbase.split(addr1);
         if !addr2.is_invalid() {
             self.flagbase.split(addr2);
@@ -3403,6 +3450,7 @@ impl Database {
 
     /// C++ `Database::clearPropertyRange` (`database.cc:3271-3291`).
     pub fn clear_property_range(&mut self, flags: uint4, addr1: &Address, addr2: &Address) {
+        self.kuna_gen += 1;
         self.flagbase.split(addr1);
         if !addr2.is_invalid() {
             self.flagbase.split(addr2);
@@ -3812,6 +3860,7 @@ impl Database {
         start: Option<ScopeId>,
         num_spaces: int4,
     ) -> KunaResult<(ScopeId, String)> {
+        self.kuna_gen += 1;
         // (kuna) The CREATE half of the `symbolnamebound` seam: one Scope per
         // `::` component at ~1.5 KB each makes an unbounded name a ~498x
         // input-to-RSS amplifier on attacker-controlled `.strtab` bytes. Shared
@@ -3853,6 +3902,7 @@ impl Database {
     /// C++ `ScopeInternal::renameSymbol` (`database.cc:2180-2192`): rename `sym`
     /// within its scope, re-keying the name tree (and the multi-entry set).
     pub fn rename_symbol(&mut self, sym: SymbolId, newname: &str) -> KunaResult<()> {
+        self.kuna_gen += 1;
         let scope = self.symbols[sym].scope;
         let oldkey = self.name_key(sym);
         self.scopes[scope].nametree.remove(&oldkey);
@@ -3876,6 +3926,7 @@ impl Database {
     /// swapped in place and the size/type lock recomputed; otherwise, for a
     /// single address-tied mapping, the mapping is rebuilt at the new size.
     pub fn retype_symbol(&mut self, sym: SymbolId, ct: Rc<Datatype>) -> KunaResult<()> {
+        self.kuna_gen += 1;
         let ct = if ct.has_stripped() { ct.get_stripped().unwrap_or(ct) } else { ct };
         let old_size = self.symbols[sym].dtype.as_ref().map(|t| t.get_size()).unwrap_or(0);
         let mapentry_len = self.symbols[sym].mapentry.len();
@@ -3914,6 +3965,7 @@ impl Database {
     /// Erase one SymbolEntry mapping of `sym` from its scope rangemap / dynamic
     /// list (the per-entry half of [`remove_symbol_mappings`]).
     fn erase_mapentry(&mut self, scope: ScopeId, _sym: SymbolId, eref: EntryRef) {
+        self.kuna_gen += 1;
         match eref {
             EntryRef::Dynamic(slot) => {
                 self.scopes[scope].dynamicentry[slot] = None;
@@ -3929,6 +3981,7 @@ impl Database {
     /// C++ `ScopeInternal::removeSymbolMappings` (`database.cc:2145-2164`): drop
     /// all SymbolEntry mappings of `sym`.
     fn remove_symbol_mappings(&mut self, sym: SymbolId) {
+        self.kuna_gen += 1;
         let scope = self.symbols[sym].scope;
         if self.symbols[sym].whole_count > 1 {
             let key = self.name_key(sym);
@@ -3953,6 +4006,7 @@ impl Database {
     /// C++ `ScopeInternal::removeSymbol` (`database.cc:2166-2178`): remove `sym`
     /// entirely (category slot, mappings, name tree, and the object).
     pub fn remove_symbol(&mut self, sym: SymbolId) {
+        self.kuna_gen += 1;
         let scope = self.symbols[sym].scope;
         let cat = self.symbols[sym].category;
         if cat >= 0 {
@@ -3984,6 +4038,7 @@ impl Database {
     /// re-injects it as a competing fixed-array `RangeHint`, overriding the scalar
     /// hint the converted Varnode then supplies.
     pub fn clear_unlocked_category_negative(&mut self, scope: ScopeId) -> KunaResult<()> {
+        self.kuna_gen += 1;
         // C++ iterates `nametree` advancing the iterator before acting on the
         // symbol (the act mutates the tree).  Collect first, then act — the arena
         // equivalent of "advance before remove".
@@ -4024,6 +4079,7 @@ impl Database {
         alias: &[uintb],
         alias_block_level: int4,
     ) {
+        self.kuna_gen += 1;
         use crate::dtype::type_metatype;
         // EntryMap *rangemap = maptable[space->getIndex()]; if 0 return;
         let entries: Vec<(SymbolId, uintb)> = {
@@ -4122,6 +4178,7 @@ impl Database {
         base: &mut int4,
         arch: &dyn DatabaseArch,
     ) -> KunaResult<()> {
+        self.kuna_gen += 1;
         use std::ops::Bound::{Excluded, Unbounded};
         // C++: iter = nametree.upper_bound(Symbol("$$undef")); walk while names
         // are still "undefined".  Collect the undefined-named ids first (the
@@ -4355,6 +4412,7 @@ impl Database {
     /// rename on, but that must not enter the analysis scope — adding it there
     /// would feed the printer's scope queries and change the emitted C.
     pub fn reserve_internal_symbol_id(&mut self, scope: ScopeId) -> uint8 {
+        self.kuna_gen += 1;
         let unique_id = self.scopes[scope].unique_id;
         let next = self.scopes[scope].next_unique_id;
         self.scopes[scope].next_unique_id += 1;
@@ -5232,5 +5290,182 @@ mod tests {
         assert_eq!(*off, 0x2000);
         assert_eq!(snap_pieces.name, "declared_callee");
         assert_eq!(snap_pieces.intypes.len(), 1);
+    }
+
+    /// `Database::kuna_gen` is what `Architecture::build_arch_handle` keys its
+    /// per-function `GlobalQuery`/callee-proto snapshot cache on, so a mutator
+    /// that forgets to bump it makes that cache serve stale symbols.  Enforce
+    /// the invariant structurally: every `&mut self` method in every
+    /// `impl Database` block of this file opens with the bump.
+    #[test]
+    fn kuna_gen_bumped_by_every_mutator() {
+        let src = include_str!("database.rs");
+        let lines: Vec<&str> = src.lines().collect();
+        // Every `impl Database` block must be one the block walk below enters --
+        // a reformatted header would otherwise skip its methods silently.
+        let declared = lines.iter().filter(|l| declares_impl_database(l)).count();
+        let mut entered = 0usize;
+        let mut checked = 0usize;
+        let mut i = 0usize;
+        while i < lines.len() {
+            if lines[i] != "impl Database {" {
+                i += 1;
+                continue;
+            }
+            entered += 1;
+            let mut j = i + 1;
+            while j < lines.len() && lines[j] != "}" {
+                if !is_method_signature_start(lines[j]) {
+                    j += 1;
+                    continue;
+                }
+                // Accumulate the signature through the close of the argument list.
+                let mut sig = String::new();
+                let mut depth = 0i32;
+                let mut started = false;
+                let mut k = j;
+                'sig: while k < lines.len() {
+                    for c in lines[k].chars() {
+                        sig.push(c);
+                        match c {
+                            '(' => {
+                                depth += 1;
+                                started = true;
+                            }
+                            ')' => depth -= 1,
+                            _ => {}
+                        }
+                        if started && depth == 0 {
+                            break 'sig;
+                        }
+                    }
+                    k += 1;
+                }
+                if sig.contains("&mut self") {
+                    let mut b = k;
+                    while b < lines.len() && !lines[b].trim_end().ends_with('{') {
+                        b += 1;
+                    }
+                    assert_eq!(
+                        lines[b + 1].trim(),
+                        "self.kuna_gen += 1;",
+                        "Database mutator at line {} does not bump kuna_gen: {}",
+                        j + 1,
+                        lines[j].trim()
+                    );
+                    checked += 1;
+                }
+                j = k + 1;
+            }
+            i = j + 1;
+        }
+        assert_eq!(declared, entered, "an `impl Database` block was not scanned");
+        assert!(checked >= 44, "the scanner found only {checked} mutators; it is broken");
+
+        // The scan reasons about `&mut self`, so interior mutability anywhere in
+        // the database's own types would let a mutation past it unseen.  Needles
+        // are assembled rather than written out so this module is not its own hit.
+        let hatches = ["Cell".to_string() + "<", "Unsafe".to_string() + "Cell"];
+        let body_end = lines
+            .iter()
+            .position(|l| l.trim() == "mod tests {")
+            .expect("the test module header moved");
+        for (n, line) in lines[..body_end].iter().enumerate() {
+            let code = line.trim_start();
+            if code.starts_with("//") {
+                continue;
+            }
+            for hatch in &hatches {
+                assert!(
+                    !code.contains(hatch.as_str()),
+                    "interior mutability at line {}: a `&mut self` scan cannot see through it, \
+                     so `kuna_gen` would stop covering every mutation",
+                    n + 1
+                );
+            }
+        }
+    }
+
+    /// True for any `impl` header whose *self* type is `Database` — inherent or
+    /// trait, generic or not.  Deliberately more permissive than the exact
+    /// literal the block walk enters on, so a header written any other way is
+    /// counted here, fails the `declared == entered` check, and is never
+    /// silently skipped.
+    fn declares_impl_database(line: &str) -> bool {
+        let rest = match line.trim_start().strip_prefix("impl") {
+            Some(r) => r,
+            None => return false,
+        };
+        // `impl<'a, T>` — drop the generic list before reading the self type.
+        let rest = match rest.trim_start().strip_prefix('<') {
+            Some(r) => match r.split_once('>') {
+                Some((_, after)) => after,
+                None => return false,
+            },
+            None => rest,
+        };
+        // `impl Trait for Database` — the self type is what follows the last `for`.
+        let self_ty = match rest.rsplit_once(" for ") {
+            Some((_, after)) => after,
+            None => rest,
+        };
+        let self_ty = match self_ty.split_once(" where ") {
+            Some((before, _)) => before,
+            None => self_ty,
+        };
+        let self_ty = self_ty.trim().trim_end_matches('{').trim();
+        self_ty == "Database" || self_ty.starts_with("Database<")
+    }
+
+    /// True for a line opening a method signature at `impl` indentation, whatever
+    /// visibility/`const`/`unsafe`/`async` modifiers precede the `fn`.
+    fn is_method_signature_start(line: &str) -> bool {
+        let mut rest = match line.strip_prefix("    ") {
+            Some(r) if !r.starts_with(' ') => r,
+            _ => return false,
+        };
+        if let Some(r) = rest.strip_prefix("pub") {
+            rest = match r.strip_prefix('(') {
+                Some(r) => match r.split_once(')') {
+                    Some((_, after)) => after,
+                    None => return false,
+                },
+                None => r,
+            };
+            rest = match rest.strip_prefix(' ') {
+                Some(r) => r,
+                None => return false,
+            };
+        }
+        for modifier in ["const ", "unsafe ", "async "] {
+            if let Some(r) = rest.strip_prefix(modifier) {
+                rest = r;
+            }
+        }
+        rest.starts_with("fn ")
+    }
+
+    /// The generation moves on a mutation and stands still on a read — the two
+    /// halves of the snapshot cache's contract.
+    #[test]
+    fn kuna_generation_tracks_mutation() {
+        let m = build_manager();
+        let ram = space(&m, 2);
+        let (mut db, g) = db_with_global(m.num_spaces());
+
+        let after_setup = db.kuna_generation();
+        // Pure reads leave the generation alone.
+        let before = db.build_global_query();
+        assert_eq!(db.kuna_generation(), after_setup);
+        let _ = db.build_callee_proto_pieces();
+        assert_eq!(db.kuna_generation(), after_setup);
+
+        // A mapped global moves it, and the snapshot with it.
+        let addr = Address::new(Rc::clone(&ram), 0x4000);
+        db.add_symbol_mapped(g, "gvar", dt(4), &addr, &Address::new_invalid())
+            .expect("map global");
+        assert!(db.kuna_generation() > after_setup);
+        let after = db.build_global_query();
+        assert_ne!(format!("{before:?}"), format!("{after:?}"));
     }
 }

--- a/decompiler/crates/kuna-decomp/src/substrate/context.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/context.rs
@@ -1195,8 +1195,10 @@ pub struct ArchContext {
     /// from the global FunctionSymbols at `build_arch_handle`; read back by
     /// `ActionDefaultParams::apply` via [`Architecture::callee_proto_pieces`] to
     /// `fc->copy(otherfunc->getFuncProto())` (`coreaction.cc:2385`).  Empty for
-    /// hand-built fixtures and undeclared callees.
-    pub callee_protos: Vec<(int4, kuna_base::types::uintb, crate::fspec::PrototypePieces)>,
+    /// hand-built fixtures and undeclared callees.  Shared behind an `Rc`
+    /// because `build_arch_handle` hands the same snapshot to every function of
+    /// a run.
+    pub callee_protos: Rc<Vec<(int4, kuna_base::types::uintb, crate::fspec::PrototypePieces)>>,
     /// The calling convention each declared callee was declared under, keyed the
     /// same way [`Self::callee_protos`] is.  Snapshotted at `build_arch_handle`
     /// from the architecture's declared-convention map and read back by
@@ -1403,7 +1405,7 @@ impl ArchContext {
             // arch and build_arch_handle shares the result.
             infer_ptr_spaces: Vec::new(),
             // No declared callee prototypes until build_arch_handle snapshots them.
-            callee_protos: Vec::new(),
+            callee_protos: Rc::new(Vec::new()),
             // No tracked registers until build_arch_handle snapshots the context DB.
             tracked_sets: kuna_base::partmap::PartMap::default(),
         }

--- a/decompiler/crates/kuna-decomp/tests/verify_symbol_snapshot_cache.rs
+++ b/decompiler/crates/kuna-decomp/tests/verify_symbol_snapshot_cache.rs
@@ -1,0 +1,193 @@
+//! `Architecture::build_arch_handle` memoizes the two whole-`symboltab`
+//! derivations it hands each `Funcdata` (the `GlobalQuery` and the
+//! declared-callee prototype list) on `Database::kuna_generation()`.  A stale hit
+//! there silently emits wrong C, so this verifies the three halves of the
+//! contract:
+//!
+//!   * an unchanged symbol table serves the *same* snapshot (the cache is live),
+//!   * a mutated symbol table serves a *different* one (invalidation works),
+//!   * the cached snapshot equals the one the bypass path re-derives.
+//!
+//! Bootstrap mechanics are the datatest-XML ones the other `verify_*` integration
+//! tests use inline (the gate's helpers are private to its own test binary).
+
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use kuna_base::address::Address;
+use kuna_base::error::{KunaError, KunaResult};
+use kuna_base::marshal::IdRegistry;
+use kuna_base::space::AddrSpaceManager;
+use kuna_base::xml::{DocumentStorage, Element};
+
+use kuna_decomp::architecture::Architecture;
+use kuna_decomp::dtype::type_metatype;
+use kuna_decomp::sleigh_arch::{register_sleigh_arch_ids, LanguageDatabase};
+use kuna_decomp::xml_arch::{XmlArchitecture, XmlArchitectureCapability};
+
+use kuna_sleigh::loadimage::LoadImage;
+use kuna_sleigh::loadimage_xml::register_loadimage_xml_ids;
+use kuna_sleigh::translate::register_translate_ids;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+fn find_named(el: &Rc<Element>, name: &str, out: &mut Vec<Rc<Element>>) {
+    if el.get_name() == name {
+        out.push(Rc::clone(el));
+    }
+    for c in el.get_children() {
+        find_named(c, name, out);
+    }
+}
+
+fn attr(el: &Element, name: &str) -> Option<String> {
+    el.get_attribute_value(name).ok().map(|b| String::from_utf8_lossy(b).into_owned())
+}
+
+struct DummyImg;
+impl LoadImage for DummyImg {
+    fn get_file_name(&self) -> &str {
+        "dummy"
+    }
+    fn load_fill(&mut self, _ptr: &mut [u8], _addr: &Address) -> KunaResult<()> {
+        Err(KunaError::data_unavail("dummy"))
+    }
+    fn get_arch_type(&self) -> Vec<u8> {
+        Vec::new()
+    }
+    fn adjust_vma(&mut self, _adjust: i64) {}
+}
+
+fn build_registry() -> IdRegistry {
+    let mut registry = IdRegistry::with_base_ids();
+    register_translate_ids(&mut registry);
+    register_sleigh_arch_ids(&mut registry);
+    register_loadimage_xml_ids(&mut registry);
+    kuna_decomp::options::register_option_elements(&mut registry);
+    registry
+}
+
+fn bootstrap(stem: &str) -> Result<XmlArchitecture, String> {
+    let root = repo_root();
+    let path = root.join("tests/datatests").join(format!("{stem}.xml"));
+    let xml = std::fs::read(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let mut store = DocumentStorage::new();
+    let doc_root =
+        store.parse_document(&xml).map_err(|e| format!("parse {stem}: {e}"))?.get_root().clone();
+    let mut bis = Vec::new();
+    find_named(&doc_root, "binaryimage", &mut bis);
+    let binaryimage = bis.into_iter().next().ok_or("no <binaryimage>")?;
+    let arch_id = attr(&binaryimage, "arch").ok_or("<binaryimage> has no arch")?;
+
+    let registry = build_registry();
+    let capability = XmlArchitectureCapability::new();
+    let mut arch = capability.build_architecture("datatest", "");
+    arch.build_loader(Rc::clone(&binaryimage)).map_err(|e| format!("build_loader: {e}"))?;
+    let mut db = LanguageDatabase::new();
+    db.scan_for_sleigh_directories(root.join("specs").to_str().unwrap());
+    db.get_descriptions(&registry).map_err(|e| format!("collect ldefs: {e}"))?;
+    arch.sleigh_mut().set_archid(&arch_id);
+    arch.sleigh_mut()
+        .resolve_architecture(&db, &arch_id)
+        .map_err(|e| format!("resolve_architecture: {e}"))?;
+    if arch.sleigh().language_index() < 0 {
+        return Err("language index unresolved".to_string());
+    }
+    let specs = arch.sleigh().build_spec_file(&db).map_err(|e| format!("build_spec_file: {e}"))?;
+    let resolved_sla = specs.slafile.ok_or("build_spec_file resolved no .sla")?;
+    let sla = std::fs::read(&resolved_sla).map_err(|e| format!("read sla: {e}"))?;
+    arch.sleigh_mut()
+        .build_translator(Box::new(DummyImg), &sla)
+        .map_err(|e| format!("build_translator: {e}"))?;
+    arch.sleigh_mut()
+        .base_mut()
+        .ok_or("no Architecture base after build_translator")?
+        .init_post_engine()
+        .map_err(|e| format!("init_post_engine: {e}"))?;
+    let manager_ptr: *const AddrSpaceManager = arch.sleigh().base().unwrap().manage();
+    // SAFETY: same shape as the gate / corpus_bootstrap — manager outlives open().
+    arch.open_image(unsafe { &*manager_ptr }, &registry).map_err(|e| format!("open_image: {e}"))?;
+    let img = arch.take_loader().ok_or("loader vanished after open")?;
+    arch.sleigh_mut().base_mut().unwrap().set_loader(Box::new(img));
+    Ok(arch)
+}
+
+/// Render a handle's two snapshots for content comparison.
+fn snapshot_text(arch: &Architecture) -> (String, String) {
+    let glb = arch.build_arch_handle();
+    (
+        format!("{:?}", glb.global_query.as_ref().expect("global query")),
+        format!("{:?}", glb.callee_protos),
+    )
+}
+
+/// Map one new global into `symboltab`, the cheapest real mutation.
+fn map_a_global(arch: &mut Architecture, name: &str, offset: u64) {
+    let ram = arch.manage().get_default_code_space().cloned().expect("code space");
+    let ty = arch.types().get_base(4, type_metatype::TYPE_INT).expect("int4 base type");
+    let g = arch.symboltab.get_global_scope().expect("global scope");
+    let addr = Address::new(ram, offset);
+    arch.symboltab
+        .add_symbol_mapped(g, name, ty, &addr, &Address::new_invalid())
+        .expect("map global");
+}
+
+#[test]
+fn symbol_snapshot_cache_reuses_and_invalidation_rebuilds() {
+    let mut xarch = match bootstrap("boolless") {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("skip (bootstrap, likely no .sla): {e}");
+            return;
+        }
+    };
+    let arch = xarch.sleigh_mut().base_mut().expect("base");
+
+    // 1. Unchanged symbol table -> the identical snapshot objects, not copies.
+    let a = arch.build_arch_handle();
+    let b = arch.build_arch_handle();
+    assert!(
+        Rc::ptr_eq(a.global_query.as_ref().unwrap(), b.global_query.as_ref().unwrap()),
+        "the global-symbol snapshot was rebuilt for an unmutated symbol table"
+    );
+    assert!(
+        Rc::ptr_eq(&a.callee_protos, &b.callee_protos),
+        "the callee-proto snapshot was rebuilt for an unmutated symbol table"
+    );
+    let (gq_before, cp_before) = snapshot_text(arch);
+
+    // 2. The cached snapshot is what the bypass path re-derives, byte for byte.
+    arch.set_symbol_snapshot_cache(false);
+    let c = arch.build_arch_handle();
+    let d = arch.build_arch_handle();
+    assert!(
+        !Rc::ptr_eq(c.global_query.as_ref().unwrap(), d.global_query.as_ref().unwrap()),
+        "the bypass did not bypass: snapshots were still shared"
+    );
+    let (gq_bypass, cp_bypass) = snapshot_text(arch);
+    assert_eq!(gq_before, gq_bypass, "cached global query differs from the re-derived one");
+    assert_eq!(cp_before, cp_bypass, "cached callee protos differ from the re-derived ones");
+
+    // 3. A mutation between two `build_arch_handle` calls must move the snapshot.
+    arch.set_symbol_snapshot_cache(true);
+    let e = arch.build_arch_handle();
+    map_a_global(arch, "kuna_snapshot_probe", 0xb000);
+    let f = arch.build_arch_handle();
+    assert!(
+        !Rc::ptr_eq(e.global_query.as_ref().unwrap(), f.global_query.as_ref().unwrap()),
+        "a mapped global was added and the cache still served the stale snapshot"
+    );
+    let (gq_after, _) = snapshot_text(arch);
+    assert_ne!(gq_before, gq_after, "the new global never reached the global query");
+    assert!(
+        gq_after.contains("kuna_snapshot_probe"),
+        "the rebuilt global query does not carry the symbol that invalidated it"
+    );
+
+    // And the post-mutation cached snapshot still matches a full re-derivation.
+    arch.set_symbol_snapshot_cache(false);
+    let (gq_after_bypass, _) = snapshot_text(arch);
+    assert_eq!(gq_after, gq_after_bypass, "post-invalidation snapshot is not the re-derived one");
+}

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -1553,6 +1553,31 @@ built. Two consequences:
   already followed (§0.8), and that adoption is refused the moment any command at
   all — an `option` among them — has run since the load.
 
+Two of those snapshots — the global-symbol query and the callee-prototype list —
+are whole-database derivations, so re-deriving them once per function dominates
+per-function cost as soon as the symbol table is large. On an 18 MB Windows PE
+with 73,366 mapped globals each pair costs about 25 ms to build and 12 ms to free,
+flat in the size of the function being decompiled, and the symbol table it reads
+does not move once for the whole run. Both are pure functions of the symbol
+database (`decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs (Database)`),
+so `build_arch_handle` derives them at most once per state of that database and
+hands every `Funcdata` a shared `Rc` to the same pair, keyed on a monotone
+mutation generation the database bumps in every one of its `&mut self` entry
+points (`decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs
+(kuna_generation)`). A mutation between two function builds — a `map addr`, a
+rename, a recovered prototype — moves the generation and both snapshots are
+rebuilt on the next build, so what a `Funcdata` sees is still the database as of
+its own build and the emitted C does not move.
+
+The reuse is only as sound as that bump, which is why the generation is not
+maintained by hand at the call sites that matter: a unit test re-reads the
+database source and fails if any `&mut self` method does not open with the bump,
+if an `impl Database` block is written in a form that scan cannot enter, or if
+interior mutability appears in the database's own types (which would let a
+mutation past a `&mut self` scan unseen). `KUNA_NO_SYMBOL_SNAPSHOT_CACHE`
+re-derives both snapshots on every handle, so the memoized and re-derived paths
+can be compared on any binary.
+
 ## 0.6 The schedule
 
 The pipeline's execution order is not the folder order. Every per-function run


### PR DESCRIPTION
Whole-binary runs spend most of their per-function time rebuilding the global
symbol table, which does not change while the run is in progress. 2,000
functions of `libstdc++.so.6`, before and after:

```
$ time kuna decompile-all /usr/lib/x86_64-linux-gnu/libstdc++.so.6 \
      --sort addr --limit 2000 --max-fn-seconds 0 --json > /dev/null

real    0m27.934s      # before
real    0m20.578s      # after
```

Interleaved over 6 alternating pairs on a shared box, that is a median of
24.5 s against 17.1 s. The saving is a flat ~20 ms per function, so it grows
with the function count: on the 18 MB PE from #510 (73,366 mapped globals,
33,214 functions) 4,500 functions go 307 s -> 212 s, of which 44 s is the
one-time load in both arms.

## The fix

- `Architecture::build_arch_handle` rebuilt `ArchContext::global_query` and the
  declared-callee prototype list from the whole symbol database for every
  `Funcdata`. Both are pure functions of that database, so they are now derived
  at most once per state of it and handed to every function as a shared `Rc`.
- The key is a monotone generation counter on `Database`, bumped by every one of
  its 44 `&mut self` entry points, rather than explicit invalidation where
  symbols change: those sites are spread across the loader, the analysis commit
  and the console command surface, and missing one is a silently wrong
  decompile. A `map addr`, a rename or a parsed prototype between two functions
  moves the generation and both snapshots are rebuilt.
- `KUNA_NO_SYMBOL_SNAPSHOT_CACHE=1` re-derives both on every handle, so the two
  paths can be compared on any binary.

## The tests

A unit test re-reads `database.rs` and fails if a `&mut self` method does not
open with the bump, if an `impl Database` block is written in a form its scan
cannot enter, or if interior mutability appears in the database's own types. An
integration test asserts that an unmutated table serves the identical `Rc`, that
a mapped global invalidates it, and that the cached snapshot equals what the
bypass re-derives.

Output does not move: `decompile-all --json` is byte-identical to main over
4,365 function records (mpengine.dll, libstdc++.so.6, /bin/ls, /bin/grep and 8
fixtures spanning ELF/PE/Mach-O and x86-64/i386/ARM), and so are three
`decompile-project` exports and the `functions`/`strings`/`xrefs` surfaces. No
datatest or stage expectation moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFpP8jNwKT29DnbXG3neNb
