### PR TITLE
[AUTOMATED] feat(cli): byte-overlay-assertion-recovered — --assert 'bytes <addr> <hex|@FILE>' overlays recovered plaintext onto the loaded image

### DIFF
--- a/decompiler/crates/kuna-analysis/src/loadimage_object.rs
+++ b/decompiler/crates/kuna-analysis/src/loadimage_object.rs
@@ -1046,6 +1046,43 @@ impl ObjectLoadImage {
         cursize
     }
 
+    /// Write `data` over the mapped bytes at `vma` (the write twin of
+    /// [`Self::fill_span`], and the loader half of `--assert bytes`).
+    ///
+    /// Resolved through [`Self::find_section`] so an overlay lands in exactly the
+    /// segment a read at the same address would come from, and refused unless
+    /// that segment maps the whole span: a partial write would leave half a
+    /// stated instruction stream in place, which is worse than not taking the
+    /// statement at all.  A span reaching into the segment's zero-filled RAM tail
+    /// materialises that tail first — the caller is stating what the running
+    /// program put there, which is precisely a `.bss`-style region's content.
+    fn overlay_span(&mut self, vma: u64, data: &[u8]) -> Result<(), String> {
+        if data.is_empty() {
+            return Err("an overlay needs at least one byte".into());
+        }
+        let end = vma
+            .checked_add(data.len() as u64) // cast: overlay byte count
+            .ok_or_else(|| "the overlay wraps past the end of the address space".to_string())?;
+        let idx = self
+            .find_section(vma)
+            .filter(|(idx, secsize)| {
+                let seg_vma = self.segments[*idx].vma;
+                vma >= seg_vma && end <= seg_vma.wadd(*secsize)
+            })
+            .map(|(idx, _)| idx)
+            .ok_or_else(|| format!("no loaded segment maps {vma:#x}-{end:#x}"))?;
+        let seg = &mut self.segments[idx];
+        let off = (vma - seg.vma) as usize; // cast: offset within a mapped segment
+        let stop = off + data.len();
+        if stop > seg.data.len() {
+            seg.data.resize(stop, 0);
+        }
+        seg.data[off..stop].copy_from_slice(data);
+        // The 512-byte read window may straddle what just moved; drop it.
+        *self.bufoffset.borrow_mut() = !0u64;
+        Ok(())
+    }
+
     /// Copy `len` bytes out of segment `idx` starting at file-relative
     /// `seg_off` into `dst` (the C++ `bfd_get_section_contents`).  A read past
     /// the segment's file data zero-fills the remainder (a `.bss`-style RAM tail
@@ -1188,6 +1225,22 @@ impl LoadImage for ObjectLoadImage {
 
     fn get_segments(&self) -> Vec<(u64, u64, u32)> {
         self.segment_info.iter().map(|s| (s.vma, s.size, s.flags)).collect()
+    }
+
+    fn kuna_overlay_bytes(&mut self, addr: &Address, data: &[u8]) -> KunaResult<()> {
+        let space = addr
+            .get_space()
+            .expect("ObjectLoadImage::kuna_overlay_bytes: address with null space");
+        match &self.spaceid {
+            Some(sp) if Rc::ptr_eq(sp, space) => {}
+            _ => {
+                return Err(KunaError::data_unavail(format!(
+                    "Trying to overlay loadimage bytes in space: {}",
+                    space.get_name()
+                )));
+            }
+        }
+        self.overlay_span(addr.get_offset(), data).map_err(KunaError::data_unavail)
     }
 
     fn get_readonly(&self, list: &mut RangeList) {
@@ -1812,6 +1865,75 @@ mod tests {
             }
             other => panic!("expected DataUnavail, got {other:?}"),
         }
+    }
+
+    /// (kuna `--assert bytes`) The overlay is a statement about RAM: every later
+    /// read serves it, the file on disk is untouched, and an address no segment
+    /// maps is refused rather than invented.
+    #[test]
+    fn an_overlay_replaces_what_every_later_read_returns() {
+        use kuna_sleigh::loadimage::LoadImage;
+        let m = manager();
+        let ram = Rc::clone(m.get_space_by_name("ram").unwrap());
+        let elf = build_elf64(0x401000, &[0x55, 0x48, 0x89, 0xe5], None);
+        let mut img = ObjectLoadImage::from_bytes("t.elf", &elf).unwrap();
+        img.attach_to_space(Rc::clone(&ram));
+
+        // Warm the 512-byte read window first: an overlay that did not drop it
+        // would be invisible to exactly the reads most likely to follow one.
+        assert_eq!(
+            img.load(4, &Address::new(Rc::clone(&ram), 0x401000)).unwrap(),
+            vec![0x55, 0x48, 0x89, 0xe5]
+        );
+        img.kuna_overlay_bytes(&Address::new(Rc::clone(&ram), 0x401001), &[0x31, 0xc0])
+            .expect("inside the segment");
+        assert_eq!(
+            img.load(4, &Address::new(Rc::clone(&ram), 0x401000)).unwrap(),
+            vec![0x55, 0x31, 0xc0, 0xe5]
+        );
+
+        // Unmapped, and straddling the end of the only segment: both refused,
+        // naming the span, because a half-applied overlay is worse than none.
+        for (vma, len) in [(0x1000u64, 1usize), (0x401002, 4)] {
+            let err = img
+                .kuna_overlay_bytes(&Address::new(Rc::clone(&ram), vma), &vec![0x90; len])
+                .unwrap_err();
+            match &err {
+                KunaError::DataUnavail { explain } => {
+                    assert!(explain.contains("no loaded segment maps"), "got {explain}");
+                }
+                other => panic!("expected DataUnavail, got {other:?}"),
+            }
+        }
+        // A wrong-space overlay is the loadFill contract, not a panic.
+        let other = Rc::clone(m.get_space_by_name("const").unwrap());
+        assert!(img.kuna_overlay_bytes(&Address::new(other, 0), &[0x90]).is_err());
+    }
+
+    /// A writable segment's zero-filled RAM tail is real mapped memory, so an
+    /// overlay reaching into it materialises the tail rather than refusing: what
+    /// the running program left there is exactly what a caller is stating.
+    #[test]
+    fn an_overlay_may_reach_into_a_zero_filled_tail() {
+        use kuna_sleigh::loadimage::LoadImage;
+        let mut bytes = build_elf64(0x401000, &[0x55, 0x48, 0x89, 0xe5], None);
+        bytes[104..112].copy_from_slice(&64u64.to_le_bytes()); // p_memsz: 4 backed + 60 zero
+        bytes[68..72].copy_from_slice(&(object::elf::PF_R | object::elf::PF_W).to_le_bytes());
+        let m = manager();
+        let ram = Rc::clone(m.get_space_by_name("ram").unwrap());
+        let mut img = ObjectLoadImage::from_bytes("t.elf", &bytes).unwrap();
+        img.attach_to_space(Rc::clone(&ram));
+
+        img.kuna_overlay_bytes(&Address::new(Rc::clone(&ram), 0x401020), &[0xde, 0xad])
+            .expect("inside the p_memsz tail");
+        assert_eq!(
+            img.load(4, &Address::new(Rc::clone(&ram), 0x40101f)).unwrap(),
+            vec![0x00, 0xde, 0xad, 0x00]
+        );
+        // Past p_memsz is not mapped at all.
+        assert!(img
+            .kuna_overlay_bytes(&Address::new(Rc::clone(&ram), 0x401040), &[0x90])
+            .is_err());
     }
 
     #[test]

--- a/decompiler/crates/kuna-cli/src/assertdecl.rs
+++ b/decompiler/crates/kuna-cli/src/assertdecl.rs
@@ -20,6 +20,8 @@
 //!   --assert 'readonly 0x404028+8'
 //!   --assert 'flow 0x1405 return'
 //!   --assert 'volatile 0x50000000+4'
+//!   --assert 'bytes 0x43d0c6 8bd581c21f324000'
+//!   --assert 'bytes 0x43d0c6 @notes/stage1.bin'
 //!   --assert @notes/overrides.kuna
 //! ```
 //!
@@ -296,6 +298,27 @@ pub(crate) fn parse_one(spec: &str) -> Result<Directive, String> {
                 Body::Volatile { addr, size }
             }
         }
+        "bytes" => {
+            let (addr, payload) = take_token(rest);
+            let addr = parse_vma(addr).ok_or_else(|| bad("bytes needs a hex <addr>"))?;
+            let (payload, tail) = take_token(payload);
+            if payload.is_empty() {
+                return Err(bad("bytes needs <addr> then hex, or @FILE of raw bytes"));
+            }
+            if !tail.is_empty() {
+                return Err(bad("bytes takes exactly <addr> <hex|@FILE>"));
+            }
+            let data = match payload.strip_prefix('@') {
+                Some(path) => std::fs::read(path)
+                    .map_err(|e| format!("--assert {raw:?}: {path}: {e}"))?,
+                None => kuna_console::assertions::parse_hex_bytes(payload)
+                    .map_err(|e| bad(&e))?,
+            };
+            if data.is_empty() {
+                return Err(bad("bytes needs at least one byte"));
+            }
+            Body::Bytes { addr, data }
+        }
         "flow" => {
             let (addr, kind) = take_token(rest);
             let (func, addr) = split_qualifier(addr);
@@ -318,7 +341,7 @@ pub(crate) fn parse_one(spec: &str) -> Result<Directive, String> {
             return Err(format!(
                 "--assert {raw:?}: unknown directive {other:?} (want one of \
                  function, typedef, prototype, data, param, return, comment, flow, name, \
-                 type, readonly, volatile)"
+                 type, readonly, volatile, bytes)"
             ))
         }
     };
@@ -398,6 +421,10 @@ pub(crate) fn console_form(
             Some(f) => return Err(unbindable(&f)),
             None => (Slot::Function, format!("override flow {addr:#x} {kind}")),
         },
+        Body::Bytes { addr, data } => {
+            let hex: String = data.iter().map(|b| format!("{b:02x}")).collect();
+            (Slot::Image, format!("override bytes {addr:#x} {hex}"))
+        }
         Body::Readonly { addr, size } => (Slot::Image, format!("readonly {addr:#x} {size}")),
         Body::Volatile { addr, size } => (Slot::Image, format!("volatile {addr:#x} {size}")),
         Body::Name { func, symbol, newname } => match names_another(func, target) {
@@ -686,6 +713,49 @@ mod tests {
     /// this the qualifier was dropped and `param callee::0 ECX char *maze`
     /// retyped the CALLER
     /// (`docs/re-needs/qualified-parameter-assertions-modify.md`).
+    #[test]
+    fn bytes_takes_an_address_and_hex_or_a_file() {
+        assert_eq!(
+            one("bytes 0x43d0c6 8bd581c21f324000").body,
+            Body::Bytes { addr: 0x43d0c6, data: vec![0x8b, 0xd5, 0x81, 0xc2, 0x1f, 0x32, 0x40, 0x00] }
+        );
+        // The address takes the `--define-function` spellings and the payload an
+        // optional 0x, so a copied dump line parses without re-editing.
+        assert_eq!(
+            one("bytes 43d0c6 0x8bd581c2").body,
+            one("bytes 0x43d0c6 8bd581c2").body
+        );
+        let dir = std::env::temp_dir().join(format!("kuna-assertbytes-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let path = dir.join("stage1.bin");
+        std::fs::write(&path, [0xb8u8, 0x2a, 0x00, 0x00, 0x00, 0xc3]).expect("write");
+        assert_eq!(
+            one(&format!("bytes 0x43d0c6 @{}", path.display())).body,
+            Body::Bytes { addr: 0x43d0c6, data: vec![0xb8, 0x2a, 0x00, 0x00, 0x00, 0xc3] }
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_bytes_directive_without_usable_hex_is_rejected() {
+        for spec in [
+            "bytes 0x43d0c6",
+            "bytes 0x43d0c6 abc",
+            "bytes 0x43d0c6 zz",
+            "bytes notanaddress 90",
+            "bytes 0x43d0c6 90 90",
+        ] {
+            assert!(parse_one(spec).is_err(), "{spec:?} should be rejected");
+        }
+    }
+
+    #[test]
+    fn bytes_lowers_to_the_console_overlay_in_the_image_slot() {
+        let form = console_form(&one("bytes 0x43d0c6 8BD5"), None).expect("lowers");
+        assert_eq!(form.slot, Slot::Image);
+        assert_eq!(form.line, "override bytes 0x43d0c6 8bd5");
+    }
+
     #[test]
     fn a_qualified_param_lowers_against_the_function_it_names() {
         let d = one("param sub_401c50::0 ECX char *maze");

--- a/decompiler/crates/kuna-cli/src/decompile.rs
+++ b/decompiler/crates/kuna-cli/src/decompile.rs
@@ -1503,9 +1503,11 @@ fn usage() {
          \n\
          --assert <directive | @file> (repeatable) states a fact the engine could not\n\
          derive.  The vocabulary is function, typedef, prototype, data, param, return,\n\
-         name, type, comment, flow, readonly, volatile -- for instance\n\
+         name, type, comment, flow, readonly, volatile, bytes -- for instance\n\
          `prototype login int login(char *user,char *pw)`, `type v2 char[16]`,\n\
          `name v2 credbuf`, `readonly 0x404028+8`, `flow 0x1405 return`.\n\
+         `bytes <addr> <hex|@FILE>` overlays recovered plaintext -- what a packer\n\
+         writes over itself -- onto the loaded image; the file on disk is untouched.\n\
          @FILE holds one per line with `#` comments, which is what makes an override\n\
          durable across invocations.  A directive the engine declines is reported and\n\
          the run still succeeds; --assert-strict makes it exit 1 instead.\n\

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -137,8 +137,9 @@ pub(crate) struct Args {
     /// flag can be non-empty.
     pub(crate) func_decls: Vec<crate::funcdecl::FuncDecl>,
     /// `--assert <directive> | @FILE` (repeatable): the caller-supplied
-    /// assertions, installed by [`load_program`] right after the analysis commit
-    /// and dispatched by the decompile loop (`kuna_console::assertions`). Empty
+    /// assertions, installed by [`load_program`] before the analysis commit for
+    /// the image-scoped `bytes` and right after it for the program-scoped rest,
+    /// then dispatched by the decompile loop (`kuna_console::assertions`). Empty
     /// for every invocation that passed none.
     pub(crate) assertions: Vec<kuna_console::assertions::Directive>,
     /// `--assert-strict`: a rejected directive makes the run exit non-zero
@@ -1538,6 +1539,15 @@ pub(crate) fn load_program(
     // BEFORE the gated analysis commit (the `option` < `read symbols` ordering
     // the script path enforces), so a per-pass gate takes effect.
     apply_runtime_options(&mut prog, &args.options)?;
+    // (kuna `--assert bytes`) The IMAGE-scoped directives, before the commit and
+    // before any read of the addresses they name: a byte overlay states what the
+    // running program put there, and every later decode has to see it. The
+    // console script surface emits `override bytes` in the same slot, ahead of
+    // `read symbols`.
+    if !args.assertions.is_empty() {
+        prog.set_assertions(args.assertions.clone());
+        kuna_console::assertions::apply_image_scoped(&mut prog);
+    }
     prog.commit_pending_analysis()
         .map_err(|e| format!("read symbols (analysis commit) failed: {}", e.explain()))?;
     // AFTER the commit: a caller-declared boundary is an assertion that outranks
@@ -1548,7 +1558,6 @@ pub(crate) fn load_program(
     // directives take effect here; the function- and symbol-scoped ones are
     // dispatched by the decompile loop (`kuna_console::assertions`).
     if !args.assertions.is_empty() {
-        prog.set_assertions(args.assertions.clone());
         kuna_console::assertions::apply_program_scoped(&mut prog);
     }
     Ok(prog)

--- a/decompiler/crates/kuna-console/src/assertions.rs
+++ b/decompiler/crates/kuna-console/src/assertions.rs
@@ -28,6 +28,7 @@
 //!   function <start>[-<end>][=<name>]      function bounds      P1  (= --define-function)
 //!   readonly <addr>+<size>                 readonly             P1 code-data-partition
 //!   volatile <addr>+<size>                 volatile             P1 code-data-partition
+//!   bytes <addr> <hex|@file>               override bytes       P1 code-data-partition
 //! ```
 //!
 //! [`Directive`] is the parsed form; the CLI's `assertdecl` module owns the text
@@ -40,12 +41,17 @@
 //!
 //! The ordering is not cosmetic; it is what makes the plane work at all.
 //!
-//! * **Image-scoped** (`readonly`, `volatile`) paints a boolean property over a
-//!   memory range.  A range property has to be stated BEFORE the symbols over it
-//!   are mapped, because `Scope::addMap` folds the property into each
-//!   `SymbolEntry` as it maps it (`database.cc:1156-1158`) and never looks at
-//!   the range again; the generated console script therefore emits these before
-//!   `read symbols`, and the in-process surface — where the loader's symbols are
+//! * **Image-scoped** (`bytes`, `readonly`, `volatile`) states what memory holds
+//!   before anything reads it.  `bytes` overlays the caller's own bytes onto the
+//!   loaded image and so must land before the analysis commit — the plaintext a
+//!   packer writes over itself is the input to every later decode, and a lifter
+//!   that has already read the ciphertext will not read it again.  `readonly`
+//!   and `volatile` paint a boolean property over a memory range, which has to
+//!   be stated BEFORE the symbols over it are mapped, because `Scope::addMap`
+//!   folds the property into each `SymbolEntry` as it maps it
+//!   (`database.cc:1156-1158`) and never looks at the range again; the generated
+//!   console script therefore emits these before `read symbols`, and the
+//!   in-process surface — where the loader's symbols are
 //!   already mapped by the time a caller can say anything — re-applies the
 //!   property to the symbols the range covers.
 //! * **Program-scoped** (`function`, `typedef`, `prototype`, `data`) is applied
@@ -123,6 +129,9 @@ pub enum Body {
     /// `volatile <addr>+<size>` — device memory: every access is a real access
     /// and two reads of one address are two reads.
     Volatile { addr: u64, size: int4 },
+    /// `bytes <addr> <hex|@file>` — the bytes mapped at this address are these,
+    /// whatever the file holds.  The plaintext a packer writes over itself.
+    Bytes { addr: u64, data: Vec<u8> },
 }
 
 /// What became of one directive.  `status` is `applied` or `rejected`; a
@@ -163,6 +172,7 @@ impl Body {
             Body::Type { .. } => ("type", "P5", "type-propagation"),
             Body::Readonly { .. } => ("readonly", "P1", "code-data-partition"),
             Body::Volatile { .. } => ("volatile", "P1", "code-data-partition"),
+            Body::Bytes { .. } => ("bytes", "P1", "code-data-partition"),
         }
     }
 
@@ -298,6 +308,66 @@ fn parse_storage(prog: &ConsoleProgram, tok: &str) -> Result<Address, String> {
     crate::ifacedecomp::parse_machaddr(prog, &mut s, false).map(|(addr, _size)| addr)
 }
 
+/// Parse a `bytes` directive's payload: one unbroken, even-length run of hex
+/// digits, optionally `0x`-prefixed.
+///
+/// One grammar for both surfaces — the `--assert` flag and the console's
+/// `override bytes` — so a directive means the same thing however it arrives.
+pub fn parse_hex_bytes(tok: &str) -> Result<Vec<u8>, String> {
+    let digits = tok.strip_prefix("0x").or_else(|| tok.strip_prefix("0X")).unwrap_or(tok);
+    if digits.is_empty() {
+        return Err("bytes needs at least one byte of hex".into());
+    }
+    if !digits.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(format!("{tok:?} is not hex"));
+    }
+    if digits.len() % 2 != 0 {
+        return Err(format!("{tok:?} has an odd number of hex digits"));
+    }
+    (0..digits.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&digits[i..i + 2], 16).map_err(|e| e.to_string()))
+        .collect()
+}
+
+/// Apply the image-scoped directives (today only `bytes`) and record an
+/// [`Outcome`] for each.
+///
+/// Called BEFORE the analysis commit, which is the only ordering that can work:
+/// the bytes a caller states are the input to every later read of that address,
+/// and nothing re-reads an address it has already decoded.  The
+/// `readonly`/`volatile` precedent is the same constraint inverted — a range
+/// property stated after the symbols over it are mapped is silently inert.
+pub fn apply_image_scoped(prog: &mut ConsoleProgram) {
+    let directives = prog.assertions().to_vec();
+    for (i, directive) in directives.iter().enumerate() {
+        let Body::Bytes { addr, data } = &directive.body else {
+            continue;
+        };
+        let outcome = match overlay_bytes(prog, *addr, data) {
+            Ok(()) => directive.applied(),
+            Err(detail) => directive.rejected(detail),
+        };
+        prog.set_assertion_outcome(i, outcome);
+    }
+}
+
+/// `bytes` — the in-process twin of the console's `override bytes`: hand the
+/// caller's plaintext to the loader, which serves it to every later read of
+/// those addresses.
+///
+/// Nothing is written to the file on disk.  The statement is about what is in
+/// RAM at that address once the program has run itself far enough to put it
+/// there, which is exactly the fact a static loader cannot derive.
+fn overlay_bytes(prog: &mut ConsoleProgram, vma: u64, data: &[u8]) -> Result<(), String> {
+    let addr = data_addr(prog, vma)?;
+    let loader_rc = prog.arch().translate().loader_rc();
+    let mut loader = loader_rc
+        .try_borrow_mut()
+        .map_err(|_| "the load image is already borrowed".to_string())?;
+    loader.kuna_overlay_bytes(&addr, data).map_err(|e| e.explain().to_string())
+}
+
 /// Apply the program-scoped directives (`function`, `typedef`, `prototype`,
 /// `data`) and record an [`Outcome`] for each.
 ///
@@ -320,6 +390,11 @@ pub fn apply_program_scoped(prog: &mut ConsoleProgram) {
                 Err(detail) => directive.rejected(detail),
             };
             prog.set_assertion_outcome(i, outcome);
+            continue;
+        }
+        // Image-scoped: already applied (and reported) by `apply_image_scoped`,
+        // which had to run before the commit this function follows.
+        if matches!(directive.body, Body::Bytes { .. }) {
             continue;
         }
         if directive.body.is_function_scoped() {

--- a/decompiler/crates/kuna-console/src/ifacedecomp.rs
+++ b/decompiler/crates/kuna-console/src/ifacedecomp.rs
@@ -3824,6 +3824,55 @@ decomp_command!(
     }
 );
 
+// --- byte overlay (kuna) ---------------------------------------------------
+
+decomp_command!(
+    /// (kuna) `override bytes <addr> <hex>`: the bytes mapped at `<addr>` are
+    /// `<hex>`, whatever the image file holds there.  Not a C++ command, so it is
+    /// registered by [`crate::kuna_console::register_kuna_commands`] rather than
+    /// here — `CPP_REGISTER_ORDER` is a transcription of upstream's own list.
+    ///
+    /// The statement a static loader cannot derive.  A stage-1 unpacker's output
+    /// exists only once that stage has run, so an agent that has recovered the
+    /// plaintext otherwise has to patch a copy of the executable outside kuna and
+    /// re-load it (`docs/re-needs/byte-overlay-assertion-recovered.md`).  The
+    /// overlay lives in the load image, so nothing is written to disk, and it
+    /// must be stated before `read symbols` — every later read of those addresses
+    /// serves it, and no read is taken twice.
+    IfcOverrideBytes,
+    fn execute(&self, status: &mut IfaceStatus, s: &mut CommandStream) -> IfaceResult<()> {
+        {
+            let dcp = dcp_mut(status)?;
+            if dcp.conf.is_none() {
+                return Err(IfaceError::execution("No load image present"));
+            }
+        }
+        let dcp = dcp_mut(status)?;
+        let prog = dcp.conf.as_mut().expect("conf checked non-None above");
+        let (addr, _size) = parse_machaddr(prog, s, false).map_err(IfaceError::parse)?;
+        s.skip_ws();
+        if s.eof() {
+            return Err(IfaceError::parse("Missing bytes"));
+        }
+        let data = crate::assertions::parse_hex_bytes(&s.read_token())
+            .map_err(IfaceError::parse)?;
+        let loader_rc = prog.arch().translate().loader_rc();
+        {
+            let mut loader = loader_rc
+                .try_borrow_mut()
+                .map_err(|_| IfaceError::execution("The load image is already borrowed"))?;
+            loader
+                .kuna_overlay_bytes(&addr, &data)
+                .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
+        }
+        let mut line = format!("Successfully overlaid {} bytes at ", data.len());
+        addr.print_raw(&mut line).map_err(|e| IfaceError::execution(e.explain().to_string()))?;
+        line.push('\n');
+        status.out(&line);
+        Ok(())
+    }
+);
+
 // --- volatile / readonly (ifacedecomp.cc) ----------------------------------
 
 decomp_command!(

--- a/decompiler/crates/kuna-console/src/kuna_console.rs
+++ b/decompiler/crates/kuna-console/src/kuna_console.rs
@@ -1437,6 +1437,12 @@ pub fn register_kuna_commands(status: &mut IfaceStatus) {
     // the name in the declaration, which is the wrong key for an override that
     // exists because the function has no name worth keeping.
     status.register_com(Box::new(IfcKunaMapPrototype), &["map", "prototype"]);
+    // (kuna) Nor is this one: the bytes a packer writes over itself exist only
+    // once it has run, so there is no image a loader could read them from.
+    status.register_com(
+        Box::new(crate::ifacedecomp::IfcOverrideBytes),
+        &["override", "bytes"],
+    );
 }
 
 /// Join tokens with single spaces — C++ `joinTokens(tokens,0,tokens.size())`.

--- a/decompiler/crates/kuna-console/src/kuna_console/tests.rs
+++ b/decompiler/crates/kuna-console/src/kuna_console/tests.rs
@@ -60,19 +60,19 @@ fn run_one(line: &str) -> String {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn registers_all_nineteen_kuna_commands() {
+fn registers_all_twenty_kuna_commands() {
     // register_decomp_commands registers 105 (see ifacedecomp/tests.rs); the
-    // kuna capability adds 19: phase list/map/status/catalog (plus the four
+    // kuna capability adds 20: phase list/map/status/catalog (plus the four
     // deprecated `stage ...` alias registrations), kassert, restarts,
     // pipeline, mode, quality, functions, region tree/blocks/walk,
-    // `function bounds` and `map prototype`.
+    // `function bounds`, `map prototype` and `override bytes`.
     let only_kuna = {
         let mut st = ConsoleCommands::into_status(vec![]);
         register_kuna_commands(&mut st);
         st.num_commands()
     };
-    assert_eq!(only_kuna, 19);
-    assert_eq!(console(&[]).num_commands(), 105 + 19);
+    assert_eq!(only_kuna, 20);
+    assert_eq!(console(&[]).num_commands(), 105 + 20);
 }
 
 #[test]

--- a/decompiler/crates/kuna-console/tests/verify_byteoverlay.rs
+++ b/decompiler/crates/kuna-console/tests/verify_byteoverlay.rs
@@ -1,0 +1,163 @@
+//! `--assert bytes` end-to-end — `docs/re-needs/byte-overlay-assertion-recovered.md`.
+//!
+//! A packer's plaintext exists only after the packer has run, so it is a fact no
+//! loader can derive and the only one an agent working a self-modifying binary
+//! actually has. Before this directive there was no way to hand it back: the
+//! recorded workaround was applying the recovered transform in Python and
+//! re-loading a patched copy of the executable.
+//!
+//! Every case here asserts the **emitted C changed**, which is the bar this
+//! family is held to — `override prototype` has printed "Successfully added
+//! override" and changed nothing since it was ported.
+//!
+//! Fixture: `kuna-analysis/tests/fixtures/assertranges_x86_64` (shared with
+//! `verify_assertranges`), whose `sample` computes `scale * a0 + bias +
+//! dat_50000000 * 2`. Overlaying `b8 2a 00 00 00 c3` on its entry is
+//! `mov eax,0x2a; ret`, so a directive that reached the lifter is visible in one
+//! line of C and one that did not is equally visible.
+//!
+//! ## `.sla` precondition
+//!
+//! Bootstrapping needs the built x86 `.sla` under `specs/` (gitignored; `make
+//! specs`). When it is absent the bootstrap fails; the test prints that and
+//! returns early (a specs-less CI is a visible skip, never a false green).
+
+use std::path::PathBuf;
+
+use kuna_console::assertions::{self, Body, Directive, Outcome};
+use kuna_console::engine::{bootstrap_from_object, ConsoleProgram, EntrySelector};
+use kuna_console::project::decompile_targets;
+
+/// `sample`'s entry in the fixture.
+const SAMPLE: u64 = 0x401140;
+/// `mov eax,0x2a; ret`.
+const RETURN_42: [u8; 6] = [0xb8, 0x2a, 0x00, 0x00, 0x00, 0xc3];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+}
+
+/// Bootstrap the fixture, WITHOUT the analysis commit: a byte overlay has to be
+/// stated before it, which is the ordering under test.
+fn load() -> Option<ConsoleProgram> {
+    let root = repo_root();
+    let spec_roots = vec![root.join("specs").to_str().unwrap().to_string()];
+    let bin = root.join("decompiler/crates/kuna-analysis/tests/fixtures/assertranges_x86_64");
+    match bootstrap_from_object(bin.to_str()?, "", &spec_roots) {
+        Ok(p) => Some(p),
+        Err(e) => {
+            eprintln!(
+                "verify_byteoverlay: skipping (bootstrap failed, build `.sla` with \
+                 `make specs`): {}",
+                e.explain()
+            );
+            None
+        }
+    }
+}
+
+fn bytes(addr: u64, data: &[u8]) -> Directive {
+    let hex: String = data.iter().map(|b| format!("{b:02x}")).collect();
+    Directive {
+        raw: format!("bytes {addr:#x} {hex}"),
+        body: Body::Bytes { addr, data: data.to_vec() },
+    }
+}
+
+/// Decompile `target` under `directives`, in the order the CLI's in-process
+/// surface applies them (`decompile_all::load_program`): image-scoped before the
+/// analysis commit, program-scoped after it.
+fn decompile_with(target: &str, directives: Vec<Directive>) -> Option<(String, Vec<Outcome>)> {
+    let mut prog = load()?;
+    if !directives.is_empty() {
+        prog.set_assertions(directives);
+        assertions::apply_image_scoped(&mut prog);
+    }
+    prog.commit_pending_analysis().expect("analysis commit");
+    assertions::apply_program_scoped(&mut prog);
+    let entry = prog
+        .resolve_entry(&EntrySelector::Name(target.to_string()))
+        .expect("the fixture has this function");
+    let funcs = decompile_targets(&mut prog, vec![entry], false, false, false);
+    let code = funcs[0].code.clone().unwrap_or_default();
+    Some((code, prog.assertion_outcomes()))
+}
+
+/// The un-asserted baseline the case below is measured against.
+#[test]
+fn the_baseline_computes_from_the_image_bytes() {
+    let Some((code, report)) = decompile_with("sample", Vec::new()) else { return };
+    assert!(report.is_empty(), "no directives ⇒ no report rows");
+    assert!(code.contains("scale"), "baseline lost the .data load:\n{code}");
+    assert!(!code.contains("0x2a"), "baseline already returns the overlay:\n{code}");
+}
+
+/// The headline: stated bytes are what gets lifted.
+#[test]
+fn an_overlay_is_what_the_lifter_decodes() {
+    let Some((code, report)) = decompile_with("sample", vec![bytes(SAMPLE, &RETURN_42)]) else {
+        return;
+    };
+    assert_eq!(report[0].status, "applied", "{report:?}");
+    assert_eq!(report[0].kind, "bytes");
+    assert!(code.contains("return 0x2a"), "the overlay never reached the lifter:\n{code}");
+    assert!(!code.contains("scale"), "the image bytes were lifted anyway:\n{code}");
+}
+
+/// An address no segment maps is REJECTED, with the span in the detail. A
+/// directive that is accepted and does nothing is worse than an error — and for
+/// this one it would be a decompilation of a program the caller never described.
+#[test]
+fn an_unmapped_overlay_is_rejected_naming_the_span() {
+    let Some((code, report)) = decompile_with("sample", vec![bytes(0x9000_0000, &RETURN_42)])
+    else {
+        return;
+    };
+    assert_eq!(report[0].status, "rejected", "{report:?}");
+    let detail = report[0].detail.clone().unwrap_or_default();
+    assert!(detail.contains("no loaded segment maps 0x90000000"), "detail: {detail:?}");
+    assert!(code.contains("scale"), "a rejected overlay still changed the C:\n{code}");
+}
+
+/// The console spelling of the same fact, from the generated script surface.
+#[test]
+fn the_console_command_overlays_and_says_so() {
+    let Some(out) = drive_console(&["override bytes 0x401140 b82a000000c3"]) else { return };
+    assert!(out.contains("Successfully overlaid 6 bytes at"), "out: {out:?}");
+
+    let Some(out) = drive_console(&["override bytes 0x401140 abc"]) else { return };
+    assert!(out.contains("odd number of hex digits"), "out: {out:?}");
+
+    let Some(out) = drive_console(&["override bytes 0x90000000 90"]) else { return };
+    assert!(out.contains("no loaded segment maps"), "out: {out:?}");
+}
+
+/// Drive `commands` through a console wired like the datatest runner, with the
+/// fixture installed as the current program.  `None` ⇒ specs-less skip.
+fn drive_console(commands: &[&str]) -> Option<String> {
+    use kuna_console::ifacedecomp::{
+        execute, register_decomp_commands, IfaceDecompData, DECOMPILE_MODULE,
+    };
+    use kuna_console::ifaceterm::ConsoleCommands;
+    use kuna_console::kuna_console::register_kuna_commands;
+
+    let program = load()?;
+    let cmds: Vec<String> = commands.iter().map(|s| s.to_string()).collect();
+    let count = cmds.len();
+    let mut status = ConsoleCommands::into_status(cmds);
+    register_decomp_commands(&mut status);
+    // `override bytes` is a kuna command, not an upstream one.
+    register_kuna_commands(&mut status);
+    {
+        let data = status.get_data_mut(DECOMPILE_MODULE).expect("decompile module data");
+        let dcp = data
+            .as_any_mut()
+            .downcast_mut::<IfaceDecompData>()
+            .expect("decompile module data is IfaceDecompData");
+        dcp.conf = Some(program);
+    }
+    for _ in 0..count {
+        execute(&mut status);
+    }
+    Some(status.optr.clone())
+}

--- a/decompiler/crates/kuna-sleigh/src/loadimage.rs
+++ b/decompiler/crates/kuna-sleigh/src/loadimage.rs
@@ -180,6 +180,22 @@ pub trait LoadImage {
         false
     }
 
+    /// (kuna) Replace the mapped bytes at `addr` with `data` — the caller
+    /// states that the image content there is not what the file holds.
+    ///
+    /// The one fact a static loader cannot derive.  Code a stage-1 unpacker
+    /// writes over itself exists only after that stage has run, so an agent that
+    /// has recovered the plaintext has no way to hand it back: the recorded
+    /// workaround was Python and a patched copy of the executable
+    /// (`docs/re-needs/byte-overlay-assertion-recovered.md`).  The overlay is a
+    /// statement about RAM, not about the file, so nothing is written to disk.
+    ///
+    /// A loader that cannot take one says so rather than accepting it silently.
+    fn kuna_overlay_bytes(&mut self, addr: &Address, data: &[u8]) -> KunaResult<()> {
+        let _ = (addr, data);
+        Err(KunaError::lowlevel("this load image does not support byte overlays"))
+    }
+
     /// (kuna) The mapped **load segments** as `(vma, size, flags)`, `flags` per
     /// [`section_flags`] — the coarser mapping unit underneath the section
     /// table.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -292,6 +292,7 @@ One directive per `--assert`, keyed by intent rather than by phase:
 | `function <start>[-<end>][=<name>]` | the `--define-function` spelling, on this plane |
 | `readonly <addr>+<size>` | the bytes in this range never change at run time |
 | `volatile <addr>+<size>` | device memory: every access is a real access |
+| `bytes <addr> <hex\|@FILE>` | the bytes mapped here are these, whatever the file holds |
 
 Storage is a register name (`RDI`), the console's `%RDI`, or its address grammar
 (`[stack,-0x18,8]`). Addresses are hexadecimal with or without `0x`. A size is
@@ -435,6 +436,34 @@ Asserting a `readonly` range turns read-only propagation on for the run, because
 painting a range read-only and then not folding it would be a directive that is
 accepted and does nothing. It is applied *before* your own `--option`s, so an
 explicit `--option readonly off` still wins.
+
+**`bytes` is for code that does not exist in the file.** A packer's plaintext
+appears only once the packer has run, so nothing a loader can read will ever
+contain it; without this directive the recovered layer had to be written back
+into a *copy* of the executable with an external script, and every later run
+started from that copy instead of from the original plus a statement.
+
+```bash
+# `decrypt_stage1` rewrites the 2967 bytes above itself. Hand the recovered
+# plaintext back at the addresses it belongs to and the next layer decompiles.
+kuna decompile ./crackme.exe 0x43d0c6 --addr --assert 'bytes 0x43d0c6 @notes/stage1.bin'
+#   - void sub_43d0c6(void) { return; }        // the ciphertext decodes to nothing
+#   + *(int *)(v2 + 0x403393) = v2 + 0x40294c; // the stage-2 body
+```
+
+The payload is one unbroken run of hex digits (an optional `0x` is allowed), or
+`@FILE` for raw bytes — which is what makes a whole recovered layer a single
+directive. The overlay lives in the load image, so **the file on disk is never
+touched**, and `--assert @overrides.kuna` beside a `function <start>-<end>=<name>`
+line for each recovered function is the durable form: state the bytes and the
+boundaries once, replay them on every run.
+
+The statement must land before anything reads those addresses, so it is applied
+ahead of the analysis commit. Two consequences worth knowing: an address no
+loaded segment maps is *rejected*, naming the span, rather than invented; and
+function discovery has already run on the file image, so functions inside a
+recovered layer are yours to declare (`function`/`--define-function`) rather than
+kuna's to find.
 
 **`flow` is the structuring lever**, and the one directive that changes which
 bytes are even *in* the function. kuna decides at P2 whether an instruction

--- a/docs/features/byte-overlay-assertion-recovered/pr_body.md
+++ b/docs/features/byte-overlay-assertion-recovered/pr_body.md
@@ -1,0 +1,67 @@
+## The problem
+
+kuna had no way to be told what a self-modifying program writes over itself. A
+stage-1 unpacker's plaintext exists only once that stage has run, so no loader
+can read it — and the assertion vocabulary had no directive for it:
+
+```console
+$ kuna decompile ./crackme.exe 0x43d060 --addr \
+    --define-function '0x43d060-0x43d0c6=decrypt_stage1' \
+    --assert 'bytes 0x43d0c6 8bd581c21f324000' --assert-strict --json
+error: --assert "bytes 0x43d0c6 8bd581c21f324000": unknown directive "bytes" (want one of function, typedef, prototype, data, param, return, comment, flow, name, type, readonly, volatile)
+$ echo $?
+2
+```
+
+`decrypt_stage1` rewrites the 2967 bytes above itself. Reported once (major):
+recovering that layer took Python and a patched copy of the executable, and every
+later run started from the copy instead of from the original plus a statement.
+
+## The fix
+
+- New `--assert 'bytes <addr> <hex|@FILE>'` directive: the bytes mapped at
+  `<addr>` are these, whatever the file holds. `@FILE` takes raw bytes, so a
+  whole recovered layer is one directive. The load image is what changes —
+  **nothing is written to disk**.
+- The console spelling is `override bytes <addr> <hex>`, so the text surface
+  (which drives `decomp_dbg`) and `--json` (in-process) apply the same fact.
+- It lands in the image slot, ahead of the analysis commit / `read symbols`. That
+  ordering is forced: the stated bytes are the input to every later decode and
+  nothing re-reads an address it has already lifted. `readonly` is the same
+  constraint inverted, and gets it wrong in the other direction.
+- `LoadImage::kuna_overlay_bytes` is a defaulted trait method (loaders that
+  cannot take an overlay say so); `ObjectLoadImage` resolves the span through
+  `find_section`, so an overlay lands in exactly the segment a read at the same
+  address comes from, materialises a writable segment's zero-filled tail, and
+  **refuses** — naming the span — anything no segment maps.
+
+With it, the reported workflow is one command:
+
+```console
+$ kuna decompile ./crackme.exe 0x43d0c6 --addr --assert 'bytes 0x43d0c6 @stage1.bin'
+void sub_43d0c6(void)
+{
+  ...
+  *(unsigned int *)(v2 + 0x40321b) = sub_43d401();
+  *(int *)(v2 + 0x403393) = v2 + 0x40294c;
+  ...
+}
+```
+
+## The tests
+
+`kuna-console/tests/verify_byteoverlay.rs` (4) is the end-to-end bar: overlaying
+`b8 2a 00 00 00 c3` on `assertranges_x86_64`'s `sample` must turn
+`return scale * a0 + bias + …` into `return 0x2a`, an unmapped address must be
+rejected naming the span, and the console command must say what it did. Plus two
+loader cases in `kuna-analysis` (a warm read window is dropped; a `p_memsz` tail
+is materialised, past it is not) and three parser cases in `kuna-cli`. The
+promoted probe `tests/cli/byte-overlay-assertion-recovered.json` asserts the
+`return 0x2a`, so it fails both if the directive is rejected and if it is
+accepted and inert.
+
+Gates: `make test` PARITY OK 675/675 · `make test-stages` PARITY OK 721/721 ·
+`make rust-test` 6,271 passed / 0 failed · `make check-spec` OK · `make test-cli` 106/106 ·
+`kuna catalog --check` OK. Acceptance probe `a-09471914203f` PASS on the witness.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/byte-overlay-assertion-recovered/record.json
+++ b/docs/features/byte-overlay-assertion-recovered/record.json
@@ -1,0 +1,91 @@
+{
+  "slug": "byte-overlay-assertion-recovered",
+  "need_id": "byte-overlay-assertion-recovered",
+  "track": "tooling",
+  "scope": "small",
+  "round": 12,
+  "branch": "feat/re-byte-overlay-assertion-recovered",
+  "probe_id": "p-a0a4c1957f1e",
+  "acceptance_id": "a-09471914203f",
+  "instances": 1,
+  "summary": "New `--assert 'bytes <addr> <hex|@FILE>'` directive: the bytes mapped at an address are the caller's, whatever the image file holds. Applied to the load image ahead of the analysis commit (console spelling `override bytes`, image slot before `read symbols`), so every later decode sees them and the file on disk is untouched. Closes the recorded workaround of applying a recovered transform in Python to a patched copy of the executable.",
+  "decisions": [
+    {
+      "what": "no hypothesis was filed and the refuter's coverage check is confirmed",
+      "detail": "The need offers no diagnosis; the round-12 refutation asked the load-bearing question for a missing-capability need -- does the capability exist under another spelling -- and came back clean. Re-confirmed here rather than assumed: `register_decomp_commands` had 105 commands and none of them wrote image bytes, `--assert data` declares a TYPE at an address rather than content, and `--raw-image` sets a load base for a headerless image rather than overlaying an already-mapped PE. This is a genuinely new directive."
+    },
+    {
+      "what": "the ordering hazard the refuter flagged is real, and it decided where the code goes",
+      "detail": "An overlay applied after the image is read is inert, exactly as `readonly` is inert when painted after the symbols it covers are mapped. So `load_program` installs the assertions and runs a new `assertions::apply_image_scoped` BEFORE `commit_pending_analysis`, and `build_script` emits `override bytes` in the existing image slot before `read symbols`. `apply_program_scoped` now skips `Body::Bytes` so the outcome recorded pre-commit survives. Measured, not argued: overlaying `b8 2a 00 00 00 c3` on the fixture's `sample` turns `return scale * a0 + bias + dat_50000000 * 2` into `return 0x2a` on BOTH surfaces."
+    },
+    {
+      "what": "patch the loader's segments, not the file and not a decode cache",
+      "detail": "`LoadImage::kuna_overlay_bytes` is a new defaulted trait method (every other implementor answers `does not support byte overlays`), implemented by `ObjectLoadImage::overlay_span`. It resolves the span through `find_section`, which is the same resolution `fill_span` reads through, so an overlay can never land in a different segment than a read at the same address; it then invalidates the 512-byte read window (`bufoffset = !0`), without which an overlay would be invisible to exactly the reads most likely to follow one. That case is a test, not a comment."
+    },
+    {
+      "what": "an unmapped span is REJECTED, not synthesized",
+      "detail": "A read at an address past a segment's mapped extent zero-fills; the overlay refuses instead, naming the span (`no loaded segment maps 0x90000000-0x90000001`). The asymmetry is deliberate -- inventing backing store would decompile a program the caller never described, and a directive accepted that does nothing is worse than an error. A WRITABLE segment's zero-filled RAM tail is inside `mapped_size()` and IS materialised, because that region is real mapped memory and what the running program left there is precisely what a caller is stating."
+    },
+    {
+      "what": "`@FILE` for the payload, because the reported case is 2967 bytes",
+      "detail": "Inline hex is one unbroken run of digits with an optional `0x`; `@FILE` reads raw bytes. The CLI resolves `@FILE` at parse time so `Body::Bytes` always carries real bytes and both surfaces mean the same thing; the console line it lowers to carries the hex, which was measured working at 5934 characters (the full recovered layer of the witness). Durability is the `--assert @overrides.kuna` contract that already exists: state the bytes and the `function <start>-<end>=<name>` boundaries once, replay on every run.",
+      "limit": "The loader's analysis passes have already run over the file image by the time a caller can say anything, so function discovery does not see a recovered layer. Documented in docs/cli.md and docs/spec/00-overview.md rather than papered over; declaring the recovered functions is what the `function` directive is for, and it is what the witness needs anyway."
+    },
+    {
+      "what": "no option, no phases.toml row, no stages XML, no catalog counter, no DIV row",
+      "detail": "A new assertion directive plus its console command cannot change emitted C for a run that does not pass it -- the code added to a decompiling path is one `matches!` skip in `apply_program_scoped` and one `set_assertions` moved earlier (verified inert: `commit_pending_analysis` never reads `prog.assertions()`). Matches the CLI-tier repipe PRs merged this round. The one hard-coded counter this DOES bump is the KUNA console command count, `kuna_console/tests.rs (registers_all_twenty_kuna_commands)` 19 -> 20. `override bytes` is registered by `register_kuna_commands`, NOT by `register_decomp_commands`: the latter's two count tests are pinned against `CPP_REGISTER_ORDER`, a positional transcription of upstream's own registration list, and a kuna-only command inside it would corrupt what that list means. Registering it in the wrong place is what the workspace suite caught."
+    }
+  ],
+  "inertness": {
+    "method": "The only edits on a path a plain decompile takes are `decompile_all.rs (load_program)` -- `set_assertions` moved ahead of the commit and guarded by `!args.assertions.is_empty()` -- and one `Body::Bytes` skip arm in `apply_program_scoped`. Everything else is new code reachable only from the new directive: a defaulted trait method, `overlay_span`, one console command, one parse arm, one lowering arm.",
+    "note": "Confirmed by the two byte-parity oracles: make test 675/675 PARITY OK and make test-stages 721/721 PARITY OK, plus make test-cli 106/106 (105 previously-promoted probes, many asserting exact output text)."
+  },
+  "sweep": {
+    "question": "does the new command shadow an existing console spelling, and does an overlay leak into a run that did not ask for one?",
+    "method": "(1) the datatest and stages corpora, which drive the console by prefix-expanded command streams, run in full; (2) the same fixture decompiled with and without the directive on both surfaces; (3) the error paths -- unmapped address, span straddling the end of the only segment, odd hex, non-hex, missing payload, missing @FILE, wrong address space -- on both surfaces and in-crate.",
+    "result": "No shadowing: `override bytes` is a two-token command in a family (`override prototype|jumptable|flow`) with no other `b`-initial member, and both corpora are byte-parity. No leak: without the directive the emitted C is what it was, and a REJECTED directive leaves it there too (`an_unmapped_overlay_is_rejected_naming_the_span` asserts the baseline C survives). A rejection is `fatal: false`, so it is a warning row unless `--assert-strict`, which is the contract every other directive has."
+  },
+  "gates": {
+    "make test": "PARITY OK, 675/675 assertions",
+    "make test-stages": "PARITY OK, 721/721 assertions",
+    "make rust-test": "6,271 passed / 0 failed / 38 ignored, 381 result blocks (run with KUNA_DECOMP_TEST unset, per the repipe-worktree oracle artifact)",
+    "make check-spec": "OK (lenient mode)",
+    "make test-cli": "106/106 with the probe promoted",
+    "kuna catalog --check": "catalog OK"
+  },
+  "acceptance": {
+    "acceptance_id": "a-09471914203f",
+    "result": "PASS",
+    "transition": "closed",
+    "promoted_to": "tests/cli/byte-overlay-assertion-recovered.json",
+    "promotion_note": "The need's acceptance arm carried NO target block at all (`ProbeError: {{BIN}} used but the context supplies no bin`, i.e. unrunnable and therefore unclosable). Bound here to the dataset witness -- corrupt.exe, sha256 bb6cd604...f00fc, matched by hash against the arena copy the tester actually ran -- so the backlog probe keeps running the image that produced the symptom; ids did not move (probe_id hashes cmd+expect only). `verify --promote` refuses `binary_source: dataset`, so `tests/cli/byte-overlay-assertion-recovered.json` is a hand-written in-repo twin on the already-vendored `kuna-analysis/tests/fixtures/assertranges_x86_64`, same command shape and clauses PLUS `stdout_matches: return 0x2a` -- the filed clauses (exit 0, JSON, no `unknown directive`) are satisfiable by a directive that parses and does nothing, and that clause is not.",
+    "reproduction_confirmed_on_main": "on b9029a8f the filed command exits 2 with `--assert \"bytes 0x43d0c6 8bd581c21f324000\": unknown directive \"bytes\"`; the same command without the directive exits 0, so the rejection is the parser and not a downstream failure."
+  },
+  "witness": {
+    "binary": "/home/mahaloz/github/kuna-re-dataset/challenges/5ab77f6633c5d40ad448cbec/bin/LoaderCrackMev2.0.zip.__x/corrupt.exe",
+    "selector": "0x43d060",
+    "note": "The tester's recovered plaintext was independently reproduced here: kuna's own decompilation of decrypt_stage1 (a 0xb97-iteration rotate/xor loop over 0x43d0c6) re-implemented in Python yields `8bd581c21f324000...` as its first eight bytes, byte-identical to the directive in the probe. `--assert 'bytes 0x43d0c6 @stage1.bin'` with the whole 2967-byte layer decompiles the next stage -- a call to sub_43d401 and fs-based SEH setup -- from the unmodified original."
+  },
+  "not_closed": [
+    "Function discovery, the string scan and the Listing all run over the FILE image inside `bootstrap_from_object`, before any caller can state anything, so a recovered layer contributes no discovered functions. Threading overlays in ahead of `run_default_analyses_per_pass` means either an env-var bridge carrying arbitrary byte payloads or re-parsing the object twice, and the passes read the raw file buffer rather than the loader, so it is a larger change than this need's scope. Declaring the recovered functions with `function`/`--define-function` is the working answer today and the witness needs a declared boundary regardless.",
+    "The overlay reaches `LoadImage::load_fill` (which is what the lifter, the emulator and jump-table recovery read through) but not readers keyed on section FILE offsets. None is on a decompiling path today; worth knowing before wiring a new one.",
+    "`kuna disassemble` takes no `--assert`, so a recovered layer cannot be listed as instructions without decompiling it. Adjacent, separately fileable.",
+    "docs/re-needs/index.json is deliberately NOT regenerated: `needs reindex` runs over the whole backlog and this worktree holds only the tracked need docs."
+  ],
+  "files": [
+    "decompiler/crates/kuna-sleigh/src/loadimage.rs",
+    "decompiler/crates/kuna-analysis/src/loadimage_object.rs",
+    "decompiler/crates/kuna-console/src/assertions.rs",
+    "decompiler/crates/kuna-console/src/ifacedecomp.rs",
+    "decompiler/crates/kuna-console/src/ifacedecomp/tests.rs",
+    "decompiler/crates/kuna-console/tests/verify_byteoverlay.rs",
+    "decompiler/crates/kuna-cli/src/assertdecl.rs",
+    "decompiler/crates/kuna-cli/src/decompile.rs",
+    "decompiler/crates/kuna-cli/src/decompile_all.rs",
+    "docs/cli.md",
+    "docs/spec/00-overview.md",
+    "docs/re-needs/byte-overlay-assertion-recovered.md",
+    "tests/cli/byte-overlay-assertion-recovered.json"
+  ],
+  "pr": "https://github.com/Noelo-Lab/kuna/pull/538"
+}

--- a/docs/re-needs/byte-overlay-assertion-recovered.md
+++ b/docs/re-needs/byte-overlay-assertion-recovered.md
@@ -1,0 +1,151 @@
+---
+need_id: byte-overlay-assertion-recovered
+title: No byte-overlay assertion for recovered self-modifying code
+track: tooling
+status: open
+severity: major
+probe_id: p-a0a4c1957f1e
+acceptance_id: a-09471914203f
+hypothesis_status: upheld
+credibility: 0.7
+instances: 1
+challenges: [5ab77f6633c5d40ad448cbec]
+rounds: [12]
+first_seen_round: 12
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-cli]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Supply recovered plaintext at original virtual addresses through durable assertions, then analyze subsequent loader stages.
+
+> **No byte-overlay assertion for recovered self-modifying code** (major, `5ab77f6633c5d40ad448cbec`)
+> The bytes directive is rejected with exit 2. Applying the recovered 2967-byte transform required Python and a copied executable. The first decrypted layer exposed further encrypted code and exception-based control flow; no serial was recovered.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x43d060",
+    "--addr",
+    "--define-function",
+    "0x43d060-0x43d0c6=decrypt_stage1",
+    "--assert",
+    "bytes 0x43d0c6 8bd581c21f324000",
+    "--assert-strict",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 2
+    },
+    "stderr_matches": [
+      "unknown directive \"bytes\""
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/LoaderCrackMev2.0.zip.__x/corrupt.exe",
+    "binary_sha256": "bb6cd6045dff9e299f60299e8dae22abb57eafd125221bb72f3d671f138f00fc",
+    "binary_size": 220798,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x43d060",
+    "--addr",
+    "--define-function",
+    "0x43d060-0x43d0c6=decrypt_stage1",
+    "--assert",
+    "bytes 0x43d0c6 8bd581c21f324000",
+    "--assert-strict",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "stderr_absent": [
+      "unknown directive"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/LoaderCrackMev2.0.zip.__x/corrupt.exe",
+    "binary_sha256": "bb6cd6045dff9e299f60299e8dae22abb57eafd125221bb72f3d671f138f00fc",
+    "binary_size": 220798,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+_none offered_
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `5ab77f6633c5d40ad448cbec` (round 12, tester t-r12-5ab77f66)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+- split by captain at T_DEDUP from round 12's `missing-capability|decompile|exit_code,stderr_absent,stdout_is_json` bucket: cluster.py's signature (kind|subcommand|clause-shape) collapsed unrelated defects, so the crop was hand-partitioned one observation per need and filed via `--from-file`. See `.kuna-repipe/rounds/12/dedup/MARKER.json`; do NOT run `cluster --round 12` bare.
+- round 12 REFUTER: hypothesis **upheld** (was inconclusive). REFUTER (round 12, captain in-tick, pre-dispatch check). VERDICT UPHELD. No hypothesis was ever filed for this need -- the section offers none -- so there was no diagnosis to overturn. I recorded upheld against the symptom rather than inconclusive, because that string IS the filed default and would read as "nobody looked".
+
+WHY THIS WAS REFUTED AT ALL, given it is effectively an absence need: for a missing-capability ask the load-bearing question is not "is the root cause right" but "does the capability already exist under another spelling", because a builder that starts here will otherwise ship a duplicate of a mechanism kuna already has. That check is the whole of this refutation and it came back clean.
+
+MEASURED ON b9029a8f, release binaries:
+
+1. The directive vocabulary is closed and does not contain bytes. From kuna decompile --help:
+       function, typedef, prototype, data, param, return,
+       name, type, comment, flow, readonly, volatile
+   The rejection is a real closed-set rejection, emitted at
+       decompiler/crates/kuna-cli/src/assertdecl.rs:319
+   as: --assert {raw}: unknown directive {other} (want one of ...). So the symptom reproduces exactly as filed and exit 2 is the parser, not a downstream failure.
+
+2. NO ADJACENT MECHANISM SUPPLIES BYTE CONTENT. I searched the whole 176-option catalog for overlay / patch / selfmod / self-mod / smc / byte content. It returned 15 apparent hits and ALL FIFTEEN ARE FALSE POSITIVES -- every one is the substring "patch" inside DISPATCH in jump-table prose (V850 jmp reg, lowered-switch cascade, CMOV dispatch, image-base-relative tables, the MSVC Duff's-device tables). There is no overlay option. DO NOT RE-RUN THAT GREP; it is answered.
+
+3. kuna docs, the whole embedded manual, has ZERO matches for patch, overlay, self-modif or --bytes.
+
+4. The nearest neighbours are not substitutes. --assert data declares a TYPE at an address, not content. --raw-image sets a load base for a headerless image; it does not overlay bytes into an already-mapped PE. The tester's recorded workaround -- Python plus a copied executable -- is exactly the evidence that no in-tool route exists.
+
+CONCLUSION FOR THE BUILDER: the gap is real and it is a genuinely new directive, not a rename or a re-exposure of existing machinery. Scope stands at small and track stands at tooling: this is CLI/assertion-parser surface (kuna-cli/src/assertdecl.rs), not a decompiler-phase change, so it should need no option, no phases.toml row and no catalog-count bump -- which is why it holds only its own cluster lease and none of the counter:* or file:* leases.
+
+ONE HAZARD WORTH CARRYING: the probe writes bytes at 0x43d0c6 INSIDE the range 0x43d060-0x43d0c6 that the same command defines as decrypt_stage1, and the acceptance is on a self-modifying stage-1 unpacker. Ordering will matter -- an overlay applied after the image is mapped but before code is lifted is the only ordering that can work, and the range-property-ordering precedent in this repo (readonly/volatile are silently inert if painted after symbols are mapped) is the direct analogue. Get the ordering wrong and the directive parses, accepts, and does nothing.

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -968,9 +968,14 @@ to know that renaming is P9 to rename something — parsed by
 | `type [<func>::]<symbol> <C type>` | `retype` | P5 type-propagation |
 | `readonly <addr>+<size>` | `readonly` | P1 code-data-partition |
 | `volatile <addr>+<size>` | `volatile` | P1 code-data-partition |
+| `bytes <addr> <hex\|@FILE>` | `override bytes` | P1 code-data-partition |
 
 Four application points, and the ordering between them is forced rather than
-stylistic. **Image-scoped** directives (`readonly`, `volatile`) OR one boolean
+stylistic. **Image-scoped** directives state what memory holds before anything
+reads it. `bytes` replaces the mapped bytes at an address with the caller's own
+(`assertions::apply_image_scoped` -> `LoadImage::kuna_overlay_bytes`, implemented
+by `decompiler/crates/kuna-analysis/src/loadimage_object.rs (overlay_span)`);
+`readonly` and `volatile` OR one boolean
 Varnode property over a memory range, and must be stated before the image's
 symbols are mapped: `Scope::addMap` folds the range property into each
 `SymbolEntry` as it maps it (`database.cc:1156-1158`) and never consults the range
@@ -979,7 +984,21 @@ loader named. The generated console script therefore emits them ahead of `read
 symbols`; the in-process surface, where `bootstrap_from_object` has already read
 the loader's symbols before a caller can say anything, re-applies the property to
 the symbols the range covers (`assertions::paint_property`). Both surfaces then
-render the same C. **Program-scoped** directives (`function`, `typedef`, `prototype`,
+render the same C. `bytes` is bound by the same ordering for a different reason:
+the bytes it states are the INPUT to every later decode, and nothing re-reads an
+address it has already lifted, so it is applied ahead of the analysis commit on
+both surfaces (`load_program` before `commit_pending_analysis`; the script's
+image slot before `read symbols`). It is the one fact a loader cannot derive at
+all — a packer's plaintext exists only once the packer has run — and the recorded
+workaround was patching a copy of the executable with an external script
+(`docs/re-needs/byte-overlay-assertion-recovered.md`). The overlay lives in the
+load image and nothing is written to disk. Two limits follow from where it lands
+and are reported rather than papered over: an address no loaded segment maps is
+REJECTED naming the span, since inventing backing store would decompile a program
+the caller never described; and the loader's analysis passes have already run over
+the file image, so function discovery does not see a recovered layer — its
+functions are declared with `function`/`--define-function` in the same assertion
+file. **Program-scoped** directives (`function`, `typedef`, `prototype`,
 `data`) are applied right after the analysis commit
 (`ConsoleProgram::set_assertions` + `assertions::apply_program_scoped`, called
 from `decompiler/crates/kuna-cli/src/decompile_all.rs (load_program)`), for the

--- a/tests/cli/byte-overlay-assertion-recovered.json
+++ b/tests/cli/byte-overlay-assertion-recovered.json
@@ -1,0 +1,46 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x401140",
+    "--addr",
+    "--define-function",
+    "0x401140-0x401146=decrypted_stage",
+    "--assert",
+    "bytes 0x401140 b82a000000c3",
+    "--assert-strict",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/assertranges_x86_64",
+    "binary_sha256": "1c9ad3b67437c7e85ac53d0755609c5b5e015225796a98c0287de5f2cb3d382e",
+    "binary_size": 15800,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/assertranges_x86_64",
+    "selector": "0x401140",
+    "selector_kind": "addr"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "stdout_matches": [
+      "return 0x2a"
+    ],
+    "stderr_absent": [
+      "unknown directive"
+    ]
+  },
+  "notes": "In-repo twin of the witness (a self-modifying PE whose stage-1 loader decrypts 2967 bytes over itself). Same command shape; the target is the vendored assertranges_x86_64, whose sample() at 0x401140 computes scale*a0+bias. The overlay b8 2a 00 00 00 c3 is mov eax,0x2a; ret, so the added stdout_matches clause fails unless the stated bytes actually reached the lifter."
+}


### PR DESCRIPTION
## The problem

kuna had no way to be told what a self-modifying program writes over itself. A
stage-1 unpacker's plaintext exists only once that stage has run, so no loader
can read it — and the assertion vocabulary had no directive for it:

```console
$ kuna decompile ./crackme.exe 0x43d060 --addr \
    --define-function '0x43d060-0x43d0c6=decrypt_stage1' \
    --assert 'bytes 0x43d0c6 8bd581c21f324000' --assert-strict --json
error: --assert "bytes 0x43d0c6 8bd581c21f324000": unknown directive "bytes" (want one of function, typedef, prototype, data, param, return, comment, flow, name, type, readonly, volatile)
$ echo $?
2
```

`decrypt_stage1` rewrites the 2967 bytes above itself. Reported once (major):
recovering that layer took Python and a patched copy of the executable, and every
later run started from the copy instead of from the original plus a statement.

## The fix

- New `--assert 'bytes <addr> <hex|@FILE>'` directive: the bytes mapped at
  `<addr>` are these, whatever the file holds. `@FILE` takes raw bytes, so a
  whole recovered layer is one directive. The load image is what changes —
  **nothing is written to disk**.
- The console spelling is `override bytes <addr> <hex>`, so the text surface
  (which drives `decomp_dbg`) and `--json` (in-process) apply the same fact.
- It lands in the image slot, ahead of the analysis commit / `read symbols`. That
  ordering is forced: the stated bytes are the input to every later decode and
  nothing re-reads an address it has already lifted. `readonly` is the same
  constraint inverted, and gets it wrong in the other direction.
- `LoadImage::kuna_overlay_bytes` is a defaulted trait method (loaders that
  cannot take an overlay say so); `ObjectLoadImage` resolves the span through
  `find_section`, so an overlay lands in exactly the segment a read at the same
  address comes from, materialises a writable segment's zero-filled tail, and
  **refuses** — naming the span — anything no segment maps.

With it, the reported workflow is one command:

```console
$ kuna decompile ./crackme.exe 0x43d0c6 --addr --assert 'bytes 0x43d0c6 @stage1.bin'
void sub_43d0c6(void)
{
  ...
  *(unsigned int *)(v2 + 0x40321b) = sub_43d401();
  *(int *)(v2 + 0x403393) = v2 + 0x40294c;
  ...
}
```

## The tests

`kuna-console/tests/verify_byteoverlay.rs` (4) is the end-to-end bar: overlaying
`b8 2a 00 00 00 c3` on `assertranges_x86_64`'s `sample` must turn
`return scale * a0 + bias + …` into `return 0x2a`, an unmapped address must be
rejected naming the span, and the console command must say what it did. Plus two
loader cases in `kuna-analysis` (a warm read window is dropped; a `p_memsz` tail
is materialised, past it is not) and three parser cases in `kuna-cli`. The
promoted probe `tests/cli/byte-overlay-assertion-recovered.json` asserts the
`return 0x2a`, so it fails both if the directive is rejected and if it is
accepted and inert.

Gates: `make test` PARITY OK 675/675 · `make test-stages` PARITY OK 721/721 ·
`make rust-test` 6,271 passed / 0 failed · `make check-spec` OK · `make test-cli` 106/106 ·
`kuna catalog --check` OK. Acceptance probe `a-09471914203f` PASS on the witness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
