### PR TITLE
[AUTOMATED] fix(analysis): elf-discovery-omits-explicit — read the non-PIE encoding of the _start->main hand-over

### DIFF
--- a/decompiler/crates/kuna-analysis/src/analyzers/entry/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/entry/mod.rs
@@ -938,10 +938,17 @@ fn libc_start_main_target(file: &object::File, entry: u64) -> Option<u64> {
     }
 }
 
-/// x86-64 SysV `_start` idiom: `main` is loaded into `rdi` (`lea rdi,[rip+disp]`,
-/// bytes `48 8d 3d <disp32>`) immediately before the `call *__libc_start_main@GOT`.
-/// Scan a small window at `e_entry` for that `lea rdi` and compute
-/// `main = (lea_addr + 7) + sign_extend(disp32)`.
+/// x86-64 SysV `_start` idiom: `main` is loaded into `rdi` immediately before the
+/// `call *__libc_start_main@GOT`. Two encodings carry it, and which one a crt uses
+/// is a link-model choice, not a different idiom:
+///
+/// - **PC-relative** (`lea rdi,[rip+disp]`, `48 8d 3d <disp32>`) — the PIE form,
+///   `main = (lea_addr + 7) + sign_extend(disp32)`.
+/// - **Absolute immediate** (`mov rdi,imm32`/`mov edi,imm32`/`movabs rdi,imm64`)
+///   — the non-PIE form, where `main` *is* the immediate.
+///
+/// The PC-relative scan runs first and is unchanged, so a PIE image decodes exactly
+/// as before; [`x86_64_immediate_main_target`] is consulted only when it misses.
 fn x86_64_main_target(file: &object::File, entry: u64) -> Option<u64> {
     let (sec_addr, data) = section_bytes_containing(file, entry)?;
     let start = (entry - sec_addr) as usize;
@@ -958,7 +965,93 @@ fn x86_64_main_target(file: &object::File, entry: u64) -> Option<u64> {
         }
         i += 1;
     }
-    None
+    x86_64_immediate_main_target(file, window)
+}
+
+/// Non-PIE x86-64 `_start`: `main` reaches `rdi` as a bare address immediate
+/// rather than a `lea` displacement — `mov edi,imm32` (`bf`, glibc's `-no-pie`
+/// crt1), `mov rdi,imm32` (`48 c7 c7`, sign-extended) or `movabs rdi,imm64`
+/// (`48 bf`). Same idiom, same register, same following call; only the encoding
+/// differs, and matching on the `lea` opcode alone loses `main` outright on an
+/// image with no `.eh_frame` to fall back on.
+///
+/// A bare immediate is a far weaker signal than a `lea` displacement (one opcode
+/// byte, and any four bytes read as an address), so a candidate is emitted only
+/// when all three of these hold:
+///
+/// - a `call` follows within [`IMM_CALL_LOOKAHEAD`] bytes (the
+///   `__libc_start_main` call the idiom is defined by),
+/// - the immediate lands inside an executable section, and
+/// - it is the *only* immediate in the window that does — an ambiguous decode is
+///   a clean miss, the same rule [`arm_main_target_raw`] applies to its GOT
+///   offsets.
+fn x86_64_immediate_main_target(file: &object::File, window: &[u8]) -> Option<u64> {
+    let execs = executable_sections(file);
+    let mut hits: Vec<u64> = Vec::new();
+    let mut i = 0usize;
+    while i < window.len() {
+        // (encoded length, main) for each `main`-into-rdi immediate encoding.
+        let hit = if window[i] == 0xbf && i + 5 <= window.len() {
+            // mov edi,imm32 — zero-extended into rdi.
+            Some((5usize, read_i32(&window[i + 1..]) as u32 as u64))
+        } else if window[i] == 0x48
+            && i + 7 <= window.len()
+            && window[i + 1] == 0xc7
+            && window[i + 2] == 0xc7
+        {
+            // mov rdi,imm32 — sign-extended into rdi.
+            Some((7usize, read_i32(&window[i + 3..]) as i64 as u64))
+        } else if window[i] == 0x48 && i + 10 <= window.len() && window[i + 1] == 0xbf {
+            // movabs rdi,imm64.
+            read_u64_opt(&window[i + 2..]).map(|v| (10usize, v))
+        } else {
+            None
+        };
+        if let Some((len, main)) = hit {
+            if main != 0
+                && in_executable_section(&execs, main)
+                && x86_64_call_follows(window, i + len)
+            {
+                hits.push(main);
+            }
+        }
+        i += 1;
+    }
+    hits.sort_unstable();
+    hits.dedup();
+    match hits.as_slice() {
+        [main] => Some(*main),
+        _ => None,
+    }
+}
+
+/// How far past a candidate `main` immediate the `__libc_start_main` call may sit.
+/// In every crt form the call is the very next instruction; the slack absorbs an
+/// `endbr64`/`nop` or a reordered argument setup without admitting an unrelated
+/// call further down `_start`.
+const IMM_CALL_LOOKAHEAD: usize = 16;
+
+/// True if a `call` begins within [`IMM_CALL_LOOKAHEAD`] bytes of `off` —
+/// `e8 <rel32>` (direct) or `ff /2` (indirect, the `call *__libc_start_main@GOT`
+/// form). Byte-level, so it is a necessary condition rather than a decode.
+fn x86_64_call_follows(window: &[u8], off: usize) -> bool {
+    let end = (off + IMM_CALL_LOOKAHEAD).min(window.len());
+    let mut i = off;
+    while i < end {
+        if window[i] == 0xe8 {
+            return true;
+        }
+        // `ff /2` = CALL r/m: the ModRM reg field selects the opcode extension.
+        if window[i] == 0xff {
+            if let Some(&modrm) = window.get(i + 1) {
+                if (modrm >> 3) & 0x7 == 2 {
+                    return true;
+                }
+            }
+        }
+        i += 1;
+    }
+    false
 }
 
 /// AArch64 PIE `_start` idiom: `main` is loaded into `x0` from a GOT slot via the
@@ -2657,6 +2750,74 @@ mod tests {
         let main = libc_start_main_target(&file, file.entry());
         // lea rdi at 0x1178, disp 0x286 → 0x117f + 0x286 = 0x1405 = main.
         assert_eq!(main, Some(0x1405), "libc-start idiom should recover main at 0x1405");
+    }
+
+    /// Non-PIE x86-64: `_start` hands `main` over as `mov rdi,imm32`
+    /// (`48 c7 c7 20 10 40 00`) rather than `lea rdi,[rip+disp]`, and the
+    /// immediate IS `main`. The `lea`-only matcher missed it, so nothing seeded
+    /// the walk into `main` and the entry before it ran on through its bytes.
+    #[test]
+    fn libc_start_main_idiom_absolute_immediate() {
+        let bytes = fixture("funcstart_patterns_x86_64");
+        let file = object::File::parse(bytes.as_slice()).expect("parse funcstart_patterns");
+        assert_eq!(file.entry(), 0x401040, "non-PIE _start (e_entry)");
+        let main = libc_start_main_target(&file, file.entry());
+        assert_eq!(main, Some(0x401020), "absolute-immediate idiom should recover main at 0x401020");
+        assert!(
+            collect_entries(&file, bytes.as_slice()).contains(&0x401020),
+            "the recovered main must reach the entry union"
+        );
+    }
+
+    /// The three guards on the immediate form, each on its own: a candidate with
+    /// no following `call` is not the libc-start idiom; two candidates that both
+    /// pass every test are an ambiguous decode and yield nothing; and the
+    /// `mov edi,imm32` encoding is read like the REX.W one.
+    #[test]
+    fn immediate_main_guards() {
+        let bytes = fixture("funcstart_patterns_x86_64");
+        let file = object::File::parse(bytes.as_slice()).expect("parse funcstart_patterns");
+
+        // mov rdi,0x401020 followed only by nops — no call, so no idiom.
+        let mut w = vec![0x48, 0xc7, 0xc7, 0x20, 0x10, 0x40, 0x00];
+        w.extend(std::iter::repeat(0x90).take(32));
+        assert_eq!(x86_64_immediate_main_target(&file, &w), None);
+
+        // The same load with the indirect `call [rip+d32]` after it.
+        let mut w = vec![0x48, 0xc7, 0xc7, 0x20, 0x10, 0x40, 0x00];
+        w.extend_from_slice(&[0xff, 0x15, 0x00, 0x00, 0x00, 0x00]);
+        assert_eq!(x86_64_immediate_main_target(&file, &w), Some(0x401020));
+
+        // Two distinct exec-section immediates, both call-followed: ambiguous.
+        let mut w = vec![0x48, 0xc7, 0xc7, 0x20, 0x10, 0x40, 0x00];
+        w.extend_from_slice(&[0xe8, 0x00, 0x00, 0x00, 0x00]);
+        w.extend_from_slice(&[0xbf, 0x40, 0x10, 0x40, 0x00]);
+        w.extend_from_slice(&[0xe8, 0x00, 0x00, 0x00, 0x00]);
+        assert_eq!(x86_64_immediate_main_target(&file, &w), None);
+
+        // `mov edi,imm32` alone, with a direct call: the glibc -no-pie form.
+        let w = vec![0xbf, 0x20, 0x10, 0x40, 0x00, 0xe8, 0x00, 0x00, 0x00, 0x00];
+        assert_eq!(x86_64_immediate_main_target(&file, &w), Some(0x401020));
+
+        // An immediate outside every executable section is not a function start.
+        let w = vec![0xbf, 0x00, 0x00, 0x00, 0x00, 0xe8, 0x00, 0x00, 0x00, 0x00];
+        assert_eq!(x86_64_immediate_main_target(&file, &w), None);
+    }
+
+    /// `x86_64_call_follows` accepts both call encodings within the lookahead and
+    /// rejects `ff /4` (`jmp r/m`), which shares the `ff` opcode byte.
+    #[test]
+    fn call_follows_reads_the_modrm_extension() {
+        assert!(x86_64_call_follows(&[0xe8, 0, 0, 0, 0], 0));
+        assert!(x86_64_call_follows(&[0xff, 0x15, 0, 0, 0, 0], 0));
+        assert!(x86_64_call_follows(&[0xff, 0xd0], 0));
+        // ff /4 = jmp r/m64 — the tail-call form, not the idiom's call.
+        assert!(!x86_64_call_follows(&[0xff, 0x25, 0, 0, 0, 0], 0));
+        assert!(!x86_64_call_follows(&[0xff, 0xe0], 0));
+        // Beyond the lookahead window.
+        let mut far = vec![0x90; IMM_CALL_LOOKAHEAD + 1];
+        far.push(0xe8);
+        assert!(!x86_64_call_follows(&far, 0));
     }
 
     // -- Oracle 4 cross-arch: _start -> main idiom (Increment 23) --------------

--- a/docs/features/elf-discovery-omits-explicit/pr_body.md
+++ b/docs/features/elf-discovery-omits-explicit/pr_body.md
@@ -1,0 +1,73 @@
+## The problem
+
+`kuna functions` loses `main` on a non-PIE x86-64 executable, and with it
+everything `main` calls. `_start` names `main` explicitly, but the entry oracle
+only reads the position-independent encoding of that hand-over.
+
+The repro is in the tree — `funcstart_patterns_x86_64` is a stripped, non-PIE
+fixture whose `main` sits at `0x401020`:
+
+```
+$ kuna functions decompiler/crates/kuna-analysis/tests/fixtures/funcstart_patterns_x86_64 --json \
+    | jq -r '.count, (.functions[] | .address_hex)'
+8
+0x401000
+0x401040      <- _start
+0x401070
+0x401080
+0x4010f0
+0x401120
+0x401130
+0x401178
+```
+
+`0x401020` is not there, and `_start` is pointing straight at it:
+
+```
+$ objdump -d --start-address=0x401058 --stop-address=0x401065 \
+    decompiler/crates/kuna-analysis/tests/fixtures/funcstart_patterns_x86_64
+  401058: 48 c7 c7 20 10 40 00   mov    $0x401020,%rdi
+  40105f: ff 15 8b 2f 00 00      call   *0x2f8b(%rip)     # __libc_start_main
+```
+
+On the reported binary (a stripped crackme with no `.eh_frame`) the same miss
+cost seven functions: the inventory reported 34, `main` at `0x11a9b` was absent,
+`xrefs --to 0x11266` answered `count: 0` for a function `main` calls directly,
+and the entry before `main` ran on through its bytes with a size of 2230.
+
+## The fix
+
+- Oracle 4 matched on `48 8d 3d` — `lea rdi,[rip+disp32]` — alone. A non-PIE
+  `_start` hands `main` over as a bare address immediate instead. It is the same
+  idiom, the same register and the same following call; only the link model
+  differs, so the three immediate encodings (`mov edi,imm32`, `mov rdi,imm32`,
+  `movabs rdi,imm64`) are now read as well.
+- The immediate scan runs only where the `lea` scan finds nothing, so a PIE image
+  decodes byte-identically to before. Of 1,919 x86-64 ELF objects swept, 1,788
+  carry the `lea` and are untouched by construction.
+- A bare immediate is much weaker evidence than a `lea` displacement, so a
+  candidate is emitted only if a `call` (`e8` or `ff /2`) begins within 16 bytes,
+  the immediate lands in an executable section, and it is the only immediate in
+  the window that satisfies both. An ambiguous decode returns nothing rather than
+  a guess — the rule the ARM GOT-offset decode already applies.
+
+Seeding `main` also corrects the bodies that had run through it: on the witness
+`sub_112e9` goes 2230 → 1855 bytes and `_INIT_0` 716 → 6 (`0x10af0` really is a
+6-byte `endbr64; jmp` thunk). No entry is lost anywhere in either sweep, and every
+newly-recovered start was checked against its disassembly.
+
+## The tests
+
+`tests/cli/elf-discovery-omits-explicit.json` is the acceptance probe on the
+vendored fixture above; it fails without this change. Three cargo tests in
+`kuna-analysis` cover the fixture's `main`, the three guards (no following call,
+two competing immediates, an immediate outside every executable section), and the
+`ff /2` vs `ff /4` ModRM read.
+
+Sweeps: 119 of the 131 fallback-reachable system binaries were runnable on both
+builds and two changed, both gaining a real `main` (`/usr/bin/busybox` 2116 → 2164);
+across the 43 ELF binaries in the RE corpus, two changed, both gaining a real
+`main`. `make test` 675/675, `make test-stages` 725/725, `make rust-test`,
+`make check-spec`, `make test-cli` 109/109 and `kuna catalog --check` all green.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/elf-discovery-omits-explicit/record.json
+++ b/docs/features/elf-discovery-omits-explicit/record.json
@@ -1,0 +1,96 @@
+{
+  "need_id": "elf-discovery-omits-explicit",
+  "track": "loader",
+  "scope": "small",
+  "opportunity": "RE-need elf-discovery-omits-explicit — `kuna functions` on a stripped non-PIE x86-64 crackme reported 34 entries and omitted `main` at 0x11a9b, which _start names explicitly (crackmes.one 67f9bdc38f555589f3530a85 bin/WeeperVM--Level_1, round 12).",
+  "test_name": "kuna functions inventory, witness + 1,919-binary x86-64 ELF A/B sweep + 43-binary RE-dataset sweep",
+  "binary": "decompiler/crates/kuna-analysis/tests/fixtures/funcstart_patterns_x86_64",
+  "selector": "0x401020",
+  "option": null,
+  "flag": null,
+  "change_kind": "analysis-decode",
+  "tier": "analysis",
+  "source_decompiler": "kuna",
+  "default_on": true,
+  "div_row": null,
+  "decisions": [
+    "The filed hypothesis is UPHELD and the refuter's mechanism is exact to the byte. Oracle 4 (`_start`->`main` libc-start idiom) matched on the three-byte prefix `48 8d 3d` (`lea rdi,[rip+disp32]`) alone. This `_start` hands `main` over as an ABSOLUTE immediate instead — `48 c7 c7 9b 1a 01 00` = `mov rdi,0x11a9b` at 0x10a18, immediately followed by the `ff 15` `__libc_start_main` GOT call. Same idiom, same register, same call, one encoding the matcher did not know. The 64-byte window was NOT the limiter (the instruction is at window index 0x18 of 0x40).",
+    "PC-relative vs absolute is a LINK MODEL, not a different idiom. The fix reads the three non-PIE encodings (`bf imm32`, `48 c7 c7 imm32`, `48 bf imm64`) as a fallback consulted only when the `lea` scan finds nothing, so every PIE image decodes byte-identically to before. Measured: of 1,919 x86-64 ELF64 objects, 1,788 carry the `lea` and are unchanged by construction.",
+    "A bare immediate is far weaker evidence than a `lea` displacement — one opcode byte, and any four bytes read as an address — so three guards were added rather than emitting the first match: a `call` (`e8` or `ff /2`) must begin within 16 bytes, the immediate must land in an executable section, and it must be the ONLY immediate in the window that satisfies both. An ambiguous decode is a clean miss, the rule `arm_main_target_raw` already applies to its GOT offsets. `ff /4` (`jmp r/m`, the tail-call form) is rejected by reading the ModRM extension rather than the `ff` byte.",
+    "NO new option, no phases.toml/catalog/DIV edits. Oracle 4 is an always-on decode of an instruction whose meaning is fixed by the ABI; reading a second encoding of it is a strict correction of a matcher that did not implement its own documented contract, not a judgment call. Same shape as the sibling loader fix arm-inventory-omits-41 (#537). The catalog/DIV/phases.toml counters were also held by another builder this round.",
+    "The refuter's second caution HELD and the change is not purely additive: seeding `main` corrects two run-on bodies. On the witness `sub_112e9` shrinks 2230 -> 1855 bytes (it had swallowed `main` at 0x11a9b) and `_INIT_0` shrinks 716 -> 6 bytes — 0x10af0 is genuinely a 6-byte `endbr64; jmp` thunk and 0x10af6 is a separate `push %r12` function it had been running into. Both are corrections. No entry is lost on any binary in either sweep.",
+    "The loss was bigger than one function, as filed: nothing decoded `main`'s body, so its callees were invisible. `xrefs --to 0x11266` reported count 0 before and count 1 after; the inventory goes 34 -> 41 with six further genuine prologues recovered (0x10af6, 0x10d2e, 0x10e27, 0x10fe7, 0x11266, 0x11a28), each verified as a real function start by disassembly.",
+    "The symptom's second clause — `main` renders with `undefined16` and four spurious parameters even with `entrymainproto` on — is NOT closed here and is not closable by that option: `entrymainproto` is PE-only by design, and its module says so, because on ELF the argument-passing call site lives in libc and is not in the image. That is a separate defect on the prototype surface; the acceptance asks only for the inventory entry and does not depend on it.",
+    "`funcstart_patterns off` was the obvious existing-option candidate and the refuter had already closed it: `decompile-all --option funcstart_patterns on` returns the same 34 functions. Re-confirmed. No shipped option covers this.",
+    "No `tests/stages/` XML testcase: the datatest/stages path uses `LoadImageXml` over `<bytechunk>` and never constructs an `ObjectLoadImage`, so an analysis-tier oracle is unreachable from it. Gated on the cargo suite plus the promoted CLI probe instead (the deviation `relocobjects`/`cortexmvectors`/`arm-inventory-omits-41` recorded)."
+  ],
+  "acceptance": {
+    "probe_id": "p-2bbc8bf1ae41",
+    "acceptance_id": "a-18663b946a0d",
+    "before": "FAIL (34 functions, no functions[*].address == 72347)",
+    "after": "PASS",
+    "verify": "scripts.repipe.verify --need elf-discovery-omits-explicit --json -> pass 1 / fail 0 / unrunnable 0, transition closed"
+  },
+  "promoted_probe": {
+    "path": "tests/cli/elf-discovery-omits-explicit.json",
+    "retargeted_from": "dataset challenges/67f9bdc38f555589f3530a85/bin/WeeperVM--Level_1 (14112 bytes)",
+    "retargeted_to": "decompiler/crates/kuna-analysis/tests/fixtures/funcstart_patterns_x86_64 (14296 bytes, already vendored)",
+    "why": "`verify --promote` refuses a dataset target (CI has no dataset) and the witness is a third-party crackme. The already-vendored fixture is the same shape and carried the same defect: stripped non-PIE x86-64, `_start` at 0x401040 handing `main` over as `mov rdi,0x401020` before `call [rip+d32]`, and `main` reachable from no other oracle. No new binary was added.",
+    "verified_on_witness": true
+  },
+  "witness": {
+    "binary": "crackmes.one 67f9bdc38f555589f3530a85 bin/WeeperVM--Level_1",
+    "functions_before": 34,
+    "functions_after": 41,
+    "main": "0x11a9b, absent before, present after (size 260)",
+    "run_on_bodies_corrected": {
+      "sub_112e9": "2230 -> 1855 bytes",
+      "_INIT_0": "716 -> 6 bytes"
+    },
+    "xrefs_to_0x11266": "count 0 -> count 1",
+    "entries_lost": 0
+  },
+  "sweep": {
+    "corpus_system": {
+      "scanned_x86_64_elf64": 1919,
+      "carry_the_lea_unchanged_by_construction": 1788,
+      "reach_the_immediate_scan": 131,
+      "runnable_on_both_builds": 119,
+      "inventories_changed": 2,
+      "changed": [
+        "/usr/bin/busybox: 2116 -> 2164 functions, main 0x525a1d recovered (endbr64; push rbp)",
+        "decompiler/crates/kuna-analysis/tests/fixtures/funcstart_patterns_x86_64: 8 -> 9, main 0x401020 recovered"
+      ],
+      "entries_lost": 0
+    },
+    "corpus_re_dataset": {
+      "scanned_elf": 43,
+      "inventories_changed": 2,
+      "changed": [
+        "67f9bdc38f555589f3530a85/WeeperVM--Level_1 (the witness): 34 -> 41",
+        "69a1f44218b5d7ee4709351d/howo-not-to-simple-keygen: 1047 -> 1048, main 0x401640 recovered; the entry at 0x40162f had run through it"
+      ],
+      "entries_lost": 0
+    },
+    "every_new_entry_verified_by_disassembly": true
+  },
+  "speed": {
+    "method": "3 runs each of `kuna functions <bin> --json`, before/after binaries built from the same tree",
+    "witness_s": {"before": [0.15, 0.14, 0.15], "after": [0.16, 0.15, 0.16]},
+    "busybox_s": {"before": [1.66, 1.31, 1.83], "after": [1.56, 1.61, 1.69]},
+    "verdict": "no measurable cost; the fallback runs only when the lea scan misses, and the extra work is one 64-byte rescan plus the walk over a genuinely larger call tree"
+  },
+  "gates": {
+    "make test": "PARITY OK, 675/675",
+    "make test-stages": "PARITY OK, 725/725",
+    "make rust-test": "green",
+    "make check-spec": "green",
+    "make test-cli": "109/109",
+    "kuna catalog --check": "catalog OK"
+  },
+  "files": [
+    "decompiler/crates/kuna-analysis/src/analyzers/entry/mod.rs",
+    "docs/spec/01-program-prep.md",
+    "tests/cli/elf-discovery-omits-explicit.json"
+  ]
+}

--- a/docs/re-needs/elf-discovery-omits-explicit.md
+++ b/docs/re-needs/elf-discovery-omits-explicit.md
@@ -1,0 +1,134 @@
+---
+need_id: elf-discovery-omits-explicit
+title: ELF discovery omits the explicit x86-64 CRT main target
+track: loader
+status: open
+severity: major
+probe_id: p-2bbc8bf1ae41
+acceptance_id: a-18663b946a0d
+hypothesis_status: upheld
+credibility: 0.85
+instances: 1
+challenges: [67f9bdc38f555589f3530a85]
+rounds: [12]
+first_seen_round: 12
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-analysis]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Inventory the main function at 0x11a9b.
+
+> **ELF discovery omits the explicit x86-64 CRT main target** (major, `67f9bdc38f555589f3530a85`)
+> functions and decompile-all report 34 functions without main. Entry disassembly loads RDI=0x11a9b before libc startup. Address-directed decompilation works, but emits a spurious undefined16 return and four parameters even with entrymainproto on.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_absent": [
+      "\"address_hex\": \"0x11a9b\""
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/WeeperVM--Level_1",
+    "binary_sha256": "8ecacb009c64989b3d269193617a742ee039ffad7e2690ed148f11312751ef03",
+    "binary_size": 14112,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "json": [
+      {
+        "path": "functions[*].address",
+        "op": "eq",
+        "value": 72347
+      }
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/WeeperVM--Level_1",
+    "binary_sha256": "8ecacb009c64989b3d269193617a742ee039ffad7e2690ed148f11312751ef03",
+    "binary_size": 14112,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- CRT-target discovery may not recognize this startup sequence or imported call.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+- `ida-decompile load ./target/WeeperVM--Level_1 --backend ida` — Server 2851be9e60 exited with status 1 before registering. No reference pseudocode obtained.
+
+## Instances
+
+- `67f9bdc38f555589f3530a85` (round 12, tester t-r12-67f9bdc3)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+- split by captain at T_DEDUP from round 12's `silent-failure|functions|exit_code,json` bucket: cluster.py's signature (kind|subcommand|clause-shape) collapsed unrelated defects, so the crop was hand-partitioned one observation per need and filed via `--from-file`. See `.kuna-repipe/rounds/12/dedup/MARKER.json`; do NOT run `cluster --round 12` bare.
+- round 12 REFUTER: hypothesis **upheld** (was inconclusive). UPHELD and reduced to one byte pattern. The symptom stands (34 functions, no 0x11a9b) and the filed cause -- CRT-target discovery does not recognise this startup sequence -- is exactly right; what the refutation adds is WHICH oracle and WHY, plus three closed lines.
+
+MECHANISM. Whole-binary discovery is EntryDiscoveryPass's union of five oracles (kuna-analysis/src/analyzers/entry/mod.rs). For this image three of them are silent and the other two cannot reach main:
+(1) Oracle 4, the _start->main libc-start idiom, is the one that should fire and it MISSES ON THE OPCODE FORM ALONE. x86_64_main_target (mod.rs:945) scans a 64-byte window from e_entry for literally '48 8d 3d <disp32>' (LEA RDI,[RIP+disp]) and computes main = lea_addr+7+disp. This _start hands main over as an ABSOLUTE immediate instead: e_entry is 0x10a00, and at 0x10a18 the bytes are 48 c7 c7 9b 1a 01 00 = MOV RDI,0x11a9b, immediately followed by ff 15 f3 23 00 00 = CALL qword ptr [0x12e18] (the __libc_start_main GOT call). The offending instruction is at window index 0x18 of 0x40, so the window is NOT the limiter -- the three-byte prefix test is. Same idiom, same register, same call, one encoding the matcher does not know.
+(2) Oracle 3 (.eh_frame FDE pcBegin), normally the highest-value oracle on a C binary, contributes NOTHING here: readelf -S shows the image has NO .eh_frame section at all (one RWE LOAD, .text at 0x10a00). So there is no second path to main.
+(3) Oracle 5 (gcc prologue byte patterns) cannot match: main's prologue at 0x11a9b is 55 31 c0 53 51 = PUSH RBP; XOR EAX,EAX; PUSH RBX; PUSH RCX -- no 'mov rbp,rsp'.
+
+DEAD LINE CLOSED, and this is the one the last tick asked about: this is NOT a shipped-option-already story. funcstart_patterns is default-OFF, so it was the obvious candidate; 'decompile-all --option funcstart_patterns on' returns the SAME 34 functions and still no 0x11a9b. (kuna functions takes no --option, so ablate through decompile-all.)
+
+THE LOSS IS BIGGER THAN ONE FUNCTION, which matters for ranking. Because main is never a function, nothing decodes its body, so its callees are invisible too: main calls 0x11266 at 0x11aa0, and 'xrefs --to 0x11266' reports count 0. Seeding main is what makes that subtree reachable at all.
+
+TWO CAUTIONS FOR THE BUILDER. First, do not read 'kuna xrefs --to 0x11a9b' as proof kuna already knows about a function there: it answers with target.name sub_11a9b and a to_function block, but that is synthesized from the queried address, not evidence of an inventory entry -- 'functions' is the oracle, and it does not list it. Second, the inventory's last row is sub_112e9 with size 2230, i.e. 0x112e9..0x11b9f, which SWALLOWS 0x11a9b; expect the bounding of that run-on function to move once main is seeded, and check it rather than assuming the fix is purely additive.
+
+Acceptance is sound: a positive json clause on functions[*].address == 72347 (0x11a9b), which cannot be satisfied by losing anything.
+- round 12 CAPTAIN (B_FANOUT, pre-dispatch brief): PROMOTION CAVEAT -- this need's probe target is `binary_source: dataset`, and `verify --promote` refuses anything that is not `in-repo` (verify.py:750, "CI has no dataset"); `--force` does not override it. B_DONE can therefore CLOSE this need on the measured acceptance flip but cannot promote its probe into `tests/cli/`, so the fix ships with no regression guard unless the builder vendors an in-repo fixture (or reuses a vendored twin) in the SAME PR and points a promotable copy of the probe at it. Same refusal already blocked virtualalloc-protection-argument-disappears and arm-inventory-invents-function.
+- BUILDER RESULT (worker b-r12-elf-discovery-om, no new option): hypothesis UPHELD and the refuter's mechanism is exact to the byte. `x86_64_main_target` matched `48 8d 3d` (`lea rdi,[rip+disp32]`) alone; this `_start` uses `48 c7 c7 9b 1a 01 00` = `mov rdi,0x11a9b` at 0x10a18, followed immediately by the `ff 15` `__libc_start_main` GOT call. PC-relative vs absolute is a LINK MODEL, not a different idiom, so the three non-PIE encodings (`bf imm32`, `48 c7 c7 imm32`, `48 bf imm64`) are now read as a fallback consulted only when the `lea` scan misses -- 1,788 of 1,919 swept x86-64 ELF objects carry the `lea` and are unchanged by construction. Guards, because a bare immediate is one opcode byte: a `call` (`e8` / `ff /2`) within 16 bytes, the immediate inside an executable section, and unique in the window (else a clean miss). Witness 34 -> 41 functions with 0x11a9b present; the refuter's second caution HELD -- `sub_112e9` 2230 -> 1855 and `_INIT_0` 716 -> 6, both corrections (0x10af0 really is a 6-byte `endbr64; jmp` thunk), 0 entries lost anywhere. `xrefs --to 0x11266` count 0 -> 1. Sweeps: 2 of 119 runnable fallback-reachable system binaries changed (busybox 2116 -> 2164) and 2 of 43 RE-dataset ELFs, every new start verified as a real prologue. NOT closed here: the symptom's second clause (`undefined16` + four spurious params) is a separate prototype-surface defect and `entrymainproto` is PE-only BY DESIGN, so it can never apply to this ELF. Promotion twin is the already-vendored `funcstart_patterns_x86_64`, which carried the same defect (8 -> 9 functions); no new binary added.

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -1799,6 +1799,33 @@ signature. PE and Mach-O dispatch to their own oracles (`.pdata`/TLS/entry;
 a wrong entry is a garbage `sub_<addr>`; a missed one is invisible until a caller
 overruns into it (§1.7).
 
+(kuna) **The x86-64 half of oracle 4 reads two encodings, because "PC-relative" is
+a link model and not part of the idiom.** `main` reaches `rdi` as a `lea
+rdi,[rip+disp]` only in a position-independent crt; a non-PIE `_start` hands it
+over as a bare address immediate — `mov edi,imm32`, `mov rdi,imm32` or `movabs
+rdi,imm64` — immediately before the same `__libc_start_main` call. Matching the
+`lea` opcode alone lost `main` outright on such an image, and with it everything
+`main` calls, since nothing else seeds the walk into that subtree: a stripped
+non-PIE executable built without `.eh_frame` has no second path to `main`, and the
+always-on prologue patterns (5) do not match a `push rbp` that is not followed by
+`mov rbp,rsp`. The inventory then stopped at the C runtime and one earlier entry
+ran on through `main`'s bytes. The immediate forms are read only where the
+PC-relative scan finds nothing
+(`decompiler/crates/kuna-analysis/src/analyzers/entry/mod.rs
+(x86_64_immediate_main_target)`), so a PIE image decodes exactly as it did.
+
+A bare immediate is far weaker evidence than a `lea` displacement — one opcode
+byte, and any four bytes read as an address — so a candidate is emitted only when a
+`call` (`e8 <rel32>` or `ff /2`) begins within sixteen bytes of it, when the
+immediate lands inside an executable section, and when it is the **only**
+immediate in the `_start` window that satisfies both. An ambiguous decode is a
+clean miss rather than a guess, the same rule the ARM GOT-offset decode applies to
+its candidates. Measured over 1,919 x86-64 ELF executables and shared objects,
+1,788 carry the `lea` and are untouched by construction; of the 131 that reach the
+immediate scan, 119 were runnable on both builds and two gained `main` — both
+verified as real function prologues, and both correcting an earlier entry that had
+run on through it.
+
 (kuna) **With no section table, the plausible-code oracle is the program header.**
 "Restricted to executable sections" is a filter every oracle above passes through
 (`decompiler/crates/kuna-analysis/src/analyzers/entry/mod.rs

--- a/tests/cli/elf-discovery-omits-explicit.json
+++ b/tests/cli/elf-discovery-omits-explicit.json
@@ -1,0 +1,39 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/funcstart_patterns_x86_64",
+    "binary_sha256": "ff6946f03161c6bbcffabeb6b42d9a05ff65a34d35bb91f8959fa9f5db602017",
+    "binary_size": 14296,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/funcstart_patterns_x86_64",
+    "selector": null,
+    "selector_kind": "none"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "json": [
+      {
+        "path": "functions[*].address",
+        "op": "eq",
+        "value": 4198432
+      }
+    ]
+  },
+  "notes": "elf-discovery-omits-explicit: vendored twin of the reported image. Same non-PIE x86-64 _start, same `mov rdi,imm32` handover of main to __libc_start_main; main is 0x401020 here and 0x11a9b in the dataset witness, which stays the need's acceptance. In-repo so the probe runs where there is no dataset."
+}


### PR DESCRIPTION
## The problem

`kuna functions` loses `main` on a non-PIE x86-64 executable, and with it
everything `main` calls. `_start` names `main` explicitly, but the entry oracle
only reads the position-independent encoding of that hand-over.

The repro is in the tree — `funcstart_patterns_x86_64` is a stripped, non-PIE
fixture whose `main` sits at `0x401020`:

```
$ kuna functions decompiler/crates/kuna-analysis/tests/fixtures/funcstart_patterns_x86_64 --json \
    | jq -r '.count, (.functions[] | .address_hex)'
8
0x401000
0x401040      <- _start
0x401070
0x401080
0x4010f0
0x401120
0x401130
0x401178
```

`0x401020` is not there, and `_start` is pointing straight at it:

```
$ objdump -d --start-address=0x401058 --stop-address=0x401065 \
    decompiler/crates/kuna-analysis/tests/fixtures/funcstart_patterns_x86_64
  401058: 48 c7 c7 20 10 40 00   mov    $0x401020,%rdi
  40105f: ff 15 8b 2f 00 00      call   *0x2f8b(%rip)     # __libc_start_main
```

On the reported binary (a stripped crackme with no `.eh_frame`) the same miss
cost seven functions: the inventory reported 34, `main` at `0x11a9b` was absent,
`xrefs --to 0x11266` answered `count: 0` for a function `main` calls directly,
and the entry before `main` ran on through its bytes with a size of 2230.

## The fix

- Oracle 4 matched on `48 8d 3d` — `lea rdi,[rip+disp32]` — alone. A non-PIE
  `_start` hands `main` over as a bare address immediate instead. It is the same
  idiom, the same register and the same following call; only the link model
  differs, so the three immediate encodings (`mov edi,imm32`, `mov rdi,imm32`,
  `movabs rdi,imm64`) are now read as well.
- The immediate scan runs only where the `lea` scan finds nothing, so a PIE image
  decodes byte-identically to before. Of 1,919 x86-64 ELF objects swept, 1,788
  carry the `lea` and are untouched by construction.
- A bare immediate is much weaker evidence than a `lea` displacement, so a
  candidate is emitted only if a `call` (`e8` or `ff /2`) begins within 16 bytes,
  the immediate lands in an executable section, and it is the only immediate in
  the window that satisfies both. An ambiguous decode returns nothing rather than
  a guess — the rule the ARM GOT-offset decode already applies.

Seeding `main` also corrects the bodies that had run through it: on the witness
`sub_112e9` goes 2230 → 1855 bytes and `_INIT_0` 716 → 6 (`0x10af0` really is a
6-byte `endbr64; jmp` thunk). No entry is lost anywhere in either sweep, and every
newly-recovered start was checked against its disassembly.

## The tests

`tests/cli/elf-discovery-omits-explicit.json` is the acceptance probe on the
vendored fixture above; it fails without this change. Three cargo tests in
`kuna-analysis` cover the fixture's `main`, the three guards (no following call,
two competing immediates, an immediate outside every executable section), and the
`ff /2` vs `ff /4` ModRM read.

Sweeps: 119 of the 131 fallback-reachable system binaries were runnable on both
builds and two changed, both gaining a real `main` (`/usr/bin/busybox` 2116 → 2164);
across the 43 ELF binaries in the RE corpus, two changed, both gaining a real
`main`. `make test` 675/675, `make test-stages` 725/725, `make rust-test`,
`make check-spec`, `make test-cli` 109/109 and `kuna catalog --check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
