### PR TITLE
[AUTOMATED] fix(analysis): guard the AIF fingerprint re-decode on length agreement

### DIFF
--- a/decompiler/crates/kuna-analysis/src/analyzers/aif/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/aif/mod.rs
@@ -280,13 +280,32 @@ impl<'a> GapDecoder<'a> {
 /// disassembly text only when a text-reading consumer asked for it (see
 /// `listing::decode::decode_one`), and this fingerprint needs just the first
 /// `FINGERPRINT_INSNS` instructions of each function — re-decoding those is ~2 per
-/// function instead of text for every instruction in the image. Equivalent either
-/// way: decoding the same address under the same painted context yields the same
-/// mnemonic the walk would have recorded, and an empty one still rejects.
+/// function instead of text for every instruction in the image.
+///
+/// That re-decode is equivalent only if it saw the SAME instruction the walk
+/// recorded, which is not free: `Sleigh::one_instruction` commits `globalset`
+/// context writes, and both the ARM (`TMode`) and MIPS (`ISA_MODE`) specs globalset
+/// a decode mode at a branch target, so a later decode can leave an address in a
+/// different mode than the walk read it in. The instruction length is the
+/// observable of that — an alternate-ISA re-decode is a different width — so a
+/// length disagreement declines the fingerprint outright rather than pairing one
+/// instruction's mnemonic with another's stride.
 fn fingerprint_in_listing(
     listing: &Listing,
     decoder: &mut GapDecoder,
     entry: u64,
+) -> Option<Fingerprint> {
+    fingerprint_over_listing(listing, entry, |vma| {
+        decoder.probe(vma).map(|p| (p.mnemonic, p.len))
+    })
+}
+
+/// [`fingerprint_in_listing`] with the lazy re-decode as a parameter, so the
+/// length-agreement guard is testable without a live SLEIGH decoder.
+fn fingerprint_over_listing(
+    listing: &Listing,
+    entry: u64,
+    mut redecode: impl FnMut(u64) -> Option<(String, u32)>,
 ) -> Option<Fingerprint> {
     let mut mnems: Vec<String> = Vec::with_capacity(FINGERPRINT_INSNS);
     let mut total_len: u64 = 0;
@@ -297,7 +316,11 @@ fn fingerprint_in_listing(
         let mnemonic = if listing.has_assembly() {
             insn.mnemonic.clone()
         } else {
-            decoder.probe(vma)?.mnemonic
+            let (mnemonic, probed_len) = redecode(vma)?;
+            if probed_len != len {
+                return None;
+            }
+            mnemonic
         };
         if mnemonic.is_empty() {
             return None;
@@ -953,6 +976,7 @@ fn is_thumb_function_prologue(data: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::listing::Insn;
 
     // The fingerprint + gap-walk + valid-subroutine logic is exercised end-to-end
     // by the cross-crate `verify_aif.rs` gate (a stripped x86-64 fixture with a
@@ -1015,6 +1039,71 @@ mod tests {
         assert!(!is_thumb_function_prologue(&[0xB5, 0x10])); // 0xB5 in the wrong byte
         assert!(!is_thumb_function_prologue(&[0x2D, 0xE9])); // truncated 32-bit -> reject
         assert!(!is_thumb_function_prologue(&[0x2D]));
+    }
+
+    /// A text-free Listing builds a HYBRID fingerprint record — mnemonic from the
+    /// re-decode, stride and total length from the Listing — and the re-decode is
+    /// not guaranteed to see the instruction the walk saw: `Sleigh::one_instruction`
+    /// commits `globalset` context writes, and both the ARM (`TMode`) and MIPS
+    /// (`ISA_MODE`) specs globalset a decode mode at a branch target, so a later
+    /// decode can change the mode a given address decodes in. The lengths are the
+    /// observable, so a disagreement must decline the fingerprint rather than pair
+    /// one instruction's mnemonic with another's stride.
+    #[test]
+    fn a_relaxed_redecode_declines_rather_than_mixing_two_instructions() {
+        // Two 4-byte instructions the walk decoded, with no captured text — the
+        // Listing a `--mode fast` load produces.
+        let insn = |addr: u64, mnemonic: &str| Insn {
+            addr,
+            len: 4,
+            fall_through: Some(addr + 4),
+            flow: Default::default(),
+            flows: Vec::new(),
+            mnemonic: mnemonic.to_string(),
+            operands: String::new(),
+            pcode: None,
+        };
+        let textless =
+            Listing::from_insns_for_test(vec![insn(0x1000, ""), insn(0x1004, "")], false);
+
+        // Agreement: the re-decode read the same two 4-byte instructions, so the
+        // fingerprint is exactly what a text-carrying Listing would have produced.
+        let agreeing = |vma: u64| Some((if vma == 0x1000 { "PUSH" } else { "MOV" }.to_string(), 4));
+        assert_eq!(
+            fingerprint_over_listing(&textless, 0x1000, agreeing),
+            Some((vec!["PUSH".to_string(), "MOV".to_string()], 8))
+        );
+
+        // Disagreement on the FIRST instruction (a 2-byte Thumb/MIPS16 re-decode of
+        // what the walk read as a 4-byte A32/MIPS32 word) — decline.
+        let alt_isa = |vma: u64| Some((if vma == 0x1000 { "push" } else { "MOV" }.to_string(), 2));
+        assert_eq!(fingerprint_over_listing(&textless, 0x1000, alt_isa), None);
+
+        // ...and on the SECOND, where the first step already contributed a mnemonic.
+        let alt_isa_second = |vma: u64| {
+            if vma == 0x1000 {
+                Some(("PUSH".to_string(), 4))
+            } else {
+                Some(("movs".to_string(), 2))
+            }
+        };
+        assert_eq!(fingerprint_over_listing(&textless, 0x1000, alt_isa_second), None);
+
+        // An undecodable re-decode and an empty mnemonic still reject, as before.
+        assert_eq!(fingerprint_over_listing(&textless, 0x1000, |_| None), None);
+        assert_eq!(
+            fingerprint_over_listing(&textless, 0x1000, |_| Some((String::new(), 4))),
+            None
+        );
+
+        // A Listing that DOES carry text never consults the re-decode at all, so a
+        // hostile probe cannot change the answer.
+        let with_text =
+            Listing::from_insns_for_test(vec![insn(0x1000, "PUSH"), insn(0x1004, "MOV")], true);
+        assert_eq!(
+            fingerprint_over_listing(&with_text, 0x1000, |_| panic!("must not re-decode")),
+            Some((vec!["PUSH".to_string(), "MOV".to_string()], 8))
+        );
     }
 
     #[test]

--- a/decompiler/crates/kuna-analysis/src/listing/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/mod.rs
@@ -229,6 +229,22 @@ impl Listing {
         }
     }
 
+    /// Test-only: a Listing over exactly `insns`, with no xrefs, no discovered
+    /// functions and one all-covering exec range. `has_assembly` selects whether the
+    /// instruction model claims to carry disassembly text, so a consumer's own unit
+    /// tests can pin either path without a live SLEIGH decoder.
+    #[cfg(test)]
+    pub(crate) fn from_insns_for_test(insns: Vec<Insn>, has_assembly: bool) -> Listing {
+        Listing {
+            insns: insns.into_iter().map(|i| (i.addr, i)).collect(),
+            refs_to: BTreeMap::new(),
+            refs_from: BTreeMap::new(),
+            funcs: BTreeMap::new(),
+            exec_ranges: vec![(0, u64::MAX)],
+            has_assembly,
+        }
+    }
+
     /// Seed the discovered-function model's `has_no_return` / `call_fixup` flags
     /// from the load-time Known passes (the `noreturn_known` / `callfixup` pass
     /// outputs, by entry VMA), so a Listing consumer can skip already-modeled

--- a/decompiler/crates/kuna-console/tests/verify_aif.rs
+++ b/decompiler/crates/kuna-console/tests/verify_aif.rs
@@ -61,6 +61,7 @@
 
 use std::path::PathBuf;
 
+use kuna_analysis::listing::Listing;
 use kuna_console::engine::bootstrap_from_object;
 use kuna_console::ifacedecomp::{execute, register_decomp_commands, IfaceDecompData, DECOMPILE_MODULE};
 use kuna_console::ifaceterm::ConsoleCommands;
@@ -175,6 +176,90 @@ fn aif_recovers_function_reachable_only_via_data_path() {
     assert!(
         body.contains("return"),
         "expected a C function body (with a return) for {HIDDEN_FN}, got:\n{body}"
+    );
+}
+
+/// The fingerprint histogram AIF gates every candidate on is built from the
+/// Listing's mnemonic text, and a `--mode fast` load captures none: the walk skips
+/// the disassembly render when no text consumer will run, so the fingerprint
+/// re-decodes each function's first two instructions through its own `GapDecoder`
+/// instead. This gate holds that substitution to its claim end-to-end with a real
+/// SLEIGH decoder: the entry set AIF accepts off a text-free Listing must equal the
+/// one it accepts off a text-carrying Listing over the same seeds.
+///
+/// The re-decode is not assumption-free — `Sleigh::one_instruction` commits
+/// `globalset` context writes, so on an architecture that globalsets a decode mode
+/// (ARM `TMode`, MIPS `ISA_MODE`) a later decode can change the mode an address
+/// decodes in, and the fingerprint's length-agreement guard declines rather than
+/// mixing two instructions. This fixture is x86-64, which has no decode mode: what
+/// it proves is that the substitution is exact where the re-decode agrees, and that
+/// the guard rejects nothing it should not.
+#[test]
+fn a_text_free_listing_fingerprints_exactly_like_a_text_carrying_one() {
+    let bin = fixture();
+    let path = bin.to_str().unwrap().to_string();
+    let root = repo_root();
+    let spec_roots = vec![root.join("specs").to_str().unwrap().to_string()];
+    let prog = match bootstrap_from_object(&path, "", &spec_roots) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("verify_aif: skipping (bootstrap failed, `make specs`): {}", e.explain());
+            return; // specs-less skip
+        }
+    };
+
+    let bytes = std::fs::read(&bin).expect("read fixture bytes");
+    let file = object::File::parse(&*bytes).expect("parse fixture ELF");
+    let image = kuna_analysis::loadimage_object::ObjectLoadImage::from_bytes(&path, &bytes)
+        .expect("open loadimage");
+    let arch = prog.arch();
+    let translate = arch.translate();
+    let seeds = kuna_analysis::entry::collect_entries(&file, &bytes);
+    let code_space =
+        std::rc::Rc::clone(arch.manage().get_default_code_space().expect("code space"));
+
+    let run = |want_assembly: bool| {
+        let listing = Listing::build_with_meta(
+            &file,
+            &image,
+            arch,
+            translate,
+            &seeds,
+            &seeds,
+            &[],
+            want_assembly,
+        );
+        let count = listing.function_count();
+        let exec = listing.exec_ranges().to_vec();
+        let entries = kuna_analysis::aif::run_aif(
+            &listing,
+            translate,
+            std::rc::Rc::clone(&code_space),
+            &exec,
+            false,
+            false,
+        );
+        (count, entries)
+    };
+
+    let (with_text, texted_entries) = run(true);
+    let (without_text, textless_entries) = run(false);
+
+    assert_eq!(with_text, without_text, "the walk itself must not depend on text capture");
+    assert!(
+        with_text >= 20,
+        "the fixture must clear MINIMUM_FUNCTION_COUNT or the comparison is vacuous \
+         (got {with_text} discovered functions)"
+    );
+    assert!(
+        !texted_entries.is_empty(),
+        "AIF must accept the indirect-only function off the text-carrying Listing, \
+         or the comparison is vacuous"
+    );
+    assert_eq!(
+        texted_entries, textless_entries,
+        "the lazy re-decode must reproduce the text-carrying fingerprint exactly: \
+         AIF accepted {texted_entries:?} with text and {textless_entries:?} without"
     );
 }
 

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -2437,8 +2437,19 @@ to `fast`. The one other reader is AIF's function-start fingerprint (§1.5), whi
 needs the mnemonics of just the first two instructions of each *discovered*
 function; rather than force whole-image capture for that, it falls back to
 re-decoding those addresses through its own gap decoder when the Listing carries
-no text. Re-decoding an address under the same painted context yields the mnemonic
-the walk would have stored, so the histogram — and every gap-walk and
+no text. That the re-decode reproduces the walk's own reading is checked rather
+than assumed: decoding an instruction commits the `globalset` context writes its
+constructor asks for, and both the ARM and MIPS specs globalset a decode mode
+(`TMode`, `ISA_MODE`) at a branch target, so a *later* decode can leave an address
+in a different mode than the walk read it in — and the re-decode would then hand
+back a mnemonic belonging to a different instruction while the stride and total
+length still came from the Listing. Instruction length is the observable of
+exactly that disagreement, since an alternate-ISA reading is a different width, so
+the fingerprint compares the re-decoded length against the Listing's and declines
+to fingerprint the function at all when they differ. Declining is the safe
+direction: a function that contributes no fingerprint only makes the histogram
+smaller, which can never admit a gap candidate the text-carrying path would have
+rejected. Where the two agree the histogram — and every gap-walk and
 pointer-target decision keyed off it — is unchanged, which is what keeps the
 pointer-only entries `fast_funcdisc` exists to find. Second, instruction-byte
 coverage, which is *derived* from the instruction map rather than mirrored into a


### PR DESCRIPTION
## The problem

AIF's function-start fingerprint pairs a mnemonic sequence with a byte length. On a
large image — the whole-binary path issue #510 is about — the Listing carries no
disassembly text, so the mnemonic is re-decoded while the length still comes from the
walk, and nothing checked the two came from the same instruction. They need not: a
decode commits its constructor's `globalset` context writes, and the ARM and MIPS
specs both globalset a decode mode at a branch target, so an address can be re-read in
a different mode than the walk read it in. The widths give it away:

```
$ rasm2 -a arm -b 32 -d 04b02de5     # what the walk recorded: one 4-byte instruction
str fp, [sp, -4]!

$ rasm2 -a arm -b 16 -d 04b02de5     # the same bytes re-read in Thumb: two 2-byte ones
add sp, 0x10
b 0xfffffa60
```

Fingerprinting a function whose first two words read like that yields
`(["push", "MOV"], 8)` — a 2-byte instruction's mnemonic carrying the stride of two
4-byte ones. That record goes straight into the histogram every gap candidate and
every pointer-validated entry is matched against.

## The fix

- Compare the re-decoded length against the Listing's, and decline the fingerprint
  when they differ rather than pairing one instruction's mnemonic with another's stride.
- Declining is the safe direction: a function that contributes no fingerprint only
  makes the histogram smaller, which can never admit a gap candidate the text-carrying
  path would have rejected.
- The re-decode moves behind a closure parameter (`fingerprint_over_listing`) so the
  guard is testable without a live SLEIGH decoder.
- `docs/spec/01-program-prep.md` claimed the re-decode reproduces the walk's reading;
  it now describes the check.

## The tests

A unit test over a synthetic text-free Listing: agreement reproduces the
text-carrying fingerprint exactly, disagreement on either instruction declines, and a
Listing that does carry text never consults the re-decode at all. Without the guard it
fails with the `(["push", "MOV"], 8)` above. `verify_aif` gains an end-to-end gate with
a real decoder: over the same seeds, the entry set AIF accepts off a text-free Listing
must equal the one off a text-carrying Listing.

Scope: the re-decode is reachable today only through `fast_funcdisc`'s pointer
validation, which diverts 32-bit ARM to a path with no histogram, leaving MIPS as the
live exposure; no in-repo MIPS fixture stages a mode flip. Over 70,328 re-decodes on a
19 MB PE and the three MIPS fixtures under `--mode fast`, no length disagreed, and
nothing moved: `functions --json` (35,770 entries) and 8,000 `decompile-all --json`
records byte-identical, plus `/bin/ls`, `/bin/grep` and six fixtures across `auto` and
`fast`. `kuna functions` on that PE, 6 interleaved pairs with alternating arm order:
32.06 s → 31.94 s median.

Gates: `make test` 675/675 PARITY OK, `make test-stages` PARITY OK, `make rust-test`
green, `make check-spec` OK, `make test-cli` 115/115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFpP8jNwKT29DnbXG3neNb
