### PR TITLE
[AUTOMATED] test(cli): pin the --jobs pool's naming, progress and auto surfaces

### DIFF
--- a/decompiler/crates/kuna-cli/src/jobs.rs
+++ b/decompiler/crates/kuna-cli/src/jobs.rs
@@ -62,9 +62,10 @@
 //! `mpengine.dll` functions *slower* than the serial one (327 s against 113 s).
 //! Chunks stay small anyway, because they now cost only a spec file, and a small
 //! chunk is what keeps a worker from sitting idle at the end of a run.  The one
-//! reason to retire a live worker is memory: the per-function arena is never
-//! released inside a process, so a worker is recycled after [`RECYCLE_AFTER`]
-//! functions.
+//! reason to retire a live worker is memory: a process holds its allocator arena
+//! at the high-water mark of the worst per-function transient it ever saw, so a
+//! worker is recycled after [`RECYCLE_AFTER`] functions and the next one starts
+//! from the floor again.
 //!
 //! ## Wire format
 //!
@@ -119,11 +120,16 @@ const MAX_AUTO_CHUNK: usize = 512;
 const CHUNKS_PER_JOB: usize = 8;
 
 /// How many functions one worker process handles before the pool retires it.
-/// This is the memory bound: the per-function arena is never released inside a
-/// process, so without a ceiling a single worker could not finish a
-/// 274,000-function image at all.  Measured flat over the 3,000 functions one
-/// worker decompiled after its load on an 18 MB PE, so the ceiling is high enough
-/// that an ordinary binary never reaches it and pays no second load.
+///
+/// This is the memory ceiling, and what it bounds is the allocator arena, not a
+/// leak: a counting `#[global_allocator]` over 587 functions of a 274,000-function
+/// IL2CPP `.so` shows the LIVE heap flat at 403 -> 411 MB (~14 KB per function
+/// retained) while RSS climbs non-monotonically to 3.3 GB and does not come back
+/// down.  Per-function transients are freed, but the process keeps their
+/// high-water mark, and only a fresh worker returns to the floor.  RSS was
+/// measured flat over the 3,000 functions one worker decompiled after its load on
+/// an 18 MB PE, so the ceiling is high enough that an ordinary binary never
+/// reaches it and pays no second load.
 const RECYCLE_AFTER: usize = 4096;
 
 /// Ceiling on `--jobs auto`.  Each worker pays a whole program load, so the
@@ -663,9 +669,9 @@ pub(crate) fn run_pool(
                             slots[slot] = Some(r);
                         }
                     }
-                    // Recycling bounds the per-function arena, which a process
-                    // never releases; it costs a whole program load, so it is a
-                    // ceiling rather than a rhythm.
+                    // Recycling returns a worker to the memory floor a process
+                    // cannot reach on its own; it costs a whole program load, so
+                    // it is a ceiling rather than a rhythm.
                     if worker.as_ref().is_some_and(|w| w.functions_done >= RECYCLE_AFTER) {
                         if let Some(w) = worker.take() {
                             retire(w);
@@ -1817,6 +1823,30 @@ mod tests {
         for bad in ["0", "-4", "", "many"] {
             assert!(parse_jobs(bad).is_err(), "{bad:?} must be rejected");
         }
+    }
+
+    /// The memory trim runs on every pool start, so it decides the worker count
+    /// as much as `--jobs` does.  `auto` is a promise not to wreck the machine
+    /// and yields to what free memory holds; an explicit count is an instruction
+    /// and is obeyed with a warning.  A request the machine can hold is never
+    /// touched either way.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn auto_yields_to_free_memory_and_an_explicit_count_does_not() {
+        let mut c = cfg(0, 0.0);
+        c.jobs = 1;
+        assert_eq!(affordable_jobs(&c), 1, "one worker fits on any machine that can run this");
+
+        // Far past what any machine holds, so the trim is reached wherever this
+        // runs rather than only on a loaded box.
+        c.jobs = 1_000_000;
+        c.jobs_auto = true;
+        let trimmed = affordable_jobs(&c);
+        assert!(trimmed >= 1, "the trim must still leave a pool: {trimmed}");
+        assert!(trimmed < c.jobs, "`auto` must come down to what fits: {trimmed}");
+
+        c.jobs_auto = false;
+        assert_eq!(affordable_jobs(&c), 1_000_000, "an explicit --jobs N is obeyed, not lowered");
     }
 
     /// Whatever the planning policy, the plan must cover every slot exactly once

--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -74,6 +74,19 @@ fn arm_entrymain() -> String {
         .to_string()
 }
 
+/// A C++ ELF whose `main` calls a **namespaced** member, `foo::Bar::baz`. A name
+/// is installed into the scope its `::` path names, so this is the fixture where
+/// a second function symbol at one address lands in a different scope from the
+/// first and the across-scopes display lookup starts answering with the wrong
+/// one.
+fn cpp_mangled() -> String {
+    repo_root()
+        .join("decompiler/crates/kuna-analysis/tests/fixtures/cpp_mangled_x86_64")
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
 /// Parse the `"count": N` field out of the decompile-all `--json` header.
 fn json_count(stdout: &str) -> Option<usize> {
     let i = stdout.find("\"count\":")? + "\"count\":".len();
@@ -1809,6 +1822,16 @@ fn jobs_output_is_byte_identical_to_serial() {
         let (got, stderr, ok) = run_kuna(&args);
         assert!(ok, "kuna decompile-all --jobs {jobs} failed: {stderr}");
         assert_eq!(got, want, "--jobs {jobs} (chunk {chunk:?}) moved the document");
+        // A run that can take an hour has to say where it is, and it has to say
+        // it on stderr — stdout is the document, byte-compared just above.
+        assert!(
+            stderr.contains("[kuna --jobs]") && stderr.contains("worker process(es)"),
+            "--jobs {jobs} reported no plan on stderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("[kuna --jobs] done:"),
+            "--jobs {jobs} never reported completion:\n{stderr}"
+        );
     }
 }
 
@@ -1843,8 +1866,79 @@ fn jobs_full_load_agrees_with_the_inventory_handoff() {
     assert_eq!(got, want, "--jobs-full-load moved the document");
 }
 
-/// A pool cannot honour a policy it cannot express, so the two it cannot are
-/// refused up front rather than silently dropped in the shards.
+/// The sharp case for the inventory hand-off, and the one the byte-identity
+/// tests above cannot reach: a **namespaced C++ callee**.  Seeding the parent's
+/// inventory into a worker has to be strictly additive, because a name is
+/// installed into the scope its `::` path names — re-register an address the
+/// worker's own load already named and that address ends up with two function
+/// symbols in different scopes, at which point the across-scopes display lookup
+/// answers with the other one and `main` prints `sub_401136(...)` where the
+/// serial run printed `foo::Bar::baz(...)`.  Preserving callee names is what the
+/// hand-off exists for, so it gets a fixture where it can actually fail.
+#[test]
+fn jobs_preserves_namespaced_cpp_callee_names() {
+    let bin = cpp_mangled();
+    let sp = specs();
+    let base =
+        ["decompile-all", bin.as_str(), "--max-fn-seconds", "0", "--sleighpath", sp.as_str()];
+    let (want, stderr, ok) = run_kuna(&base);
+    if !ok {
+        if is_specs_skip(&stderr) {
+            eprintln!("jobs c++ names: skipping (no `.sla`; run `make specs`): {stderr}");
+            return;
+        }
+        panic!("kuna decompile-all failed: {stderr}");
+    }
+    assert!(
+        want.contains("foo::Bar::baz("),
+        "the fixture no longer calls a namespaced member, so this pins nothing:\n{want}"
+    );
+
+    for chunk in ["1", "2", "3"] {
+        let mut args = base.to_vec();
+        args.extend_from_slice(&["--jobs", "6", "--jobs-chunk", chunk]);
+        let (got, stderr, ok) = run_kuna(&args);
+        assert!(ok, "kuna decompile-all --jobs 6 --jobs-chunk {chunk} failed: {stderr}");
+        assert_eq!(got, want, "--jobs-chunk {chunk} moved a namespaced callee name");
+    }
+}
+
+/// The other half of the surface: `--jobs auto` resolves the worker count from
+/// the machine (cores, capped, then trimmed to what free memory holds) instead
+/// of the command line, and the plain concatenated-C output has no record
+/// framing to hide a mis-ordered merge.  Both have to land on the serial
+/// document exactly.
+#[test]
+fn jobs_auto_and_the_plain_c_surface_match_serial() {
+    let bin = fauxware();
+    let sp = specs();
+    let base =
+        ["decompile-all", bin.as_str(), "--max-fn-seconds", "0", "--sleighpath", sp.as_str()];
+    let (want, stderr, ok) = run_kuna(&base);
+    if !ok {
+        if is_specs_skip(&stderr) {
+            eprintln!("jobs auto: skipping (no `.sla`; run `make specs`): {stderr}");
+            return;
+        }
+        panic!("kuna decompile-all failed: {stderr}");
+    }
+    assert!(want.matches("// Function:").count() > 1, "the fixture must hold several functions");
+
+    for extra in [vec!["--jobs", "auto"], vec!["--jobs", "3", "--jobs-chunk", "1"]] {
+        let mut args = base.to_vec();
+        args.extend_from_slice(&extra);
+        let (got, stderr, ok) = run_kuna(&args);
+        assert!(ok, "kuna decompile-all {extra:?} failed: {stderr}");
+        // Agreeing with the serial document is also what a silent fall back to
+        // the serial path would do, so the pool has to be seen coming up.
+        assert!(stderr.contains("worker process(es)"), "{extra:?} ran no pool:\n{stderr}");
+        assert_eq!(got, want, "{extra:?} moved the concatenated-C document");
+    }
+}
+
+/// A pool cannot honour a policy it cannot express, so the ones it cannot are
+/// refused up front rather than silently dropped in the shards — as is a worker
+/// or chunk count that is not a count at all.
 #[test]
 fn jobs_refuses_what_a_pool_cannot_carry() {
     let bin = fauxware();
@@ -1866,6 +1960,20 @@ fn jobs_refuses_what_a_pool_cannot_carry() {
         run_kuna(&["decompile-all", &bin, "--json", "--jobs", "0", "--sleighpath", &specs()]);
     assert!(!ok, "--jobs 0 must be refused");
     assert!(stderr.contains("--jobs"), "the refusal must name the flag:\n{stderr}");
+
+    let (_, stderr, ok) = run_kuna(&[
+        "decompile-all",
+        &bin,
+        "--json",
+        "--jobs",
+        "2",
+        "--jobs-chunk",
+        "0",
+        "--sleighpath",
+        &specs(),
+    ]);
+    assert!(!ok, "--jobs-chunk 0 must be refused, not rounded up to a real chunk");
+    assert!(stderr.contains("--jobs-chunk"), "the refusal must name the flag:\n{stderr}");
 }
 
 /// The pool's scratch directory carries the whole program's symbol inventory and

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -902,11 +902,13 @@ its load.
 A worker's load is the expensive half of it — 17 s and 469 MB on an 18 MB PE, next
 to ~70 ms for the average function — so a worker is started once and then serves
 chunk after chunk down a pipe until the plan is empty, and is recycled only when
-the functions it has decompiled reach the ceiling that bounds the per-function
-arena a process never releases. A worker also skips the whole-binary discovery the
-parent has already run (`fast_funcdisc`), because that discovery is most of the
-load; its *product* is what `FlowInfo::queryCall` reads, so the parent hands its
-canonical inventory over instead, replayed through the loader-symbol seam
+the functions it has decompiled reach a ceiling. That ceiling bounds an allocator
+arena rather than a leak: per-function transients are freed, but a process keeps
+their high-water mark, so only a fresh worker returns to the memory floor. A
+worker also skips the whole-binary discovery the parent has already run
+(`fast_funcdisc`), because that discovery is most of the load; its *product* is
+what `FlowInfo::queryCall` reads, so the parent hands its canonical inventory
+over instead, replayed through the loader-symbol seam
 (`decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::seed_function_inventory)`).
 The seeding is strictly additive — an address this load already resolves, or a name
 it already carries, is left alone — because a name is installed into the scope its


### PR DESCRIPTION
Sharding a whole-binary run must not change a callee's name, and the parent's
inventory hand-off is what keeps it from doing so. Nothing tested that: both
byte-identity tests use a target whose names cannot move either way.

```
$ kuna decompile-all decompiler/crates/kuna-analysis/tests/fixtures/cpp_mangled_x86_64 \
      --jobs 6 --jobs-chunk 1 | sed -n '/Function: main/,+7p'
// Function: main @ 0x401154
unsigned long main(void)
{
  long v1;

  foo::Bar::baz(&v1,0x2a);
  return 0;
}
```

Drop the two skips that keep `ConsoleProgram::seed_function_inventory` additive
and that line becomes `sub_401136(&v1,0x2a)`, while `cargo test -p kuna-cli jobs`
stays green.

## The change

- `jobs_preserves_namespaced_cpp_callee_names` runs that fixture through the pool
  at three chunk sizes — the case where the seeding rule can fail.
- `jobs_output_is_byte_identical_to_serial` now also asserts the plan and
  completion lines on stderr; nothing pinned that the pool reports progress.
- `jobs_auto_and_the_plain_c_surface_match_serial` covers `--jobs auto` and the
  concatenated-C surface, and asserts a pool actually came up: agreeing with the
  serial document is also what a silent fall back to serial would do.
- `auto_yields_to_free_memory_and_an_explicit_count_does_not` covers the
  `/proc/meminfo` trim that runs on every pool start — `auto` yields to it, an
  explicit `--jobs N` is obeyed. `--jobs-chunk 0` joins the refusal test.
- Corrects the recycling rationale in `jobs.rs` and `docs/spec/00-overview.md`.
  The comments said the per-function arena is never released, and concluded a
  single worker could not finish a 274,000-function image at all. A counting
  `#[global_allocator]` over 587 functions of that image shows the live heap flat
  at 403 -> 411 MB while RSS climbs to 3.3 GB and stays: the transients are freed
  and the process keeps their high-water mark. Still a reason to recycle, not
  that one.

## Tests

Each new assertion was checked against a tree with the behaviour it pins removed:
non-additive seeding (only the new C++ test catches it — the other five pass),
silenced progress, a merge that files results in completion order, `--jobs auto`
resolving to 1, an explicit count trimmed like `auto`, and `--jobs-chunk`
accepting 0.

Gates: `make test` 675/675 PARITY OK, `make test-stages` 730/730 PARITY OK,
`make rust-test` 6328 passed / 0 failed, `make check-spec` OK, `make test-cli`
115/115. `decompile-all --json` is byte-identical to main over 1,500 functions of
the 18 MB PE from #510, `/bin/ls` and both fixtures — 0 differing records of
1,811. The two new end-to-end tests cost about 2.8 s (median of 5 interleaved
pairs, single-threaded: 3.49 s to 5.99 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFpP8jNwKT29DnbXG3neNb
