### PR TITLE
[AUTOMATED] fix(cli): mach-o-import-data — an import name selects its code half

### DIFF
--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -866,27 +866,34 @@ impl ConsoleProgram {
     /// name-narrowing the old `(name, offset)` dedup was keeping duplicate records
     /// for.
     ///
-    /// `None` also when the name identifies SEVERAL entries: a caller that can
+    /// `None` also when the name identifies SEVERAL entries no
+    /// [`Self::lone_executable_candidate`] narrowing settles: a caller that can
     /// only answer yes-or-no must not silently pick one of them. A caller that
     /// can report the ambiguity asks [`Self::resolve_entry`] instead, which
-    /// names every candidate.
+    /// names every candidate. The narrowing is shared with `resolve_entry` so
+    /// that the two name lookups cannot answer one name at two addresses —
+    /// `disassemble` and `read` reach a name through this one and fall through
+    /// to the raw symbol table when it declines, which on a PE import pair is
+    /// the pointer slot rather than the thunk `decompile` would have picked.
     pub fn find_entry_by_name(&self, want: &str) -> Option<FunctionEntry> {
         // (kuna `symbolnamebound`) The enumeration reports the bounded spelling,
         // so bound the query too -- a caller holding the binary's ORIGINAL name
         // must still resolve. Idempotent, so the bounded spelling resolves as
         // well, and a no-op for every real name.
         let want = &*kuna_decomp::kuna_symbolnamebound::bound_scope_path(want, "::");
-        let mut matches = self
+        let mut matches: Vec<FunctionEntry> = self
             .function_entries_canonical()
             .into_iter()
-            .filter(|e| e.name == want || e.aliases.iter().any(|a| a == want));
-        let Some(entry) = matches.next() else {
-            // (kuna, RE-need `string-owner-function-name`) Same placeholder
-            // fallback [`Self::resolve_entry`] takes, so the two name lookups
-            // answer one name the same way.
-            return self.entry_by_placeholder_name(want);
-        };
-        matches.next().is_none().then_some(entry)
+            .filter(|e| e.name == want || e.aliases.iter().any(|a| a == want))
+            .collect();
+        // On a miss, the (kuna, RE-need `string-owner-function-name`) placeholder
+        // fallback [`Self::resolve_entry`] takes, so the two name lookups answer
+        // one name the same way.
+        match matches.len() {
+            0 => self.entry_by_placeholder_name(want),
+            1 => Some(matches.remove(0)),
+            _ => self.lone_executable_candidate(&matches),
+        }
     }
 
     /// (kuna, issue #197) Resolve the canonical entry AT `vma`, tolerating an
@@ -1111,6 +1118,11 @@ impl ConsoleProgram {
     ) -> Result<FunctionEntry, EntryLookupError> {
         candidates.sort_by_key(|entry| entry.addr.get_offset());
         candidates.dedup_by_key(|entry| entry.addr.get_offset());
+        if candidates.len() > 1 {
+            if let Some(entry) = self.lone_executable_candidate(&candidates) {
+                return Ok(entry);
+            }
+        }
         match candidates.len() {
             0 => Err(EntryLookupError::NotFound {
                 selector: selector.display(),
@@ -1121,6 +1133,34 @@ impl ConsoleProgram {
                 candidates,
             }),
         }
+    }
+
+    /// (kuna, RE-need `mach-o-import-data`) The one candidate that lives in
+    /// executable memory, when a selector matches several and exactly one does.
+    ///
+    /// An import name is spelled twice in a dynamically linked image: once on
+    /// the stub a direct call jumps to, and once on the pointer slot that stub
+    /// reads. Both are entries — the slot's name is what makes an indirect call
+    /// through it readable, and a slot with no stub twin (`__DATA,__got`,
+    /// `__DATA,__nl_symbol_ptr`) is the only place its name appears at all — so
+    /// neither can be dropped from the inventory. On a Mach-O they collide by
+    /// name, and `kuna decompile <image> strcmp` answered `selector "strcmp" is
+    /// ambiguous` for all nine imports of a 26-entry inventory, with only a raw
+    /// `--addr` left to the caller. ELF already behaves the way this makes
+    /// Mach-O behave, by naming only the PLT stub.
+    ///
+    /// Resolved at SELECTION time rather than by pruning the inventory, so it
+    /// fires only where a twin actually exists and every lone slot row survives.
+    /// Narrowing to EXACTLY one keeps a genuine collision an error: two
+    /// same-named definitions in different code sections of a relocatable object
+    /// are both executable, and picking either would be a guess.
+    fn lone_executable_candidate(&self, candidates: &[FunctionEntry]) -> Option<FunctionEntry> {
+        let sections = self.sections();
+        let mut executable = candidates
+            .iter()
+            .filter(|entry| self.entry_is_executable(entry.addr.get_offset(), &sections));
+        let only = executable.next()?;
+        executable.next().is_none().then(|| only.clone())
     }
 
     /// (kuna, RE-need `string-owner-function-name`) The address an ENGINE-MINTED

--- a/decompiler/crates/kuna-console/tests/verify_entry_selectors.rs
+++ b/decompiler/crates/kuna-console/tests/verify_entry_selectors.rs
@@ -424,3 +424,51 @@ fn a_placeholder_name_is_not_read_as_an_address_unless_this_build_would_mint_it(
         assert!(program.find_entry_by_name(miss).is_none(), "{miss}");
     }
 }
+
+/// (RE-need `mach-o-import-data`) An import name spelled on both a `__stubs`
+/// veneer and the `__la_symbol_ptr` slot that veneer reads resolves to the
+/// veneer, and BOTH entries stay in the inventory.
+///
+/// Dropping the data row would close the ambiguity too, and would delete the
+/// only name a slot with no veneer (`__DATA,__got`, `__DATA,__nl_symbol_ptr`)
+/// ever carries — so the narrowing is at selection, not in the enumeration.
+#[test]
+fn a_macho_import_name_resolves_to_its_stub_without_losing_the_slot() {
+    let Some(program) = boot_fixture("macho_imports") else {
+        return;
+    };
+
+    let entry = program
+        .resolve_entry(&EntrySelector::Name("printf".into()))
+        .expect("the __stubs veneer is the one executable candidate");
+    assert_eq!(entry.addr.get_offset(), 0x1000005cc);
+
+    let rows: Vec<u64> = program
+        .function_entries_canonical()
+        .into_iter()
+        .filter(|e| e.name == "printf")
+        .map(|e| e.addr.get_offset())
+        .collect();
+    assert_eq!(rows, vec![0x1000005cc, 0x100003000], "both rows survive");
+    assert!(
+        !program.any_executable_entry(&[program
+            .find_entry_at(0x100003000)
+            .expect("the slot row")]),
+        "the slot is what makes the veneer the lone executable candidate"
+    );
+}
+
+/// The narrowing needs EXACTLY one executable candidate: two definitions in
+/// different code sections of one object are both executable and stay
+/// ambiguous, and a sectionless XML image reads every address as executable, so
+/// neither can be silently guessed.
+#[test]
+fn same_named_code_definitions_are_still_ambiguous() {
+    let Some(program) = boot_fixture("entry_selectors_x86_64.o") else {
+        return;
+    };
+    let error = program
+        .resolve_entry(&EntrySelector::Name("duplicate_local".into()))
+        .expect_err("two .text definitions are both executable");
+    assert!(matches!(error, EntryLookupError::Ambiguous { .. }), "{error}");
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -157,6 +157,25 @@ kuna decompile ./graphy sub_deadbeef
 #          an address with --addr
 ```
 
+**An import name selects the code half.** A dynamically linked image spells an
+import's name twice — on the forwarding veneer a direct `call` targets, and on
+the IAT/GOT slot that veneer reads — so `strcmp` matches two entries. The
+executable one wins: the veneer is the only candidate that has a body, so the
+selector is answered there rather than refused.
+
+```bash
+kuna decompile ./mach-o-crackme strcmp
+#   int strcmp(char *a0,char *a1) { ... }      # the __TEXT,__stubs veneer
+```
+
+Both entries stay in `kuna functions` — a slot with no veneer (`__DATA,__got`,
+`__DATA,__nl_symbol_ptr`, an IAT entry a `call [slot]` reaches directly) is the
+only place its name appears at all — and every surface that takes a name
+(`decompile`, `decompile-all --functions`, `disassemble`, `read`, `xrefs`)
+resolves it to the same veneer. The narrowing needs **exactly one** executable
+candidate, so two same-named definitions in different code sections of a
+relocatable object still report the ambiguity with every candidate listed.
+
 **The instruction budget.** Flow following decodes at most `maxinstruction`
 instructions per function — 100000 by default, which no ordinary function comes
 near and an obfuscated one blows through. Past the budget the decompiling

--- a/docs/features/mach-o-import-data/pr_body.md
+++ b/docs/features/mach-o-import-data/pr_body.md
@@ -1,0 +1,53 @@
+## The problem
+
+An import's name sits on two entries — the veneer a direct `call` targets and the
+pointer slot that veneer reads — so asking for it by name was refused. Every one
+of the nine imports in this Mach-O crackme is that shape.
+
+```
+$ kuna decompile ./bin/main strcmp
+error: selector "strcmp" is ambiguous; candidates:
+  strcmp at synthetic 0x100003ede
+  strcmp at synthetic 0x100008030
+use a section-qualified selector to choose one candidate
+```
+
+Only `--addr` reached the function. The same names fared worse on `disassemble`
+and `read`, which do not report the ambiguity — they fall through to the raw
+symbol table and answer at the pointer word, so on a MinGW PE
+`kuna disassemble ./a.exe memcpy` listed eight bytes of import table as
+instructions.
+
+## The fix
+
+- A selector that matches several entries resolves to the one in executable
+  memory, when exactly one is. That is the same test whole-binary decompilation
+  already uses (`entry_is_executable`: a loader section carrying `CODE`, minus
+  the import slots the loader itself filled in) — reusing it is what handles the
+  one-section PE whose IAT sits inside `.text`, where the section flag alone
+  cannot tell the two apart.
+- Both name lookups take it, not just the one that reports ambiguity. Narrowing
+  only `resolve_entry` would have left `decompile` and `disassemble` answering
+  one name at two different addresses.
+- The inventory is not pruned. Dropping non-executable import rows would settle
+  the ambiguity too, and would delete the only name a slot with no veneer ever
+  carries — `__DATA,__got`, `__DATA,__nl_symbol_ptr`, an IAT entry a
+  `call [slot]` reaches directly. Two of the nine such rows on a nearby Mach-O
+  are exactly that.
+- It requires *exactly* one executable candidate, so two same-named definitions
+  in different code sections of a relocatable object still report every
+  candidate.
+
+## The tests
+
+`verify_entry_selectors.rs` gains the Mach-O import pair (resolves to the veneer,
+both rows survive) — it fails on the unpatched tree — and a case pinning that two
+`.text` definitions stay ambiguous. `tests/cli/mach-o-import-data.json` guards the
+CLI surface against the vendored `macho_imports`.
+
+Swept across 163 vendored images: of 155 duplicated names, 134 go from the
+ambiguity error to a resolved veneer and none go the other way; on `disassemble`
+and `read`, 78 names move from the pointer word to its thunk, and 77 of those old
+answers were ones kuna itself flagged as "in a non-executable data section".
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/features/mach-o-import-data/record.json
+++ b/docs/features/mach-o-import-data/record.json
@@ -1,0 +1,53 @@
+{
+  "need_id": "mach-o-import-data",
+  "track": "loader",
+  "scope": "small",
+  "worker": "b-r12-mach-o-import-da",
+  "branch": "feat/re-mach-o-import-data",
+  "symptom": "`kuna decompile <macho> strcmp` exits 1 with `selector \"strcmp\" is ambiguous; candidates: strcmp at synthetic 0x100003ede / strcmp at synthetic 0x100008030`. 1 instance, round 12 (crackmes.one 64c8b272b25df8732eebc2a6, bin/main), and all 9 imports of that 26-row inventory are the same shape.",
+  "diagnosis": "An import's name is on two entries -- the __TEXT,__stubs veneer and the __DATA,__la_symbol_ptr slot it reads -- and `ConsoleProgram::one_candidate` returned `Ok` only for a single candidate, so every by-name surface refused the name. The engine already knew which candidate is code: `entry_is_executable` (CODE section flag, minus the loader's own import slots) backs `function_entries_executable`. It was simply never consulted at selection.",
+  "hypothesis_status": "upheld",
+  "decisions": [
+    "The filed hypothesis ('import pointer slots compete with executable stubs during function selection') is right and the refuter's safe rule is implemented verbatim: narrow at SELECTION time, prefer the executable candidate, fire only when EXACTLY one candidate qualifies.",
+    "The inventory is NOT pruned. Dropping non-executable import rows settles the ambiguity too and is wrong: a slot with no veneer is the only place its name appears. Re-measured on the sibling `mach-o-objc-msgsend`'s own binary -- 84 rows before and after, objc_msgSend still at 0x100004038 and dyld_stub_binder still at 0x100004028, and both still resolve by name.",
+    "Wired into BOTH name lookups, not just `resolve_entry`. `disassemble` and `read` reach a name through `find_entry_by_name`, which returns None on several candidates and falls through to the raw symbol table -- which on an import pair holds the pointer word. Fixing only `resolve_entry` would have left `kuna decompile X memcpy` and `kuna disassemble X memcpy` answering at two different addresses; measured, 78 names across the vendored PE fixtures moved from the slot's bytes to the thunk's `jmp [slot]`.",
+    "The predicate is the existing `entry_is_executable`, not a fresh section-flag test. That is what covers the one-section PE where the IAT lives inside the CODE section: win32sigs_pe_i386.exe's LoadLibraryExW slot at 0x401000 passes the flag test and is still excluded, because the loader knows it put the name there.",
+    "EXACTLY one, never a majority. Two same-named definitions in different code sections of a relocatable object are both executable and keep the ambiguity error, and a sectionless XML image reads every address as executable, so the datatest corpus cannot reach the narrowing at all.",
+    "No option row and no DIV row: a selector-resolution bug fix that corrects a refusal. It emits no C that was emitted before -- the previous answer on every case it touches was an error or a data address. phases.toml, options.rs, docs/options.md, docs/history.md, the catalog counters and tests/stages are untouched (they are also the sibling builder's leases this wave).",
+    "The acceptance stays on the dataset witness; `tests/cli/mach-o-import-data.json` is a hand-written CI twin retargeted onto the already-vendored `macho_imports` fixture, whose printf carries the identical veneer(0x1000005cc)+slot(0x100003000) shape. No new fixture binary was needed."
+  ],
+  "changed": [
+    "decompiler/crates/kuna-console/src/engine.rs",
+    "decompiler/crates/kuna-console/tests/verify_entry_selectors.rs",
+    "tests/cli/mach-o-import-data.json",
+    "docs/cli.md",
+    "docs/spec/00-overview.md",
+    "docs/re-needs/mach-o-import-data.md"
+  ],
+  "acceptance": "PASS -- on the filed dataset witness, `kuna decompile bin/main strcmp --option calleearity on --option varargstackargs on` exits 0 and emits `int strcmp(char *a0,char *a1)`; both clauses (exit_code, stdout_matches `strcmp\\(`) flipped from fail.",
+  "sweep": {
+    "duplicate names, resolve_entry": "163 vendored ELF/PE/Mach-O/COFF images, every duplicated name run through `kuna decompile-all --functions <name>` before and after: 155 duplicated names, 134 changed, ALL of them rc=1 (ambiguous) -> rc=0. Zero went the other way and zero previously-successful resolution moved. The 21 unchanged are same-named CODE definitions (mcount_x86_64's duplicated libc symbols, entry_selectors_x86_64.o, cppproto_x86_64) or PE pairs where both candidates are import slots.",
+    "duplicate names, find_entry_by_name": "the same names through `kuna disassemble` and `kuna read`: 310 pairs, 156 changed (78 names x 2 surfaces). Every one moves from the pointer word to its thunk -- 77 of 78 old picks were flagged by kuna's own `--as auto` as 'in a non-executable data section'; the 78th (win32sigs_pe_i386.exe LoadLibraryExW) is the one-section PE where the IAT shares the CODE section, and its old pick disassembled the pointer bytes 0x00401010 as `MOV AL,[0x10]` while the new pick is `JMP dword ptr [0x401000]`.",
+    "sibling need": "mach-o-objc-msgsend's binary (arena 11/5ab77f56): 84 rows before and after, same 7 duplicated names, both lone slot rows intact. All 9 names now resolve by `kuna decompile`; the 2 lone ones were never ambiguous and are unchanged.",
+    "xrefs": "the 7 duplicated names on that binary go from `error: ... is ambiguous` to a real answer at the veneer; the 2 lone rows answer identically before and after."
+  },
+  "speed": {
+    "method": "kuna functions / kuna decompile-all --functions main on pe_imports.exe, warmup + 8 repeats, median",
+    "before": "functions 0.29 s, decompile-all 0.29 s",
+    "after": "functions 0.28 s, decompile-all 0.29 s",
+    "delta": "0.0% -- the section walk runs only on the multi-candidate path, at most once per selector"
+  },
+  "tests": {
+    "kuna-console/tests/verify_entry_selectors.rs": "2 e2e tests on the vendored macho_imports: printf resolves to the 0x1000005cc veneer while BOTH canonical rows survive (fails on the unpatched tree with the two-candidate Ambiguous), and two .text definitions of `duplicate_local` stay ambiguous so the narrowing cannot be a majority vote",
+    "tests/cli": "mach-o-import-data.json, 116/116"
+  },
+  "gates": {
+    "make test": "PARITY OK, 675/675",
+    "make test-stages": "PARITY OK, 730/730",
+    "make rust-test": "GREEN (rc=0, 6325 tests passed, 0 failures), run with `env -u KUNA_DECOMP_TEST` -- the repipe launcher exports that var at the worktree's own decomp_test_dbg, which makes verify_w10_* read as oracle drift",
+    "make check-spec": "OK (strict OK)",
+    "kuna catalog --check": "OK",
+    "make test-cli": "116/116",
+    "re acceptance suite": "111 needs replayed: mach-o-import-data CLOSED, 56 closed, 0 regressions attributable here. The two rows the suite calls `regressed` are pre-existing: `getprocaddress-result-discarded` produces BYTE-IDENTICAL output on a build without this change, and `decompiling-3396-byte-main` is the 10s wall-clock bar, measured at 10.2-10.6 s unpatched and 10.0-10.2 s patched."
+  }
+}

--- a/docs/re-needs/mach-o-import-data.md
+++ b/docs/re-needs/mach-o-import-data.md
@@ -1,0 +1,128 @@
+---
+need_id: mach-o-import-data
+title: Mach-O import data slots make function names ambiguous
+track: loader
+status: open
+severity: minor
+probe_id: p-0574eaac8b66
+acceptance_id: a-17a1cf6a6f7c
+hypothesis_status: upheld
+credibility: 0.7
+instances: 1
+challenges: [64c8b272b25df8732eebc2a6]
+rounds: [12]
+first_seen_round: 12
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-analysis]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Decompile strcmp by its inventory name.
+
+> **Mach-O import data slots make function names ambiguous** (minor, `64c8b272b25df8732eebc2a6`)
+> Rejected strcmp as ambiguous between code at 0x100003ede and a lazy pointer at 0x100008030. Both candidates were labelled synthetic.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "strcmp",
+    "--option",
+    "calleearity",
+    "on",
+    "--option",
+    "varargstackargs",
+    "on"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 1
+    },
+    "stderr_matches": [
+      "selector .*strcmp.* is ambiguous"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/main",
+    "binary_sha256": "979555f6b20fc5f024358ef26603f4c25e8db326941f86af30726eca9fea453e",
+    "binary_size": 50080,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "strcmp",
+    "--option",
+    "calleearity",
+    "on",
+    "--option",
+    "varargstackargs",
+    "on"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "strcmp\\("
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/main",
+    "binary_sha256": "979555f6b20fc5f024358ef26603f4c25e8db326941f86af30726eca9fea453e",
+    "binary_size": 50080,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- Import pointer slots compete with executable stubs during function selection.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `64c8b272b25df8732eebc2a6` (round 12, tester t-r12-64c8b272)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+- split by captain at T_DEDUP from round 12's `bad-ux|decompile|exit_code,stdout_matches` bucket: cluster.py's signature (kind|subcommand|clause-shape) collapsed unrelated defects, so the crop was hand-partitioned one observation per need and filed via `--from-file`. See `.kuna-repipe/rounds/12/dedup/MARKER.json`; do NOT run `cluster --round 12` bare.
+- round 12 REFUTER: hypothesis **upheld** (was inconclusive). UPHELD, measured, but the OBVIOUS FIX ROUTE IS WRONG-OUTPUT AND WOULD TAKE OUT A SIBLING NEED. Hypothesis as filed ("import pointer slots compete with executable stubs during function selection") is exactly right. Mapped both candidates to Mach-O sections by hand: 0x100003ede is __TEXT,__stubs initprot=5 (r-x, EXECUTABLE), section type 0x08 = S_SYMBOL_STUBS, size 6 (one jmp *(%rip)); 0x100008030 is __DATA,__la_symbol_ptr initprot=3 (rw-, NOT executable), type 0x07 = S_LAZY_SYMBOL_POINTERS, size 0. Not a one-off: ALL 9 duplicated names in this 26-row inventory are that exact shape (__stack_chk_fail/__strcpy_chk/printf/rand/scanf/srand/strcmp/strlen/time), each one executable stub + one non-executable slot, so the executable bit resolves 9 of 9 uniquely. CAUTION ON MY OWN NUMBERS: my first pass printed execs=2 for every pair because I tested initprot&1, which is the READ bit; execute is &4. Corrected it is 1 of 2 per pair. THE ACCEPTANCE IS REACHABLE AND HONEST: kuna decompile <bin> 0x100003ede --addr --option calleearity on --option varargstackargs on already exits 0 and emits "int strcmp(char *a0,char *a1)", so resolving the selector to the executable candidate satisfies stdout_matches "strcmp\(" with correct output, not a technicality. ELF CONTROL SAYS THIS IS MACH-O-LOCAL AND THE CORRECT BEHAVIOUR IS ALREADY SHIPPED ELSEWHERE: kuna functions /bin/ls --json gives 278 rows and ZERO duplicated names, i.e. the ELF loader already declines to emit a function row for .got.plt while naming the PLT stub. So the target state is "make Mach-O match ELF", not new policy. NOW THE PART A BUILDER MUST NOT GET WRONG. The tempting route -- drop non-executable import-pointer rows from the function inventory -- SHIPS WRONG OUTPUT AND REGRESSES THE OPEN SIBLING mach-o-objc-msgsend. Measured on that needs own binary (arena 11/5ab77f56, fat Mach-O, x86_64 slice): 84 rows, 9 non-executable. SEVEN of them have a stub twin (twins=2) and are safe to drop, but TWO ARE LONE ROWS WITH NO EXECUTABLE TWIN -- objc_msgSend 0x100004038 in __DATA,__got (twins=1) and dyld_stub_binder 0x100004028 in __DATA,__nl_symbol_ptr (twins=1). objc_msgSend 0x100004038 is LITERALLY the row mach-o-objc-msgsend is built on ("functions identifies objc_msgSend at 0x100004038"); deleting it destroys the only place that name appears and kills the sibling. __got/__nl_symbol_ptr slots reached by direct indirect call have no stub, so a blanket drop loses names permanently. THE SAFE RULE: disambiguate at SELECTION time -- when a selector matches several candidates, prefer the one in an executable section -- which only fires when a twin exists, resolves all 9 pairs here and all 7 there, and leaves every lone slot row intact. NOT AN OPPOSING ACCEPTANCE with the other same-binary sibling: typed-mach-o-tail asserts "data 0x100008030 int (*strcmp_ptr)(char *,char *)" and so already treats 0x100008030 as DATA, keyed by address in the data plane rather than by the function inventory; it agrees with this fix rather than fighting it.
+- round 12 BUILDER b-r12-mach-o-import-da: symptom reproduced, hypothesis UPHELD and the refuter's safe rule implemented verbatim -- `ConsoleProgram::lone_executable_candidate` narrows a multi-candidate selector to the one entry in executable memory (`entry_is_executable`: a loader section carrying CODE, minus the loader's own import slots), and only when EXACTLY one candidate qualifies. Wired into BOTH name lookups: `resolve_entry` (decompile / decompile-all --functions / xrefs) and `find_entry_by_name` (disassemble / read), because narrowing only the first would have made `kuna decompile X memcpy` and `kuna disassemble X memcpy` answer at two different addresses -- measured on the vendored PE fixtures, 78 names resolved to the pointer word rather than the thunk. Inventory untouched, so the sibling `mach-o-objc-msgsend`'s lone rows survive (verified: that binary still reports 84 rows with objc_msgSend at 0x100004038 and dyld_stub_binder at 0x100004028, and both still resolve). Sweep over 163 vendored images: 134 of 155 duplicated names go error -> resolved, 0 go the other way, and the 21 that stay ambiguous are all same-named CODE definitions. CI twin is `tests/cli/mach-o-import-data.json`, retargeted onto the vendored `macho_imports` (printf at 0x1000005cc / 0x100003000, the same veneer+slot shape); the acceptance here stays on the dataset witness.

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -254,9 +254,31 @@ Four front-ends drive one engine assembly:
   `decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::function_entries_executable)`:
   only entries inside a loader section carrying `CODE` are treated as function
   bodies. Import slots remain installed for call naming, prototypes, and
-  unrestricted explicit address selection; name selection keeps its normal
-  first matching canonical-entry behavior when a stub and slot share a name. A
+  unrestricted explicit address selection. A
   loader that publishes no section metadata retains the complete canonical set.
+
+  When a stub and its slot share a name, that same executability test settles the
+  SELECTION rather than pruning the inventory
+  (`decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::lone_executable_candidate)`,
+  reached from both name lookups). A dynamically linked image spells an import's
+  name on both the forwarding veneer a direct call targets and the IAT/GOT slot
+  that veneer reads, so the name matches two entries and every by-name surface
+  refused it: `kuna decompile <macho> strcmp` answered `selector "strcmp" is
+  ambiguous` for all nine imports of a 26-entry inventory, while `disassemble`
+  and `read`, which fall through to the raw symbol table when
+  `find_entry_by_name` declines, answered at the pointer word instead — 78 names
+  across the vendored PE fixtures listed the slot's bytes rather than the thunk's
+  `jmp [slot]`. Exactly one candidate is executable, and it is the only one that
+  can have a body, so that one is the answer. Pruning the data row would settle
+  the ambiguity too and is wrong: a slot with no veneer — a `__DATA,__got` or
+  `__DATA,__nl_symbol_ptr` word, an IAT entry a `call [slot]` reaches directly —
+  is the only place its name appears at all, and on one measured Mach-O two of
+  nine non-executable rows were lone. The narrowing therefore fires only where a
+  veneer exists, and it requires EXACTLY one executable candidate: two
+  same-named definitions in different code sections of a relocatable object are
+  both executable and keep the ambiguity error, as does every candidate set on a
+  sectionless image, where the test reads every address as executable. This is
+  what makes Mach-O behave the way ELF already did by naming only the PLT stub.
   A **caller-declared** entry (the declared-extent plane below) is kept whatever the section flags say
   (`decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::is_declared_entry)`).
   The `CODE` test is a guess about where code lives, and a packer defeats it for

--- a/tests/cli/mach-o-import-data.json
+++ b/tests/cli/mach-o-import-data.json
@@ -1,0 +1,44 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "printf",
+    "--option",
+    "calleearity",
+    "on",
+    "--option",
+    "varargstackargs",
+    "on"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/macho_imports",
+    "binary_sha256": "0394e1be81c4ccdfb28a50cf5dba55a6d95a692cd5504f2305a8f139e8f86675",
+    "binary_size": 16688,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/macho_imports",
+    "selector": "printf",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "printf\\("
+    ],
+    "stderr_absent": [
+      "is ambiguous"
+    ]
+  },
+  "notes": "mach-o-import-data: an import name spelled on both a __stubs veneer and its __la_symbol_ptr slot made the name unselectable. Witness crackmes.one 64c8b272b25df8732eebc2a6 bin/main (strcmp, 9 such pairs); retargeted onto the vendored macho_imports, the same shape at printf 0x1000005cc / 0x100003000, so it runs where there is no dataset."
+}


### PR DESCRIPTION
## The problem

An import's name sits on two entries — the veneer a direct `call` targets and the
pointer slot that veneer reads — so asking for it by name was refused. Every one
of the nine imports in this Mach-O crackme is that shape.

```
$ kuna decompile ./bin/main strcmp
error: selector "strcmp" is ambiguous; candidates:
  strcmp at synthetic 0x100003ede
  strcmp at synthetic 0x100008030
use a section-qualified selector to choose one candidate
```

Only `--addr` reached the function. The same names fared worse on `disassemble`
and `read`, which do not report the ambiguity — they fall through to the raw
symbol table and answer at the pointer word, so on a MinGW PE
`kuna disassemble ./a.exe memcpy` listed eight bytes of import table as
instructions.

## The fix

- A selector that matches several entries resolves to the one in executable
  memory, when exactly one is. That is the same test whole-binary decompilation
  already uses (`entry_is_executable`: a loader section carrying `CODE`, minus
  the import slots the loader itself filled in) — reusing it is what handles the
  one-section PE whose IAT sits inside `.text`, where the section flag alone
  cannot tell the two apart.
- Both name lookups take it, not just the one that reports ambiguity. Narrowing
  only `resolve_entry` would have left `decompile` and `disassemble` answering
  one name at two different addresses.
- The inventory is not pruned. Dropping non-executable import rows would settle
  the ambiguity too, and would delete the only name a slot with no veneer ever
  carries — `__DATA,__got`, `__DATA,__nl_symbol_ptr`, an IAT entry a
  `call [slot]` reaches directly. Two of the nine such rows on a nearby Mach-O
  are exactly that.
- It requires *exactly* one executable candidate, so two same-named definitions
  in different code sections of a relocatable object still report every
  candidate.

## The tests

`verify_entry_selectors.rs` gains the Mach-O import pair (resolves to the veneer,
both rows survive) — it fails on the unpatched tree — and a case pinning that two
`.text` definitions stay ambiguous. `tests/cli/mach-o-import-data.json` guards the
CLI surface against the vendored `macho_imports`.

Swept across 163 vendored images: of 155 duplicated names, 134 go from the
ambiguity error to a resolved veneer and none go the other way; on `disassemble`
and `read`, 78 names move from the pointer word to its thunk, and 77 of those old
answers were ones kuna itself flagged as "in a non-executable data section".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
