### PR TITLE
[AUTOMATED] fix(repipe): recover stale builder launches safely

### DIFF
--- a/docs/re-pipeline.md
+++ b/docs/re-pipeline.md
@@ -337,7 +337,18 @@ come from a slot.
 - **IDA `.i64`** files land in the arena, because `bin/ida-decompile` points declib's
   `DECLIB_SERVER_REGISTRY` and `--project-dir` there and IDA only ever sees the arena copy.
 - **Crash recovery.** State is the file, not the process. `captain.py --recover` reaps dead
-  pids (freeing their slots, claims and leases) and resumes at the *recorded* state.
+  pids (freeing their slots, claims and leases) and resumes at the *recorded* state. It does
+  not leave `HALTED`: after correcting a halt, an operator uses `captain.py --resume-halted`.
+  That command reaps again, requires empty tester/builder pools, refuses `STOP` or `ABORT`,
+  reruns preflight, consumes the old `HALT_REASON`, and then records the operator restart. A
+  reason written by a later halt is therefore never removed after `RUNNING` is published.
+- **Builder branches fail closed.** `tools/pipeline/worker.sh` accepts `WORKER_BRANCH` as an
+  explicit fresh-branch seam. Normal RE builders use the stable round-specific name
+  `feat/re-<need>-r<round>`, avoiding old canonical refs from earlier rounds. Only an exact
+  worktree-path/branch match is reused. An existing wrong path or branch without that exact
+  worktree is preserved and refused; resuming it requires `IMPL_PROPOSAL=1` plus
+  `RESUME_BRANCH`. The launcher never deletes, resets, renames, stashes, or falls back to a
+  detached/base-branch checkout when setup is ambiguous.
 - **The genuinely unsafe part, stated plainly.** Builders run
   `claude -p --dangerously-skip-permissions` with the network on, inside a worktree, confined
   only by convention and post-hoc checks. There is no sandbox around a builder, and that is

--- a/scripts/repipe/captain.py
+++ b/scripts/repipe/captain.py
@@ -221,6 +221,10 @@ def spawn_tester(round_n, hexid):
     return str(log)
 
 
+def _builder_branch(round_n, need_id):
+    return "feat/re-%s-r%s" % (need_id, round_n)
+
+
 def spawn_builder(round_n, need, resources):
     """Reuse tools/pipeline/worker.sh through its seams rather than forking it.
 
@@ -248,6 +252,7 @@ def spawn_builder(round_n, need, resources):
         SLUG=need.need_id, ARCH="",
         WORKER_PROMPT=str(config.repo_root() / "tools" / "repipe" / "builder_prompt.md"),
         WORKER_BRANCH_PREFIX="feat/re-",
+        WORKER_BRANCH=_builder_branch(round_n, need.need_id),
         WORKER_EXTRA_PROMPT=str(contracts),
         WORKER_BUDGET_USD=str(config.BUILDER_USD),
         WORKER_TIMEOUT=str(config.BUILDER_TIMEOUT),
@@ -360,10 +365,66 @@ def recover():
     return {"round": n, "reaped": reaped, "resumed_at": {k: doc[k] for k in MACHINES}}
 
 
+def resume_halted():
+    """Operator-only recovery from HALTED after the machine is safe again."""
+    reaped = pstate.reap(stale_seconds=0)
+    n = current_round()
+    controls = [name for name, present in (("STOP", stop_requested()), ("ABORT", abort_requested()))
+                if present]
+    if controls:
+        return {"ok": False, "round": n, "reaped": reaped,
+                "problems": ["%s control file present" % ", ".join(controls)]}
+    live = {pool: live_agents(pool) for pool in ("tester", "builder")}
+    if any(live.values()):
+        return {"ok": False, "round": n, "reaped": reaped,
+                "problems": ["live agent slots remain"], "live": live}
+    problems = preflight()
+    if problems:
+        return {"ok": False, "round": n, "reaped": reaped, "problems": problems, "live": live}
+
+    note = "operator resume after reap, empty agent slots, and preflight OK"
+    with _round_lock(n):
+        doc = load_round(n)
+        if doc["supervisor"] != "HALTED":
+            return {"ok": False, "round": n, "reaped": reaped,
+                    "problems": ["supervisor is %s, not HALTED" % doc["supervisor"]],
+                    "live": live}
+        controls = [name for name, present in (("STOP", stop_requested()),
+                                                ("ABORT", abort_requested())) if present]
+        if controls:
+            return {"ok": False, "round": n, "reaped": reaped,
+                    "problems": ["%s control file appeared during recovery"
+                                 % ", ".join(controls)], "live": live}
+        # Recheck after acquiring the state lock. A halted supervisor cannot legitimately spawn,
+        # but an operator may have touched the shared inventory while preflight was running.
+        live = {pool: live_agents(pool) for pool in ("tester", "builder")}
+        if any(live.values()):
+            return {"ok": False, "round": n, "reaped": reaped,
+                    "problems": ["live agent slots appeared during recovery"], "live": live}
+        # Consume the reason for this halt before publishing RUNNING. A later halt may write a
+        # new reason after save_round(); there must be no post-publication unlink that erases it.
+        halt_reason = config.state_dir() / "HALT_REASON"
+        try:
+            halt_reason.unlink()
+        except FileNotFoundError:
+            pass
+        doc["supervisor"] = "RUNNING"
+        doc.setdefault("notes", []).append(note)
+        rec = {"ts": time.time(), "machine": "supervisor", "from": "HALTED",
+               "to": "RUNNING", "note": note, "pid": os.getpid(), "operator_resume": True}
+        with open(_round_dir(n) / "transitions.jsonl", "a") as fh:
+            fh.write(json.dumps(rec) + "\n")
+        save_round(doc)
+
+    return {"ok": True, "round": n, "reaped": reaped,
+            "resumed_at": {k: doc[k] for k in MACHINES}, "live": live}
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser(prog="python -m scripts.repipe.captain")
     ap.add_argument("--tick", action="store_true")
     ap.add_argument("--recover", action="store_true")
+    ap.add_argument("--resume-halted", action="store_true")
     ap.add_argument("--preflight", action="store_true")
     ap.add_argument("--status", action="store_true")
     ap.add_argument("--round", type=int, default=None)
@@ -386,6 +447,11 @@ def main(argv=None):
         out = recover()
         print(json.dumps(out, indent=2, default=str))
         return 0
+
+    if args.resume_halted:
+        out = resume_halted()
+        print(json.dumps(out, indent=2, default=str))
+        return 0 if out["ok"] else 1
 
     if args.transition:
         machine, to = args.transition

--- a/tools/pipeline/worker.sh
+++ b/tools/pipeline/worker.sh
@@ -25,6 +25,8 @@ STATE_DIRNAME="${PIPELINE_STATE_DIRNAME:-.kuna-pipeline}"
 WORKER_BUDGET_USD="${WORKER_BUDGET_USD:-}"      # empty = no --max-budget-usd flag
 WORKER_SESSION_ID="${WORKER_SESSION_ID:-}"      # empty = let claude allocate one
 WORKER_EXTRA_PROMPT="${WORKER_EXTRA_PROMPT:-}"  # file spliced in at {{SIBLINGS}}
+WORKER_BRANCH="${WORKER_BRANCH:-}"              # empty = BRANCH_PREFIX + SLUG
+WORKER_PREPARE_ONLY="${WORKER_PREPARE_ONLY:-0}" # test seam: stop after worktree setup
 
 : "${WORKER_ID:?need WORKER_ID}"
 : "${OPP_ID:?need OPP_ID}"
@@ -47,8 +49,14 @@ export KUNA_PIPELINE_STATE_DIR="${KUNA_PIPELINE_STATE_DIR:-$REPO/$STATE_DIRNAME}
 # an APPROVED proposal's existing branch (RESUME_BRANCH) instead of branching fresh.
 IMPL_PROPOSAL="${IMPL_PROPOSAL:-0}"
 RESUME_BRANCH="${RESUME_BRANCH:-}"
-if [ "$IMPL_PROPOSAL" = 1 ] && [ -n "$RESUME_BRANCH" ]; then
+if [ "$IMPL_PROPOSAL" = 1 ] && [ -z "$RESUME_BRANCH" ]; then
+  echo "worker $WORKER_ID: IMPL_PROPOSAL=1 requires RESUME_BRANCH" >&2
+  exit 2
+fi
+if [ "$IMPL_PROPOSAL" = 1 ]; then
   BRANCH="$RESUME_BRANCH"
+elif [ -n "$WORKER_BRANCH" ]; then
+  BRANCH="$WORKER_BRANCH"
 else
   BRANCH="${BRANCH_PREFIX}${SLUG}"
 fi
@@ -62,6 +70,15 @@ LOG="$LOG_DIR/$WORKER_ID.log"
 
 log() { echo "[$(date +%H:%M:%S)] worker $WORKER_ID: $*" | tee -a "$LOG"; }
 
+git_common_dir() {
+  local root="$1" raw
+  raw="$(git -C "$root" rev-parse --git-common-dir 2>/dev/null)" || return 1
+  case "$raw" in
+    /*) (cd "$raw" 2>/dev/null && pwd -P) ;;
+    *)  (cd "$root/$raw" 2>/dev/null && pwd -P) ;;
+  esac
+}
+
 # --- 1. isolated worktree (fresh branch, or an approved proposal's branch) --
 if [ "$IMPL_PROPOSAL" = 1 ]; then
   log "resuming approved proposal on existing branch $BRANCH"
@@ -69,28 +86,35 @@ if [ "$IMPL_PROPOSAL" = 1 ]; then
     "$KUNA_PY" -m scripts.pipeline.state update --worker "$WORKER_ID" --status failed --note "resume worktree add failed"
     exit 1
   }
-elif [ -d "$WT" ] && git -C "$REPO" worktree list --porcelain 2>/dev/null \
-       | grep -qxF "branch refs/heads/$BRANCH" ; then
+elif [ -d "$WT" ] \
+     && [ "$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null)" = "$WT" ] \
+     && [ "$(git_common_dir "$WT")" = "$(git_common_dir "$REPO")" ] \
+     && [ "$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null)" = "$BRANCH" ]; then
   # A killed builder leaves its worktree behind on purpose ("for inspection"), and
   # `worktree add` FAILS on an existing path -- so before this arm, the second attempt at a
   # need could not even start, let alone resume the first attempt's work. Reuse it.
   #
-  # Only this one case is handled here. A stale or wrong-branch directory is deliberately NOT
-  # cleaned up: `git worktree remove --force` is precisely the flag that deletes a worktree
-  # holding modified and untracked files, so "tidying" would destroy the work this arm exists
-  # to preserve -- strictly more destructive than main's behaviour of failing. Those cases
-  # still fall through to the add-and-fail path below, where a human or the GC decides.
+  # Only this exact path+branch case is reusable. Matching the branch anywhere in `worktree
+  # list` is insufficient: the expected path may be a different, dirty worktree.
   log "reusing the existing worktree $WT, already on $BRANCH"
+elif [ -e "$WT" ]; then
+  log "refusing to replace ambiguous existing path $WT; inspect it and choose explicit recovery"
+  "$KUNA_PY" -m scripts.pipeline.state update --worker "$WORKER_ID" --status failed --note "ambiguous worktree path exists" >>"$LOG" 2>&1
+  exit 1
+elif git -C "$REPO" show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  log "refusing to reuse ambiguous existing branch $BRANCH without its exact worktree; set IMPL_PROPOSAL=1 and RESUME_BRANCH to resume it, or WORKER_BRANCH to create a fresh branch"
+  "$KUNA_PY" -m scripts.pipeline.state update --worker "$WORKER_ID" --status failed --note "ambiguous branch exists without worktree" >>"$LOG" 2>&1
+  exit 1
 else
   log "creating worktree $WT on $BRANCH (base $BASE_BRANCH)"
   git -C "$REPO" worktree add -b "$BRANCH" "$WT" "$BASE_BRANCH" >>"$LOG" 2>&1 || {
-    log "worktree add failed (branch may exist); trying detached reuse"
-    git -C "$REPO" worktree add "$WT" "$BASE_BRANCH" >>"$LOG" 2>&1 || {
-      "$KUNA_PY" -m scripts.pipeline.state update --worker "$WORKER_ID" --status failed --note "worktree add failed"
-      exit 1
-    }
+    log "worktree add failed; preserving every existing path and ref"
+    "$KUNA_PY" -m scripts.pipeline.state update --worker "$WORKER_ID" --status failed --note "worktree add failed" >>"$LOG" 2>&1
+    exit 1
   }
 fi
+
+[ "$WORKER_PREPARE_ONLY" = 1 ] && { log "prepare-only: worktree ready"; exit 0; }
 
 # --pid $$ is THIS driver's pid, which lives as long as the worker does. Without it the
 # inventory records the ephemeral `state register` process and reap() cannot tell a live

--- a/tools/repipe/smoke.sh
+++ b/tools/repipe/smoke.sh
@@ -89,6 +89,155 @@ for shape in shape-B-averted shape-C-averted shape-C2-averted; do
   echo "$MC" | grep -q "$shape" && ok "$shape" || bad "$shape not caught"
 done
 
+head_ "L0  worker worktree collisions fail closed"
+LAUNCH_REPO="$SMOKE_STATE/launcher-repo"
+git init -q -b main "$LAUNCH_REPO"
+git -C "$LAUNCH_REPO" config user.email smoke@example.invalid
+git -C "$LAUNCH_REPO" config user.name smoke
+printf 'base\n' > "$LAUNCH_REPO/tracked"
+git -C "$LAUNCH_REPO" add tracked
+git -C "$LAUNCH_REPO" commit -qm base
+run_prepare() {
+  KUNA_REPO="$LAUNCH_REPO" KUNA_PY="$PY" PIPELINE_STATE_DIRNAME=.state \
+    WORKER_PREPARE_ONLY=1 WORKER_ID="$1" OPP_ID=smoke TEST_NAME=smoke \
+    SELECTOR=- BINARY=- SLUG=collision ARCH= WORKER_BRANCH="$2" \
+    IMPL_PROPOSAL="${3:-0}" RESUME_BRANCH="${4:-}" \
+    bash "$REPO/tools/pipeline/worker.sh" >/dev/null 2>&1
+}
+if run_prepare fresh feat/re-collision-r7 \
+   && [ "$(git -C "$LAUNCH_REPO/.state/worktrees/fresh" branch --show-current)" = feat/re-collision-r7 ]; then
+  ok "explicit WORKER_BRANCH creates an attached fresh worktree"
+else
+  bad "explicit WORKER_BRANCH did not create the requested branch"
+fi
+run_prepare fresh feat/re-collision-r7 \
+  && ok "an exact path+branch worktree is reusable" \
+  || bad "exact path+branch reuse was refused"
+
+git -C "$LAUNCH_REPO" branch feat/re-stale main
+STALE_BEFORE="$(git -C "$LAUNCH_REPO" rev-parse feat/re-stale)"
+if run_prepare stale feat/re-stale; then
+  bad "a stale branch without its worktree was reused"
+elif [ ! -e "$LAUNCH_REPO/.state/worktrees/stale" ] \
+     && [ "$(git -C "$LAUNCH_REPO" rev-parse feat/re-stale)" = "$STALE_BEFORE" ] \
+     && [ "$(git -C "$LAUNCH_REPO" branch --show-current)" = main ]; then
+  ok "a stale branch is refused without moving its ref or root checkout"
+else
+  bad "stale-branch refusal mutated a path, ref, or root checkout"
+fi
+
+git -C "$LAUNCH_REPO" worktree add -q -b feat/re-wrong "$LAUNCH_REPO/.state/worktrees/wrong" main
+printf 'keep\n' > "$LAUNCH_REPO/.state/worktrees/wrong/untracked"
+if run_prepare wrong feat/re-wanted; then
+  bad "an existing wrong-branch path was replaced"
+elif [ -f "$LAUNCH_REPO/.state/worktrees/wrong/untracked" ] \
+     && [ "$(git -C "$LAUNCH_REPO/.state/worktrees/wrong" branch --show-current)" = feat/re-wrong ] \
+     && ! git -C "$LAUNCH_REPO" show-ref --verify --quiet refs/heads/feat/re-wanted; then
+  ok "a wrong-branch dirty path and its untracked file are preserved"
+else
+  bad "wrong-path refusal damaged the existing worktree"
+fi
+
+FOREIGN="$LAUNCH_REPO/.state/worktrees/foreign"
+git init -q -b feat/re-foreign "$FOREIGN"
+git -C "$FOREIGN" config user.email smoke@example.invalid
+git -C "$FOREIGN" config user.name smoke
+printf 'foreign\n' > "$FOREIGN/keep"
+git -C "$FOREIGN" add keep
+git -C "$FOREIGN" commit -qm foreign
+if run_prepare foreign feat/re-foreign; then
+  bad "an independent repository with the requested branch was reused"
+elif [ "$(git -C "$FOREIGN" rev-parse --show-toplevel)" = "$FOREIGN" ] \
+     && [ "$(git -C "$FOREIGN" branch --show-current)" = feat/re-foreign ] \
+     && [ "$(cat "$FOREIGN/keep")" = foreign ]; then
+  ok "same-named branch in an independent repository is preserved and refused"
+else
+  bad "foreign repository refusal damaged the independent repository"
+fi
+
+git -C "$LAUNCH_REPO" branch feat/re-resume main
+if run_prepare missing-resume feat/re-must-not-exist 1; then
+  bad "proposal mode accepted an empty RESUME_BRANCH"
+elif [ ! -e "$LAUNCH_REPO/.state/worktrees/missing-resume" ] \
+     && ! git -C "$LAUNCH_REPO" show-ref --verify --quiet refs/heads/feat/re-must-not-exist; then
+  ok "proposal mode without RESUME_BRANCH fails before creating a ref or worktree"
+else
+  bad "empty proposal resume created or attached Git state"
+fi
+if run_prepare resume ignored 1 feat/re-resume \
+   && [ "$(git -C "$LAUNCH_REPO/.state/worktrees/resume" branch --show-current)" = feat/re-resume ]; then
+  ok "IMPL_PROPOSAL and RESUME_BRANCH still attach the approved branch"
+else
+  bad "explicit proposal resume no longer works"
+fi
+
+CAP_BRANCH="$($PY -c 'from scripts.repipe.captain import _builder_branch; print(_builder_branch(12, "need-name"))')"
+[ "$CAP_BRANCH" = feat/re-need-name-r12 ] \
+  && ok "RE captain assigns a stable round-specific fresh branch" \
+  || bad "RE captain branch is not stable and round-specific" "$CAP_BRANCH"
+
+KUNA_PIPELINE_STATE_DIR="$SMOKE_STATE/resume-test" "$PY" - <<'PY' >/dev/null 2>&1 \
+  && ok "operator resume is guarded and clears HALT_REASON only on success" \
+  || bad "operator HALTED recovery guard failed"
+from scripts.repipe import captain, config
+
+doc = captain.load_round(9)
+doc["supervisor"] = "HALTED"
+captain.save_round(doc)
+reason = config.state_dir() / "HALT_REASON"
+reason.write_text("smoke halt\n")
+captain.current_round = lambda: 9
+captain.pstate.reap = lambda stale_seconds=0: []
+captain.preflight = lambda: []
+captain.live_agents = lambda pool: []
+out = captain.resume_halted()
+assert out["ok"], out
+assert captain.load_round(9)["supervisor"] == "RUNNING"
+assert captain.load_round(9)["notes"][-1].startswith("operator resume after reap"), captain.load_round(9)
+assert not reason.exists()
+rec = list((config.rounds_dir() / "9" / "transitions.jsonl").read_text().splitlines())[-1]
+assert '"from": "HALTED"' in rec and '"operator_resume": true' in rec, rec
+
+doc = captain.load_round(9)
+doc["supervisor"] = "HALTED"
+captain.save_round(doc)
+reason.write_text("keep me\n")
+captain.live_agents = lambda pool: ["busy"] if pool == "builder" else []
+out = captain.resume_halted()
+assert not out["ok"], out
+assert captain.load_round(9)["supervisor"] == "HALTED"
+assert reason.read_text() == "keep me\n"
+
+captain.live_agents = lambda pool: []
+(config.state_dir() / "STOP").write_text("")
+out = captain.resume_halted()
+assert not out["ok"] and "STOP" in out["problems"][0], out
+assert captain.load_round(9)["supervisor"] == "HALTED"
+assert reason.read_text() == "keep me\n"
+(config.state_dir() / "STOP").unlink()
+
+def controls_during_preflight():
+    (config.state_dir() / "ABORT").write_text("")
+    return []
+captain.preflight = controls_during_preflight
+out = captain.resume_halted()
+assert not out["ok"] and "ABORT" in out["problems"][0], out
+assert captain.load_round(9)["supervisor"] == "HALTED"
+assert reason.read_text() == "keep me\n"
+(config.state_dir() / "ABORT").unlink()
+
+captain.preflight = lambda: []
+real_save = captain.save_round
+def later_halt(doc):
+    real_save(doc)
+    reason.write_text("later halt\n")
+captain.save_round = later_halt
+out = captain.resume_halted()
+assert out["ok"], out
+assert captain.load_round(9)["supervisor"] == "RUNNING"
+assert reason.read_text() == "later halt\n"
+PY
+
 [ "$LEVEL" = "0" ] && { printf '\nL0 only: %d passed, %d failed\n' "$PASS" "$FAIL"; exit $((FAIL>0)); }
 
 # ---------------------------------------------------------------- level 1 ---


### PR DESCRIPTION
[AUTOMATED]

## Reproduction

Round 12 selected decompiling-3396-byte-main, but worker launch failed because an older canonical branch already existed. The fallback then attempted another worktree from main, leaving the supervisor HALTED at B_DRAIN with no builder.

## Change

Use stable round-specific builder branches, reuse only an exact same-repository path/branch worktree, and fail closed for every ambiguous path or ref. Add an explicit guarded --resume-halted operator transition that rechecks controls and live agents while holding the round lock.

## Verification

- tools/repipe/smoke.sh --level 0 (34/34)
- make test (675/675 parity)
- make test-stages (749/749 parity)
- make test-cli (119/119)
- make rust-test
- make check-spec
- kuna catalog --check
- git diff --check, shell syntax, Python bytecode compile
- two independent Sol-low safety reviews