### PR TITLE
[AUTOMATED] perf: reduce CLI cold startup overhead

### DIFF
--- a/decompiler/crates/kuna-base/src/marshal.rs
+++ b/decompiler/crates/kuna-base/src/marshal.rs
@@ -1474,6 +1474,7 @@ impl<'a> PackedDecode<'a> {
 
     /// Get the byte at the current position and advance to the next byte.
     /// An error is returned if there are no additional bytes in the stream.
+    #[inline(always)]
     fn get_next_byte(in_stream: &[Vec<u8>], pos: &mut Position) -> KunaResult<u8> {
         let res = in_stream[pos.seq][pos.current];
         pos.current += 1;
@@ -2434,6 +2435,39 @@ mod tests {
         let nextel = dec.peek_element().unwrap();
         assert_eq!(nextel, 0);
         dec.close_element(el).unwrap();
+    }
+
+    #[test]
+    fn test_marshal_packed_integer_at_every_chunk_edge() {
+        let manager = test_manager();
+        for length in 1008..1032 {
+            let mut buf = Vec::new();
+            let mut enc = PackedEncode::new(&mut buf);
+            enc.open_element(&ELEM_DATA);
+            enc.write_string(&ATTRIB_NAME, &vec![b'x'; length]);
+            enc.write_unsigned_integer(&ATTRIB_OFFSET, u64::MAX);
+            enc.write_signed_integer(&ATTRIB_ID, i64::MIN);
+            enc.close_element(&ELEM_DATA);
+            let mut dec = PackedDecode::new(&manager);
+            dec.ingest_stream(&buf).unwrap();
+            let el = dec.open_element_id(&ELEM_DATA).unwrap();
+            assert_eq!(dec.read_unsigned_integer_id(&ATTRIB_OFFSET).unwrap(), u64::MAX);
+            assert_eq!(dec.read_signed_integer_id(&ATTRIB_ID).unwrap(), i64::MIN);
+            dec.close_element(el).unwrap();
+            assert_eq!(dec.peek_element().unwrap(), 0);
+        }
+    }
+
+    #[test]
+    fn test_marshal_packed_byte_cursor_bounds() {
+        let chunks = vec![vec![0x81, 0x82], vec![0x83]];
+        let mut pos = Position { seq: 0, current: 0, end: 2 };
+        assert_eq!(PackedDecode::get_next_byte(&chunks, &mut pos).unwrap(), 0x81);
+        assert_eq!((pos.seq, pos.current, pos.end), (0, 1, 2));
+        assert_eq!(PackedDecode::get_next_byte(&chunks, &mut pos).unwrap(), 0x82);
+        assert_eq!((pos.seq, pos.current, pos.end), (1, 0, 1));
+        let err = PackedDecode::get_next_byte(&chunks, &mut pos).unwrap_err();
+        assert_eq!(err.to_string(), "Unexpected end of stream");
     }
 
     #[test]

--- a/decompiler/crates/kuna-base/src/marshal.rs
+++ b/decompiler/crates/kuna-base/src/marshal.rs
@@ -1452,7 +1452,11 @@ impl<'a> PackedDecode<'a> {
         }
     }
 
-    /// Ingest an owned buffer, copying only the final partial chunk for padding.
+    /// Ingest an owned buffer, keeping it as the leading chunk instead of
+    /// copying it into `BUFFER_SIZE` chunks.  Only the trailing partial chunk
+    /// is copied, so that `end_ingest` has a chunk to pad.  The chunk
+    /// *boundaries* move; the ingested bytes, the NUL termination and the byte
+    /// at which the stream ends do not, so decoding matches `ingest_stream`.
     pub fn ingest_owned(&mut self, mut data: Vec<u8>) -> KunaResult<()> {
         let length = data.iter().position(|&byte| byte == 0).unwrap_or(data.len());
         let remainder = length % Self::BUFFER_SIZE as usize;
@@ -1462,12 +1466,12 @@ impl<'a> PackedDecode<'a> {
         }
         data.truncate(length);
         let mut tail = data.split_off(full_length);
+        // A tail of exactly zero bytes is the one-byte chunk end_ingest would
+        // have pushed for a full last buffer, not a 1024-byte one.
         tail.resize(if remainder == 0 { 1 } else { Self::BUFFER_SIZE as usize }, 0);
-        tail[remainder] = pf::ELEMENT_END;
         self.in_stream.push(data);
         self.in_stream.push(tail);
-        self.end_pos = Position { seq: 0, current: 0, end: self.in_stream[0].len() };
-        Ok(())
+        self.end_ingest(remainder as i32)
     }
 
     /// Get the byte at the current position, do not advance
@@ -1534,6 +1538,11 @@ impl<'a> PackedDecode<'a> {
     /// bytes.  The integer is encoded, 7-bits per byte, starting with the
     /// most significant 7-bits.  The integer is decoded from the \e current
     /// position, and the position is advanced.
+    ///
+    /// A read that ends strictly inside the current chunk is taken from that
+    /// chunk's slice and advances the position once; a read that reaches the
+    /// chunk's end stays on the byte cursor, which is where end-of-stream is
+    /// detected.
     #[inline]
     fn read_integer(&mut self, mut len: i32) -> KunaResult<u64> {
         let mut res: u64 = 0;

--- a/decompiler/crates/kuna-base/src/marshal.rs
+++ b/decompiler/crates/kuna-base/src/marshal.rs
@@ -1452,6 +1452,24 @@ impl<'a> PackedDecode<'a> {
         }
     }
 
+    /// Ingest an owned buffer, copying only the final partial chunk for padding.
+    pub fn ingest_owned(&mut self, mut data: Vec<u8>) -> KunaResult<()> {
+        let length = data.iter().position(|&byte| byte == 0).unwrap_or(data.len());
+        let remainder = length % Self::BUFFER_SIZE as usize;
+        let full_length = length - remainder;
+        if full_length == 0 {
+            return self.ingest_stream(&data[..length]);
+        }
+        data.truncate(length);
+        let mut tail = data.split_off(full_length);
+        tail.resize(if remainder == 0 { 1 } else { Self::BUFFER_SIZE as usize }, 0);
+        tail[remainder] = pf::ELEMENT_END;
+        self.in_stream.push(data);
+        self.in_stream.push(tail);
+        self.end_pos = Position { seq: 0, current: 0, end: self.in_stream[0].len() };
+        Ok(())
+    }
+
     /// Get the byte at the current position, do not advance
     fn get_byte(in_stream: &[Vec<u8>], pos: &Position) -> u8 {
         in_stream[pos.seq][pos.current]
@@ -2464,6 +2482,81 @@ mod tests {
             assert_eq!(dec.read_signed_integer_id(&ATTRIB_ID).unwrap(), i64::MIN);
             dec.close_element(el).unwrap();
             assert_eq!(dec.peek_element().unwrap(), 0);
+        }
+    }
+
+    #[test]
+    fn test_marshal_owned_ingestion_matches_borrowed_stream() {
+        let manager = test_manager();
+        for length in [0, 1, 1000, 1018, 1019, 1020, 1021, 1024, 2042, 4096, 8192] {
+            let mut encoded = Vec::new();
+            let mut enc = PackedEncode::new(&mut encoded);
+            enc.open_element(&ELEM_DATA);
+            enc.write_string(&ATTRIB_NAME, &vec![b'x'; length]);
+            enc.write_unsigned_integer(&ATTRIB_OFFSET, u64::MAX);
+            enc.write_bool(&ATTRIB_STORAGE, true);
+            enc.close_element(&ELEM_DATA);
+            for nul in [false, true] {
+                let mut input = encoded.clone();
+                if nul {
+                    input.extend_from_slice(&[0, 0x41, 0x81]);
+                }
+                let mut borrowed = PackedDecode::new(&manager);
+                borrowed.ingest_stream(&input).unwrap();
+                let mut owned = PackedDecode::new(&manager);
+                owned.ingest_owned(input).unwrap();
+                let expected: Vec<_> = borrowed.in_stream.iter().flatten().copied().collect();
+                let actual: Vec<_> = owned.in_stream.iter().flatten().copied().collect();
+                assert_eq!(actual, expected, "padding for length {length}");
+                let el = owned.open_element_id(&ELEM_DATA).unwrap();
+                assert!(owned.read_bool_id(&ATTRIB_STORAGE).unwrap());
+                assert_eq!(owned.read_unsigned_integer_id(&ATTRIB_OFFSET).unwrap(), u64::MAX);
+                assert_eq!(owned.read_string_id(&ATTRIB_NAME).unwrap(), vec![b'x'; length]);
+                owned.rewind_attributes();
+                assert_eq!(owned.get_next_attribute_id().unwrap(), ATTRIB_NAME.get_id());
+                assert_eq!(owned.get_next_attribute_id().unwrap(), ATTRIB_OFFSET.get_id());
+                assert_eq!(owned.read_unsigned_integer().unwrap(), u64::MAX);
+                owned.close_element(el).unwrap();
+                assert_eq!(owned.peek_element().unwrap(), 0);
+            }
+        }
+        for input in [vec![], vec![0, 0x41, 0x81]] {
+            let mut dec = PackedDecode::new(&manager);
+            assert_eq!(dec.ingest_owned(input).unwrap_err().to_string(), "Ended ingestion without any input");
+        }
+    }
+
+    #[test]
+    fn test_marshal_owned_ingestion_reuses_all_full_chunks() {
+        let manager = test_manager();
+        for length in [1024, 1025, 2048, 2049, 8192] {
+            let input = vec![0x81; length];
+            let ptr = input.as_ptr();
+            let mut dec = PackedDecode::new(&manager);
+            dec.ingest_owned(input).unwrap();
+            assert_eq!(dec.in_stream.len(), 2);
+            assert_eq!(dec.in_stream[0].as_ptr(), ptr);
+            assert_eq!(dec.in_stream[0].len(), length / 1024 * 1024);
+            assert_eq!(dec.in_stream[1][length % 1024], pf::ELEMENT_END);
+        }
+    }
+
+    #[test]
+    fn test_marshal_owned_ingestion_preserves_truncated_integer_errors() {
+        let manager = test_manager();
+        let mut input = vec![0x81; 1024];
+        input[0] = 0x41;
+        input[1022] = 0xd0;
+        input[1023] = 0x4f;
+        for owned in [false, true] {
+            let mut dec = PackedDecode::new(&manager);
+            if owned {
+                dec.ingest_owned(input.clone()).unwrap();
+            } else {
+                dec.ingest_stream(&input).unwrap();
+            }
+            dec.cur_pos = Position { seq: 0, current: 1022, end: 1024 };
+            assert_eq!(dec.read_unsigned_integer().unwrap_err().to_string(), "Unexpected end of stream");
         }
     }
 

--- a/decompiler/crates/kuna-base/src/marshal.rs
+++ b/decompiler/crates/kuna-base/src/marshal.rs
@@ -1516,8 +1516,17 @@ impl<'a> PackedDecode<'a> {
     /// bytes.  The integer is encoded, 7-bits per byte, starting with the
     /// most significant 7-bits.  The integer is decoded from the \e current
     /// position, and the position is advanced.
+    #[inline]
     fn read_integer(&mut self, mut len: i32) -> KunaResult<u64> {
         let mut res: u64 = 0;
+        if len >= 0 && (len as usize) < self.cur_pos.end - self.cur_pos.current {
+            let end = self.cur_pos.current + len as usize;
+            for &byte in &self.in_stream[self.cur_pos.seq][self.cur_pos.current..end] {
+                res = (res << pf::RAWDATA_BITSPERBYTE) | u64::from(byte & pf::RAWDATA_MASK);
+            }
+            self.cur_pos.current = end;
+            return Ok(res);
+        }
         while len > 0 {
             res <<= pf::RAWDATA_BITSPERBYTE;
             res |= (Self::get_next_byte(&self.in_stream, &mut self.cur_pos)? & pf::RAWDATA_MASK)
@@ -2456,6 +2465,34 @@ mod tests {
             dec.close_element(el).unwrap();
             assert_eq!(dec.peek_element().unwrap(), 0);
         }
+    }
+
+    #[test]
+    fn test_marshal_packed_integer_fast_path_matches_chunked_reads() {
+        let manager = test_manager();
+        let chunks = vec![vec![0xff; 32], vec![0xfe; 32]];
+        for len in 0..=15 {
+            for start in 16..32 {
+                let mut dec = PackedDecode::new(&manager);
+                dec.in_stream = chunks.clone();
+                dec.cur_pos = Position { seq: 0, current: start, end: 32 };
+                let mut expected_pos = dec.cur_pos;
+                let mut expected = 0u64;
+                for _ in 0..len {
+                    expected = (expected << pf::RAWDATA_BITSPERBYTE)
+                        | u64::from(PackedDecode::get_next_byte(&chunks, &mut expected_pos).unwrap()
+                            & pf::RAWDATA_MASK);
+                }
+                assert_eq!(dec.read_integer(len).unwrap(), expected, "{start}, {len}");
+                assert_eq!(dec.cur_pos.seq, expected_pos.seq);
+                assert_eq!(dec.cur_pos.current, expected_pos.current);
+                assert_eq!(dec.cur_pos.end, expected_pos.end);
+            }
+        }
+        let mut dec = PackedDecode::new(&manager);
+        dec.in_stream = vec![vec![0xff; 4]];
+        dec.cur_pos = Position { seq: 0, current: 0, end: 4 };
+        assert_eq!(dec.read_integer(4).unwrap_err().to_string(), "Unexpected end of stream");
     }
 
     #[test]

--- a/decompiler/crates/kuna-sleigh/src/slaformat.rs
+++ b/decompiler/crates/kuna-sleigh/src/slaformat.rs
@@ -13,11 +13,11 @@
 //!   `slghsymbol::sla` / `semantics::sla` so a single `register_sla_ids` call
 //!   covers the whole table without duplicate `ElementId` objects.
 //! - [`FormatDecode`] is the C++ `FormatDecode : PackedDecode`: it verifies
-//!   the `sla\x04` header, decompresses the zlib stream, and feeds the
-//!   decompressed bytes into a [`PackedDecode`].  Inheritance becomes
+//!   the `sla\x04` header, decompresses the zlib stream, and hands the
+//!   decompressed buffer to a [`PackedDecode`].  Inheritance becomes
 //!   composition: [`FormatDecode`] *owns* a [`PackedDecode`] and forwards the
 //!   whole [`Decoder`] surface to it (every packed byte has a high-bit
-//!   pattern set, so the inner `ingest_stream`'s NUL-terminator scan never
+//!   pattern set, so the inner `ingest_owned`'s NUL-terminator scan never
 //!   trips on valid data).
 //! - [`FormatEncode`]/[`write_sla_header`]/`isSlaFormat` are the writer side
 //!   (used by the unported compiler); [`FormatEncode`] wraps a
@@ -338,7 +338,13 @@ impl<'a> FormatDecode<'a> {
         FormatDecode { inner: PackedDecode::new(spc_manager) }
     }
 
-    /// Verify and decompress the SLA stream, then transfer its buffer to the packed decoder.
+    /// C++ `FormatDecode::ingestStream(istream &)`: verify the header,
+    /// decompress the whole stream, then hand the decompressed buffer to the
+    /// inner [`PackedDecode`].  The C++ decompresses directly into the
+    /// PackedDecode chunk buffers; the Rust decompresses into one `Vec<u8>`
+    /// and transfers it with `ingest_owned`, which copies only the trailing
+    /// partial chunk so `endIngest` has one to pad — every packed byte has its
+    /// high bit set, so the NUL-terminator scan never trips.
     pub fn ingest_stream(&mut self, s: &[u8]) -> KunaResult<()> {
         let (ok, compressed) = is_sla_format(s);
         if !ok {

--- a/decompiler/crates/kuna-sleigh/src/slaformat.rs
+++ b/decompiler/crates/kuna-sleigh/src/slaformat.rs
@@ -338,13 +338,7 @@ impl<'a> FormatDecode<'a> {
         FormatDecode { inner: PackedDecode::new(spc_manager) }
     }
 
-    /// C++ `FormatDecode::ingestStream(istream &)`: verify the header,
-    /// decompress the whole stream, then ingest the decompressed bytes into
-    /// the inner [`PackedDecode`].  The C++ decompresses directly into the
-    /// PackedDecode chunk buffers; the Rust decompresses into one `Vec<u8>`
-    /// and delegates to `PackedDecode::ingest_stream` (identical chunking and
-    /// `endIngest` padding — every packed byte has its high bit set, so the
-    /// inner NUL-terminator scan never trips).
+    /// Verify and decompress the SLA stream, then transfer its buffer to the packed decoder.
     pub fn ingest_stream(&mut self, s: &[u8]) -> KunaResult<()> {
         let (ok, compressed) = is_sla_format(s);
         if !ok {
@@ -375,7 +369,7 @@ impl<'a> FormatDecode<'a> {
                 return Err(KunaError::lowlevel("Truncated SLA compressed stream"));
             }
         }
-        self.inner.ingest_stream(&out)
+        self.inner.ingest_owned(out)
     }
 
     /// Borrow the inner [`PackedDecode`] as a `&mut dyn Decoder`.
@@ -467,6 +461,71 @@ impl Decoder for FormatDecode<'_> {
         attrib_id: &AttributeId,
     ) -> KunaResult<Rc<kuna_base::space::AddrSpace>> {
         self.inner.read_space_id(attrib_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kuna_base::marshal::{Encoder, ATTRIB_CONTENT, ELEM_DATA};
+
+    fn compressed(payload: &[u8]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        write_sla_header(&mut bytes).unwrap();
+        let mut compressor = CompressBuffer::new(&mut bytes, -1).unwrap();
+        compressor.write_all(payload).unwrap();
+        compressor.flush().unwrap();
+        bytes
+    }
+
+    #[test]
+    fn owned_sla_buffer_decodes_across_inflate_and_packed_boundaries() {
+        let manager = AddrSpaceManager::new();
+        for length in [1018, 1019, 1020, 4090, 4091, 4092, 8192, 20000] {
+            let payload: Vec<_> = (0..length).map(|i| (i % 255 + 1) as u8).collect();
+            let mut packed = Vec::new();
+            let mut enc = PackedEncode::new(&mut packed);
+            enc.open_element(&ELEM_DATA);
+            enc.write_string(&ATTRIB_CONTENT, &payload);
+            enc.close_element(&ELEM_DATA);
+            let bytes = compressed(&packed);
+            let mut dec = FormatDecode::new(&manager);
+            dec.ingest_stream(&bytes).unwrap();
+            let el = dec.open_element_id(&ELEM_DATA).unwrap();
+            assert_eq!(dec.read_string_id(&ATTRIB_CONTENT).unwrap(), payload);
+            dec.close_element(el).unwrap();
+            assert_eq!(dec.peek_element().unwrap(), 0);
+        }
+    }
+
+    #[test]
+    fn owned_sla_buffer_keeps_header_truncation_and_checksum_checks() {
+        let manager = AddrSpaceManager::new();
+        let bytes = compressed(&[0x41, 0x81]);
+        for end in 0..bytes.len() {
+            let mut dec = FormatDecode::new(&manager);
+            assert!(dec.ingest_stream(&bytes[..end]).is_err(), "truncation at {end}");
+        }
+        let mut corrupt = bytes.clone();
+        *corrupt.last_mut().unwrap() ^= 1;
+        assert!(FormatDecode::new(&manager).ingest_stream(&corrupt).is_err());
+        let mut wrong_header = bytes;
+        wrong_header[3] = 0;
+        assert!(FormatDecode::new(&manager).ingest_stream(&wrong_header).is_err());
+        assert!(FormatDecode::new(&manager).ingest_stream(&compressed(&[])).is_err());
+    }
+
+    #[test]
+    fn nul_termination_does_not_skip_the_compressed_checksum() {
+        let manager = AddrSpaceManager::new();
+        let mut bytes = compressed(&[0x41, 0x81, 0, 0x41, 0x81]);
+        let mut dec = FormatDecode::new(&manager);
+        dec.ingest_stream(&bytes).unwrap();
+        let el = dec.open_element().unwrap();
+        dec.close_element(el).unwrap();
+        assert_eq!(dec.peek_element().unwrap(), 0);
+        *bytes.last_mut().unwrap() ^= 1;
+        assert!(FormatDecode::new(&manager).ingest_stream(&bytes).is_err());
     }
 }
 

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -29,6 +29,9 @@ SLA initialization uses the packed decoder in
 is inlined into the attribute readers so startup does not pay a function call
 per encoded byte. Chunk transitions, end-of-stream errors, NUL termination,
 and the packed format remain unchanged; this requires no cached program state.
+An integer contained within a chunk is decoded from a checked slice, advancing
+the cursor once rather than once per byte. Reads ending at or crossing a chunk
+boundary retain the byte-cursor path, including the final-byte EOF check.
 
 kuna is two engines with one boundary. The **program-preparation tier**
 (`kuna-analysis`, chapter 01) looks at the whole binary once — loader parse, symbol

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -24,20 +24,6 @@ described in chapter 01, §1.3.
 
 ## 0.1 The two tiers
 
-SLA initialization uses the packed decoder in
-`decompiler/crates/kuna-base/src/marshal.rs (PackedDecode)`. Its hot byte cursor
-is inlined into the attribute readers so startup does not pay a function call
-per encoded byte. Chunk transitions, end-of-stream errors, NUL termination,
-and the packed format remain unchanged; this requires no cached program state.
-An integer contained within a chunk is decoded from a checked slice, advancing
-the cursor once rather than once per byte. Reads ending at or crossing a chunk
-boundary retain the byte-cursor path, including the final-byte EOF check.
-`decompiler/crates/kuna-sleigh/src/slaformat.rs (FormatDecode)` transfers the
-decompressed allocation to `PackedDecode` instead of copying it into chunks.
-Only the final partial 1024-byte chunk is copied for padding; complete chunks
-share one contiguous allocation. The first NUL still terminates packed input,
-and decompression still validates the entire zlib stream before decoding.
-
 kuna is two engines with one boundary. The **program-preparation tier**
 (`kuna-analysis`, chapter 01) looks at the whole binary once — loader parse, symbol
 and relocation markup, strings, DWARF, entry discovery, the Listing, the no-return
@@ -699,6 +685,24 @@ names the directories it looked in: the in-tree path a checkout would have built
 to is not an answer on a machine that has no checkout, and a missing SLEIGH tree
 is reported where it is resolved rather than as the engine's downstream
 `No sleigh specification` — which reads as a problem with the binary.
+
+(kuna) **Loading a spec.** A `.sla` is a zlib stream behind a `sla\x04` header,
+inflated and checksum-verified in full before a single element is decoded
+(`decompiler/crates/kuna-sleigh/src/slaformat.rs (FormatDecode::ingest_stream)`).
+The decompressed buffer is then *handed* to the packed decoder rather than
+copied into it (`decompiler/crates/kuna-base/src/marshal.rs
+(PackedDecode::ingest_owned)`): the inflate buffer becomes the decoder's leading
+byte chunk as it stands, and only the trailing partial chunk is copied, to carry
+the `ELEMENT_END` pad that ends the input one byte past its last. Where the
+chunk boundaries fall is not observable — a Position carries its chunk index and
+that chunk's own end offset, so a boundary decides only how often the cursor
+crosses one — and nothing else about ingestion moves: the first NUL byte still
+ends the input (no valid packed byte is zero), and reading past the pad is still
+`Unexpected end of stream`. Decoding rests on the same distinction: an encoded
+integer lying wholly inside the current chunk is read from that chunk's slice in
+one step, while a read that reaches the chunk's end stays on the byte cursor,
+which is where end-of-stream is detected (`marshal.rs
+(PackedDecode::read_integer)`).
 
 (kuna) **The option-name contract.** Every `kuna` surface that takes
 `--option NAME VALUE` checks the NAME in its own parser, before a binary is

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -32,6 +32,11 @@ and the packed format remain unchanged; this requires no cached program state.
 An integer contained within a chunk is decoded from a checked slice, advancing
 the cursor once rather than once per byte. Reads ending at or crossing a chunk
 boundary retain the byte-cursor path, including the final-byte EOF check.
+`decompiler/crates/kuna-sleigh/src/slaformat.rs (FormatDecode)` transfers the
+decompressed allocation to `PackedDecode` instead of copying it into chunks.
+Only the final partial 1024-byte chunk is copied for padding; complete chunks
+share one contiguous allocation. The first NUL still terminates packed input,
+and decompression still validates the entire zlib stream before decoding.
 
 kuna is two engines with one boundary. The **program-preparation tier**
 (`kuna-analysis`, chapter 01) looks at the whole binary once — loader parse, symbol

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -24,6 +24,12 @@ described in chapter 01, §1.3.
 
 ## 0.1 The two tiers
 
+SLA initialization uses the packed decoder in
+`decompiler/crates/kuna-base/src/marshal.rs (PackedDecode)`. Its hot byte cursor
+is inlined into the attribute readers so startup does not pay a function call
+per encoded byte. Chunk transitions, end-of-stream errors, NUL termination,
+and the packed format remain unchanged; this requires no cached program state.
+
 kuna is two engines with one boundary. The **program-preparation tier**
 (`kuna-analysis`, chapter 01) looks at the whole binary once — loader parse, symbol
 and relocation markup, strings, DWARF, entry discovery, the Listing, the no-return


### PR DESCRIPTION
## What improves

A fresh CLI process spends less time loading the SLEIGH spec, and emits exactly
the same bytes. From the repository root:

```sh
decompiler/target/release/kuna decompile \
  decompiler/crates/kuna-analysis/tests/fixtures/fauxware main --json
```

Interleaved fresh-process pairs against the unpatched tree, output asserted
equal on every run:

| command | before | after | |
|---|---|---|---|
| `decompile --json` | 152.6 ms | 139.3 ms | -8.7%, 59/60 pairs faster |
| `decompile` (text) | 157.4 ms | 143.7 ms | -8.7%, 59/60 |
| `functions --json` | 148.1 ms | 132.9 ms | -10.2%, 56/60 |

(medians, Linux x86-64, warm filesystem cache; 80 pairs on macOS arm64 gave
84.8 -> 77.2 ms for the first row.) The saving is a fixed startup cost, so it is
the whole of a short command and invisible in a long one.

## The change

- An encoded integer that lies wholly inside the current chunk is read from that
  chunk's slice in one step instead of one call per byte. A read that reaches
  the chunk's end stays on the byte cursor, which is where end-of-stream is
  detected — no bounds or EOF check is skipped — and that cursor is now inlined.
- `FormatDecode` hands the inflated buffer to `PackedDecode` instead of copying
  it into 1 KiB chunks; only the trailing partial chunk is copied, to carry the
  padding terminator. The chunk boundaries move; the ingested bytes, the NUL
  termination and the byte at which the stream ends do not.

## Tests

New cases cover integers at every chunk edge, owned-vs-borrowed ingestion
equality, the leading chunk not being copied, truncated-integer errors, a
fast-path/byte-cursor cross-check, and SLA header, truncation, checksum and NUL
handling.

`make test` 675/675, `make test-stages` 776/776, `make test-cli` 127/127,
`make test-ghidra`, `make rust-test` (6500 passed, 0 failed), `make check-spec`
(strict) and `kuna catalog --check` all pass. `decompile-all --json` is
byte-identical — stdout, stderr and exit code — against 173 fixture binaries
spanning x86-64, i386, ARM, Thumb, ELF and PE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9qJyRdQu6vTqagaeSp4ef
