### PR TITLE
[AUTOMATED] fix(repipe): enforce Sol role split

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -23,7 +23,7 @@ is not needed for day-to-day work.
 | `tests/golden/` | Differential golden vectors for the workspace suite (`make rust-test`). |
 | `specs/Ghidra/Processors/` | Vendored SLEIGH specs. `.sla` files are built artifacts (gitignored), produced by `slacomp`. |
 | `scripts/` + `tools/pipeline/` | Python helpers (`decompile.py` library shim, `paths.py`, `pipeline/`, `decbench/`) + driver for the improvement pipeline (`docs/improvement-pipeline.md`) and the decbench campaign (`docs/decbench-loop.md`). |
-| `scripts/repipe/` + `tools/repipe/` | The RE-friction loop (`docs/re-pipeline.md`): codex testers reverse-engineer crackmes with kuna and record where it fails them; claude builders close those gaps and self-merge. Durable backlog in `docs/re-needs/`; promoted regression probes in `tests/cli/`. |
+| `scripts/repipe/` + `tools/repipe/` | The RE-friction loop (`docs/re-pipeline.md`): Codex Sol-low testers reverse-engineer crackmes with kuna and record where it fails them; Codex Sol-high-or-above builders close those gaps and self-merge. Durable backlog in `docs/re-needs/`; promoted regression probes in `tests/cli/`. |
 | `integrations/` | Front-ends embedding the engine: `ghidra/` (kuna as stock Ghidra's decompiler core), `web/` (the project site + in-browser decompiler at `kuna.noelo.org`). |
 
 ## Build & test

--- a/docs/improvement-pipeline.md
+++ b/docs/improvement-pipeline.md
@@ -322,8 +322,11 @@ re-queues violations.
 ## The headless fleet (optional automation)
 
 The same loop, driven autonomously: `run.sh` keeps N workers alive, each an isolated
-git-worktree `claude -p` session executing `tools/pipeline/worker_prompt.md` (the
-templated per-feature version of §§2–4, with heartbeats and the state protocol).
+git-worktree agent session executing `tools/pipeline/worker_prompt.md` (the templated
+per-feature version of §§2–4, with heartbeats and the state protocol). Claude remains the
+default. Set `WORKER_BACKEND=codex`, `WORKER_MODEL=gpt-5.6-sol`, and
+`WORKER_REASONING=high` (or `xhigh`/`max`) to use Codex; its multi-agent features are disabled
+so every concurrent implementation session remains visible to the driver.
 
 ```bash
 tools/pipeline/install_gh.sh                       # one-time PR tooling (Linux host)
@@ -337,8 +340,9 @@ Mechanics an operator should know: workers claim opportunities atomically
 (`state claim`, exit code 0/1); state always lives in the **main** tree
 (`KUNA_PIPELINE_STATE_DIR`) so `status` sees worktree workers; worktrees reuse the main
 tree's compiled specs (`KUNA_SPECS` — never `make specs` in a worktree); session ids are
-recorded for `claude --resume` review; merged/closed-PR worktrees are GC'd, open ones
-kept. Proposals: `status --proposals` lists parked drafts;
+recorded for review (`claude --resume` for Claude, `codex exec resume` for Codex), and Codex
+JSONL plus final output are retained beside the worker log; merged/closed-PR worktrees are
+GC'd, open ones kept. Proposals: `status --proposals` lists parked drafts;
 `state approve --opportunity <id>` green-lights one.
 
 ## Machinery reference

--- a/docs/re-pipeline.md
+++ b/docs/re-pipeline.md
@@ -17,7 +17,8 @@ One iteration:
 2. **Gate** — every recorded observation is replayed by machine. Two executable predicates
    decide whether it is real (§3).
 3. **Cluster** — surviving observations collapse into needs in `docs/re-needs/` (§4).
-4. **Build** — claude agents close one need each, on one of three tracks, and self-merge (§5).
+4. **Build** — Codex implementation agents close one need each, on one of three tracks, and
+   self-merge (§5).
 5. **Verify** — the acceptance probe is re-run on merged `main`. Needs that flipped are
    closed; the next round's testers are pointed at the new surface and asked to break it (§6).
 
@@ -28,13 +29,15 @@ make binaries && make specs
 tools/repipe/run.sh --preflight        # hard-fails on anything missing
 ```
 
-Preflight requires: `git`, `gh` (authed, `repo` scope), `codex`, `claude`, `python3`, a built
-`kuna`, compiled `.sla`, the dataset, and `REPIPE_MIN_FREE_GB` free. It also **fails if
+Preflight requires: `git`, `gh` (authed, `repo` scope), `codex`, `python3`, a built `kuna`,
+compiled `.sla`, the dataset, and `REPIPE_MIN_FREE_GB` free. It also **fails if
 `bwrap` is unavailable** — see §2, containment is not optional by default.
 
 The default captain remains Claude for compatibility. Set `REPIPE_CAPTAIN_BACKEND=codex` to
-run bounded captain ticks with Codex instead; the preflight still requires both binaries
-because builders use Claude and testers use Codex.
+run bounded captain ticks with Codex instead. Reversers are fixed to GPT-5.6 Sol at low
+reasoning; implementation builders are fixed to GPT-5.6 Sol at high reasoning or above.
+Preflight rejects a role/model configuration that weakens either boundary. Claude is only
+required when explicitly selected as the captain backend.
 
 Everything is stdlib Python run as `PYTHONPATH=$REPO python3 -m scripts.repipe.<mod>`; there is
 no install step and no third-party dependency, matching `scripts/pipeline/`.
@@ -61,7 +64,9 @@ touch .kuna-repipe/ABORT                # hard stop; worktrees and arenas left i
 | `REPIPE_SANDBOX` | `auto` \| `bwrap` \| `none` — `none` is prompt-only containment |
 | `REPIPE_ENABLE_IDA` | let testers reach IDA as a logged last resort (1) |
 | `REPIPE_REFUTE_MODE` | `absence-skip` — do not spend refuters on "the subcommand does not exist" |
-| `REPIPE_TESTER_MODEL` / `REPIPE_TESTER_REASONING` | optional Codex tester model and reasoning effort overrides |
+| `REPIPE_TESTER_MODEL` / `REPIPE_TESTER_REASONING` | reverser model and effort; required `gpt-5.6-sol` / `low` |
+| `REPIPE_BUILDER_BACKEND` | implementation backend; required `codex` |
+| `REPIPE_BUILDER_MODEL` / `REPIPE_BUILDER_REASONING` | implementation model and effort; required `gpt-5.6-sol` / `high`, `xhigh`, or `max` |
 | `REPIPE_CAPTAIN_BACKEND` | `claude` \| `codex` (default `claude`) |
 | `REPIPE_CAPTAIN_MODEL` / `REPIPE_CAPTAIN_REASONING` | captain model; Codex defaults to `gpt-5.6-sol` / `low` |
 | `REPIPE_CAPTAIN_USD` | Claude-only dollar cap; Codex ticks are bounded by timeout, model, and reasoning effort |
@@ -350,7 +355,7 @@ come from a slot.
   `RESUME_BRANCH`. The launcher never deletes, resets, renames, stashes, or falls back to a
   detached/base-branch checkout when setup is ambiguous.
 - **The genuinely unsafe part, stated plainly.** Builders run
-  `claude -p --dangerously-skip-permissions` with the network on, inside a worktree, confined
+  `codex exec --sandbox danger-full-access` with the network on, inside a worktree, confined
   only by convention and post-hoc checks. There is no sandbox around a builder, and that is
   inherent to "implement in the kuna repo and self-merge". What *is* contained: `main` only
   ever advances through the serialized merge step, `docs/baseline.json` is a hard reject, and

--- a/scripts/pipeline/state.py
+++ b/scripts/pipeline/state.py
@@ -1,6 +1,6 @@
 """Shared, file-backed pipeline state: the worker inventory + opportunity claims.
 
-Workers run as independent processes (headless `claude -p` sessions in worktrees) and the
+Workers run as independent processes (headless agent sessions in worktrees) and the
 driver loop is a separate process again, so live state lives in flock-guarded JSON under
 ``.kuna-pipeline/`` (gitignored), not in memory. This is the single place ``status.py``
 reads to answer "how many workers are running and what is each doing", and the place the

--- a/scripts/repipe/captain.py
+++ b/scripts/repipe/captain.py
@@ -2,7 +2,7 @@
 
 Three cooperating machines — Supervisor, TestTrack, BuildTrack — whose transitions are
 guarded here and appended to `<state>/rounds/<n>/transitions.jsonl`. **An illegal transition
-raises and exits 2.** That split is the whole point: the captain is a Claude Code session
+raises and exits 2.** That split is the whole point: the captain is an agent session
 doing the judgment work (clustering residue, scope calls, proposal approval, deciding a
 round is finished), but it cannot talk the machine into skipping a gate, because the machine
 is not made of prose.
@@ -166,9 +166,13 @@ def preflight():
     """Hard preconditions. A missing one is a HALT, not a warning — the loop would otherwise
     fail slowly, hours in, having spent real money."""
     bad, warn = [], []
-    for tool in ("git", "gh", "codex", "claude", "python3"):
+    tools = ["git", "gh", "codex", "python3"]
+    if config.CAPTAIN_BACKEND == "claude":
+        tools.append("claude")
+    for tool in tools:
         if not shutil.which(tool):
             bad.append("missing tool: %s" % tool)
+    bad.extend(config.role_policy_problems())
     if not config.kuna_bin().exists():
         bad.append("no kuna binary at %s (run `make binaries`)" % config.kuna_bin())
     if not config.dataset_root().exists():
@@ -210,6 +214,8 @@ def set_caps(split):
 
 def spawn_tester(round_n, hexid):
     env = dict(os.environ, ROUND=str(round_n), HEXID=hexid,
+               REPIPE_TESTER_MODEL=config.TESTER_MODEL,
+               REPIPE_TESTER_REASONING=config.TESTER_REASONING,
                KUNA_PIPELINE_STATE_DIR=str(config.state_dir()),
                PYTHONPATH=str(config.repo_root()))
     log = config.logs_dir() / ("spawn-t-%s.log" % hexid[:8])
@@ -256,7 +262,9 @@ def spawn_builder(round_n, need, resources):
         WORKER_EXTRA_PROMPT=str(contracts),
         WORKER_BUDGET_USD=str(config.BUILDER_USD),
         WORKER_TIMEOUT=str(config.BUILDER_TIMEOUT),
+        WORKER_BACKEND=config.BUILDER_BACKEND,
         WORKER_MODEL=config.BUILDER_MODEL,
+        WORKER_REASONING=config.BUILDER_REASONING,
         PIPELINE_STATE_DIRNAME=config.STATE_DIRNAME,
         KUNA_PIPELINE_STATE_DIR=str(config.state_dir()),
         PYTHONPATH=str(config.repo_root()),

--- a/scripts/repipe/config.py
+++ b/scripts/repipe/config.py
@@ -179,13 +179,31 @@ ENABLE_IDA = os.environ.get("REPIPE_ENABLE_IDA", "1") not in ("0", "false", "no"
 
 # --- models -----------------------------------------------------------------
 
-TESTER_MODEL = os.environ.get("REPIPE_TESTER_MODEL", "")     # "" -> codex config default
-TESTER_REASONING = os.environ.get("REPIPE_TESTER_REASONING", "")
-BUILDER_MODEL = os.environ.get("REPIPE_BUILDER_MODEL", "opus")
+TESTER_MODEL = os.environ.get("REPIPE_TESTER_MODEL", "gpt-5.6-sol")
+TESTER_REASONING = os.environ.get("REPIPE_TESTER_REASONING", "low")
+BUILDER_BACKEND = os.environ.get("REPIPE_BUILDER_BACKEND", "codex")
+BUILDER_MODEL = os.environ.get("REPIPE_BUILDER_MODEL", "gpt-5.6-sol")
+BUILDER_REASONING = os.environ.get("REPIPE_BUILDER_REASONING", "high")
 CAPTAIN_BACKEND = os.environ.get("REPIPE_CAPTAIN_BACKEND", "claude")
 CAPTAIN_MODEL = os.environ.get(
     "REPIPE_CAPTAIN_MODEL", "gpt-5.6-sol" if CAPTAIN_BACKEND == "codex" else "opus"
 )
 CAPTAIN_REASONING = os.environ.get("REPIPE_CAPTAIN_REASONING", "low")
+
+
+def role_policy_problems():
+    """Return configuration errors that would weaken the RE-pipeline role split."""
+    problems = []
+    if TESTER_MODEL != "gpt-5.6-sol" or TESTER_REASONING != "low":
+        problems.append("reversers require REPIPE_TESTER_MODEL=gpt-5.6-sol and "
+                        "REPIPE_TESTER_REASONING=low")
+    if BUILDER_BACKEND != "codex" or BUILDER_MODEL != "gpt-5.6-sol":
+        problems.append("implementation requires REPIPE_BUILDER_BACKEND=codex and "
+                        "REPIPE_BUILDER_MODEL=gpt-5.6-sol")
+    if BUILDER_REASONING not in ("high", "xhigh", "max"):
+        problems.append("implementation reasoning must be high, xhigh, or max")
+    if CAPTAIN_BACKEND not in ("claude", "codex"):
+        problems.append("REPIPE_CAPTAIN_BACKEND must be claude or codex")
+    return problems
 
 GH_REPO = os.environ.get("REPIPE_GH_REPO", "Noelo-Lab/kuna")

--- a/tools/pipeline/worker.sh
+++ b/tools/pipeline/worker.sh
@@ -1,21 +1,67 @@
 #!/usr/bin/env bash
-# Launch ONE feature worker: an isolated git worktree + a headless `claude -p` session
+# Launch ONE feature worker: an isolated git worktree + a headless agent session
 # that implements one angr-inspired kuna feature end-to-end and opens a PR.
 #
 # Invoked by tools/pipeline/run.sh, but runnable standalone for a single iteration:
 #   WORKER_ID=w1 OPP_ID='test_x::main' TEST_NAME=test_x SELECTOR=main \
 #   BINARY=/path/bin SLUG=myfeat-ab12cd ARCH= tools/pipeline/worker.sh
 #
-# The worktree and the Claude session transcript are PRESERVED after the run so a human
-# reviewer can resume the session on the PR (`claude --resume <session_id>` in the worktree).
+# The worktree and the agent transcript are PRESERVED after the run. Claude sessions can be
+# resumed directly; Codex runs also retain their JSONL event stream and thread id.
 # tools/pipeline/run.sh garbage-collects a worktree only once its PR is merged/closed.
 set -uo pipefail
 
 REPO="${KUNA_REPO:-$(git -C "$(dirname "$0")" rev-parse --show-toplevel)}"
 KUNA_PY="${KUNA_PY:-$HOME/.virtualenvs/kuna/bin/python}"
-MODEL="${WORKER_MODEL:-opus}"
+BACKEND="${WORKER_BACKEND:-claude}"
+if [ "$BACKEND" = codex ]; then
+  MODEL="${WORKER_MODEL:-gpt-5.6-sol}"
+  REASONING="${WORKER_REASONING:-high}"
+else
+  MODEL="${WORKER_MODEL:-opus}"
+  REASONING="${WORKER_REASONING:-}"
+fi
 WORKER_TIMEOUT="${WORKER_TIMEOUT:-7200}"   # seconds; hard cap per feature
 BASE_BRANCH="${BASE_BRANCH:-main}"
+
+: "${WORKER_ID:?need WORKER_ID}"
+: "${OPP_ID:?need OPP_ID}"
+: "${TEST_NAME:?need TEST_NAME}"
+: "${SELECTOR:?need SELECTOR}"
+: "${BINARY:?need BINARY}"
+: "${SLUG:?need SLUG}"
+ARCH="${ARCH:-}"
+
+case "$BACKEND" in
+  claude)
+    WORKER_AGENT="Claude Code worker using $MODEL"
+    WORKER_COMMAND="claude -p <this entire prompt>"
+    WORKER_DECIDER_INSTRUCTIONS='For any genuine judgment call (which stage to hook, whether the construct generalizes, scope), spawn a **decider subagent** (use the Task/Agent tool) to make and justify the call, and record its decision verbatim in `docs/features/'"$SLUG"'/record.json` under `"decisions"`. Write `docs/features/'"$SLUG"'/plan.md`.
+- **Scope check (the proposal gate, Hard rule 7).** Ask the decider to return `scope: small|large`.'
+    WORKER_TRAILER="Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+    WORKER_GENERATED_WITH='🤖 Generated with [Claude Code](https://claude.com/claude-code)'
+    ;;
+  codex)
+    if [ "$MODEL" != "gpt-5.6-sol" ]; then
+      echo "worker $WORKER_ID: Codex implementation requires model gpt-5.6-sol (got '$MODEL')" >&2
+      exit 2
+    fi
+    case "$REASONING" in
+      high|xhigh|max) ;;
+      *) echo "worker $WORKER_ID: Codex implementation requires high, xhigh, or max reasoning (got '$REASONING')" >&2; exit 2 ;;
+    esac
+    WORKER_AGENT="Codex implementation worker using $MODEL with $REASONING reasoning"
+    WORKER_COMMAND="codex exec <this entire prompt>"
+    WORKER_DECIDER_INSTRUCTIONS='Codex multi-agent features are disabled so every agent process remains accounted for by a pipeline slot. Make and justify each judgment call yourself, record the decision verbatim in `docs/features/'"$SLUG"'/record.json` under `"decisions"`, and write `docs/features/'"$SLUG"'/plan.md`.
+- **Scope check (the proposal gate, Hard rule 7).** Return your own explicit `scope: small|large` decision.'
+    WORKER_TRAILER="Co-Authored-By: OpenAI Codex <noreply@openai.com>"
+    WORKER_GENERATED_WITH='🤖 Generated with [OpenAI Codex](https://openai.com/codex/)'
+    ;;
+  *)
+    echo "worker $WORKER_ID: unknown WORKER_BACKEND '$BACKEND' (expected claude or codex)" >&2
+    exit 2
+    ;;
+esac
 
 # Seams so a second pipeline reuses this driver without a fork (docs/re-pipeline.md).
 # Unset == the angr fleet's behaviour, byte for byte.
@@ -27,14 +73,6 @@ WORKER_SESSION_ID="${WORKER_SESSION_ID:-}"      # empty = let claude allocate on
 WORKER_EXTRA_PROMPT="${WORKER_EXTRA_PROMPT:-}"  # file spliced in at {{SIBLINGS}}
 WORKER_BRANCH="${WORKER_BRANCH:-}"              # empty = BRANCH_PREFIX + SLUG
 WORKER_PREPARE_ONLY="${WORKER_PREPARE_ONLY:-0}" # test seam: stop after worktree setup
-
-: "${WORKER_ID:?need WORKER_ID}"
-: "${OPP_ID:?need OPP_ID}"
-: "${TEST_NAME:?need TEST_NAME}"
-: "${SELECTOR:?need SELECTOR}"
-: "${BINARY:?need BINARY}"
-: "${SLUG:?need SLUG}"
-ARCH="${ARCH:-}"
 
 # Run the Python pipeline (scripts.pipeline.*) from the main tree so the `scripts`
 # package is importable without an install (no pyproject/pip install -e).
@@ -175,49 +213,118 @@ else
   RESUME_PROPOSAL_LINE=""
 fi
 PROMPT_FILE="$LOG_DIR/$WORKER_ID.prompt.md"
-sed \
-  -e "s|{{WORKER_ID}}|$WORKER_ID|g" \
-  -e "s|{{OPPORTUNITY_ID}}|$OPP_ID|g" \
-  -e "s|{{TEST_NAME}}|$TEST_NAME|g" \
-  -e "s|{{SELECTOR}}|$SELECTOR|g" \
-  -e "s|{{BINARY}}|$BINARY|g" \
-  -e "s|{{ARCH}}|${ARCH:-none}|g" \
-  -e "s|{{SLUG}}|$SLUG|g" \
-  -e "s|{{BRANCH}}|$BRANCH|g" \
-  -e "s|{{WORKTREE}}|$WT|g" \
-  -e "s|{{KUNA_PY}}|$KUNA_PY|g" \
-  -e "s|{{DATE}}|$DATE|g" \
-  -e "s|{{RESUME_PROPOSAL}}|$RESUME_PROPOSAL_LINE|g" \
-  "$PROMPT_TMPL" > "$PROMPT_FILE"
+"$KUNA_PY" - "$PROMPT_TMPL" "$PROMPT_FILE" "$WORKER_EXTRA_PROMPT" \
+  "$WORKER_ID" "$OPP_ID" "$TEST_NAME" "$SELECTOR" "$BINARY" "${ARCH:-none}" \
+  "$SLUG" "$BRANCH" "$WT" "$KUNA_PY" "$DATE" "$WORKER_AGENT" "$WORKER_COMMAND" \
+  "$WORKER_DECIDER_INSTRUCTIONS" "$WORKER_TRAILER" "$WORKER_GENERATED_WITH" \
+  "$RESUME_PROPOSAL_LINE" <<'PY' || {
+import pathlib, re, sys
 
-# {{SIBLINGS}} is a whole FILE, not a line, so it is spliced after the sed pass: the captain
-# writes what the other in-flight builders are doing so they stay off each other's files.
-if [ -n "$WORKER_EXTRA_PROMPT" ] && [ -f "$WORKER_EXTRA_PROMPT" ]; then
-  "$KUNA_PY" -c 'import sys; t,e=sys.argv[1],sys.argv[2]; b=open(t).read(); open(t,"w").write(b.replace("{{SIBLINGS}}", open(e).read()))' "$PROMPT_FILE" "$WORKER_EXTRA_PROMPT"
-else
-  sed -i 's|{{SIBLINGS}}||g' "$PROMPT_FILE"
-fi
+template_path, output_path, extra_path = sys.argv[1:4]
+names = (
+    "WORKER_ID", "OPPORTUNITY_ID", "TEST_NAME", "SELECTOR", "BINARY", "ARCH",
+    "SLUG", "BRANCH", "WORKTREE", "KUNA_PY", "DATE", "WORKER_AGENT",
+    "WORKER_COMMAND", "WORKER_DECIDER_INSTRUCTIONS", "WORKER_TRAILER",
+    "WORKER_GENERATED_WITH", "RESUME_PROPOSAL",
+)
+values = dict(zip(names, sys.argv[4:]))
+values["SIBLINGS"] = (pathlib.Path(extra_path).read_text(errors="replace")
+                      if extra_path and pathlib.Path(extra_path).is_file() else "")
+template = pathlib.Path(template_path).read_text(errors="strict")
+token = re.compile(r"\{\{([A-Z0-9_]+)\}\}")
+missing = sorted(set(token.findall(template)) - set(values))
+if missing:
+    raise SystemExit("unknown worker prompt placeholder(s): " + ", ".join(missing))
+pathlib.Path(output_path).write_text(token.sub(lambda match: values[match.group(1)], template))
+PY
+  log "prompt render failed"
+  "$KUNA_PY" -m scripts.pipeline.state update --worker "$WORKER_ID" --status failed --note "prompt render failed" >>"$LOG" 2>&1
+  exit 1
+}
 
-# --- 5. headless Claude session (highest-effort model), in the worktree -----
-log "launching claude -p (model $MODEL, timeout ${WORKER_TIMEOUT}s)"
+# --- 5. headless implementation session, in the worktree -------------------
+log "launching $BACKEND (model $MODEL${REASONING:+, reasoning $REASONING}, timeout ${WORKER_TIMEOUT}s)"
 "$KUNA_PY" -m scripts.pipeline.state update --worker "$WORKER_ID" --phase analyze >>"$LOG" 2>&1
 
 RESULT_JSON="$LOG_DIR/$WORKER_ID.result.json"
-CLAUDE_EXTRA=()
-# A caller-supplied session id makes the transcript path deterministic BEFORE the run, which
-# is what lets a harness tail a live builder. codex has no equivalent.
-[ -n "$WORKER_SESSION_ID" ] && CLAUDE_EXTRA+=(--session-id "$WORKER_SESSION_ID")
-[ -n "$WORKER_BUDGET_USD" ] && CLAUDE_EXTRA+=(--max-budget-usd "$WORKER_BUDGET_USD")
-# env -u ANTHROPIC_API_KEY: a stale/invalid ANTHROPIC_API_KEY in the environment makes
-# headless `claude -p` fail with "Invalid API key"; unsetting it falls back to the working
-# session auth. </dev/null so claude does not wait on stdin.
-( cd "$WT" && env -u ANTHROPIC_API_KEY timeout "$WORKER_TIMEOUT" claude -p "$(cat "$PROMPT_FILE")" \
-    --model "$MODEL" \
-    --output-format json \
-    --dangerously-skip-permissions \
-    "${CLAUDE_EXTRA[@]+"${CLAUDE_EXTRA[@]}"}" \
-    < /dev/null > "$RESULT_JSON" 2>>"$LOG" )
-RC=$?
+if ! : > "$RESULT_JSON"; then
+  log "cannot initialize result file $RESULT_JSON"
+  "$KUNA_PY" -m scripts.pipeline.state update --worker "$WORKER_ID" --status failed --note "result file initialization failed" >>"$LOG" 2>&1
+  exit 1
+fi
+case "$BACKEND" in
+  claude)
+    CLAUDE_EXTRA=()
+    # A caller-supplied session id makes the transcript path deterministic BEFORE the run,
+    # which is what lets a harness tail a live builder. Codex has no equivalent.
+    [ -n "$WORKER_SESSION_ID" ] && CLAUDE_EXTRA+=(--session-id "$WORKER_SESSION_ID")
+    [ -n "$WORKER_BUDGET_USD" ] && CLAUDE_EXTRA+=(--max-budget-usd "$WORKER_BUDGET_USD")
+    # A stale ANTHROPIC_API_KEY makes headless Claude fail instead of using session auth.
+    ( cd "$WT" && env -u ANTHROPIC_API_KEY timeout "$WORKER_TIMEOUT" claude -p "$(cat "$PROMPT_FILE")" \
+        --model "$MODEL" \
+        --output-format json \
+        --dangerously-skip-permissions \
+        "${CLAUDE_EXTRA[@]+"${CLAUDE_EXTRA[@]}"}" \
+        < /dev/null > "$RESULT_JSON" 2>>"$LOG" )
+    RC=$?
+    ;;
+  codex)
+    EVENTS_JSONL="$LOG_DIR/$WORKER_ID.events.jsonl"
+    FINAL_TEXT="$LOG_DIR/$WORKER_ID.final.txt"
+    if ! : > "$EVENTS_JSONL" || ! : > "$FINAL_TEXT"; then
+      log "cannot initialize Codex transcript files under $LOG_DIR"
+      "$KUNA_PY" -m scripts.pipeline.state update --worker "$WORKER_ID" --status failed --note "transcript initialization failed" >>"$LOG" 2>&1
+      exit 1
+    fi
+    # Disable Codex's own multi-agent feature: every concurrent worker must hold a pipeline
+    # slot. The builder needs full worktree and network access to build, test, push, and merge.
+    ( cd "$WT" && timeout -k 60 "$WORKER_TIMEOUT" codex exec \
+        --cd "$WT" \
+        --sandbox danger-full-access \
+        -c approval_policy=never \
+        -c "model_reasoning_effort=$REASONING" \
+        --model "$MODEL" \
+        --disable multi_agent \
+        --disable multi_agent_v2 \
+        --json \
+        -o "$FINAL_TEXT" \
+        "$(cat "$PROMPT_FILE")" \
+        < /dev/null > "$EVENTS_JSONL" 2>>"$LOG" )
+    RC=$?
+    # Preserve the same result.json contract used by the captain and recovery notes while
+    # retaining Codex's full JSONL stream separately.
+    if ! "$KUNA_PY" - "$EVENTS_JSONL" "$FINAL_TEXT" "$RESULT_JSON" "$RC" <<'PY'
+import json, pathlib, sys
+events_path, final_path, result_path, rc = sys.argv[1:]
+thread_id = ""
+errors = []
+last_message = ""
+for line in pathlib.Path(events_path).read_text(errors="replace").splitlines():
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    if event.get("type") == "thread.started":
+        thread_id = event.get("thread_id") or event.get("threadId") or ""
+    if event.get("type") == "error":
+        errors.append(str(event.get("message") or event.get("error") or event))
+    item = event.get("item") or {}
+    if event.get("type") == "item.completed" and item.get("type") == "agent_message":
+        last_message = str(item.get("text") or "")
+final = pathlib.Path(final_path).read_text(errors="replace") if pathlib.Path(final_path).exists() else ""
+result = final or last_message or "\n".join(errors)
+pathlib.Path(result_path).write_text(json.dumps({
+    "backend": "codex", "session_id": thread_id, "result": result,
+    "return_code": int(rc), "events": events_path, "final_output": final_path,
+    "errors": errors,
+}) + "\n")
+PY
+    then
+      log "could not preserve Codex result metadata; raw JSONL remains at $EVENTS_JSONL"
+      [ "$RC" -ne 0 ] || RC=1
+    fi
+    ;;
+esac
 
 # capture the session id so a reviewer can resume the exact session on the PR
 SID="$("$KUNA_PY" - "$RESULT_JSON" <<'PY' 2>/dev/null
@@ -232,7 +339,7 @@ PY
 [ -n "$SID" ] && "$KUNA_PY" -m scripts.pipeline.state update --worker "$WORKER_ID" --note "session=$SID" >>"$LOG" 2>&1
 
 if [ $RC -ne 0 ]; then
-  # An account quota kill is indistinguishable from a crash by exit code alone: claude exits a
+  # An account quota kill is indistinguishable from a crash by exit code alone: Claude exits a
   # bare 1 and the result JSON reads `"subtype": "success"` with `"is_error": true`. The only
   # discriminator is the `result` string, and both of round 2's builders died this way
   # ("You've hit your session limit"). Read it ONLY on the failure path: a finished session can
@@ -265,9 +372,9 @@ QEOF
 )"
   if [ -n "$QUOTA" ]; then
     log "STOPPED BY A CAP, not a build failure: $QUOTA"
-    NOTE="capped: $QUOTA (claude rc=$RC)"
+    NOTE="capped: $QUOTA ($BACKEND rc=$RC)"
   else
-    NOTE="claude rc=$RC"
+    NOTE="$BACKEND rc=$RC"
   fi
 
   # Preserve what the session had written. Round 2 lost 618 insertions across 19 files -- a new
@@ -277,7 +384,7 @@ QEOF
   # Guarded, because committing blind is worse than not committing: `git commit` lands on
   # whatever HEAD is, so a session that died mid-rebase or on a detached HEAD would put the
   # commit somewhere the branch cannot reach while the log claimed otherwise. Deliberately not
-  # a trap -- an EXIT trap fires on SIGTERM without waiting for the claude subshell, and would
+  # a trap -- an EXIT trap fires on SIGTERM without waiting for the agent subshell, and would
   # stage a tree still being written.
   WT_HEAD="$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')"
   WT_GITDIR="$(git -C "$WT" rev-parse --git-dir 2>/dev/null || echo '')"
@@ -307,11 +414,11 @@ print(w.get("phase") or "unknown")' 2>/dev/null || echo unknown)"
     fi
   fi
 
-  log "claude session exited rc=$RC (timeout=124); leaving worktree for inspection"
+  log "$BACKEND session exited rc=$RC (timeout=124); leaving worktree for inspection"
   "$KUNA_PY" -m scripts.pipeline.state update --worker "$WORKER_ID" --status failed --note "$NOTE" >>"$LOG" 2>&1
   exit $RC
 fi
 
-log "session complete (rc=0). worktree $WT and session $SID preserved for PR review."
+log "$BACKEND session complete (rc=0). worktree $WT and session $SID preserved for PR review."
 # the worker itself records `state done --pr <url>` when it opens the PR
 exit 0

--- a/tools/pipeline/worker.sh
+++ b/tools/pipeline/worker.sh
@@ -152,6 +152,31 @@ else
   }
 fi
 
+# The base is the branch point, not necessarily HEAD: a retry may start on the WIP snapshot
+# that the failure path committed. Keep the marker in durable pipeline state rather than /tmp,
+# validate it against the current branch point, and only rewrite it when missing or stale.
+BASE_MARKER="$LOG_DIR/$WORKER_ID.base"
+EXPECTED_BASE="$(git -C "$WT" merge-base HEAD "$BASE_BRANCH" 2>/dev/null)" || {
+  log "cannot determine the branch point between $BRANCH and $BASE_BRANCH"
+  "$KUNA_PY" -m scripts.pipeline.state update --worker "$WORKER_ID" --status failed --note "base commit resolution failed" >>"$LOG" 2>&1
+  exit 1
+}
+MARKED_BASE="$(cat "$BASE_MARKER" 2>/dev/null || true)"
+if [ "$MARKED_BASE" = "$EXPECTED_BASE" ] \
+   && git -C "$WT" rev-parse --verify --quiet "$MARKED_BASE^{commit}" >/dev/null; then
+  log "preserving base marker $BASE_MARKER at $MARKED_BASE"
+else
+  BASE_MARKER_TMP="$BASE_MARKER.tmp.$$"
+  if ! printf '%s\n' "$EXPECTED_BASE" > "$BASE_MARKER_TMP" \
+     || ! mv -f "$BASE_MARKER_TMP" "$BASE_MARKER"; then
+    rm -f "$BASE_MARKER_TMP"
+    log "cannot initialize base marker $BASE_MARKER"
+    "$KUNA_PY" -m scripts.pipeline.state update --worker "$WORKER_ID" --status failed --note "base marker initialization failed" >>"$LOG" 2>&1
+    exit 1
+  fi
+  log "initialized base marker $BASE_MARKER at $EXPECTED_BASE"
+fi
+
 [ "$WORKER_PREPARE_ONLY" = 1 ] && { log "prepare-only: worktree ready"; exit 0; }
 
 # --pid $$ is THIS driver's pid, which lives as long as the worker does. Without it the
@@ -217,7 +242,7 @@ PROMPT_FILE="$LOG_DIR/$WORKER_ID.prompt.md"
   "$WORKER_ID" "$OPP_ID" "$TEST_NAME" "$SELECTOR" "$BINARY" "${ARCH:-none}" \
   "$SLUG" "$BRANCH" "$WT" "$KUNA_PY" "$DATE" "$WORKER_AGENT" "$WORKER_COMMAND" \
   "$WORKER_DECIDER_INSTRUCTIONS" "$WORKER_TRAILER" "$WORKER_GENERATED_WITH" \
-  "$RESUME_PROPOSAL_LINE" <<'PY' || {
+  "$RESUME_PROPOSAL_LINE" "$BASE_MARKER" <<'PY' || {
 import pathlib, re, sys
 
 template_path, output_path, extra_path = sys.argv[1:4]
@@ -225,7 +250,7 @@ names = (
     "WORKER_ID", "OPPORTUNITY_ID", "TEST_NAME", "SELECTOR", "BINARY", "ARCH",
     "SLUG", "BRANCH", "WORKTREE", "KUNA_PY", "DATE", "WORKER_AGENT",
     "WORKER_COMMAND", "WORKER_DECIDER_INSTRUCTIONS", "WORKER_TRAILER",
-    "WORKER_GENERATED_WITH", "RESUME_PROPOSAL",
+    "WORKER_GENERATED_WITH", "RESUME_PROPOSAL", "WORKER_BASE_FILE",
 )
 values = dict(zip(names, sys.argv[4:]))
 values["SIBLINGS"] = (pathlib.Path(extra_path).read_text(errors="replace")

--- a/tools/pipeline/worker_prompt.md
+++ b/tools/pipeline/worker_prompt.md
@@ -1,6 +1,6 @@
 # kuna feature worker — implement ONE angr-inspired feature, open ONE PR
 
-You are an autonomous, highest-effort Claude Code worker running **inside an isolated git
+You are an autonomous {{WORKER_AGENT}} running **inside an isolated git
 worktree** on branch `{{BRANCH}}`. Your entire job this session is to close **one** specific
 gap where the angr decompiler is better than kuna, by adding **one** option-gated kuna
 feature to the **Rust** engine, verifying it, and opening a PR — then stop. A human reviewer
@@ -88,11 +88,9 @@ where `<PHASE>` ∈ analyze, design, code, build, test, docs, commit, pr. If you
 
 ### 2. design — decide the minimal feature (use a decider for judgment calls)
 - Design the smallest pass/rule that produces angr-like output, gated by your new option (default-OFF while
-  developing). For any genuine judgment call (which stage to hook, whether the construct generalizes, scope),
-  spawn a **decider subagent** (use the Task/Agent tool) to make and justify the call, and record its decision
-  verbatim in `docs/features/{{SLUG}}/record.json` under `"decisions"`. Write `docs/features/{{SLUG}}/plan.md`.
-- **Scope check (the proposal gate, Hard rule 7).** Ask the decider to return `scope: small|large`.
-  Treat as **large** if: the decider says `large`; OR it needs a new pass *type*/infrastructure (not one
+  developing).
+{{WORKER_DECIDER_INSTRUCTIONS}}
+  Treat as **large** if: the scope decision says `large`; OR it needs a new pass *type*/infrastructure (not one
   Action/Rule like `kuna_loweredswitch.rs`); OR it must touch S7 structuring/region code beyond a single
   gated early-return; OR it needs >3 ported-core anchor files / >1 new module.
   - **If large — STOP. Do NOT implement.** Write `docs/features/{{SLUG}}/proposal.md` (the problem; the angr
@@ -163,10 +161,10 @@ where `<PHASE>` ∈ analyze, design, code, build, test, docs, commit, pr. If you
 
 ### 8. commit + PR
 - `git add -A && git commit` with a descriptive subject `{{SLUG}}: <one line>` and the trailer
-  `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>`.
+  `{{WORKER_TRAILER}}`.
 - Write the PR body to `docs/features/{{SLUG}}/pr_body.md`: a short summary, a link to
   `docs/features/{{SLUG}}/analysis.md`, the mechanism, the option name + how to flip it, and the
-  ablation/parity result, ending with `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+  ablation/parity result, ending with `{{WORKER_GENERATED_WITH}}`.
   Do NOT hand-write the before/after decompilation — `open_pr.sh` auto-appends a REAL captured
   before/after (kuna with the option off vs on, on the feature's target function) + the reference
   rendering, generated from `record.json`. So make sure `record.json` has correct `option`, `binary`,

--- a/tools/repipe/builder_prompt.md
+++ b/tools/repipe/builder_prompt.md
@@ -161,11 +161,13 @@ On abort: `... --status failed --note "<one line why>"`.
 
 ## Worktree hygiene — these have each cost real work here
 
-- **Record your base commit before you touch anything**:
-  `git rev-parse HEAD > /tmp/{{WORKER_ID}}.base`. The captain's local `main` can run *ahead*
-  of `origin/main`, so at merge time a plain `git rebase origin/main` is a silent no-op and
-  your squash swallows the captain's commits — that orphaned a PR this round. The merge
-  recipe below rebases `--onto` this recorded base instead.
+- **Preserve the launcher-recorded base commit** in `{{WORKER_BASE_FILE}}`. Verify it with
+  `BASE=$(cat "{{WORKER_BASE_FILE}}") && git rev-parse --verify "$BASE^{commit}"`, but do not rewrite it to
+  the current `HEAD`: on a retry, `HEAD` may be the preserved WIP snapshot rather than the
+  branch point. The captain's local `main` can run *ahead* of `origin/main`, so at merge time
+  a plain `git rebase origin/main` is a silent no-op and your squash swallows the captain's
+  commits — that orphaned a PR this round. The merge recipe below rebases `--onto` the
+  launcher-owned base instead.
 - **Never `git stash`.** `refs/stash` is one stack shared by every worktree and work has
   already been lost that way. To A/B something, `cp` the file aside.
 - **Never `make specs`** in a worktree. The main tree's compiled `.sla` are already
@@ -228,7 +230,8 @@ the rebase, and only then merge:
 
 ```
 {{KUNA_PY}} -m scripts.pipeline.state lease-acquire --resource merge --worker {{WORKER_ID}} --pid $$
-git fetch origin && git rebase --onto origin/main "$(cat /tmp/{{WORKER_ID}}.base)"
+BASE=$(cat "{{WORKER_BASE_FILE}}")
+git fetch origin && git rebase --onto origin/main "$BASE"
 {{KUNA_PY}} -m scripts.repipe.counters --fix
 git log --oneline origin/main..HEAD    # ONLY your own commits may appear here
 {{KUNA_PY}} -m scripts.repipe.mergecheck --against origin/main     # must be clean

--- a/tools/repipe/builder_prompt.md
+++ b/tools/repipe/builder_prompt.md
@@ -1,6 +1,6 @@
 # kuna RE-friction builder — close ONE need, open ONE PR, merge it
 
-You are an autonomous, highest-effort Claude Code worker in an isolated git worktree on
+You are an autonomous {{WORKER_AGENT}} in an isolated git worktree on
 branch `{{BRANCH}}`. Your entire job this session is to close **one** recorded way that kuna
 is bad for reverse engineering, verify it, and land it. Then stop.
 
@@ -208,7 +208,7 @@ decompiler/target/release/kuna catalog --check    # catalog OK
 ### Backgrounding a long gate — never wait on it with `pgrep`
 
 The workspace suite takes ~10 minutes, so background it if you want, but **do not poll for it
-with `pgrep -f '<gate name>'`**. Your own parent process is `claude -p <this entire prompt>`,
+with `pgrep -f '<gate name>'`**. Your own parent process is `{{WORKER_COMMAND}}`,
 and this prompt contains the literal gate strings, so such a pgrep matches *you* and never
 goes quiet. Builders have deadlocked on exactly that twice in one round, once sitting on a
 green log they could not read. Put the completion marker on the gate's own command line, and
@@ -250,13 +250,13 @@ and `<scope>` is the crate or phase (`cli`, `analysis`, `p9`, …). `[AUTOMATED]
 on anything created fully automatically — PRs, issues and commits alike. Trailers:
 
 ```
-Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+{{WORKER_TRAILER}}
 ```
 
 PR body goes in `docs/features/{{SLUG}}/pr_body.md`: what was broken (quote the need's
 symptom and its instance count), the mechanism, the acceptance probe that now passes, and the
 gate results with real numbers. End with
-`🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+`{{WORKER_GENERATED_WITH}}`.
 
 ## Negative result
 

--- a/tools/repipe/smoke.sh
+++ b/tools/repipe/smoke.sh
@@ -165,8 +165,34 @@ else
   bad "explicit WORKER_BRANCH did not create the requested branch"
 fi
 run_prepare fresh feat/re-collision-r7 \
-  && ok "an exact path+branch worktree is reusable" \
   || bad "exact path+branch reuse was refused"
+FRESH_BASE="$(cat "$LAUNCH_REPO/.state/logs/fresh.base" 2>/dev/null)"
+printf 'preserved work\n' > "$LAUNCH_REPO/.state/worktrees/fresh/wip"
+git -C "$LAUNCH_REPO/.state/worktrees/fresh" add wip
+git -C "$LAUNCH_REPO/.state/worktrees/fresh" commit -qm \
+  '[AUTOMATED] WIP UNFINISHED, DO NOT MERGE: smoke'
+FRESH_WIP="$(git -C "$LAUNCH_REPO/.state/worktrees/fresh" rev-parse HEAD)"
+if run_prepare fresh feat/re-collision-r7 \
+   && [ "$(cat "$LAUNCH_REPO/.state/logs/fresh.base")" = "$FRESH_BASE" ] \
+   && [ "$FRESH_BASE" != "$FRESH_WIP" ]; then
+  ok "an exact WIP worktree retry preserves its original base marker"
+else
+  bad "exact WIP worktree retry replaced its base with the WIP commit"
+fi
+printf 'not-a-commit\n' > "$LAUNCH_REPO/.state/logs/fresh.base"
+if run_prepare fresh feat/re-collision-r7 \
+   && [ "$(cat "$LAUNCH_REPO/.state/logs/fresh.base")" = "$FRESH_BASE" ]; then
+  ok "a stale base marker is repaired from the branch point, not WIP HEAD"
+else
+  bad "stale base marker was repaired to the WIP commit"
+fi
+rm -f "$LAUNCH_REPO/.state/logs/fresh.base"
+if run_prepare fresh feat/re-collision-r7 \
+   && [ "$(cat "$LAUNCH_REPO/.state/logs/fresh.base")" = "$FRESH_BASE" ]; then
+  ok "a missing base marker is restored from the branch point, not WIP HEAD"
+else
+  bad "missing base marker was initialized to the WIP commit"
+fi
 
 git -C "$LAUNCH_REPO" branch feat/re-stale main
 STALE_BEFORE="$(git -C "$LAUNCH_REPO" rev-parse feat/re-stale)"
@@ -243,10 +269,10 @@ printf '%s\n' \
   > "$FAKE_BIN/codex"
 chmod +x "$FAKE_BIN/codex"
 if PATH="$FAKE_BIN:$PATH" PYTHONPATH="$REPO" KUNA_REPO="$LAUNCH_REPO" KUNA_PY="$PY" \
-   PIPELINE_STATE_DIRNAME=.state WORKER_ID=codex-launch OPP_ID=smoke TEST_NAME=smoke \
-   SELECTOR=- BINARY='odd&|path\name' SLUG=codex-launch ARCH= \
+   PIPELINE_STATE_DIRNAME=.state WORKER_ID=codex-launch OPP_ID='odd&|path\name' TEST_NAME=smoke \
+   SELECTOR=- BINARY=- SLUG=codex-launch ARCH= \
    WORKER_BRANCH=feat/re-codex-launch WORKER_BACKEND=codex WORKER_MODEL=gpt-5.6-sol \
-   WORKER_REASONING=high WORKER_PROMPT="$REPO/tools/pipeline/worker_prompt.md" \
+   WORKER_REASONING=high WORKER_PROMPT="$REPO/tools/repipe/builder_prompt.md" \
    bash "$REPO/tools/pipeline/worker.sh" >/dev/null 2>&1; then
   CODEX_RESULT="$LAUNCH_REPO/.state/logs/codex-launch.result.json"
   CODEX_EVENTS="$LAUNCH_REPO/.state/logs/codex-launch.events.jsonl"
@@ -262,6 +288,7 @@ assert pathlib.Path(sys.argv[2]).read_text().count("\n") == 2
 prompt = pathlib.Path(sys.argv[3]).read_text()
 assert "odd&|path\\name" in prompt
 assert "Codex implementation worker using gpt-5.6-sol with high reasoning" in prompt
+assert "/.state/logs/codex-launch.base" in prompt
 assert "{{WORKER_" not in prompt
 PY
   then

--- a/tools/repipe/smoke.sh
+++ b/tools/repipe/smoke.sh
@@ -49,6 +49,40 @@ SPLIT="$("$PY" -c 'from scripts.repipe import config; import json; print(json.du
 echo "$SPLIT" | grep -q '"7": {"captain": 1, "testers": 3, "builders": 3' \
   && ok "max-agents 7 -> 1 captain + 3 testers + 3 builders" \
   || bad "7 does not split 1/3/3" "$SPLIT"
+ROLES="$("$PY" -c 'from scripts.repipe import config as c; print(":".join((c.TESTER_MODEL,c.TESTER_REASONING,c.BUILDER_BACKEND,c.BUILDER_MODEL,c.BUILDER_REASONING)))')"
+[ "$ROLES" = "gpt-5.6-sol:low:codex:gpt-5.6-sol:high" ] \
+  && ok "role defaults are Sol-low reversers and Sol-high builders" \
+  || bad "role defaults weakened" "$ROLES"
+POLICY="$(REPIPE_TESTER_REASONING=medium REPIPE_BUILDER_MODEL=other \
+  REPIPE_BUILDER_REASONING=medium REPIPE_CAPTAIN_BACKEND=other \
+  "$PY" -c 'from scripts.repipe import config as c; print("\n".join(c.role_policy_problems()))')"
+for expected in "reversers require" "implementation requires" \
+                "implementation reasoning must" "CAPTAIN_BACKEND must"; do
+  echo "$POLICY" | grep -q "$expected" \
+    && ok "preflight role policy rejects: $expected" \
+    || bad "preflight role policy missed: $expected" "$POLICY"
+done
+TESTER_REFUSAL="$(REPIPE_TESTER_MODEL=other bash "$REPO/tools/repipe/tester.sh" 2>&1)"
+if [ "$?" -eq 2 ] && echo "$TESTER_REFUSAL" | grep -q 'reversers require'; then
+  ok "standalone reverser refuses a weak model before launch"
+else
+  bad "standalone reverser accepted a weak model" "$TESTER_REFUSAL"
+fi
+grep -q -- '--disable multi_agent' "$REPO/tools/repipe/tester.sh" \
+  && grep -q -- '--disable multi_agent_v2' "$REPO/tools/repipe/tester.sh" \
+  && ok "reversers cannot bypass pipeline slots with Codex sub-agents" \
+  || bad "reverser launch does not disable Codex multi-agent features"
+KUNA_PIPELINE_STATE_DIR="$SMOKE_STATE/spawn-policy" "$PY" - <<'PY' >/dev/null 2>&1 \
+  && ok "captain exports the validated Sol-low policy to reversers" \
+  || bad "captain does not pin the reverser subprocess environment"
+from scripts.repipe import captain
+
+seen = {}
+captain.subprocess.Popen = lambda *args, **kwargs: seen.update(kwargs) or object()
+captain.spawn_tester(1, "0123456789abcdef")
+assert seen["env"]["REPIPE_TESTER_MODEL"] == "gpt-5.6-sol"
+assert seen["env"]["REPIPE_TESTER_REASONING"] == "low"
+PY
 
 head_ "L0  state machine refuses an illegal transition"
 "$PY" -m scripts.repipe.captain --transition test T_PLAN --note smoke >/dev/null 2>&1
@@ -95,7 +129,9 @@ git init -q -b main "$LAUNCH_REPO"
 git -C "$LAUNCH_REPO" config user.email smoke@example.invalid
 git -C "$LAUNCH_REPO" config user.name smoke
 printf 'base\n' > "$LAUNCH_REPO/tracked"
+printf 'binaries:\n\t@:\n' > "$LAUNCH_REPO/Makefile"
 git -C "$LAUNCH_REPO" add tracked
+git -C "$LAUNCH_REPO" add Makefile
 git -C "$LAUNCH_REPO" commit -qm base
 run_prepare() {
   KUNA_REPO="$LAUNCH_REPO" KUNA_PY="$PY" PIPELINE_STATE_DIRNAME=.state \
@@ -104,6 +140,24 @@ run_prepare() {
     IMPL_PROPOSAL="${3:-0}" RESUME_BRANCH="${4:-}" \
     bash "$REPO/tools/pipeline/worker.sh" >/dev/null 2>&1
 }
+if WORKER_BACKEND=codex WORKER_MODEL=gpt-5.6-sol WORKER_REASONING=low \
+   run_prepare weak-model feat/re-weak-model; then
+  bad "Codex builder accepted reasoning below high"
+elif [ ! -e "$LAUNCH_REPO/.state/worktrees/weak-model" ] \
+     && ! git -C "$LAUNCH_REPO" show-ref --verify --quiet refs/heads/feat/re-weak-model; then
+  ok "Codex builder refuses reasoning below high before touching Git state"
+else
+  bad "weak-model refusal touched Git state"
+fi
+if WORKER_BACKEND=codex WORKER_MODEL=other WORKER_REASONING=high \
+   run_prepare wrong-sol feat/re-wrong-sol; then
+  bad "Codex builder accepted a non-Sol model"
+elif [ ! -e "$LAUNCH_REPO/.state/worktrees/wrong-sol" ] \
+     && ! git -C "$LAUNCH_REPO" show-ref --verify --quiet refs/heads/feat/re-wrong-sol; then
+  ok "Codex builder refuses a non-Sol model before touching Git state"
+else
+  bad "non-Sol refusal touched Git state"
+fi
 if run_prepare fresh feat/re-collision-r7 \
    && [ "$(git -C "$LAUNCH_REPO/.state/worktrees/fresh" branch --show-current)" = feat/re-collision-r7 ]; then
   ok "explicit WORKER_BRANCH creates an attached fresh worktree"
@@ -169,6 +223,84 @@ if run_prepare resume ignored 1 feat/re-resume \
   ok "IMPL_PROPOSAL and RESUME_BRANCH still attach the approved branch"
 else
   bad "explicit proposal resume no longer works"
+fi
+
+# Exercise the real Codex branch without spending tokens. The shim emits the two artifacts
+# Codex promises: JSONL on stdout and the final response at -o/--output-last-message.
+FAKE_BIN="$SMOKE_STATE/fake-bin"
+mkdir -p "$FAKE_BIN"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -u' \
+  'out=' \
+  'while [ "$#" -gt 0 ]; do' \
+  '  case "$1" in -o|--output-last-message) shift; out="$1";; esac' \
+  '  shift' \
+  'done' \
+  'printf "mock final response\\n" > "$out"' \
+  'printf "%s\\n" '\''{"type":"thread.started","thread_id":"thread-smoke"}'\''' \
+  'printf "%s\\n" '\''{"type":"item.completed","item":{"type":"agent_message","text":"event fallback"}}'\''' \
+  > "$FAKE_BIN/codex"
+chmod +x "$FAKE_BIN/codex"
+if PATH="$FAKE_BIN:$PATH" PYTHONPATH="$REPO" KUNA_REPO="$LAUNCH_REPO" KUNA_PY="$PY" \
+   PIPELINE_STATE_DIRNAME=.state WORKER_ID=codex-launch OPP_ID=smoke TEST_NAME=smoke \
+   SELECTOR=- BINARY='odd&|path\name' SLUG=codex-launch ARCH= \
+   WORKER_BRANCH=feat/re-codex-launch WORKER_BACKEND=codex WORKER_MODEL=gpt-5.6-sol \
+   WORKER_REASONING=high WORKER_PROMPT="$REPO/tools/pipeline/worker_prompt.md" \
+   bash "$REPO/tools/pipeline/worker.sh" >/dev/null 2>&1; then
+  CODEX_RESULT="$LAUNCH_REPO/.state/logs/codex-launch.result.json"
+  CODEX_EVENTS="$LAUNCH_REPO/.state/logs/codex-launch.events.jsonl"
+  CODEX_PROMPT="$LAUNCH_REPO/.state/logs/codex-launch.prompt.md"
+  if "$PY" - "$CODEX_RESULT" "$CODEX_EVENTS" "$CODEX_PROMPT" <<'PY' >/dev/null 2>&1
+import json, pathlib, sys
+result = json.load(open(sys.argv[1]))
+assert result["backend"] == "codex"
+assert result["session_id"] == "thread-smoke"
+assert result["result"] == "mock final response\n"
+assert result["return_code"] == 0
+assert pathlib.Path(sys.argv[2]).read_text().count("\n") == 2
+prompt = pathlib.Path(sys.argv[3]).read_text()
+assert "odd&|path\\name" in prompt
+assert "Codex implementation worker using gpt-5.6-sol with high reasoning" in prompt
+assert "{{WORKER_" not in prompt
+PY
+  then
+    ok "Codex worker preserves JSONL/result metadata and renders provider-safe prompts"
+  else
+    bad "Codex worker artifacts or rendered prompt are incorrect"
+  fi
+else
+  bad "mocked Codex worker launch failed" "$(tail -8 "$LAUNCH_REPO/.state/logs/codex-launch.log" 2>/dev/null)"
+fi
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "%s\\n" '\''{"session_id":"claude-smoke","result":"mock final response"}'\''' \
+  > "$FAKE_BIN/claude"
+chmod +x "$FAKE_BIN/claude"
+if PATH="$FAKE_BIN:$PATH" PYTHONPATH="$REPO" KUNA_REPO="$LAUNCH_REPO" KUNA_PY="$PY" \
+   PIPELINE_STATE_DIRNAME=.state WORKER_ID=claude-launch OPP_ID=smoke TEST_NAME=smoke \
+   SELECTOR=- BINARY=- SLUG=claude-launch ARCH= WORKER_BRANCH=feat/re-claude-launch \
+   WORKER_BACKEND=claude WORKER_MODEL=opus \
+   WORKER_PROMPT="$REPO/tools/pipeline/worker_prompt.md" \
+   bash "$REPO/tools/pipeline/worker.sh" >/dev/null 2>&1; then
+  CLAUDE_RESULT="$LAUNCH_REPO/.state/logs/claude-launch.result.json"
+  CLAUDE_PROMPT="$LAUNCH_REPO/.state/logs/claude-launch.prompt.md"
+  if "$PY" - "$CLAUDE_RESULT" "$CLAUDE_PROMPT" <<'PY' >/dev/null 2>&1
+import json, pathlib, sys
+assert json.load(open(sys.argv[1]))["session_id"] == "claude-smoke"
+prompt = pathlib.Path(sys.argv[2]).read_text()
+assert "Claude Code worker using opus" in prompt
+assert "spawn a **decider subagent**" in prompt
+assert "Co-Authored-By: Claude Opus 5" in prompt
+assert "{{WORKER_" not in prompt
+PY
+  then
+    ok "shared worker retains its Claude launch and provider-specific prompt"
+  else
+    bad "Claude worker result or rendered prompt is incorrect"
+  fi
+else
+  bad "mocked Claude worker launch failed" "$(tail -8 "$LAUNCH_REPO/.state/logs/claude-launch.log" 2>/dev/null)"
 fi
 
 CAP_BRANCH="$($PY -c 'from scripts.repipe.captain import _builder_branch; print(_builder_branch(12, "need-name"))')"

--- a/tools/repipe/tester.sh
+++ b/tools/repipe/tester.sh
@@ -25,10 +25,15 @@ KUNA_PY="${KUNA_PY:-$HOME/.virtualenvs/kuna/bin/python}"
 STATE_DIR="${KUNA_PIPELINE_STATE_DIR:-$REPO/.kuna-repipe}"
 DATASET="${REPIPE_DATASET:-$HOME/github/kuna-re-dataset}"
 TIMEOUT="${REPIPE_TESTER_TIMEOUT:-3600}"
-MODEL="${REPIPE_TESTER_MODEL:-}"
-REASONING="${REPIPE_TESTER_REASONING:-}"
+MODEL="${REPIPE_TESTER_MODEL:-gpt-5.6-sol}"
+REASONING="${REPIPE_TESTER_REASONING:-low}"
 SANDBOX="${REPIPE_SANDBOX:-auto}"
 ENABLE_IDA="${REPIPE_ENABLE_IDA:-1}"
+
+if [ "$MODEL" != "gpt-5.6-sol" ] || [ "$REASONING" != "low" ]; then
+  echo "reversers require REPIPE_TESTER_MODEL=gpt-5.6-sol and REPIPE_TESTER_REASONING=low" >&2
+  exit 2
+fi
 
 : "${ROUND:?need ROUND}"
 : "${HEXID:?need HEXID}"
@@ -129,6 +134,8 @@ CODEX_ARGS=(exec
   -s workspace-write
   -c approval_policy=never
   -c sandbox_workspace_write.network_access=false
+  --disable multi_agent
+  --disable multi_agent_v2
   --json
   --output-schema "$REPO/tools/repipe/schema/report.schema.json"
   -o "$ARENA/report.json")


### PR DESCRIPTION
## Problem

RE-pipeline builders were hard-wired to `claude -p`, and standalone testers could silently inherit a user's Codex defaults instead of the configured Sol-low policy. The live symptom was an implementation worker launched as Claude even though the operator required Sol-high.

```text
worker b-r12-call-pop-pointer: launching claude -p (model opus, timeout 7200s)
```

## Fix

- Pin reversers to `gpt-5.6-sol` / `low` at configuration, spawn, and launch boundaries.
- Add a Codex builder backend pinned to `gpt-5.6-sol` with `high`, `xhigh`, or `max` reasoning.
- Preserve provider-specific prompts, transcripts, results, failure recovery, and optional Claude compatibility for the shared sibling pipeline.
- Disable nested Codex multi-agent execution so pipeline slots remain authoritative.

## Tests

`tools/repipe/smoke.sh --level 0`: 46/46 passed, including mocked Codex and Claude launches and fail-closed model-policy checks.

🤖 Generated with OpenAI Codex.