### PR TITLE
[AUTOMATED] fix(repipe): require stable performance regression evidence

### DIFF
--- a/docs/re-pipeline.md
+++ b/docs/re-pipeline.md
@@ -285,9 +285,14 @@ python3 -m scripts.repipe.verify --acceptance-suite --all --json
 ```
 
 A previously-closed need whose acceptance flips back becomes `regressed` and outranks
-everything. The next round's testers are automatically handed the closed set with an explicit
-mandate to try to break it, so the loop closes on evidence twice: a machine re-runs the
-predicate, and a fresh agent attacks the new surface.
+everything. Aggregate performance clauses have two extra evidence guards without changing
+their authored bound: repeated samples that land on both sides of the bound are `flaky`, and
+an otherwise-stable timing- or memory-only failure must fail a second independent batch before
+it can trigger that transition. A contradictory batch is `indeterminate`, not PASS, so the
+contract remains visible without rolling back unrelated code on a near-bound coin flip. The
+next round's testers are automatically handed the closed set with an explicit mandate to try to
+break it, so the loop closes on evidence twice: a machine re-runs the predicate, and a fresh
+agent attacks the new surface.
 
 ## 7. Collision avoidance
 

--- a/scripts/repipe/probe.py
+++ b/scripts/repipe/probe.py
@@ -1145,6 +1145,43 @@ def _stat_clause(metric, sp, runs, baselines):
     return ok, actual
 
 
+def _stat_sample_outcomes(metric, sp, runs, baselines):
+    """Evaluate an aggregate predicate against each measured sample.
+
+    A median/mean predicate still passes or fails on its requested aggregate. These
+    per-sample outcomes answer a different question: did the repeated observations
+    stay on one side of the boundary? Crossing it is the aggregate equivalent of
+    ordinary per-run disagreement and therefore makes the verdict flaky rather than
+    evidence for a state transition.
+    """
+    # A max/min predicate intentionally makes one extreme sample decisive; treating
+    # the other samples as disagreement would erase that authored contract.
+    if sp.get("stat") not in ("median", "mean"):
+        return []
+    samples = _samples(runs, metric)
+    base = None
+    if "ratio_lt" in sp or "ratio_gt" in sp:
+        base = _baseline_stat(baselines, sp.get("rel_to"), metric, sp["stat"])
+        if base is None or base == 0:
+            return []
+
+    outcomes = []
+    for value in samples:
+        ok = True
+        if "lt" in sp:
+            ok = ok and value < sp["lt"]
+        if "gt" in sp:
+            ok = ok and value > sp["gt"]
+        if base is not None:
+            ratio = value / base
+            if "ratio_lt" in sp:
+                ok = ok and ratio < sp["ratio_lt"]
+            if "ratio_gt" in sp:
+                ok = ok and ratio > sp["ratio_gt"]
+        outcomes.append(ok)
+    return outcomes
+
+
 def _collapse(actuals):
     keys = set()
     for a in actuals:
@@ -1162,11 +1199,13 @@ def evaluate(probe, observation):
     caller can tell "the behaviour is not there" from "the gate could not decide". A flaky probe
     never passes, since passing requires every run to satisfy every clause.
 
-    ``wall_ms``/``max_rss_kb`` are aggregates over the repeats and so cannot be attributed to one
-    run; they are excluded from the flakiness verdict and evaluated once. A run that timed out or
-    could not be executed adds a synthetic failing ``run`` clause: an incomplete observation is not
-    a pass. ``rel_to`` baselines are read from ``observation["baselines"]``, which :func:`run`
-    copies out of ``ctx["baselines"]`` -- the caller must supply them.
+    ``wall_ms``/``max_rss_kb`` pass or fail on their requested aggregate, but each sample is also
+    tested against the same bound for stability. Samples on both sides make the verdict flaky:
+    a median that changes truth when one near-bound sample moves is not evidence for a pipeline
+    state transition. A run that timed out or could not be executed adds a synthetic failing
+    ``run`` clause: an incomplete observation is not a pass. ``rel_to`` baselines are read from
+    ``observation["baselines"]``, which :func:`run` copies out of ``ctx["baselines"]`` -- the
+    caller must supply them.
     """
     p = normalize(probe)
     expect = p["expect"]
@@ -1190,11 +1229,15 @@ def evaluate(probe, observation):
             "actual": _collapse([x[1] for x in results]),
             "ok": bool(results) and all(x[0] for x in results),
         })
+    aggregate_flaky = []
     for metric in _STAT_CLAUSES:
         if metric in expect:
             ok, actual = _stat_clause(metric, expect[metric], runs, baselines)
             clauses.append({"clause": metric, "expected": expect[metric],
                             "actual": actual, "ok": ok})
+            outcomes = _stat_sample_outcomes(metric, expect[metric], runs, baselines)
+            if len(set(outcomes)) > 1:
+                aggregate_flaky.append(metric)
 
     broken = [r for r in runs if r.get("timed_out") or r.get("error")]
     if not runs:
@@ -1210,12 +1253,14 @@ def evaluate(probe, observation):
     per_run = [all(fn(r, parsed[i])[0] for _, _, fn in checkers) for i, r in enumerate(runs)]
     wall = _samples(runs, "wall_ms")
     rss = _samples(runs, "max_rss_kb")
+    is_flaky = len(set(per_run)) > 1 or bool(aggregate_flaky)
     return {
         "schema": "re-verdict/1",
         "probe_id": p["probe_id"],
         "kind": p.get("kind"),
-        "passed": bool(runs) and all(c["ok"] for c in clauses),
-        "flaky": len(set(per_run)) > 1,
+        "passed": bool(runs) and all(c["ok"] for c in clauses) and not is_flaky,
+        "flaky": is_flaky,
+        "flaky_clauses": aggregate_flaky,
         "repeat": len(runs),
         "run_passed": per_run,
         "clauses": clauses,

--- a/scripts/repipe/verify.py
+++ b/scripts/repipe/verify.py
@@ -28,8 +28,10 @@ The five verdicts, in the precedence `gate()` decides them:
 `acceptance_suite()` is the other half of the loop and the machine's entire answer to
 "have the builders fixed what the testers asked for": it re-runs the acceptance probe of
 every need in docs/re-needs/ against the CURRENT build. FAIL->PASS closes a need; PASS->
-FAIL on a closed need is a regression that goes back at rank 0. Neither is a judgment
-call, and neither fires off a flaky or unrunnable replay.
+FAIL on a closed need is a regression that goes back at rank 0. Neither fires off a flaky
+or unrunnable replay. An otherwise-stable aggregate-only regression is measured in a
+second independent batch before it can move state; disagreement is flaky evidence, not a
+reason to roll back unrelated code.
 
 `promote()` copies a closed need's acceptance probe verbatim into tests/cli/<need_id>.json
 so every shipped need leaves a permanent regression test behind it. It refuses a probe
@@ -677,6 +679,49 @@ def _wants_baseline(probe_doc):
     return False
 
 
+def _aggregate_only_failure(verdict):
+    """Whether only a central wall-time or memory aggregate made this verdict fail."""
+    return bool(_failed_central_aggregates(verdict))
+
+
+def _failed_central_aggregates(verdict):
+    """Return the central aggregate clauses responsible for a clean failure."""
+    clauses = list((verdict or {}).get("clauses") or [])
+    failed = [c for c in clauses if not c.get("ok")]
+    if not failed or not all(
+        c.get("clause") in ("wall_ms", "max_rss_kb")
+        and (c.get("expected") or {}).get("stat") in ("median", "mean")
+        for c in failed
+    ):
+        return ()
+    return tuple(sorted(c["clause"] for c in failed))
+
+
+def _confirm_aggregate_regression(primary, confirmation):
+    """Attach a second batch and withhold a regression unless it reproduces.
+
+    This does not turn either failed batch into a pass or alter the probe's bound.
+    It only prevents a noisy aggregate from causing the PASS->FAIL state transition
+    when another independent replay cannot confirm it.
+    """
+    out = dict(primary)
+    out["confirmation"] = confirmation
+    out["batch_passed"] = [bool(primary.get("passed")), bool(confirmation.get("passed"))]
+    inconclusive = (
+        confirmation.get("unrunnable")
+        or confirmation.get("flaky")
+        or confirmation.get("passed")
+        or _failed_central_aggregates(confirmation)
+        != _failed_central_aggregates(primary)
+    )
+    if inconclusive:
+        out["flaky"] = True
+        reasons = list(out.get("flaky_clauses") or [])
+        reasons.append("aggregate-confirmation")
+        out["flaky_clauses"] = reasons
+    return out
+
+
 def acceptance_suite(need_ids=None, reps=None):
     """Re-run every filed acceptance probe against the CURRENT build.
 
@@ -684,7 +729,9 @@ def acceptance_suite(need_ids=None, reps=None):
     for". A need whose acceptance flips FAIL->PASS is `closed`; a previously-closed need
     whose acceptance flips PASS->FAIL is `regressed` and must be re-queued at rank 0. A
     flaky or unrunnable replay is `indeterminate` and moves nothing -- closing a need on a
-    coin-flip would be worse than not closing it.
+    coin-flip would be worse than not closing it. A closed need whose only failure is an
+    otherwise-stable wall-time or memory aggregate gets one independent confirmation batch;
+    only two failures may requeue it as a regression.
     """
     sha = head_sha()
     rows, closed, regressed = [], [], []
@@ -708,6 +755,18 @@ def acceptance_suite(need_ids=None, reps=None):
         # whole perf idiom dead on arrival.
         baselines = _acceptance_baselines(rec, chal, reps)
         v = run_probe(p, True, None, None, chal, reps, baselines=baselines)
+        if (
+            status == "closed"
+            and not v.get("passed")
+            and not v.get("unrunnable")
+            and not v.get("flaky")
+            and _aggregate_only_failure(v)
+        ):
+            confirmation_baselines = _acceptance_baselines(rec, chal, reps)
+            confirmation = run_probe(
+                p, True, None, None, chal, reps, baselines=confirmation_baselines
+            )
+            v = _confirm_aggregate_regression(v, confirmation)
         if v.get("unrunnable") or v.get("flaky"):
             trans = "indeterminate"
         elif v.get("passed") and status in OPEN_STATUSES:

--- a/tools/repipe/smoke.sh
+++ b/tools/repipe/smoke.sh
@@ -44,6 +44,66 @@ for m in config probe verify workspace redact sample grade needs cluster select 
   if "$PY" -c "import scripts.repipe.$m" 2>/dev/null; then ok "import $m"; else bad "import $m"; fi
 done
 
+head_ "L0  aggregate performance regressions require stable evidence"
+"$PY" - <<'PY' >/dev/null 2>&1 \
+  && ok "near-bound samples and contradictory confirmation cannot requeue a need" \
+  || bad "aggregate timing noise can still trigger a regression"
+from scripts.repipe import probe, verify
+
+doc = {
+    "schema": "re-probe/1", "kind": "timing", "cmd": ["kuna"], "timeout_s": 5,
+    "repeat": 3, "expect": {"exit_code": {"eq": 0},
+                            "wall_ms": {"stat": "median", "lt": 10}},
+}
+def observation(samples):
+    return {"runs": [{"exit_code": 0, "stdout": "", "stderr": "", "wall_ms": value,
+                       "timed_out": False, "error": None} for value in samples],
+            "baselines": {}}
+
+crossing = probe.evaluate(probe.normalize(doc), observation([9, 11, 12]))
+assert not crossing["passed"] and crossing["flaky"], crossing
+assert crossing["flaky_clauses"] == ["wall_ms"], crossing
+crossing_pass = probe.evaluate(probe.normalize(doc), observation([9, 9, 11]))
+assert not crossing_pass["passed"] and crossing_pass["flaky"], crossing_pass
+max_doc = dict(doc, expect={"exit_code": {"eq": 0},
+                            "wall_ms": {"stat": "max", "lt": 10}})
+extreme = probe.evaluate(probe.normalize(max_doc), observation([9, 11, 12]))
+assert not extreme["passed"] and not extreme["flaky"], extreme
+
+def verdict(passed):
+    return {"passed": passed, "flaky": False, "unrunnable": False, "error": None,
+            "probe_id": "a-smoke", "clauses": [
+                {"clause": "exit_code", "ok": True},
+                {"clause": "wall_ms", "ok": passed,
+                 "expected": {"stat": "median", "lt": 10}},
+            ]}
+
+record = {"need_id": "perf-smoke", "front_matter": {"status": "closed", "challenges": []}}
+verify.need_records = lambda _ids=None: [record]
+verify.acceptance_of = lambda _rec: (doc, "{}", "record")
+verify.head_sha = lambda: "abc123"
+
+answers = iter([verdict(False), verdict(True)])
+verify.run_probe = lambda *_args, **_kwargs: next(answers)
+row = verify.acceptance_suite()["needs"][0]
+assert row["transition"] == "indeterminate" and row["flaky"], row
+assert row["acceptance"]["batch_passed"] == [False, True], row
+
+answers = iter([verdict(False), dict(verdict(False), clauses=[
+    {"clause": "exit_code", "ok": False},
+    {"clause": "wall_ms", "ok": True,
+     "expected": {"stat": "median", "lt": 10}},
+])])
+verify.run_probe = lambda *_args, **_kwargs: next(answers)
+row = verify.acceptance_suite()["needs"][0]
+assert row["transition"] == "indeterminate" and row["flaky"], row
+
+answers = iter([verdict(False), verdict(False)])
+verify.run_probe = lambda *_args, **_kwargs: next(answers)
+row = verify.acceptance_suite()["needs"][0]
+assert row["transition"] == "regressed" and not row["flaky"], row
+PY
+
 head_ "L0  agent split matches the documented table"
 SPLIT="$("$PY" -c 'from scripts.repipe import config; import json; print(json.dumps({n: config.agent_split(n) for n in (2,4,5,7,9)}))')"
 echo "$SPLIT" | grep -q '"7": {"captain": 1, "testers": 3, "builders": 3' \


### PR DESCRIPTION
## The problem

A closed median-latency need can flip to `regressed` on timing noise and force an unrelated rollback. On the same tree containing #565, independent seven-run batches straddled the unchanged 10-second boundary: 9.522–10.516 seconds (median 9.922) and 9.611–10.237 seconds (median 9.918).

```bash
PYTHONPATH=$PWD python3 -m scripts.repipe.verify \
  --acceptance-suite --need decompiling-3396-byte-main --json
```

## The fix

- Treat median/mean samples crossing their authored bound as flaky, so they cannot move pipeline state.
- Require an otherwise-stable aggregate-only failure of a closed need to reproduce in a second independent batch before requeueing it.
- Require the confirmation to fail the same aggregate clauses; retain decisive min/max semantics and the exact authored threshold.

## The tests

- Smoke coverage pins cross-bound samples, min/max behavior, contradictory or unrelated confirmation, and two-batch failure.
- `tools/repipe/smoke.sh --level 0`: 49/49.
- `make test`: 675/675; `make test-stages`: 774/774; `make rust-test`; `make check-spec`.
- Real #565 replay: no regression; the near-bound timing is retained as indeterminate evidence.
