### PR TITLE
[AUTOMATED] fix(repipe): restart stopped supervisors safely

### DIFF
--- a/docs/re-pipeline.md
+++ b/docs/re-pipeline.md
@@ -357,8 +357,9 @@ come from a slot.
   reason written by a later halt is therefore never removed after `RUNNING` is published.
   A fresh `run.sh` invocation similarly consumes the completed round's `STOP` and uses
   `captain.py --restart-stopped` to leave `STOPPED`; the same empty-pool, control-file, and
-  preflight guards apply, and the `STOPPED -> RUNNING` operator edge is appended to the
-  transition audit. `ABORT` is never consumed implicitly.
+  preflight guards apply. Startup recovery is serialized, `STOP` is consumed under the round
+  lock, and the `STOPPED -> RUNNING` operator edge is appended to the transition audit.
+  `ABORT` is never consumed implicitly.
 - **Builder branches fail closed.** `tools/pipeline/worker.sh` accepts `WORKER_BRANCH` as an
   explicit fresh-branch seam. Normal RE builders use the stable round-specific name
   `feat/re-<need>-r<round>`, avoiding old canonical refs from earlier rounds. Only an exact

--- a/docs/re-pipeline.md
+++ b/docs/re-pipeline.md
@@ -58,7 +58,7 @@ touch .kuna-repipe/ABORT                # hard stop; worktrees and arenas left i
 | `REPIPE_MAX_AGENTS` | total concurrent LLM processes (**7** = 1 captain + 3 testers + 3 builders) |
 | `REPIPE_TESTER_SHARE` | tester fraction of the non-captain slots (0.5) |
 | `REPIPE_ROUND_CHALLENGES` | challenges per round (9) |
-| `REPIPE_TESTER_TIMEOUT` / `REPIPE_BUILDER_TIMEOUT` / `REPIPE_CAPTAIN_TIMEOUT` | 3600 / 7200 / 1200 s |
+| `REPIPE_TESTER_TIMEOUT` / `REPIPE_BUILDER_TIMEOUT` / `REPIPE_CAPTAIN_TIMEOUT` | 3600 / 7200 / 3600 s |
 | `REPIPE_BUILDER_USD` / `REPIPE_ROUND_USD` / `REPIPE_RUN_USD` | 25 / 150 / 1500 |
 | `REPIPE_MIN_FREE_GB` / `REPIPE_HALT_FREE_GB` | stop dispatching / halt outright (250 / 60) |
 | `REPIPE_SANDBOX` | `auto` \| `bwrap` \| `none` — `none` is prompt-only containment |
@@ -72,6 +72,9 @@ touch .kuna-repipe/ABORT                # hard stop; worktrees and arenas left i
 | `REPIPE_CAPTAIN_USD` | Claude-only dollar cap; Codex ticks are bounded by timeout, model, and reasoning effort |
 | `REPIPE_DATASET` | the crackme corpus (`~/github/kuna-re-dataset`) |
 | `KUNA_PIPELINE_STATE_DIR` | live state (`.kuna-repipe/`, gitignored) |
+
+The captain timeout is one hour because a cold `B_VERIFY` tick owns the release build, all
+four repository gates, and the acceptance suite; that supported path can exceed 20 minutes.
 
 The agent split at other values: 2→1/1/1, 4→1/2/1, 5→1/2/2, 6→1/3/2, **7→1/3/3**, 9→1/4/4.
 Below 5 the two tracks cannot overlap, so the live process count is
@@ -352,6 +355,10 @@ come from a slot.
   That command reaps again, requires empty tester/builder pools, refuses `STOP` or `ABORT`,
   reruns preflight, consumes the old `HALT_REASON`, and then records the operator restart. A
   reason written by a later halt is therefore never removed after `RUNNING` is published.
+  A fresh `run.sh` invocation similarly consumes the completed round's `STOP` and uses
+  `captain.py --restart-stopped` to leave `STOPPED`; the same empty-pool, control-file, and
+  preflight guards apply, and the `STOPPED -> RUNNING` operator edge is appended to the
+  transition audit. `ABORT` is never consumed implicitly.
 - **Builder branches fail closed.** `tools/pipeline/worker.sh` accepts `WORKER_BRANCH` as an
   explicit fresh-branch seam. Normal RE builders use the stable round-specific name
   `feat/re-<need>-r<round>`, avoiding old canonical refs from earlier rounds. Only an exact
@@ -722,6 +729,13 @@ file is **shared state**: every supervisor sharing the state dir sees it, transi
 round to `DRAINING`, and stops dispatching. Removing the file does not undo it —
 `DRAINING → RUNNING` is deliberately not a legal edge, so the round can only go on to
 `STOPPED`.
+
+Once it is `STOPPED`, invoking `tools/repipe/run.sh` again is the explicit operator restart.
+The launcher consumes the completed drain's `STOP`, reaps dead workers, requires no live
+tester or builder slots, reruns preflight, and records `STOPPED → RUNNING` before dispatching.
+It refuses an `ABORT`; remove that file manually only after resolving why the hard stop was
+requested. The lower-level equivalent is `rm .kuna-repipe/STOP` followed by
+`python3 -m scripts.repipe.captain --restart-stopped`.
 
 So `kill <supervisor>` is not "stop this process". It is "end this round". To remove a
 duplicate or stuck supervisor without ending the round, use `kill -9`, which skips the trap.

--- a/docs/re-pipeline.md
+++ b/docs/re-pipeline.md
@@ -358,8 +358,11 @@ come from a slot.
   A fresh `run.sh` invocation similarly consumes the completed round's `STOP` and uses
   `captain.py --restart-stopped` to leave `STOPPED`; the same empty-pool, control-file, and
   preflight guards apply. Startup recovery is serialized, `STOP` is consumed under the round
-  lock, and the `STOPPED -> RUNNING` operator edge is appended to the transition audit.
-  `ABORT` is never consumed implicitly.
+  lock, and the `STOPPED -> RUNNING` operator edge is appended to the transition audit. A
+  separate process-lifetime ownership lock admits only one `run.sh` loop, including when a
+  second launcher arrives after the first has already published `RUNNING`; the kernel releases
+  that lock if its owner exits, so crash recovery remains possible. `ABORT` is never consumed
+  implicitly.
 - **Builder branches fail closed.** `tools/pipeline/worker.sh` accepts `WORKER_BRANCH` as an
   explicit fresh-branch seam. Normal RE builders use the stable round-specific name
   `feat/re-<need>-r<round>`, avoiding old canonical refs from earlier rounds. Only an exact

--- a/docs/re-pipeline.md
+++ b/docs/re-pipeline.md
@@ -360,9 +360,11 @@ come from a slot.
   preflight guards apply. Startup recovery is serialized, `STOP` is consumed under the round
   lock, and the `STOPPED -> RUNNING` operator edge is appended to the transition audit. A
   separate process-lifetime ownership lock admits only one `run.sh` loop, including when a
-  second launcher arrives after the first has already published `RUNNING`; the kernel releases
-  that lock if its owner exits, so crash recovery remains possible. `ABORT` is never consumed
-  implicitly.
+  second launcher arrives after the first has already published `RUNNING`. The actual supervisor
+  owns and verifies an inherited, PID-bound lock descriptor; foreground descendants inherit it,
+  so a killed supervisor cannot admit a replacement while an orphan captain is still alive. The
+  kernel releases the lock after the owner and its inheriting descendants exit, allowing crash
+  recovery. `ABORT` is never consumed implicitly.
 - **Builder branches fail closed.** `tools/pipeline/worker.sh` accepts `WORKER_BRANCH` as an
   explicit fresh-branch seam. Normal RE builders use the stable round-specific name
   `feat/re-<need>-r<round>`, avoiding old canonical refs from earlier rounds. Only an exact

--- a/scripts/repipe/captain.py
+++ b/scripts/repipe/captain.py
@@ -109,6 +109,19 @@ def _round_lock(n):
         fh.close()
 
 
+@contextlib.contextmanager
+def _startup_lock():
+    """Serialize operator recovery and launcher startup decisions."""
+    os.makedirs(config.state_dir(), exist_ok=True)
+    fh = open(config.state_dir() / ".supervisor-start.lock", "w")
+    try:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fh, fcntl.LOCK_UN)
+        fh.close()
+
+
 def save_round(doc):
     p = _round_path(doc["round"])
     # A per-process temp name: a shared "<path>.tmp" lets two writers interleave into the same
@@ -373,12 +386,12 @@ def recover():
     return {"round": n, "reaped": reaped, "resumed_at": {k: doc[k] for k in MACHINES}}
 
 
-def _operator_resume(expected, note, consume_halt_reason=False):
+def _operator_resume(expected, note, consume_halt_reason=False, consume_stop=False):
     """Guard and audit an operator-only terminal supervisor recovery."""
     reaped = pstate.reap(stale_seconds=0)
     n = current_round()
-    controls = [name for name, present in (("STOP", stop_requested()), ("ABORT", abort_requested()))
-                if present]
+    controls = (["STOP"] if stop_requested() and not consume_stop else [])
+    controls.extend(["ABORT"] if abort_requested() else [])
     if controls:
         return {"ok": False, "round": n, "reaped": reaped,
                 "problems": ["%s control file present" % ", ".join(controls)]}
@@ -396,8 +409,8 @@ def _operator_resume(expected, note, consume_halt_reason=False):
             return {"ok": False, "round": n, "reaped": reaped,
                     "problems": ["supervisor is %s, not %s" % (doc["supervisor"], expected)],
                     "live": live}
-        controls = [name for name, present in (("STOP", stop_requested()),
-                                                ("ABORT", abort_requested())) if present]
+        controls = (["STOP"] if stop_requested() and not consume_stop else [])
+        controls.extend(["ABORT"] if abort_requested() else [])
         if controls:
             return {"ok": False, "round": n, "reaped": reaped,
                     "problems": ["%s control file appeared during recovery"
@@ -408,6 +421,9 @@ def _operator_resume(expected, note, consume_halt_reason=False):
         if any(live.values()):
             return {"ok": False, "round": n, "reaped": reaped,
                     "problems": ["live agent slots appeared during recovery"], "live": live}
+        consumed_stop = consume_stop and stop_requested()
+        if consumed_stop:
+            (config.state_dir() / "STOP").unlink()
         # HALTED recovery consumes its reason before publishing RUNNING. A later halt may write
         # a new reason after save_round(); there must be no post-publication unlink that erases it.
         if consume_halt_reason:
@@ -416,29 +432,39 @@ def _operator_resume(expected, note, consume_halt_reason=False):
                 halt_reason.unlink()
             except FileNotFoundError:
                 pass
-        doc["supervisor"] = "RUNNING"
-        doc.setdefault("notes", []).append(note)
-        rec = {"ts": time.time(), "machine": "supervisor", "from": expected,
-               "to": "RUNNING", "note": note, "pid": os.getpid(), "operator_resume": True}
-        with open(_round_dir(n) / "transitions.jsonl", "a") as fh:
-            fh.write(json.dumps(rec) + "\n")
-        save_round(doc)
+        try:
+            doc["supervisor"] = "RUNNING"
+            doc.setdefault("notes", []).append(note)
+            rec = {"ts": time.time(), "machine": "supervisor", "from": expected,
+                   "to": "RUNNING", "note": note, "pid": os.getpid(),
+                   "operator_resume": True}
+            with open(_round_dir(n) / "transitions.jsonl", "a") as fh:
+                fh.write(json.dumps(rec) + "\n")
+            save_round(doc)
+        except BaseException:
+            if consumed_stop:
+                (config.state_dir() / "STOP").touch()
+            raise
 
     return {"ok": True, "round": n, "reaped": reaped,
-            "resumed_at": {k: doc[k] for k in MACHINES}, "live": live}
+            "resumed_at": {k: doc[k] for k in MACHINES}, "live": live,
+            "consumed_stop": consumed_stop}
 
 
 def resume_halted():
     """Operator-only recovery from HALTED after the machine is safe again."""
-    return _operator_resume(
-        "HALTED", "operator resume after reap, empty agent slots, and preflight OK",
-        consume_halt_reason=True)
+    with _startup_lock():
+        return _operator_resume(
+            "HALTED", "operator resume after reap, empty agent slots, and preflight OK",
+            consume_halt_reason=True)
 
 
-def restart_stopped():
+def restart_stopped(consume_stop=False):
     """Operator-only restart of a cleanly stopped round after the machine is safe again."""
-    return _operator_resume(
-        "STOPPED", "operator restart after reap, empty agent slots, and preflight OK")
+    with _startup_lock():
+        return _operator_resume(
+            "STOPPED", "operator restart after reap, empty agent slots, and preflight OK",
+            consume_stop=consume_stop)
 
 
 def main(argv=None):
@@ -447,6 +473,7 @@ def main(argv=None):
     ap.add_argument("--recover", action="store_true")
     ap.add_argument("--resume-halted", action="store_true")
     ap.add_argument("--restart-stopped", action="store_true")
+    ap.add_argument("--consume-stop", action="store_true")
     ap.add_argument("--preflight", action="store_true")
     ap.add_argument("--status", action="store_true")
     ap.add_argument("--round", type=int, default=None)
@@ -456,6 +483,10 @@ def main(argv=None):
                     help="how many of the round's most recent notes --status carries (0 = none)")
     ap.add_argument("--json", action="store_true")
     args = ap.parse_args(argv)
+
+    if args.consume_stop and not args.restart_stopped:
+        print("--consume-stop requires --restart-stopped", file=sys.stderr)
+        return 2
 
     if args.preflight:
         problems = preflight()
@@ -476,7 +507,7 @@ def main(argv=None):
         return 0 if out["ok"] else 1
 
     if args.restart_stopped:
-        out = restart_stopped()
+        out = restart_stopped(consume_stop=args.consume_stop)
         print(json.dumps(out, indent=2, default=str))
         return 0 if out["ok"] else 1
 

--- a/scripts/repipe/captain.py
+++ b/scripts/repipe/captain.py
@@ -373,8 +373,8 @@ def recover():
     return {"round": n, "reaped": reaped, "resumed_at": {k: doc[k] for k in MACHINES}}
 
 
-def resume_halted():
-    """Operator-only recovery from HALTED after the machine is safe again."""
+def _operator_resume(expected, note, consume_halt_reason=False):
+    """Guard and audit an operator-only terminal supervisor recovery."""
     reaped = pstate.reap(stale_seconds=0)
     n = current_round()
     controls = [name for name, present in (("STOP", stop_requested()), ("ABORT", abort_requested()))
@@ -390,12 +390,11 @@ def resume_halted():
     if problems:
         return {"ok": False, "round": n, "reaped": reaped, "problems": problems, "live": live}
 
-    note = "operator resume after reap, empty agent slots, and preflight OK"
     with _round_lock(n):
         doc = load_round(n)
-        if doc["supervisor"] != "HALTED":
+        if doc["supervisor"] != expected:
             return {"ok": False, "round": n, "reaped": reaped,
-                    "problems": ["supervisor is %s, not HALTED" % doc["supervisor"]],
+                    "problems": ["supervisor is %s, not %s" % (doc["supervisor"], expected)],
                     "live": live}
         controls = [name for name, present in (("STOP", stop_requested()),
                                                 ("ABORT", abort_requested())) if present]
@@ -409,16 +408,17 @@ def resume_halted():
         if any(live.values()):
             return {"ok": False, "round": n, "reaped": reaped,
                     "problems": ["live agent slots appeared during recovery"], "live": live}
-        # Consume the reason for this halt before publishing RUNNING. A later halt may write a
-        # new reason after save_round(); there must be no post-publication unlink that erases it.
-        halt_reason = config.state_dir() / "HALT_REASON"
-        try:
-            halt_reason.unlink()
-        except FileNotFoundError:
-            pass
+        # HALTED recovery consumes its reason before publishing RUNNING. A later halt may write
+        # a new reason after save_round(); there must be no post-publication unlink that erases it.
+        if consume_halt_reason:
+            halt_reason = config.state_dir() / "HALT_REASON"
+            try:
+                halt_reason.unlink()
+            except FileNotFoundError:
+                pass
         doc["supervisor"] = "RUNNING"
         doc.setdefault("notes", []).append(note)
-        rec = {"ts": time.time(), "machine": "supervisor", "from": "HALTED",
+        rec = {"ts": time.time(), "machine": "supervisor", "from": expected,
                "to": "RUNNING", "note": note, "pid": os.getpid(), "operator_resume": True}
         with open(_round_dir(n) / "transitions.jsonl", "a") as fh:
             fh.write(json.dumps(rec) + "\n")
@@ -428,11 +428,25 @@ def resume_halted():
             "resumed_at": {k: doc[k] for k in MACHINES}, "live": live}
 
 
+def resume_halted():
+    """Operator-only recovery from HALTED after the machine is safe again."""
+    return _operator_resume(
+        "HALTED", "operator resume after reap, empty agent slots, and preflight OK",
+        consume_halt_reason=True)
+
+
+def restart_stopped():
+    """Operator-only restart of a cleanly stopped round after the machine is safe again."""
+    return _operator_resume(
+        "STOPPED", "operator restart after reap, empty agent slots, and preflight OK")
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser(prog="python -m scripts.repipe.captain")
     ap.add_argument("--tick", action="store_true")
     ap.add_argument("--recover", action="store_true")
     ap.add_argument("--resume-halted", action="store_true")
+    ap.add_argument("--restart-stopped", action="store_true")
     ap.add_argument("--preflight", action="store_true")
     ap.add_argument("--status", action="store_true")
     ap.add_argument("--round", type=int, default=None)
@@ -458,6 +472,11 @@ def main(argv=None):
 
     if args.resume_halted:
         out = resume_halted()
+        print(json.dumps(out, indent=2, default=str))
+        return 0 if out["ok"] else 1
+
+    if args.restart_stopped:
+        out = restart_stopped()
         print(json.dumps(out, indent=2, default=str))
         return 0 if out["ok"] else 1
 

--- a/scripts/repipe/config.py
+++ b/scripts/repipe/config.py
@@ -154,7 +154,7 @@ def agent_split(max_agents=None, testers=None, builders=None):
 ROUND_CHALLENGES = int(os.environ.get("REPIPE_ROUND_CHALLENGES", "9"))
 TESTER_TIMEOUT = int(os.environ.get("REPIPE_TESTER_TIMEOUT", "3600"))
 BUILDER_TIMEOUT = int(os.environ.get("REPIPE_BUILDER_TIMEOUT", "7200"))
-CAPTAIN_TIMEOUT = int(os.environ.get("REPIPE_CAPTAIN_TIMEOUT", "1200"))
+CAPTAIN_TIMEOUT = int(os.environ.get("REPIPE_CAPTAIN_TIMEOUT", "3600"))
 BUILDER_USD = float(os.environ.get("REPIPE_BUILDER_USD", "25"))
 ROUND_USD = float(os.environ.get("REPIPE_ROUND_USD", "150"))
 RUN_USD = float(os.environ.get("REPIPE_RUN_USD", "1500"))

--- a/scripts/repipe/supervisor_lock.py
+++ b/scripts/repipe/supervisor_lock.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Run one supervisor command while holding its process-lifetime ownership lock."""
+
+import argparse
+import ctypes
+import fcntl
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+
+
+CONFLICT_EXIT = 1
+PR_SET_PDEATHSIG = 1
+
+
+def _kill_if_owner_dies(expected_parent):
+    """Keep a SIGKILLed lock runner from leaving its supervisor loop orphaned on Linux."""
+    if not sys.platform.startswith("linux"):
+        return
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(PR_SET_PDEATHSIG, signal.SIGKILL, 0, 0, 0) != 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+    # Close the fork-to-prctl race: if ownership already disappeared, do not exec the loop.
+    if os.getppid() != expected_parent:
+        os.kill(os.getpid(), signal.SIGKILL)
+
+
+def run_locked(lock_path, command):
+    """Run command while exclusively owning lock_path, or fail without spawning it."""
+    path = Path(lock_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a+") as lock:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            print("another repipe supervisor already owns the lifetime lock", file=sys.stderr)
+            return CONFLICT_EXIT
+
+        child = None
+        pending = []
+
+        def forward(signum, _frame):
+            if child is None:
+                pending.append(signum)
+            elif child.poll() is None:
+                try:
+                    child.send_signal(signum)
+                except ProcessLookupError:
+                    pass
+
+        previous = {
+            signum: signal.getsignal(signum) for signum in (signal.SIGINT, signal.SIGTERM)
+        }
+        for signum in previous:
+            signal.signal(signum, forward)
+        try:
+            # Python lock descriptors are non-inheritable. close_fds also makes the ownership
+            # boundary explicit: captain/worker descendants cannot accidentally retain it.
+            owner_pid = os.getpid()
+            child = subprocess.Popen(
+                command, close_fds=True,
+                preexec_fn=lambda: _kill_if_owner_dies(owner_pid),
+            )
+            for signum in pending:
+                if child.poll() is None:
+                    try:
+                        child.send_signal(signum)
+                    except ProcessLookupError:
+                        pass
+            returncode = child.wait()
+            return returncode if returncode >= 0 else 128 - returncode
+        finally:
+            for signum, handler in previous.items():
+                signal.signal(signum, handler)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lock", required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    command = args.command[1:] if args.command[:1] == ["--"] else args.command
+    if not command:
+        parser.error("a command is required after --")
+    return run_locked(args.lock, command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repipe/supervisor_lock.py
+++ b/scripts/repipe/supervisor_lock.py
@@ -1,91 +1,89 @@
 #!/usr/bin/env python3
-"""Run one supervisor command while holding its process-lifetime ownership lock."""
+"""Acquire or verify the inherited process-lifetime repipe supervisor lock."""
 
 import argparse
-import ctypes
 import fcntl
 import os
 from pathlib import Path
-import signal
-import subprocess
 import sys
 
 
 CONFLICT_EXIT = 1
-PR_SET_PDEATHSIG = 1
+FD_ENV = "REPIPE_SUPERVISOR_LOCK_FD"
+OWNER_ENV = "REPIPE_SUPERVISOR_LOCK_OWNER_PID"
 
 
-def _kill_if_owner_dies(expected_parent):
-    """Keep a SIGKILLed lock runner from leaving its supervisor loop orphaned on Linux."""
-    if not sys.platform.startswith("linux"):
-        return
-    libc = ctypes.CDLL(None, use_errno=True)
-    if libc.prctl(PR_SET_PDEATHSIG, signal.SIGKILL, 0, 0, 0) != 0:
-        error = ctypes.get_errno()
-        raise OSError(error, os.strerror(error))
-    # Close the fork-to-prctl race: if ownership already disappeared, do not exec the loop.
-    if os.getppid() != expected_parent:
-        os.kill(os.getpid(), signal.SIGKILL)
+def verify_inherited(lock_path, owner_pid):
+    """Verify that owner_pid is this caller's parent and holds lock_path via its inherited FD."""
+    try:
+        fd = int(os.environ[FD_ENV])
+        recorded_owner = int(os.environ[OWNER_ENV])
+    except (KeyError, TypeError, ValueError):
+        return False
+    if fd < 3 or recorded_owner != owner_pid or os.getppid() != owner_pid:
+        return False
+    try:
+        held = os.fstat(fd)
+        expected = Path(lock_path).stat()
+        if (held.st_dev, held.st_ino) != (expected.st_dev, expected.st_ino):
+            return False
+        # An inherited duplicate shares the owner's open-file description, so re-locking is a
+        # no-op. A forged descriptor opened independently conflicts with the real owner.
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError):
+        return False
+    return True
 
 
-def run_locked(lock_path, command):
-    """Run command while exclusively owning lock_path, or fail without spawning it."""
+def acquire_and_exec(lock_path, command):
+    """Acquire lock_path and exec command as its owner, or fail without spawning command."""
     path = Path(lock_path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "a+") as lock:
-        try:
-            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
-            print("another repipe supervisor already owns the lifetime lock", file=sys.stderr)
-            return CONFLICT_EXIT
+    lock = open(path, "a+")
+    try:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        lock.close()
+        print("another repipe supervisor already owns the lifetime lock", file=sys.stderr)
+        return CONFLICT_EXIT
 
-        child = None
-        pending = []
-
-        def forward(signum, _frame):
-            if child is None:
-                pending.append(signum)
-            elif child.poll() is None:
-                try:
-                    child.send_signal(signum)
-                except ProcessLookupError:
-                    pass
-
-        previous = {
-            signum: signal.getsignal(signum) for signum in (signal.SIGINT, signal.SIGTERM)
-        }
-        for signum in previous:
-            signal.signal(signum, forward)
-        try:
-            # Python lock descriptors are non-inheritable. close_fds also makes the ownership
-            # boundary explicit: captain/worker descendants cannot accidentally retain it.
-            owner_pid = os.getpid()
-            child = subprocess.Popen(
-                command, close_fds=True,
-                preexec_fn=lambda: _kill_if_owner_dies(owner_pid),
-            )
-            for signum in pending:
-                if child.poll() is None:
-                    try:
-                        child.send_signal(signum)
-                    except ProcessLookupError:
-                        pass
-            returncode = child.wait()
-            return returncode if returncode >= 0 else 128 - returncode
-        finally:
-            for signum, handler in previous.items():
-                signal.signal(signum, handler)
+    owner_pid = os.getpid()
+    lock.seek(0)
+    lock.truncate()
+    lock.write("%s\n" % owner_pid)
+    lock.flush()
+    # Use a high descriptor so Bash cannot reuse the capability for script/input plumbing.
+    capability_fd = fcntl.fcntl(lock.fileno(), fcntl.F_DUPFD, 100)
+    os.set_inheritable(capability_fd, True)
+    lock.close()
+    env = os.environ.copy()
+    env[FD_ENV] = str(capability_fd)
+    env[OWNER_ENV] = str(owner_pid)
+    try:
+        os.execvpe(command[0], command, env)
+    except OSError as exc:
+        print("could not exec repipe supervisor: %s" % exc, file=sys.stderr)
+        os.close(capability_fd)
+        return 126
 
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--lock", required=True)
+    parser.add_argument("--verify", action="store_true")
+    parser.add_argument("--owner-pid", type=int)
     parser.add_argument("command", nargs=argparse.REMAINDER)
     args = parser.parse_args(argv)
+
+    if args.verify:
+        if args.owner_pid is None or args.command:
+            parser.error("--verify requires --owner-pid and no command")
+        return 0 if verify_inherited(args.lock, args.owner_pid) else 1
+
     command = args.command[1:] if args.command[:1] == ["--"] else args.command
-    if not command:
+    if args.owner_pid is not None or not command:
         parser.error("a command is required after --")
-    return run_locked(args.lock, command)
+    return acquire_and_exec(args.lock, command)
 
 
 if __name__ == "__main__":

--- a/tools/repipe/captain.sh
+++ b/tools/repipe/captain.sh
@@ -8,7 +8,7 @@ set -uo pipefail
 REPO="${KUNA_REPO:-$(git -C "$(dirname "$0")" rev-parse --show-toplevel)}"
 KUNA_PY="${KUNA_PY:-$HOME/.virtualenvs/kuna/bin/python}"
 STATE_DIR="${KUNA_PIPELINE_STATE_DIR:-$REPO/.kuna-repipe}"
-TIMEOUT="${REPIPE_CAPTAIN_TIMEOUT:-1200}"
+TIMEOUT="${REPIPE_CAPTAIN_TIMEOUT:-3600}"
 BACKEND="${REPIPE_CAPTAIN_BACKEND:-claude}"
 if [ "$BACKEND" = codex ]; then
   MODEL="${REPIPE_CAPTAIN_MODEL:-gpt-5.6-sol}"

--- a/tools/repipe/fixtures/concurrent_launcher_python.py
+++ b/tools/repipe/fixtures/concurrent_launcher_python.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Minimal KUNA_PY stand-in for the concurrent run.sh restart smoke."""
+"""Minimal KUNA_PY stand-in for run.sh lifetime-lock smoke tests."""
 import fcntl
 import json
 import os
@@ -31,20 +31,21 @@ if "--restart-stopped" in args:
         (state_dir / "fake-state").write_text("RUNNING\n")
         with open(state_dir / "fake-restarts", "a") as out:
             out.write("restart\n")
-        time.sleep(0.1)
+    raise SystemExit(0)
+
+if "--tick" in args:
+    (state_dir / "tick-waiting").touch()
+    deadline = time.time() + 10
+    while not (state_dir / "release-supervisor").exists() and time.time() < deadline:
+        time.sleep(0.01)
+    if not (state_dir / "release-supervisor").exists():
+        raise SystemExit(2)
+    (state_dir / "fake-state").write_text("STOPPED\n")
     raise SystemExit(0)
 
 if "--status" in args:
-    with locked("fake-status.lock"):
-        count_path = state_dir / "fake-status-count"
-        count = int(count_path.read_text()) if count_path.exists() else 0
-        count += 1
-        count_path.write_text(str(count))
-    if count <= 2:
-        deadline = time.time() + 10
-        while int(count_path.read_text()) < 2 and time.time() < deadline:
-            time.sleep(0.01)
-    print(json.dumps({"states": {"supervisor": "STOPPED"}, "round": 1}))
+    state = (state_dir / "fake-state").read_text().strip()
+    print(json.dumps({"states": {"supervisor": state}, "round": 1}))
     raise SystemExit(0)
 
 if "-c" in args:

--- a/tools/repipe/fixtures/concurrent_launcher_python.py
+++ b/tools/repipe/fixtures/concurrent_launcher_python.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Minimal KUNA_PY stand-in for the concurrent run.sh restart smoke."""
+import fcntl
+import json
+import os
+from pathlib import Path
+import sys
+import time
+
+
+state_dir = Path(os.environ["KUNA_PIPELINE_STATE_DIR"])
+args = sys.argv[1:]
+
+
+def locked(name):
+    lock = open(state_dir / name, "a+")
+    fcntl.flock(lock, fcntl.LOCK_EX)
+    return lock
+
+
+if "--preflight" in args:
+    raise SystemExit(0)
+
+if "--restart-stopped" in args:
+    with locked("fake-restart.lock"):
+        state = (state_dir / "fake-state").read_text().strip()
+        if state != "STOPPED":
+            raise SystemExit(1)
+        if "--consume-stop" in args:
+            (state_dir / "STOP").unlink(missing_ok=True)
+        (state_dir / "fake-state").write_text("RUNNING\n")
+        with open(state_dir / "fake-restarts", "a") as out:
+            out.write("restart\n")
+        time.sleep(0.1)
+    raise SystemExit(0)
+
+if "--status" in args:
+    with locked("fake-status.lock"):
+        count_path = state_dir / "fake-status-count"
+        count = int(count_path.read_text()) if count_path.exists() else 0
+        count += 1
+        count_path.write_text(str(count))
+    if count <= 2:
+        deadline = time.time() + 10
+        while int(count_path.read_text()) < 2 and time.time() < deadline:
+            time.sleep(0.01)
+    print(json.dumps({"states": {"supervisor": "STOPPED"}, "round": 1}))
+    raise SystemExit(0)
+
+if "-c" in args:
+    code = args[-1]
+    if '["states"]["supervisor"]' in code:
+        print(json.load(sys.stdin)["states"]["supervisor"])
+    elif '["round"]' in code:
+        print(json.load(sys.stdin)["round"])
+    else:
+        print(0)
+    raise SystemExit(0)
+
+raise SystemExit(0)

--- a/tools/repipe/fixtures/supervisor_lock_tree.sh
+++ b/tools/repipe/fixtures/supervisor_lock_tree.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# A foreground shell -> shell -> shell tree used to exercise inherited supervisor ownership.
+set -uo pipefail
+
+STATE="$1"
+ROLE="$2"
+
+case "$ROLE" in
+  owner)
+    echo "$$" > "$STATE/owner.pid"
+    trap 'touch "$STATE/owner-term"; exit 0' TERM
+    bash "$0" "$STATE" child
+    touch "$STATE/owner-child-returned"
+    ;;
+  child)
+    echo "$$" > "$STATE/child.pid"
+    bash "$0" "$STATE" grandchild
+    touch "$STATE/child-returned"
+    ;;
+  grandchild)
+    echo "$$" > "$STATE/grandchild.pid"
+    touch "$STATE/tree-ready"
+    while [ ! -e "$STATE/release-tree" ]; do sleep 0.01; done
+    touch "$STATE/grandchild-released"
+    ;;
+  *)
+    exit 2
+    ;;
+esac

--- a/tools/repipe/run.sh
+++ b/tools/repipe/run.sh
@@ -23,13 +23,11 @@ ROUNDS="${REPIPE_ROUNDS:-3}"
 HOURS="${REPIPE_HOURS:-0}"
 CAPTAIN_TIMEOUT="${REPIPE_CAPTAIN_TIMEOUT:-3600}"
 ONCE=0
-SUPERVISOR_LOCK_HELD=0
 
 for a in "$@"; do
   case "$a" in
     --once) ONCE=1; ROUNDS=1;;
     --preflight) PREFLIGHT_ONLY=1;;
-    --internal-supervisor-lock-held) SUPERVISOR_LOCK_HELD=1;;
     *) echo "unknown flag: $a" 1>&2; exit 2;;
   esac
 done
@@ -42,15 +40,22 @@ mkdir -p "$STATE_DIR/logs" "$STATE_DIR/rounds" "$STATE_DIR/arena" "$STATE_DIR/ru
 
 log() { echo "[$(date +%H:%M:%S)] supervisor: $*" | tee -a "$STATE_DIR/logs/supervisor.log"; }
 
-# A state transition lock only serializes the instant STOPPED becomes RUNNING. Keep a distinct
-# ownership lock for this process's whole lifetime so a late launcher cannot observe RUNNING and
-# join the same supervisor loop. The lock runner owns the descriptor; captain/worker descendants
-# do not inherit it, and a killed/crashed owner releases it automatically.
-if [ "${PREFLIGHT_ONLY:-0}" != 1 ] && [ "$SUPERVISOR_LOCK_HELD" != 1 ]; then
+# A state transition lock only serializes the instant STOPPED becomes RUNNING. The outer launch
+# execs back into this script while holding a distinct lifetime lock. Re-entry is accepted only
+# when a helper verifies the inherited locked FD and this shell's PID-bound capability. Foreground
+# descendants retain the FD, so a killed shell cannot release ownership around an orphan captain.
+if [ "${PREFLIGHT_ONLY:-0}" != 1 ]; then
   LOCK_PY="${REPIPE_LOCK_PY:-$KUNA_PY}"
-  exec "$LOCK_PY" -m scripts.repipe.supervisor_lock \
-    --lock "$STATE_DIR/.supervisor.lock" -- \
-    bash "$0" --internal-supervisor-lock-held "$@"
+  if [ -n "${REPIPE_SUPERVISOR_LOCK_FD:-}" ] \
+     && [ -n "${REPIPE_SUPERVISOR_LOCK_OWNER_PID:-}" ] \
+     && "$LOCK_PY" -m scripts.repipe.supervisor_lock --verify \
+          --lock "$STATE_DIR/.supervisor.lock" --owner-pid "$$"; then
+    : # This exact supervisor process owns the inherited lock capability.
+  else
+    unset REPIPE_SUPERVISOR_LOCK_FD REPIPE_SUPERVISOR_LOCK_OWNER_PID
+    exec "$LOCK_PY" -m scripts.repipe.supervisor_lock \
+      --lock "$STATE_DIR/.supervisor.lock" -- bash "$0" "$@"
+  fi
 fi
 
 if ! "$KUNA_PY" -m scripts.repipe.captain --preflight; then

--- a/tools/repipe/run.sh
+++ b/tools/repipe/run.sh
@@ -57,11 +57,8 @@ if [ -f "$STATE_DIR/ABORT" ]; then
   exit 1
 fi
 if [ "$START_STATE" = "STOPPED" ]; then
-  HAD_STOP=0
-  [ -f "$STATE_DIR/STOP" ] && HAD_STOP=1
-  rm -f "$STATE_DIR/STOP"
-  if ! "$KUNA_PY" -m scripts.repipe.captain --restart-stopped >>"$STATE_DIR/logs/captain.log" 2>&1; then
-    [ "$HAD_STOP" = 1 ] && touch "$STATE_DIR/STOP"
+  if ! "$KUNA_PY" -m scripts.repipe.captain --restart-stopped --consume-stop \
+      >>"$STATE_DIR/logs/captain.log" 2>&1; then
     log "STOPPED restart refused; see $STATE_DIR/logs/captain.log"
     exit 1
   fi

--- a/tools/repipe/run.sh
+++ b/tools/repipe/run.sh
@@ -23,11 +23,13 @@ ROUNDS="${REPIPE_ROUNDS:-3}"
 HOURS="${REPIPE_HOURS:-0}"
 CAPTAIN_TIMEOUT="${REPIPE_CAPTAIN_TIMEOUT:-3600}"
 ONCE=0
+SUPERVISOR_LOCK_HELD=0
 
 for a in "$@"; do
   case "$a" in
     --once) ONCE=1; ROUNDS=1;;
     --preflight) PREFLIGHT_ONLY=1;;
+    --internal-supervisor-lock-held) SUPERVISOR_LOCK_HELD=1;;
     *) echo "unknown flag: $a" 1>&2; exit 2;;
   esac
 done
@@ -39,6 +41,17 @@ export REPIPE_STATE_DIRNAME="${REPIPE_STATE_DIRNAME:-.kuna-repipe}"
 mkdir -p "$STATE_DIR/logs" "$STATE_DIR/rounds" "$STATE_DIR/arena" "$STATE_DIR/runs" "$STATE_DIR/worktrees"
 
 log() { echo "[$(date +%H:%M:%S)] supervisor: $*" | tee -a "$STATE_DIR/logs/supervisor.log"; }
+
+# A state transition lock only serializes the instant STOPPED becomes RUNNING. Keep a distinct
+# ownership lock for this process's whole lifetime so a late launcher cannot observe RUNNING and
+# join the same supervisor loop. The lock runner owns the descriptor; captain/worker descendants
+# do not inherit it, and a killed/crashed owner releases it automatically.
+if [ "${PREFLIGHT_ONLY:-0}" != 1 ] && [ "$SUPERVISOR_LOCK_HELD" != 1 ]; then
+  LOCK_PY="${REPIPE_LOCK_PY:-$KUNA_PY}"
+  exec "$LOCK_PY" -m scripts.repipe.supervisor_lock \
+    --lock "$STATE_DIR/.supervisor.lock" -- \
+    bash "$0" --internal-supervisor-lock-held "$@"
+fi
 
 if ! "$KUNA_PY" -m scripts.repipe.captain --preflight; then
   log "preflight failed; refusing to start"

--- a/tools/repipe/run.sh
+++ b/tools/repipe/run.sh
@@ -21,7 +21,7 @@ STATE_DIR="$REPO/${REPIPE_STATE_DIRNAME:-.kuna-repipe}"
 POLL="${REPIPE_POLL:-15}"
 ROUNDS="${REPIPE_ROUNDS:-3}"
 HOURS="${REPIPE_HOURS:-0}"
-CAPTAIN_TIMEOUT="${REPIPE_CAPTAIN_TIMEOUT:-1200}"
+CAPTAIN_TIMEOUT="${REPIPE_CAPTAIN_TIMEOUT:-3600}"
 ONCE=0
 
 for a in "$@"; do
@@ -37,7 +37,6 @@ export PYTHONPATH="$REPO${PYTHONPATH:+:$PYTHONPATH}"
 export KUNA_PIPELINE_STATE_DIR="$STATE_DIR"
 export REPIPE_STATE_DIRNAME="${REPIPE_STATE_DIRNAME:-.kuna-repipe}"
 mkdir -p "$STATE_DIR/logs" "$STATE_DIR/rounds" "$STATE_DIR/arena" "$STATE_DIR/runs" "$STATE_DIR/worktrees"
-rm -f "$STATE_DIR/STOP" "$STATE_DIR/ABORT"
 
 log() { echo "[$(date +%H:%M:%S)] supervisor: $*" | tee -a "$STATE_DIR/logs/supervisor.log"; }
 
@@ -46,6 +45,28 @@ if ! "$KUNA_PY" -m scripts.repipe.captain --preflight; then
   exit 1
 fi
 [ "${PREFLIGHT_ONLY:-0}" = 1 ] && exit 0
+
+START_STATE="$("$KUNA_PY" -m scripts.repipe.captain --status 2>/dev/null \
+  | "$KUNA_PY" -c 'import json,sys; print(json.load(sys.stdin)["states"]["supervisor"])' 2>/dev/null)"
+if [ -z "$START_STATE" ]; then
+  log "could not read supervisor state; refusing to start"
+  exit 1
+fi
+if [ -f "$STATE_DIR/ABORT" ]; then
+  log "ABORT present; remove it explicitly before starting"
+  exit 1
+fi
+if [ "$START_STATE" = "STOPPED" ]; then
+  HAD_STOP=0
+  [ -f "$STATE_DIR/STOP" ] && HAD_STOP=1
+  rm -f "$STATE_DIR/STOP"
+  if ! "$KUNA_PY" -m scripts.repipe.captain --restart-stopped >>"$STATE_DIR/logs/captain.log" 2>&1; then
+    [ "$HAD_STOP" = 1 ] && touch "$STATE_DIR/STOP"
+    log "STOPPED restart refused; see $STATE_DIR/logs/captain.log"
+    exit 1
+  fi
+  log "restarted STOPPED supervisor after guarded recovery"
+fi
 
 trap 'log "signal received -> graceful stop"; touch "$STATE_DIR/STOP"' INT TERM
 

--- a/tools/repipe/smoke.sh
+++ b/tools/repipe/smoke.sh
@@ -557,55 +557,102 @@ assert len(operator_edges) == 1, records
 assert operator_edges[0]["from"] == "STOPPED" and operator_edges[0]["to"] == "RUNNING"
 PY
 
-KUNA_PIPELINE_STATE_DIR="$SMOKE_STATE/lifetime-lock" "$PY" - <<'PY' >/dev/null 2>&1 \
-  && ok "supervisor lifetime lock refuses a live owner, forwards TERM, and releases" \
-  || bad "supervisor lifetime ownership lock failed"
+KUNA_PIPELINE_STATE_DIR="$SMOKE_STATE/lifetime-lock" \
+  REPIPE_LOCK_TREE="$FIX/supervisor_lock_tree.sh" "$PY" - <<'PY' >/dev/null 2>&1 \
+  && ok "nested foreground trees retain supervisor ownership across TERM and SIGKILL" \
+  || bad "nested supervisor lifetime ownership failed"
 import os
 from pathlib import Path
+import signal
 import subprocess
 import sys
 import time
 
 root = Path(os.environ["KUNA_PIPELINE_STATE_DIR"])
 root.mkdir(parents=True)
-lock = root / "supervisor.lock"
-ready = root / "ready"
-release = root / "release"
-unexpected = root / "unexpected"
-success = root / "success"
-holder_code = """\
-import pathlib, sys, time
-ready, release = map(pathlib.Path, sys.argv[1:])
-ready.touch()
-deadline = time.time() + 10
-while not release.exists() and time.time() < deadline:
-    time.sleep(0.01)
-raise SystemExit(0 if release.exists() else 2)
-"""
-holder = subprocess.Popen([
-    sys.executable, "-m", "scripts.repipe.supervisor_lock", "--lock", str(lock), "--",
-    sys.executable, "-c", holder_code, str(ready), str(release),
-])
-deadline = time.time() + 5
-while not ready.exists() and time.time() < deadline:
-    time.sleep(0.01)
-assert ready.exists()
-loser = subprocess.run([
-    sys.executable, "-m", "scripts.repipe.supervisor_lock", "--lock", str(lock), "--",
-    sys.executable, "-c", "import sys; from pathlib import Path; Path(sys.argv[1]).touch()",
-    str(unexpected),
-], capture_output=True, text=True, timeout=5)
-assert loser.returncode == 1, loser
-assert "already owns" in loser.stderr, loser.stderr
-assert not unexpected.exists()
-holder.terminate()
-assert holder.wait(timeout=5) == 143
-successor = subprocess.run([
-    sys.executable, "-m", "scripts.repipe.supervisor_lock", "--lock", str(lock), "--",
-    sys.executable, "-c", "import sys; from pathlib import Path; Path(sys.argv[1]).touch()",
-    str(success),
+tree = os.environ["REPIPE_LOCK_TREE"]
+
+def wait_for(path, timeout=5):
+    deadline = time.time() + timeout
+    while not path.exists() and time.time() < deadline:
+        time.sleep(0.01)
+    assert path.exists(), path
+
+def launch(state):
+    state.mkdir()
+    lock = state / "supervisor.lock"
+    holder = subprocess.Popen([
+        sys.executable, "-m", "scripts.repipe.supervisor_lock", "--lock", str(lock), "--",
+        "bash", tree, str(state), "owner",
+    ])
+    wait_for(state / "tree-ready")
+    assert int((state / "owner.pid").read_text()) == holder.pid
+    return lock, holder
+
+def contender(lock, marker):
+    result = subprocess.run([
+        sys.executable, "-m", "scripts.repipe.supervisor_lock", "--lock", str(lock), "--",
+        sys.executable, "-c",
+        "import sys; from pathlib import Path; Path(sys.argv[1]).touch()", str(marker),
+    ], capture_output=True, text=True, timeout=5)
+    assert result.returncode == 1, result
+    assert "already owns" in result.stderr, result.stderr
+    assert not marker.exists()
+
+term_state = root / "term"
+term_lock, term_owner = launch(term_state)
+term_owner.send_signal(signal.SIGTERM)
+time.sleep(0.1)
+assert term_owner.poll() is None, "owner did not defer TERM while its child was foreground"
+assert not (term_state / "owner-term").exists()
+contender(term_lock, term_state / "overlap")
+(term_state / "release-tree").touch()
+assert term_owner.wait(timeout=5) == 0
+wait_for(term_state / "owner-term")
+success = term_state / "success"
+result = subprocess.run([
+    sys.executable, "-m", "scripts.repipe.supervisor_lock", "--lock", str(term_lock), "--",
+    sys.executable, "-c",
+    "import sys; from pathlib import Path; Path(sys.argv[1]).touch()", str(success),
 ], timeout=5)
-assert successor.returncode == 0 and success.exists(), successor
+assert result.returncode == 0 and success.exists(), result
+
+kill_state = root / "kill"
+kill_lock, kill_owner = launch(kill_state)
+child_pid = int((kill_state / "child.pid").read_text())
+grandchild_pid = int((kill_state / "grandchild.pid").read_text())
+kill_owner.kill()
+assert kill_owner.wait(timeout=5) == -signal.SIGKILL
+os.kill(child_pid, 0)
+os.kill(grandchild_pid, 0)
+contender(kill_lock, kill_state / "overlap")
+(kill_state / "release-tree").touch()
+wait_for(kill_state / "child-returned")
+success = kill_state / "success"
+deadline = time.time() + 5
+while time.time() < deadline:
+    result = subprocess.run([
+        sys.executable, "-m", "scripts.repipe.supervisor_lock", "--lock", str(kill_lock), "--",
+        sys.executable, "-c",
+        "import sys; from pathlib import Path; Path(sys.argv[1]).touch()", str(success),
+    ], capture_output=True, timeout=5)
+    if result.returncode == 0:
+        break
+    time.sleep(0.01)
+assert result.returncode == 0 and success.exists(), result
+
+# A public environment value plus an unrelated inherited descriptor is not a capability.
+forged = root / "forged"
+forged.touch()
+env = os.environ.copy()
+with open(forged) as unrelated:
+    env["REPIPE_SUPERVISOR_LOCK_FD"] = str(unrelated.fileno())
+    env["REPIPE_SUPERVISOR_LOCK_OWNER_PID"] = str(os.getpid())
+    result = subprocess.run([
+        sys.executable, "-m", "scripts.repipe.supervisor_lock", "--verify",
+        "--lock", str(term_lock), "--owner-pid", str(os.getpid()),
+    ], env=env, pass_fds=(unrelated.fileno(),), timeout=5)
+assert result.returncode == 1, result
 PY
 
 RUN_REPO="$SMOKE_STATE/run-repo"
@@ -645,6 +692,14 @@ elif [ -e "$RUN_REPO/.state/STOP" ] && [ -e "$RUN_REPO/.state/ABORT" ] \
   ok "run.sh refuses ABORT without consuming control files"
 else
   bad "run.sh mutated control files while refusing ABORT"
+fi
+KUNA_REPO="$RUN_REPO" KUNA_PY="$RUN_PY" REPIPE_LOCK_PY="$PY" REPIPE_STATE_DIRNAME=.state \
+  bash "$REPO/tools/repipe/run.sh" --internal-supervisor-lock-held >/dev/null 2>&1
+RC=$?
+if [ "$RC" -eq 2 ] && [ ! -e "$RUN_REPO/.state/restarted" ]; then
+  ok "run.sh rejects the former public lifetime-lock bypass flag"
+else
+  bad "run.sh still accepts a public lifetime-lock bypass" "rc=$RC"
 fi
 
 CONCURRENT_REPO="$SMOKE_STATE/concurrent-run-repo"

--- a/tools/repipe/smoke.sh
+++ b/tools/repipe/smoke.sh
@@ -498,7 +498,14 @@ captain.live_agents = lambda pool: []
 out = captain.restart_stopped()
 assert not out["ok"] and "STOP" in out["problems"][0], out
 assert captain.load_round(10)["supervisor"] == "STOPPED"
-(config.state_dir() / "STOP").unlink()
+out = captain.restart_stopped(consume_stop=True)
+assert out["ok"] and out["consumed_stop"], out
+assert captain.load_round(10)["supervisor"] == "RUNNING"
+assert not (config.state_dir() / "STOP").exists()
+
+restarted = captain.load_round(10)
+restarted["supervisor"] = "STOPPED"
+captain.save_round(restarted)
 
 def controls_during_preflight():
     (config.state_dir() / "ABORT").write_text("")
@@ -507,6 +514,47 @@ captain.preflight = controls_during_preflight
 out = captain.restart_stopped()
 assert not out["ok"] and "ABORT" in out["problems"][0], out
 assert captain.load_round(10)["supervisor"] == "STOPPED"
+PY
+
+KUNA_PIPELINE_STATE_DIR="$SMOKE_STATE/restart-concurrent" "$PY" - <<'PY' >/dev/null 2>&1 \
+  && ok "concurrent launchers produce one restart without a stale STOP" \
+  || bad "concurrent STOPPED launchers can still drain the winner"
+import json
+import multiprocessing
+from scripts.repipe import captain, config
+
+doc = captain.load_round(11)
+doc["supervisor"] = "STOPPED"
+captain.save_round(doc)
+(config.state_dir() / "STOP").write_text("")
+captain.current_round = lambda: 11
+captain.pstate.reap = lambda stale_seconds=0: []
+captain.preflight = lambda: []
+captain.live_agents = lambda pool: []
+
+ctx = multiprocessing.get_context("fork")
+start = ctx.Event()
+results = ctx.Queue()
+def launch():
+    start.wait()
+    results.put(captain.restart_stopped(consume_stop=True))
+
+workers = [ctx.Process(target=launch) for _ in range(2)]
+for worker in workers:
+    worker.start()
+start.set()
+for worker in workers:
+    worker.join(10)
+    assert worker.exitcode == 0, worker.exitcode
+out = [results.get(timeout=1) for _ in workers]
+assert sorted(row["ok"] for row in out) == [False, True], out
+assert captain.load_round(11)["supervisor"] == "RUNNING"
+assert not (config.state_dir() / "STOP").exists()
+records = [json.loads(line) for line in
+           (config.rounds_dir() / "11" / "transitions.jsonl").read_text().splitlines()]
+operator_edges = [row for row in records if row.get("operator_resume")]
+assert len(operator_edges) == 1, records
+assert operator_edges[0]["from"] == "STOPPED" and operator_edges[0]["to"] == "RUNNING"
 PY
 
 RUN_REPO="$SMOKE_STATE/run-repo"
@@ -518,6 +566,7 @@ printf '%s\n' \
   'case "$*" in' \
   '  *"--preflight"*) exit 0;;' \
   '  *"--restart-stopped"*)' \
+  '    case "$*" in *"--consume-stop"*) rm -f "$KUNA_PIPELINE_STATE_DIR/STOP";; esac' \
   '    [ ! -e "$KUNA_PIPELINE_STATE_DIR/STOP" ] || exit 1' \
   '    [ ! -e "$KUNA_PIPELINE_STATE_DIR/ABORT" ] || exit 1' \
   '    touch "$KUNA_PIPELINE_STATE_DIR/restarted";;' \
@@ -545,6 +594,32 @@ elif [ -e "$RUN_REPO/.state/STOP" ] && [ -e "$RUN_REPO/.state/ABORT" ] \
   ok "run.sh refuses ABORT without consuming control files"
 else
   bad "run.sh mutated control files while refusing ABORT"
+fi
+
+CONCURRENT_REPO="$SMOKE_STATE/concurrent-run-repo"
+mkdir -p "$CONCURRENT_REPO/tools/repipe" "$CONCURRENT_REPO/.state"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$CONCURRENT_REPO/tools/repipe/captain.sh"
+chmod +x "$CONCURRENT_REPO/tools/repipe/captain.sh"
+printf 'STOPPED\n' > "$CONCURRENT_REPO/.state/fake-state"
+touch "$CONCURRENT_REPO/.state/STOP"
+KUNA_REPO="$CONCURRENT_REPO" KUNA_PY="$FIX/concurrent_launcher_python.py" \
+  REPIPE_STATE_DIRNAME=.state timeout 15 bash "$REPO/tools/repipe/run.sh" \
+  >"$SMOKE_STATE/concurrent-run-1.log" 2>&1 &
+RUN1=$!
+KUNA_REPO="$CONCURRENT_REPO" KUNA_PY="$FIX/concurrent_launcher_python.py" \
+  REPIPE_STATE_DIRNAME=.state timeout 15 bash "$REPO/tools/repipe/run.sh" \
+  >"$SMOKE_STATE/concurrent-run-2.log" 2>&1 &
+RUN2=$!
+wait "$RUN1"; RC1=$?
+wait "$RUN2"; RC2=$?
+RESTARTS="$(wc -l < "$CONCURRENT_REPO/.state/fake-restarts" 2>/dev/null || echo 0)"
+if [ $((RC1 + RC2)) -eq 1 ] && [ "$RESTARTS" -eq 1 ] \
+   && [ "$(cat "$CONCURRENT_REPO/.state/fake-state")" = RUNNING ] \
+   && [ ! -e "$CONCURRENT_REPO/.state/STOP" ]; then
+  ok "two concurrent run.sh launchers cannot restore a stale STOP"
+else
+  bad "concurrent run.sh restart was not serialized" \
+    "rc=$RC1/$RC2 restarts=$RESTARTS state=$(cat "$CONCURRENT_REPO/.state/fake-state") stop=$([ -e "$CONCURRENT_REPO/.state/STOP" ] && echo yes || echo no)"
 fi
 
 [ "$LEVEL" = "0" ] && { printf '\nL0 only: %d passed, %d failed\n' "$PASS" "$FAIL"; exit $((FAIL>0)); }

--- a/tools/repipe/smoke.sh
+++ b/tools/repipe/smoke.sh
@@ -113,6 +113,13 @@ ROLES="$("$PY" -c 'from scripts.repipe import config as c; print(":".join((c.TES
 [ "$ROLES" = "gpt-5.6-sol:low:codex:gpt-5.6-sol:high" ] \
   && ok "role defaults are Sol-low reversers and Sol-high builders" \
   || bad "role defaults weakened" "$ROLES"
+CAPTAIN_TIMEOUT="$(env -u REPIPE_CAPTAIN_TIMEOUT "$PY" -c \
+  'from scripts.repipe import config; print(config.CAPTAIN_TIMEOUT)')"
+[ "$CAPTAIN_TIMEOUT" = 3600 ] \
+  && grep -q 'REPIPE_CAPTAIN_TIMEOUT:-3600' "$REPO/tools/repipe/captain.sh" \
+  && grep -q 'REPIPE_CAPTAIN_TIMEOUT:-3600' "$REPO/tools/repipe/run.sh" \
+  && ok "captain timeout defaults agree at 3600s" \
+  || bad "captain timeout defaults disagree" "$CAPTAIN_TIMEOUT"
 POLICY="$(REPIPE_TESTER_REASONING=medium REPIPE_BUILDER_MODEL=other \
   REPIPE_BUILDER_REASONING=medium REPIPE_CAPTAIN_BACKEND=other \
   "$PY" -c 'from scripts.repipe import config as c; print("\n".join(c.role_policy_problems()))')"
@@ -456,6 +463,89 @@ assert out["ok"], out
 assert captain.load_round(9)["supervisor"] == "RUNNING"
 assert reason.read_text() == "later halt\n"
 PY
+
+KUNA_PIPELINE_STATE_DIR="$SMOKE_STATE/restart-test" "$PY" - <<'PY' >/dev/null 2>&1 \
+  && ok "STOPPED restart is guarded and records the operator edge" \
+  || bad "operator STOPPED restart guard failed"
+import json
+from scripts.repipe import captain, config
+
+doc = captain.load_round(10)
+doc["supervisor"] = "STOPPED"
+captain.save_round(doc)
+captain.current_round = lambda: 10
+captain.pstate.reap = lambda stale_seconds=0: []
+captain.preflight = lambda: []
+captain.live_agents = lambda pool: []
+out = captain.restart_stopped()
+assert out["ok"], out
+restarted = captain.load_round(10)
+assert restarted["supervisor"] == "RUNNING", restarted
+assert restarted["notes"][-1].startswith("operator restart after reap"), restarted
+rec = json.loads((config.rounds_dir() / "10" / "transitions.jsonl").read_text().splitlines()[-1])
+assert rec["from"] == "STOPPED" and rec["to"] == "RUNNING", rec
+assert rec["operator_resume"] is True, rec
+
+restarted["supervisor"] = "STOPPED"
+captain.save_round(restarted)
+captain.live_agents = lambda pool: ["busy"] if pool == "tester" else []
+out = captain.restart_stopped()
+assert not out["ok"] and out["problems"] == ["live agent slots remain"], out
+assert captain.load_round(10)["supervisor"] == "STOPPED"
+
+captain.live_agents = lambda pool: []
+(config.state_dir() / "STOP").write_text("")
+out = captain.restart_stopped()
+assert not out["ok"] and "STOP" in out["problems"][0], out
+assert captain.load_round(10)["supervisor"] == "STOPPED"
+(config.state_dir() / "STOP").unlink()
+
+def controls_during_preflight():
+    (config.state_dir() / "ABORT").write_text("")
+    return []
+captain.preflight = controls_during_preflight
+out = captain.restart_stopped()
+assert not out["ok"] and "ABORT" in out["problems"][0], out
+assert captain.load_round(10)["supervisor"] == "STOPPED"
+PY
+
+RUN_REPO="$SMOKE_STATE/run-repo"
+RUN_PY="$SMOKE_STATE/fake-run-python"
+mkdir -p "$RUN_REPO/tools/repipe" "$RUN_REPO/.state"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$RUN_REPO/tools/repipe/captain.sh"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'case "$*" in' \
+  '  *"--preflight"*) exit 0;;' \
+  '  *"--restart-stopped"*)' \
+  '    [ ! -e "$KUNA_PIPELINE_STATE_DIR/STOP" ] || exit 1' \
+  '    [ ! -e "$KUNA_PIPELINE_STATE_DIR/ABORT" ] || exit 1' \
+  '    touch "$KUNA_PIPELINE_STATE_DIR/restarted";;' \
+  '  *"--status"*) printf '\''{"states":{"supervisor":"STOPPED"},"round":1}\n'\'';;' \
+  '  *'\''["states"]["supervisor"]'\''*) printf '\''STOPPED\n'\'';;' \
+  '  *'\''["round"]'\''*) printf '\''1\n'\'';;' \
+  '  *"-c"*) printf '\''0\n'\'';;' \
+  'esac' > "$RUN_PY"
+chmod +x "$RUN_REPO/tools/repipe/captain.sh" "$RUN_PY"
+touch "$RUN_REPO/.state/STOP"
+if KUNA_REPO="$RUN_REPO" KUNA_PY="$RUN_PY" REPIPE_STATE_DIRNAME=.state \
+   bash "$REPO/tools/repipe/run.sh" >/dev/null 2>&1 \
+   && [ -e "$RUN_REPO/.state/restarted" ] && [ ! -e "$RUN_REPO/.state/STOP" ]; then
+  ok "run.sh consumes a completed STOP and invokes guarded restart"
+else
+  bad "run.sh did not restart a STOPPED supervisor"
+fi
+rm -f "$RUN_REPO/.state/restarted"
+touch "$RUN_REPO/.state/STOP" "$RUN_REPO/.state/ABORT"
+if KUNA_REPO="$RUN_REPO" KUNA_PY="$RUN_PY" REPIPE_STATE_DIRNAME=.state \
+   bash "$REPO/tools/repipe/run.sh" >/dev/null 2>&1; then
+  bad "run.sh accepted an uncleared ABORT"
+elif [ -e "$RUN_REPO/.state/STOP" ] && [ -e "$RUN_REPO/.state/ABORT" ] \
+     && [ ! -e "$RUN_REPO/.state/restarted" ]; then
+  ok "run.sh refuses ABORT without consuming control files"
+else
+  bad "run.sh mutated control files while refusing ABORT"
+fi
 
 [ "$LEVEL" = "0" ] && { printf '\nL0 only: %d passed, %d failed\n' "$PASS" "$FAIL"; exit $((FAIL>0)); }
 

--- a/tools/repipe/smoke.sh
+++ b/tools/repipe/smoke.sh
@@ -40,7 +40,7 @@ head_() { printf '\n\033[1m%s\033[0m\n' "$1"; }
 
 # ---------------------------------------------------------------- level 0 ---
 head_ "L0  modules import and self-describe"
-for m in config probe verify workspace redact sample grade needs cluster select counters mergecheck captain webui render_tester_prompt; do
+for m in config probe verify workspace redact sample grade needs cluster select counters mergecheck captain supervisor_lock webui render_tester_prompt; do
   if "$PY" -c "import scripts.repipe.$m" 2>/dev/null; then ok "import $m"; else bad "import $m"; fi
 done
 
@@ -557,6 +557,57 @@ assert len(operator_edges) == 1, records
 assert operator_edges[0]["from"] == "STOPPED" and operator_edges[0]["to"] == "RUNNING"
 PY
 
+KUNA_PIPELINE_STATE_DIR="$SMOKE_STATE/lifetime-lock" "$PY" - <<'PY' >/dev/null 2>&1 \
+  && ok "supervisor lifetime lock refuses a live owner, forwards TERM, and releases" \
+  || bad "supervisor lifetime ownership lock failed"
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+root = Path(os.environ["KUNA_PIPELINE_STATE_DIR"])
+root.mkdir(parents=True)
+lock = root / "supervisor.lock"
+ready = root / "ready"
+release = root / "release"
+unexpected = root / "unexpected"
+success = root / "success"
+holder_code = """\
+import pathlib, sys, time
+ready, release = map(pathlib.Path, sys.argv[1:])
+ready.touch()
+deadline = time.time() + 10
+while not release.exists() and time.time() < deadline:
+    time.sleep(0.01)
+raise SystemExit(0 if release.exists() else 2)
+"""
+holder = subprocess.Popen([
+    sys.executable, "-m", "scripts.repipe.supervisor_lock", "--lock", str(lock), "--",
+    sys.executable, "-c", holder_code, str(ready), str(release),
+])
+deadline = time.time() + 5
+while not ready.exists() and time.time() < deadline:
+    time.sleep(0.01)
+assert ready.exists()
+loser = subprocess.run([
+    sys.executable, "-m", "scripts.repipe.supervisor_lock", "--lock", str(lock), "--",
+    sys.executable, "-c", "import sys; from pathlib import Path; Path(sys.argv[1]).touch()",
+    str(unexpected),
+], capture_output=True, text=True, timeout=5)
+assert loser.returncode == 1, loser
+assert "already owns" in loser.stderr, loser.stderr
+assert not unexpected.exists()
+holder.terminate()
+assert holder.wait(timeout=5) == 143
+successor = subprocess.run([
+    sys.executable, "-m", "scripts.repipe.supervisor_lock", "--lock", str(lock), "--",
+    sys.executable, "-c", "import sys; from pathlib import Path; Path(sys.argv[1]).touch()",
+    str(success),
+], timeout=5)
+assert successor.returncode == 0 and success.exists(), successor
+PY
+
 RUN_REPO="$SMOKE_STATE/run-repo"
 RUN_PY="$SMOKE_STATE/fake-run-python"
 mkdir -p "$RUN_REPO/tools/repipe" "$RUN_REPO/.state"
@@ -577,7 +628,7 @@ printf '%s\n' \
   'esac' > "$RUN_PY"
 chmod +x "$RUN_REPO/tools/repipe/captain.sh" "$RUN_PY"
 touch "$RUN_REPO/.state/STOP"
-if KUNA_REPO="$RUN_REPO" KUNA_PY="$RUN_PY" REPIPE_STATE_DIRNAME=.state \
+if KUNA_REPO="$RUN_REPO" KUNA_PY="$RUN_PY" REPIPE_LOCK_PY="$PY" REPIPE_STATE_DIRNAME=.state \
    bash "$REPO/tools/repipe/run.sh" >/dev/null 2>&1 \
    && [ -e "$RUN_REPO/.state/restarted" ] && [ ! -e "$RUN_REPO/.state/STOP" ]; then
   ok "run.sh consumes a completed STOP and invokes guarded restart"
@@ -586,7 +637,7 @@ else
 fi
 rm -f "$RUN_REPO/.state/restarted"
 touch "$RUN_REPO/.state/STOP" "$RUN_REPO/.state/ABORT"
-if KUNA_REPO="$RUN_REPO" KUNA_PY="$RUN_PY" REPIPE_STATE_DIRNAME=.state \
+if KUNA_REPO="$RUN_REPO" KUNA_PY="$RUN_PY" REPIPE_LOCK_PY="$PY" REPIPE_STATE_DIRNAME=.state \
    bash "$REPO/tools/repipe/run.sh" >/dev/null 2>&1; then
   bad "run.sh accepted an uncleared ABORT"
 elif [ -e "$RUN_REPO/.state/STOP" ] && [ -e "$RUN_REPO/.state/ABORT" ] \
@@ -597,29 +648,84 @@ else
 fi
 
 CONCURRENT_REPO="$SMOKE_STATE/concurrent-run-repo"
-mkdir -p "$CONCURRENT_REPO/tools/repipe" "$CONCURRENT_REPO/.state"
+mkdir -p "$CONCURRENT_REPO/tools/repipe" "$CONCURRENT_REPO/.state" "$CONCURRENT_REPO/gate"
 printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$CONCURRENT_REPO/tools/repipe/captain.sh"
 chmod +x "$CONCURRENT_REPO/tools/repipe/captain.sh"
 printf 'STOPPED\n' > "$CONCURRENT_REPO/.state/fake-state"
 touch "$CONCURRENT_REPO/.state/STOP"
-KUNA_REPO="$CONCURRENT_REPO" KUNA_PY="$FIX/concurrent_launcher_python.py" \
-  REPIPE_STATE_DIRNAME=.state timeout 15 bash "$REPO/tools/repipe/run.sh" \
-  >"$SMOKE_STATE/concurrent-run-1.log" 2>&1 &
+(
+  touch "$CONCURRENT_REPO/gate/1"
+  while [ ! -e "$CONCURRENT_REPO/gate/2" ]; do sleep 0.01; done
+  KUNA_REPO="$CONCURRENT_REPO" KUNA_PY="$FIX/concurrent_launcher_python.py" \
+    REPIPE_LOCK_PY="$PY" REPIPE_STATE_DIRNAME=.state REPIPE_POLL=0 \
+    timeout 15 bash "$REPO/tools/repipe/run.sh"
+) >"$SMOKE_STATE/concurrent-run-1.log" 2>&1 &
 RUN1=$!
-KUNA_REPO="$CONCURRENT_REPO" KUNA_PY="$FIX/concurrent_launcher_python.py" \
-  REPIPE_STATE_DIRNAME=.state timeout 15 bash "$REPO/tools/repipe/run.sh" \
-  >"$SMOKE_STATE/concurrent-run-2.log" 2>&1 &
+(
+  touch "$CONCURRENT_REPO/gate/2"
+  while [ ! -e "$CONCURRENT_REPO/gate/1" ]; do sleep 0.01; done
+  KUNA_REPO="$CONCURRENT_REPO" KUNA_PY="$FIX/concurrent_launcher_python.py" \
+    REPIPE_LOCK_PY="$PY" REPIPE_STATE_DIRNAME=.state REPIPE_POLL=0 \
+    timeout 15 bash "$REPO/tools/repipe/run.sh"
+) >"$SMOKE_STATE/concurrent-run-2.log" 2>&1 &
 RUN2=$!
+READY=0
+for _ in $(seq 1 500); do
+  if [ -e "$CONCURRENT_REPO/.state/tick-waiting" ] \
+     && grep -q "already owns" "$SMOKE_STATE"/concurrent-run-*.log; then
+    READY=1
+    break
+  fi
+  sleep 0.01
+done
+touch "$CONCURRENT_REPO/.state/release-supervisor"
 wait "$RUN1"; RC1=$?
 wait "$RUN2"; RC2=$?
-RESTARTS="$(wc -l < "$CONCURRENT_REPO/.state/fake-restarts" 2>/dev/null || echo 0)"
-if [ $((RC1 + RC2)) -eq 1 ] && [ "$RESTARTS" -eq 1 ] \
-   && [ "$(cat "$CONCURRENT_REPO/.state/fake-state")" = RUNNING ] \
+RESTARTS=0
+[ ! -e "$CONCURRENT_REPO/.state/fake-restarts" ] \
+  || RESTARTS="$(wc -l < "$CONCURRENT_REPO/.state/fake-restarts")"
+if [ "$READY" -eq 1 ] && [ $((RC1 + RC2)) -eq 1 ] && [ "$RESTARTS" -eq 1 ] \
+   && [ "$(cat "$CONCURRENT_REPO/.state/fake-state")" = STOPPED ] \
    && [ ! -e "$CONCURRENT_REPO/.state/STOP" ]; then
-  ok "two concurrent run.sh launchers cannot restore a stale STOP"
+  ok "simultaneous run.sh launchers admit exactly one lifetime owner"
 else
-  bad "concurrent run.sh restart was not serialized" \
-    "rc=$RC1/$RC2 restarts=$RESTARTS state=$(cat "$CONCURRENT_REPO/.state/fake-state") stop=$([ -e "$CONCURRENT_REPO/.state/STOP" ] && echo yes || echo no)"
+  bad "simultaneous run.sh ownership was not exclusive" \
+    "ready=$READY rc=$RC1/$RC2 restarts=$RESTARTS state=$(cat "$CONCURRENT_REPO/.state/fake-state") stop=$([ -e "$CONCURRENT_REPO/.state/STOP" ] && echo yes || echo no)"
+fi
+
+DELAYED_REPO="$SMOKE_STATE/delayed-run-repo"
+mkdir -p "$DELAYED_REPO/tools/repipe" "$DELAYED_REPO/.state"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$DELAYED_REPO/tools/repipe/captain.sh"
+chmod +x "$DELAYED_REPO/tools/repipe/captain.sh"
+printf 'STOPPED\n' > "$DELAYED_REPO/.state/fake-state"
+touch "$DELAYED_REPO/.state/STOP"
+KUNA_REPO="$DELAYED_REPO" KUNA_PY="$FIX/concurrent_launcher_python.py" \
+  REPIPE_LOCK_PY="$PY" REPIPE_STATE_DIRNAME=.state REPIPE_POLL=0 \
+  timeout 15 bash "$REPO/tools/repipe/run.sh" \
+  >"$SMOKE_STATE/delayed-run-1.log" 2>&1 &
+RUN1=$!
+READY=0
+for _ in $(seq 1 500); do
+  if [ -e "$DELAYED_REPO/.state/tick-waiting" ]; then READY=1; break; fi
+  sleep 0.01
+done
+KUNA_REPO="$DELAYED_REPO" KUNA_PY="$FIX/concurrent_launcher_python.py" \
+  REPIPE_LOCK_PY="$PY" REPIPE_STATE_DIRNAME=.state REPIPE_POLL=0 \
+  timeout 5 bash "$REPO/tools/repipe/run.sh" \
+  >"$SMOKE_STATE/delayed-run-2.log" 2>&1
+RC2=$?
+touch "$DELAYED_REPO/.state/release-supervisor"
+wait "$RUN1"; RC1=$?
+RESTARTS=0
+[ ! -e "$DELAYED_REPO/.state/fake-restarts" ] \
+  || RESTARTS="$(wc -l < "$DELAYED_REPO/.state/fake-restarts")"
+if [ "$READY" -eq 1 ] && [ "$RC1" -eq 0 ] && [ "$RC2" -eq 1 ] \
+   && grep -q "already owns" "$SMOKE_STATE/delayed-run-2.log" \
+   && [ "$RESTARTS" -eq 1 ] && [ ! -e "$DELAYED_REPO/.state/STOP" ]; then
+  ok "delayed run.sh launcher cannot join an already-RUNNING supervisor"
+else
+  bad "delayed run.sh launcher bypassed lifetime ownership" \
+    "ready=$READY rc=$RC1/$RC2 restarts=$RESTARTS stop=$([ -e "$DELAYED_REPO/.state/STOP" ] && echo yes || echo no)"
 fi
 
 [ "$LEVEL" = "0" ] && { printf '\nL0 only: %d passed, %d failed\n' "$PASS" "$FAIL"; exit $((FAIL>0)); }


### PR DESCRIPTION
## The problem

A drained RE pipeline cannot be started again: recovery preserves the terminal `STOPPED`
state, and the state machine offers no guarded operator edge back to `RUNNING`.

```sh
state=$(mktemp -d)
KUNA_PIPELINE_STATE_DIR="$state" python3 - <<'PY'
from scripts.repipe import captain
doc = captain.load_round(1)
doc["supervisor"] = "STOPPED"
captain.save_round(doc)
PY
KUNA_PIPELINE_STATE_DIR="$state" python3 -m scripts.repipe.captain --recover
```

```text
"resumed_at": {
  "supervisor": "STOPPED",
  "test": "T_IDLE",
  "build": "B_IDLE"
}
```

## The fix

- Add an operator-only `--restart-stopped` path that reaps dead workers, refuses control
  files or live tester/builder slots, reruns preflight, and audits `STOPPED -> RUNNING`.
- Make a fresh `run.sh` invocation consume only a completed drain's `STOP`, use that guarded
  path, restore `STOP` if recovery fails, and never clear `ABORT` implicitly.
- Raise all documented and executable captain timeout defaults from 1200s to 3600s so a cold
  full-verification tick has headroom.

## The tests

`tools/repipe/smoke.sh --level 0` covers successful restart, every guard, transition audit,
launcher wiring, `ABORT` preservation, and timeout consistency. The four repository gates
also pass locally.
