### PR TITLE
[AUTOMATED] perf(analysis): skip the Listing reference model when nothing reads it (90.9 s -> 73.7 s, 12.9 GB -> 6.0 GB on a 147 MB binary)

### DIFF
--- a/decompiler/crates/kuna-analysis/src/listing/kuna_tailcallentry.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/kuna_tailcallentry.rs
@@ -78,10 +78,16 @@ pub enum Guard {
 /// The accepted tail-call function entries, address-sorted.
 ///
 /// ARM-only (the corpus the containment model was measured on); a strict no-op
-/// on every other architecture.
+/// on every other architecture, and on a Listing built without the reference
+/// model or the disassembly text — [`predecessors_are_branches`] and
+/// [`restores_frame`] are satisfied by an absent model rather than by evidence,
+/// so the precondition is structural and not left to the caller's gate.
 pub fn tail_call_entries(file: &object::File, listing: &Listing) -> Vec<u64> {
     use object::read::Object;
     if file.architecture() != object::Architecture::Arm {
+        return Vec::new();
+    }
+    if !listing.has_refs() || !listing.has_assembly() {
         return Vec::new();
     }
     let entries: Vec<u64> = listing.functions().map(|(&a, _)| a).collect();

--- a/decompiler/crates/kuna-analysis/src/listing/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/mod.rs
@@ -58,6 +58,34 @@ pub use model::{
     CodeUnit, DiscoveredFunction, FlowKind, FlowType, Insn, RawOp, RefKind, Reference,
 };
 
+/// What a Listing build captures beyond the instruction partition.
+///
+/// The partition (which bytes are instructions, and which addresses are
+/// functions) is what the walk exists for; the disassembly TEXT and the
+/// cross-reference MODEL are each an extra, and each costs per instruction —
+/// the text a second full SLEIGH parse plus two heap `String`s, the references
+/// two B-tree inserts plus a `Vec` allocation per control-flow edge. Neither is
+/// free to build and discard: on a 94 MB `.text` the reference model alone is
+/// 23 million edges across two maps.
+///
+/// Every consumer of either is gated on `--option listing on`, so a build that
+/// only wants the partition ([`ListingDetail::PARTITION_ONLY`]) is asking for
+/// the exact model it will read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListingDetail {
+    /// Capture each instruction's disassembly text (`mnemonic` / `operands`).
+    pub assembly: bool,
+    /// Build the cross-reference model (`refs_to` / `refs_from`).
+    pub refs: bool,
+}
+
+impl ListingDetail {
+    /// Everything: the partition, the disassembly text and the references.
+    pub const FULL: ListingDetail = ListingDetail { assembly: true, refs: true };
+    /// The instruction/function partition alone.
+    pub const PARTITION_ONLY: ListingDetail = ListingDetail { assembly: false, refs: false };
+}
+
 /// The Listing facade: three sub-models sharing one decode pass (design §2.5).
 pub struct Listing {
     /// Instruction model, keyed by VMA.
@@ -72,6 +100,8 @@ pub struct Listing {
     exec_ranges: Vec<(u64, u64)>,
     /// Whether the instruction model carries disassembly text.
     has_assembly: bool,
+    /// Whether the reference model was built (vs. deliberately skipped).
+    has_refs: bool,
 }
 
 impl Listing {
@@ -93,7 +123,7 @@ impl Listing {
         translate: &dyn Translate,
         seeds: &[u64],
     ) -> Listing {
-        Self::build_with_meta(file, _image, arch, translate, seeds, &[], &[], true)
+        Self::build_with_meta(file, _image, arch, translate, seeds, &[], &[], ListingDetail::FULL)
     }
 
     /// A Listing assembled from a partition someone else already decoded.
@@ -117,6 +147,7 @@ impl Listing {
             funcs,
             exec_ranges,
             has_assembly: true,
+            has_refs: false,
         }
     }
 
@@ -124,11 +155,21 @@ impl Listing {
     /// subset of `seeds` that came from a real funcsym (sets `from_symbol`), and
     /// `seed_names` is an `(addr, name)` overlay for naming seed functions.
     ///
-    /// `want_assembly` selects whether each [`Insn`] carries its disassembly text.
-    /// Every consumer that reads it runs behind `--option listing on`, except AIF's
-    /// prologue fingerprint, which re-decodes the two addresses it needs; the
-    /// `fast_funcdisc`-only path therefore passes `false` and skips a second full
-    /// SLEIGH parse per instruction (see [`decode::decode_one`]).
+    /// `detail` selects what is captured beyond the instruction/function
+    /// partition (see [`ListingDetail`]).
+    ///
+    /// `detail.assembly` selects whether each [`Insn`] carries its disassembly
+    /// text. Every consumer that reads it runs behind `--option listing on`,
+    /// except AIF's prologue fingerprint, which re-decodes the two addresses it
+    /// needs; the `fast_funcdisc`-only path therefore passes `false` and skips a
+    /// second full SLEIGH parse per instruction (see [`decode::decode_one`]).
+    ///
+    /// `detail.refs` selects whether the reference model is built at all. Its
+    /// only two consumers — the `noreturn_disc` Listing pass and
+    /// `tailcallentry` — are both gated on `--option listing on`, so the
+    /// `fast_funcdisc`-only path passes `false` and skips filing (and then
+    /// sorting, and then dropping) one edge per control-flow successor of every
+    /// instruction in the program.
     #[allow(clippy::too_many_arguments)]
     pub fn build_with_meta(
         file: &object::File,
@@ -138,7 +179,7 @@ impl Listing {
         seeds: &[u64],
         funcsym_seeds: &[u64],
         seed_names: &[(u64, String)],
-        want_assembly: bool,
+        detail: ListingDetail,
     ) -> Listing {
         // The executable-range universe (design §2.4 / §3.4 out-of-bounds gate),
         // sorted by low VMA so the partition / gap queries can binary-search it.
@@ -159,7 +200,8 @@ impl Listing {
                     refs_from: BTreeMap::new(),
                     funcs: BTreeMap::new(),
                     exec_ranges,
-                    has_assembly: want_assembly,
+                    has_assembly: detail.assembly,
+                    has_refs: detail.refs,
                 };
             }
         };
@@ -207,7 +249,7 @@ impl Listing {
             &seed_funcs,
             &painter,
             &local_entries,
-            want_assembly,
+            detail,
         );
 
         let mut refs_to = st.refs_to;
@@ -217,6 +259,7 @@ impl Listing {
         // VMA then kind) and de-duplicated on `(from, to, kind)`, so a target
         // referenced twice from the same call site contributes one edge and
         // `ref_count_to` equals the number of distinct referencing sites.
+        // Both maps are empty when the walk was told not to build them.
         finalize_refs(&mut refs_to, /* by_source = */ true);
         finalize_refs(&mut refs_from, /* by_source = */ false);
 
@@ -226,7 +269,8 @@ impl Listing {
             refs_from,
             funcs: st.funcs,
             exec_ranges,
-            has_assembly: want_assembly,
+            has_assembly: detail.assembly,
+            has_refs: detail.refs,
         }
     }
 
@@ -243,6 +287,7 @@ impl Listing {
             funcs: BTreeMap::new(),
             exec_ranges: vec![(0, u64::MAX)],
             has_assembly,
+            has_refs: false,
         }
     }
 
@@ -325,9 +370,16 @@ impl Listing {
         &self.exec_ranges
     }
 
+    /// Whether [`Listing::refs_to`]/[`Listing::refs_from`] were populated. False
+    /// for a Listing built with [`ListingDetail::refs`] off, where both answer
+    /// "no references" for every address because none were ever filed.
+    pub fn has_refs(&self) -> bool {
+        self.has_refs
+    }
+
     /// Whether [`Insn::mnemonic`]/[`Insn::operands`] carry disassembly text. False
-    /// for a Listing built with `want_assembly = false`, whose only text reader
-    /// (AIF's prologue fingerprint) re-decodes the addresses it needs.
+    /// for a Listing built with [`ListingDetail::assembly`] off, whose only text
+    /// reader (AIF's prologue fingerprint) re-decodes the addresses it needs.
     pub fn has_assembly(&self) -> bool {
         self.has_assembly
     }
@@ -540,6 +592,7 @@ mod tests {
             funcs: BTreeMap::new(),
             exec_ranges: Vec::new(),
             has_assembly: true,
+            has_refs: true,
         };
         let addrs = |start, end| {
             listing

--- a/decompiler/crates/kuna-analysis/src/listing/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/mod.rs
@@ -194,6 +194,9 @@ impl Listing {
             Some(s) => Rc::clone(s),
             None => {
                 // No code space ⇒ nothing decodable; return an empty Listing.
+                // There was no walk, so there is no reference model whatever the
+                // caller asked for: `has_refs` reports what was built, not what
+                // was requested.
                 return Listing {
                     insns: BTreeMap::new(),
                     refs_to: BTreeMap::new(),
@@ -201,7 +204,7 @@ impl Listing {
                     funcs: BTreeMap::new(),
                     exec_ranges,
                     has_assembly: detail.assembly,
-                    has_refs: detail.refs,
+                    has_refs: false,
                 };
             }
         };
@@ -370,9 +373,13 @@ impl Listing {
         &self.exec_ranges
     }
 
-    /// Whether [`Listing::refs_to`]/[`Listing::refs_from`] were populated. False
-    /// for a Listing built with [`ListingDetail::refs`] off, where both answer
-    /// "no references" for every address because none were ever filed.
+    /// Whether a reference model was built. False for a Listing built with
+    /// [`ListingDetail::refs`] off — and for one with nothing to walk — where
+    /// every reference query answers "none" because none were ever filed.
+    ///
+    /// A consumer whose result depends on the *absence* of a reference (the
+    /// `tailcallentry` guards do) has to check this first: an empty bucket is
+    /// otherwise indistinguishable from an unbuilt model.
     pub fn has_refs(&self) -> bool {
         self.has_refs
     }
@@ -471,6 +478,12 @@ impl Listing {
     }
 
     // ---- xref model (read-only, design §6 / PR4) ----
+    //
+    // Every reader below answers over the model that was actually built, so each
+    // reports "none" on a PARTITION_ONLY Listing; `has_refs` is what tells that
+    // apart from a genuinely unreferenced address. They stay callable there on
+    // purpose — the walk-equivalence test reads them to pin that a
+    // partition-only build files nothing.
 
     /// Incoming references to `to` (callers / branch sources), sorted by source
     /// VMA then kind, de-duplicated on `(from, to, kind)`.

--- a/decompiler/crates/kuna-analysis/src/listing/model.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/model.rs
@@ -139,7 +139,7 @@ pub struct Reference {
 }
 
 /// A function entry discovered (or seeded) by the walk.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiscoveredFunction {
     /// The function entry VMA.
     pub entry: u64,

--- a/decompiler/crates/kuna-analysis/src/listing/walk.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/walk.rs
@@ -26,6 +26,7 @@ use super::classify::classify;
 use super::context::ContextPainter;
 use super::decode::decode_one;
 use super::model::{DiscoveredFunction, Insn, Reference, RefKind};
+use super::ListingDetail;
 
 /// The accumulating maps the walk fills. Lifted into [`super::Listing`] by
 /// [`super::Listing::build`].
@@ -38,20 +39,29 @@ pub(super) struct WalkState {
     pub refs_from: BTreeMap<u64, Vec<Reference>>,
     /// Discovered/seeded functions, keyed by entry VMA (ordered).
     pub funcs: BTreeMap<u64, DiscoveredFunction>,
+    /// Whether [`WalkState::file_ref`] records anything at all.
+    want_refs: bool,
 }
 
 impl WalkState {
-    fn new() -> Self {
+    fn new(want_refs: bool) -> Self {
         WalkState {
             insns: BTreeMap::new(),
             refs_to: BTreeMap::new(),
             refs_from: BTreeMap::new(),
             funcs: BTreeMap::new(),
+            want_refs,
         }
     }
 
     /// File a reference into both directions (`refs_to[to]` and `refs_from[from]`).
+    ///
+    /// A no-op when the caller asked for no reference model, so the walk's edge
+    /// sites read the same either way and a new one cannot miss the gate.
     fn file_ref(&mut self, from: u64, to: u64, kind: RefKind) {
+        if !self.want_refs {
+            return;
+        }
         let r = Reference { from, to, kind, op_index: None };
         self.refs_to.entry(to).or_default().push(r.clone());
         self.refs_from.entry(from).or_default().push(r);
@@ -81,9 +91,15 @@ pub(super) fn in_exec(exec_ranges: &[(u64, u64)], vma: u64) -> bool {
 /// INTERIOR of the function at its value, so no function is claimed there. Empty
 /// on every other architecture and whenever the option is off.
 ///
-/// `want_assembly` is forwarded to [`decode_one`]: `false` leaves every
+/// `detail.assembly` is forwarded to [`decode_one`]: `false` leaves every
 /// [`Insn::mnemonic`]/[`Insn::operands`] empty and skips the second SLEIGH parse
 /// that produces them (see [`decode_one`] for the cost).
+///
+/// `detail.refs` selects whether the reference model is filed at all
+/// ([`WalkState::file_ref`] becomes a no-op). Every instruction contributes an
+/// edge per successor, a fall-through included, so on a large program this is
+/// the same order of magnitude as the instruction model itself; `false` leaves
+/// both maps empty for a caller that reads neither.
 pub(super) fn walk(
     translate: &dyn Translate,
     arch: &Architecture,
@@ -93,7 +109,7 @@ pub(super) fn walk(
     seed_funcs: &BTreeMap<u64, DiscoveredFunction>,
     painter: &ContextPainter,
     local_entries: &BTreeMap<u64, u64>,
-    want_assembly: bool,
+    detail: ListingDetail,
 ) -> WalkState {
     // Paint the decode-mode context (ARM TMode / MIPS ISA_MODE) into the engine's
     // ContextDatabase BEFORE we decode a single instruction — the timing the
@@ -105,7 +121,7 @@ pub(super) fn walk(
         painter.paint_all(arch, code_space);
     }
 
-    let mut st = WalkState::new();
+    let mut st = WalkState::new(detail.refs);
 
     // Function-entry worklist, seeded from the root set.
     let mut func_worklist: Vec<u64> = seeds.to_vec();
@@ -133,7 +149,7 @@ pub(super) fn walk(
                 continue; // out-of-bounds gate (flow.rs:891 analog)
             }
 
-            let decoded = match decode_one(translate, vma, code_space, want_assembly) {
+            let decoded = match decode_one(translate, vma, code_space, detail.assembly) {
                 Ok(d) => d,
                 Err(_) => continue, // decode error: stop this path (mark gap)
             };
@@ -165,7 +181,8 @@ pub(super) fn walk(
                     // (`unmappedentry`) and where the target is not the callee's own
                     // PPC64 ELFv2 local entry (`ppclocalentry` — a point inside a
                     // function whose global entry is already a seed, so the bytes
-                    // here are walked either way). The reference is always filed;
+                    // here are walked either way). The reference is filed whatever
+                    // the claim decides (where there is a reference model at all);
                     // only the function claim is withheld.
                     if !local_entries.contains_key(&t)
                         && super::kuna_unmappedentry::admits_call_entry(arch, exec_ranges, t)

--- a/decompiler/crates/kuna-analysis/src/passes.rs
+++ b/decompiler/crates/kuna-analysis/src/passes.rs
@@ -639,7 +639,18 @@ pub fn run_listing_consumers(
     // there is no text reader left (AIF's fingerprint re-decodes the two addresses
     // it needs), so the walk skips capturing text: a second SLEIGH parse per
     // instruction. See `listing::decode::decode_one`.
-    let want_assembly = arch.analysis_listing;
+    //
+    // The reference model has the same two gated readers and nothing else —
+    // `noreturn_disc` (a `listing_consumer_passes` pass) and `tailcallentry` —
+    // so a `fast_funcdisc`-only build skips it too. It is not a rounding error
+    // on a large image: the walk files an edge per control-flow successor of
+    // every instruction, a fall-through included, so a 94 MB `.text` produced 23
+    // million edges spread over two `BTreeMap<u64, Vec<Reference>>` that nothing
+    // then read.
+    let detail = crate::listing::ListingDetail {
+        assembly: arch.analysis_listing,
+        refs: arch.analysis_listing,
+    };
     let mut listing = crate::listing::Listing::build_with_meta(
         &file,
         image,
@@ -648,7 +659,7 @@ pub fn run_listing_consumers(
         &seeds,
         &funcsym_seeds,
         &seed_names,
-        want_assembly,
+        detail,
     );
     // (kuna, Stage-2 ARM discovery) Raw, UNPAIRED Thumb-prologue gap seeding — the
     // angr `CFGFast._func_addrs_from_prologues()` mirror. After the first walk, scan
@@ -687,7 +698,7 @@ pub fn run_listing_consumers(
                         &seeds,
                         &funcsym_seeds,
                         &seed_names,
-                        want_assembly,
+                        detail,
                     );
                 }
             }
@@ -732,7 +743,7 @@ pub fn run_listing_consumers(
                         &seeds,
                         &funcsym_seeds,
                         &seed_names,
-                        want_assembly,
+                        detail,
                     );
                 }
             }

--- a/decompiler/crates/kuna-console/tests/verify_aif.rs
+++ b/decompiler/crates/kuna-console/tests/verify_aif.rs
@@ -194,6 +194,15 @@ fn aif_recovers_function_reachable_only_via_data_path() {
 /// mixing two instructions. This fixture is x86-64, which has no decode mode: what
 /// it proves is that the substitution is exact where the re-decode agrees, and that
 /// the guard rejects nothing it should not.
+///
+/// Text is the only thing that varies here: the lean run asks for
+/// `ListingDetail { assembly: false, refs: true }` rather than
+/// [`ListingDetail::PARTITION_ONLY`], so a difference cannot be laid at the
+/// reference model's door. That is also the one place the mixed `ListingDetail`
+/// combination is exercised — production only ever asks for the two named
+/// constants — and the refs axis has its own single-variable gate,
+/// `a_partition_only_listing_walks_identically_and_files_no_references` in
+/// `verify_listing_queries.rs`.
 #[test]
 fn a_text_free_listing_fingerprints_exactly_like_a_text_carrying_one() {
     let bin = fixture();
@@ -243,15 +252,15 @@ fn a_text_free_listing_fingerprints_exactly_like_a_text_carrying_one() {
         (count, insns, entries)
     };
 
-    let (with_text, full_insns, texted_entries) = run(ListingDetail::FULL);
-    let (without_text, lean_insns, textless_entries) = run(ListingDetail::PARTITION_ONLY);
+    let (with_text, texted_insns, texted_entries) = run(ListingDetail::FULL);
+    let (without_text, textless_insns, textless_entries) =
+        run(ListingDetail { assembly: false, refs: true });
 
     assert_eq!(with_text, without_text, "the walk itself must not depend on text capture");
     assert_eq!(
-        full_insns, lean_insns,
-        "the instruction partition must not depend on what the walk was asked to \
-         capture alongside it: {full_insns} instructions with text + references, \
-         {lean_insns} without"
+        texted_insns, textless_insns,
+        "the instruction partition must not depend on text capture: \
+         {texted_insns} instructions with text, {textless_insns} without"
     );
     assert!(
         with_text >= 20,

--- a/decompiler/crates/kuna-console/tests/verify_aif.rs
+++ b/decompiler/crates/kuna-console/tests/verify_aif.rs
@@ -61,7 +61,7 @@
 
 use std::path::PathBuf;
 
-use kuna_analysis::listing::Listing;
+use kuna_analysis::listing::{Listing, ListingDetail};
 use kuna_console::engine::bootstrap_from_object;
 use kuna_console::ifacedecomp::{execute, register_decomp_commands, IfaceDecompData, DECOMPILE_MODULE};
 use kuna_console::ifaceterm::ConsoleCommands;
@@ -218,7 +218,7 @@ fn a_text_free_listing_fingerprints_exactly_like_a_text_carrying_one() {
     let code_space =
         std::rc::Rc::clone(arch.manage().get_default_code_space().expect("code space"));
 
-    let run = |want_assembly: bool| {
+    let run = |detail: ListingDetail| {
         let listing = Listing::build_with_meta(
             &file,
             &image,
@@ -227,9 +227,10 @@ fn a_text_free_listing_fingerprints_exactly_like_a_text_carrying_one() {
             &seeds,
             &seeds,
             &[],
-            want_assembly,
+            detail,
         );
         let count = listing.function_count();
+        let insns = listing.num_instructions();
         let exec = listing.exec_ranges().to_vec();
         let entries = kuna_analysis::aif::run_aif(
             &listing,
@@ -239,13 +240,19 @@ fn a_text_free_listing_fingerprints_exactly_like_a_text_carrying_one() {
             false,
             false,
         );
-        (count, entries)
+        (count, insns, entries)
     };
 
-    let (with_text, texted_entries) = run(true);
-    let (without_text, textless_entries) = run(false);
+    let (with_text, full_insns, texted_entries) = run(ListingDetail::FULL);
+    let (without_text, lean_insns, textless_entries) = run(ListingDetail::PARTITION_ONLY);
 
     assert_eq!(with_text, without_text, "the walk itself must not depend on text capture");
+    assert_eq!(
+        full_insns, lean_insns,
+        "the instruction partition must not depend on what the walk was asked to \
+         capture alongside it: {full_insns} instructions with text + references, \
+         {lean_insns} without"
+    );
     assert!(
         with_text >= 20,
         "the fixture must clear MINIMUM_FUNCTION_COUNT or the comparison is vacuous \

--- a/decompiler/crates/kuna-console/tests/verify_listing_queries.rs
+++ b/decompiler/crates/kuna-console/tests/verify_listing_queries.rs
@@ -24,7 +24,9 @@
 
 use std::path::PathBuf;
 
-use kuna_analysis::listing::{CodeUnit, Listing, ListingDetail, RefKind};
+use kuna_analysis::listing::{
+    CodeUnit, DiscoveredFunction, FlowType, Listing, ListingDetail, RefKind,
+};
 use kuna_console::engine::bootstrap_from_object;
 
 fn repo_root() -> PathBuf {
@@ -345,17 +347,26 @@ fn a_partition_only_listing_walks_identically_and_files_no_references() {
         full.function_count()
     );
 
+    // Everything the walk produces except the two fields the lean build is also
+    // asked not to capture (`mnemonic` / `operands`): each instruction's extent
+    // AND its classified flow, plus whole `DiscoveredFunction` values. Comparing
+    // addresses alone would pass on a walk that decoded the same bytes and
+    // classified them differently.
     let partition = |l: &Listing| {
-        let insns: Vec<(u64, u32)> = l.instructions().map(|(&a, i)| (a, i.len)).collect();
-        let funcs: Vec<(u64, Option<String>, bool)> =
-            l.functions().map(|(&a, f)| (a, f.name.clone(), f.from_symbol)).collect();
+        let insns: Vec<(u64, u32, Option<u64>, FlowType, Vec<u64>)> = l
+            .instructions()
+            .map(|(&a, i)| (a, i.len, i.fall_through, i.flow, i.flows.clone()))
+            .collect();
+        let funcs: Vec<(u64, DiscoveredFunction)> =
+            l.functions().map(|(&a, f)| (a, f.clone())).collect();
         (insns, funcs, l.exec_ranges().to_vec())
     };
     assert_eq!(
         partition(&full),
         partition(&lean),
-        "the instruction partition, the discovered-function model and the executable \
-         ranges must not depend on whether the reference model was built"
+        "the decoded instructions (extent, fall-through and classified flow), the \
+         discovered-function model and the executable ranges must not depend on \
+         whether the reference model was built"
     );
 
     // The full build has real edges at the sites the query gate pins; the lean

--- a/decompiler/crates/kuna-console/tests/verify_listing_queries.rs
+++ b/decompiler/crates/kuna-console/tests/verify_listing_queries.rs
@@ -24,7 +24,7 @@
 
 use std::path::PathBuf;
 
-use kuna_analysis::listing::{CodeUnit, Listing, RefKind};
+use kuna_analysis::listing::{CodeUnit, Listing, ListingDetail, RefKind};
 use kuna_console::engine::bootstrap_from_object;
 
 fn repo_root() -> PathBuf {
@@ -285,4 +285,96 @@ fn listing_query_surface_partition_functions_and_xrefs() {
             .collect::<Vec<_>>()
     );
     eprintln!("  ref_count_to(authenticate) (Call) = {call_refs_to_auth}");
+}
+
+/// A `ListingDetail::PARTITION_ONLY` build is the same walk with the reference
+/// model left unbuilt: the instructions it decodes and the functions it discovers
+/// must be identical to a full build's, and every xref query must answer "none".
+///
+/// This is the claim the `fast_funcdisc`-only path rests on. That path asks for a
+/// program-wide walk purely to enumerate functions, and the two readers of the
+/// reference model (`noreturn_disc` and `tailcallentry`) are both gated on
+/// `--option listing on`, so it builds neither map. On a large image the skipped
+/// work is the same order as the instruction model itself — a 94 MB `.text`
+/// produced 23 million edges across two `BTreeMap`s — so what has to hold is that
+/// dropping it changes nothing else about the walk.
+#[test]
+fn a_partition_only_listing_walks_identically_and_files_no_references() {
+    let root = repo_root();
+    let spec_roots = vec![root.join("specs").to_str().unwrap().to_string()];
+
+    let bin = match fauxware().to_str() {
+        Some(s) => s.to_string(),
+        None => return,
+    };
+    let prog = match bootstrap_from_object(&bin, "", &spec_roots) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "verify_listing_queries: skipping (bootstrap failed, `make specs`): {}",
+                e.explain()
+            );
+            return;
+        }
+    };
+
+    let bytes = std::fs::read(&bin).expect("read fixture bytes");
+    let file = object::File::parse(&*bytes).expect("parse fixture ELF");
+    let image = kuna_analysis::loadimage_object::ObjectLoadImage::from_bytes(&bin, &bytes)
+        .expect("open throwaway loadimage");
+    let arch = prog.arch();
+    let translate = arch.translate();
+    let mut seeds = kuna_analysis::entry::collect_entries(&file, &bytes);
+    seeds.push(MAIN);
+    seeds.push(CSU_INIT);
+    seeds.sort_unstable();
+    seeds.dedup();
+
+    let build = |detail| {
+        Listing::build_with_meta(&file, &image, arch, translate, &seeds, &seeds, &[], detail)
+    };
+    let full = build(ListingDetail::FULL);
+    let lean = build(ListingDetail::PARTITION_ONLY);
+
+    assert!(full.has_refs() && !lean.has_refs(), "each build must report what it captured");
+    assert!(
+        full.num_instructions() > 50 && full.function_count() > 2,
+        "the fixture must decode a real program or the comparison is vacuous \
+         ({} instructions, {} functions)",
+        full.num_instructions(),
+        full.function_count()
+    );
+
+    let partition = |l: &Listing| {
+        let insns: Vec<(u64, u32)> = l.instructions().map(|(&a, i)| (a, i.len)).collect();
+        let funcs: Vec<(u64, Option<String>, bool)> =
+            l.functions().map(|(&a, f)| (a, f.name.clone(), f.from_symbol)).collect();
+        (insns, funcs, l.exec_ranges().to_vec())
+    };
+    assert_eq!(
+        partition(&full),
+        partition(&lean),
+        "the instruction partition, the discovered-function model and the executable \
+         ranges must not depend on whether the reference model was built"
+    );
+
+    // The full build has real edges at the sites the query gate pins; the lean
+    // build answers "none" at every one of them rather than a wrong subset.
+    assert!(full.has_refs_to(AUTHENTICATE), "the full build must see the call to authenticate");
+    assert!(!full.refs_from(CALL_AUTH).is_empty(), "the full build must see the call site's edge");
+    assert_eq!(lean.ref_source_iter().count(), 0, "a partition-only build files no ref sources");
+    for &vma in &[MAIN, MAIN_MID, AUTHENTICATE, CALL_AUTH, RET, CSU_INIT] {
+        assert!(lean.refs_to(vma).is_empty(), "refs_to({vma:#x}) must be empty");
+        assert!(lean.refs_from(vma).is_empty(), "refs_from({vma:#x}) must be empty");
+        assert!(!lean.has_refs_to(vma), "has_refs_to({vma:#x}) must be false");
+        assert_eq!(lean.ref_count_to(vma), 0, "ref_count_to({vma:#x}) must be 0");
+    }
+
+    eprintln!(
+        "verify_listing_queries: partition {} insns / {} funcs; refs {} sources (full) vs {} (lean)",
+        full.num_instructions(),
+        full.function_count(),
+        full.ref_source_iter().count(),
+        lean.ref_source_iter().count(),
+    );
 }

--- a/decompiler/crates/kuna-console/tests/verify_tailcallentry.rs
+++ b/decompiler/crates/kuna-console/tests/verify_tailcallentry.rs
@@ -40,6 +40,8 @@
 
 use std::path::PathBuf;
 
+use kuna_analysis::listing::kuna_tailcallentry::tail_call_entries;
+use kuna_analysis::listing::{Listing, ListingDetail};
 use kuna_console::engine::bootstrap_from_object;
 use kuna_console::ifacedecomp::{execute, register_decomp_commands, IfaceDecompData, DECOMPILE_MODULE};
 use kuna_console::ifaceterm::ConsoleCommands;
@@ -67,6 +69,8 @@ const IN_REGION: &str = "sub_8008038";
 const EPILOGUE: &str = "sub_8008058";
 /// An unconditional-branch target whose flow region never terminates.
 const NON_TERMINATING: &str = "sub_8008060";
+/// [`TAIL`]'s VMA — the one entry the pass is expected to accept here.
+const TAIL_VMA: u64 = 0x0800_8020;
 
 /// Bootstrap the fixture with the Listing tier on, optionally flipping
 /// `tailcallentry` on before the deferred commit (the live-CLI ordering).
@@ -202,4 +206,68 @@ fn tailcallentry_only_adds_entries() {
         );
     }
     assert!(off.lookup_symbol(TAIL).is_none() && on.lookup_symbol(TAIL).is_some());
+}
+
+/// The pass refuses a Listing that was not asked for the models it reads, rather
+/// than answering from their absence. Two of the four guards are satisfied by an
+/// empty model rather than by evidence — `predecessors_are_branches` is
+/// vacuously true over an empty `refs_to` bucket, and the epilogue guard reads a
+/// mnemonic a text-free walk leaves `""` — so judged off a
+/// [`ListingDetail::PARTITION_ONLY`] build the acceptance predicate decays into
+/// the naive rule the containment model exists to replace, and would ADD entries
+/// (the near misses above) that the full build correctly rejects. `passes.rs`
+/// pins the pass behind `--option listing on`, which is also what turns those
+/// models on; this keeps the two from drifting apart.
+#[test]
+fn a_partition_only_listing_yields_no_tail_call_entries() {
+    let root = repo_root();
+    let spec_roots = vec![root.join("specs").to_str().unwrap().to_string()];
+    let bin = match fixture().to_str() {
+        Some(s) => s.to_string(),
+        None => return,
+    };
+    let prog = match bootstrap_from_object(&bin, "", &spec_roots) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "verify_tailcallentry: skipping (bootstrap failed, build `.sla` \
+                 with `make specs`): {}",
+                e.explain()
+            );
+            return; // specs-less skip
+        }
+    };
+
+    let bytes = std::fs::read(&bin).expect("read fixture bytes");
+    let file = object::File::parse(&*bytes).expect("parse fixture ELF");
+    let image = kuna_analysis::loadimage_object::ObjectLoadImage::from_bytes(&bin, &bytes)
+        .expect("open throwaway loadimage");
+    let arch = prog.arch();
+    let translate = arch.translate();
+    let seeds = kuna_analysis::entry::collect_entries(&file, &bytes);
+
+    let build = |detail| {
+        Listing::build_with_meta(&file, &image, arch, translate, &seeds, &seeds, &[], detail)
+    };
+    let full = build(ListingDetail::FULL);
+    let lean = build(ListingDetail::PARTITION_ONLY);
+
+    let accepted = tail_call_entries(&file, &full);
+    assert!(
+        accepted.contains(&TAIL_VMA),
+        "the full build must accept {TAIL_VMA:#x} or the comparison is vacuous \
+         (accepted {accepted:x?})"
+    );
+    assert_eq!(
+        full.num_instructions(),
+        lean.num_instructions(),
+        "the two builds must be the same walk ({} vs {} instructions)",
+        full.num_instructions(),
+        lean.num_instructions()
+    );
+    assert!(
+        tail_call_entries(&file, &lean).is_empty(),
+        "a partition-only Listing carries neither model the guards read, so the \
+         pass must yield nothing rather than accept on vacuous evidence"
+    );
 }

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -2522,15 +2522,18 @@ the instruction worklist uses, so the walk claims a function only where it is
 willing to disassemble. It withholds the function claim only: wherever the
 reference model is being built at all, the Call cross-reference is filed in both
 directions either way, because the instruction really does encode a call to that
-address and `kuna xrefs` should still say so. A target inside an executable
-section is admitted exactly as before even when the decode there fails — that
-is a genuine gap in the walk, not a fabricated entry — so the gate can never
-remove an entry that had a body. Measured over 234 crackmes images it removes
-150 entries on 19 of them and adds none; every one is `size: 0`
-and outside every executable section, and emitted C over 6,085 functions of those
-images changes in exactly one function, where two parameters wrongly typed `code *`
-(a phantom sat at the address they pointed to) come back as the data pointers they
-are. Off restores the previous, phantom-producing discovery set exactly.
+address. Where that model was not built the Listing's own xref API answers
+"none" for this edge as for every other; the `kuna xrefs` and `decompile-graph`
+answers are unaffected either way, because they come from a separate index over
+the same bytes (`decompiler/crates/kuna-analysis/src/listing/xrefs.rs (build)`)
+and not from the Listing. A target inside an executable section is admitted
+exactly as before even when the decode there fails — that is a genuine gap in
+the walk, not a fabricated entry — so the gate can never remove an entry that
+had a body. Measured over 234 crackmes images it removes 150 entries on 19 of
+them and adds none; every one is `size: 0` and outside every executable section,
+and emitted C over 6,085 functions of those images changes in exactly one
+function, where two parameters wrongly typed `code *` (a phantom sat at the
+address they pointed to) come back as the data pointers they are. Off restores the previous, phantom-producing discovery set exactly.
 
 (kuna) The same seam carries `ppclocalentry` (default-on;
 `decompiler/crates/kuna-analysis/src/listing/kuna_ppclocalentry.rs (fold_map)`),
@@ -2618,7 +2621,18 @@ identical either way, and `Listing::has_refs` reports which model was built rath
 than leaving a caller to read an empty map as an answer. On a 147 MB C++ server
 image (20.2 million instructions, 392,814 functions) the skipped model is 23.3
 million edges: the whole `kuna functions` run drops from 12.9 GB resident to 6.0
-GB and from 90.9 s to 73.7 s, for byte-identical output.
+GB and from 90.9 s to 73.7 s. The output of that command is byte-identical:
+`kuna functions` carries no per-function budget, so nothing it prints can depend
+on how long the run took. The whole-binary decompile surfaces do carry one —
+`decompile-all`, `decompile-project` and `decompile-graph` under `--mode fast`
+abandon a function after ten seconds of WALL CLOCK
+(`decompiler/crates/kuna-console/src/project.rs`,
+`FAST_WHOLE_BINARY_FN_BUDGET_SECONDS`) — so a run that spends less time
+elsewhere legitimately finishes functions a slower one gave up on: measured on
+this image, 4 of 2,233 A/B function pairs differ, in both directions, every one
+of them at that budget. Those surfaces are byte-identical at a fixed budget
+(`--max-fn-seconds 0`), and the wall-clock watchdog is the documented exception
+— the same exception for any change that moves the clock.
 
 Third, instruction-byte coverage, which is *derived* from the instruction map
 rather than mirrored into a range list: because a range list merges overlapping
@@ -2825,7 +2839,15 @@ unmatched `PUSH`/`SUB SP` still open) was implemented, measured, and dominated b
 it on both precision and recall. As with `ptrentry`, the region is the
 entry-ordered one — the nearest preceding discovered entry — which is the
 granularity the tier has and errs conservative on a sparsely discovered image.
-Output-changing (more functions), hence default-off; ARM-only and Listing-tier, so
+Two of the four guards are satisfied by an *absent* model rather than by
+evidence: the predecessor test reads the reference model and the epilogue test
+the disassembly text, and a walk can be told to capture neither (above), which
+would leave the naive rule — and on the fixture it accepts the shared epilogue
+the full model rejects. So the pass checks for both models up front and yields
+nothing without them. In production the gate that enables the pass is the same
+one that enables the models, so the check is invisible there; it is what keeps a
+later change to either gate from quietly reducing the four guards to the rule
+they replaced. Output-changing (more functions), hence default-off; ARM-only and Listing-tier, so
 it is a strict no-op on every other architecture, with `listing off`, and on the
 XML datatest path.
 

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -2519,13 +2519,14 @@ directly: `xor eax,eax; je +1; e8 ...` puts the `e8` one byte before the real
 instruction, and following the (never-executed) fall-through reads a call to an
 address four gigabytes above a 25 KB image. The gate applies the *same* predicate
 the instruction worklist uses, so the walk claims a function only where it is
-willing to disassemble. It withholds the function claim only: the Call
-cross-reference is filed in both directions either way, because the instruction
-really does encode a call to that address and `kuna xrefs` should still say so. A
-target inside an executable section is admitted exactly as before even when the
-decode there fails — that is a genuine gap in the walk, not a fabricated entry —
-so the gate can never remove an entry that had a body. Measured over 234 crackmes
-images it removes 150 entries on 19 of them and adds none; every one is `size: 0`
+willing to disassemble. It withholds the function claim only: wherever the
+reference model is being built at all, the Call cross-reference is filed in both
+directions either way, because the instruction really does encode a call to that
+address and `kuna xrefs` should still say so. A target inside an executable
+section is admitted exactly as before even when the decode there fails — that
+is a genuine gap in the walk, not a fabricated entry — so the gate can never
+remove an entry that had a body. Measured over 234 crackmes images it removes
+150 entries on 19 of them and adds none; every one is `size: 0`
 and outside every executable section, and emitted C over 6,085 functions of those
 images changes in exactly one function, where two parameters wrongly typed `code *`
 (a phantom sat at the address they pointed to) come back as the data pointers they
@@ -2573,7 +2574,7 @@ load-bearing gotchas are worth restating: a constant-space branch operand is
 p-code-relative (an intra-instruction branch), never a VMA; fall-through is decided
 by the *last* op only; and delay slots are already folded into the reported length.
 
-Two things the walk deliberately does **not** always produce. First, the human
+Three things the walk deliberately does **not** always produce. First, the human
 assembly text on each instruction: capturing it means a *second* full SLEIGH parse
 of the same bytes (`Translate::print_assembly`) plus two heap strings per
 instruction, which roughly doubles the cost of the walk and is pure waste whenever
@@ -2600,11 +2601,30 @@ direction: a function that contributes no fingerprint only makes the histogram
 smaller, which can never admit a gap candidate the text-carrying path would have
 rejected. Where the two agree the histogram — and every gap-walk and
 pointer-target decision keyed off it — is unchanged, which is what keeps the
-pointer-only entries `fast_funcdisc` exists to find. Second, instruction-byte
-coverage, which is *derived* from the instruction map rather than mirrored into a
-range list: because a range list merges overlapping but not adjacent ranges, a
-straight-line run of instructions would cost one node per instruction, and the
-undefined-gap queries already answer from the instruction map.
+pointer-only entries `fast_funcdisc` exists to find.
+
+Second, the cross-reference model itself, on the same reasoning and the same
+gate. An edge is filed for every control-flow successor of every instruction, a
+plain fall-through included, so the two direction maps together hold rather more
+entries than the instruction model does — and each is a `Vec` of its own inside a
+B-tree, which is several times the per-edge cost of an instruction. The model has
+exactly two readers, `noreturn_disc` and `tailcallentry`, and both are `listing`
+consumers, so a `fast_funcdisc`-only walk — again, the whole-binary export's path
+on any image `--mode auto` resolves to `fast` — builds neither map and every xref
+query answers "none" for every address. What must hold is that nothing else about
+the walk changes, and nothing does: the reference filing is a pure sink, so the
+instructions decoded, the functions discovered and the executable ranges are
+identical either way, and `Listing::has_refs` reports which model was built rather
+than leaving a caller to read an empty map as an answer. On a 147 MB C++ server
+image (20.2 million instructions, 392,814 functions) the skipped model is 23.3
+million edges: the whole `kuna functions` run drops from 12.9 GB resident to 6.0
+GB and from 90.9 s to 73.7 s, for byte-identical output.
+
+Third, instruction-byte coverage, which is *derived* from the instruction map
+rather than mirrored into a range list: because a range list merges overlapping
+but not adjacent ranges, a straight-line run of instructions would cost one node
+per instruction, and the undefined-gap queries already answer from the
+instruction map.
 
 **Fast function discovery with conservative pointer validation** (`fast_funcdisc`, default-off;
 `decompiler/crates/kuna-analysis/src/analyzers/fast_funcdisc/mod.rs


### PR DESCRIPTION
## The problem

`kuna functions` on a large binary spends a fifth of its wall clock and over half
its peak memory building a cross-reference model that nothing on that path reads.
Every image of 2 MiB or larger takes that path, because `--mode auto` resolves to
`fast` at that size.

```
$ /usr/bin/time -v kuna functions ./server --json > /dev/null
	Elapsed (wall clock) time (h:mm:ss or m:ss): 1:30.93
	Maximum resident set size (kbytes): 12909184
```

The binary above is private (147 MB, stripped x86-64 PIE, 392,814 functions), but
the largest ELF on your box reproduces the shape — a `libLLVM-*.so`, say. Same
command after this change:

```
	Elapsed (wall clock) time (h:mm:ss or m:ss): 1:13.65
	Maximum resident set size (kbytes): 6021120
```

## The fix

- The walk filed a cross-reference edge for every control-flow successor of every
  instruction, a plain fall-through included: 23.3 M edges across two
  `BTreeMap<u64, Vec<Reference>>`, built, sorted and dropped unread. The model has
  exactly two readers, the `noreturn_disc` Listing pass and `kuna_tailcallentry`,
  and both are gated on `--option listing on`, which the `fast` preset does not set.
- `Listing::build_with_meta` takes a `ListingDetail { assembly, refs }` in place of
  the lone `want_assembly` bool, so the argument that already skipped the
  disassembly text now skips the reference model on the same gate.
- The gate lives inside `WalkState::file_ref` rather than at its three call sites,
  so an edge kind added to the walk later inherits it.
- `has_refs()` mirrors `has_assembly()`, and `tail_call_entries` refuses a Listing
  that carries neither model instead of reading their absence as evidence: two of
  its four guards pass vacuously over an empty reference model and an empty
  mnemonic.
- No option and no DIV row: there is no output change to gate.

## The tests

- New `verify_listing_queries` case: a partition-only build walks identically to a
  full one — same instructions with the same extents, fall-through and classified
  flow, same `DiscoveredFunction` values, same executable ranges — files no
  references, and answers every xref query empty.
- New `verify_tailcallentry` case: that same build yields no tail-call entries.
  Without the precondition it accepts `0x8008058`, the shared epilogue the full
  build rejects.
- Output byte-identical on the 147 MB binary (stdout and stderr), on 7 binaries
  across 4 option sets, and for `decompile-all` on 3 and `xrefs` on 3. `kuna
  functions` carries no per-function budget; the whole-binary decompile surfaces
  under `--mode fast` carry a 10 s wall-clock one, so 4 of 2,233 A/B function pairs
  differ there, in both directions — a faster run finishing what a slower one
  abandoned. At `--max-fn-seconds 0` those surfaces are byte-identical too.
- `make test` 675/675, `make test-stages` 779/779, `make rust-test`, `make check-spec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtBJ5ecQSx3ApARyQzAsdA
