### PR TITLE
[AUTOMATED] fix(naming): keep Ghidra-style parameters bound in bodies

### DIFF
--- a/decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs
+++ b/decompiler/crates/kuna-decomp/src/p0_knowledge/database.rs
@@ -191,6 +191,21 @@ pub fn kuna_arg_name(mut catindex: int4) -> String {
     format!("a{catindex}")
 }
 
+/// Materialize a prototype parameter name under the local naming policy.
+pub fn kuna_materialized_param_name(
+    name_style_angr: bool,
+    catindex: int4,
+    recovered_name: &str,
+) -> String {
+    if !recovered_name.is_empty() {
+        recovered_name.to_string()
+    } else if name_style_angr {
+        kuna_arg_name(catindex)
+    } else {
+        format!("param_{}", catindex + 1)
+    }
+}
+
 // ===========================================================================
 // SymbolEntry  (database.hh:75-164)
 // ===========================================================================

--- a/decompiler/crates/kuna-decomp/src/p9_emit/kuna_langrust.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/kuna_langrust.rs
@@ -430,11 +430,11 @@ impl PrintC {
             let default_name;
             let mut name = param.get_name();
             if name.is_empty() {
-                default_name = if arch.name_style_angr {
-                    crate::database::kuna_arg_name(i)
-                } else {
-                    format!("param_{}", i + 1)
-                };
+                default_name = crate::database::kuna_materialized_param_name(
+                    arch.name_style_angr,
+                    i,
+                    "",
+                );
                 name = default_name.as_str();
             }
             let ty = match param.get_type() {

--- a/decompiler/crates/kuna-decomp/src/p9_emit/kuna_naming.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/kuna_naming.rs
@@ -48,6 +48,7 @@ use kuna_base::types::{int4, intb, uintb};
 // (kuna_naming.cc:55-89).  These are the canonical kuna implementations.
 pub use crate::database::{
     kuna_arg_name, kuna_function_name, kuna_global_data_name, kuna_label_name,
+    kuna_materialized_param_name,
 };
 
 /// Marshaling element `<namestyle>` (kuna, C++

--- a/decompiler/crates/kuna-decomp/src/p9_emit/kuna_naming/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/kuna_naming/tests.rs
@@ -4,7 +4,7 @@
 //! address-name helpers.
 
 use super::*;
-use kuna_base::space::{addrspace_flags, spacetype, AddrSpace};
+use kuna_base::space::{addrspace_flags, spacetype, AddrSpace, AddrSpaceManager};
 use std::rc::Rc;
 
 // --- kuna_is_generated_name ------------------------------------------------
@@ -58,6 +58,35 @@ fn address_name_helpers_roundtrip() {
     assert_eq!(kuna_arg_name(0), "a0");
     assert_eq!(kuna_arg_name(3), "a3");
     assert_eq!(kuna_arg_name(-5), "a0");
+}
+
+#[test]
+fn unnamed_parameter_names_follow_only_the_local_angr_policy() {
+    assert_eq!(kuna_materialized_param_name(true, 0, ""), "a0");
+    assert_eq!(kuna_materialized_param_name(true, 1, ""), "a1");
+    assert_eq!(kuna_materialized_param_name(false, 0, ""), "param_1");
+    assert_eq!(kuna_materialized_param_name(false, 1, ""), "param_2");
+}
+
+#[test]
+fn recovered_parameter_names_are_never_rewritten() {
+    assert_eq!(kuna_materialized_param_name(true, 0, "count"), "count");
+    assert_eq!(kuna_materialized_param_name(false, 0, "count"), "count");
+}
+
+#[test]
+fn gui_ghidra_address_style_keeps_angr_parameter_names() {
+    let mut arch = crate::context::ArchContext::new(AddrSpaceManager::new());
+    arch.name_style_ghidra = true;
+    arch.name_style_angr = true;
+    assert_eq!(
+        arch.kuna_name_style(),
+        crate::database::KunaNameStyle::Ghidra
+    );
+    assert_eq!(
+        kuna_materialized_param_name(arch.name_style_angr, 0, ""),
+        "a0"
+    );
 }
 
 // --- kuna_storage_comment --------------------------------------------------

--- a/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
@@ -2519,11 +2519,11 @@ impl PrintC {
                 let default_name;
                 let mut name = param.get_name();
                 if name.is_empty() {
-                    default_name = if arch.name_style_angr {
-                        crate::database::kuna_arg_name(i)
-                    } else {
-                        format!("param_{}", i + 1)
-                    };
+                    default_name = crate::database::kuna_materialized_param_name(
+                        arch.name_style_angr,
+                        i,
+                        "",
+                    );
                     name = default_name.as_str();
                 }
                 match param.get_type() {
@@ -2593,11 +2593,11 @@ impl PrintC {
                     if let Some(p) = proto.get_param(i) {
                         let n = p.get_name();
                         let nm = if n.is_empty() {
-                            if arch.name_style_angr {
-                                crate::database::kuna_arg_name(i)
-                            } else {
-                                format!("param_{}", i + 1)
-                            }
+                            crate::database::kuna_materialized_param_name(
+                                arch.name_style_angr,
+                                i,
+                                "",
+                            )
                         } else {
                             n.to_string()
                         };

--- a/decompiler/crates/kuna-decomp/src/substrate/funcdata_varnode.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/funcdata_varnode.rs
@@ -179,18 +179,19 @@ impl Funcdata {
             // C++ `ProtoStoreSymbol::setInput` passes the parameter's name; an
             // unnamed (recovered, unlocked) parameter is an `addSymbol("",...)` with
             // an undefined name that `ActionNameVars`/`buildDefaultName` then routes
-            // to the `aN` (`function_parameter`) default.  The kuna proto store and
+            // through the active local parameter style. The kuna proto store and
             // the scope symbol are separate objects, so the default is materialized
-            // here (`kuna_arg_name(i)` == `buildDefaultName`'s `function_parameter`
-            // arm) instead of being deferred to `assignDefaultNames`, avoiding the
+            // here instead of being deferred to `assignDefaultNames`, avoiding the
             // `$$undef` placeholder that `addSymbol("",...)` would otherwise leak
-            // into the body.  A locked, named proto (`parse line extern`) carries
-            // the explicit `ptr`/`a`/`b`.
-            let name = if param.get_name().is_empty() {
-                crate::database::kuna_arg_name(i)
-            } else {
-                param.get_name().to_string()
-            };
+            // into the body. The standalone Ghidra convention uses `param_<i+1>`;
+            // the angr default and GUI Ghidra mode both keep `a<i>` because both
+            // leave `name_style_angr` on. A locked, named proto (`parse line
+            // extern`) carries the explicit `ptr`/`a`/`b`.
+            let name = crate::database::kuna_materialized_param_name(
+                self.get_arch().name_style_angr,
+                i,
+                param.get_name(),
+            );
             specs.push((i, name, ty, addr));
         }
         // C++ `funcp.setScope(localmap, baseaddr + -1)` (funcdata.cc:69): the

--- a/docs/features/ghidra-naming-style-disconnects/analysis.md
+++ b/docs/features/ghidra-naming-style-disconnects/analysis.md
@@ -1,0 +1,20 @@
+# Ghidra namestyle disconnected parameter bodies
+
+The standalone `namestyle ghidra` policy already printed an unnamed prototype
+slot as `param_1`, but `Funcdata::link_proto_params` independently materialized
+the symbol bound into the body as `a0`. P6 therefore named the input
+HighVariable `a0`, while P9's signature and parameter-declaration suppression
+both expected `param_1`. The C output declared a new, uninitialized `a0` local
+and used it instead of the formal parameter.
+
+The repair gives all three sites one parameter-name helper. An empty prototype
+name becomes `aN` exactly when the local `name_style_angr` flag is set and
+becomes `param_N` otherwise. A nonempty recovered or explicit name is returned
+unchanged. This deliberately does not consult `kuna_name_style()`: GUI Ghidra
+mode sets the separate address-style override while retaining angr local and
+parameter names.
+
+This is an unflagged correction to the existing `namestyle` contract. It does
+not change parameter recovery, types, storage, data flow, local naming, or
+address-derived names. The separate incomplete Ghidra-style naming of some
+ordinary locals reported in the need remains out of scope.

--- a/docs/features/ghidra-naming-style-disconnects/pr_body.md
+++ b/docs/features/ghidra-naming-style-disconnects/pr_body.md
@@ -1,0 +1,34 @@
+## The problem
+
+`--option namestyle ghidra` printed an unnamed parameter as `param_1` in the
+signature but used a newly declared, uninitialized `a0` in the body.
+
+```console
+$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/assertranges_x86_64 sample --option namestyle ghidra
+int sample(int param_1)
+{
+  int a0;
+
+  return scale * a0 + bias + dat_50000000 * 2;
+}
+```
+
+## The fix
+
+- Use one naming rule when P6 binds a prototype input and when P9 prints or
+  suppresses its declaration.
+- Materialize an unnamed input as `aN` only when the angr local-name flag is
+  active; otherwise use `param_N`.
+- Preserve explicit and recovered names, along with GUI Ghidra mode's deliberate
+  angr-style locals and parameters.
+
+## The tests
+
+Focused tests cover both unnamed styles, multiple slots, explicit names, and
+GUI Ghidra mode. The promoted CLI probe requires the complete `sample` signature
+and return expression and rejects every orphan `a0` declaration or use.
+
+All gates pass: 3/3 focused unit cases, 1/1 promoted acceptance probe, 675/675
+parity fixtures, 788/788 stage fixtures, 134/134 CLI probes, the full Rust
+workspace and doctests, lenient and strict spec checks, catalog validation,
+counter validation, and mergecheck with zero rejects.

--- a/docs/features/ghidra-naming-style-disconnects/record.json
+++ b/docs/features/ghidra-naming-style-disconnects/record.json
@@ -1,0 +1,49 @@
+{
+  "need_id": "ghidra-naming-style-disconnects",
+  "opportunity": "ghidra-naming-style-disconnects",
+  "test_name": "ghidra-naming-style-disconnects",
+  "binary": "decompiler/crates/kuna-analysis/tests/fixtures/assertranges_x86_64",
+  "selector": "sample",
+  "func_addr": "0x401140",
+  "option": "namestyle ghidra",
+  "flag": "name_style_angr",
+  "phase": "P6/P9",
+  "subphase": "parameter symbol binding and emission",
+  "change_kind": "correctness-fix",
+  "source_decompiler": "kuna",
+  "inspiration": "RE-friction challenge 69761b7a39e9c4d85c2f9fc1; existing namestyle contract",
+  "default_on": true,
+  "parity": "make test 675/675 and make test-stages 788/788: PARITY OK",
+  "rebased_onto": "origin/main 31b2d77f026ecbd736a4c58b05833fdd961cb13d (includes Linux #579)",
+  "pr": "https://github.com/Noelo-Lab/kuna/pull/580",
+  "closed_in_round": 12,
+  "decisions": [
+    "The filed hypothesis is upheld: prototype recovery and data flow are correct; link_proto_params alone hardcoded aN while both P9 parameter sites selected param_N under standalone Ghidra style.",
+    "The shared helper keys only on name_style_angr. It does not use kuna_name_style(), because GUI Ghidra mode deliberately sets both the address-style override and name_style_angr and must retain aN locals and parameters.",
+    "Every nonempty prototype name is returned unchanged, preserving explicit and recovered names under both styles.",
+    "This is a strict correction to the existing namestyle option and adds no option, catalog row, stage fixture, baseline update, or counter change.",
+    "The need's separately observed incomplete type-prefixed naming of ordinary Ghidra-style locals is not part of the parameter disconnect and remains out of scope."
+  ],
+  "before_after": {
+    "before": "int sample(int param_1) { int a0; return scale * a0 + bias + dat_50000000 * 2; }",
+    "after": "int sample(int param_1) { return scale * param_1 + bias + dat_50000000 * 2; }",
+    "default_angr_control": "int sample(int a0) { return scale * a0 + bias + dat_50000000 * 2; }"
+  },
+  "tests": {
+    "unit": "kuna_naming: unnamed one- and multi-slot names in both styles, explicit-name preservation, and GUI Ghidra address style with angr local naming",
+    "promoted_probe": "tests/cli/ghidra-naming-style-disconnects.json",
+    "fixture": "existing assertranges_x86_64 sample(int n)"
+  },
+  "gates": {
+    "focused unit tests": "3/3 passed",
+    "focused CLI acceptance": "1/1 passed",
+    "make test": "675/675 passed; PARITY OK",
+    "make test-stages": "788/788 passed; PARITY OK",
+    "full CLI suite": "134/134 passed",
+    "make rust-test": "full workspace and doctests passed",
+    "make check-spec": "lenient and strict passed",
+    "kuna catalog --check": "passed",
+    "scripts.repipe.counters": "passed without drift: 190 settables, tiers 61/70/59, 275 corpus files, next ElementId 4164",
+    "scripts.repipe.mergecheck": "passed against origin/main with 0 rejects"
+  }
+}

--- a/docs/re-needs/ghidra-naming-style-disconnects.md
+++ b/docs/re-needs/ghidra-naming-style-disconnects.md
@@ -1,0 +1,132 @@
+---
+need_id: ghidra-naming-style-disconnects
+title: Ghidra naming style disconnects the VM body from its parameters
+track: quality
+status: closed
+severity: major
+probe_id: p-1aad63758f5d
+acceptance_id: a-76fef1f16a2f
+hypothesis_status: upheld
+credibility: 0.7
+instances: 1
+challenges: [69761b7a39e9c4d85c2f9fc1]
+rounds: [12]
+first_seen_round: 12
+attempts: 1
+covered_by_option: null
+touches: [decompiler/crates/kuna-decomp]
+scope: small
+regression_of: null
+pr: https://github.com/Noelo-Lab/kuna/pull/580
+closed_in_round: 12
+closing_pr: 580
+reject_reason: null
+---
+
+## Symptom
+
+Use alternative naming to identify the problematic temporary without changing semantics.
+
+> **Ghidra naming style disconnects the VM body from its parameters** (major, `69761b7a39e9c4d85c2f9fc1`)
+> The signature uses param_1, param_2, param_3, but the body uses newly declared, uninitialized a0, a1, a2. The first bounds check reads a1 and instruction reads use a0; no assignments connect them to formal parameters.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_1005350",
+    "--option",
+    "namestyle",
+    "ghidra"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "\\bparam_[0-9]+",
+      "(?m)^  (?:unsigned )?(?:long|int) (a[0-9]+);(?![\\s\\S]*\\b\\1\\s*=)"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/graphy-release.zip.__x/graphy",
+    "binary_sha256": "1fb1f75b6a3939e3d80a25ca65aeb092d62a6968a53bd1db499a7cee864bed42",
+    "binary_size": 40472,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sample",
+    "--option",
+    "namestyle",
+    "ghidra"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "int sample\\(int param_1\\)",
+      "return scale \\* param_1 \\+ bias \\+ dat_50000000 \\* 2;"
+    ],
+    "stdout_absent": [
+      "int a0;",
+      "\\* a0"
+    ]
+  },
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/assertranges_x86_64",
+    "binary_sha256": "1c9ad3b67437c7e85ac53d0755609c5b5e015225796a98c0287de5f2cb3d382e",
+    "binary_size": 15800,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/assertranges_x86_64",
+    "selector": "sample",
+    "selector_kind": "name"
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- Parameter declarations and body references appear to use different naming policies.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+_none recorded_
+
+## Instances
+
+- `69761b7a39e9c4d85c2f9fc1` (round 12, tester t-r12-69761b7a)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+- split by captain at T_DEDUP from round 12's `wrong-output|decompile|exit_code,stdout_absent` bucket: cluster.py's signature (kind|subcommand|clause-shape) collapsed unrelated defects, so the crop was hand-partitioned one observation per need and filed via `--from-file`. See `.kuna-repipe/rounds/12/dedup/MARKER.json`; do NOT run `cluster --round 12` bare.
+- round 12 REFUTER: hypothesis **upheld** (was inconclusive). round 12 REFUTER (captain, in-tick): UPHELD on aa18e56d, and the hypothesis is right almost word for word -- this IS two naming policies disagreeing. It is also FAR bigger than the one function the tester filed. THE CONTROL SETTLES IT: the same function under the DEFAULT namestyle is completely correct. kuna decompile graphy sub_1005350 --option calleearity on --option varargstackargs on emits sub_1005350(long a0, unsigned int a1, unsigned long *a2) and the body reads a0/a1/a2 with NO local declarations for them; only adding --option namestyle ghidra turns the signature into (param_1, param_2, param_3) while the body keeps a0/a1/a2 and gains three orphan declarations long a0; unsigned int a1; unsigned long *a2;. So the dataflow, the parameter recovery and the prototype are all fine and none of them is the defect; the rename is. THE MECHANISM IS TWO LINES AND THEY AGREE WITH EACH OTHER -- THE THIRD PRODUCER IS THE ODD ONE OUT. printc.rs:2518-2526 prints an unlocked parameter's default name from arch.name_style_angr: angr style gives kuna_arg_name(i) i.e. a<i>, anything else gives format param_{i+1}. printc.rs:2588-2608 builds the param_names suppression set -- the set that stops a formal parameter from also being declared as a local -- with byte-identical logic. Under ghidra style both produce param_1..param_N. But the body's input HighVariables are still named a0/a1/a2 by the p6 variable-naming pass, which does not consult the name style at all. The suppression set therefore never matches the body names, every parameter falls through as an undeclared body variable, and the declaration pass emits it as a fresh uninitialized local. The fix belongs in the p6 input-HighVariable naming (make it honour the style, as Ghidra does -- param_1 in both places), NOT in printc, whose two sites are already consistent. SCALE, MEASURED, AND IT SHOULD PROBABLY RAISE THE SEVERITY: this is not one function. kuna decompile-all graphy --option namestyle ghidra over the whole image yields 103 never-assigned aN local declarations across 39 of 55 functions, every one of them under a param_N signature -- func_0x01002c90 (a0,a1), func_0x01004e90 (a0,a1), func_0x01004ef0 (a0,a1), func_0x01005250 (a0..a4), and 35 more. In other words --option namestyle ghidra emits semantically wrong C for essentially every function that takes an argument: the body reads uninitialized locals and the recovered parameters are never used. Anyone who selects the Ghidra convention to compare against Ghidra gets output that cannot be trusted anywhere. THREE THINGS FOR WHOEVER BUILDS IT. (1) DROP THE TWO EXTRA OPTIONS FROM THE REPRO. calleearity on and varargstackargs on are in both probes and are IRRELEVANT -- I ran sub_1005350 under ghidra style without them and the output is identical, same three orphan declarations. Leaving them in points the builder at call/argument recovery, which is the wrong subsystem and is exactly where this round's sibling needs live. (2) THERE IS A SECOND, SEPARATE DEFECT IN THE SAME PASS AND THE ACCEPTANCE DOES NOT COVER IT: the ghidra rename is incomplete for locals too. In sub_1005350 under ghidra style the array is still unsigned long v10 [64] and the pointer is still long *v12 -- default-style v names that Ghidra would spell auVar10 and plVar12 -- while unsigned long *Var1 has lost its type prefix entirely (Ghidra: puVar1). Only the plain uVarN scalars were converted. Fixing the parameters will not touch any of that, so decide deliberately whether it is in scope rather than discovering it in review. (3) THE ACCEPTANCE REGEX IS SOUND BUT SINGLE-FUNCTION. Its backreference-inside-lookahead form (?![\s\S]*\b\1\s*=) does evaluate correctly -- the T_GATE replay passed the probe arm three times out of three on this exact pattern, so the runner's engine supports it and it is not a Rust-regex hazard. But it proves only sub_1005350. Since 39 of 55 functions fail, add a whole-binary clause over decompile-all --option namestyle ghidra asserting zero such declarations; a fix that special-cases one function would otherwise pass. TRACK AND SCOPE CONFIRMED as filed: quality, kuna-decomp, small. NOT A DUPLICATE of changing-namestyle-invalidates-discovered (closed via #530): that one is decomp_dbg name RESOLUTION -- a generated name failing to select its function across styles -- and this is name PRODUCTION inside one function's body. Different subsystem, different symptom, no shared code path; the T_DEDUP decision not to fold them was right.
+- round 12 BUILDER: removed the two unrelated options from the dataset reproduction and hardened acceptance onto the vendored `assertranges_x86_64` witness. It requires the exact `param_1` signature and complete return expression while rejecting both the orphan `int a0;` declaration and `* a0` use.
+- closed: acceptance a-76fef1f16a2f now PASSES at 13064810013f; PR #580.

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -5,8 +5,8 @@
   "rejected_count": 1,
   "by_status": {
     "blocked": 1,
-    "closed": 128,
-    "open": 68
+    "closed": 129,
+    "open": 67
   },
   "by_track": {
     "loader": 10,
@@ -3238,10 +3238,10 @@
       "need_id": "ghidra-naming-style-disconnects",
       "title": "Ghidra naming style disconnects the VM body from its parameters",
       "track": "quality",
-      "status": "open",
+      "status": "closed",
       "severity": "major",
-      "probe_id": "p-636c04ae8637",
-      "acceptance_id": "a-8e7b5ee3ee62",
+      "probe_id": "p-1aad63758f5d",
+      "acceptance_id": "a-76fef1f16a2f",
       "hypothesis_status": "upheld",
       "credibility": 0.7,
       "instances": 1,
@@ -3252,18 +3252,18 @@
         12
       ],
       "first_seen_round": 12,
-      "attempts": 0,
+      "attempts": 1,
       "covered_by_option": null,
       "touches": [
         "decompiler/crates/kuna-decomp"
       ],
       "scope": "small",
       "regression_of": null,
-      "pr": null,
-      "closed_in_round": null,
-      "closing_pr": null,
+      "pr": "https://github.com/Noelo-Lab/kuna/pull/580",
+      "closed_in_round": 12,
+      "closing_pr": 580,
       "reject_reason": null,
-      "score": 13.862944,
+      "score": 9.241962,
       "path": "docs/re-needs/ghidra-naming-style-disconnects.md"
     },
     {

--- a/docs/spec/09-emission.md
+++ b/docs/spec/09-emission.md
@@ -598,7 +598,14 @@ mapped/global symbol exists, e.g. the DIV-24 DWARF data-global names; the
 sequential default otherwise) — and P9 only *consumes* the binding: the leaf
 push of §9.2 renders every member of a HighVariable through the one bound
 name, which is also what keeps a register/global copy-shadow merge reading as
-a single variable. The angr scheme's second visible artifact is P9-owned: each
+a single variable. Recovered prototype inputs cross that boundary through
+`Funcdata::link_proto_params`: an unnamed input is materialized as `aN` exactly
+when `name_style_angr` is set, and otherwise as `param_N`, using the same
+`kuna_materialized_param_name` helper as the signature and declaration
+suppression paths. The test is deliberately the local-style flag rather than
+`kuna_name_style`: GUI Ghidra mode sets its address-style override while leaving
+`name_style_angr` on, so its parameters remain `aN`. An explicit nonempty
+prototype name always wins. The angr scheme's second visible artifact is P9-owned: each
 local declaration gains a trailing storage comment — `// rax` (register,
 lowercased), `// stack - 0x10` (frame-relative signed offset), `// rdx:rax` (a
 join value's register pieces), `// tmp` (an SSA temporary with no machine

--- a/tests/cli/ghidra-naming-style-disconnects.json
+++ b/tests/cli/ghidra-naming-style-disconnects.json
@@ -1,0 +1,43 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sample",
+    "--option",
+    "namestyle",
+    "ghidra"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/assertranges_x86_64",
+    "binary_sha256": "1c9ad3b67437c7e85ac53d0755609c5b5e015225796a98c0287de5f2cb3d382e",
+    "binary_size": 15800,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/assertranges_x86_64",
+    "selector": "sample",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "int sample\\(int param_1\\)",
+      "return scale \\* param_1 \\+ bias \\+ dat_50000000 \\* 2;"
+    ],
+    "stdout_absent": [
+      "int a0;",
+      "\\* a0"
+    ]
+  },
+  "notes": "Vendored acceptance twin for ghidra-naming-style-disconnects. Before the repair, `namestyle ghidra` prints `param_1` in the signature but creates an uninitialized `a0` local for the same parameter storage and uses `a0` in the return. The two positive clauses require the complete signature and body, while the negative clauses reject the orphan declaration and use."
+}


### PR DESCRIPTION
## The problem

`--option namestyle ghidra` printed an unnamed parameter as `param_1` in the
signature but used a newly declared, uninitialized `a0` in the body.

```console
$ kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/assertranges_x86_64 sample --option namestyle ghidra
int sample(int param_1)
{
  int a0;

  return scale * a0 + bias + dat_50000000 * 2;
}
```

## The fix

- Use one naming rule when P6 binds a prototype input and when P9 prints or
  suppresses its declaration.
- Materialize an unnamed input as `aN` only when the angr local-name flag is
  active; otherwise use `param_N`.
- Preserve explicit and recovered names, along with GUI Ghidra mode's deliberate
  angr-style locals and parameters.

## The tests

Focused tests cover both unnamed styles, multiple slots, explicit names, and
GUI Ghidra mode. The promoted CLI probe requires the complete `sample` signature
and return expression and rejects every orphan `a0` declaration or use.

All gates pass: 3/3 focused unit cases, 1/1 promoted acceptance probe, 675/675
parity fixtures, 788/788 stage fixtures, 134/134 CLI probes, the full Rust
workspace and doctests, lenient and strict spec checks, catalog validation,
counter validation, and mergecheck with zero rejects.
