### PR TITLE
fix(assertions): bind named prototypes to resolved entries

### DIFF
--- a/decompiler/crates/kuna-console/src/assertions.rs
+++ b/decompiler/crates/kuna-console/src/assertions.rs
@@ -87,7 +87,7 @@ use kuna_decomp::dtype::Datatype;
 use kuna_decomp::fspec::{ParameterPieces, ProtoModel, PrototypePieces};
 use kuna_decomp::funcdata::Funcdata;
 
-use crate::engine::ConsoleProgram;
+use crate::engine::{ConsoleProgram, EntryLookupError, EntrySelector};
 use crate::grammar::DataOrg;
 
 /// One parsed assertion.  `raw` is the caller's own text, echoed back in the
@@ -544,11 +544,18 @@ fn with_semicolon(decl: &str) -> String {
 /// has been consulted.
 ///
 /// `<func>` is a NAME first — that is what every existing directive meant — and
-/// an ENTRY ADDRESS second.  An agent working on a stripped or import-heavy
-/// binary has the address long before it has a name it trusts, and the address
-/// form used to be accepted and then discarded: nothing is called
-/// `0x140003ddf`, so the by-name park landed on no symbol at all and the call
-/// site kept its recovered signature
+/// an ENTRY ADDRESS second.  A name which already resolves is canonicalized to
+/// its entry address before parking.  That is observable on an imported PE
+/// function: the IAT slot and the executable thunk carry the same name, but a
+/// direct call reaches only the thunk.  The shared entry resolver chooses that
+/// lone executable candidate and rejects genuinely ambiguous executable
+/// definitions.  A name which does not resolve stays pending by name, preserving
+/// the console's ability to state a prototype before symbols are loaded.
+///
+/// An agent working on a stripped or import-heavy binary has an address long
+/// before it has a name it trusts, and the address form used to be accepted and
+/// then discarded: nothing is called `0x140003ddf`, so the by-name park landed
+/// on no symbol at all and the call site kept its recovered signature
 /// (`docs/re-needs/accepted-sqrt-prototype-still.md`).
 ///
 /// Address is also the key the READ side already uses
@@ -592,12 +599,16 @@ pub(crate) fn resolve_proto_target(
     prog: &ConsoleProgram,
     func: &str,
 ) -> Result<ProtoTarget, String> {
-    let named = match prog.arch().symboltab.get_global_scope() {
-        Some(g) => prog.arch().symboltab.query_function_by_name(g, func).is_some(),
-        None => false,
-    };
-    if named {
-        return Ok(ProtoTarget::Named(func.to_string()));
+    match prog.resolve_entry(&EntrySelector::Name(func.to_string())) {
+        Ok(entry) => return Ok(ProtoTarget::At(entry.addr, entry.name)),
+        // An unresolved name is deliberately legal: it parks in the pending
+        // store for a symbol that may be loaded later. Keep going because a
+        // hexadecimal operand can still be the address form below.
+        Err(EntryLookupError::NotFound { .. }) => {}
+        // In particular, do not turn two executable definitions with the same
+        // name into an arbitrary global-scope choice. The public selector
+        // reports every candidate, which lets an agent retry with an address.
+        Err(err) => return Err(err.to_string()),
     }
     let hex = func.strip_prefix("0x").or_else(|| func.strip_prefix("0X"));
     let explicit = hex.is_some();

--- a/decompiler/crates/kuna-console/tests/verify_assertplane.rs
+++ b/decompiler/crates/kuna-console/tests/verify_assertplane.rs
@@ -73,6 +73,42 @@ fn decompile_with(directives: Vec<Directive>) -> Option<(String, Vec<Outcome>)> 
     Some((code, prog.assertion_outcomes()))
 }
 
+/// Load a durable analysis fixture with one option disabled before the commit.
+/// These are regression fences for the assertion plane itself, so a missing
+/// spec is a failure rather than a green skip.
+fn load_fixture(fixture: &str, disabled_option: &str) -> ConsoleProgram {
+    let root = repo_root();
+    let spec_roots = vec![root.join("specs").to_str().unwrap().to_string()];
+    let bin = root.join("decompiler/crates/kuna-analysis/tests/fixtures").join(fixture);
+    let mut prog = bootstrap_from_object(bin.to_str().unwrap(), "", &spec_roots)
+        .unwrap_or_else(|e| panic!(
+            "bootstrap {fixture} (build `.sla` with `make specs`): {}", e.explain()
+        ));
+    prog.arch_mut().set_kuna_option(disabled_option, "off")
+        .unwrap_or_else(|_| panic!("{disabled_option} is a registered option"));
+    prog.commit_pending_analysis().expect("analysis commit");
+    prog
+}
+
+fn decompile_fixture_with_prototype(
+    fixture: &str,
+    disabled_option: &str,
+    caller: u64,
+    target: &str,
+    decl: &str,
+) -> (String, Vec<Outcome>) {
+    let mut prog = load_fixture(fixture, disabled_option);
+    prog.set_assertions(vec![directive(
+        &format!("prototype {target} {decl}"),
+        Body::Prototype { func: target.into(), decl: decl.into() },
+    )]);
+    assertions::apply_program_scoped(&mut prog);
+    let entry = prog.resolve_entry(&EntrySelector::Numeric(caller))
+        .unwrap_or_else(|e| panic!("fixture caller at 0x{caller:x}: {e}"));
+    let funcs = decompile_targets(&mut prog, vec![entry], false, false, false);
+    (funcs[0].code.clone().unwrap_or_default(), prog.assertion_outcomes())
+}
+
 /// Every outcome is `applied`; panics naming the offender otherwise.
 fn all_applied(report: &[Outcome]) {
     for outcome in report {
@@ -578,6 +614,74 @@ fn an_address_form_prototype_reaches_a_callee_at_that_address() {
         code.contains("strcmp(a1,sneaky,"),
         "the declared third argument never reached the call site:\n{code}"
     );
+}
+
+/// A resolved name and its executable import veneer are one assertion target.
+/// The fixture also contains a same-named IAT slot, which the old global-scope
+/// query selected: the directive reported `applied` but retained one guessed
+/// argument. The disabled built-in table makes the assertion the only source.
+#[test]
+fn a_named_import_prototype_canonicalizes_to_its_executable_veneer() {
+    const FIXTURE: &str = "win32sigs_pe_i386.exe";
+    const CALLER: u64 = 0x401020;
+    const VENEER: u64 = 0x401010;
+    const DECL: &str = "void *LoadLibraryExW(wchar_t *name,void *file,unsigned int flags)";
+
+    let (named, named_report) = decompile_fixture_with_prototype(
+        FIXTURE, "win32sigs", CALLER, "LoadLibraryExW", DECL,
+    );
+    let (addressed, addressed_report) = decompile_fixture_with_prototype(
+        FIXTURE, "win32sigs", CALLER, &format!("0x{VENEER:x}"), DECL,
+    );
+    all_applied(&named_report);
+    all_applied(&addressed_report);
+    assert_eq!(named, addressed,
+        "the name and executable-veneer address must park the same prototype");
+    let call = named.lines().find(|line| line.contains("LoadLibraryExW("))
+        .unwrap_or_else(|| panic!("named assertion lost the call:\n{named}"));
+    assert_eq!(call.matches(',').count(), 2,
+        "the named prototype did not supply exactly three arguments: {call}");
+    assert!(!call.contains("LoadLibraryExW()"), "the call is still argumentless: {call}");
+}
+
+/// Executability only disambiguates an import slot from its code veneer. When
+/// an export and an import veneer with the same spelling are both executable,
+/// the caller must choose an address instead of receiving an arbitrary target.
+#[test]
+fn a_named_prototype_rejects_two_executable_candidates() {
+    let mut prog = load_fixture("libcsigs_pe_x86_64.exe", "libcsigs");
+    prog.set_assertions(vec![directive(
+        "prototype memcmp int memcmp(void *a,void *b,unsigned long n)",
+        Body::Prototype {
+            func: "memcmp".into(),
+            decl: "int memcmp(void *a,void *b,unsigned long n)".into(),
+        },
+    )]);
+    assertions::apply_program_scoped(&mut prog);
+    let report = prog.assertion_outcomes();
+    assert_eq!(report.len(), 1);
+    assert_eq!(report[0].status, "rejected", "{report:?}");
+    let detail = report[0].detail.as_deref().unwrap_or_default();
+    assert!(detail.contains("ambiguous"), "unhelpful rejection: {detail}");
+    assert!(detail.matches("synthetic 0x").count() >= 2,
+        "the rejection must identify both executable candidates: {detail}");
+}
+
+/// A true miss remains a pending by-name prototype for the interactive
+/// pre-symbol workflow. Existing unique names are exercised throughout this
+/// suite, including `authenticate` and the import-veneer case above.
+#[test]
+fn an_unresolved_name_remains_a_legal_pending_prototype() {
+    let mut prog = load_fixture("win32sigs_pe_i386.exe", "win32sigs");
+    prog.set_assertions(vec![directive(
+        "prototype future_symbol int future_symbol(char *value)",
+        Body::Prototype {
+            func: "future_symbol".into(),
+            decl: "int future_symbol(char *value)".into(),
+        },
+    )]);
+    assertions::apply_program_scoped(&mut prog);
+    all_applied(&prog.assertion_outcomes());
 }
 
 /// An explicitly `0x`-prefixed operand that starts no function is REJECTED with

--- a/docs/features/named-log-prototype-repair/pr_body.md
+++ b/docs/features/named-log-prototype-repair/pr_body.md
@@ -1,0 +1,39 @@
+## The problem
+
+A named prototype assertion could report `applied` while changing the wrong
+program entry. PE imports can expose the same name on a data-only IAT slot and
+an executable thunk; the old assertion resolver selected the first name match,
+even when calls targeted the thunk. Consequently the asserted signature did not
+reach those calls.
+
+## The fix
+
+Named prototype targets now go through `ConsoleProgram::resolve_entry`, the
+same public contract used by entry-selecting CLI surfaces. A name with one
+executable definition canonicalizes to that address and canonical name. Two
+executable definitions reject as ambiguous. A name not present in the program
+still remains pending for later discovery, and numeric target behavior is
+unchanged.
+
+This changes only assertion routing in the existing prototype source. It adds
+no option, phase, catalog element, fixture, database behavior, P6/P9 behavior,
+stage baseline, or history row.
+
+## The tests
+
+- A console integration test on the existing win32sigs PE fixture disables
+  built-in signatures and proves a named three-argument `LoadLibraryExW`
+  assertion produces byte-identical C to an address assertion at the executable
+  thunk (`0x401010`).
+- An overbreadth test on the existing libcsigs PE collision fixture proves two
+  same-named executable candidates reject with both addresses in the ambiguity
+  diagnostic.
+- The suite also pins unresolved-name pending behavior.
+- The promoted CLI probe passes 1/1 and fails against an unpatched build. The
+  focused console suite passes 29/29; the full Rust workspace exits 0; spec,
+  strict spec, catalog, counters, and mergecheck are clean.
+
+The restored durable dataset acceptance is hardened to require a rename-tolerant
+full assignment containing a nonempty `log(...)` call while retaining the
+`log(SUB84(` absence guard. It passes on the original PolyMLP.exe witness under
+its recomputed ID, `a-43296fdf37fe`.

--- a/docs/features/named-log-prototype-repair/record.json
+++ b/docs/features/named-log-prototype-repair/record.json
@@ -1,0 +1,60 @@
+{
+  "slug": "named-log-prototype-repair",
+  "need_id": "named-log-prototype-repair",
+  "track": "quality",
+  "scope": "small",
+  "round": 12,
+  "branch": "fix/named-log-prototype-repair",
+  "rebased_onto": "origin/main 7b9948f07af3fdf99b0ae88e6522d33069a9ff05 (#577, #579, and #580 preserved; #577's streamed-export changes are disjoint from assertion resolution)",
+  "summary": "Named prototype assertions now use ConsoleProgram's public entry resolver before being parked. When an import name denotes both a non-executable IAT slot and one executable veneer, the assertion is canonicalized to the veneer address and name; multiple executable definitions reject as ambiguous, while a genuinely unresolved name remains pending for later discovery. Numeric targets retain their existing address semantics.",
+  "decisions": [
+    {
+      "what": "reuse the public entry-selection contract",
+      "detail": "resolve_proto_target calls ConsoleProgram::resolve_entry with EntrySelector::Name. This keeps prototype assertions aligned with the CLI's alias, placeholder, executability, and ambiguity rules instead of growing a second symbol-ranking policy in the assertion plane."
+    },
+    {
+      "what": "canonicalize a resolved name to ProtoTarget::At",
+      "detail": "The resolved entry's address and canonical name are stored together. This prevents a same-named IAT slot from accepting the assertion while the actual call targets the executable import veneer. The win32sigs fixture proves that a named three-argument LoadLibraryExW assertion now emits byte-identical C to an explicit 0x401010 assertion."
+    },
+    {
+      "what": "fail closed on ambiguous executable definitions",
+      "detail": "Errors other than NotFound are returned to the assertion ledger. The libcsigs PE fixture contains a same-named export and import veneer; its named assertion is rejected and reports both executable candidates rather than choosing by accident."
+    },
+    {
+      "what": "preserve forward declarations",
+      "detail": "Only EntryLookupError::NotFound falls through to ProtoTarget::Named. Assertions for symbols that discovery has not created yet therefore remain legal and pending exactly as before. Existing numeric parsing is left below this lookup unchanged."
+    },
+    {
+      "what": "no phase, option, database, or baseline expansion",
+      "detail": "This is assertion-target routing in the existing P4 prototype source. It adds no option, catalog element, fixture, phase, database mutation, P6/P9 behavior, stage baseline, or history entry."
+    }
+  ],
+  "acceptance": {
+    "dataset_acceptance_id_after_hardening": "a-43296fdf37fe",
+    "dataset_status": "PASS on the original PolyMLP.exe dataset witness: scripts.repipe.verify reports 1 pass, 0 fail, with `v3 = v5 + log(v3 + v6);` satisfying the rename-tolerant full-assignment guard and `log(SUB84(` absent.",
+    "promoted_probe": "tests/cli/named-log-prototype-repair.json",
+    "promoted_probe_id": "a-20918fc99877",
+    "fixed_result": "PASS: JSON reports one applied assertion and the emitted call has three arguments.",
+    "negative_control": "The same promoted probe fails its stdout_matches clause against an unpatched build from the same pre-fix lineage, which emits the old under-parameterized call."
+  },
+  "tests": {
+    "focused": "cargo test -p kuna-console --test verify_assertplane -- --nocapture: 29 passed",
+    "promoted": "scripts.repipe.clitests --name named-log-prototype-repair --json: 1/1 passed",
+    "workspace": "cargo test --workspace --no-fail-fast on the immediately prior 7c890180 main: exit 0; all workspace and doc-test targets passed, with only their declared ignored tests. After the final 7b9948f rebase (#577 streamed project export), the touched code paths were audited as disjoint and the focused suite, release build, promoted probe, dataset acceptance, both spec modes, catalog, counters, and mergecheck were rerun and passed.",
+    "cli_sweep": "The debug-binary sweep passed 131/134 probes. The new probe passed. Two unrelated wall-time budgets were expectedly unsuitable for a debug binary; one unrelated 60-second probe timed out under concurrent load.",
+    "spec": "make check-spec and python3 tools/check_spec.py --strict: OK",
+    "catalog": "decompiler/target/debug/kuna catalog --check: OK",
+    "counters": "190 settables; tiers 61/70/59; stage corpus 275 (83 core + 192 stage); next ElementId 4164; no drift",
+    "mergecheck": "scripts.repipe.mergecheck against origin/main: ok=true, rejects=0; only pre-existing DIV-76/DIV-77 duplicate warnings"
+  },
+  "files": [
+    "decompiler/crates/kuna-console/src/assertions.rs",
+    "decompiler/crates/kuna-console/tests/verify_assertplane.rs",
+    "tests/cli/named-log-prototype-repair.json",
+    "docs/spec/00-overview.md",
+    "docs/features/named-log-prototype-repair/record.json",
+    "docs/features/named-log-prototype-repair/pr_body.md",
+    "docs/re-needs/named-log-prototype-repair.md",
+    "docs/re-needs/index.json"
+  ]
+}

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -5,8 +5,8 @@
   "rejected_count": 1,
   "by_status": {
     "blocked": 1,
-    "closed": 129,
-    "open": 67
+    "closed": 130,
+    "open": 66
   },
   "by_track": {
     "loader": 10,
@@ -3594,10 +3594,10 @@
       "need_id": "named-log-prototype-repair",
       "title": "Named log prototype does not repair the call through its PE thunk",
       "track": "quality",
-      "status": "open",
+      "status": "closed",
       "severity": "major",
       "probe_id": "p-eaee43130b01",
-      "acceptance_id": "a-ef3b3cdc4ea5",
+      "acceptance_id": "a-43296fdf37fe",
       "hypothesis_status": "upheld",
       "credibility": 0.85,
       "instances": 1,
@@ -3605,21 +3605,22 @@
         "69a54bd70f5b9757a6a5f72f"
       ],
       "rounds": [
-        9
+        9,
+        12
       ],
       "first_seen_round": 9,
-      "attempts": 0,
+      "attempts": 1,
       "covered_by_option": null,
       "touches": [
-        "decompiler/crates/kuna-decomp"
+        "decompiler/crates/kuna-console"
       ],
       "scope": "small",
       "regression_of": null,
-      "pr": null,
-      "closed_in_round": null,
-      "closing_pr": null,
+      "pr": "https://github.com/Noelo-Lab/kuna/pull/581",
+      "closed_in_round": 12,
+      "closing_pr": 581,
       "reject_reason": null,
-      "score": 13.862944,
+      "score": 9.241962,
       "path": "docs/re-needs/named-log-prototype-repair.md"
     },
     {

--- a/docs/re-needs/named-log-prototype-repair.md
+++ b/docs/re-needs/named-log-prototype-repair.md
@@ -1,0 +1,141 @@
+---
+need_id: named-log-prototype-repair
+title: Named log prototype does not repair the call through its PE thunk
+track: quality
+status: closed
+severity: major
+probe_id: p-eaee43130b01
+acceptance_id: a-43296fdf37fe
+hypothesis_status: upheld
+credibility: 0.85
+instances: 1
+challenges: [69a54bd70f5b9757a6a5f72f]
+rounds: [9, 12]
+first_seen_round: 9
+attempts: 1
+covered_by_option: null
+touches: [decompiler/crates/kuna-console]
+scope: small
+regression_of: null
+pr: https://github.com/Noelo-Lab/kuna/pull/581
+closed_in_round: 12
+closing_pr: 581
+reject_reason: null
+---
+
+## Symptom
+
+Recover the double-precision log input and result using the documented named prototype override.
+
+> **Named log prototype does not repair the call through its PE thunk** (major, `69a54bd70f5b9757a6a5f72f`)
+> Exits 0 but emits log(SUB84(...,0)); and then uses unassigned XMM0 halves. The inventory names both the thunk and import slot log. Applying the identical prototype to thunk address 0x14000904f repairs the call. Enabling calleearity and varargstackargs does not.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_140003150",
+    "--assert",
+    "prototype log double log(double x)"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "log\\(SUB84\\("
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/Release.zip.__x/PolyMLP.exe",
+    "binary_sha256": "01652e8b03e2bec127f5726320db4c9925d495d75583a8bb4534ac640f6ec230",
+    "binary_size": 54272,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "target": {
+    "binary_rel": "bin/Release.zip.__x/PolyMLP.exe",
+    "binary_sha256": "01652e8b03e2bec127f5726320db4c9925d495d75583a8bb4534ac640f6ec230",
+    "binary_size": 54272,
+    "binary_source": "dataset"
+  },
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "sub_140003150",
+    "--assert",
+    "prototype log double log(double x)"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "(?m)^\\s*[A-Za-z_][A-Za-z0-9_]*(?:\\[[^\\]\\n]+\\])?\\s*=\\s*[^;\\n]*\\blog\\(\\s*[^\\s);][^;\\n]*\\)[^;\\n]*;"
+    ],
+    "stdout_absent": [
+      "log\\(SUB84\\("
+    ]
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- The named override may bind only to the import slot without propagating to the identically named thunk.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+- `ida-decompile load target/Release.zip.__x/PolyMLP.exe` — Reference unavailable: server exited with status 1 before registering. No successful IDA comparison.
+
+## Instances
+
+- `69a54bd70f5b9757a6a5f72f` (round 9, tester t-r9-69a54bd7)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+- round 9 REFUTER: hypothesis **upheld** (was inconclusive). UPHELD, with the mechanism pinned by a single-variable control and one correction to the wording. Three runs on the arena binary (.kuna-repipe/arena/9/69a54bd70f5b9757a6a5f72f/target/Release.zip.__x/PolyMLP.exe), release kuna, function sub_140003150, only the assertion changing: (A) no assert -> 'log(SUB84(*(double *)((long long)v38 + (long long)v8 * 8) + v6,0));' [the bug]; (B) --assert 'prototype log double log(double x)' -> BYTE-IDENTICAL to (A), same 179 lines, same call line; (C) --assert 'prototype 0x14000904f double log(double x)' -> 'v3 = v5 + log(v3 + v6);' [correct, and the return value is now consumed]. So the by-name form is wholly inert while the by-address form on the same function repairs the call. WHICH SYMBOL IT LANDS ON, PROVEN: 'kuna functions --json' shows TWO FunctionSymbols named log -- the 33-byte thunk at 0x14000904f that every call targets, and the IAT slot at 0x14000a2d8 with size 0. Run (D) --assert 'prototype 0x14000a2d8 double log(double x)' reproduces (B) exactly: status applied, output identical to default. The name form resolves to the slot. CORRECTION TO THE FILED WORDING: 'binds only to the import slot without propagating to the thunk' is right about the destination but wrong to frame it as a propagation gap -- there is nothing to propagate. The read side (ActionDefaultParams -> callee_proto_pieces(entry_addr)) is keyed by the CALLEE ENTRY ADDRESS, and the call targets the thunk's entry, so a prototype parked on the slot is simply never consulted. SILENT-FAILURE HALF, WHICH THE FILING MISSES ENTIRELY: both (B) and (D) report status 'applied' in the --json assertions array with detail null. kuna tells the agent the override took effect when it changed nothing, so the tester's next three ablations (calleearity, varargstackargs) were spent on the wrong plane. Whatever the fix is, the assertion report must stop saying 'applied' for a prototype that reaches no call site. NOT A NEW GAP -- this is the residual of accepted-sqrt-prototype-still (closed by PR #470, round 3): #470 fixed the 0x-prefixed form (name first, entry address second, reject a 0x operand that starts no function) and left the by-NAME form still answering from the global scope, which on a PE import is the IAT slot. Same binary shape, different import. The builder should read assertions::resolve_proto_target and Architecture::set_function_prototype_pieces(name)/queryFunction(name); the address-keyed twin set_function_prototype_pieces_at already exists and is what DWARF/cppsig use. Obvious disambiguator: when a name matches more than one FunctionSymbol, prefer the entry that starts a body (thunk size 33 vs slot size 0), or apply to every match. Note this also reaches the library-prototype bootstrap pass (engine.rs step 5), which parks memcpy/malloc/log the same way. ACCEPTANCE IS WEAK, TIGHTEN BEFORE DISPATCH: it requires 'log\\(' present and 'log\\(SUB84\\(' absent, so an argumentless 'log()' -- the classic shape when a declared prototype reaches a call but argument recovery does not -- passes it. Require a non-empty argument, e.g. 'log\\([^)]' alongside the SUB84 absence.
+
+### 2026-09-08T06:05Z — captain, round 9 B_DRAIN: acceptance target bound
+
+The acceptance probe carried no `target`, so the suite could not resolve `{{BIN}}` and
+reported `ProbeError: {{BIN}} used but the context supplies no bin` — indeterminate rather
+than failing, and therefore unclosable by B_DONE however good a fix was. Bound to the
+challenge's own image (challenge `69a54bd7`, one image, no ambiguity):
+
+    bin/Release.zip.__x/PolyMLP.exe (54272 B, sha256 01652e8b…)
+
+Re-run through `verify --acceptance-suite --need named-log-prototype-repair` on the current build it now RUNS
+and FAILS, on the clause that carries the filed symptom:
+
+    stdout_absent[0] → actual "log(SUB84("
+
+Nothing about the probe's command or expectations was changed — only the target it
+resolves against.
+- round 10 CAPTAIN (18:45Z tick, B_DRAIN off-critical-path repair): REPRODUCTION ARM TARGET BOUND. This need's `## Acceptance` arm was already bound but its `## Reproduction` arm carried no `target` block, so the arm that is supposed to assert the bug EXISTS TODAY could not run (`ProbeError: {{BIN}} used but the context supplies no bin`). That never blocked B_DONE -- closure is gated on the ACCEPTANCE arm alone, measured -- but it blinded the refuter and the builder's reproduction step. Repaired by COPYING this need's own acceptance target verbatim, which is a copy and not a guess: the need has exactly one `challenges:` entry, so both arms necessarily address the same binary, and verify.resolve_binary treats a binary_sha256 mismatch as a hard stop. Measured after the write: the reproduction arm runs (unrunnable=false) and PASSES -- a passing reproduction arm means the defect still reproduces on main at b23e01ec, so this doubles as a re-confirmation that the symptom is live. Probe ids did NOT move (probe_id_of is keyed on cmd+expect only, needs.py:269; all 32 arms across the 16 repaired needs re-hashed byte-identically). PROMOTION CAVEAT unchanged: binary_source is `dataset` and `verify --promote` refuses that verbatim -- vendor an in-repo fixture in the SAME PR or B_DONE closes the need but cannot promote its probe.
+- round 12 BUILDER: named prototype assertions now resolve through `ConsoleProgram::resolve_entry`: a same-named IAT slot and lone executable thunk canonicalize to the thunk address, while two executable definitions reject as ambiguous and a genuinely unresolved name remains pending. Hardened the dataset acceptance from mere `log(` presence to a rename-tolerant complete assignment containing `log(nonempty arguments);`, while retaining the exact `log(SUB84(` absence guard. The command and dataset target are unchanged; the canonical acceptance id is `a-43296fdf37fe`. The in-repo promoted twin is `tests/cli/named-log-prototype-repair.json` (`a-20918fc99877`).
+- closed: acceptance a-43296fdf37fe now PASSES at 151300280020; PR #581.

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -1244,18 +1244,22 @@ parks the pieces under it; `parse line extern` keeps its upstream meaning.
 
 (kuna) **`<func>` is a name first and an ENTRY ADDRESS second.** Both surfaces
 resolve the operand through
-`decompiler/crates/kuna-console/src/assertions.rs (resolve_proto_target)`: a
-`FunctionSymbol` of that name wins, and failing that a hexadecimal operand that a
-function starts at binds by address. The address form exists because parking by
-name is not always expressible. The park is the callee's `FunctionSymbol`, and
-the READ side — `ArchContext::callee_proto_pieces`, which `ActionDefaultParams`
-consults per call site — is keyed by the callee's ENTRY ADDRESS, so a by-name
-park has to resolve to the same symbol the call reaches. A PE import thunk and
-the IAT slot it jumps to are two FunctionSymbols with the same name; the global
-by-name query answers with one of them while every call in the program targets
-the other, and the directive was accepted, reported `applied`, and read back as
-nothing (`docs/re-needs/accepted-sqrt-prototype-still.md`). Stating the address
-removes the ambiguity, and the park goes through
+`decompiler/crates/kuna-console/src/assertions.rs (resolve_proto_target)`. An
+existing name first goes through the same public `ConsoleProgram::resolve_entry`
+contract as decompilation: aliases canonicalize to their entry, a PE import
+slot/thunk pair narrows to its lone executable thunk, and two executable
+definitions are rejected as ambiguous rather than chosen by symbol-table order.
+The result parks by that entry address. An unresolved name stays pending by name,
+which preserves the console workflow where `map prototype main …` precedes the
+symbols it describes; failing that, a hexadecimal operand that a function starts
+at binds by address. The address form exists because parking by name is not
+always expressible. The park is the callee's `FunctionSymbol`, and the READ side
+— `ArchContext::callee_proto_pieces`, which `ActionDefaultParams` consults per
+call site — is keyed by the callee's ENTRY ADDRESS. Before this canonicalization,
+a PE import thunk and the IAT slot it jumps to were two FunctionSymbols with the
+same name, the global by-name query answered with the slot while every direct
+call targeted the thunk, and the directive was accepted, reported `applied`, and
+read back as nothing. An explicit address also goes through
 `Architecture::set_function_prototype_pieces_at`, the same address-keyed door the
 DWARF and demangled-signature passes use. `pieces.name` is set to the resolved
 function's own display name, so an address operand states a signature without

--- a/tests/cli/named-log-prototype-repair.json
+++ b/tests/cli/named-log-prototype-repair.json
@@ -1,0 +1,54 @@
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-20918fc99877",
+  "kind": "cli",
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/win32sigs_pe_i386.exe",
+    "binary_sha256": "5ee4b01f7352ab14e6c5a54010bd67206f355412421288d737f1a818dfe566d0",
+    "binary_size": 4608,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/win32sigs_pe_i386.exe",
+    "selector": "0x401020",
+    "selector_kind": "addr"
+  },
+  "timeout_s": 120,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x401020",
+    "--json",
+    "--option",
+    "win32sigs",
+    "off",
+    "--assert",
+    "prototype LoadLibraryExW void *LoadLibraryExW(wchar_t *name,void *file,unsigned int flags)"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_is_json": true,
+    "stdout_matches": [
+      "LoadLibraryExW\\([^,\\n]+,[^,\\n]+,[^,\\n]+\\);"
+    ],
+    "json": [
+      {
+        "path": "assertions",
+        "op": "len_eq",
+        "value": 1
+      },
+      {
+        "path": "assertions[0].status",
+        "op": "eq",
+        "value": "applied"
+      },
+      {
+        "path": "functions[0].code",
+        "op": "not_contains",
+        "value": "LoadLibraryExW()"
+      }
+    ]
+  },
+  "notes": "With win32sigs disabled, the named assertion is the only source of the three-argument prototype. The fixture has an executable veneer at 0x401010 and a same-named IAT slot; before this fix the assertion reported applied on the slot and retained one guessed argument. The console test also requires equality with the explicit 0x401010 assertion."
+}


### PR DESCRIPTION
## The problem

A named prototype assertion could report `applied` while changing the wrong
program entry. PE imports can expose the same name on a data-only IAT slot and
an executable thunk; the old assertion resolver selected the first name match,
even when calls targeted the thunk. Consequently the asserted signature did not
reach those calls.

## The fix

Named prototype targets now go through `ConsoleProgram::resolve_entry`, the
same public contract used by entry-selecting CLI surfaces. A name with one
executable definition canonicalizes to that address and canonical name. Two
executable definitions reject as ambiguous. A name not present in the program
still remains pending for later discovery, and numeric target behavior is
unchanged.

This changes only assertion routing in the existing prototype source. It adds
no option, phase, catalog element, fixture, database behavior, P6/P9 behavior,
stage baseline, or history row.

## The tests

- A console integration test on the existing win32sigs PE fixture disables
  built-in signatures and proves a named three-argument `LoadLibraryExW`
  assertion produces byte-identical C to an address assertion at the executable
  thunk (`0x401010`).
- An overbreadth test on the existing libcsigs PE collision fixture proves two
  same-named executable candidates reject with both addresses in the ambiguity
  diagnostic.
- The suite also pins unresolved-name pending behavior.
- The promoted CLI probe passes 1/1 and fails against an unpatched build. The
  focused console suite passes 29/29; the full Rust workspace exits 0; spec,
  strict spec, catalog, counters, and mergecheck are clean.

The restored durable dataset acceptance is hardened to require a rename-tolerant
full assignment containing a nonempty `log(...)` call while retaining the
`log(SUB84(` absence guard. It passes on the original PolyMLP.exe witness under
its recomputed ID, `a-43296fdf37fe`.
