### PR TITLE
[AUTOMATED] fix(analysis): discover stack-passed callbacks

### DIFF
--- a/decompiler/crates/kuna-analysis/src/analyzers/aif/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/aif/mod.rs
@@ -232,7 +232,7 @@ impl<'a> GapDecoder<'a> {
         }
         // `want_assembly = true`: the prologue fingerprint below is built from the
         // mnemonic text.
-        let decoded = decode_one(self.translate, vma, &self.code_space, true).ok()?;
+        let decoded = decode_one(self.translate, vma, &self.code_space, true, false).ok()?;
         if decoded.len == 0 {
             return None;
         }
@@ -391,6 +391,38 @@ fn check_valid_subroutine_strict(
         .map(|(body, _adds_info)| body)
 }
 
+/// A strict speculative instruction must fit wholly before the next known
+/// instruction start. Checking only `vma < gap_hi` lets a multi-byte decode
+/// overlap bytes the Listing already assigned to another instruction.
+fn strict_instruction_fits_gap(vma: u64, len: u32, gap_hi: u64) -> bool {
+    vma.checked_add(u64::from(len)).is_some_and(|end| end <= gap_hi)
+}
+
+pub(crate) fn validate_referenced_targets(
+    listing: &Listing,
+    translate: &dyn Translate,
+    code_space: Rc<AddrSpace>,
+    exec_ranges: &[(u64, u64)],
+    candidates: impl IntoIterator<Item = u64>,
+) -> Vec<u64> {
+    let mut decoder = GapDecoder::new(translate, code_space, exec_ranges);
+    let mut accepted = BTreeSet::new();
+    let mut claimed = BTreeSet::new();
+    for target in candidates {
+        if !listing.is_undefined(target) || claimed.contains(&target) {
+            continue;
+        }
+        let gap_hi = listing.next_instruction_start_after(target).unwrap_or(u64::MAX);
+        if let Some(body) =
+            check_valid_subroutine_strict(&mut decoder, listing, target, target, gap_hi)
+        {
+            accepted.insert(target);
+            claimed.extend(body);
+        }
+    }
+    accepted.into_iter().collect()
+}
+
 /// Returns `Some((body, corroborated))`. `corroborated` is Ghidra's `addsInfo`
 /// computed the upstream way — set by a CALL, or by a jump whose target is already a
 /// decoded instruction, and by nothing else. It is deliberately NOT the local
@@ -453,6 +485,9 @@ fn check_valid_subroutine_with_policy(
         let Some(insn) = decoder.probe(vma) else {
             return None;
         };
+        if strict && !strict_instruction_fits_gap(vma, insn.len, gap_hi) {
+            return None;
+        }
         body.insert(vma);
 
         if insn.is_terminal {
@@ -989,6 +1024,13 @@ mod tests {
         assert_eq!(FINGERPRINT_THRESHOLD, 4);
         assert_eq!(MIN_SUBROUTINE_INSNS, 3);
         assert_eq!(FINGERPRINT_INSNS, 2);
+    }
+
+    #[test]
+    fn strict_candidate_instruction_cannot_cross_into_known_code() {
+        assert!(strict_instruction_fits_gap(0x1000, 5, 0x1005));
+        assert!(!strict_instruction_fits_gap(0x1000, 6, 0x1005));
+        assert!(!strict_instruction_fits_gap(u64::MAX - 1, 4, u64::MAX));
     }
 
     #[test]

--- a/decompiler/crates/kuna-analysis/src/analyzers/fid/build.rs
+++ b/decompiler/crates/kuna-analysis/src/analyzers/fid/build.rs
@@ -228,7 +228,7 @@ fn decode_extent(
         guard -= 1;
 
         // `want_assembly = false`: the extent clip reads only `len` and `ops`.
-        let Ok(dec) = decode_one(translate, vma, code_space, false) else {
+        let Ok(dec) = decode_one(translate, vma, code_space, false, false) else {
             break; // an undecodable byte ends the clip
         };
         let len = dec.len.max(1); // never advance by 0 (avoid an infinite loop)

--- a/decompiler/crates/kuna-analysis/src/listing/decode.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/decode.rs
@@ -28,6 +28,49 @@ use super::model::RawOp;
 #[derive(Default)]
 struct OpCapture {
     ops: Vec<RawOp>,
+    /// Address-like constants written by a STORE's value input. On x86 this is
+    /// the p-code provenance of `PUSH imm`; a LOAD's space/address inputs and a
+    /// STORE's space/address inputs are deliberately not eligible.
+    stored_scalar_values: Vec<u64>,
+    /// Within-instruction COPY/extension provenance. SLEIGH lowers x86
+    /// `PUSH imm` through a unique temporary before STORE slot 2.
+    scalar_origins: Vec<(VarnodeData, u64)>,
+    want_stored_scalars: bool,
+}
+
+impl OpCapture {
+    fn scalar_origin(&self, vn: &VarnodeData) -> Option<u64> {
+        let space = vn.space.as_ref()?;
+        if space.get_type() == kuna_base::space::spacetype::IPTR_CONSTANT {
+            return Some(vn.offset);
+        }
+        self.scalar_origins
+            .iter()
+            .rev()
+            .find_map(|(defined, value)| (defined == vn).then_some(*value))
+    }
+
+    fn remember_scalar_origin(
+        &mut self,
+        opc: OpCode,
+        outvar: Option<&VarnodeData>,
+        vars: &[VarnodeData],
+    ) {
+        let Some(out) = outvar else { return };
+        self.scalar_origins.retain(|(defined, _)| defined != out);
+        if !matches!(opc, OpCode::CPUI_COPY | OpCode::CPUI_INT_ZEXT | OpCode::CPUI_INT_SEXT) {
+            return;
+        }
+        let Some(input) = vars.first() else { return };
+        let Some(mut value) = self.scalar_origin(input) else { return };
+        let bits = input.size.saturating_mul(8).min(64);
+        let mask = if bits == 64 { u64::MAX } else { (1u64 << bits) - 1 };
+        value &= mask;
+        if opc == OpCode::CPUI_INT_SEXT && bits != 0 && value & (1u64 << (bits - 1)) != 0 {
+            value |= !mask;
+        }
+        self.scalar_origins.push((out.clone(), value));
+    }
 }
 
 impl PcodeEmit for OpCapture {
@@ -35,10 +78,27 @@ impl PcodeEmit for OpCapture {
         &mut self,
         _addr: &Address,
         opc: OpCode,
-        _outvar: Option<&VarnodeData>,
+        outvar: Option<&VarnodeData>,
         vars: &[VarnodeData],
     ) {
         self.ops.push(RawOp { opcode: opc, in0: vars.first().cloned() });
+        if !self.want_stored_scalars {
+            return;
+        }
+        if opc != OpCode::CPUI_STORE {
+            self.remember_scalar_origin(opc, outvar, vars);
+            return;
+        }
+        // STORE(space, address, value): only the VALUE can be the immediate a
+        // PUSH places on the stack. In particular, `push [absolute]` first
+        // LOADs from that absolute address and STOREs a temporary; harvesting
+        // LOAD slot 1 would falsely turn the memory address into a callback.
+        let Some(vn) = vars.get(2) else { return };
+        if let Some(value) = self.scalar_origin(vn) {
+            if super::xrefs::looks_like_address(value) {
+                self.stored_scalar_values.push(value);
+            }
+        }
     }
 }
 
@@ -68,6 +128,9 @@ pub struct Decoded {
     pub mnemonic: String,
     /// The decoded operand body (the `body` half of `AssemblyEmit::dump`).
     pub operands: String,
+    /// Address-like constants materialized by this instruction, excluding
+    /// direct control-flow and memory-address operand slots.
+    pub stored_scalar_values: Vec<u64>,
 }
 
 /// Decode the instruction at `vma` (in `code_space`) by driving `translate`.
@@ -85,16 +148,19 @@ pub struct Decoded {
 /// instruction. Only the text-reading consumers need it (`noreturn_propagate`,
 /// `tailcallentry` and `poolentry` off [`super::Insn`], and the AIF prologue
 /// fingerprinter); pass `false` wherever only `len`/`ops` are read and the two
-/// text fields come back empty.
+/// text fields come back empty. `want_stored_scalars` selects the narrow x86
+/// callback provenance described by [`Decoded::stored_scalar_values`]; it is
+/// false for every caller except the x86 fast-discovery Listing walk.
 pub fn decode_one(
     translate: &dyn Translate,
     vma: u64,
     code_space: &Rc<AddrSpace>,
     want_assembly: bool,
+    want_stored_scalars: bool,
 ) -> KunaResult<Decoded> {
     let addr = Address::new(Rc::clone(code_space), vma);
 
-    let mut cap = OpCapture::default();
+    let mut cap = OpCapture { want_stored_scalars, ..OpCapture::default() };
     let len = translate.one_instruction(&mut cap, &addr)?;
 
     let mut asm = AsmCapture::default();
@@ -104,7 +170,15 @@ pub fn decode_one(
         let _ = translate.print_assembly(&mut asm, &addr);
     }
 
-    Ok(Decoded { len: len.max(0) as u32, ops: cap.ops, mnemonic: asm.mnemonic, operands: asm.operands })
+    cap.stored_scalar_values.sort_unstable();
+    cap.stored_scalar_values.dedup();
+    Ok(Decoded {
+        len: len.max(0) as u32,
+        ops: cap.ops,
+        mnemonic: asm.mnemonic,
+        operands: asm.operands,
+        stored_scalar_values: cap.stored_scalar_values,
+    })
 }
 
 /// The mnemonic at `vma` alone, for a consumer that has already decoded the
@@ -115,4 +189,101 @@ pub fn mnemonic_at(translate: &dyn Translate, vma: u64, code_space: &Rc<AddrSpac
     let mut asm = AsmCapture::default();
     let _ = translate.print_assembly(&mut asm, &addr);
     asm.mnemonic
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use kuna_base::error::KunaError;
+    use kuna_sleigh::globalcontext::ContextInternal;
+    use kuna_sleigh::loadimage::LoadImage;
+    use kuna_sleigh::sleigh::Sleigh;
+
+    use super::*;
+
+    struct MemImage {
+        base: u64,
+        bytes: Vec<u8>,
+    }
+
+    impl LoadImage for MemImage {
+        fn get_file_name(&self) -> &str {
+            "callback-decode"
+        }
+
+        fn load_fill(&mut self, ptr: &mut [u8], addr: &Address) -> KunaResult<()> {
+            for (i, byte) in ptr.iter_mut().enumerate() {
+                let vma = addr.get_offset().wrapping_add(i as u64);
+                *byte = vma
+                    .checked_sub(self.base)
+                    .and_then(|offset| self.bytes.get(offset as usize).copied())
+                    .unwrap_or(0);
+            }
+            Ok(())
+        }
+
+        fn get_arch_type(&self) -> Vec<u8> {
+            Vec::new()
+        }
+
+        fn adjust_vma(&mut self, _adjust: i64) {}
+    }
+
+    struct DummyImage;
+
+    impl LoadImage for DummyImage {
+        fn get_file_name(&self) -> &str {
+            "dummy"
+        }
+
+        fn load_fill(&mut self, _ptr: &mut [u8], _addr: &Address) -> KunaResult<()> {
+            Err(KunaError::data_unavail("dummy"))
+        }
+
+        fn get_arch_type(&self) -> Vec<u8> {
+            Vec::new()
+        }
+
+        fn adjust_vma(&mut self, _adjust: i64) {}
+    }
+
+    fn repo_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").canonicalize().unwrap()
+    }
+
+    fn x86(bytes: &[u8]) -> Option<(Sleigh, Rc<AddrSpace>)> {
+        let path = repo_root().join("specs/Ghidra/Processors/x86/data/languages/x86.sla");
+        let Ok(sla) = std::fs::read(&path) else {
+            eprintln!("callback decode tests: skipping (no `{}`; run `make specs`)", path.display());
+            return None;
+        };
+        let mut sleigh = Sleigh::new(Box::new(DummyImage), Box::new(ContextInternal::new()));
+        sleigh.initialize_from_sla(&sla).expect("initialize x86.sla");
+        sleigh.set_context_default("addrsize", 1);
+        sleigh.set_context_default("opsize", 1);
+        sleigh.set_loader(Box::new(MemImage { base: 0x1000, bytes: bytes.to_vec() }));
+        let ram = Rc::clone(sleigh.base().manager().get_space_by_name("ram").expect("ram space"));
+        Some((sleigh, ram))
+    }
+
+    #[test]
+    fn decoded_x86_push_immediate_harvests_the_stored_value() {
+        // `push 0x2000`: SUB ESP followed by STORE(space, ESP, 0x2000).
+        let Some((sleigh, ram)) = x86(&[0x68, 0x00, 0x20, 0x00, 0x00]) else { return };
+        let decoded = decode_one(&sleigh, 0x1000, &ram, true, true).unwrap();
+        assert_eq!(decoded.mnemonic, "PUSH");
+        assert_eq!(decoded.stored_scalar_values, vec![0x2000]);
+    }
+
+    #[test]
+    fn decoded_x86_push_absolute_memory_does_not_harvest_the_load_address() {
+        // `push dword ptr [0x2000]`: LOAD(space, 0x2000), then STORE the loaded
+        // temporary. The memory address is not the value pushed and must not be
+        // proposed as a callback.
+        let Some((sleigh, ram)) = x86(&[0xff, 0x35, 0x00, 0x20, 0x00, 0x00]) else { return };
+        let decoded = decode_one(&sleigh, 0x1000, &ram, true, true).unwrap();
+        assert_eq!(decoded.mnemonic, "PUSH");
+        assert!(decoded.stored_scalar_values.is_empty());
+    }
 }

--- a/decompiler/crates/kuna-analysis/src/listing/kuna_callbackentry.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/kuna_callbackentry.rs
@@ -1,0 +1,131 @@
+//! Executable-pointer callback roots passed on the x86 stack.
+//!
+//! An address materialized by reachable code is not by itself a function: it can
+//! be an integer, a label, or data embedded in an executable section. This pass
+//! admits only the stack-argument shape: a `PUSH <executable address>` reaches the
+//! next call through one straight-line run. The target must also be undefined in
+//! the current Listing and pass the bounded strict-subroutine validator before it
+//! is re-seeded by the caller.
+
+use super::Listing;
+
+const MAX_ARGUMENT_INSNS: usize = 16;
+/// Maximum unique `PUSH imm` targets retained by one Listing walk. This is
+/// intentionally larger than the total root-commit budget: invalid low-address
+/// candidates should not readily starve a later valid callback, while the side
+/// model remains bounded to a few thousand `(target, source)` pairs.
+pub(crate) const MAX_CALLBACK_EVIDENCE: usize = 4096;
+
+fn reaches_next_call(listing: &Listing, source: u64) -> bool {
+    let Some(source_insn) = listing.instruction_at(source) else {
+        return false;
+    };
+    let Some(mut next) = source_insn.fall_through else {
+        return false;
+    };
+    for _ in 0..MAX_ARGUMENT_INSNS {
+        let Some(insn) = listing.instruction_at(next) else {
+            return false;
+        };
+        if insn.flow.is_call {
+            return true;
+        }
+        if insn.flow.is_jump || insn.flow.is_terminal {
+            return false;
+        }
+        let Some(fall) = insn.fall_through else {
+            return false;
+        };
+        if fall != insn.addr.wrapping_add(u64::from(insn.len)) {
+            return false;
+        }
+        next = fall;
+    }
+    false
+}
+
+pub(crate) fn stack_callback_candidates(listing: &Listing) -> Vec<u64> {
+    let mut candidates = Vec::new();
+    for &(source, target) in listing.stack_callback_refs() {
+        if !reaches_next_call(listing, source) {
+            continue;
+        }
+        if listing.is_undefined(target) {
+            candidates.push(target);
+        }
+    }
+    candidates.sort_unstable();
+    candidates.dedup();
+    candidates
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::listing::{DiscoveredFunction, FlowKind, FlowType, Insn};
+
+    fn insn(addr: u64, len: u32, mnemonic: &str, call: bool) -> Insn {
+        Insn {
+            addr,
+            len,
+            fall_through: Some(addr + u64::from(len)),
+            flow: FlowType {
+                kind: if call {
+                    FlowKind::ComputedCall
+                } else {
+                    FlowKind::Fallthrough
+                },
+                is_call: call,
+                has_fallthrough: true,
+                ..FlowType::default()
+            },
+            flows: Vec::new(),
+            mnemonic: mnemonic.into(),
+            operands: String::new(),
+            pcode: None,
+        }
+    }
+
+    fn listing(target: u64, target_insn: Option<Insn>) -> Listing {
+        let mut insns = vec![
+            insn(0x2000, 5, "PUSH", false),
+            insn(0x2005, 6, "CALL", true),
+        ];
+        if let Some(target_insn) = target_insn {
+            insns.push(target_insn);
+        }
+        Listing::from_model_for_test(
+            insns,
+            vec![DiscoveredFunction {
+                entry: 0x2000,
+                name: None,
+                from_symbol: false,
+                has_no_return: false,
+                call_fixup: None,
+            }],
+            vec![(0x2000, target)],
+            vec![(0x1000, 0x3000)],
+        )
+    }
+
+    #[test]
+    fn pushed_executable_pointer_reaching_a_call_is_a_candidate() {
+        assert_eq!(
+            stack_callback_candidates(&listing(0x1000, None)),
+            vec![0x1000]
+        );
+    }
+
+    #[test]
+    fn instruction_interior_is_not_a_candidate() {
+        let covered = insn(0x1000, 8, "MOV", false);
+        assert!(stack_callback_candidates(&listing(0x1004, Some(covered))).is_empty());
+    }
+
+    #[test]
+    fn pushed_pointer_without_a_following_call_is_not_a_candidate() {
+        let mut model = listing(0x1000, None);
+        model.insns.remove(&0x2005);
+        assert!(stack_callback_candidates(&model).is_empty());
+    }
+}

--- a/decompiler/crates/kuna-analysis/src/listing/kuna_entrythumbflow.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/kuna_entrythumbflow.rs
@@ -199,7 +199,7 @@ fn walk_from_entry(
             return (painted, true);
         }
         visited.insert(addr);
-        let Ok(decoded) = decode_one(translate, addr, code_space, false) else {
+        let Ok(decoded) = decode_one(translate, addr, code_space, false, false) else {
             continue;
         };
         let Some(instruction_end) = addr.checked_add(u64::from(decoded.len)) else {

--- a/decompiler/crates/kuna-analysis/src/listing/mod.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/mod.rs
@@ -31,6 +31,7 @@
 pub mod classify;
 pub mod context;
 pub mod decode;
+pub mod kuna_callbackentry;
 pub mod kuna_entrythumbflow;
 pub mod kuna_tailcallentry;
 mod kuna_picbase;
@@ -51,6 +52,7 @@ use std::rc::Rc;
 
 use kuna_decomp::architecture::Architecture;
 use kuna_sleigh::translate::Translate;
+use object::Object;
 
 use crate::loadimage_object::ObjectLoadImage;
 
@@ -102,6 +104,8 @@ pub struct Listing {
     has_assembly: bool,
     /// Whether the reference model was built (vs. deliberately skipped).
     has_refs: bool,
+    /// Bounded, deduplicated x86 `PUSH imm` candidates collected for fast discovery.
+    stack_callback_refs: Vec<(u64, u64)>,
 }
 
 impl Listing {
@@ -148,6 +152,7 @@ impl Listing {
             exec_ranges,
             has_assembly: true,
             has_refs: false,
+            stack_callback_refs: Vec::new(),
         }
     }
 
@@ -205,6 +210,7 @@ impl Listing {
                     exec_ranges,
                     has_assembly: detail.assembly,
                     has_refs: false,
+                    stack_callback_refs: Vec::new(),
                 };
             }
         };
@@ -242,6 +248,8 @@ impl Listing {
         // not a function of its own. Empty on every other architecture and
         // whenever the option is off (see `kuna_ppclocalentry`).
         let local_entries = kuna_ppclocalentry::fold_map(arch, file, seeds);
+        let want_stack_callbacks = arch.analysis_fast_funcdisc
+            && matches!(file.architecture(), object::Architecture::I386 | object::Architecture::X86_64);
 
         let st = walk::walk(
             translate,
@@ -253,6 +261,7 @@ impl Listing {
             &painter,
             &local_entries,
             detail,
+            want_stack_callbacks,
         );
 
         let mut refs_to = st.refs_to;
@@ -274,6 +283,11 @@ impl Listing {
             exec_ranges,
             has_assembly: detail.assembly,
             has_refs: detail.refs,
+            stack_callback_refs: st
+                .stack_callback_refs
+                .into_iter()
+                .map(|(target, source)| (source, target))
+                .collect(),
         }
     }
 
@@ -291,6 +305,26 @@ impl Listing {
             exec_ranges: vec![(0, u64::MAX)],
             has_assembly,
             has_refs: false,
+            stack_callback_refs: Vec::new(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_model_for_test(
+        insns: Vec<Insn>,
+        funcs: Vec<DiscoveredFunction>,
+        stack_callback_refs: Vec<(u64, u64)>,
+        exec_ranges: Vec<(u64, u64)>,
+    ) -> Listing {
+        Listing {
+            insns: insns.into_iter().map(|i| (i.addr, i)).collect(),
+            refs_to: BTreeMap::new(),
+            refs_from: BTreeMap::new(),
+            funcs: funcs.into_iter().map(|f| (f.entry, f)).collect(),
+            exec_ranges,
+            has_assembly: true,
+            has_refs: false,
+            stack_callback_refs,
         }
     }
 
@@ -389,6 +423,10 @@ impl Listing {
     /// reader (AIF's prologue fingerprint) re-decodes the addresses it needs.
     pub fn has_assembly(&self) -> bool {
         self.has_assembly
+    }
+
+    pub(crate) fn stack_callback_refs(&self) -> &[(u64, u64)] {
+        &self.stack_callback_refs
     }
 
     /// The decoded instruction whose `[addr, addr+len)` byte span contains `vma`
@@ -606,6 +644,7 @@ mod tests {
             exec_ranges: Vec::new(),
             has_assembly: true,
             has_refs: true,
+            stack_callback_refs: Vec::new(),
         };
         let addrs = |start, end| {
             listing

--- a/decompiler/crates/kuna-analysis/src/listing/walk.rs
+++ b/decompiler/crates/kuna-analysis/src/listing/walk.rs
@@ -39,6 +39,12 @@ pub(super) struct WalkState {
     pub refs_from: BTreeMap<u64, Vec<Reference>>,
     /// Discovered/seeded functions, keyed by entry VMA (ordered).
     pub funcs: BTreeMap<u64, DiscoveredFunction>,
+    /// Plausible x86 `PUSH imm` callback evidence, keyed by target and bounded
+    /// during the walk. The value is the lowest source address for that target.
+    pub stack_callback_refs: BTreeMap<u64, u64>,
+    /// Stable sampling rank for each retained target. This prevents the bounded
+    /// model from systematically starving callbacks in a high-address section.
+    stack_callback_ranks: BTreeSet<(u64, u64)>,
     /// Whether [`WalkState::file_ref`] records anything at all.
     want_refs: bool,
 }
@@ -50,6 +56,8 @@ impl WalkState {
             refs_to: BTreeMap::new(),
             refs_from: BTreeMap::new(),
             funcs: BTreeMap::new(),
+            stack_callback_refs: BTreeMap::new(),
+            stack_callback_ranks: BTreeSet::new(),
             want_refs,
         }
     }
@@ -66,6 +74,35 @@ impl WalkState {
         self.refs_to.entry(to).or_default().push(r.clone());
         self.refs_from.entry(from).or_default().push(r);
     }
+
+    /// Record one already-proven `PUSH imm` site without letting a large image
+    /// accumulate an unbounded side model. Keeping the lowest source per target
+    /// deduplicates before storage. A stable hash rank samples across the address
+    /// space instead of systematically starving high-address sections, and makes
+    /// the cap deterministic regardless of recursive-descent worklist order.
+    fn file_stack_callback_ref(&mut self, source: u64, target: u64) {
+        if let Some(prior) = self.stack_callback_refs.get_mut(&target) {
+            *prior = (*prior).min(source);
+            return;
+        }
+        let rank = callback_rank(target);
+        self.stack_callback_refs.insert(target, source);
+        self.stack_callback_ranks.insert((rank, target));
+        if self.stack_callback_refs.len() > super::kuna_callbackentry::MAX_CALLBACK_EVIDENCE {
+            if let Some(worst) = self.stack_callback_ranks.pop_last() {
+                self.stack_callback_refs.remove(&worst.1);
+            }
+        }
+    }
+}
+
+/// SplitMix64's finalizer gives every target a stable, inexpensive sampling
+/// rank. This is not randomness: the same evidence set always retains the same
+/// targets, independent of discovery order.
+fn callback_rank(mut target: u64) -> u64 {
+    target = (target ^ (target >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    target = (target ^ (target >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    target ^ (target >> 31)
 }
 
 /// True if `vma` lands inside any executable range `[lo, hi)`.
@@ -110,6 +147,7 @@ pub(super) fn walk(
     painter: &ContextPainter,
     local_entries: &BTreeMap<u64, u64>,
     detail: ListingDetail,
+    want_stack_callbacks: bool,
 ) -> WalkState {
     // Paint the decode-mode context (ARM TMode / MIPS ISA_MODE) into the engine's
     // ContextDatabase BEFORE we decode a single instruction — the timing the
@@ -149,7 +187,13 @@ pub(super) fn walk(
                 continue; // out-of-bounds gate (flow.rs:891 analog)
             }
 
-            let decoded = match decode_one(translate, vma, code_space, detail.assembly) {
+            let decoded = match decode_one(
+                translate,
+                vma,
+                code_space,
+                detail.assembly,
+                want_stack_callbacks,
+            ) {
                 Ok(d) => d,
                 Err(_) => continue, // decode error: stop this path (mark gap)
             };
@@ -159,6 +203,28 @@ pub(super) fn walk(
 
             let c = classify(&decoded.ops, vma, decoded.len);
 
+            let fall_through = vma.wrapping_add(u64::from(decoded.len));
+            let stack_values: Vec<u64> = if want_stack_callbacks {
+                decoded
+                    .stored_scalar_values
+                    .iter()
+                    .copied()
+                    .filter(|&target| target != fall_through && in_exec(exec_ranges, target))
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            // A constant STORE value is the narrow p-code shape shared by
+            // `PUSH imm` and `MOV [mem],imm`. Only that shape earns the on-demand
+            // assembly parse; register immediates and absolute LOAD addresses do
+            // not trigger a second decode.
+            let mnemonic = if !stack_values.is_empty() && decoded.mnemonic.is_empty() {
+                super::decode::mnemonic_at(translate, vma, code_space)
+            } else {
+                decoded.mnemonic
+            };
+            let is_stack_callback_push = mnemonic.eq_ignore_ascii_case("PUSH");
+
             st.insns.insert(
                 vma,
                 Insn {
@@ -167,11 +233,17 @@ pub(super) fn walk(
                     fall_through: c.fall_through,
                     flow: c.flow,
                     flows: c.flows.clone(),
-                    mnemonic: decoded.mnemonic,
+                    mnemonic,
                     operands: decoded.operands,
                     pcode: None,
                 },
             );
+
+            if is_stack_callback_push {
+                for target in stack_values {
+                    st.file_stack_callback_ref(vma, target);
+                }
+            }
 
             // Successor edges.
             for &t in &c.flows {
@@ -215,5 +287,35 @@ fn discovered(entry: u64) -> DiscoveredFunction {
         from_symbol: false,
         has_no_return: false,
         call_fixup: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn callback_evidence_cap_is_deduplicated_and_order_independent() {
+        let count = super::super::kuna_callbackentry::MAX_CALLBACK_EVIDENCE + 32;
+        let mut forward = WalkState::new(false);
+        let mut reverse = WalkState::new(false);
+        for target in 0..count as u64 {
+            forward.file_stack_callback_ref(0x2000 + target, 0x1000 + target);
+        }
+        for target in (0..count as u64).rev() {
+            reverse.file_stack_callback_ref(0x3000 + target, 0x1000 + target);
+        }
+        assert_eq!(
+            forward.stack_callback_refs.len(),
+            super::super::kuna_callbackentry::MAX_CALLBACK_EVIDENCE
+        );
+        assert_eq!(
+            forward.stack_callback_refs.keys().collect::<Vec<_>>(),
+            reverse.stack_callback_refs.keys().collect::<Vec<_>>()
+        );
+
+        let retained = *forward.stack_callback_refs.keys().next().unwrap();
+        forward.file_stack_callback_ref(1, retained);
+        assert_eq!(forward.stack_callback_refs[&retained], 1);
     }
 }

--- a/decompiler/crates/kuna-analysis/src/passes.rs
+++ b/decompiler/crates/kuna-analysis/src/passes.rs
@@ -12,6 +12,7 @@
 use kuna_decomp::architecture::Architecture;
 use kuna_decomp::kuna_symbolnamechars::symbolnamechars_mode;
 use kuna_sleigh::translate::Translate;
+use object::Object;
 
 use crate::loadimage_object::ObjectLoadImage;
 use crate::pass::{run_analyses, AnalysisCtx, AnalysisOutput, AnalysisPass};
@@ -661,6 +662,61 @@ pub fn run_listing_consumers(
         &seed_names,
         detail,
     );
+    if arch.analysis_fast_funcdisc
+        && matches!(file.architecture(), object::Architecture::I386 | object::Architecture::X86_64)
+    {
+        // One initial walk plus at most four accepted callback generations. The
+        // witness needs two; four retains nested-registration headroom without
+        // allowing the old nine-full-walk worst case.
+        const MAX_CALLBACK_ROUNDS: usize = 4;
+        const MAX_CALLBACK_ROOTS: usize = 1024;
+        let mut callback_roots = 0usize;
+        let mut examined = std::collections::BTreeSet::new();
+        for _ in 0..MAX_CALLBACK_ROUNDS {
+            let Some(code_space) = arch.manage().get_default_code_space() else { break };
+            let candidates: Vec<u64> =
+                crate::listing::kuna_callbackentry::stack_callback_candidates(&listing)
+                    .into_iter()
+                    .filter(|target| examined.insert(*target))
+                    .collect();
+            if candidates.is_empty() {
+                break;
+            }
+            let accepted = crate::aif::validate_referenced_targets(
+                &listing,
+                translate,
+                std::rc::Rc::clone(code_space),
+                listing.exec_ranges(),
+                candidates,
+            );
+            if accepted.is_empty() {
+                break;
+            }
+            let remaining = MAX_CALLBACK_ROOTS.saturating_sub(callback_roots);
+            if remaining == 0 {
+                break;
+            }
+            let before = seeds.len();
+            seeds.extend(accepted.into_iter().take(remaining));
+            seeds.sort_unstable();
+            seeds.dedup();
+            let added = seeds.len() - before;
+            if added == 0 {
+                break;
+            }
+            callback_roots += added;
+            listing = crate::listing::Listing::build_with_meta(
+                &file,
+                image,
+                arch,
+                translate,
+                &seeds,
+                &funcsym_seeds,
+                &seed_names,
+                detail,
+            );
+        }
+    }
     // (kuna, Stage-2 ARM discovery) Raw, UNPAIRED Thumb-prologue gap seeding — the
     // angr `CFGFast._func_addrs_from_prologues()` mirror. After the first walk, scan
     // for canonical LR-saving Thumb prologues (`PUSH {..,lr}` / `PUSH.W {..,lr}`)

--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -57,6 +57,67 @@ fn arm_thumb_pe() -> String {
         .to_string()
 }
 
+fn dialog_callbacks_pe() -> String {
+    repo_root()
+        .join("decompiler/crates/kuna-analysis/tests/fixtures/stdcallpop_pe_i386.exe")
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+/// An executable callback pointer passed to DialogBoxParamA must seed the dialog
+/// procedure, and rebuilding from that procedure must discover its nested dialog
+/// callback in the same run.
+#[test]
+fn inventory_and_decompile_all_include_nested_dialog_callbacks() {
+    let bin = dialog_callbacks_pe();
+    let sp = specs();
+    let (inventory, stderr, ok) =
+        run_kuna(&["functions", &bin, "--json", "--sleighpath", &sp]);
+    assert!(ok, "kuna functions failed: {stderr}");
+    assert!(
+        inventory.contains("\"address_hex\": \"0x401000\"")
+            && inventory.contains("\"address_hex\": \"0x401410\""),
+        "nested dialog callbacks are absent from the inventory: {inventory}"
+    );
+    let parent = inventory
+        .find("\"address_hex\": \"0x4013e0\"")
+        .map(|start| &inventory[start..inventory.len().min(start + 240)])
+        .expect("parent function 0x4013e0 is absent");
+    assert!(
+        (41..=48).any(|size| parent.contains(&format!("\"size\": {size}"))),
+        "the parent extent still covers its callback: {parent}"
+    );
+
+    let (without, stderr, ok) = run_kuna(&[
+        "functions",
+        &bin,
+        "--json",
+        "--sleighpath",
+        &sp,
+        "--option",
+        "fast_funcdisc",
+        "off",
+    ]);
+    assert!(ok, "kuna functions with fast_funcdisc off failed: {stderr}");
+    assert!(
+        !without.contains("\"address_hex\": \"0x401000\"")
+            && !without.contains("\"address_hex\": \"0x401410\""),
+        "fast_funcdisc off no longer restores the prior inventory: {without}"
+    );
+
+    let (whole, stderr, ok) =
+        run_kuna(&["decompile-all", &bin, "--json", "--sleighpath", &sp]);
+    assert!(ok, "kuna decompile-all failed: {stderr}");
+    for (address, body) in [("0x401000", "sub_401000"), ("0x401410", "sub_401410")] {
+        assert!(
+            whole.contains(&format!("\"address_hex\": \"{address}\""))
+                && whole.contains(body),
+            "decompile-all omitted callback {address}: {whole}"
+        );
+    }
+}
+
 fn write_thumb_te() -> PathBuf {
     let bytes = kuna_analysis::loadimage_te::synthetic::TeImage::thumb(&[0x07, 0x20, 0x70, 0x47]).build();
     let path = common::scratch_file("cli-thumb", "te");

--- a/decompiler/crates/kuna-cli/tests/decompile_project_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_project_cli.rs
@@ -807,6 +807,33 @@ fn streamed_artifacts_match_the_non_stream_export() {
     }
 }
 
+/// Streamed project selection reads the same discovered inventory as
+/// `functions` and `decompile-all`, including callbacks found by a later
+/// discovery round.
+#[test]
+fn streamed_project_can_select_nested_dialog_callbacks() {
+    let Some(dir) = stream_project(
+        "stdcallpop_pe_i386.exe",
+        "stream_dialog_callbacks",
+        &["--functions", "sub_401000,sub_401410"],
+    ) else {
+        return;
+    };
+    let c = std::fs::read_to_string(dir.join("stdcallpop_pe_i386.exe.c")).unwrap();
+    for (address, name) in [("0x401000", "sub_401000"), ("0x401410", "sub_401410")] {
+        assert!(
+            c.contains(&format!("// Function: {name} @ {address}")),
+            "streamed project omitted discovered callback {address}:\n{c}"
+        );
+    }
+    assert_eq!(
+        std::fs::read_to_string(dir.join("index.jsonl")).unwrap().lines().count(),
+        2,
+        "selected callbacks must produce exactly two stream records"
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
 /// The point of the feature: the entry point and what it reaches are written
 /// first, ahead of functions that come earlier in address order.
 #[test]

--- a/docs/re-needs/function-inventory-omits-dialog.md
+++ b/docs/re-needs/function-inventory-omits-dialog.md
@@ -2,7 +2,7 @@
 need_id: function-inventory-omits-dialog
 title: Function inventory omits the dialog callback that xrefs recognizes
 track: quality
-status: open
+status: closed
 severity: major
 probe_id: p-5e71731ba9ec
 acceptance_id: a-5a48b22e4076
@@ -10,16 +10,16 @@ hypothesis_status: upheld
 credibility: 0.7
 instances: 1
 challenges: [5ab77f5d33c5d40ad448c6f6]
-rounds: [10]
+rounds: [10, 12]
 first_seen_round: 10
-attempts: 0
+attempts: 1
 covered_by_option: fast_funcdisc
 touches: [decompiler/crates/kuna-analysis]
 scope: small
 regression_of: null
-pr: null
-closed_in_round: null
-closing_pr: null
+pr: https://github.com/Noelo-Lab/kuna/pull/582
+closed_in_round: 12
+closing_pr: 582
 reject_reason: null
 ---
 
@@ -118,3 +118,4 @@ Ghidra 11.4 also omits both callbacks on this stripped witness. Recovering the s
 - round 10 B_DRAIN: both probe arms were bound to the dataset witness; CI promotion remained impossible while the target was dataset-only.
 - implementation triage: instruction-level Listing inspection overturned the proposed extent mechanism. The Listing leaves 0x401410 undefined after the parent's return; the 144-byte extent is assigned later and is not what suppresses discovery. The existing xref walk observes the pointer, but the discovery walk had no guarded consumer for executable scalar arguments. The vendored `stdcallpop_pe_i386.exe` is byte-identical to the witness (same SHA-256 and size), so both arms now use the in-repo fixture. Acceptance also pins the parent extent to 41..48 bytes and requires positive callback extents; CLI coverage requires unfiltered `decompile-all --json` to emit both callback bodies and streamed project selection to resolve both callbacks from the shared inventory.
 - adversarial implementation review: narrowed evidence to the value stored by a real x86 `PUSH` (including COPY/sign-extension provenance), explicitly excluding absolute LOAD/STORE addresses; bounded and deduplicated the side model to 4,096 targets with a deterministic address-space sample; capped cascading discovery at four generations and 1,024 roots; and made strict validation reject an instruction whose bytes cross into already-known code. Live SLEIGH tests pin `push imm` positive and `push [absolute]` negative behavior.
+- round 12 closure: PR #582 was opened from exact reviewed implementation head `10bf38abaafccdd3c97bf92d463d41d9970a0802`. The promoted acceptance passed in the 137/137 CLI corpus, both nested callbacks passed the whole-binary and streamed-project Rust tests, the default 36-PE differential sweep changed only this witness, and seven interleaved optimized runs on `/usr/bin/python3.11` preserved median peak RSS while showing no latency regression. Final merge remains gated on exact-head delta review and the `full-ci` workflow.

--- a/docs/re-needs/function-inventory-omits-dialog.md
+++ b/docs/re-needs/function-inventory-omits-dialog.md
@@ -1,0 +1,120 @@
+---
+need_id: function-inventory-omits-dialog
+title: Function inventory omits the dialog callback that xrefs recognizes
+track: quality
+status: open
+severity: major
+probe_id: p-5e71731ba9ec
+acceptance_id: a-5a48b22e4076
+hypothesis_status: upheld
+credibility: 0.7
+instances: 1
+challenges: [5ab77f5d33c5d40ad448c6f6]
+rounds: [10]
+first_seen_round: 10
+attempts: 0
+covered_by_option: fast_funcdisc
+touches: [decompiler/crates/kuna-analysis]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Include the callbacks at 0x401410 and 0x401000 in the application inventory and whole-binary decompilation.
+
+> **Function inventory omits the dialog callback that xrefs recognizes** (major, `5ab77f5d33c5d40ad448c6f6`)
+> functions returns 150 entries without 0x401410; filtering 401410 returns count 0. Yet xrefs identifies its to_function and the PUSH at 0x4013ed. Explicit address decompilation recovers the dialog handler successfully. The define-function interface works, so this is an automatic inventory inconsistency.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_absent": [
+      "\"address_hex\":\\s*\"0x401410\""
+    ]
+  },
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/stdcallpop_pe_i386.exe",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/stdcallpop_pe_i386.exe",
+    "binary_sha256": "78d28ec6d13b9c1634101e86b2042ed61560db31ba63705adfb2b75f5757b7b4",
+    "binary_size": 40960,
+    "binary_source": "in-repo"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "\"address_hex\":\\s*\"0x401000\"[\\s\\S]{0,240}\"size\":\\s*[1-9][0-9]*",
+      "\"address_hex\":\\s*\"0x4013e0\"[\\s\\S]{0,240}\"size\":\\s*4[1-8]",
+      "\"address_hex\":\\s*\"0x401410\"[\\s\\S]{0,240}\"size\":\\s*[1-9][0-9]*"
+    ]
+  },
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/stdcallpop_pe_i386.exe",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/stdcallpop_pe_i386.exe",
+    "binary_sha256": "78d28ec6d13b9c1634101e86b2042ed61560db31ba63705adfb2b75f5757b7b4",
+    "binary_size": 40960,
+    "binary_source": "in-repo"
+  }
+}
+```
+
+## Hypothesis
+
+Executable code-pointer operands that are passed as stack arguments should be promoted only after target-validity checks, then re-seeded so newly reached callback bodies can expose nested callbacks.
+
+## Refutation
+
+The earlier extent diagnosis was overturned. The Listing's flow walk leaves 0x401410 undefined after the parent returns; the later inventory extent is only a downstream size estimate. The xref walk already proves the address operand at 0x4013ed, but the discovery walk did not consume executable data references.
+
+## Reference
+
+Ghidra 11.4 also omits both callbacks on this stripped witness. Recovering the stack-passed callback chain is therefore a concrete Kuna completeness advantage rather than a parity repair.
+
+## Instances
+
+- `5ab77f5d33c5d40ad448c6f6` (round 10, tester t-r10-5ab77f5d)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+- round 10 REFUTER (2026-09-08): upheld the inventory inconsistency and initially attributed it to the parent function's reported 144-byte extent swallowing 0x401410. The refuter also identified 0x401000 as a second, cascading omission and warned that accepting 0x401410 alone would stop one link short.
+- round 10 T_TRIAGE: acceptance widened to require both cascading callback entries.
+- round 10 B_DRAIN: both probe arms were bound to the dataset witness; CI promotion remained impossible while the target was dataset-only.
+- implementation triage: instruction-level Listing inspection overturned the proposed extent mechanism. The Listing leaves 0x401410 undefined after the parent's return; the 144-byte extent is assigned later and is not what suppresses discovery. The existing xref walk observes the pointer, but the discovery walk had no guarded consumer for executable scalar arguments. The vendored `stdcallpop_pe_i386.exe` is byte-identical to the witness (same SHA-256 and size), so both arms now use the in-repo fixture. Acceptance also pins the parent extent to 41..48 bytes and requires positive callback extents; CLI coverage requires unfiltered `decompile-all --json` to emit both callback bodies and streamed project selection to resolve both callbacks from the shared inventory.
+- adversarial implementation review: narrowed evidence to the value stored by a real x86 `PUSH` (including COPY/sign-extension provenance), explicitly excluding absolute LOAD/STORE addresses; bounded and deduplicated the side model to 4,096 targets with a deterministic address-space sample; capped cascading discovery at four generations and 1,024 roots; and made strict validation reject an instruction whose bytes cross into already-known code. Live SLEIGH tests pin `push imm` positive and `push [absolute]` negative behavior.

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -5,8 +5,8 @@
   "rejected_count": 1,
   "by_status": {
     "blocked": 1,
-    "closed": 130,
-    "open": 66
+    "closed": 131,
+    "open": 65
   },
   "by_track": {
     "loader": 10,
@@ -3206,7 +3206,7 @@
       "need_id": "function-inventory-omits-dialog",
       "title": "Function inventory omits the dialog callback that xrefs recognizes",
       "track": "quality",
-      "status": "open",
+      "status": "closed",
       "severity": "major",
       "probe_id": "p-5e71731ba9ec",
       "acceptance_id": "a-5a48b22e4076",
@@ -3217,21 +3217,22 @@
         "5ab77f5d33c5d40ad448c6f6"
       ],
       "rounds": [
-        10
+        10,
+        12
       ],
       "first_seen_round": 10,
-      "attempts": 0,
+      "attempts": 1,
       "covered_by_option": "fast_funcdisc",
       "touches": [
         "decompiler/crates/kuna-analysis"
       ],
       "scope": "small",
       "regression_of": null,
-      "pr": null,
-      "closed_in_round": null,
-      "closing_pr": null,
+      "pr": "https://github.com/Noelo-Lab/kuna/pull/582",
+      "closed_in_round": 12,
+      "closing_pr": 582,
       "reject_reason": null,
-      "score": 13.862944,
+      "score": 9.241962,
       "path": "docs/re-needs/function-inventory-omits-dialog.md"
     },
     {

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -3209,7 +3209,7 @@
       "status": "open",
       "severity": "major",
       "probe_id": "p-5e71731ba9ec",
-      "acceptance_id": "a-3cebdc5e1843",
+      "acceptance_id": "a-5a48b22e4076",
       "hypothesis_status": "upheld",
       "credibility": 0.7,
       "instances": 1,
@@ -3221,9 +3221,9 @@
       ],
       "first_seen_round": 10,
       "attempts": 0,
-      "covered_by_option": null,
+      "covered_by_option": "fast_funcdisc",
       "touches": [
-        "decompiler/crates/kuna-decomp"
+        "decompiler/crates/kuna-analysis"
       ],
       "scope": "small",
       "regression_of": null,

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -2689,12 +2689,33 @@ candidate cannot split them. ARM instead reuses the existing Thumb-pointer
 oracle: an aligned odd code pointer is accepted only at an undefined
 frame-establishing prologue that passes the same valid-subroutine probe.
 
-Pointer-derived roots are committed but are deliberately not fed through a
+Table-derived roots are committed but are deliberately not fed through a
 second recursive walk. Thus the bounded path obtains direct-call closure and
 high-confidence callback/vtable roots while avoiding the full prologue scan,
 the AIF cursor over every undefined code gap, and recursive expansion from
 disconnected pointer roots. Turning on `fast_funcdisc` alone does not run no-return, FID, AIF, or any
 other ordinary Listing consumer.
+
+Executable-section operands use a narrower rule because instruction immediates
+are not pointer tables. On x86, the walk records an address-like executable
+constant only when p-code stores that constant as the instruction's value (not
+as a LOAD/STORE address); it is promoted when the instruction is `PUSH`, a
+straight-line run of at most sixteen instructions reaches the next call, the
+target is not an existing instruction or an interior instruction byte, and the
+strict bounded subroutine probe reaches a valid termination. Accepted stack
+callback roots are added to the Listing seeds and the walk is rebuilt, up to
+four rounds and 1,024 roots, so a dialog callback that registers a second
+callback contributes both bodies to one project inventory. Other code-looking
+immediates, targets already claimed by a body, and targets that only happen to
+decode without a valid return path remain unpromoted.
+
+Candidate provenance is deduplicated by target before storage and bounded to
+4,096 target/source pairs per walk. Only a constant STORE value earns the
+on-demand mnemonic decode, preserving the reference-free Listing detail used by
+fast discovery. A stable hash rank samples the bounded set across the address
+space without traversal-order or low-address bias; the root budget and
+four-generation limit still prefer bounded load time over complete recovery of
+adversarially deep or unusually callback-dense registration graphs.
 
 The full Listing **consumers** run over the built model and are individually gated before
 invocation (with the commit gate retained defensively): the

--- a/tests/cli/function-inventory-omits-dialog.json
+++ b/tests/cli/function-inventory-omits-dialog.json
@@ -1,0 +1,38 @@
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-5a48b22e4076",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "functions",
+    "{{BIN}}",
+    "--json"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/stdcallpop_pe_i386.exe",
+    "binary_sha256": "78d28ec6d13b9c1634101e86b2042ed61560db31ba63705adfb2b75f5757b7b4",
+    "binary_size": 40960,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/stdcallpop_pe_i386.exe",
+    "selector": null,
+    "selector_kind": "none"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "\"address_hex\":\\s*\"0x401000\"[\\s\\S]{0,240}\"size\":\\s*[1-9][0-9]*",
+      "\"address_hex\":\\s*\"0x4013e0\"[\\s\\S]{0,240}\"size\":\\s*4[1-8]",
+      "\"address_hex\":\\s*\"0x401410\"[\\s\\S]{0,240}\"size\":\\s*[1-9][0-9]*"
+    ]
+  },
+  "notes": "Promoted acceptance of function-inventory-omits-dialog on its byte-identical vendored PE. It requires both nested DialogBoxParamA callbacks and positive extents, while the parent 0x4013e0 must end before 0x401410. The Rust CLI test separately proves unfiltered decompile-all emits both callback bodies."
+}


### PR DESCRIPTION
## Summary

- discover x86 callbacks passed as immediate stack arguments to a subsequent call
- validate callback candidates strictly and re-seed nested callback generations with bounded work
- keep fast discovery's reference-free Listing path and reject absolute-memory load addresses
- close the function-inventory dialog witness with CLI, project-stream, live-SLEIGH, and boundary tests

## Verification

- `make rust-test`
- `make test` — 675/675, baseline parity
- `make test-stages` — 788/788, baseline parity
- `make test-cli` — 137/137
- `make check-spec`
- `kuna catalog --check`
- `scripts.repipe.counters --fix` — no drift
- `scripts.repipe.mergecheck --against origin/main` — 0 rejects
- 36-fixture PE differential sweep against exact parent `71b0fb66`: only the intended dialog witness changes in default mode (150 → 153)
- seven interleaved optimized `/usr/bin/python3.11` fast-mode runs: parent median 2.63 s / 247,936 KiB; candidate 2.37 s / 247,936 KiB

## Result

The default inventory now includes `0x401410` and its nested callback `0x401000`; disabling `fast_funcdisc` restores the exact 150-function parent inventory.
