### PR TITLE
[AUTOMATED] fix(decomp): preserve typed indirect tail-call arguments

### DIFF
--- a/decompiler/crates/kuna-cli/tests/typed_macho_tail_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/typed_macho_tail_cli.rs
@@ -1,0 +1,183 @@
+//! End-to-end regression for an import veneer whose whole body is
+//! `jmp qword ptr [slot]`: the slot's callable type/prototype must seed the
+//! CALLIND before parameter recovery, without treating arbitrary data as code.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+const STUB: &str = "0x1000005cc";
+const SLOT: &str = "0x100003000";
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .canonicalize()
+        .unwrap()
+}
+
+fn fixture() -> String {
+    repo_root()
+        .join("decompiler/crates/kuna-analysis/tests/fixtures/macho_imports")
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+fn specs() -> String {
+    repo_root().join("specs").to_str().unwrap().to_string()
+}
+
+fn run(args: &[&str]) -> (String, String, bool) {
+    let out = Command::new(env!("CARGO_BIN_EXE_kuna"))
+        .env_remove("KUNA_DECOMP_DBG")
+        .env_remove("KUNA_DECOMP_TEST")
+        .env_remove("KUNA_SLACOMP")
+        .args(args)
+        .output()
+        .expect("run kuna");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.success(),
+    )
+}
+
+fn is_specs_skip(stderr: &str) -> bool {
+    stderr.contains("could not build an architecture")
+        || stderr.contains("SLEIGH")
+        || stderr.contains("Could not discover")
+}
+
+#[test]
+fn explicit_function_pointer_prototype_types_the_tail_call() {
+    let bin = fixture();
+    let sp = specs();
+    let prototype = format!("prototype {STUB} int printf(char *fmt,int value)");
+    let data = format!("data {SLOT} int (*printf_ptr)(char *,int)");
+    let (stdout, stderr, ok) = run(&[
+        "decompile",
+        &bin,
+        "printf",
+        "--sleighpath",
+        &sp,
+        "--assert",
+        &prototype,
+        "--assert",
+        &data,
+        "--assert-strict",
+    ]);
+    if !ok && is_specs_skip(&stderr) {
+        eprintln!("typed_macho_tail_cli: skipping (no `.sla`): {stderr}");
+        return;
+    }
+    assert!(ok, "explicit typed decompile failed: {stderr}");
+    assert!(
+        stdout.contains("int printf(char *fmt,int value)")
+            && stdout.contains("(*printf_ptr)(fmt,value)"),
+        "the function-pointer prototype did not reach the CALLIND:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("(*printf_ptr)()"),
+        "the typed call stayed empty:\n{stdout}"
+    );
+}
+
+#[test]
+fn non_callable_slot_declarations_do_not_clone_the_current_function_prototype() {
+    let bin = fixture();
+    let sp = specs();
+    let prototype = format!("prototype {STUB} int printf(char *fmt,int value)");
+    for declaration in [
+        format!("data {SLOT} long printf_slot"),
+        format!("data {SLOT} long *printf_slot"),
+        format!("data {SLOT} code printf_slot"),
+        format!("data {SLOT} code *printf_slot"),
+    ] {
+        let (stdout, stderr, ok) = run(&[
+            "decompile",
+            &bin,
+            "printf",
+            "--sleighpath",
+            &sp,
+            "--assert",
+            &prototype,
+            "--assert",
+            &declaration,
+            "--assert-strict",
+        ]);
+        if !ok && is_specs_skip(&stderr) {
+            eprintln!("typed_macho_tail_cli: skipping (no `.sla`): {stderr}");
+            return;
+        }
+        assert!(ok, "negative control rejected {declaration:?}: {stderr}");
+        assert!(
+            stdout.contains("int printf(char *fmt,int value)"),
+            "the current prototype was not installed:\n{stdout}"
+        );
+        assert!(
+            stdout.contains(")(); // jump-as-call"),
+            "a non-callable slot declaration supplied arguments ({declaration:?}):\n{stdout}"
+        );
+        assert!(
+            !stdout.contains("(fmt,value); // jump-as-call"),
+            "the resolver cloned the current function prototype ({declaration:?}):\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn default_single_batch_and_project_surfaces_keep_the_import_argument() {
+    let bin = fixture();
+    let sp = specs();
+
+    let (single, stderr, ok) = run(&["decompile", &bin, "printf", "--sleighpath", &sp]);
+    if !ok && is_specs_skip(&stderr) {
+        eprintln!("typed_macho_tail_cli: skipping (no `.sla`): {stderr}");
+        return;
+    }
+    assert!(ok, "single decompile failed: {stderr}");
+    assert!(
+        single.contains("(*dat_100003000)(a0)"),
+        "single call lost a0:\n{single}"
+    );
+
+    let (batch, stderr, ok) = run(&[
+        "decompile-all",
+        &bin,
+        "--filter",
+        "^printf$",
+        "--sleighpath",
+        &sp,
+    ]);
+    assert!(ok, "batch decompile failed: {stderr}");
+    assert!(
+        batch.contains("(*dat_100003000)(a0)"),
+        "batch call lost a0:\n{batch}"
+    );
+
+    let out_dir = std::env::temp_dir().join(format!(
+        "kuna_typed_macho_tail_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let (_stdout, stderr, ok) = run(&[
+        "decompile-project",
+        &bin,
+        "--functions",
+        "printf",
+        "-o",
+        out_dir.to_str().unwrap(),
+        "--sleighpath",
+        &sp,
+    ]);
+    assert!(ok, "project decompile failed: {stderr}");
+    let c = std::fs::read_to_string(out_dir.join("macho_imports.c")).expect("project C artifact");
+    let _ = std::fs::remove_dir_all(&out_dir);
+    assert!(
+        c.contains("(*dat_100003000)(a0)"),
+        "project call lost a0:\n{c}"
+    );
+}

--- a/decompiler/crates/kuna-console/tests/verify_typed_macho_tail.rs
+++ b/decompiler/crates/kuna-console/tests/verify_typed_macho_tail.rs
@@ -1,0 +1,85 @@
+//! Precedence regression for the typed Mach-O import tail: a prototype forced
+//! at the CALLIND instruction must win over the callable type on its slot.
+
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use kuna_base::address::Address;
+use kuna_console::decompile_step::{decompile_one, DecompileSeed};
+use kuna_console::engine::{bootstrap_from_object, EntrySelector};
+use kuna_console::grammar::{parse_protopieces, DataOrg};
+use kuna_decomp::dtype::type_metatype;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .canonicalize()
+        .unwrap()
+}
+
+#[test]
+fn callsite_prototype_override_wins_over_slot_prototype() {
+    let root = repo_root();
+    let fixture = root.join("decompiler/crates/kuna-analysis/tests/fixtures/macho_imports");
+    let spec_roots = vec![root.join("specs").to_str().unwrap().to_string()];
+    let mut prog = match bootstrap_from_object(fixture.to_str().unwrap(), "", &spec_roots) {
+        Ok(prog) => prog,
+        Err(err) => {
+            eprintln!(
+                "verify_typed_macho_tail: skipping (no `.sla`): {}",
+                err.explain()
+            );
+            return;
+        }
+    };
+    prog.commit_pending_analysis().expect("analysis commit");
+    let entry = prog
+        .resolve_entry(&EntrySelector::Name("printf".to_string()))
+        .expect("printf stub entry");
+    let (addr_size, word_size) = prog.arch().data_org();
+    let override_pieces = parse_protopieces(
+        "int override(long x);",
+        prog.arch().types(),
+        DataOrg {
+            addr_size,
+            word_size,
+        },
+    )
+    .expect("override declaration");
+    let code = Rc::clone(prog.arch().manage().get_default_code_space().unwrap());
+    let callpoint = Address::new(code, 0x1000005cc);
+    let overrides = vec![(callpoint, override_pieces)];
+    let seed = DecompileSeed::plain(&[], &[]);
+    let step = decompile_one(
+        prog.arch_mut(),
+        &entry.name,
+        entry.addr,
+        entry.size as i32,
+        &seed,
+        &overrides,
+    );
+    let fd = step.result.expect("decompile printf stub");
+
+    assert_eq!(fd.num_calls(), 1, "the veneer should contain one CALLIND");
+    let call = fd.get_call_specs(0);
+    assert!(
+        call.is_input_locked(),
+        "call-site override must remain locked"
+    );
+    assert!(
+        !call.is_dotdotdot(),
+        "slot's variadic printf prototype replaced the override"
+    );
+    assert_eq!(call.proto().num_params(), 1);
+    let ty = call
+        .proto()
+        .get_param(0)
+        .and_then(|param| param.get_type())
+        .expect("override parameter");
+    assert_eq!(ty.get_metatype(), type_metatype::TYPE_INT);
+    assert_eq!(
+        ty.get_size(),
+        8,
+        "the `long` override, not slot `char *`, must win"
+    );
+}

--- a/decompiler/crates/kuna-decomp/src/p4_calls/coreaction_protos.rs
+++ b/decompiler/crates/kuna-decomp/src/p4_calls/coreaction_protos.rs
@@ -89,12 +89,55 @@
 
 use std::rc::Rc;
 
+use kuna_base::address::Address;
 use kuna_base::types::{int4, uintb};
 
 use kuna_num::opcodes::OpCode;
 
 use crate::action::{ruleflags, Action, ActionBase, ActionContext, ActionGroupList, ApplyResult};
 use crate::funcdata::Funcdata;
+
+/// Resolve only a literal memory slot feeding `CALLIND`.
+///
+/// SLEIGH may spell the dereference either as `LOAD(slot) -> CALLIND` or as an
+/// unwritten memory Varnode directly in input 0.  No COPY chasing or pointer
+/// arithmetic is accepted here: those shapes need type recovery and the later
+/// de-indirection restart contract.  This early query exists for import veneers
+/// whose complete body is one exact load+jump.
+fn exact_indirect_target_slot(
+    data: &Funcdata,
+    call_op: crate::context::OpId,
+) -> Option<(Address, int4)> {
+    let call = data.obank().get(call_op)?;
+    if call.code() != OpCode::CPUI_CALLIND {
+        return None;
+    }
+    let target = call.get_in(0)?;
+    let target_vn = data.vbank().get(target)?;
+    let Some(load_id) = target_vn.get_def() else {
+        if target_vn.is_constant() || target_vn.is_written() {
+            return None;
+        }
+        return Some((target_vn.get_addr().clone(), target_vn.get_size()));
+    };
+    let load = data.obank().get(load_id)?;
+    if load.code() != OpCode::CPUI_LOAD || load.get_out() != Some(target) {
+        return None;
+    }
+    let space_id = data.vbank().get(load.get_in(0)?)?;
+    let pointer = data.vbank().get(load.get_in(1)?)?;
+    if !space_id.is_constant() || !pointer.is_constant() {
+        return None;
+    }
+    let index = space_id.get_offset();
+    let manager = data.get_arch().manage();
+    if index >= manager.num_spaces() as u64 {
+        return None;
+    }
+    let space = Rc::clone(manager.get_space(index as int4)?);
+    let offset = space.wrap_offset(pointer.get_offset());
+    Some((Address::new(space, offset), target_vn.get_size()))
+}
 
 // =============================================================================
 // ActionPrototypeTypes (coreaction.hh:658, coreaction.cc:4843)
@@ -404,8 +447,37 @@ impl Action for ActionDefaultParams {
                 // `Architecture::set_function_prototype_pieces` (the kuna stand-in for
                 // the C++ callee `Funcdata`'s lazily-built `FuncProto`).
                 let has_funcdata = data.get_call_specs(i).has_funcdata();
-                let (callee_pieces, callee_model) = if has_funcdata {
-                    let entry = data.get_call_specs(i).get_entry_address().clone();
+                let indirect_slot = if has_funcdata {
+                    None
+                } else {
+                    let op = data.get_call_specs(i).get_op();
+                    exact_indirect_target_slot(data, op).and_then(|(slot, size)| {
+                        let usepoint = data
+                            .obank()
+                            .get(op)
+                            .map(|call| call.get_addr().clone())
+                            .unwrap_or_default();
+                        arch.query_indirect_slot_type(&slot, size, &usepoint)
+                            .map(|slot_type| (slot, slot_type))
+                    })
+                };
+                let slot_proto = match &indirect_slot {
+                    Some((_, crate::context::IndirectSlotType::Prototype(proto))) => {
+                        Some(Rc::clone(proto))
+                    }
+                    _ => None,
+                };
+                let pieces_entry = if has_funcdata {
+                    Some(data.get_call_specs(i).get_entry_address().clone())
+                } else {
+                    match &indirect_slot {
+                        Some((slot, crate::context::IndirectSlotType::FunctionCode)) => {
+                            Some(slot.clone())
+                        }
+                        _ => None,
+                    }
+                };
+                let (callee_pieces, callee_model) = if let Some(entry) = pieces_entry {
                     // (kuna, Phase 3) A host-declared prototype model rides the
                     // locked pieces (ghidra-mode `<prototype model=…>`); `None`
                     // on the standalone path, keeping the default-model seed.
@@ -432,7 +504,9 @@ impl Action for ActionDefaultParams {
                     }
                     None => None,
                 };
-                let callee_proto = if custom_output_only.is_some() {
+                let callee_proto = if slot_proto.is_some() {
+                    slot_proto
+                } else if custom_output_only.is_some() {
                     None
                 } else {
                     match (callee_pieces, default_fp.clone(), arch.types()) {
@@ -457,7 +531,7 @@ impl Action for ActionDefaultParams {
                                         arch.callee_proto_stack,
                                         &mut fp,
                                     );
-                                    Some(fp)
+                                    Some(Rc::new(fp))
                                 }
                                 // The callee storage assignment hit an un-ported boundary: fall
                                 // back to the default-model recovery for this call site.
@@ -2035,6 +2109,7 @@ mod tests {
     use super::*;
     use crate::action::ruleflags;
     use crate::context::ArchContext;
+    use crate::dtype::{type_metatype, Datatype};
 
     // Mirrors the coreaction_early.rs test harness (funcdata_block fixtures).
     fn build_manager() -> AddrSpaceManager {
@@ -2067,6 +2142,55 @@ mod tests {
     /// Build a `(name, flags)` pair from a boxed action's base.
     fn name_flags(a: &dyn Action) -> (String, u32) {
         (a.get_name().to_string(), a.base().flags)
+    }
+
+    fn callind(fd: &mut Funcdata, target: crate::context::VarnodeId) -> crate::context::OpId {
+        let ram = Rc::clone(fd.get_arch().manage().get_space_by_name("ram").unwrap());
+        let op = fd.new_op(1, Address::new(ram, 0x1010));
+        fd.op_set_opcode_code(op, OpCode::CPUI_CALLIND);
+        fd.op_set_input(op, target, 0).unwrap();
+        op
+    }
+
+    #[test]
+    fn exact_indirect_slot_accepts_direct_unwritten_memory_varnode() {
+        let mut fd = build_fd();
+        let ram = Rc::clone(fd.get_arch().manage().get_space_by_name("ram").unwrap());
+        let target = fd.vbank_mut().create(
+            8,
+            Address::new(Rc::clone(&ram), 0x3000),
+            Rc::new(Datatype::new(8, type_metatype::TYPE_UNKNOWN)),
+        );
+        let call = callind(&mut fd, target);
+
+        let (slot, size) = exact_indirect_target_slot(&fd, call).expect("exact RAM target");
+        assert_eq!(slot.get_offset(), 0x3000);
+        assert_eq!(size, 8);
+    }
+
+    #[test]
+    fn exact_indirect_slot_accepts_only_literal_load_definition() {
+        let mut fd = build_fd();
+        let ram = Rc::clone(fd.get_arch().manage().get_space_by_name("ram").unwrap());
+        let load = fd.new_op(2, Address::new(Rc::clone(&ram), 0x1008));
+        fd.op_set_opcode_code(load, OpCode::CPUI_LOAD);
+        let space_id = fd.new_constant(4, ram.get_index() as u64);
+        let pointer = fd.new_constant(8, 0x3000);
+        fd.op_set_input(load, space_id, 0).unwrap();
+        fd.op_set_input(load, pointer, 1).unwrap();
+        let loaded = fd.new_unique_out(8, load).unwrap();
+        let call = callind(&mut fd, loaded);
+
+        let (slot, size) = exact_indirect_target_slot(&fd, call).expect("literal LOAD target");
+        assert_eq!(slot.get_offset(), 0x3000);
+        assert_eq!(size, 8);
+
+        let copy = fd.new_op(1, Address::new(ram, 0x100c));
+        fd.op_set_opcode_code(copy, OpCode::CPUI_COPY);
+        fd.op_set_input(copy, pointer, 0).unwrap();
+        let copied = fd.new_unique_out(8, copy).unwrap();
+        let copied_call = callind(&mut fd, copied);
+        assert!(exact_indirect_target_slot(&fd, copied_call).is_none());
     }
 
     #[test]

--- a/decompiler/crates/kuna-decomp/src/substrate/context.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/context.rs
@@ -206,6 +206,24 @@ pub struct GlobalQuery {
     pub flagbase: kuna_base::partmap::PartMap<Address, uint4>,
 }
 
+/// Prototype evidence attached to an exact memory slot feeding a `CALLIND`.
+///
+/// A loader models an import pointer slot as a `FunctionSymbol` whose code type
+/// receives separately parked prototype pieces.  An explicit data declaration
+/// instead models the slot as a pointer to a prototype-bearing code type.  Keep
+/// the two cases distinct so a plain `code`, integer, or pointer-to-data symbol
+/// cannot borrow unrelated address-keyed function pieces.
+#[derive(Debug, Clone)]
+pub(crate) enum IndirectSlotType {
+    /// An exact function-symbol entry with a code type.  `ActionDefaultParams`
+    /// may consult the prototype pieces parked at this same address.
+    FunctionCode,
+    /// A pointer-to-code data symbol carrying its complete prototype.
+    Prototype(Rc<crate::fspec::FuncProto>),
+    /// An exact symbol exists, but its type does not prove a callable prototype.
+    Untyped,
+}
+
 #[derive(Debug, Clone)]
 struct GlobalSpaceIndex {
     space_index: int4,
@@ -416,6 +434,89 @@ impl GlobalQuery {
             _ => best,
         };
         selected.map(|entry_index| &self.entries[entry_index])
+    }
+
+    /// Classify an exact global slot read by a `CALLIND` target `LOAD`.
+    ///
+    /// The address is never adjusted: a containing aggregate or an interior
+    /// symbol piece is insufficient.  A later non-function symbol at the exact
+    /// address (the assertion/data-map ordering) shadows loader function
+    /// metadata even when its declared size is not the machine pointer width.
+    fn indirect_slot_type(
+        &self,
+        addr: &Address,
+        size: int4,
+        usepoint: &Address,
+    ) -> Option<IndirectSlotType> {
+        let space_index = addr.get_space()?.get_index();
+        let start = addr.get_offset();
+
+        let classify_data = |entry: &GlobalEntry| {
+            if entry.first != start || entry.symbol_offset != 0 || entry.size != size {
+                return IndirectSlotType::Untyped;
+            }
+            let Some(pointer) = entry.symbol_type.as_ref() else {
+                return IndirectSlotType::Untyped;
+            };
+            if pointer.get_metatype() != crate::dtype::type_metatype::TYPE_PTR {
+                return IndirectSlotType::Untyped;
+            }
+            let Some(code) = pointer.get_ptr_to() else {
+                return IndirectSlotType::Untyped;
+            };
+            if code.get_metatype() != crate::dtype::type_metatype::TYPE_CODE {
+                return IndirectSlotType::Untyped;
+            }
+            match code.get_code_prototype() {
+                Some(proto) => IndirectSlotType::Prototype(Rc::clone(proto)),
+                None => IndirectSlotType::Untyped,
+            }
+        };
+
+        if let Some(entry) = self.find_container_entry(addr, size, usepoint) {
+            if !entry.is_function {
+                return Some(classify_data(entry));
+            }
+            if entry.first != start || entry.symbol_offset != 0 {
+                return Some(IndirectSlotType::Untyped);
+            }
+        }
+
+        let entries = self.entries_for_space(space_index);
+        let active = |entry: &GlobalEntry| {
+            entry.addrtied
+                || (!usepoint.is_invalid() && entry.uselimit.in_range(usepoint, 1))
+        };
+        if let Some(entry) = entries
+            .iter()
+            .rev()
+            .find(|entry| entry.first == start && !entry.is_function && active(entry))
+        {
+            return Some(classify_data(entry));
+        }
+
+        // FunctionSymbols use the code type's one-byte storage convention even
+        // when they describe an import pointer slot.  Validate the LOAD itself
+        // against the address-space pointer width instead of comparing it with
+        // that synthetic symbol size.
+        if size != addr.get_space()?.get_addr_size() as int4 {
+            return Some(IndirectSlotType::Untyped);
+        }
+
+        let entry = entries.iter().find(|entry| {
+            entry.first == start
+                && entry.symbol_offset == 0
+                && entry.is_function
+                && active(entry)
+                && entry
+                    .symbol_type
+                    .as_ref()
+                    .is_some_and(|ty| ty.get_metatype() == crate::dtype::type_metatype::TYPE_CODE)
+        })?;
+        match entry.symbol_type.as_ref().and_then(|ty| ty.get_code_prototype()) {
+            Some(proto) => Some(IndirectSlotType::Prototype(Rc::clone(proto))),
+            None => Some(IndirectSlotType::FunctionCode),
+        }
     }
 
     /// Resolve the global Symbol covering a Varnode for the naming pass — the C++
@@ -1912,6 +2013,18 @@ impl ArchContext {
             }
         }
         None
+    }
+
+    /// Return the callable type attached to the exact global slot loaded as an
+    /// indirect-call target.  See [`GlobalQuery::indirect_slot_type`].
+    pub(crate) fn query_indirect_slot_type(
+        &self,
+        addr: &Address,
+        size: int4,
+        usepoint: &Address,
+    ) -> Option<IndirectSlotType> {
+        self.effective_global_query(addr)?
+            .indirect_slot_type(addr, size, usepoint)
     }
 
     /// C++ `Scope::queryFunction(addr)` (`database.cc:1292`) restricted to the

--- a/decompiler/crates/kuna-decomp/src/substrate/context_tests.rs
+++ b/decompiler/crates/kuna-decomp/src/substrate/context_tests.rs
@@ -4,7 +4,9 @@ use kuna_base::address::{Address, RangeList};
 use kuna_base::partmap::PartMap;
 use kuna_base::space::{spacetype, AddrSpace};
 
-use super::{GlobalEntry, GlobalQuery};
+use crate::dtype::{type_metatype, Datatype, DatatypeKind};
+
+use super::{GlobalEntry, GlobalQuery, IndirectSlotType};
 
 fn space(index: i32) -> Rc<AddrSpace> {
     Rc::new(AddrSpace::new(
@@ -54,6 +56,202 @@ fn entry(
 
 fn query(entries: Vec<GlobalEntry>) -> GlobalQuery {
     GlobalQuery::new(entries, RangeList::new(), PartMap::new(0))
+}
+
+fn typed_entry(
+    space: &Rc<AddrSpace>,
+    first: u64,
+    size: i32,
+    name: &str,
+    ty: Rc<Datatype>,
+    is_function: bool,
+) -> GlobalEntry {
+    let mut result = entry(space, first, size, 0, name, true, RangeList::new());
+    result.symbol_type = Some(ty);
+    result.is_function = is_function;
+    result
+}
+
+fn code_noproto() -> Rc<Datatype> {
+    let mut ty = Datatype::new(1, type_metatype::TYPE_CODE);
+    ty.kind = DatatypeKind::Code { proto: None };
+    Rc::new(ty)
+}
+
+fn code_proto(proto: Rc<crate::fspec::FuncProto>) -> Rc<Datatype> {
+    let mut ty = Datatype::new(1, type_metatype::TYPE_CODE);
+    ty.kind = DatatypeKind::Code { proto: Some(proto) };
+    Rc::new(ty)
+}
+
+fn ptr_to(ty: Rc<Datatype>) -> Rc<Datatype> {
+    let mut ptr = Datatype::new(8, type_metatype::TYPE_PTR);
+    ptr.kind = DatatypeKind::Pointer {
+        ptrto: ty,
+        spaceid: None,
+        truncate: None,
+        wordsize: 1,
+    };
+    Rc::new(ptr)
+}
+
+#[test]
+fn indirect_slot_accepts_only_an_exact_function_or_prototyped_function_pointer() {
+    let data = space(3);
+    let at = addr(&data, 0x100);
+    let usepoint = Address::new_invalid();
+
+    let function = query(vec![typed_entry(
+        &data,
+        0x100,
+        1,
+        "target",
+        code_noproto(),
+        true,
+    )]);
+    assert!(matches!(
+        function.indirect_slot_type(&at, 8, &usepoint),
+        Some(IndirectSlotType::FunctionCode)
+    ));
+    for malformed_width in [4, 16] {
+        assert!(matches!(
+            function.indirect_slot_type(&at, malformed_width, &usepoint),
+            Some(IndirectSlotType::Untyped)
+        ));
+    }
+
+    let non_pointer = query(vec![typed_entry(
+        &data,
+        0x100,
+        8,
+        "scalar",
+        Rc::new(Datatype::new(8, type_metatype::TYPE_INT)),
+        false,
+    )]);
+    assert!(matches!(
+        non_pointer.indirect_slot_type(&at, 8, &usepoint),
+        Some(IndirectSlotType::Untyped)
+    ));
+
+    let pointer_to_data = query(vec![typed_entry(
+        &data,
+        0x100,
+        8,
+        "data_ptr",
+        ptr_to(Rc::new(Datatype::new(4, type_metatype::TYPE_INT))),
+        false,
+    )]);
+    assert!(matches!(
+        pointer_to_data.indirect_slot_type(&at, 8, &usepoint),
+        Some(IndirectSlotType::Untyped)
+    ));
+
+    let unprototyped_code_pointer = query(vec![typed_entry(
+        &data,
+        0x100,
+        8,
+        "code_ptr",
+        ptr_to(code_noproto()),
+        false,
+    )]);
+    assert!(matches!(
+        unprototyped_code_pointer.indirect_slot_type(&at, 8, &usepoint),
+        Some(IndirectSlotType::Untyped)
+    ));
+
+    let proto = Rc::new(crate::fspec::FuncProto::new());
+    let function_pointer = query(vec![typed_entry(
+        &data,
+        0x100,
+        8,
+        "function_ptr",
+        ptr_to(code_proto(Rc::clone(&proto))),
+        false,
+    )]);
+    match function_pointer.indirect_slot_type(&at, 8, &usepoint) {
+        Some(IndirectSlotType::Prototype(resolved)) => assert!(
+            Rc::ptr_eq(&resolved, &proto),
+            "the exact FuncProto, including its model, must survive classification"
+        ),
+        other => panic!("function pointer was not classified as callable: {other:?}"),
+    }
+    assert!(matches!(
+        function_pointer.indirect_slot_type(&at, 4, &usepoint),
+        Some(IndirectSlotType::Untyped)
+    ));
+}
+
+#[test]
+fn explicit_data_at_slot_shadows_loader_function_metadata() {
+    let data = space(3);
+    let at = addr(&data, 0x100);
+    let query = query(vec![
+        typed_entry(&data, 0x100, 1, "target", code_noproto(), true),
+        typed_entry(
+            &data,
+            0x100,
+            8,
+            "operator_data",
+            Rc::new(Datatype::new(8, type_metatype::TYPE_INT)),
+            false,
+        ),
+    ]);
+
+    assert!(matches!(
+        query.indirect_slot_type(&at, 8, &Address::new_invalid()),
+        Some(IndirectSlotType::Untyped)
+    ));
+}
+
+#[test]
+fn usepoint_limited_data_shadows_only_where_it_is_active() {
+    let data = space(3);
+    let code = space(4);
+    let at = addr(&data, 0x100);
+    let mut limited = typed_entry(
+        &data,
+        0x100,
+        8,
+        "local_view",
+        Rc::new(Datatype::new(8, type_metatype::TYPE_INT)),
+        false,
+    );
+    limited.addrtied = false;
+    limited.uselimit.insert_range(Rc::clone(&code), 0x400, 0x4ff);
+    let query = query(vec![
+        typed_entry(&data, 0x100, 1, "target", code_noproto(), true),
+        limited,
+    ]);
+
+    assert!(matches!(
+        query.indirect_slot_type(&at, 8, &addr(&code, 0x440)),
+        Some(IndirectSlotType::Untyped)
+    ));
+    assert!(matches!(
+        query.indirect_slot_type(&at, 8, &addr(&code, 0x540)),
+        Some(IndirectSlotType::FunctionCode)
+    ));
+}
+
+#[test]
+fn indirect_slot_does_not_reinterpret_an_interior_aggregate_address() {
+    let data = space(3);
+    let query = query(vec![typed_entry(
+        &data,
+        0x100,
+        16,
+        "aggregate",
+        Rc::new(Datatype::new(16, type_metatype::TYPE_STRUCT)),
+        false,
+    )]);
+
+    assert!(matches!(
+        query.indirect_slot_type(&addr(&data, 0x108), 8, &Address::new_invalid()),
+        Some(IndirectSlotType::Untyped)
+    ));
+    assert!(query
+        .indirect_slot_type(&addr(&data, 0x200), 8, &Address::new_invalid())
+        .is_none());
 }
 
 fn linear_container_flags(

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -4436,7 +4436,7 @@
       "status": "open",
       "severity": "major",
       "probe_id": "p-4d8cc41166db",
-      "acceptance_id": "a-907ef770cc72",
+      "acceptance_id": "a-0f1c487a5eb9",
       "hypothesis_status": "upheld",
       "credibility": 0.85,
       "instances": 1,

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -5,8 +5,8 @@
   "rejected_count": 1,
   "by_status": {
     "blocked": 1,
-    "closed": 131,
-    "open": 65
+    "closed": 132,
+    "open": 64
   },
   "by_track": {
     "loader": 10,
@@ -4433,7 +4433,7 @@
       "need_id": "typed-mach-o-tail",
       "title": "Typed Mach-O tail stub drops both forwarded arguments",
       "track": "quality",
-      "status": "open",
+      "status": "closed",
       "severity": "major",
       "probe_id": "p-4d8cc41166db",
       "acceptance_id": "a-0f1c487a5eb9",
@@ -4447,18 +4447,18 @@
         12
       ],
       "first_seen_round": 12,
-      "attempts": 0,
+      "attempts": 1,
       "covered_by_option": null,
       "touches": [
         "decompiler/crates/kuna-decomp"
       ],
       "scope": "small",
       "regression_of": null,
-      "pr": null,
-      "closed_in_round": null,
-      "closing_pr": null,
+      "pr": "https://github.com/Noelo-Lab/kuna/pull/585",
+      "closed_in_round": 12,
+      "closing_pr": 585,
       "reject_reason": null,
-      "score": 13.862944,
+      "score": 9.241962,
       "path": "docs/re-needs/typed-mach-o-tail.md"
     },
     {

--- a/docs/re-needs/typed-mach-o-tail.md
+++ b/docs/re-needs/typed-mach-o-tail.md
@@ -2,7 +2,7 @@
 need_id: typed-mach-o-tail
 title: Typed Mach-O tail stub drops both forwarded arguments
 track: quality
-status: open
+status: closed
 severity: major
 probe_id: p-4d8cc41166db
 acceptance_id: a-0f1c487a5eb9
@@ -12,14 +12,14 @@ instances: 1
 challenges: [64c8b272b25df8732eebc2a6]
 rounds: [12]
 first_seen_round: 12
-attempts: 0
+attempts: 1
 covered_by_option: null
 touches: [decompiler/crates/kuna-decomp]
 scope: small
 regression_of: null
-pr: null
-closed_in_round: null
-closing_pr: null
+pr: https://github.com/Noelo-Lab/kuna/pull/585
+closed_in_round: 12
+closing_pr: 585
 reject_reason: null
 ---
 
@@ -154,3 +154,16 @@ form.
   It could pass if the asserted name disappeared while the empty call remained,
   so the promoted acceptance pins both the declared parameters and the positive
   `(*printf_ptr)(fmt,value)` call.
+- Round 12 builder: indirect call recovery now accepts only an exact unwritten
+  memory target or its exact direct LOAD, then prefers an existing call-site
+  override, an exact explicit function-pointer data type, loader metadata at the
+  same pointer-width slot, and finally the generic prototype. Usepoint-scoped
+  declarations, malformed widths, interior addresses, scalars, pointers to data,
+  bare code, and copied or computed targets remain generic. Complete explicit
+  prototypes retain their calling-convention model.
+- Round 12 closure: PR #585 was opened from the exact twice-reviewed implementation
+  head `ca9cc21bcf075d4e40f8b14fe7dc8532e2c455fa`. The promoted acceptance passed,
+  explicit typing rendered `(*printf_ptr)(fmt,value)`, loader metadata rendered
+  `(*dat_100003000)(a0)` in decompile, decompile-all, and project export, and all
+  focused, parity, staged, spec, workspace, and doc-test gates passed. Final merge
+  remains gated on exact-head metadata review and the `full-ci` workflow.

--- a/docs/re-needs/typed-mach-o-tail.md
+++ b/docs/re-needs/typed-mach-o-tail.md
@@ -1,0 +1,156 @@
+---
+need_id: typed-mach-o-tail
+title: Typed Mach-O tail stub drops both forwarded arguments
+track: quality
+status: open
+severity: major
+probe_id: p-4d8cc41166db
+acceptance_id: a-0f1c487a5eb9
+hypothesis_status: upheld
+credibility: 0.85
+instances: 1
+challenges: [64c8b272b25df8732eebc2a6]
+rounds: [12]
+first_seen_round: 12
+attempts: 0
+covered_by_option: null
+touches: [decompiler/crates/kuna-decomp]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Preserve arguments through an indirect Mach-O import tail jump, including when
+the import pointer is explicitly typed.
+
+> **Typed Mach-O tail stub drops both forwarded arguments** (major,
+> `64c8b272b25df8732eebc2a6`)
+> Emitted `(*strcmp_ptr)()` despite the two-argument signature and explicit
+> pointer type. Disassembly shows one JMP through the import slot, preserving
+> RDI and RSI.
+
+The vendored `macho_imports` reduction has the same one-instruction x86-64
+shape at `printf` (`0x1000005cc`):
+
+```text
+ff 25 2e 2a 00 00    jmp qword ptr [0x100003000]
+```
+
+Before the repair, even the stronger two-parameter declaration below rendered
+`(*printf_ptr)()` while the surrounding function declared `fmt` and `value`.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x100003ede",
+    "--addr",
+    "--assert",
+    "data 0x100008030 int (*strcmp_ptr)(char *,char *)"
+  ],
+  "expect": {
+    "exit_code": { "eq": 0 },
+    "stdout_matches": [
+      "\\(\\*strcmp_ptr\\)\\(\\s*\\)"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/main",
+    "binary_sha256": "979555f6b20fc5f024358ef26603f4c25e8db326941f86af30726eca9fea453e",
+    "binary_size": 50080,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-0f1c487a5eb9",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "printf",
+    "--assert",
+    "prototype 0x1000005cc int printf(char *fmt,int value)",
+    "--assert",
+    "data 0x100003000 int (*printf_ptr)(char *,int)",
+    "--assert-strict"
+  ],
+  "expect": {
+    "exit_code": { "eq": 0 },
+    "stdout_matches": [
+      "int printf\\(char \\*fmt,int value\\)",
+      "\\(\\*printf_ptr\\)\\(fmt,value\\)"
+    ],
+    "stdout_absent": [
+      "\\(\\*printf_ptr\\)\\(\\s*\\)"
+    ]
+  },
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/macho_imports",
+    "binary_sha256": "0394e1be81c4ccdfb28a50cf5dba55a6d95a692cd5504f2305a8f139e8f86675",
+    "binary_size": 16688,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/macho_imports",
+    "selector": "printf",
+    "selector_kind": "name"
+  },
+  "notes": "Positive match is required: merely losing the asserted slot name would also make the historical absent-only clause pass."
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** The CALLIND call spec never
+consulted the exact global slot supplying its target. Consequently both a
+prototype-bearing function-pointer data assertion and the address-keyed import
+prototype parked by the library analysis were available but inert.
+
+## Refutation
+
+The hypothesis was upheld on the original dataset witness and on the vendored
+reduction. The latter lifts the instruction as a CALLIND whose target is the
+unwritten RAM Varnode at `0x100003000`; no explicit LOAD survives in that SLEIGH
+form.
+
+## Reference
+
+- IDA, Ghidra, and angr backends were attempted through the repository's
+  decompiler workflow. Each server exited before registering, so no external
+  reference pseudocode was available. The machine instruction and Kuna raw
+  p-code above are the available ground truth.
+
+## Instances
+
+- `64c8b272b25df8732eebc2a6` (round 12, tester t-r12-64c8b272)
+
+## Decision log
+
+- Filed by `cluster.py` from one observation and split by the captain from the
+  broader argument-loss family: in that family a call-site prototype restores
+  arguments, while here an explicit function-pointer type did not change arity.
+- Round 12 refutation upheld the symptom. The original dataset stub is one
+  `JMP qword ptr [0x100008030]`; the emitted `strcmp` function declared two
+  inputs and used neither.
+- The historical acceptance had only an absent clause for `(*strcmp_ptr)()`.
+  It could pass if the asserted name disappeared while the empty call remained,
+  so the promoted acceptance pins both the declared parameters and the positive
+  `(*printf_ptr)(fmt,value)` call.

--- a/docs/spec/04-calls-and-prototypes.md
+++ b/docs/spec/04-calls-and-prototypes.md
@@ -646,7 +646,22 @@ that machinery.
   param <func>::<i> <storage> <decl>` and `map return <func>::<storage>
   <decl>`, reached from the CLI as `--assert 'param <func>::<i> …'`. A slot no
   directive named is `undefined` of pointer width, so slots may be declared in
-  any order.
+  any order. A CALLIND through a literal global slot has one additional early
+  source: when input 0 is either the unwritten memory Varnode at that exact
+  address or the result of exactly `LOAD(constant-space, constant-address)`,
+  the slot is queried before generic recovery. An exact data symbol contributes
+  a prototype only when its full storage is a pointer to a prototype-bearing
+  code type. Otherwise a loader FunctionSymbol at that exact address may supply
+  its address-keyed parked pieces (its synthetic code-symbol size is one byte,
+  so the LOAD is instead checked against the address-space pointer width).
+  Scalars, pointers to data, code/code pointers without a prototype, interior
+  aggregate addresses, truncated/wide loads, COPY chains, and computed addresses
+  all stay generic. A later exact data declaration shadows loader metadata even
+  when it is non-callable. The priority is call-site override, explicit typed
+  data slot, loader FunctionSymbol prototype, then generic recovery; copying the
+  current function's own prototype is never a fallback. A `FuncProto` taken
+  from a typed data slot is copied intact, including its calling-convention
+  model.
 - **`ActionExtraPopSetup`** (`coreaction_protos.rs (ActionExtraPopSetup)`)
   models the stack pointer across each call: a known extrapop becomes an
   explicit `INT_ADD sp, #extrapop` after the call; an unknown one becomes an
@@ -1040,7 +1055,10 @@ inline/no-return flow effects — inline queues the site for body injection, and
 no-return plants an artificial halt after the call plus the "Subroutine does
 not return" warning (`decompiler/crates/kuna-decomp/src/p2_lift/flow.rs
 (FlowInfo::check_for_flow_modification)`; the fact-producing analyses are
-chapter 01 §1.7, the lift-time behavior chapter 02 §2.4).
+chapter 01 §1.7, the lift-time behavior chapter 02 §2.4). Because that override
+already gives the call spec a model, the later exact-slot query in
+`ActionDefaultParams` declines, preserving the per-call-site priority for both
+direct and indirect calls.
 
 ### Effect lists
 
@@ -1139,7 +1157,9 @@ restart contract ((kuna) reason `ProtoForced`) and input-lock tail, but its
 override-persist and success-commit halves are documented port seams, and the
 `ActionDeindirect` arm that would invoke it (a typed function-pointer reaching
 the CALLIND after type recovery starts) is not wired; such a site today keeps
-its model-recovered argument list. Restarts triggered here are refused during
+its model-recovered argument list. This does not include the literal import-slot
+case above: `ActionDefaultParams` consumes that already-present global type
+before input trials start and needs no target rewrite or restart. Restarts triggered here are refused during
 jump-table sub-decompilation like every other feedback edge (00 §0.7).
 
 **The prototype wire encode.** The recovered prototype marshals out for the

--- a/tests/cli/typed-mach-o-tail.json
+++ b/tests/cli/typed-mach-o-tail.json
@@ -1,0 +1,45 @@
+{
+  "schema": "re-probe/1",
+  "probe_id": "a-0f1c487a5eb9",
+  "kind": "cli",
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "printf",
+    "--assert",
+    "prototype 0x1000005cc int printf(char *fmt,int value)",
+    "--assert",
+    "data 0x100003000 int (*printf_ptr)(char *,int)",
+    "--assert-strict"
+  ],
+  "cwd": "{{WORK}}",
+  "env": {
+    "SLEIGHHOME": "{{SPECS}}"
+  },
+  "stdin": null,
+  "timeout_s": 60,
+  "repeat": 1,
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/macho_imports",
+    "binary_sha256": "0394e1be81c4ccdfb28a50cf5dba55a6d95a692cd5504f2305a8f139e8f86675",
+    "binary_size": 16688,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/macho_imports",
+    "selector": "printf",
+    "selector_kind": "name"
+  },
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "int printf\\(char \\*fmt,int value\\)",
+      "\\(\\*printf_ptr\\)\\(fmt,value\\)"
+    ],
+    "stdout_absent": [
+      "\\(\\*printf_ptr\\)\\(\\s*\\)"
+    ]
+  },
+  "notes": "Promoted acceptance for typed-mach-o-tail on the vendored one-instruction x86-64 Mach-O import veneer. The positive call match closes the historical false-pass hole where merely losing the asserted pointer name satisfied the absent-only clause."
+}


### PR DESCRIPTION
## The problem

Typed Mach-O import veneers dropped every forwarded argument even when the indirect slot had an explicit function-pointer prototype.

```sh
decompiler/target/release/kuna decompile decompiler/crates/kuna-analysis/tests/fixtures/macho_imports printf --assert "prototype 0x1000005cc int printf(char *fmt,int value)" --assert "data 0x100003000 int (*printf_ptr)(char *,int)" --assert-strict
```

```c
v1 = (*printf_ptr)(); // jump-as-call
```

## The fix

- Recover an indirect call prototype only from the exact target slot or its exact direct load.
- Prefer call-site overrides, then explicit typed data, then loader metadata; preserve the selected calling-convention model.
- Keep scalar, non-code pointers, bare code types, malformed widths, and non-exact expressions on the generic path.

## The tests

Adds CLI coverage for explicit and loader-derived prototypes across decompile, decompile-all, and project export. Unit tests pin exact target shapes, scoping, widths, negative types, model preservation, and call-site override precedence.