### PR TITLE
[AUTOMATED] fix(cli): refuse PE import slots as decompile bodies

### DIFF
--- a/decompiler/crates/kuna-analysis/src/loadimage_object.rs
+++ b/decompiler/crates/kuna-analysis/src/loadimage_object.rs
@@ -2430,6 +2430,35 @@ mod tests {
         }
     }
 
+    /// PE import slots retain their loader identity independently of section
+    /// permissions. The side table, not CODE versus DATA, is what body
+    /// selection can rely on while keeping the slot's function symbol.
+    #[test]
+    fn pe_import_slots_are_reported_in_code_and_data_sections() {
+        for (fixture, slot, name, executable) in [
+            ("pe_imports.exe", 0x1_4000_d1ecu64, "GetLastError", false),
+            ("pe_iatincode_i386.exe", 0x40_1000u64, "VirtualAlloc", true),
+        ] {
+            let path = format!("{}/tests/fixtures/{fixture}", env!("CARGO_MANIFEST_DIR"));
+            let bytes = std::fs::read(&path).expect("fixture");
+            let img = ObjectLoadImage::from_bytes(&path, &bytes).expect("load the PE");
+            assert!(
+                img.import_slot_ranges().iter().any(|&(lo, hi)| slot >= lo && slot < hi),
+                "{fixture}: missing import slot at {slot:#x}"
+            );
+            assert!(
+                img.func_symbols().iter().any(|(addr, found)| *addr == slot && found == name),
+                "{fixture}: the slot FunctionSymbol must remain installed"
+            );
+            let section_is_code = img
+                .section_snapshot()
+                .iter()
+                .find(|&&(start, size, _)| slot >= start && slot - start < size)
+                .is_some_and(|&(_, _, flags)| flags & section_flags::CODE != 0);
+            assert_eq!(section_is_code, executable, "{fixture}: wrong section control");
+        }
+    }
+
     /// (kuna, `pe-zero-filled-data`) A PE section that declares more RAM than
     /// the file backs maps its whole `VirtualSize`: the file extent reads back
     /// its own bytes, the tail past `SizeOfRawData` reads back zeroes, and the

--- a/decompiler/crates/kuna-cli/src/decompile.rs
+++ b/decompiler/crates/kuna-cli/src/decompile.rs
@@ -234,7 +234,7 @@ fn build_script_for_input(
         lines.push(decl.console_line());
     }
     // (kuna, RE-need `prototype-assertion-rejects-explicit`) A by-address run
-    // DECLARES that a function starts where it points: `load addr` follows flow
+    // ensures that a function symbol exists where it points: `load addr` follows flow
     // from the address without installing a `FunctionSymbol`, so a directive
     // naming the very address this run decompiles was answered `no function
     // starts at 0x…` while the body was emitted in full.  This is the same
@@ -243,7 +243,7 @@ fn build_script_for_input(
     // clear.
     if let Some(vma) = selected_vma(target, by_address) {
         if !func_decls.iter().any(|decl| decl.start == vma) {
-            lines.push(format!("function bounds {vma:#x}"));
+            lines.push(format!("function symbol {vma:#x}"));
         }
     }
     // (kuna `--assert`) The PROGRAM-scoped directives -- a parsed type, a
@@ -1040,7 +1040,7 @@ fn decompile(args: &DecompileArgs) -> Result<DecompileOutcome, String> {
         if c_text.trim().is_empty() {
             // An EXTERNAL, not a failure: the selected entry has no mapped bytes
             // because its definition lives in another module (a relocatable
-            // object's undefined symbol, a PE import slot). Those carry an
+            // object's undefined symbol). Those carry an
             // address only so a call to one renders by name. Say so, rather than
             // dumping a console transcript whose "Unable to load N bytes" reads
             // like a decompiler defect. The whole-binary surfaces answer the same
@@ -1985,11 +1985,11 @@ Decompilation complete
         );
     }
 
-    /// A by-address run DECLARES the entry it points at, before the directives
-    /// that name it: `load addr` alone installs no `FunctionSymbol`, so
+    /// A by-address run installs a symbol at the entry it points at, before the
+    /// directives that name it: `load addr` alone installs no `FunctionSymbol`, so
     /// `prototype 0x…` for the very address being decompiled was rejected.
     #[test]
-    fn build_script_declares_the_entry_a_by_address_run_selected() {
+    fn build_script_symbols_the_entry_a_by_address_run_selected() {
         let directives = vec![crate::assertdecl::parse_one(
             "prototype 0x401571 void decrypt(unsigned int key)",
         )
@@ -2015,18 +2015,18 @@ Decompilation complete
                 .unwrap_or_else(|| panic!("{needle:?} missing from:\n{script}"))
         };
         assert!(
-            line("read symbols") < line("function bounds 0x401571")
-                && line("function bounds 0x401571")
+            line("read symbols") < line("function symbol 0x401571")
+                && line("function symbol 0x401571")
                     < line("map prototype 0x401571 void decrypt(unsigned int key);"),
             "wrong order in:\n{script}"
         );
     }
 
-    /// A bare hex target under `--addr` takes the same declaration, and a NAMED
+    /// A bare hex target under `--addr` takes the same symbol install, and a NAMED
     /// selection takes none — the name path resolves through the symbol table
     /// that already has the entry.
     #[test]
-    fn only_an_addressed_selection_is_declared() {
+    fn only_an_addressed_selection_gets_an_implicit_symbol() {
         let script = |target: &str, by_address: bool| {
             build_script(
                 "/tmp/a.out",
@@ -2043,10 +2043,10 @@ Decompilation complete
                 None,
             )
         };
-        assert!(script("401571", true).contains("\nfunction bounds 0x401571\n"));
-        assert!(!script("authenticate", false).contains("function bounds"));
+        assert!(script("401571", true).contains("\nfunction symbol 0x401571\n"));
+        assert!(!script("authenticate", false).contains("function symbol"));
         // An object-file coordinate is not a VMA, so there is nothing to declare.
-        assert!(!script(".text+0x10", true).contains("function bounds"));
+        assert!(!script(".text+0x10", true).contains("function symbol"));
     }
 
     /// A caller who declared the same start keeps the extent they declared: a

--- a/decompiler/crates/kuna-cli/src/decompile_all.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_all.rs
@@ -1677,6 +1677,24 @@ pub(crate) fn resolve_targets(
     prog: &ConsoleProgram,
     args: &Args,
 ) -> Result<Vec<FunctionEntry>, String> {
+    resolve_targets_with_policy(prog, args, true)
+}
+
+/// Resolve graph selections while retaining bodyless import rows. The graph
+/// labels these addresses and omits their code; it never passes them to the
+/// lifter. Decompilation surfaces use [`resolve_targets`] and refuse them.
+pub(crate) fn resolve_targets_allow_bodyless(
+    prog: &ConsoleProgram,
+    args: &Args,
+) -> Result<Vec<FunctionEntry>, String> {
+    resolve_targets_with_policy(prog, args, false)
+}
+
+fn resolve_targets_with_policy(
+    prog: &ConsoleProgram,
+    args: &Args,
+    require_body: bool,
+) -> Result<Vec<FunctionEntry>, String> {
     let mut targets: Vec<FunctionEntry> = Vec::new();
 
     // Resolve every address form through the program's shared selector model.
@@ -1689,7 +1707,12 @@ pub(crate) fn resolve_targets(
             (true, _) => unreachable!("raw parser requires numeric entries"),
             (false, selector) => selector.clone(),
         };
-        targets.push(prog.resolve_entry(&selector).map_err(|error| error.to_string())?);
+        let entry = if require_body {
+            prog.resolve_body_entry(&selector)
+        } else {
+            prog.resolve_entry(&selector)
+        };
+        targets.push(entry.map_err(|error| error.to_string())?);
     }
 
     // `--functions a,b,c`: intersect names with the enumerated set.  An ALIAS
@@ -1698,7 +1721,13 @@ pub(crate) fn resolve_targets(
     // generated `sub_<addr>` names).
     if let Some(names) = &args.names {
         for want in names {
-            match prog.resolve_entry(&EntrySelector::Name(want.clone())) {
+            let selector = EntrySelector::Name(want.clone());
+            let entry = if require_body {
+                prog.resolve_body_entry(&selector)
+            } else {
+                prog.resolve_entry(&selector)
+            };
+            match entry {
                 Ok(entry) => targets.push(entry),
                 Err(EntryLookupError::NotFound { .. }) => {
                     eprintln!("warning: no function named {want:?} in {}", args.binary)
@@ -1714,9 +1743,7 @@ pub(crate) fn resolve_targets(
     let mut seen = std::collections::HashSet::new();
     targets.retain(|e| seen.insert(e.addr.get_offset()));
 
-    // No filter at all ⇒ every executable function, exactly once. Import pointer
-    // slots remain explicitly selectable, but are data rather than function
-    // bodies.
+    // No filter at all ⇒ every executable function, exactly once.
     if args.addrs.is_empty() && args.names.is_none() {
         targets = prog.function_entries_executable();
     }

--- a/decompiler/crates/kuna-cli/src/decompile_graph.rs
+++ b/decompiler/crates/kuna-cli/src/decompile_graph.rs
@@ -15,7 +15,7 @@
 //! same policies, read from the same helpers rather than restated here:
 //!
 //! * which entries exist, and which of them have bodies worth decompiling
-//!   ([`resolve_targets`], i.e. `function_entries_executable`);
+//!   ([`resolve_targets_allow_bodyless`], i.e. `function_entries_executable`);
 //! * what a function *is* ([`Classifier`], the per-function `kind` the browser
 //!   inventory already labels with);
 //! * what calls what ([`CallGraph`], the edge model `--reachable-from` walks and
@@ -38,8 +38,8 @@ use kuna_console::project::{decompile_targets, FuncResult};
 use object::{Object, ObjectSegment};
 
 use crate::decompile_all::{
-    decompile_targets_pooled, load_program, parse_args, resolve_targets, Args, CallGraph,
-    DriverDefaults,
+    decompile_targets_pooled, load_program, parse_args, resolve_targets_allow_bodyless, Args,
+    CallGraph, DriverDefaults,
 };
 use crate::jsonfmt::{dumps_indent2, Json};
 
@@ -153,7 +153,7 @@ fn export(args: &Args, label: &str) -> Result<String, String> {
     // the executable set comes from the policy, not from the results.
     let executable: BTreeSet<u64> =
         prog.function_entries_executable().iter().map(|e| e.addr.get_offset()).collect();
-    let mut targets = resolve_targets(&prog, args)?;
+    let mut targets = resolve_targets_allow_bodyless(&prog, args)?;
     targets.retain(|entry| {
         let selected = executable.contains(&entry.addr.get_offset());
         if !selected {

--- a/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_all_cli.rs
@@ -274,6 +274,37 @@ fn is_specs_skip(stderr: &str) -> bool {
         || stderr.contains("Could not discover")
 }
 
+/// A filtered whole-binary run is still a body-lifting surface. Selecting a
+/// mapped IAT word must fail before it can become a result row.
+#[test]
+fn decompile_all_refuses_an_executable_section_iat_slot() {
+    let bin = repo_root()
+        .join("decompiler/crates/kuna-analysis/tests/fixtures/pe_iatincode_i386.exe")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile-all",
+        &bin,
+        "--addr",
+        "0x401000",
+        "--json",
+        "--sleighpath",
+        &specs(),
+    ]);
+    if is_specs_skip(&stderr) {
+        eprintln!("decompile_all_iat: skipping (no `.sla`; run `make specs`): {stderr}");
+        return;
+    }
+    assert!(!ok, "an IAT slot unexpectedly decompiled: {stdout}");
+    assert!(stdout.trim().is_empty(), "an IAT result row escaped: {stdout}");
+    assert_eq!(
+        stderr,
+        "error: selector \"0x401000\" identifies import VirtualAlloc at 0x401000; \
+         the IAT slot contains a loader-written pointer, not a function body\n"
+    );
+}
+
 #[test]
 fn decompile_all_emits_json_for_main() {
     let bin = fauxware();

--- a/decompiler/crates/kuna-cli/tests/decompile_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_cli.rs
@@ -299,6 +299,141 @@ fn specs() -> String {
     repo_root().join("specs").to_str().unwrap().to_string()
 }
 
+fn pe_fixture(name: &str) -> String {
+    repo_root()
+        .join("decompiler/crates/kuna-analysis/tests/fixtures")
+        .join(name)
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+fn run_pe_decompile(binary: &str, target: &str, extra: &[&str]) -> std::process::Output {
+    let specs = specs();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_kuna"));
+    cmd.args(["decompile", binary, target, "--sleighpath", specs.as_str()]);
+    cmd.args(extra);
+    cmd
+        .output()
+        .expect("run kuna decompile on PE fixture")
+}
+
+/// An IAT word is a call-binding address, not a body, regardless of section
+/// permissions. Name and address selection report the same stable refusal, and
+/// refusing one slot never advances into either adjacent slot.
+#[test]
+fn pe_iat_body_selection_refuses_name_address_and_adjacent_slots() {
+    let executable = pe_fixture("pe_iatincode_i386.exe");
+    let data = pe_fixture("pe_imports.exe");
+    let cases = [
+        (
+            executable.as_str(),
+            "VirtualAlloc",
+            vec![],
+            "selector \"VirtualAlloc\" identifies import VirtualAlloc at 0x401000; \
+             the IAT slot contains a loader-written pointer, not a function body",
+        ),
+        (
+            executable.as_str(),
+            "0x401000",
+            vec!["--addr"],
+            "selector \"0x401000\" identifies import VirtualAlloc at 0x401000; \
+             the IAT slot contains a loader-written pointer, not a function body",
+        ),
+        (
+            executable.as_str(),
+            "0x401004",
+            vec!["--addr"],
+            "selector \"0x401004\" identifies import GetModuleHandleA at 0x401004; \
+             the IAT slot contains a loader-written pointer, not a function body",
+        ),
+        (
+            executable.as_str(),
+            "0x401008",
+            vec!["--addr"],
+            "selector \"0x401008\" identifies import ExitProcess at 0x401008; \
+             the IAT slot contains a loader-written pointer, not a function body",
+        ),
+        (
+            data.as_str(),
+            "0x14000d1ec",
+            vec!["--addr"],
+            "selector \"0x14000d1ec\" identifies import GetLastError at 0x14000d1ec; \
+             the IAT slot contains a loader-written pointer, not a function body",
+        ),
+    ];
+
+    for (binary, target, extra, expected) in cases {
+        let out = run_pe_decompile(binary, target, &extra);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        if is_specs_skip(&stderr) {
+            eprintln!("skipping: specs-less environment: {stderr}");
+            return;
+        }
+        assert_eq!(out.status.code(), Some(1), "{target} must be refused: {stderr}");
+        assert!(stdout.trim().is_empty(), "{target} emitted a body:\n{stdout}");
+        assert_eq!(stderr, format!("error: {expected}\n"), "unstable diagnostic for {target}");
+        assert!(!stderr.contains("CARRY1(") && !stderr.contains("*v"));
+    }
+}
+
+/// The guard must not disturb the two uses the IAT symbol exists for: selecting
+/// the executable thunk keeps its imported prototype, and calls from an
+/// ordinary function still deindirect through the slots by name.
+#[test]
+fn pe_import_thunk_and_real_function_still_decompile_with_named_prototypes() {
+    let data = pe_fixture("pe_imports.exe");
+    let thunk = run_pe_decompile(&data, "GetLastError", &[]);
+    let thunk_stderr = String::from_utf8_lossy(&thunk.stderr);
+    if is_specs_skip(&thunk_stderr) {
+        eprintln!("skipping: specs-less environment: {thunk_stderr}");
+        return;
+    }
+    let thunk_stdout = String::from_utf8_lossy(&thunk.stdout);
+    assert_eq!(thunk.status.code(), Some(0), "thunk failed: {thunk_stderr}");
+    assert!(
+        thunk_stdout.contains("unsigned int GetLastError(void)")
+            && thunk_stdout.contains("return GetLastError()"),
+        "the thunk lost its import prototype or identity:\n{thunk_stdout}"
+    );
+
+    let executable = pe_fixture("pe_iatincode_i386.exe");
+    let caller = run_pe_decompile(&executable, "0x401010", &["--addr"]);
+    let caller_stderr = String::from_utf8_lossy(&caller.stderr);
+    let caller_stdout = String::from_utf8_lossy(&caller.stdout);
+    assert_eq!(caller.status.code(), Some(0), "real entry failed: {caller_stderr}");
+    assert!(
+        caller_stdout.contains("VirtualAlloc(") && caller_stdout.contains("GetModuleHandleA("),
+        "the import calls no longer deindirect by name:\n{caller_stdout}"
+    );
+}
+
+/// The in-process JSON path uses the same body selection policy and preserves
+/// its machine-readable error document while returning a failed verdict.
+#[test]
+fn pe_iat_json_selection_is_a_non_success_without_code() {
+    let binary = pe_fixture("pe_iatincode_i386.exe");
+    let out = run_pe_decompile(&binary, "0x401000", &["--addr", "--json"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    if is_specs_skip(&stderr) {
+        eprintln!("skipping: specs-less environment: {stderr}");
+        return;
+    }
+    let expected = "selector \"0x401000\" identifies import VirtualAlloc at 0x401000; \
+                    the IAT slot contains a loader-written pointer, not a function body";
+    assert_eq!(out.status.code(), Some(1), "JSON selection must fail: {stderr}");
+    assert_eq!(stderr, format!("error: {expected}\n"));
+    assert!(stdout.contains("\"functions\": []"), "a code record escaped:\n{stdout}");
+    let json_expected = expected.replace('"', "\\\"");
+    assert!(
+        stdout.contains(&json_expected),
+        "the JSON error lost the reason:\n{stdout}"
+    );
+    assert!(!stdout.contains("CARRY1(") && !stdout.contains("*v"));
+}
+
 /// The DIV-88 fixture: an ELF whose `.symtab` carries `::b`, a qualified name
 /// with an empty scope component.  `symbolnamerepair` (default-ON) skips the
 /// degenerate component; `off` restores the hard load failure this test needs.

--- a/decompiler/crates/kuna-cli/tests/decompile_project_cli.rs
+++ b/decompiler/crates/kuna-cli/tests/decompile_project_cli.rs
@@ -89,6 +89,36 @@ fn project(fixture_name: &str, tag: &str) -> Option<PathBuf> {
     Some(dir)
 }
 
+/// A selected project begins with the same body-bearing target resolution as
+/// decompile-all. Refusal happens before an output folder is created.
+#[test]
+fn selected_project_refuses_an_executable_section_iat_slot() {
+    let bin = fixture("pe_iatincode_i386.exe");
+    let dir = out_dir("iat_slot");
+    let (stdout, stderr, ok) = run_kuna(&[
+        "decompile-project",
+        &bin,
+        "-o",
+        dir.to_str().unwrap(),
+        "--addr",
+        "0x401000",
+        "--sleighpath",
+        &specs(),
+    ]);
+    if is_specs_skip(&stderr) {
+        eprintln!("decompile_project_iat: skipping (no `.sla`; run `make specs`): {stderr}");
+        return;
+    }
+    assert!(!ok, "an IAT slot unexpectedly exported: {stdout}");
+    assert!(stdout.trim().is_empty(), "an IAT project summary escaped: {stdout}");
+    assert_eq!(
+        stderr,
+        "error: selector \"0x401000\" identifies import VirtualAlloc at 0x401000; \
+         the IAT slot contains a loader-written pointer, not a function body\n"
+    );
+    assert!(!dir.exists(), "refusal left a project folder at {}", dir.display());
+}
+
 /// The four artifact paths for a `<file_name>` project export.
 fn artifacts(dir: &std::path::Path, file_name: &str) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
     (

--- a/decompiler/crates/kuna-console/src/engine.rs
+++ b/decompiler/crates/kuna-console/src/engine.rs
@@ -830,7 +830,7 @@ impl ConsoleProgram {
     /// The canonical entries eligible for automatic whole-binary decompilation.
     ///
     /// Import pointer slots remain in the canonical inventory for call naming
-    /// and explicit address selection, but data addresses are not function bodies.
+    /// and generic address lookup, but pointer words are not function bodies.
     /// Loaders without section metadata retain the complete inventory.
     ///
     /// Two things disqualify an entry, and the second is not a section-flag
@@ -880,11 +880,11 @@ impl ConsoleProgram {
     /// The per-entry half of [`Self::function_entries_executable`], with the
     /// section table hoisted out so a whole inventory costs one loader walk.
     fn entry_is_executable(&self, vma: u64, sections: &[(u64, u64, u32)]) -> bool {
+        if !self.is_body_entry(vma) {
+            return false;
+        }
         if self.is_declared_entry(vma) {
             return true;
-        }
-        if self.is_import_slot(vma) {
-            return false;
         }
         sections.is_empty()
             || sections.iter().any(|&(start, size, flags)| {
@@ -900,6 +900,15 @@ impl ConsoleProgram {
     /// path, for a raw image, and for every non-PE object.
     pub fn is_import_slot(&self, vma: u64) -> bool {
         self.import_slots.iter().any(|&(lo, hi)| vma >= lo && vma < hi)
+    }
+
+    /// Whether `vma` may be treated as the start of a function body.
+    ///
+    /// An import slot remains a `FunctionSymbol` so calls through its address
+    /// bind to the import name and prototype, but the word itself is not code.
+    /// A caller declaration deliberately outranks the loader classification.
+    pub fn is_body_entry(&self, vma: u64) -> bool {
+        self.is_declared_entry(vma) || !self.is_import_slot(vma)
     }
 
     /// (kuna, issue #197) Resolve a canonical entry by ANY of its names — the
@@ -1052,6 +1061,26 @@ impl ConsoleProgram {
                 })
             }
         }
+    }
+
+    /// Resolve a selector specifically for an operation that will lift a body.
+    ///
+    /// Generic symbol resolution intentionally accepts import slots: their
+    /// addresses are load-bearing call targets. Body selection adds the one
+    /// semantic check that resolution alone cannot make.
+    pub fn resolve_body_entry(
+        &self,
+        selector: &EntrySelector,
+    ) -> Result<FunctionEntry, EntryLookupError> {
+        let entry = self.resolve_entry(selector)?;
+        if self.is_body_entry(entry.addr.get_offset()) {
+            return Ok(entry);
+        }
+        Err(EntryLookupError::BodylessImport {
+            selector: selector.display(),
+            name: entry.name,
+            address: entry.addr.get_offset(),
+        })
     }
 
     /// Resolve an already-parsed machine address without discarding its address
@@ -1942,6 +1971,37 @@ impl ConsoleProgram {
         if explicit.is_some() {
             self.seed_declared_libc_prototype(&name, &addr);
         }
+        Ok(name)
+    }
+
+    /// Ensure a `FunctionSymbol` exists at `addr` without asserting that the
+    /// address has a body. Used by an addressed CLI run that needs a symbol for
+    /// prototype directives before selection.
+    pub fn ensure_function_symbol(&mut self, addr: Address) -> KunaResult<String> {
+        let addr = match addr.get_space() {
+            Some(space) => Address::new(
+                std::rc::Rc::clone(space),
+                self.thumb_normalized(addr.get_offset()),
+            ),
+            None => addr,
+        };
+        let name = match self.arch().symboltab.find_function_across_scopes(&addr) {
+            Some((sym, _)) => self.arch().symboltab.symbol(sym).get_display_name().to_string(),
+            None => {
+                let name = self.arch().name_function(&addr);
+                let type_code = self.arch().types().get_type_code()?;
+                let min_size = self.arch().min_funcsymbol_size;
+                let num_spaces = self.arch().manage().num_spaces() as int4;
+                let arch = self.arch_mut();
+                let (scope, basename) = arch
+                    .symboltab
+                    .find_create_scope_from_symbol_name(&name, "::", None, num_spaces)?;
+                arch.symboltab
+                    .add_function(scope, &addr, &basename, min_size, type_code)?;
+                name
+            }
+        };
+        self.register_symbol(&name, addr);
         Ok(name)
     }
 

--- a/decompiler/crates/kuna-console/src/entry_selector.rs
+++ b/decompiler/crates/kuna-console/src/entry_selector.rs
@@ -105,6 +105,11 @@ pub enum EntryLookupError {
         selector: String,
         candidates: Vec<FunctionEntry>,
     },
+    BodylessImport {
+        selector: String,
+        name: String,
+        address: u64,
+    },
 }
 
 impl fmt::Display for EntryLookupError {
@@ -154,6 +159,15 @@ impl fmt::Display for EntryLookupError {
                     "use a section-qualified selector to choose one candidate"
                 )
             }
+            Self::BodylessImport {
+                selector,
+                name,
+                address,
+            } => write!(
+                f,
+                "selector {selector:?} identifies import {name} at 0x{address:x}; \
+                 the IAT slot contains a loader-written pointer, not a function body"
+            ),
         }
     }
 }

--- a/decompiler/crates/kuna-console/src/ifacedecomp.rs
+++ b/decompiler/crates/kuna-console/src/ifacedecomp.rs
@@ -1308,7 +1308,7 @@ decomp_command!(
             .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
         let selector = crate::engine::EntrySelector::parse(&funcname);
         let selected = prog
-            .resolve_entry(&selector)
+            .resolve_body_entry(&selector)
             .map_err(|error| IfaceError::execution(error.to_string()))?;
         let entry = selected.addr;
         let resolved_name = if matches!(selector, crate::engine::EntrySelector::Name(_)) {
@@ -1382,7 +1382,7 @@ decomp_command!(
             .zip(prog.arch().manage().get_default_code_space())
             .is_some_and(|(requested, default)| std::rc::Rc::ptr_eq(requested, default));
         let selected = if in_default_space {
-            prog.resolve_entry(&crate::engine::EntrySelector::Numeric(requested.get_offset()))
+            prog.resolve_body_entry(&crate::engine::EntrySelector::Numeric(requested.get_offset()))
         } else {
             prog.resolve_address(&requested)
         }

--- a/decompiler/crates/kuna-console/src/kuna_console.rs
+++ b/decompiler/crates/kuna-console/src/kuna_console.rs
@@ -1356,6 +1356,40 @@ impl IfaceCommandAction for IfcKunaFunctionBounds {
     }
 }
 
+/// `function symbol <start>`: ensure an address-backed `FunctionSymbol` exists
+/// without asserting that the address contains a function body.
+pub struct IfcKunaFunctionSymbol;
+
+impl IfaceCommandAction for IfcKunaFunctionSymbol {
+    fn execute(&self, status: &mut IfaceStatus, s: &mut CommandStream) -> IfaceResult<()> {
+        let display_start = read_vma(&s.read_token())
+            .ok_or_else(|| IfaceError::parse("Missing function symbol address"))?;
+        let dcp = dcp_mut(status)?;
+        let prog = dcp
+            .conf
+            .as_mut()
+            .ok_or_else(|| IfaceError::execution("No load image present"))?;
+        let start = prog
+            .input_code_offset(display_start)
+            .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
+        let space = prog
+            .arch()
+            .manage()
+            .get_default_code_space()
+            .cloned()
+            .ok_or_else(|| IfaceError::execution("No default code space"))?;
+        let name = prog
+            .ensure_function_symbol(kuna_base::address::Address::new(space, start))
+            .map_err(|e| IfaceError::execution(e.explain().to_string()))?;
+        status.out(&format!("Registered {name} at {display_start:#x} without a body assertion\n"));
+        Ok(())
+    }
+
+    fn module(&self) -> String {
+        DECOMPILE_MODULE.to_string()
+    }
+}
+
 /// (kuna) `map prototype <func> <C declaration>`: bind a declared signature to
 /// the function NAMED by `<func>`.
 ///
@@ -1436,6 +1470,7 @@ pub fn register_kuna_commands(status: &mut IfaceStatus) {
     // (kuna) Not a C++ command: the function-boundary override the `kuna` binary
     // exposes as `--define-function`.
     status.register_com(Box::new(IfcKunaFunctionBounds), &["function", "bounds"]);
+    status.register_com(Box::new(IfcKunaFunctionSymbol), &["function", "symbol"]);
     // (kuna) Not a C++ command either: `parse line extern` binds a prototype by
     // the name in the declaration, which is the wrong key for an override that
     // exists because the function has no name worth keeping.

--- a/decompiler/crates/kuna-console/src/kuna_console/tests.rs
+++ b/decompiler/crates/kuna-console/src/kuna_console/tests.rs
@@ -60,19 +60,19 @@ fn run_one(line: &str) -> String {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn registers_all_twenty_kuna_commands() {
+fn registers_all_twenty_one_kuna_commands() {
     // register_decomp_commands registers 105 (see ifacedecomp/tests.rs); the
-    // kuna capability adds 20: phase list/map/status/catalog (plus the four
+    // kuna capability adds 21: phase list/map/status/catalog (plus the four
     // deprecated `stage ...` alias registrations), kassert, restarts,
     // pipeline, mode, quality, functions, region tree/blocks/walk,
-    // `function bounds`, `map prototype` and `override bytes`.
+    // `function bounds`/`function symbol`, `map prototype` and `override bytes`.
     let only_kuna = {
         let mut st = ConsoleCommands::into_status(vec![]);
         register_kuna_commands(&mut st);
         st.num_commands()
     };
-    assert_eq!(only_kuna, 20);
-    assert_eq!(console(&[]).num_commands(), 105 + 20);
+    assert_eq!(only_kuna, 21);
+    assert_eq!(console(&[]).num_commands(), 105 + 21);
 }
 
 #[test]

--- a/decompiler/crates/kuna-console/src/project.rs
+++ b/decompiler/crates/kuna-console/src/project.rs
@@ -198,9 +198,32 @@ pub fn decompile_pulled(
         }
         let byte_address = entry.get_offset();
         let address = prog.output_code_offset(byte_address);
+        if !prog.is_body_entry(byte_address) {
+            let error = crate::engine::EntryLookupError::BodylessImport {
+                selector: name.clone(),
+                name: name.clone(),
+                address: byte_address,
+            }
+            .to_string();
+            sink(FuncResult {
+                code: None,
+                name,
+                address,
+                byte_address,
+                size: size as i64,
+                error: Some(error),
+                proto: None,
+                variables: Vec::new(),
+                line_mappings: Vec::new(),
+                aliases,
+                object_location,
+                callee_hints: Vec::new(),
+            });
+            continue;
+        }
         // (kuna) An entry with no mapped bytes is an EXTERNAL, not a decompile
-        // failure: a relocatable object's undefined symbols (and a PE import
-        // slot) carry an address only so a call to one renders by name, and the
+        // failure: a relocatable object's undefined symbols carry an address
+        // only so a call to one renders by name, and the
         // definition lives in another module. The whole-binary surfaces never
         // reach one (`function_entries_executable` drops them), but selecting one
         // by name or address — clicking its row in the browser inventory — used to

--- a/decompiler/crates/kuna-console/tests/verify_pe_imports.rs
+++ b/decompiler/crates/kuna-console/tests/verify_pe_imports.rs
@@ -46,7 +46,7 @@
 use std::path::PathBuf;
 
 use kuna_base::address::Address;
-use kuna_console::engine::{bootstrap_from_object, ConsoleProgram};
+use kuna_console::engine::{bootstrap_from_object, ConsoleProgram, EntrySelector};
 use kuna_console::ifacedecomp::{
     execute, register_decomp_commands, IfaceDecompData, DECOMPILE_MODULE,
 };
@@ -73,6 +73,8 @@ fn fixtures() -> PathBuf {
 const MAIN_VMA: u64 = 0x140001592;
 const PUTS_THUNK_VMA: u64 = 0x140007240;
 const PUTS_IAT_VMA: u64 = 0x14000d33c;
+const GETLASTERROR_THUNK_VMA: u64 = 0x1400079f8;
+const GETLASTERROR_IAT_VMA: u64 = 0x14000d1ec;
 
 /// Bootstrap, run `load function`/`load addr`-driven `decompile` → `print C`, and
 /// return the captured C. `func_cmd` is the `load function …`/`load addr …`
@@ -216,6 +218,36 @@ fn pe_batch_targets_exclude_iat_data_slots() {
     );
 }
 
+/// A non-executable `.idata` slot is still resolvable for call binding but is
+/// refused when the consumer asks for a body. The same-named executable thunk
+/// remains the preferred body-bearing name selection and keeps its prototype.
+#[test]
+fn pe_data_iat_slot_is_not_a_body_target() {
+    let Some(mut prog) = boot("pe_imports.exe") else { return };
+    prog.commit_pending_analysis().expect("PE analysis commit must succeed");
+
+    let slot = EntrySelector::Numeric(GETLASTERROR_IAT_VMA);
+    assert_eq!(
+        prog.resolve_entry(&slot).expect("the slot stays resolvable").name,
+        "GetLastError"
+    );
+    assert_eq!(
+        prog.resolve_body_entry(&slot).unwrap_err().to_string(),
+        "selector \"0x14000d1ec\" identifies import GetLastError at 0x14000d1ec; \
+         the IAT slot contains a loader-written pointer, not a function body"
+    );
+
+    let by_name = prog
+        .resolve_body_entry(&EntrySelector::Name("GetLastError".into()))
+        .expect("the executable thunk is the body-bearing candidate");
+    assert_eq!(by_name.addr.get_offset(), GETLASTERROR_THUNK_VMA);
+    let out = decompile_func(prog, "load function GetLastError");
+    assert!(
+        out.contains("uint4 GetLastError(void)") && out.contains("return GetLastError()"),
+        "the thunk must keep the imported prototype and identity:\n{out}"
+    );
+}
+
 // ---- The IAT inside a CODE section (RE-need `bulk-decompilation-decodes-pe`) --
 //
 // `pe_iatincode_i386.exe` (synthesized; see the sibling `.py`) reproduces a
@@ -264,7 +296,23 @@ fn pe_batch_excludes_iat_slots_inside_a_code_section() {
             prog.find_entry_at(slot).is_some(),
             "PE: explicit lookup must retain the slot at {slot:#x}"
         );
+        let selector = EntrySelector::Numeric(slot);
+        assert!(
+            prog.resolve_entry(&selector).is_ok(),
+            "PE: generic call-target resolution must retain {slot:#x}"
+        );
+        assert!(
+            prog.resolve_body_entry(&selector).is_err(),
+            "PE: executable section flags must not make {slot:#x} a body"
+        );
     }
+    assert_eq!(
+        prog.resolve_body_entry(&EntrySelector::Name("VirtualAlloc".into()))
+            .unwrap_err()
+            .to_string(),
+        "selector \"VirtualAlloc\" identifies import VirtualAlloc at 0x401000; \
+         the IAT slot contains a loader-written pointer, not a function body"
+    );
     assert_eq!(executable, vec![IATINCODE_ENTRY_VMA]);
 }
 
@@ -299,5 +347,9 @@ fn pe_declared_entry_outranks_the_import_slot_test() {
     assert!(
         executable.contains(&IATINCODE_SLOTS[0]),
         "PE: a declared entry must survive the slot test, got {executable:x?}"
+    );
+    assert!(
+        prog.resolve_body_entry(&EntrySelector::Numeric(IATINCODE_SLOTS[0])).is_ok(),
+        "an explicit function declaration must make the slot a body target"
     );
 }

--- a/decompiler/crates/kuna-wasm/src/lib.rs
+++ b/decompiler/crates/kuna-wasm/src/lib.rs
@@ -397,11 +397,11 @@ fn resolve_targets(
         // An ALIAS resolves too — collapsing the enumeration must not make a
         // name that used to select a function stop working.
         Cmd::DecompileName(want) => prog
-            .resolve_entry(&EntrySelector::parse(want))
+            .resolve_body_entry(&EntrySelector::parse(want))
             .map(|entry| vec![entry])
             .map_err(|error| error.to_string()),
         Cmd::DecompileAddr(vma) => prog
-            .resolve_entry(&EntrySelector::Numeric(*vma))
+            .resolve_body_entry(&EntrySelector::Numeric(*vma))
             .map(|entry| vec![entry])
             .map_err(|error| error.to_string()),
         Cmd::List | Cmd::Project(_) => unreachable!("List/Project handled by caller"),

--- a/decompiler/crates/kuna-wasm/src/lib.rs
+++ b/decompiler/crates/kuna-wasm/src/lib.rs
@@ -677,6 +677,44 @@ mod tests {
         );
     }
 
+    /// Direct browser decompilation uses body-bearing selection too; inventory
+    /// remains free to retain this same import symbol for call binding.
+    #[test]
+    fn wasm_direct_decompile_refuses_an_executable_section_iat_slot() {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../..")
+            .canonicalize()
+            .unwrap();
+        let binary =
+            root.join("decompiler/crates/kuna-analysis/tests/fixtures/pe_iatincode_i386.exe");
+        let specs = root.join("specs");
+        let expected = "identifies import VirtualAlloc at 0x401000; \
+                        the IAT slot contains a loader-written pointer, not a function body";
+        for selector in ["VirtualAlloc", "0x401000"] {
+            match super::run_with_mode(
+                binary.to_str().unwrap(),
+                specs.to_str().unwrap(),
+                "decompile",
+                Some(selector),
+                Some("reliable"),
+            ) {
+                Err(error)
+                    if error.contains("could not build an architecture")
+                        || error.contains("SLEIGH")
+                        || error.contains("Could not discover") =>
+                {
+                    eprintln!("wasm_direct_decompile_iat: skipping: {error}");
+                    return;
+                }
+                Err(error) => {
+                    assert!(error.contains(expected), "{selector}: {error}");
+                    assert!(!error.contains("CARRY1("), "{selector}: {error}");
+                }
+                Ok(json) => panic!("{selector} unexpectedly emitted a WASM result: {json}"),
+            }
+        }
+    }
+
     /// The browser sidebar is built from `list`, so anything `project` exports
     /// but `list` omits is unreachable in the UI. `list` used to skip the
     /// discovery injections (`kuna functions`' cheap-enumeration trade), which

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -176,6 +176,15 @@ resolves it to the same veneer. The narrowing needs **exactly one** executable
 candidate, so two same-named definitions in different code sections of a
 relocatable object still report the ambiguity with every candidate listed.
 
+When an import has no body-bearing veneer, `decompile` and explicitly filtered
+whole-binary decompilation refuse its IAT slot with exit code 1. The diagnostic
+names the import and slot and explains that the bytes are a loader-written
+pointer, so neither an executable section flag nor direct `--addr` turns
+adjacent IAT words into instructions. Inventory, graph, disassembly/read, and
+xref consumers still resolve the slot because they do not lift a body. An
+explicit `--define-function` or `--assert function` declaration overrides the
+loader classification when the image's import directory is known to be false.
+
 **The instruction budget.** Flow following decodes at most `maxinstruction`
 instructions per function — 100000 by default, which no ordinary function comes
 near and an obfuscated one blows through. Past the budget the decompiling

--- a/docs/re-needs/decompiling-executable-section-iat.md
+++ b/docs/re-needs/decompiling-executable-section-iat.md
@@ -1,0 +1,158 @@
+---
+need_id: decompiling-executable-section-iat
+title: Decompiling an executable-section IAT slot invents an arithmetic function
+track: quality
+status: open
+severity: major
+probe_id: p-b0ded31a46b9
+acceptance_id: a-fffdb4ce0518
+hypothesis_status: overturned
+credibility: 0.85
+instances: 1
+challenges: [5ab77f6433c5d40ad448cae1]
+rounds: [12]
+first_seen_round: 12
+attempts: 1
+covered_by_option: null
+touches: [decompiler/crates/kuna-decomp]
+scope: small
+regression_of: null
+pr: null
+closed_in_round: null
+closing_pr: null
+reject_reason: null
+---
+
+## Symptom
+
+Inspect GetDlgItemTextA as an import without decoding its four-byte pointer slot as a function.
+
+> **Decompiling an executable-section IAT slot invents an arithmetic function** (major, `5ab77f6433c5d40ad448cae1`)
+> Resolved GetDlgItemTextA to 0x401078, then emitted CARRY1, pointer arithmetic, a memory write, and an overlapbranch warning. This entry is IAT data within .text.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "GetDlgItemTextA"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "\\*v[0-9]+\\s*=\\s*\\*v[0-9]+\\s*\\+"
+    ]
+  },
+  "target": {
+    "binary_rel": "bin/GiTS_2010_Crypto_Crackmes.zip.__x/crypto4.exe",
+    "binary_sha256": "f88284c9bfe6e8581261ee224395c83d79507b26a64f81614631d78498cf63b9",
+    "binary_size": 123904,
+    "binary_source": "dataset"
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/pe_iatincode_i386.exe",
+    "binary_sha256": "fc9a367d8615741a122c5b0dbd3d3042f408cbce93451a796bcc45f7710c719b",
+    "binary_size": 4608,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/pe_iatincode_i386.exe"
+  },
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "VirtualAlloc"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 1
+    },
+    "stdout_absent": [
+      "CARRY1\\(",
+      "\\*v[0-9]+\\s*=\\s*\\*v[0-9]+"
+    ],
+    "stderr_matches": [
+      "^error: selector \\\"VirtualAlloc\\\" identifies import VirtualAlloc at 0x401000; the IAT slot contains a loader-written pointer, not a function body\\n$"
+    ]
+  },
+  "notes": "The vendored PE reproduces the dataset witness's layout: its IAT is inside a CODE|EXECUTE section. The CLI must retain VirtualAlloc as a call-binding symbol but refuse to lift its pointer slot."
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- Function-body selection does not exclude known IAT slots when their section is executable.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+- `objdump -p target/GiTS_2010_Crypto_Crackmes.zip.__x/crypto4.exe` — Identifies GetDlgItemTextA as the fourth USER32.dll import, placing its pointer slot at 0x401078. The bytes kuna decoded are import data. IDA's server failed before registering.
+
+## Instances
+
+- `5ab77f6433c5d40ad448cae1` (round 12, tester t-r12-5ab77f64)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+- split by captain at T_DEDUP from round 12's `wrong-output|decompile|stdout_absent` bucket: cluster.py's signature (kind|subcommand|clause-shape) collapsed unrelated defects, so the crop was hand-partitioned one observation per need and filed via `--from-file`. See `.kuna-repipe/rounds/12/dedup/MARKER.json`; do NOT run `cluster --round 12` bare.
+- sibling of `pe-import-calls-become` — shared root condition (IAT data inside .text); kept separate, this half is a CLI refusal.
+- round 12 REFUTER: hypothesis **overturned** (was inconclusive). OVERTURNED. The symptom is exact and now reproduces on a SECOND, unrelated binary, but the hypothesis's discriminator -- "when their section is executable" -- is measurably false, and the clause that is true is misframed in a way that would send a builder at load-bearing code.
+
+MEASURED ON b9029a8f (release binaries rebuilt 05:39).
+
+THE CONTROL THAT OVERTURNS IT. decompiler/crates/kuna-analysis/tests/fixtures/pe_imports.exe puts its IAT in .idata at 0x14000d000, flags CONTENTS ALLOC LOAD DATA -- WRITABLE and NOT EXECUTABLE, the exact opposite of the filed condition. kuna registers 50 functions inside that .idata range (DeleteCriticalSection 0x14000d1dc, EnterCriticalSection 0x14000d1e4, GetLastError 0x14000d1ec, ...), and kuna decompile <fixture> 0x14000d1ec --addr emits the SAME class of invented arithmetic body: "v2 = *v8; *(unsigned int *)CONCAT71(v3,v2) = *(int *)CONCAT71(v3,v2) << (v4 & 0x1f) | ...; *(char *)CONCAT71(v3,v2) = *(char *)CONCAT71(v3,v2) + v2;". Pointer arithmetic and a memory write off decoded import-pointer bytes, in a non-executable data section. Section permission is NOT the discriminator. A builder who adds an is-executable guard changes nothing on either binary.
+
+BOTH SHIPPED OPTIONS ARE PROVEN INNOCENT on the reported command. kuna decompile crypto4.exe GetDlgItemTextA emits the identical CARRY1 body under --option litpoolconst off AND under --option peimportcall off. So this is NOT the constant-fold defect its sibling turned out to be (see pe-import-calls-become, UPHELD, cause litpoolconst) -- the two needs do not share a root cause, only a binary.
+
+WHAT IS ACTUALLY HAPPENING, and why the other clause is misframed. It is not that "function-body selection does not exclude known IAT slots". kuna's PE loader POSITIVELY ASSERTS that each IAT slot is a function: loader/pe_iat.rs registers a FunctionSymbol at every slot VA, and kuna_peimportcall.rs:28-31 says so in as many words -- "ActionDeindirect resolves it through the FunctionSymbol pe_iat already registered at the slot VA... kuna's query_function keys on the Varnode's own address rather than upstream's ExternRefSymbol::refaddr indirection, so the slot-VA registration lines up without a second symbol." THE SLOT-VA FUNCTION REGISTRATION IS LOAD-BEARING FOR DIV-57. Deleting it, or teaching body selection to skip IAT slots wholesale, breaks peimportcall's import binding on every PE. That is the trap in the filed wording and it is why this reads overturned rather than upheld-with-detail.
+
+The real gap is narrower: an import is modelled as a function whose ENTRY is its IAT slot, and nothing between that symbol and the decoder distinguishes "this entry exists so a call can be bound by address" from "this entry has a body worth lifting". kuna's own decoder already notices the collision -- the emitted body carries "warn: overlapbranch: this instruction overlaps the branch target at 0x00401088", and 0x401088 is SetWindowPos, the NEIGHBOURING IAT slot, also registered as a function. The registered sizes admit it too: in crypto4 the slots come out size 4, or size 8 for the last entry of a DLL block where the null terminator is absorbed (SetBkMode 0x40100c, HeapDestroy 0x401064); in the control they come out size 0.
+
+REDIRECT, not a proven line: make the refusal at the decompile entry point, on the fact that the target is a known import slot (loader/pe_iat.rs:93 resolve_pe_import_slots already returns exactly those ranges), and keep the symbol. An import has no body in this image by definition, so declining with the import's identity -- name, ordinal, DLL -- is strictly more useful to an agent than four bytes of decoded pointer.
+
+A SECOND OBSERVATION THE CONTROL SURFACED, not this need but adjacent: on the control fixture, kuna decompile <fixture> GetLastError errors with "selector is ambiguous; candidates: GetLastError at synthetic 0x1400079f8, GetLastError at synthetic 0x14000d1ec" -- the thunk veneer and the IAT slot both carry the name -- AND EXITS 0. A name-selector error path returning success is its own hazard for a scripted agent.
+
+ACCEPTANCE IS PERMISSIVE, READ IT BEFORE BUILDING. It has no exit_code clause and no positive clause: only stdout_absent of the pointer-arithmetic shape and of CARRY1. Any refusal, any error, or empty stdout passes it. That matches this need's stated intent (the T_DEDUP note calls this half "a CLI refusal"), so it is not wrong -- but it cannot distinguish a good refusal from a suppressed one, and a builder must not satisfy it by making the emitter quieter in general. Pair it with the sibling's acceptance, which is strict.
+
+DISPATCH CONSEQUENCE: the T_DEDUP note's stated shared root condition, "IAT data living inside .text", is now MEASURED FALSE for this half -- it reproduces where the IAT is not in .text at all. Do not cluster the pair on that premise. They remain adjacent work (both live in loader/pe_iat.rs and both need resolve_pe_import_slots), so one builder taking both is still reasonable, but for the code they touch, not for a shared cause.
+- round 12 B_IDLE (captain): **probe target bound by hand; this need is now dispatchable.** Both
+  its probe blocks used `{{BIN}}` with no `target`, so every replay died with "`{{BIN}}` used but the
+  context supplies no bin" -- clauses `[]`, repeat 0 -- and two consecutive `B_PLAN` ticks had to
+  skip it because an acceptance that cannot run can never flip, however good the fix. The binary is
+  identified from the filing tester's own `toolcalls.jsonl`, by an argv that matches the probe cmd
+  exactly, not by guessing from the arena: `kuna decompile target/GiTS_2010_Crypto_Crackmes.zip.__x/crypto4.exe GetDlgItemTextA`. Bound to
+  `bin/GiTS_2010_Crypto_Crackmes.zip.__x/crypto4.exe` (sha256 `f88284c9bfe6e8581261ee224395c83d79507b26a64f81614631d78498cf63b9`, 123904 bytes,
+  source `dataset`, resolved as `challenges/5ab77f6433c5d40ad448cae1/<rel>`). `target` is not part of
+  `probe_id`/`acceptance_id` (they hash `cmd`+`expect` only), so both ids are unchanged and no
+  front-matter drifted. Replayed on unpatched main `17da9472`: **reproduction PASSES** (the defect
+  is present) and **acceptance FAILS** on both `stdout_absent` clauses (`*v1 = *v1 +` and `CARRY1(` are still emitted) -- runnable, honestly failing, which is the
+  dispatch precondition.
+- builder attempt 1: promoted acceptance to the shipped in-repo `pe_iatincode_i386.exe`
+  fixture so CI pins an executable-section IAT, a non-success verdict, stable import identity,
+  and absence of lifted pointer arithmetic. Canonical acceptance changed from
+  `a-adefc9329f47` to `a-fffdb4ce0518`; the original dataset reproduction and
+  `p-b0ded31a46b9` remain unchanged. Implementation is pending review and merge, so status
+  remains `open` with `pr: null`.

--- a/docs/re-needs/decompiling-executable-section-iat.md
+++ b/docs/re-needs/decompiling-executable-section-iat.md
@@ -2,7 +2,7 @@
 need_id: decompiling-executable-section-iat
 title: Decompiling an executable-section IAT slot invents an arithmetic function
 track: quality
-status: open
+status: closed
 severity: major
 probe_id: p-b0ded31a46b9
 acceptance_id: a-fffdb4ce0518
@@ -17,9 +17,9 @@ covered_by_option: null
 touches: [decompiler/crates/kuna-decomp]
 scope: small
 regression_of: null
-pr: null
-closed_in_round: null
-closing_pr: null
+pr: "588"
+closed_in_round: 12
+closing_pr: "588"
 reject_reason: null
 ---
 
@@ -156,3 +156,14 @@ DISPATCH CONSEQUENCE: the T_DEDUP note's stated shared root condition, "IAT data
   `a-adefc9329f47` to `a-fffdb4ce0518`; the original dataset reproduction and
   `p-b0ded31a46b9` remain unchanged. Implementation is pending review and merge, so status
   remains `open` with `pr: null`.
+- closed: acceptance `a-fffdb4ce0518` now PASSES at exact implementation head
+  `46075ebcf48df2aff29a6ee2701bf283c1b3e7a2`. Measured surfaces: the dataset
+  witness `GetDlgItemTextA` at `0x401078` exits 1 with the stable import-slot
+  diagnostic and no `CARRY1`/invented pointer arithmetic; the executable-IAT
+  fixture's `VirtualAlloc` at `0x401000` and the non-executable-IAT fixture's
+  `GetLastError` at `0x14000d1ec` are likewise refused; an ordinary real body at
+  `0x401010` still decompiles with named `VirtualAlloc`/`GetModuleHandleA` calls;
+  and the executable thunk for `GetLastError` still decompiles with its imported
+  `unsigned int` prototype. Filtered decompile-all/project and direct WASM
+  name/address paths also pass. Closure metadata is durable only when PR #588
+  merges.

--- a/docs/re-needs/decompiling-executable-section-iat.md
+++ b/docs/re-needs/decompiling-executable-section-iat.md
@@ -14,7 +14,7 @@ rounds: [12]
 first_seen_round: 12
 attempts: 1
 covered_by_option: null
-touches: [decompiler/crates/kuna-decomp]
+touches: [decompiler/crates/kuna-analysis, decompiler/crates/kuna-console, decompiler/crates/kuna-cli, decompiler/crates/kuna-wasm]
 scope: small
 regression_of: null
 pr: "588"
@@ -167,3 +167,8 @@ DISPATCH CONSEQUENCE: the T_DEDUP note's stated shared root condition, "IAT data
   `unsigned int` prototype. Filtered decompile-all/project and direct WASM
   name/address paths also pass. Closure metadata is durable only when PR #588
   merges.
+- final review: corrected `touches` to the four crates changed by the implementation:
+  `kuna-analysis`, `kuna-console`, `kuna-cli`, and `kuna-wasm`; `kuna-decomp` is
+  not changed. Scope remains `small` because it classifies implementation
+  complexity: the body-eligibility policy is narrow and centralized, while the
+  CLI and WASM changes are surface adapters for that same policy.

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -2661,7 +2661,7 @@
       "status": "open",
       "severity": "major",
       "probe_id": "p-b0ded31a46b9",
-      "acceptance_id": "a-adefc9329f47",
+      "acceptance_id": "a-fffdb4ce0518",
       "hypothesis_status": "overturned",
       "credibility": 0.85,
       "instances": 1,
@@ -2672,7 +2672,7 @@
         12
       ],
       "first_seen_round": 12,
-      "attempts": 0,
+      "attempts": 1,
       "covered_by_option": null,
       "touches": [
         "decompiler/crates/kuna-decomp"
@@ -2683,7 +2683,7 @@
       "closed_in_round": null,
       "closing_pr": null,
       "reject_reason": null,
-      "score": 13.862944,
+      "score": 9.241962,
       "path": "docs/re-needs/decompiling-executable-section-iat.md"
     },
     {

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -5,8 +5,8 @@
   "rejected_count": 1,
   "by_status": {
     "blocked": 1,
-    "closed": 133,
-    "open": 63
+    "closed": 134,
+    "open": 62
   },
   "by_track": {
     "loader": 10,
@@ -2658,7 +2658,7 @@
       "need_id": "decompiling-executable-section-iat",
       "title": "Decompiling an executable-section IAT slot invents an arithmetic function",
       "track": "quality",
-      "status": "open",
+      "status": "closed",
       "severity": "major",
       "probe_id": "p-b0ded31a46b9",
       "acceptance_id": "a-fffdb4ce0518",
@@ -2679,9 +2679,9 @@
       ],
       "scope": "small",
       "regression_of": null,
-      "pr": null,
-      "closed_in_round": null,
-      "closing_pr": null,
+      "pr": "588",
+      "closed_in_round": 12,
+      "closing_pr": "588",
       "reject_reason": null,
       "score": 9.241962,
       "path": "docs/re-needs/decompiling-executable-section-iat.md"

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -2675,7 +2675,10 @@
       "attempts": 1,
       "covered_by_option": null,
       "touches": [
-        "decompiler/crates/kuna-decomp"
+        "decompiler/crates/kuna-analysis",
+        "decompiler/crates/kuna-console",
+        "decompiler/crates/kuna-cli",
+        "decompiler/crates/kuna-wasm"
       ],
       "scope": "small",
       "regression_of": null,

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -253,8 +253,11 @@ Four front-ends drive one engine assembly:
   default target set through
   `decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::function_entries_executable)`:
   only entries inside a loader section carrying `CODE` are treated as function
-  bodies. Import slots remain installed for call naming, prototypes, and
-  unrestricted explicit address selection. A
+  bodies. Import slots remain installed for call naming, prototypes, and generic
+  symbol/address lookup. A decompiling selection adds a body check: a known IAT
+  slot is refused instead of lifting its pointer bytes, even when its section is
+  executable. A caller declaration overrides that classification when the image
+  metadata is wrong. A
   loader that publishes no section metadata retains the complete canonical set.
 
   When a stub and its slot share a name, that same executability test settles the
@@ -307,12 +310,15 @@ Four front-ends drive one engine assembly:
   listing beside the error, because a name the packed stub is going to call is
   the answer for that file. A declaration is still what clears the verdict: one
   declared body makes the run a run.
-  Explicit selection of an entry with **no mapped bytes** — an import slot, or a
-  relocatable object's undefined symbol bound to a synthetic extern-area address
+  Explicit selection of an entry with **no mapped bytes** — a relocatable
+  object's undefined symbol bound to a synthetic extern-area address
   so that calls to it render by name — answers with the entry's nature rather
   than with the lifter's byte-load failure: the shared decompile step probes
   `decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::entry_bytes_mapped)`
-  first and emits a one-line external-symbol body. The probe is a one-byte read
+  first and emits a one-line external-symbol body. A PE IAT slot is different:
+  its pointer bytes are mapped, so body selection consults the loader's import
+  ranges and returns a non-success diagnostic naming the import and slot before
+  flow following starts. The mapped-byte probe remains a one-byte read
   rather than a section-flag test, so an address that is mapped but outside any
   `CODE` section (packed code in `.data`, a hand-picked `--addr`) decompiles
   exactly as before. The browser inventory sorts the same entries into its
@@ -1272,7 +1278,7 @@ path only when it resolves and nothing of that name exists, and never errors.
 The same resolution serves the cross-function `param <func>::<i>` /
 `return <func>::<storage>` qualifier.
 
-(kuna) **A by-address selection DECLARES its own entry, so a directive can name
+(kuna) **A by-address selection installs its own symbol, so a directive can name
 it.** `load addr <vma>` builds the `Funcdata` and follows flow from an address
 without installing a `FunctionSymbol` there (the symbol-table `addFunction` is a
 later boundary), which is fine for printing C and fatal for the assertion plane:
@@ -1280,18 +1286,21 @@ the resolution above reads the symbol table, so `kuna decompile <bin> 0x401571
 --assert 'prototype 0x401571 …'` emitted the function in full and answered
 `rejected: no function starts at 0x401571` — the address it had just decompiled —
 while the identical directive bound the moment the same run selected the function
-BY NAME. Pointing `--addr` at an address is itself the claim that a function
-starts there, so the generated script declares that entry
+BY NAME. Pointing `--addr` at an address claims a lift entry, but does not
+override loader knowledge that the address is an import pointer. The generated
+script ensures a symbol exists
 (`decompiler/crates/kuna-cli/src/decompile.rs (build_script, selected_vma)` ->
-`function bounds <vma>` -> `ConsoleProgram::declare_function`) between the
+`function symbol <vma>` -> `ConsoleProgram::ensure_function_symbol`) between the
 caller's own `--define-function` declarations and the program-scoped directives.
-It is the same install `--define-function <start>` performs, and it is skipped
+It is the symbol-table half of `--define-function <start>`, and it is skipped
 when the caller declared that start themselves, whose extent a second bare
-declaration would clear back to unbounded. The declaration is the SELECTION's
-alone: an operand naming some other address that starts no function is still
+declaration would clear back to unbounded. Only an explicit declaration records
+body provenance; the implicit symbol cannot turn an IAT word into code. The
+symbol is the SELECTION's alone: an operand naming some other address that starts
+no function is still
 rejected, which is the only signal an agent gets that a directive is inert
-(`docs/re-needs/prototype-assertion-rejects-explicit.md`). Declaring an entry
-preserves why that entry exists — an import's synthetic address stays an
+(`docs/re-needs/prototype-assertion-rejects-explicit.md`). Installing the symbol
+preserves why that address exists — an import's synthetic address stays an
 `UndefinedExternal`, so an addressed import keeps answering with its
 external-symbol note rather than `not mapped in this input` — and folds the
 ARM/Thumb mode bit out of the address, so the declaration lands where every later

--- a/docs/spec/01-program-prep.md
+++ b/docs/spec/01-program-prep.md
@@ -1007,10 +1007,11 @@ calls resolve to a name and library prototype. They are not function bodies.
 The complete canonical inventory retains both, while automatic whole-binary
 decompilation selects only entries contained by a loader `CODE` section
 (`decompiler/crates/kuna-console/src/engine.rs
-(ConsoleProgram::function_entries_executable)`). Explicit address selection
-remains unrestricted; name selection keeps its normal first-match behavior when
-a stub and slot share a name. Loaders without section metadata keep the complete
-inventory.
+(ConsoleProgram::function_entries_executable)`). Explicit decompiling selection
+uses the same body distinction: a lone IAT slot is refused with its import name
+and address, while a name shared by a stub and slot selects the sole body-bearing
+stub. Generic lookup still resolves the slot for call binding and inventory
+consumers. Loaders without section metadata keep the complete inventory.
 
 (kuna) "In a data section" is the usual place for a slot and not a property of
 one, so the section flags cannot carry that filter alone. A PE is free to put its
@@ -1027,8 +1028,9 @@ empty everywhere else) beside the names themselves, and the engine carries them
 as `[lo, hi)` ranges (`ObjectLoadImage::import_slot_ranges` →
 `ConsoleProgram::is_import_slot`). An entry inside one is excluded from the
 batch set whatever the section says. Nothing else moves: the canonical
-inventory, `kuna functions`, `--addr`/`--functions` selection and the call
-naming the slot exists for are all unchanged — on the crypter the batch goes
+inventory, `kuna functions`, generic symbol resolution and the call naming the
+slot exists for are unchanged. Decompiling `--addr`/`--functions` selection
+refuses a slot before decode — on the crypter the batch goes
 from 56 entries to its 6 real ones while the surviving body still renders
 `ExitProcess(0)`. A caller-declared entry (`--define-function`) outranks this
 test as it outranks the section-flag one, so an analyst who asserts a function

--- a/tests/cli/decompiling-executable-section-iat.json
+++ b/tests/cli/decompiling-executable-section-iat.json
@@ -1,0 +1,31 @@
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "target": {
+    "binary_rel": "decompiler/crates/kuna-analysis/tests/fixtures/pe_iatincode_i386.exe",
+    "binary_sha256": "fc9a367d8615741a122c5b0dbd3d3042f408cbce93451a796bcc45f7710c719b",
+    "binary_size": 4608,
+    "binary_source": "in-repo",
+    "in_repo_path": "decompiler/crates/kuna-analysis/tests/fixtures/pe_iatincode_i386.exe"
+  },
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "VirtualAlloc"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 1
+    },
+    "stdout_absent": [
+      "CARRY1\\(",
+      "\\*v[0-9]+\\s*=\\s*\\*v[0-9]+"
+    ],
+    "stderr_matches": [
+      "^error: selector \\\"VirtualAlloc\\\" identifies import VirtualAlloc at 0x401000; the IAT slot contains a loader-written pointer, not a function body\\n$"
+    ]
+  },
+  "notes": "The vendored PE reproduces the dataset witness's layout: its IAT is inside a CODE|EXECUTE section. The CLI must retain VirtualAlloc as a call-binding symbol but refuse to lift its pointer slot."
+}


### PR DESCRIPTION
## Behavior

Known PE Import Address Table slots remain registered as function symbols for import naming, prototypes, and indirect-call binding, but direct body-bearing decompile selection now refuses them before lifting pointer bytes. The rule is independent of section permissions and applies consistently to CLI text/JSON, filtered whole-binary runs, project export, console loading, and WASM direct selection. Explicit caller declarations still override loader classification.

## Controls

- Dataset crypto4.exe GetDlgItemTextA now exits 1 with a stable import/address diagnostic and no invented arithmetic body.
- Executable-section IAT name/address and adjacent slots refuse identically.
- Non-executable .idata IAT address refuses identically.
- The executable GetLastError thunk keeps its imported prototype.
- An ordinary PE body still renders named VirtualAlloc and GetModuleHandleA calls.
- Generic import-slot resolution and graph inventory semantics remain intact.

## Validation

- Affected Rust packages: kuna-analysis, kuna-console, kuna-cli, and kuna-wasm pass.
- Datatests: 675/675, baseline parity OK.
- Stage tests: 794/794, baseline parity OK.
- Promoted CLI corpus: 139/139.
- Durable acceptance a-fffdb4ce0518 passes all exit/stdout/stderr clauses.
- Strict spec, counters, catalog, mergecheck, diff, and exact-head reviews pass.

Durable closure is recorded only once this PR merges.