### PR TITLE
[AUTOMATED] Report mapped decode failures as errors

### DIFF
--- a/decompiler/crates/kuna-cli/src/decompile.rs
+++ b/decompiler/crates/kuna-cli/src/decompile.rs
@@ -532,17 +532,10 @@ fn is_unknown_function(out: &str) -> bool {
         || out.contains("Bad namespace:")
 }
 
-/// Whether the console transcript says the selected entry has no mapped bytes
-/// (`LoadImage::load_fill`'s "Unable to load N bytes at <addr>", raised the
-/// moment the flow-follower asks for the first instruction).
-///
-/// For an object-backed input, that is the signature of an **external**: an
-/// entry that carries an address for call naming but whose definition is in
-/// another module. A raw image can emit the same diagnostic when a mapped entry
-/// reaches EOF or undecodable trailing bytes, so callers must not apply this
-/// shortcut to raw inputs.
+/// The console's mapping check precedes flow following. A later byte-load
+/// failure can come from decoding mapped code and does not identify an external.
 fn is_unmapped_entry(out: &str) -> bool {
-    out.contains("Unable to load ") && out.contains(" bytes at ")
+    selection_failure(out).as_deref() == Some("Selected entry has no mapped bytes")
 }
 
 /// The console's per-function abort notice: `IfcDecompile` catches a

--- a/decompiler/crates/kuna-cli/src/decompile.rs
+++ b/decompiler/crates/kuna-cli/src/decompile.rs
@@ -463,15 +463,14 @@ fn selection_failure(out: &str) -> Option<String> {
 /// The architecture arm must stay ahead of the analysis-commit arm: a failed
 /// `load file` leaves no image, so every later command — `read symbols`
 /// included — answers `No load image present`, which is a consequence, not the
-/// reason. `unmapped_is_external` is false for raw images because their seeds
-/// are known to be mapped; a short or undecodable raw image can produce the
-/// same loader diagnostic while failing to decode a real entry.
+/// reason. `allow_external` is false for raw images because their entries must
+/// have mapped bytes.
 fn check_errors(
     out: &str,
     target: &str,
     binary: &str,
     by_address: bool,
-    unmapped_is_external: bool,
+    allow_external: bool,
 ) -> Option<String> {
     if out.contains("Could not discover root of Ghidra installation") {
         return Some(
@@ -508,11 +507,10 @@ fn check_errors(
     // An ambiguous or unmapped selector is answered by the selector model, whose
     // report names every candidate. Return it verbatim: the transcript dump the
     // caller falls back to is capped at its FIRST 2000 characters, which in the
-    // default mode is all option chatter, so the answer would be cut off. The
-    // For object inputs, the unmapped-entry probe stays ahead of it — an
-    // external is not a bad selector. Raw entries were range-validated at load,
-    // so the same text is a decode failure and must remain an error.
-    if !(unmapped_is_external && is_unmapped_entry(out)) {
+    // default mode is all option chatter, so the answer would be cut off.
+    // A proven undefined external is not a bad selector. Other entries with
+    // missing bytes remain selection failures.
+    if !(allow_external && is_undefined_external_entry(out)) {
         if let Some(reason) = selection_failure(out) {
             return Some(reason);
         }
@@ -532,10 +530,10 @@ fn is_unknown_function(out: &str) -> bool {
         || out.contains("Bad namespace:")
 }
 
-/// The console's mapping check precedes flow following. A later byte-load
-/// failure can come from decoding mapped code and does not identify an external.
-fn is_unmapped_entry(out: &str) -> bool {
-    selection_failure(out).as_deref() == Some("Selected entry has no mapped bytes")
+/// The console identifies undefined externals from the selected entry's
+/// provenance. Missing bytes alone do not identify an external.
+fn is_undefined_external_entry(out: &str) -> bool {
+    selection_failure(out).as_deref() == Some("Selected entry is an undefined external symbol")
 }
 
 /// The console's per-function abort notice: `IfcDecompile` catches a
@@ -1039,8 +1037,9 @@ fn decompile(args: &DecompileArgs) -> Result<DecompileOutcome, String> {
             // like a decompiler defect. The whole-binary surfaces answer the same
             // way through `kuna_console::project::decompile_targets`, which asks
             // the engine directly (`ConsoleProgram::entry_bytes_mapped`); this
-            // path drives `decomp_dbg` as a subprocess and so reads its report.
-            if !args.raw_image && is_unmapped_entry(&combined) {
+            // path drives `decomp_dbg` as a subprocess and so reads its
+            // provenance-specific report.
+            if !args.raw_image && is_undefined_external_entry(&combined) {
                 return Ok(DecompileOutcome {
                     c: format!(
                         "// {}: external symbol -- no code at this address in this module",

--- a/decompiler/crates/kuna-cli/tests/mapped_decode_failure.rs
+++ b/decompiler/crates/kuna-cli/tests/mapped_decode_failure.rs
@@ -1,0 +1,73 @@
+mod common;
+#[path = "common/arm_images.rs"]
+#[allow(dead_code)]
+mod arm_images;
+
+use std::process::Command;
+
+#[test]
+fn undefined_function_still_reports_an_external_symbol() {
+    use object::write::{Object, Symbol, SymbolSection};
+    use object::{Architecture, BinaryFormat, Endianness, SectionKind, SymbolFlags, SymbolKind, SymbolScope};
+    let mut obj = Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
+    let text = obj.add_section(Vec::new(), b".text".to_vec(), SectionKind::Text);
+    obj.append_section_data(text, &[0xe8, 0, 0, 0, 0, 0xc3], 1);
+    let outside = obj.add_symbol(Symbol {
+        name: b"outside".to_vec(), value: 0, size: 0, kind: SymbolKind::Text,
+        scope: SymbolScope::Linkage, weak: false, section: SymbolSection::Undefined,
+        flags: SymbolFlags::None,
+    });
+    obj.add_relocation(text, object::write::Relocation {
+        offset: 1, symbol: outside, addend: -4,
+        flags: object::RelocationFlags::Generic {
+            kind: object::RelocationKind::Relative,
+            encoding: object::RelocationEncoding::X86Branch,
+            size: 32,
+        },
+    }).unwrap();
+    let path = common::scratch_file("undefined-function", "o");
+    std::fs::write(&path, obj.write().unwrap()).unwrap();
+    for json in [false, true] {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_kuna"));
+        cmd.args(["decompile", path.to_str().unwrap(), "outside"]);
+        if json { cmd.arg("--json"); }
+        let output = cmd.output().unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(output.status.success(), "{stdout}\n{stderr}");
+        assert!(stdout.contains("external symbol"), "{stdout}");
+    }
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn mapped_decode_failure_is_not_an_external_symbol() {
+    let path = common::scratch_file("mapped-thumb-code", "elf");
+    // movs r0, #7; bx lr, deliberately without ARM/Thumb metadata.
+    let mut elf = arm_images::elf(&[7, 0x20, 0x70, 0x47], &[], &[]);
+    let ph = u32::from_le_bytes(elf[28..32].try_into().unwrap()) as usize;
+    let base = u32::from_le_bytes(elf[ph + 8..ph + 12].try_into().unwrap());
+    for (field, value) in [(4, 0x10000 - base), (8, 0x10000), (12, 0x10000), (16, 4), (20, 4)] {
+        elf[ph + field..ph + field + 4].copy_from_slice(&value.to_le_bytes());
+    }
+    std::fs::write(&path, elf).unwrap();
+    for json in [false, true] {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_kuna"));
+        cmd.args(["decompile", path.to_str().unwrap(), "0x10000", "--addr"]);
+        if json {
+            cmd.arg("--json");
+        }
+        let output = cmd.output().unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!output.status.success(), "{stdout}\n{stderr}");
+        assert!(!stdout.contains("external symbol"), "{stdout}");
+        assert!(stderr.contains("Unable to load"), "{stderr}");
+    }
+    let output = Command::new(env!("CARGO_BIN_EXE_kuna"))
+        .args(["decompile", path.to_str().unwrap(), "0x10000", "--addr", "--isa", "thumb"])
+        .output().unwrap();
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    assert!(String::from_utf8_lossy(&output.stdout).contains("return 7;"));
+    std::fs::remove_file(path).unwrap();
+}

--- a/decompiler/crates/kuna-cli/tests/mapped_decode_failure.rs
+++ b/decompiler/crates/kuna-cli/tests/mapped_decode_failure.rs
@@ -6,12 +6,43 @@ mod arm_images;
 use std::process::Command;
 
 #[test]
+fn mapped_symbol_without_bytes_is_not_an_external_symbol() {
+    let path = common::scratch_file("missing-symbol-bytes", "xml");
+    std::fs::write(&path, r#"<binaryimage arch="x86:LE:64:default:gcc">
+<bytechunk space="ram" offset="0x100000" readonly="true">b807000000c3</bytechunk>
+<symbol space="ram" offset="0x100000" name="mapped"/>
+<symbol space="ram" offset="0x200000" name="missing"/>
+</binaryimage>"#).unwrap();
+    let mapped = Command::new(env!("CARGO_BIN_EXE_kuna"))
+        .args(["decompile", path.to_str().unwrap(), "mapped"])
+        .output().unwrap();
+    assert!(mapped.status.success(), "{}", String::from_utf8_lossy(&mapped.stderr));
+    assert!(String::from_utf8_lossy(&mapped.stdout).contains("return 7;"));
+    for selector in ["missing", "0x200000"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_kuna"))
+            .args(["decompile", path.to_str().unwrap(), selector])
+            .output().unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!output.status.success(), "{stdout}\n{stderr}");
+        assert!(!stdout.contains("external symbol"), "{stdout}");
+        assert!(stderr.contains("no mapped bytes") || stderr.contains("not mapped"), "{stderr}");
+    }
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
 fn undefined_function_still_reports_an_external_symbol() {
     use object::write::{Object, Symbol, SymbolSection};
     use object::{Architecture, BinaryFormat, Endianness, SectionKind, SymbolFlags, SymbolKind, SymbolScope};
     let mut obj = Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
     let text = obj.add_section(Vec::new(), b".text".to_vec(), SectionKind::Text);
     obj.append_section_data(text, &[0xe8, 0, 0, 0, 0, 0xc3], 1);
+    obj.add_symbol(Symbol {
+        name: b"caller".to_vec(), value: 0, size: 6, kind: SymbolKind::Text,
+        scope: SymbolScope::Linkage, weak: false, section: SymbolSection::Section(text),
+        flags: SymbolFlags::None,
+    });
     let outside = obj.add_symbol(Symbol {
         name: b"outside".to_vec(), value: 0, size: 0, kind: SymbolKind::Text,
         scope: SymbolScope::Linkage, weak: false, section: SymbolSection::Undefined,
@@ -27,9 +58,18 @@ fn undefined_function_still_reports_an_external_symbol() {
     }).unwrap();
     let path = common::scratch_file("undefined-function", "o");
     std::fs::write(&path, obj.write().unwrap()).unwrap();
-    for json in [false, true] {
+    let output = Command::new(env!("CARGO_BIN_EXE_kuna"))
+        .args(["functions", path.to_str().unwrap()])
+        .output().unwrap();
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let listing = String::from_utf8_lossy(&output.stdout);
+    let outside_line = listing.lines()
+        .find(|line| line.split_whitespace().nth(1) == Some("outside"))
+        .expect("undefined function in inventory");
+    let address = outside_line.split_whitespace().next().unwrap();
+    for (selector, json) in [("outside", false), ("outside", true), (address, false), (address, true)] {
         let mut cmd = Command::new(env!("CARGO_BIN_EXE_kuna"));
-        cmd.args(["decompile", path.to_str().unwrap(), "outside"]);
+        cmd.args(["decompile", path.to_str().unwrap(), selector]);
         if json { cmd.arg("--json"); }
         let output = cmd.output().unwrap();
         let stdout = String::from_utf8_lossy(&output.stdout);

--- a/decompiler/crates/kuna-console/src/ifacedecomp.rs
+++ b/decompiler/crates/kuna-console/src/ifacedecomp.rs
@@ -1311,6 +1311,9 @@ decomp_command!(
             .resolve_body_entry(&selector)
             .map_err(|error| IfaceError::execution(error.to_string()))?;
         let entry = selected.addr;
+        if !prog.entry_bytes_mapped(&entry) {
+            return Err(IfaceError::execution("Selected entry has no mapped bytes"));
+        }
         let resolved_name = if matches!(selector, crate::engine::EntrySelector::Name(_)) {
             funcname
         } else {
@@ -1388,6 +1391,9 @@ decomp_command!(
         }
         .map_err(|error| IfaceError::execution(error.to_string()))?;
         let offset = selected.addr;
+        if !prog.entry_bytes_mapped(&offset) {
+            return Err(IfaceError::execution("Selected entry has no mapped bytes"));
+        }
         s.skip_ws();
         let name = s.read_token(); // optional
         // No explicit name: prefer the FunctionSymbol already installed here,

--- a/decompiler/crates/kuna-console/src/ifacedecomp.rs
+++ b/decompiler/crates/kuna-console/src/ifacedecomp.rs
@@ -1312,7 +1312,13 @@ decomp_command!(
             .map_err(|error| IfaceError::execution(error.to_string()))?;
         let entry = selected.addr;
         if !prog.entry_bytes_mapped(&entry) {
-            return Err(IfaceError::execution("Selected entry has no mapped bytes"));
+            return Err(IfaceError::execution(
+                if selected.provenance == crate::engine::EntryProvenance::UndefinedExternal {
+                    "Selected entry is an undefined external symbol"
+                } else {
+                    "Selected entry has no mapped bytes"
+                },
+            ));
         }
         let resolved_name = if matches!(selector, crate::engine::EntrySelector::Name(_)) {
             funcname
@@ -1392,7 +1398,13 @@ decomp_command!(
         .map_err(|error| IfaceError::execution(error.to_string()))?;
         let offset = selected.addr;
         if !prog.entry_bytes_mapped(&offset) {
-            return Err(IfaceError::execution("Selected entry has no mapped bytes"));
+            return Err(IfaceError::execution(
+                if selected.provenance == crate::engine::EntryProvenance::UndefinedExternal {
+                    "Selected entry is an undefined external symbol"
+                } else {
+                    "Selected entry has no mapped bytes"
+                },
+            ));
         }
         s.skip_ws();
         let name = s.read_token(); // optional

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -315,7 +315,11 @@ Four front-ends drive one engine assembly:
   so that calls to it render by name — answers with the entry's nature rather
   than with the lifter's byte-load failure: the shared decompile step probes
   `decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::entry_bytes_mapped)`
-  first and emits a one-line external-symbol body. A PE IAT slot is different:
+  first and emits a one-line external-symbol body. The console performs the same
+  check before following flow and reports `Selected entry has no mapped bytes`.
+  The text CLI recognizes only that selection diagnostic as an external; a later
+  byte-load error while decoding a mapped entry remains a failure, as it does in
+  JSON output. A PE IAT slot is different:
   its pointer bytes are mapped, so body selection consults the loader's import
   ranges and returns a non-success diagnostic naming the import and slot before
   flow following starts. The mapped-byte probe remains a one-byte read

--- a/docs/spec/00-overview.md
+++ b/docs/spec/00-overview.md
@@ -316,10 +316,13 @@ Four front-ends drive one engine assembly:
   than with the lifter's byte-load failure: the shared decompile step probes
   `decompiler/crates/kuna-console/src/engine.rs (ConsoleProgram::entry_bytes_mapped)`
   first and emits a one-line external-symbol body. The console performs the same
-  check before following flow and reports `Selected entry has no mapped bytes`.
-  The text CLI recognizes only that selection diagnostic as an external; a later
-  byte-load error while decoding a mapped entry remains a failure, as it does in
-  JSON output. A PE IAT slot is different:
+  check before following flow and reports
+  `Selected entry is an undefined external symbol` only for entries with
+  `UndefinedExternal` provenance. The text CLI recognizes only that diagnostic
+  as an external. A named XML symbol outside its byte chunks still fails with
+  `Selected entry has no mapped bytes`; a later byte-load error while decoding
+  a mapped entry also remains a failure, as it does in JSON output. A PE IAT slot
+  is different:
   its pointer bytes are mapped, so body selection consults the loader's import
   ranges and returns a non-success diagnostic naming the import and slot before
   flow following starts. The mapped-byte probe remains a one-byte read


### PR DESCRIPTION
### The problem

Text decompilation can report an external symbol and exit 0 when mapped code fails to decode.

```
printf '\007\040\160\107' > thumb.bin
arm-linux-gnueabi-objcopy -I binary -O elf32-littlearm -B arm \
  --rename-section .data=.text,alloc,load,readonly,code,contents thumb.bin thumb.o
arm-linux-gnueabi-ld -Ttext=0x1000 -e 0x1000 thumb.o -o thumb.elf
decompiler/target/release/kuna decompile thumb.elf 0x1000 --addr

Wrong output:

// 0x1000: external symbol -- no code at this address in this module
```

### The fix

- Check entry mapping before following flow.
- Require undefined-symbol provenance for external results; preserve selection and decode errors.

### The tests

Synthetic regressions cover text/JSON decode failure, Thumb override, undefined symbols by name/address, and missing XML bytes. The text decode case fails without the fix.