### PR TITLE
[AUTOMATED] docs(re-needs): reconcile bytecode reader closure

### DIFF
--- a/docs/re-needs/bytecode-reader-return-discarded.md
+++ b/docs/re-needs/bytecode-reader-return-discarded.md
@@ -2,7 +2,7 @@
 need_id: bytecode-reader-return-discarded
 title: Bytecode-reader return is discarded despite immediate use of RAX and RDX
 track: quality
-status: open
+status: closed
 severity: major
 probe_id: p-352a35192231
 acceptance_id: a-675031196902
@@ -13,13 +13,13 @@ challenges: [673da52e9b533b4c22bd2eeb]
 rounds: [8]
 first_seen_round: 8
 attempts: 0
-covered_by_option: null
+covered_by_option: callretpair
 touches: [decompiler/crates/kuna-decomp]
 scope: small
 regression_of: null
-pr: null
-closed_in_round: null
-closing_pr: null
+pr: https://github.com/Noelo-Lab/kuna/pull/565
+closed_in_round: 12
+closing_pr: "565"
 reject_reason: null
 ---
 
@@ -131,3 +131,7 @@ _not yet refuted_
 - filed by cluster.py from 1 observation(s)
 - captain T_DEDUP (r8): SPLIT from `bytecode-reader-call-site` even though both are the same caller (`sub_9d9c0`), the same callee (`sub_875e0`) and the same run — i.e. the r7 BCrypt double-finding shape, which is normally one root cause. The evidence says otherwise here: THIS probe already supplies the other need's fix by hand (`--assert param sub_875e0::0..3`) and the return is STILL discarded. A fix for the argument half therefore does not close this one, so merging them would have retired this probe for free.
 - round 8 TRIAGE (captain): SIBLING NOTICE -- see bytecode-reader-call-site, same binary, same caller sub_9d9c0, same callee sub_875e0, opposite side of the same prototype. Note this need was filed with an EMPTY hypothesis and no refuter ran on it, so its `inconclusive` is the filed default and not a verdict. Its acceptance and the sibling's are compatible; one PR may close both.
+- closed: acceptance a-675031196902 now PASSES at 5490ae7c30be
+- round 12 reconciliation: PR #565 (squash `12a86b24f101cf5c3302b8ab66014d8efd9a8e0d`) implemented `callretpair` for this need and passed the acceptance gate. Its squash introduced this record with the pre-closure `open` front matter, while the later acceptance-state write remained outside the merged commit; that stale snapshot is why the shipped option and durable status disagreed.
+- current controls at `5490ae7c30be05fdeb586aaddd96402e998b9506`: the exact dataset acceptance passes with default `callretpair on`, connecting `sub_875e0` to a 16-byte result and extracting both halves; adding `--option callretpair off` restores the filed bare call followed by a cast of an unassigned `// rdx` local. The promoted in-repo acceptance at `tests/cli/bytecode-reader-return-discarded.json` also passes against `callretpair_x86_64`.
+- index reconciliation constraint: at `5490ae7c30be05fdeb586aaddd96402e998b9506`, the authoritative committed index contains 197 active and 1 rejected records, but the clean commit exposes only 139 active Markdown sources and no rejected source directory to `needs reindex`. A sparse-source regeneration would destructively discard 58 active rows and the rejected ledger row, so this closure preserves the authoritative index byte-for-byte except for its `closed`/`open` totals and this need's object. Regenerate only after the missing sources have landed.

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -5,8 +5,8 @@
   "rejected_count": 1,
   "by_status": {
     "blocked": 1,
-    "closed": 141,
-    "open": 55
+    "closed": 142,
+    "open": 54
   },
   "by_track": {
     "loader": 10,
@@ -2241,7 +2241,7 @@
       "need_id": "bytecode-reader-return-discarded",
       "title": "Bytecode-reader return is discarded despite immediate use of RAX and RDX",
       "track": "quality",
-      "status": "open",
+      "status": "closed",
       "severity": "major",
       "probe_id": "p-352a35192231",
       "acceptance_id": "a-675031196902",
@@ -2256,15 +2256,15 @@
       ],
       "first_seen_round": 8,
       "attempts": 0,
-      "covered_by_option": null,
+      "covered_by_option": "callretpair",
       "touches": [
         "decompiler/crates/kuna-decomp"
       ],
       "scope": "small",
       "regression_of": null,
-      "pr": null,
-      "closed_in_round": null,
-      "closing_pr": null,
+      "pr": "https://github.com/Noelo-Lab/kuna/pull/565",
+      "closed_in_round": 12,
+      "closing_pr": "565",
       "reject_reason": null,
       "score": 13.862944,
       "path": "docs/re-needs/bytecode-reader-return-discarded.md"


### PR DESCRIPTION
## Stale registry

[#565](https://github.com/Noelo-Lab/kuna/pull/565) shipped `callretpair` and its acceptance coverage in squash `12a86b24f101cf5c3302b8ab66014d8efd9a8e0d`, but the durable need record retained its pre-closure `open` state.

## Reconciliation

- Mark `bytecode-reader-return-discarded` closed in round 12 under `callretpair`, with #565 as the implementing and closing PR.
- Preserve the original probe and acceptance IDs, rounds, attempts, and all unrelated registry rows.
- Adjust only the aggregate closed/open totals; this PR contains no implementation changes.

## Verification

The dataset acceptance `a-675031196902` and its promoted in-repo probe both pass. Disabling `callretpair` restores the filed bare-call/unassigned-RDX witness. Counter, spec, catalog, normalized-index, and isolated merge checks pass.
