### PR TITLE
[AUTOMATED] fix(p9): vm-terminal-opcode-emitted — preserve terminal case labels without op anchors

### DIFF
--- a/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/printc.rs
@@ -4376,14 +4376,7 @@ impl PrintC {
                 Some(o) => self.op_markup(fd, o),
                 None => MarkupRef::none(),
             };
-            self.emit.tag_line();
-            self.emit.tag_case_label(
-                self.lang().kw_default,
-                SyntaxHighlight::KeywordColor,
-                &case_markup,
-                case.label,
-            );
-            self.emit.print(self.lang().kw_colon, SyntaxHighlight::NoColor);
+            self.emit_default_case_label(case.label, &case_markup);
         } else {
             // case <label>: — one line per index targeting this case.
             let jt_index = fd.sblocks_ref().block(blk).switch_jt_index();
@@ -4404,9 +4397,6 @@ impl PrintC {
                     }
                     _ => case.label,
                 };
-                self.emit.tag_line();
-                self.emit.print(self.lang().kw_case, SyntaxHighlight::KeywordColor);
-                self.emit.spaces(1, 0);
                 let sz = self.switch_var_size(fd, blk);
                 // (kuna) Render the label signed when the recovered switch variable
                 // is signed (the lowered-switch install records this on the table;
@@ -4414,18 +4404,66 @@ impl PrintC {
                 let signed = jt_index
                     .map(|j| fd.get_jump_table(j as int4).kuna_has_signed_labels())
                     .unwrap_or(false);
-                if let Some(op) = firstop.or_else(|| self.any_op(fd, case.block)) {
-                    if signed {
-                        self.push_constant_ir_fmt_sign(val, sz, op, display_format::NONE, true);
-                    } else {
-                        self.push_constant_ir(val, sz, op);
-                    }
-                }
-                self.recurse();
-                self.emit.print(self.lang().kw_colon, SyntaxHighlight::NoColor);
+                self.emit_numeric_case_label(
+                    val,
+                    sz,
+                    signed,
+                    firstop.or_else(|| self.any_op(fd, case.block)),
+                );
             }
         }
         let _ = arch;
+    }
+
+    fn emit_default_case_label(&mut self, value: uintb, markup: &MarkupRef) {
+        self.emit.tag_line();
+        self.emit.tag_case_label(
+            self.lang().kw_default,
+            SyntaxHighlight::KeywordColor,
+            markup,
+            value,
+        );
+        self.emit.print(self.lang().kw_colon, SyntaxHighlight::NoColor);
+    }
+
+    fn emit_numeric_case_label(&mut self, value: uintb, size: int4, signed: bool, op: Option<OpId>) {
+        self.emit.tag_line();
+        self.emit.print(self.lang().kw_case, SyntaxHighlight::KeywordColor);
+        self.emit.spaces(1, 0);
+        match op {
+            Some(op) => {
+                if signed {
+                    self.push_constant_ir_fmt_sign(value, size, op, display_format::NONE, true);
+                } else {
+                    self.push_constant_ir(value, size, op);
+                }
+                self.recurse();
+            }
+            None => {
+                let force_dec = self.context.is_set(modifiers::FORCE_DEC);
+                let force_hex = self.context.is_set(modifiers::FORCE_HEX);
+                let (print_negsign, value, display_fmt) = resolve_integer_format(
+                    value,
+                    size,
+                    signed,
+                    display_format::NONE,
+                    force_hex,
+                    force_dec,
+                );
+                let token = format_integer_token(
+                    print_negsign,
+                    value,
+                    display_fmt,
+                    size,
+                    false,
+                    false,
+                    true,
+                    "",
+                );
+                self.emit.print(&token, SyntaxHighlight::ConstColor);
+            }
+        }
+        self.emit.print(self.lang().kw_colon, SyntaxHighlight::NoColor);
     }
 
     /// First op of a case block (C++ `FlowBlock::firstOp` → front-leaf basic

--- a/decompiler/crates/kuna-decomp/src/p9_emit/printc/tests.rs
+++ b/decompiler/crates/kuna-decomp/src/p9_emit/printc/tests.rs
@@ -13,6 +13,44 @@
 use super::*;
 use crate::printlanguage::{parentheses, ReversePolish};
 
+#[test]
+fn case_labels_without_ops_keep_their_numeric_value() {
+    let mut print = PrintC::new();
+    print.set_output_stream();
+
+    print.emit_numeric_case_label(0xff, 1, false, None);
+    print.emit_numeric_case_label(0xff, 1, true, None);
+
+    let output = print.emit_mut().output_str();
+    assert_eq!(output, "\ncase 0xff:\ncase -1:");
+    assert!(!output.contains("case :"));
+}
+
+#[test]
+fn ordinary_and_default_case_labels_are_unchanged() {
+    let mut print = PrintC::new();
+    print.set_output_stream();
+
+    print.emit_numeric_case_label(0xff, 1, false, Some(OpId::default()));
+    print.emit_default_case_label(0, &MarkupRef::none());
+
+    assert_eq!(print.emit_mut().output_str(), "\ncase 0xff:\ndefault:");
+}
+
+#[test]
+fn case_label_without_an_op_survives_markup_without_fabricated_provenance() {
+    let mut print = PrintC::new();
+    print.set_markup(true);
+
+    print.emit_numeric_case_label(0xff, 1, false, None);
+
+    let bytes = print.emit_mut().take_markup_bytes();
+    for token in [b"case".as_slice(), b"0xff".as_slice(), b":".as_slice()] {
+        assert!(bytes.windows(token.len()).any(|window| window == token));
+    }
+    assert!(print.emit_mut().take_markup_provenance().associations.is_empty());
+}
+
 mod stack_pointer_high_leaf {
     use super::*;
     use crate::context::ArchContext;

--- a/docs/re-needs/index.json
+++ b/docs/re-needs/index.json
@@ -5,8 +5,8 @@
   "rejected_count": 1,
   "by_status": {
     "blocked": 1,
-    "closed": 142,
-    "open": 54
+    "closed": 143,
+    "open": 53
   },
   "by_track": {
     "loader": 10,
@@ -4606,7 +4606,7 @@
       "need_id": "vm-terminal-opcode-emitted",
       "title": "VM terminal opcode is emitted as an empty case label",
       "track": "quality",
-      "status": "open",
+      "status": "closed",
       "severity": "major",
       "probe_id": "p-b0dfb36b575d",
       "acceptance_id": "a-c051e63bb8de",
@@ -4617,21 +4617,22 @@
         "6a17264017539b5175d123a9"
       ],
       "rounds": [
-        6
+        6,
+        12
       ],
       "first_seen_round": 6,
-      "attempts": 0,
+      "attempts": 1,
       "covered_by_option": null,
       "touches": [
         "decompiler/crates/kuna-decomp"
       ],
       "scope": "small",
       "regression_of": null,
-      "pr": null,
-      "closed_in_round": null,
-      "closing_pr": null,
+      "pr": 598,
+      "closed_in_round": 12,
+      "closing_pr": "598",
       "reject_reason": null,
-      "score": 13.862944,
+      "score": 9.241962,
       "path": "docs/re-needs/vm-terminal-opcode-emitted.md"
     },
     {

--- a/docs/re-needs/vm-terminal-opcode-emitted.md
+++ b/docs/re-needs/vm-terminal-opcode-emitted.md
@@ -1,0 +1,120 @@
+---
+need_id: vm-terminal-opcode-emitted
+title: VM terminal opcode is emitted as an empty case label
+track: quality
+status: closed
+severity: major
+probe_id: p-b0dfb36b575d
+acceptance_id: a-c051e63bb8de
+hypothesis_status: overturned
+credibility: 0.85
+instances: 1
+challenges: [6a17264017539b5175d123a9]
+rounds: [6, 12]
+first_seen_round: 6
+attempts: 1
+covered_by_option: null
+touches: [decompiler/crates/kuna-decomp]
+scope: small
+regression_of: null
+pr: 598
+closed_in_round: 12
+closing_pr: "598"
+reject_reason: null
+---
+
+## Symptom
+
+Recover all VM opcode labels, especially the success-return opcode.
+
+> **VM terminal opcode is emitted as an empty case label** (major, `6a17264017539b5175d123a9`)
+> Emits case : with exit 0 and no warning. The empty label remains with switchselector on, argument recovery enabled, and loweredswitch off. Reading the two-level table at 0x140003d64 proves opcode 0xff maps to 0x140003c40, the terminal Boolean-return handler.
+
+## Reproduction
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "target": {
+    "binary_rel": "bin/crackme_very_hard.exe",
+    "binary_sha256": "9d250e1c9e0fab29b860494cefc0093cff989d01c801f79bf571512692c1ae42",
+    "binary_size": 31744,
+    "binary_source": "dataset"
+  },
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x1400033c0"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "\\bcase\\s*:"
+    ]
+  }
+}
+```
+
+## Acceptance
+
+```json
+{
+  "schema": "re-probe/1",
+  "kind": "cli",
+  "target": {
+    "binary_rel": "bin/crackme_very_hard.exe",
+    "binary_sha256": "9d250e1c9e0fab29b860494cefc0093cff989d01c801f79bf571512692c1ae42",
+    "binary_size": 31744,
+    "binary_source": "dataset"
+  },
+  "timeout_s": 60,
+  "cmd": [
+    "{{KUNA}}",
+    "decompile",
+    "{{BIN}}",
+    "0x1400033c0"
+  ],
+  "expect": {
+    "exit_code": {
+      "eq": 0
+    },
+    "stdout_matches": [
+      "case\\s+(?:0xff|255)\\s*:"
+    ],
+    "stdout_absent": [
+      "\\bcase\\s*:"
+    ]
+  }
+}
+```
+
+## Hypothesis
+
+**Advisory — the builder is not bound by this.** In the sibling campaign 3 of 8 filed diagnoses were overturned while the symptom stood in all 8.
+
+- Possibly loses the highest selector value when translating the byte-indexed, two-level jump table.
+
+## Refutation
+
+_not yet refuted_
+
+## Reference
+
+- `ida-decompile load ./target/crackme_very_hard.exe` — Server exited with status 1 before registering. No reference pseudocode was obtained; this does not establish whether IDA handles the function.
+
+## Instances
+
+- `6a17264017539b5175d123a9` (round 6, tester t-r6-6a172640)
+
+## Decision log
+
+- filed by cluster.py from 1 observation(s)
+- round 6 REFUTER: hypothesis **overturned** (was inconclusive). OVERTURNED on the CAUSE; the SYMPTOM stands and the tester's table reading is exactly right. Measured on .kuna-repipe/arena/6/6a17264017539b5175d123a9/target/crackme_very_hard.exe with the release kuna at 9c4c4508. (1) I DECODED THE TABLE BY HAND AND THE TESTER IS CORRECT. Dispatch at 0x1400035de: 'LEA EAX,[RDX-0x11]; CMP EAX,0xee; JA 0x140003c70; CDQE; MOVZX EAX,byte ptr [R12+RAX+0x3d94]; MOV ECX,dword ptr [R12+RAX*4+0x3d64]; ADD RCX,R12; JMP RCX' (R12 = imagebase). Byte index table 0x140003d94 (0xef entries), dword RVA table 0x140003d64. 12 distinct targets: 10 one-opcode handlers (0x11 0x12 0x21 0x22 0x23 0x24 0x31 0x32 0x33 0x41), the catch-all 0x140003c70 taking 228 opcodes, and **opcode 0xff (index 0xee) -> 0x140003c40, a target distinct from the default**. kuna emits those same 10 labels plus 'default:' plus one 'case :' with an EMPTY label list -- so exactly one label is missing and it is 0xff, the highest selector. (2) WHY THE FILED CAUSE IS WRONG. 'Loses the highest selector when translating the two-level table' predicts the destination was never enumerated -- but it WAS: the 'case :' block exists in the switch as a node separate from 'default:', so the guard bound (0xee INCLUSIVE) and the table walk both reached index 0xee. There is no off-by-one to find in the jumptable recovery. The loss is at label ATTACHMENT/emission, downstream of the table. A builder sent into the jump-table code on this diagnosis will find the bound already correct and will burn the dispatch. (3) THE BIGGER FINDING -- THE EMPTY CASE'S BODY IS NOT THE 0xff HANDLER, IT IS THE EPILOGUE. 0x140003c40 computes the function's boolean result: 'MOV ECX,EDI; SUB RAX,RDX (program length); CMP RCX,RAX; JC 0x140003c61; MOV AL,0xff; TEST AL,AL; SETNZ AL; JMP 0x140003c72' / else 'MOVZX EAX,[RSP+0x40]; XOR AL,[RCX+RDX]; SETNZ AL; JMP 0x140003c72'. kuna's 'case :' body is only 'sub_140004930(v35 ^ v21); return;' -- BYTE-IDENTICAL to the 'default:' body (default is 0x140003c70 = 'XOR AL,AL' then the same epilogue at 0x140003c72). The whole handler is dead-coded. (4) TWO CONTROLS, NEITHER RESURRECTS IT. kuna declares 'void sub_1400033c0(...)' although every caller does 'MOVZX R14D,AL' / 'TEST AL,AL'. Forcing the real return with --assert-strict 'prototype sub_1400033c0 unsigned char sub_1400033c0(unsigned long long *a0, unsigned int a1, char a2)' (rc=0, signature really changes) turns both bodies into 'return sub_140004930(v20);' -- i.e. it returns the void __security_check_cookie call -- but the length compare and the XOR/SETNZ are STILL absent. Adding '--option msvcstackguard on' on top changes nothing at all. So the void prototype is not the whole story either; do not assume fixing the return type fixes the body. (5) NOTE THE OVERLAP BUT DO NOT MERGE THE NEEDS: 'return sub_140004930(v20);' is the same cookie-call-eats-the-return-value shape as msvc-cookie-removal-changes / main-returns-invented-cookie, on a third binary. *** WARNING FOR T_TRIAGE -- THE ACCEPTANCE PROBE (a-4d58a42b70bc) IS CLOSED BY THE WORST FIX AVAILABLE. *** It is absence-only on '\\bcase\\s*:'. The cheapest way to make that regex stop matching is to DELETE the label-less block (fold it into default) -- which destroys the 0xff destination entirely and is strictly worse than today's output. The probe must require the label positively: stdout_matches 'case 0xff:' (or 'case 0x?ff\\s*:'). Third probe this round that is wrong in the closing direction; see the guard-dispatch and code-byte-loads notes.
+- round 6 T_TRIAGE: ACCEPTANCE REWRITTEN (a-4d58a42b70bc -> a-c051e63bb8de), and it was verified two-sided before the swap: it FAILS on the need's own arena binary at 9c4c4508 (`probe check --bin` rc=1) and PASSES when simulated against plausible correct renderings. It was absence-only on `\bcase\s*:`, whose cheapest satisfier is deleting the label-less block into `default:` -- strictly worse than today. Now also REQUIRES `case 0xff:` (kuna renders case labels in hex, verified: `case 0x11:` .. `case 0x41:`).
+- implementation: `PrintC::emit_switch_case` only pushed the numeric token when the case block supplied an op to anchor markup. The no-op path now renders the same width-aware, signed integer token directly, without inventing an `opref`. The crackme witness emits `case 0xff:` and retains the separate arm body; Rust remains `255 =>`. Printer tests cover no-op unsigned and signed labels, the ordinary op-backed path, `default:`, packed markup, and absent fabricated provenance.
+- closed: acceptance a-c051e63bb8de now PASSES at 65e2cf60fb32

--- a/docs/spec/09-emission.md
+++ b/docs/spec/09-emission.md
@@ -272,6 +272,12 @@ addl-flag on the condition's `CBRANCH` and emit the condition through the same
 parenthesization, short-circuiting and any comma-expression side effects are
 identical to the `if` form they replace.
 
+Every non-default switch arm emits its recovered numeric label even when the
+arm has no p-code op available as a token-markup anchor. Such labels use the
+same switch-width, signedness, and integer-format rules as op-backed labels,
+but are emitted as plain syntax with no fabricated `opref`; `default:` remains
+an unvalued label.
+
 **Pending-brace ownership.** The `else if` collapse is a *lazy* brace. An
 if-node that is itself the else-clause of its parent registers a brace with the
 emitter (`printc.rs (PrintC::emit_block_if)`); the brace opens only if


### PR DESCRIPTION
# VM terminal opcode is emitted as an empty case label

The recovered switch for `crackme_very_hard.exe` retained a distinct terminal arm, but P9 emitted its label as `case :` whenever the block had no operation available to anchor token provenance. That produced invalid C and hid the proven `0xff` selector value.

This change makes `PrintC::emit_switch_case` render the same width- and signedness-aware integer token in both paths. The existing op-backed path is unchanged. The no-op fallback emits a syntax token directly and deliberately does not fabricate an `opref`.

The focused printer coverage pins unsigned and signed no-op labels (`0xff` and `-1`), packed markup with empty provenance, the ordinary op-backed path, and the unvalued `default:` arm.

## Exact witness

Binary SHA-256: `9d250e1c9e0fab29b860494cefc0093cff989d01c801f79bf571512692c1ae42`

Function: `0x1400033c0`

C now keeps both destinations distinct:

```c
default:
label_140003c70:
  sub_140004930(v35 ^ (unsigned long long)v21); // return-dupe
  return;

case 0xff:
  sub_140004930(v35 ^ (unsigned long long)v21);
  return;
```

Rust independently retains the selector and fallback:

```rust
255 => {
  sub_140004930(v35 ^ v21 as u64); // return-dupe
  return;
}
_ => {
  // label_140003c70:
  sub_140004930(v35 ^ v21 as u64);
  return;
}
```

The acceptance probe `a-c051e63bb8de` passes by finding exactly `case 0xff:` and rejecting a blank `case :`. An extracted fragment containing the emitted label also passes `gcc -std=gnu11 -fsyntax-only`.

## Scope boundary

This is intentionally a P9 label-emission repair. It does not claim to recover the terminal handler's missing boolean computation or correct the function's inferred `void` prototype. Those upstream body/type defects remain visible in the need's decision log and are not hidden by folding the terminal arm into `default:`.

Validation includes the focused printer tests, C/Rust witness assertions, the acceptance probe, parity and stages suites, strict and lenient spec checks, catalog/counter checks, mergecheck, and the full Rust workspace. The rebased seam also includes the PR #586 decode/load regression tests.

Generated with Codex (GPT-5.6 Sol, high reasoning).
